### PR TITLE
CQL binary protocol in-wire types

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -7,3 +7,8 @@ repository = "https://github.com/psarna/scylla-rust-driver"
 readme = "../README.md"
 keywords = ["database", "scylla", "cql"]
 categories = ["database"]
+
+[dependencies]
+anyhow = "1.0.33"
+byteorder = "1.3.4"
+bytes = "0.6.0"

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -1,1 +1,6 @@
 //! Async CQL driver for Rust, optimized for Scylla.
+
+#[macro_use]
+extern crate anyhow;
+
+pub mod types;


### PR DESCRIPTION
Add serialization/deserialization functions for the following CQL binary
protocol types:

 - int (32-bit)
 - long (64-bit)
 - short (16-bit)
 - string (16-bit length + UTF-8)
 - long string (32-bit length + UTF-8)
  - string map