### PR TITLE
examples: Add example program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
-    "scylla"
+    "examples",
+    "scylla",
 ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # scylla-rust-driver
 Async CQL driver for Rust, optimized for Scylla!
 
+## Getting Started
+
+You can run the [example](examples/example.rs) program as follows:
+
+```
+$ SCYLLA_URI="localhost:9042" cargo run --example example
+```
+
 ## License
 
 This project is licensed under either of

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "examples"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[dev-dependencies]
+anyhow = "1.0.33"
+scylla = { path = "../scylla" }
+tokio = { version = "0.3.0", features = ["full"] }
+
+[[example]]
+name = "example"
+path = "example.rs"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use scylla::transport::session::Session;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or("localhost:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session = Session::connect(uri).await?;
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}").await?;
+
+    session.query("CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))").await?;
+
+    session.query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')").await?;
+
+    println!("Ok.");
+
+    Ok(())
+}


### PR DESCRIPTION
This adds an example program of how to use the Scylla rust driver.

You can run the program with:

 SCYLLA_URI="localhost:9042" cargo run --example example