### PR TITLE
frame: add repreparing executed prepared statements

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -20,11 +20,11 @@ async fn main() -> Result<()> {
         .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')")
         .await?;
 
-    let prepared = session
+    let mut prepared = session
         .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, 7, ?)")
         .await?;
     session
-        .execute(&prepared, scylla::values!(42_i32, "I'm prepared!"))
+        .execute(&mut prepared, &scylla::values!(42_i32, "I'm prepared!"))
         .await?;
 
     if let Some(rs) = session.query("SELECT a, b, c FROM ks.t").await? {

--- a/scylla/src/frame/request/execute.rs
+++ b/scylla/src/frame/request/execute.rs
@@ -7,12 +7,12 @@ use crate::{
     frame::value::Value,
 };
 
-pub struct Execute {
+pub struct Execute<'a> {
     pub id: Bytes,
-    pub values: Vec<Value>,
+    pub values: &'a [Value],
 }
 
-impl Request for Execute {
+impl Request for Execute<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Execute;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
@@ -25,7 +25,7 @@ impl Request for Execute {
         if !self.values.is_empty() {
             buf.put_i16(self.values.len() as i16);
         }
-        for value in &self.values {
+        for value in self.values {
             match value {
                 Value::Val(v) => {
                     types::write_int(v.len() as i32, buf);

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -77,16 +77,16 @@ impl Connection {
         self.send_request(&request::Query::from(query), true).await
     }
 
-    pub async fn execute(
+    pub async fn execute<'a>(
         &self,
         prepared_statement: &PreparedStatement,
-        values: Vec<Value>,
+        values: &'a [Value],
     ) -> Result<Response> {
         let execute_frame = execute::Execute {
             id: prepared_statement.get_id().to_owned(),
             values,
         };
-        //TODO: reprepare if execution failed because the statement was evicted from the server
+
         self.send_request(&execute_frame, true).await
     }
 

--- a/scylla/src/transport/connection_test.rs
+++ b/scylla/src/transport/connection_test.rs
@@ -15,15 +15,15 @@ async fn test_connecting() {
         .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')")
         .await
         .unwrap();
-    let prepared_statement = session
+    let mut prepared_statement = session
         .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)")
         .await
         .unwrap();
     println!("Prepared statement: {:?}", prepared_statement);
     session
         .execute(
-            &prepared_statement,
-            values!(17_i32, 16_i32, "I'm prepared!!!"),
+            &mut prepared_statement,
+            &values!(17_i32, 16_i32, "I'm prepared!!!"),
         )
         .await
         .unwrap();


### PR DESCRIPTION
When error 9472 is encountered, the statement should be reprepared
and retried.
While at it, the `EXECUTE` statement now takes the vector of values by reference instead of owning it. Also, the prepared statement may get its id updated in the process if repreparation was performed.