### PR TITLE
examples: Avoid unwrap() when processing result set

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -17,12 +17,13 @@ async fn main() -> Result<()> {
 
     session.query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')").await?;
 
-    let rs = session.query("SELECT a, b, c FROM ks.t").await?.unwrap();
-    for r in rs {
-        let a = r.columns[0].as_ref().unwrap().as_int().unwrap();
-        let b = r.columns[1].as_ref().unwrap().as_int().unwrap();
-        let c = r.columns[2].as_ref().unwrap().as_text().unwrap();
-        println!("a, b, c: {}, {}, {}", a, b, c);
+    if let Some(rs) = session.query("SELECT a, b, c FROM ks.t").await? {
+        for r in rs {
+            let a = r.columns[0].as_ref().unwrap().as_int().unwrap();
+            let b = r.columns[1].as_ref().unwrap().as_int().unwrap();
+            let c = r.columns[2].as_ref().unwrap().as_text().unwrap();
+            println!("a, b, c: {}, {}, {}", a, b, c);
+        }
     }
 
     println!("Ok.");


### PR DESCRIPTION
A query can return an empty result set so make the example code reflect that.