### PR TITLE
.gitignore: add .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode
 /target
 Cargo.lock


### PR DESCRIPTION
Adds .vscode to .gitignore so that anybody using VSCode can setup a custom configuration without needing to care about that directory popping up in `git status` all the time.