### PR TITLE
get rid of close()

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -87,29 +87,6 @@ impl Session {
         Ok(Session { pool })
     }
 
-    /// Closes a CQL session
-    pub async fn close(self) -> Result<()> {
-        let mut result = Ok(());
-        for (_, conn) in self.pool.into_iter() {
-            let close_result = conn.close().await;
-
-            // Attempt to close all connections, but report the error
-            // from the first one only
-            if let Err(err) = close_result {
-                // TODO: Proper logging
-                eprintln!(
-                    "session: error occured while closing a connection: {:?}",
-                    result
-                );
-                if result.is_ok() {
-                    result = Err(err);
-                }
-            }
-        }
-
-        result
-    }
-
     // TODO: Should return an iterator over results
     // actually, if we consider "INSERT" a query, then no.
     // But maybe "INSERT" and "SELECT" should go through different methods,

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -56,8 +56,6 @@ async fn test_unprepared_statement() {
             (7, 11, &String::from(""))
         ]
     );
-
-    session.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -162,5 +160,4 @@ async fn test_prepared_statement() {
         assert!(e.is_none());
         assert_eq!((a, b, c, d), (17, 16, &String::from("I'm prepared!!!"), 7))
     }
-    session.close().await.unwrap();
 }


### PR DESCRIPTION
futures_util::future::RemoteHandle is now used to schedule Connection's
workers for destruction by tokio's executor when Connection is dropped.
Yay for RAII.

There is no need for an explicit "wait for stuff to finish" method,
really. If the user wants there to be no in-flight requests when
they drop the Connection or Session, just wait for the requests to
finish before dropping.