### PR TITLE
example/parallel.rs: wait for in-flight requests to finish

### DIFF
--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -22,7 +22,8 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    let sem = Arc::new(Semaphore::new(256));
+    let parallelism = 256;
+    let sem = Arc::new(Semaphore::new(parallelism));
 
     for i in 0..100_000usize {
         if i % 1000 == 0 {
@@ -46,6 +47,11 @@ async fn main() -> Result<()> {
 
             let _permit = permit;
         });
+    }
+
+    // Wait for all in-flight requests to finish
+    for _ in 0..parallelism {
+        sem.acquire().await.forget();
     }
 
     println!("Ok.");


### PR DESCRIPTION
The `parallel` example did not wait for all write requests to finish.
This would result in the following message being printed in logs by
Scylla:

  INFO  2020-10-25 23:43:16,926 [shard 0] cql_server - exception while processing connection: seastar::nested_exception: std::system_error (error system:32, sendmsg: Broken pipe) (while cleaning up after std::system_error (error system:104, sendmsg: Connection reset by peer))

This patch fixes the example so that it properly waits for all writes to
finish before exiting.