### PR TITLE
Allow query to take parameters

### DIFF
--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str());
-                session.query(line).await.unwrap();
+                session.query(line, &[]).await.unwrap();
             }
             Err(ReadlineError::Interrupted) => break,
             Err(ReadlineError::Eof) => break,

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -13,10 +13,13 @@ async fn main() -> Result<()> {
 
     let session = Arc::new(Session::connect(uri, None).await?);
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}").await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
-        .query("CREATE TABLE IF NOT EXISTS ks.t2 (a int, b int, c text, primary key (a, b))")
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t2 (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
         .await?;
 
     let sem = Arc::new(Semaphore::new(256));
@@ -30,11 +33,14 @@ async fn main() -> Result<()> {
         tokio::task::spawn(async move {
             let i = i;
             session
-                .query(format!(
-                    "INSERT INTO ks.t2 (a, b, c) VALUES ({}, {}, 'abc')",
-                    i,
-                    2 * i
-                ))
+                .query(
+                    format!(
+                        "INSERT INTO ks.t2 (a, b, c) VALUES ({}, {}, 'abc')",
+                        i,
+                        2 * i
+                    ),
+                    &[],
+                )
                 .await
                 .unwrap();
 

--- a/scylla/src/frame/request/execute.rs
+++ b/scylla/src/frame/request/execute.rs
@@ -2,14 +2,13 @@ use anyhow::Result;
 use bytes::{BufMut, Bytes};
 
 use crate::{
-    frame::request::{Request, RequestOpcode},
+    frame::request::{query, Request, RequestOpcode},
     frame::types,
-    frame::value::Value,
 };
 
 pub struct Execute<'a> {
     pub id: Bytes,
-    pub values: &'a [Value],
+    pub parameters: query::QueryParameters<'a>,
 }
 
 impl Request for Execute<'_> {
@@ -17,25 +16,10 @@ impl Request for Execute<'_> {
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
         // Serializing statement id
-        types::write_short(self.id.len() as i16, buf);
-        buf.put_slice(&self.id[..]);
+        types::write_short_bytes(&self.id[..], buf)?;
+
         // Serializing params
-        types::write_short(1, buf); // consistency ONE
-        buf.put_u8(if self.values.is_empty() { 0x0 } else { 0x1 }); // Flags: 0x1 means that values are present
-        if !self.values.is_empty() {
-            buf.put_i16(self.values.len() as i16);
-        }
-        for value in self.values {
-            match value {
-                Value::Val(v) => {
-                    types::write_int(v.len() as i32, buf);
-                    buf.put_slice(&v[..]);
-                }
-                Value::Null => types::write_int(-1, buf),
-                Value::NotSet => types::write_int(-2, buf),
-            }
-        }
-        println!("Buf {:?}", self.values);
+        self.parameters.serialize(buf)?;
         Ok(())
     }
 }

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -90,6 +90,16 @@ pub fn read_bytes<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8]> {
     Ok(v)
 }
 
+pub fn write_short_bytes<'a>(v: &[u8], buf: &mut impl BufMut) -> Result<()> {
+    let len = v.len();
+    if len > i16::MAX as usize {
+        return Err(anyhow!("Byte slice is too long for 16-bits: {} bytes", len));
+    }
+    write_short(len as i16, buf);
+    buf.put_slice(v);
+    Ok(())
+}
+
 pub fn read_string<'a>(buf: &mut &'a [u8]) -> Result<&'a str> {
     let len = read_short(buf)? as usize;
     if buf.len() < len {

--- a/scylla/src/transport/connection_test.rs
+++ b/scylla/src/transport/connection_test.rs
@@ -6,13 +6,16 @@ use crate::transport::session::Session;
 async fn test_connecting() {
     let session = Session::connect("localhost:9042", None).await.unwrap();
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}").await.unwrap();
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session
-        .query("CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))")
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
         .await
         .unwrap();
     session
-        .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')")
+        .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')", &[])
         .await
         .unwrap();
     let mut prepared_statement = session

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -60,8 +60,12 @@ impl Session {
     // actually, if we consider "INSERT" a query, then no.
     // But maybe "INSERT" and "SELECT" should go through different methods,
     // so we expect "SELECT" to always return Vec<result::Row>?
-    pub async fn query(&self, query: impl Into<Query>) -> Result<Option<Vec<result::Row>>> {
-        let result = self.any_connection().query(&query.into()).await?;
+    pub async fn query<'a>(
+        &self,
+        query: impl Into<Query>,
+        values: &'a [Value],
+    ) -> Result<Option<Vec<result::Row>>> {
+        let result = self.any_connection().query(&query.into(), values).await?;
         match result {
             Response::Error(err) => Err(err.into()),
             Response::Result(result::Result::Rows(rs)) => Ok(Some(rs.rows)),


### PR DESCRIPTION
Adds a possibility to pass parameters to unprepared queries. Refactors Query and Execute frames so that they both are able to have query parameters.