### PR TITLE
[RFC] Query builder

### DIFF
--- a/scylla/src/frame/request/query.rs
+++ b/scylla/src/frame/request/query.rs
@@ -5,6 +5,7 @@ use crate::{
     frame::request::{Request, RequestOpcode},
     frame::types,
     frame::value::Value,
+    statement,
 };
 
 // Query flags
@@ -51,6 +52,19 @@ impl Default for QueryParameters<'_> {
 }
 
 impl QueryParameters<'_> {
+    pub(crate) fn new<'a>(
+        params: &statement::QueryParameters,
+        paging_state: Option<Bytes>,
+        values: &'a [Value],
+    ) -> QueryParameters<'a> {
+        QueryParameters {
+            consistency: params.consistency as i16,
+            page_size: params.page_size,
+            paging_state,
+            values,
+        }
+    }
+
     pub fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
         types::write_short(self.consistency, buf);
 

--- a/scylla/src/statement/builder.rs
+++ b/scylla/src/statement/builder.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+
+use crate::transport::session::Session;
+
+use super::{prepared_statement::PreparedStatement, query::Query, Consistency, QueryParameters};
+
+#[derive(Default, Debug, Clone)]
+pub struct Builder {
+    default_params: QueryParameters,
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Self {
+            default_params: Default::default(),
+        }
+    }
+
+    pub fn build(&self) -> BuilderSession {
+        BuilderSession {
+            params: self.default_params.clone(),
+        }
+    }
+
+    pub fn set_default_page_size(&mut self, page_size: i32) {
+        assert!(page_size > 0, "page size must be larger than 0");
+        self.default_params.page_size = Some(page_size);
+    }
+
+    pub fn set_no_paging_by_default(&mut self) {
+        self.default_params.page_size = None;
+    }
+
+    pub fn set_default_consistency(&mut self, consistency: Consistency) {
+        self.default_params.consistency = consistency;
+    }
+}
+
+pub struct BuilderSession {
+    params: QueryParameters,
+}
+
+impl BuilderSession {
+    pub fn with_page_size(mut self, page_size: i32) -> Self {
+        assert!(page_size > 0, "page size must be larger than 0");
+        self.params.page_size = Some(page_size);
+        self
+    }
+
+    pub fn with_no_paging(mut self) -> Self {
+        self.params.page_size = None;
+        self
+    }
+
+    pub fn with_consistency(mut self, consistency: Consistency) -> Self {
+        self.params.consistency = consistency;
+        self
+    }
+
+    pub async fn prepared(
+        self,
+        session: &Session,
+        contents: impl AsRef<str>,
+    ) -> Result<PreparedStatement> {
+        session
+            .prepare_with_params(contents.as_ref(), self.params)
+            .await
+    }
+
+    pub fn query(self, contents: impl Into<String>) -> Query {
+        Query::new(contents.into(), self.params)
+    }
+}

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,3 +1,4 @@
+pub mod builder;
 pub mod prepared_statement;
 pub mod query;
 

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,2 +1,32 @@
 pub mod prepared_statement;
 pub mod query;
+
+#[derive(Copy, Clone, Debug)]
+pub enum Consistency {
+    Any = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Quorum = 4,
+    All = 5,
+    LocalQuorum = 6,
+    EachQuorum = 7,
+    Serial = 8,
+    LocalSerial = 9,
+    LocalOne = 10,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct QueryParameters {
+    pub consistency: Consistency,
+    pub page_size: Option<i32>,
+}
+
+impl Default for QueryParameters {
+    fn default() -> Self {
+        Self {
+            consistency: Consistency::Quorum,
+            page_size: Some(1024),
+        }
+    }
+}

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -2,13 +2,15 @@ use crate::frame::response::result::PreparedMetadata;
 use crate::frame::value::Value;
 use bytes::{BufMut, Bytes, BytesMut};
 
+use super::QueryParameters;
+
 /// Represents a statement prepared on the server.
 #[derive(Debug, Clone)]
 pub struct PreparedStatement {
     id: Bytes,
     metadata: PreparedMetadata,
     statement: String,
-    page_size: Option<i32>,
+    params: QueryParameters,
 }
 
 impl PreparedStatement {
@@ -17,7 +19,7 @@ impl PreparedStatement {
             id,
             metadata,
             statement,
-            page_size: None,
+            params: Default::default(),
         }
     }
 
@@ -32,17 +34,17 @@ impl PreparedStatement {
     /// Sets the page size for this CQL query.
     pub fn set_page_size(&mut self, page_size: i32) {
         assert!(page_size > 0, "page size must be larger than 0");
-        self.page_size = Some(page_size);
+        self.params.page_size = Some(page_size);
     }
 
     /// Disables paging for this CQL query.
     pub fn disable_paging(&mut self) {
-        self.page_size = None;
+        self.params.page_size = None;
     }
 
     /// Returns the page size for this CQL query.
     pub fn get_page_size(&self) -> Option<i32> {
-        self.page_size
+        self.params.page_size
     }
 
     /// Computes the partition key of the target table from given values
@@ -67,5 +69,9 @@ impl PreparedStatement {
             }
         }
         buf.into()
+    }
+
+    pub(crate) fn get_params(&self) -> &QueryParameters {
+        &self.params
     }
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -14,12 +14,17 @@ pub struct PreparedStatement {
 }
 
 impl PreparedStatement {
-    pub fn new(id: Bytes, metadata: PreparedMetadata, statement: String) -> Self {
+    pub(crate) fn new(
+        id: Bytes,
+        metadata: PreparedMetadata,
+        statement: String,
+        params: QueryParameters,
+    ) -> Self {
         Self {
             id,
             metadata,
             statement,
-            params: Default::default(),
+            params,
         }
     }
 

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -11,11 +11,8 @@ pub struct Query {
 
 impl Query {
     /// Creates a new `Query` from a CQL query string.
-    pub fn new(contents: String) -> Self {
-        Self {
-            contents,
-            params: Default::default(),
-        }
+    pub(crate) fn new(contents: String, params: QueryParameters) -> Self {
+        Self { contents, params }
     }
 
     /// Returns the string representation of the CQL query.
@@ -46,12 +43,12 @@ impl Query {
 
 impl From<String> for Query {
     fn from(s: String) -> Query {
-        Query::new(s)
+        Query::new(s, Default::default())
     }
 }
 
 impl<'a> From<&'a str> for Query {
     fn from(s: &'a str) -> Query {
-        Query::new(s.to_owned())
+        Query::new(s.to_owned(), Default::default())
     }
 }

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -1,10 +1,12 @@
+use super::QueryParameters;
+
 /// CQL query statement.
 ///
 /// This represents a CQL query that can be executed on a server.
 #[derive(Clone)]
 pub struct Query {
     contents: String,
-    page_size: Option<i32>,
+    params: QueryParameters,
 }
 
 impl Query {
@@ -12,7 +14,7 @@ impl Query {
     pub fn new(contents: String) -> Self {
         Self {
             contents,
-            page_size: None,
+            params: Default::default(),
         }
     }
 
@@ -24,17 +26,21 @@ impl Query {
     /// Sets the page size for this CQL query.
     pub fn set_page_size(&mut self, page_size: i32) {
         assert!(page_size > 0, "page size must be larger than 0");
-        self.page_size = Some(page_size);
+        self.params.page_size = Some(page_size);
     }
 
     /// Disables paging for this CQL query.
     pub fn disable_paging(&mut self) {
-        self.page_size = None;
+        self.params.page_size = None;
     }
 
     /// Returns the page size for this CQL query.
     pub fn get_page_size(&self) -> Option<i32> {
-        self.page_size
+        self.params.page_size
+    }
+
+    pub(crate) fn get_params(&self) -> &QueryParameters {
+        &self.params
     }
 }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -92,14 +92,11 @@ impl Connection {
         values: &'a [Value],
         paging_state: Option<Bytes>,
     ) -> Result<Response> {
+        let params = query.get_params();
+
         let query_frame = query::Query {
             contents: query.get_contents().to_owned(),
-            parameters: query::QueryParameters {
-                values,
-                page_size: query.get_page_size(),
-                paging_state,
-                ..Default::default()
-            },
+            parameters: query::QueryParameters::new(&params, paging_state, values),
         };
 
         self.send_request(&query_frame, true).await
@@ -111,14 +108,11 @@ impl Connection {
         values: &'a [Value],
         paging_state: Option<Bytes>,
     ) -> Result<Response> {
+        let params = prepared_statement.get_params();
+
         let execute_frame = execute::Execute {
             id: prepared_statement.get_id().to_owned(),
-            parameters: query::QueryParameters {
-                values,
-                page_size: prepared_statement.get_page_size(),
-                paging_state,
-                ..Default::default()
-            },
+            parameters: query::QueryParameters::new(&params, paging_state, values),
         };
 
         self.send_request(&execute_frame, true).await


### PR DESCRIPTION
This is an implementation of query builders.
- There is a main `Builder` object which can be configured with default parameters:
  ```rust
  let mut builder = Builder::new();
  builder.set_no_paging_by_default();
  builder.set_default_consistency(Consistency::All);
  ```
- You can use it to create a new statement and adjust query parameters:
  ```rust
  builder
      .build()
      .with_page_size(1024)
      .query("SELECT (a, b, c) FROM ks.t");
  ```
- Prepared statements are supported as well:
  ```rust
  builder
      .build()
      .with_consistency(Consistency::One)
      .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)");
  ```

I'm not sure this is the right direction, so I'd really like to hear your opinion on how to improve this API.