### PR TITLE
routing: Optimize shard_of()

### DIFF
--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -19,14 +19,9 @@ impl ShardInfo {
     }
 
     pub fn shard_of(&self, token: Token) -> Shard {
-        let nr_shards = self.nr_shards as u64;
-        let z = ((token.value.wrapping_add(i64::MIN)) as u64) << self.msb_ignore;
-        let lo = z & 0xffffffff;
-        let hi = (z >> 32) & 0xffffffff;
-        let mul1 = lo * nr_shards;
-        let mul2 = hi * nr_shards;
-        let sum = (mul1 >> 32) + mul2;
-        (sum >> 32) as Shard
+        let mut biased_token = (token.value as u64).wrapping_add(1u64 << 63);
+        biased_token <<= self.msb_ignore;
+        return (((biased_token as u128) * (self.nr_shards as u128)) >> 64) as Shard;
     }
 }
 


### PR DESCRIPTION
Rust support 128-bit arihtmetic so use it to optimize shard_of() as per:

https://github.com/scylladb/scylla/blob/master/docs/protocol-extensions.md#intranode-sharding

Before:

0000000000000000 <_ZN6scylla7routing9ShardInfo8shard_of17hf610fd0002c771baE>:
   0:   48 ba 00 00 00 00 00    movabs $0x8000000000000000,%rdx
   7:   00 00 80
   a:   48 31 f2                xor    %rsi,%rdx
   d:   8a 4f 02                mov    0x2(%rdi),%cl
  10:   48 d3 e2                shl    %cl,%rdx
  13:   0f b7 0f                movzwl (%rdi),%ecx
  16:   89 d0                   mov    %edx,%eax
  18:   48 c1 ea 20             shr    $0x20,%rdx
  1c:   48 0f af c1             imul   %rcx,%rax
  20:   48 0f af d1             imul   %rcx,%rdx
  24:   48 c1 e8 20             shr    $0x20,%rax
  28:   48 01 d0                add    %rdx,%rax
  2b:   48 c1 e8 20             shr    $0x20,%rax
  2f:   c3                      retq

After:

0000000000000000 <_ZN6scylla7routing9ShardInfo8shard_of17hf610fd0002c771baE>:
   0:   48 b8 00 00 00 00 00    movabs $0x8000000000000000,%rax
   7:   00 00 80
   a:   48 31 f0                xor    %rsi,%rax
   d:   8a 4f 02                mov    0x2(%rdi),%cl
  10:   48 d3 e0                shl    %cl,%rax
  13:   0f b7 0f                movzwl (%rdi),%ecx
  16:   48 f7 e1                mul    %rcx
  19:   48 89 d0                mov    %rdx,%rax
  1c:   c3                      retq

Fixes #52