### PR TITLE
treewide: unmutate the prepared statement

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -30,11 +30,11 @@ async fn main() -> Result<()> {
         .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')", &[])
         .await?;
 
-    let mut prepared = session
+    let prepared = session
         .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, 7, ?)")
         .await?;
     session
-        .execute(&mut prepared, &scylla::values!(42_i32, "I'm prepared!"))
+        .execute(&prepared, &scylla::values!(42_i32, "I'm prepared!"))
         .await?;
 
     if let Some(rs) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -15,10 +15,6 @@ impl PreparedStatement {
         &self.id
     }
 
-    pub fn update_id(&mut self, id: Bytes) {
-        self.id = id
-    }
-
     pub fn get_statement(&self) -> &str {
         &self.statement
     }

--- a/scylla/src/transport/connection_test.rs
+++ b/scylla/src/transport/connection_test.rs
@@ -18,14 +18,14 @@ async fn test_connecting() {
         .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')", &[])
         .await
         .unwrap();
-    let mut prepared_statement = session
+    let prepared_statement = session
         .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)")
         .await
         .unwrap();
     println!("Prepared statement: {:?}", prepared_statement);
     session
         .execute(
-            &mut prepared_statement,
+            &prepared_statement,
             &values!(17_i32, 16_i32, "I'm prepared!!!"),
         )
         .await

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -89,7 +89,7 @@ impl Session {
 
     pub async fn execute<'a>(
         &self,
-        prepared: &mut PreparedStatement,
+        prepared: &PreparedStatement,
         values: &'a [Value],
     ) -> Result<Option<Vec<result::Row>>> {
         // FIXME: Prepared statement ids are local to a node, so we must make sure
@@ -102,7 +102,9 @@ impl Session {
                     9472 => {
                         // Repreparation of a statement is needed
                         let reprepared = self.prepare(prepared.get_statement()).await?;
-                        prepared.update_id(reprepared.get_id().to_owned());
+                        // Reprepared statement should keep its id - it's the md5 sum
+                        // of statement contents
+                        assert!(reprepared.get_id() == prepared.get_id());
                         let result = connection.execute(prepared, values).await?;
                         match result {
                             Response::Error(err) => Err(err.into()),


### PR DESCRIPTION
Prepared statement was passed via a mutable reference
under a false impression that it can change during repreparation.
Actually, the id is computed by taking an md5 sum of the statement,
which means that it will not change.