### PR TITLE
frame: correctly handle extensions to the frame body

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -18,6 +18,7 @@ compress = "0.2.1"
 tokio = { version = "0.3.0", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 fasthash = "0.4.0"
 snappy = "0.4.0"
+uuid = "0.8.1"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Up to this point, our code was not prepared to handle frames which
contained additional data in its body, such as warnings, custom payloads
and trace IDs. This commit makes the frame parsing code handle such
extensions properly.