### PR TITLE
Add "scylla/target" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
+/scylla/target
 /target
 Cargo.lock


### PR DESCRIPTION
The "cargo bench" command builds stuff in "scylla/target" so add it to
.gitignore.