### PR TITLE
examples: cqlsh-like command line tool

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,12 @@ edition = "2018"
 anyhow = "1.0.33"
 scylla = { path = "../scylla" }
 tokio = { version = "0.3.0", features = ["full"] }
+rustyline = "6.3.0"
 
 [[example]]
 name = "example"
 path = "example.rs"
+
+[[example]]
+name = "cqlsh-rs"
+path = "cqlsh-rs.rs"

--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
+use scylla::transport::session::Session;
+use scylla::transport::Compression;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or("localhost:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session = Session::connect(uri, Some(Compression::LZ4)).await?;
+
+    let mut rl = Editor::<()>::new();
+    loop {
+        let readline = rl.readline(">> ");
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(line.as_str());
+                session.query(line).await.unwrap();
+            }
+            Err(ReadlineError::Interrupted) => break,
+            Err(ReadlineError::Eof) => break,
+            Err(err) => {
+                println!("Error: {:?}", err);
+                break;
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This implements a simple cqlsh-like command line tool with rustyline to
make testing our driver easier:

  [penberg@nero rust-driver]$ SCYLLA_URI="localhost:9042" cargo run --example cqlsh-rs

  Connecting to localhost:9042 ...
  >> INSERT INTO ks.t (a, b, c) VALUES (9, 8, 'foo');
  >>