### PR TITLE
transport: allow repreparing prepared statements

### DIFF
--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -3,14 +3,23 @@ use bytes::Bytes;
 #[derive(Debug)]
 pub struct PreparedStatement {
     id: Bytes,
+    statement: String,
 }
 
 impl PreparedStatement {
-    pub fn new(id: Bytes) -> Self {
-        Self { id }
+    pub fn new(id: Bytes, statement: String) -> Self {
+        Self { id, statement }
     }
 
     pub fn get_id(&self) -> &Bytes {
         &self.id
+    }
+
+    pub fn update_id(&mut self, id: Bytes) {
+        self.id = id
+    }
+
+    pub fn get_statement(&self) -> &str {
+        &self.statement
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -33,14 +33,14 @@ impl Session {
     }
 
     pub async fn prepare(&self, query: String) -> Result<PreparedStatement> {
-        let result = self.connection.prepare(query).await?;
+        let result = self.connection.prepare(query.clone()).await?;
         match result {
             Response::Error(err) => {
                 Err(err.into())
             }
             Response::Result(_) => {
                 //FIXME: actually read the id
-                Ok(PreparedStatement::new("stub_id".into()))
+                Ok(PreparedStatement::new("stub_id".into(), query))
             }
             _ => return Err(anyhow!("Unexpected frame received")),
         }


### PR DESCRIPTION
Statements occasionally need to be reprepared, so it's a good idea
to remember the original text of the query. Also, such a statement
might need to get its id rewritten, after the session reprepares it.

Refs #22 