### PR TITLE
Strongly typed query rows (Fixes #99)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "examples",
     "scylla",
+    "scylla-macros",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,3 +29,7 @@ path = "parallel-prepared.rs"
 [[example]]
 name = "compare-tokens"
 path = "compare-tokens.rs"
+
+[[example]]
+name = "select-paging"
+path = "select-paging.rs"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use scylla::cql_to_rust::FromRow;
 use scylla::macros::FromRow;
-use scylla::transport::session::{IntoTypedRows, Session};
+use scylla::transport::session::Session;
 use std::env;
 
 #[tokio::main]
@@ -48,7 +48,8 @@ async fn main() -> Result<()> {
 
     // Rows can be parsed as tuples
     if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
-        for (a, b, c) in rows.into_typed::<(i32, i32, String)>().map(|r| r.unwrap()) {
+        for row in rows {
+            let (a, b, c) = row.into_typed::<(i32, i32, String)>()?;
             println!("a, b, c: {}, {}, {}", a, b, c);
         }
     }
@@ -62,8 +63,8 @@ async fn main() -> Result<()> {
     }
 
     if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
-        for row_data in rows.into_typed::<RowData>() {
-            let row_data = row_data.expect("Parsing typed row failed!");
+        for row_data in rows {
+            let row_data = row_data.into_typed::<RowData>()?;
             println!("row_data: {:?}", row_data);
         }
     }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use scylla::macros::FromRow;
 use scylla::transport::session::{IntoTypedRows, Session};
 use std::env;
 
@@ -48,6 +49,20 @@ async fn main() -> Result<()> {
     if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
         for (a, b, c) in rows.into_typed::<(i32, i32, String)>() {
             println!("a, b, c: {}, {}, {}", a, b, c);
+        }
+    }
+
+    // Or as custom structs that derive FromRow
+    #[derive(Debug, FromRow)]
+    struct RowData {
+        a: i32,
+        b: Option<i32>,
+        c: String,
+    }
+
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
+        for row_data in rows.into_typed::<RowData>() {
+            println!("row_data: {:?}", row_data);
         }
     }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use scylla::cql_to_rust::FromRow;
 use scylla::macros::FromRow;
 use scylla::transport::session::{IntoTypedRows, Session};
 use std::env;
@@ -47,7 +48,7 @@ async fn main() -> Result<()> {
 
     // Rows can be parsed as tuples
     if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
-        for (a, b, c) in rows.into_typed::<(i32, i32, String)>() {
+        for (a, b, c) in rows.into_typed::<(i32, i32, String)>().map(|r| r.unwrap()) {
             println!("a, b, c: {}, {}, {}", a, b, c);
         }
     }
@@ -62,6 +63,7 @@ async fn main() -> Result<()> {
 
     if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
         for row_data in rows.into_typed::<RowData>() {
+            let row_data = row_data.expect("Parsing typed row failed!");
             println!("row_data: {:?}", row_data);
         }
     }

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -31,12 +31,10 @@ async fn main() -> Result<()> {
     }
 
     // Iterate through select result with paging
-    let mut rows_stream = session
-        .query_iter("SELECT a, b, c FROM ks.t", &[])?
-        .into_typed::<(i32, i32, String)>();
+    let mut rows_stream = session.query_iter("SELECT a, b, c FROM ks.t", &[])?;
 
     while let Some(next_row_res) = rows_stream.next().await {
-        let (a, b, c) = next_row_res?;
+        let (a, b, c) = next_row_res?.into_typed::<(i32, i32, String)>()?;
         println!("a, b, c: {}, {}, {}", a, b, c);
     }
 

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use scylla::transport::session::Session;
+use std::env;
+use tokio::stream::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session = Session::connect(uri, None).await?;
+    session.refresh_topology().await?;
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    for i in 0..16_i32 {
+        session
+            .query(
+                "INSERT INTO ks.t (a, b, c) VALUES (?, ?, 'abc')",
+                &scylla::values!(i, 2 * i),
+            )
+            .await?;
+    }
+
+    // Iterate through select result with paging
+    let mut rows_stream = session
+        .query_iter("SELECT a, b, c FROM ks.t", &[])?
+        .into_typed::<(i32, i32, String)>();
+
+    while let Some(next_row_res) = rows_stream.next().await {
+        let (a, b, c) = next_row_res?;
+        println!("a, b, c: {}, {}, {}", a, b, c);
+    }
+
+    println!("Ok.");
+
+    Ok(())
+}

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -31,10 +31,12 @@ async fn main() -> Result<()> {
     }
 
     // Iterate through select result with paging
-    let mut rows_stream = session.query_iter("SELECT a, b, c FROM ks.t", &[])?;
+    let mut rows_stream = session
+        .query_iter("SELECT a, b, c FROM ks.t", &[])?
+        .into_typed::<(i32, i32, String)>();
 
     while let Some(next_row_res) = rows_stream.next().await {
-        let (a, b, c) = next_row_res?.into_typed::<(i32, i32, String)>()?;
+        let (a, b, c) = next_row_res?;
         println!("a, b, c: {}, {}, {}", a, b, c);
     }
 

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "scylla-macros"
+version = "0.1.0"
+edition = "2018"
+description = "proc macros for scylla async CQL driver"
+repository = "https://github.com/scylladb/scylla-rust-driver"
+readme = "../README.md"
+categories = ["database"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0" 

--- a/scylla-macros/src/lib.rs
+++ b/scylla-macros/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
 
-/// #[derive(FromRow)] derives From<Row> for struct
+/// #[derive(FromRow)] derives FromRow for struct
 /// Works only on simple structs without generics etc
 #[proc_macro_derive(FromRow)]
 pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
@@ -20,7 +20,7 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
         _ => panic!("derive(FromRow) works only on structs!")
     };
 
-    // Generates tokens for field_name: field_type::from(vals_iter.next().unwrap_or(...)), ...
+    // Generates tokens for field_name: field_type::from_cql(vals_iter.next().ok_or(...)?), ...
     let set_fields_code = struct_fields.named.iter().map(|field| {
         let field_name = &field.ident;
         let field_type = &field.ty;

--- a/scylla-macros/src/lib.rs
+++ b/scylla-macros/src/lib.rs
@@ -1,0 +1,53 @@
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
+
+/// #[derive(FromRow)] derives From<Row> for struct
+/// Works only on simple structs without generics etc
+#[proc_macro_derive(FromRow)]
+pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(tokens_input as DeriveInput);
+
+    let struct_name = &input.ident;
+
+    // Generates tokens for field_name: field_type::from(vals_iter.next().unwrap_or(...)), ...
+    let set_fields = match &input.data {
+        Data::Struct(ref data) => {
+            match &data.fields {
+                Fields::Named(fields) => {
+                    fields.named.iter().map(|field| {
+                        let field_name = &field.ident;
+                        let field_type = &field.ty;
+
+                        quote_spanned! {field.span() =>
+                            #field_name: <#field_type as FromCQLVal<Option<CQLValue>>>::from_cql(
+                                vals_iter
+                                .next().unwrap_or_else(
+                                || panic!("Row too short to convert to {}!", stringify!(#struct_name)))
+                            ),
+                        }
+                    })
+                },
+                _ => panic!("derive(FromRow) works only for structs with named fields. Tuples don't need derive.")
+            }
+        },
+        _ => panic!("derive(FromRow) works only on structs!")
+    };
+
+    let generated = quote! {
+        impl From<scylla::frame::response::result::Row> for #struct_name {
+            fn from(row: scylla::frame::response::result::Row) -> Self {
+                let mut vals_iter = row.columns.into_iter();
+
+                use scylla::frame::response::result::CQLValue;
+                use scylla::frame::response::cql_to_rust::FromCQLVal;
+
+                #struct_name {
+                    #(#set_fields)*
+                }
+            }
+        }
+    };
+
+    TokenStream::from(generated)
+}

--- a/scylla-macros/src/lib.rs
+++ b/scylla-macros/src/lib.rs
@@ -22,9 +22,9 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
                         quote_spanned! {field.span() =>
                             #field_name: <#field_type as FromCQLVal<Option<CQLValue>>>::from_cql(
                                 vals_iter
-                                .next().unwrap_or_else(
-                                || panic!("Row too short to convert to {}!", stringify!(#struct_name)))
-                            ),
+                                .next()
+                                .ok_or(FromRowError::RowTooShort) ?
+                            ) ?,
                         }
                     })
                 },
@@ -35,16 +35,17 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
     };
 
     let generated = quote! {
-        impl From<scylla::frame::response::result::Row> for #struct_name {
-            fn from(row: scylla::frame::response::result::Row) -> Self {
+        impl FromRow for #struct_name {
+            fn from_row(row: scylla::frame::response::result::Row)
+            -> Result<Self, scylla::cql_to_rust::FromRowError> {
+                use scylla::frame::response::result::CQLValue;
+                use scylla::cql_to_rust::{FromCQLVal, FromRow, FromRowError};
+
                 let mut vals_iter = row.columns.into_iter();
 
-                use scylla::frame::response::result::CQLValue;
-                use scylla::frame::response::cql_to_rust::FromCQLVal;
-
-                #struct_name {
+                Ok(#struct_name {
                     #(#set_fields)*
-                }
+                })
             }
         }
     };

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["database", "scylla", "cql"]
 categories = ["database"]
 
 [dependencies]
+scylla-macros = { version = "0.1.0", path = "../scylla-macros"}
 anyhow = "1.0.33"
 byteorder = "1.3.4"
 bytes = "0.6.0"

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -99,6 +99,8 @@ impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 #[cfg(test)]
 mod tests {
     use super::{CQLValue, FromCQLVal, Row};
+    use crate as scylla;
+    use crate::macros::FromRow;
     use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
@@ -168,5 +170,29 @@ mod tests {
     #[should_panic]
     fn from_cql_wrong_type_panic() {
         let _ = i32::from_cql(CQLValue::BigInt(1234));
+    }
+
+    #[test]
+    fn struct_from_row() {
+        #[derive(FromRow)]
+        struct MyRow {
+            a: i32,
+            b: Option<String>,
+            c: Option<Vec<i32>>,
+        }
+
+        let row = Row {
+            columns: vec![
+                Some(CQLValue::Int(16)),
+                None,
+                Some(CQLValue::Set(vec![CQLValue::Int(1), CQLValue::Int(2)])),
+            ],
+        };
+
+        let my_row: MyRow = MyRow::from(row);
+
+        assert_eq!(my_row.a, 16);
+        assert_eq!(my_row.b, None);
+        assert_eq!(my_row.c, Some(vec![1, 2]));
     }
 }

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -93,7 +93,7 @@ impl<T: FromCQLVal<CQLValue>> FromCQLVal<CQLValue> for Vec<T> {
     }
 }
 
-// This macro implements TreFrom<Row> for tuple of types that have FromCQLVal
+// This macro implements FromRow for tuple of types that have FromCQLVal
 macro_rules! impl_tuple_from_row {
     ( $($Ti:tt),+ ) => {
         impl<$($Ti),+> FromRow for ($($Ti,)+)
@@ -116,7 +116,7 @@ macro_rules! impl_tuple_from_row {
     }
 }
 
-// Implement From<Row> for tuples of size up to 16
+// Implement FromRow for tuples of size up to 16
 impl_tuple_from_row!(T1);
 impl_tuple_from_row!(T1, T2);
 impl_tuple_from_row!(T1, T2, T3);

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -1,0 +1,172 @@
+use super::result::{CQLValue, Row};
+use std::net::IpAddr;
+
+/// This trait defines a way to convert CQLValue or Option<CQLValue> into some rust type  
+// We can't use From trait because impl From<Option<CQLValue>> for String {...}
+// is forbidden since neither From nor String are defined in this crate
+pub trait FromCQLVal<T> {
+    fn from_cql(cql_val: T) -> Self;
+}
+
+// Implement from_cql<Option<CQLValue>> for every type that has from_cql<CQLValue>
+// Option gets unwrapped to convert the value inside
+impl<T: FromCQLVal<CQLValue>> FromCQLVal<Option<CQLValue>> for T {
+    fn from_cql(cql_val_opt: Option<CQLValue>) -> Self {
+        T::from_cql(cql_val_opt.expect("Tried to convert from CQLValue that is NULL!"))
+    }
+}
+
+// Implement from_cql<Option<CQLValue>> for Option<T> for every type that has from_cql<CQLValue>
+// Value inside Option gets mapped from CQLValue to T
+impl<T: FromCQLVal<CQLValue>> FromCQLVal<Option<CQLValue>> for Option<T> {
+    fn from_cql(cql_val_opt: Option<CQLValue>) -> Self {
+        cql_val_opt.map(T::from_cql)
+    }
+}
+
+// This macro implements FromCQLVal given a type and method of CQLValue that returns this type
+macro_rules! impl_from_cql_val {
+    ($T:ty, $convert_func:ident) => {
+        impl FromCQLVal<CQLValue> for $T {
+            fn from_cql(cql_val: CQLValue) -> $T {
+                return cql_val.$convert_func().unwrap_or_else(|| {
+                    panic!("Converting from CQLValue to {} failed!", stringify!($T))
+                });
+            }
+        }
+    };
+}
+
+impl_from_cql_val!(i32, as_int); // i32::from_cql<CQLValue>
+impl_from_cql_val!(i64, as_bigint); // i64::from_cql<CQLValue>
+impl_from_cql_val!(String, into_string); // String::from_cql<CQLValue>
+impl_from_cql_val!(IpAddr, as_inet); // IpAddr::from_cql<CQLValue>
+
+// Vec<T>::from_cql<CQLValue>
+impl<T: FromCQLVal<CQLValue>> FromCQLVal<CQLValue> for Vec<T> {
+    fn from_cql(cql_val: CQLValue) -> Self {
+        cql_val
+            .into_vec()
+            .expect("Converting from CQLValue to Vec<T> failed!")
+            .into_iter()
+            .map(|cql_val| T::from_cql(cql_val))
+            .collect()
+    }
+}
+
+// This macro implements From<Row> for tuple of types that have FromCQLVal
+macro_rules! impl_tuple_from_row {
+    ( $($Ti:tt),+ ) => {
+        impl<$($Ti),+> From<Row> for ($($Ti,)+)
+        where
+            $($Ti: FromCQLVal<Option<CQLValue>>),+
+        {
+            fn from(row: Row) -> Self {
+                let mut vals_iter = row.columns.into_iter();
+                const TUPLE_AS_STR: &'static str = stringify!(($($Ti,)+));
+
+                (
+                    $(
+                        $Ti::from_cql(vals_iter
+                                      .next()
+                                      .unwrap_or_else(
+                                       || panic!("Row is too short to convert to {}!", TUPLE_AS_STR)))
+                    ,)+
+                )
+            }
+        }
+    }
+}
+
+// Implement From<Row> for tuples of size up to 16
+impl_tuple_from_row!(T1);
+impl_tuple_from_row!(T1, T2);
+impl_tuple_from_row!(T1, T2, T3);
+impl_tuple_from_row!(T1, T2, T3, T4);
+impl_tuple_from_row!(T1, T2, T3, T4, T5);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+
+#[cfg(test)]
+mod tests {
+    use super::{CQLValue, FromCQLVal, Row};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[test]
+    fn i32_from_cql() {
+        assert_eq!(1234, i32::from_cql(CQLValue::Int(1234)));
+    }
+
+    #[test]
+    fn i64_from_cql() {
+        assert_eq!(1234, i64::from_cql(CQLValue::BigInt(1234)));
+    }
+
+    #[test]
+    fn string_from_cql() {
+        assert_eq!(
+            "ascii_test".to_string(),
+            String::from_cql(CQLValue::Ascii("ascii_test".to_string()))
+        );
+        assert_eq!(
+            "text_test".to_string(),
+            String::from_cql(CQLValue::Text("text_test".to_string()))
+        );
+    }
+
+    #[test]
+    fn ip_addr_from_cql() {
+        let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        assert_eq!(ip_addr, IpAddr::from_cql(CQLValue::Inet(ip_addr)));
+    }
+
+    #[test]
+    fn vec_from_cql() {
+        let cql_val = CQLValue::Set(vec![CQLValue::Int(1), CQLValue::Int(2), CQLValue::Int(3)]);
+        assert_eq!(vec![1, 2, 3], Vec::<i32>::from_cql(cql_val));
+    }
+
+    #[test]
+    fn tuple_from_row() {
+        let row = Row {
+            columns: vec![
+                Some(CQLValue::Int(1)),
+                Some(CQLValue::Text("some_text".to_string())),
+                None,
+            ],
+        };
+
+        let (a, b, c) = <(i32, Option<String>, Option<i64>)>::from(row);
+        assert_eq!(a, 1);
+        assert_eq!(b, Some("some_text".to_string()));
+        assert_eq!(c, None);
+
+        let row2 = Row {
+            columns: vec![Some(CQLValue::Int(1)), Some(CQLValue::Int(2))],
+        };
+
+        let (d,) = <(i32,)>::from(row2);
+        assert_eq!(d, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_cql_null_panic() {
+        let _ = i32::from_cql(None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_cql_wrong_type_panic() {
+        let _ = i32::from_cql(CQLValue::BigInt(1234));
+    }
+}

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -4,34 +4,73 @@ use std::net::IpAddr;
 /// This trait defines a way to convert CQLValue or Option<CQLValue> into some rust type  
 // We can't use From trait because impl From<Option<CQLValue>> for String {...}
 // is forbidden since neither From nor String are defined in this crate
-pub trait FromCQLVal<T> {
-    fn from_cql(cql_val: T) -> Self;
+pub trait FromCQLVal<T>: Sized {
+    fn from_cql(cql_val: T) -> Result<Self, FromCQLValError>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum FromCQLValError {
+    BadCQLType,
+    ValIsNull,
+}
+
+/// This trait defines a way to convert CQL Row into some rust type
+pub trait FromRow: Sized {
+    fn from_row(row: Row) -> Result<Self, FromRowError>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum FromRowError {
+    BadCQLVal(FromCQLValError),
+    RowTooShort,
+}
+
+// TODO - replace with some error crate
+impl std::fmt::Display for FromCQLValError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::fmt::Display for FromRowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for FromCQLValError {}
+impl std::error::Error for FromRowError {}
+
+impl From<FromCQLValError> for FromRowError {
+    fn from(from_cql_err: FromCQLValError) -> FromRowError {
+        FromRowError::BadCQLVal(from_cql_err)
+    }
 }
 
 // Implement from_cql<Option<CQLValue>> for every type that has from_cql<CQLValue>
-// Option gets unwrapped to convert the value inside
+// This tries to unwrap the option or fails with an error
 impl<T: FromCQLVal<CQLValue>> FromCQLVal<Option<CQLValue>> for T {
-    fn from_cql(cql_val_opt: Option<CQLValue>) -> Self {
-        T::from_cql(cql_val_opt.expect("Tried to convert from CQLValue that is NULL!"))
+    fn from_cql(cql_val_opt: Option<CQLValue>) -> Result<Self, FromCQLValError> {
+        T::from_cql(cql_val_opt.ok_or(FromCQLValError::ValIsNull)?)
     }
 }
 
 // Implement from_cql<Option<CQLValue>> for Option<T> for every type that has from_cql<CQLValue>
 // Value inside Option gets mapped from CQLValue to T
 impl<T: FromCQLVal<CQLValue>> FromCQLVal<Option<CQLValue>> for Option<T> {
-    fn from_cql(cql_val_opt: Option<CQLValue>) -> Self {
-        cql_val_opt.map(T::from_cql)
+    fn from_cql(cql_val_opt: Option<CQLValue>) -> Result<Self, FromCQLValError> {
+        match cql_val_opt {
+            Some(cql_val) => Ok(Some(T::from_cql(cql_val)?)),
+            None => Ok(None),
+        }
     }
 }
-
 // This macro implements FromCQLVal given a type and method of CQLValue that returns this type
 macro_rules! impl_from_cql_val {
     ($T:ty, $convert_func:ident) => {
         impl FromCQLVal<CQLValue> for $T {
-            fn from_cql(cql_val: CQLValue) -> $T {
-                return cql_val.$convert_func().unwrap_or_else(|| {
-                    panic!("Converting from CQLValue to {} failed!", stringify!($T))
-                });
+            fn from_cql(cql_val: CQLValue) -> Result<$T, FromCQLValError> {
+                cql_val.$convert_func().ok_or(FromCQLValError::BadCQLType)
             }
         }
     };
@@ -44,35 +83,34 @@ impl_from_cql_val!(IpAddr, as_inet); // IpAddr::from_cql<CQLValue>
 
 // Vec<T>::from_cql<CQLValue>
 impl<T: FromCQLVal<CQLValue>> FromCQLVal<CQLValue> for Vec<T> {
-    fn from_cql(cql_val: CQLValue) -> Self {
+    fn from_cql(cql_val: CQLValue) -> Result<Self, FromCQLValError> {
         cql_val
             .into_vec()
-            .expect("Converting from CQLValue to Vec<T> failed!")
+            .ok_or(FromCQLValError::BadCQLType)?
             .into_iter()
-            .map(|cql_val| T::from_cql(cql_val))
-            .collect()
+            .map(T::from_cql)
+            .collect::<Result<Vec<T>, FromCQLValError>>()
     }
 }
 
-// This macro implements From<Row> for tuple of types that have FromCQLVal
+// This macro implements TreFrom<Row> for tuple of types that have FromCQLVal
 macro_rules! impl_tuple_from_row {
     ( $($Ti:tt),+ ) => {
-        impl<$($Ti),+> From<Row> for ($($Ti,)+)
+        impl<$($Ti),+> FromRow for ($($Ti,)+)
         where
             $($Ti: FromCQLVal<Option<CQLValue>>),+
         {
-            fn from(row: Row) -> Self {
+            fn from_row(row: Row) -> Result<Self, FromRowError> {
                 let mut vals_iter = row.columns.into_iter();
-                const TUPLE_AS_STR: &'static str = stringify!(($($Ti,)+));
 
-                (
+                Ok((
                     $(
                         $Ti::from_cql(vals_iter
                                       .next()
-                                      .unwrap_or_else(
-                                       || panic!("Row is too short to convert to {}!", TUPLE_AS_STR)))
+                                      .ok_or(FromRowError::RowTooShort) ?
+                                     ) ?
                     ,)+
-                )
+                ))
             }
         }
     }
@@ -98,29 +136,29 @@ impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 #[cfg(test)]
 mod tests {
-    use super::{CQLValue, FromCQLVal, Row};
+    use super::{CQLValue, FromCQLVal, FromCQLValError, FromRow, FromRowError, Row};
     use crate as scylla;
     use crate::macros::FromRow;
     use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
     fn i32_from_cql() {
-        assert_eq!(1234, i32::from_cql(CQLValue::Int(1234)));
+        assert_eq!(Ok(1234), i32::from_cql(CQLValue::Int(1234)));
     }
 
     #[test]
     fn i64_from_cql() {
-        assert_eq!(1234, i64::from_cql(CQLValue::BigInt(1234)));
+        assert_eq!(Ok(1234), i64::from_cql(CQLValue::BigInt(1234)));
     }
 
     #[test]
     fn string_from_cql() {
         assert_eq!(
-            "ascii_test".to_string(),
+            Ok("ascii_test".to_string()),
             String::from_cql(CQLValue::Ascii("ascii_test".to_string()))
         );
         assert_eq!(
-            "text_test".to_string(),
+            Ok("text_test".to_string()),
             String::from_cql(CQLValue::Text("text_test".to_string()))
         );
     }
@@ -128,13 +166,13 @@ mod tests {
     #[test]
     fn ip_addr_from_cql() {
         let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        assert_eq!(ip_addr, IpAddr::from_cql(CQLValue::Inet(ip_addr)));
+        assert_eq!(Ok(ip_addr), IpAddr::from_cql(CQLValue::Inet(ip_addr)));
     }
 
     #[test]
     fn vec_from_cql() {
         let cql_val = CQLValue::Set(vec![CQLValue::Int(1), CQLValue::Int(2), CQLValue::Int(3)]);
-        assert_eq!(vec![1, 2, 3], Vec::<i32>::from_cql(cql_val));
+        assert_eq!(Ok(vec![1, 2, 3]), Vec::<i32>::from_cql(cql_val));
     }
 
     #[test]
@@ -147,7 +185,7 @@ mod tests {
             ],
         };
 
-        let (a, b, c) = <(i32, Option<String>, Option<i64>)>::from(row);
+        let (a, b, c) = <(i32, Option<String>, Option<i64>)>::from_row(row).unwrap();
         assert_eq!(a, 1);
         assert_eq!(b, Some("some_text".to_string()));
         assert_eq!(c, None);
@@ -156,20 +194,54 @@ mod tests {
             columns: vec![Some(CQLValue::Int(1)), Some(CQLValue::Int(2))],
         };
 
-        let (d,) = <(i32,)>::from(row2);
+        let (d,) = <(i32,)>::from_row(row2).unwrap();
         assert_eq!(d, 1);
     }
 
     #[test]
-    #[should_panic]
-    fn from_cql_null_panic() {
-        let _ = i32::from_cql(None);
+    fn from_cql_null() {
+        assert_eq!(i32::from_cql(None), Err(FromCQLValError::ValIsNull));
     }
 
     #[test]
-    #[should_panic]
-    fn from_cql_wrong_type_panic() {
-        let _ = i32::from_cql(CQLValue::BigInt(1234));
+    fn from_cql_wrong_type() {
+        assert_eq!(
+            i32::from_cql(CQLValue::BigInt(1234)),
+            Err(FromCQLValError::BadCQLType)
+        );
+    }
+
+    #[test]
+    fn from_row_null() {
+        let row = Row {
+            columns: vec![None],
+        };
+
+        assert_eq!(
+            <(i32,)>::from_row(row),
+            Err(FromRowError::BadCQLVal(FromCQLValError::ValIsNull))
+        );
+    }
+
+    #[test]
+    fn from_row_wrong_type() {
+        let row = Row {
+            columns: vec![Some(CQLValue::Int(1234))],
+        };
+
+        assert_eq!(
+            <(String,)>::from_row(row),
+            Err(FromRowError::BadCQLVal(FromCQLValError::BadCQLType))
+        );
+    }
+
+    #[test]
+    fn from_row_too_short() {
+        let row = Row {
+            columns: vec![Some(CQLValue::Int(1234))],
+        };
+
+        assert_eq!(<(i32, i32)>::from_row(row), Err(FromRowError::RowTooShort));
     }
 
     #[test]
@@ -189,7 +261,7 @@ mod tests {
             ],
         };
 
-        let my_row: MyRow = MyRow::from(row);
+        let my_row: MyRow = MyRow::from_row(row).unwrap();
 
         assert_eq!(my_row.a, 16);
         assert_eq!(my_row.b, None);

--- a/scylla/src/frame/response/mod.rs
+++ b/scylla/src/frame/response/mod.rs
@@ -1,3 +1,4 @@
+pub mod cql_to_rust;
 pub mod error;
 pub mod result;
 pub mod supported;

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -81,6 +81,14 @@ impl CQLValue {
         }
     }
 
+    pub fn into_string(self) -> Option<String> {
+        match self {
+            Self::Ascii(s) => Some(s),
+            Self::Text(s) => Some(s),
+            _ => None,
+        }
+    }
+
     pub fn as_inet(&self) -> Option<IpAddr> {
         match self {
             Self::Inet(a) => Some(*a),
@@ -91,6 +99,13 @@ impl CQLValue {
     pub fn as_set(&self) -> Option<&Vec<CQLValue>> {
         match self {
             Self::Set(s) => Some(&s),
+            _ => None,
+        }
+    }
+
+    pub fn into_vec(self) -> Option<Vec<CQLValue>> {
+        match self {
+            Self::Set(s) => Some(s),
             _ => None,
         }
     }

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -1,8 +1,10 @@
+use crate::cql_to_rust::{FromRow, FromRowError};
 use anyhow::Result as AResult;
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{Buf, Bytes};
 use std::convert::TryFrom;
 use std::net::IpAddr;
+use std::result::Result as StdResult;
 use std::str;
 
 use crate::frame::types;
@@ -137,6 +139,13 @@ pub struct PreparedMetadata {
 #[derive(Debug, Default)]
 pub struct Row {
     pub columns: Vec<Option<CQLValue>>,
+}
+
+impl Row {
+    /// Allows converting Row into tuple of rust types or custom struct deriving FromRow
+    pub fn into_typed<RowT: FromRow>(self) -> StdResult<RowT, FromRowError> {
+        RowT::from_row(self)
+    }
 }
 
 #[derive(Debug, Default)]

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -14,3 +14,5 @@ pub mod transport;
 pub use macros::*;
 pub use statement::prepared_statement;
 pub use statement::query;
+
+pub use frame::response::cql_to_rust;

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -13,3 +13,7 @@ macro_rules! values {
         }
     };
 }
+
+/// #[derive(FromRow)] derives From<Row> for struct
+/// Works only on simple structs without generics etc
+pub use scylla_macros::FromRow;

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -14,6 +14,6 @@ macro_rules! values {
     };
 }
 
-/// #[derive(FromRow)] derives From<Row> for struct
+/// #[derive(FromRow)] derives FromRow for struct
 /// Works only on simple structs without generics etc
 pub use scylla_macros::FromRow;

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 use futures::Stream;
 use tokio::sync::mpsc;
 
+use crate::cql_to_rust::FromRow;
 use crate::frame::{
     response::{
         result::{Result, Row, Rows},
@@ -58,6 +59,13 @@ impl Stream for RowIterator {
 }
 
 impl RowIterator {
+    pub fn into_typed<RowT: FromRow>(self) -> TypedRowIterator<RowT> {
+        TypedRowIterator {
+            row_iterator: self,
+            phantom_data: Default::default(),
+        }
+    }
+
     pub(crate) fn new_for_query(
         conn: Arc<Connection>,
         query: Query,
@@ -155,3 +163,32 @@ impl WorkerHelper {
         }
     }
 }
+
+pub struct TypedRowIterator<RowT> {
+    row_iterator: RowIterator,
+    phantom_data: std::marker::PhantomData<RowT>,
+}
+
+impl<RowT: FromRow> Stream for TypedRowIterator<RowT> {
+    type Item = AResult<RowT>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut s = self.as_mut();
+
+        let next_elem: Option<AResult<Row>> = match Pin::new(&mut s.row_iterator).poll_next(cx) {
+            Poll::Ready(next_elem) => next_elem,
+            Poll::Pending => return Poll::Pending,
+        };
+
+        let next_ready: Option<Self::Item> = match next_elem {
+            Some(Ok(next_row)) => Some(RowT::from_row(next_row).map_err(anyhow::Error::from)),
+            Some(Err(e)) => Some(Err(e)),
+            None => None,
+        };
+
+        Poll::Ready(next_ready)
+    }
+}
+
+// TypedRowIterator can be moved freely for any RowT so it's Unpin
+impl<RowT> Unpin for TypedRowIterator<RowT> {}

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 use tokio::net::{lookup_host, ToSocketAddrs};
 
+use crate::cql_to_rust::{FromRow, FromRowError};
 use crate::frame::response::result;
 use crate::frame::response::Response;
 use crate::frame::value::Value;
@@ -48,14 +49,14 @@ struct NodePool {
 // Trait used to implement Vec<result::Row>::into_typed<RowT>(self)
 // This is the only way to add custom method to Vec
 pub trait IntoTypedRows {
-    fn into_typed<RowT: From<result::Row>>(self) -> TypedRowIter<RowT>;
+    fn into_typed<RowT: FromRow>(self) -> TypedRowIter<Result<RowT, FromRowError>>;
 }
 
 // Adds method Vec<result::Row>::into_typed<RowT>(self)
 // It transforms the Vec into iterator mapping to custom row type
 impl IntoTypedRows for Vec<result::Row> {
-    fn into_typed<RowT: From<result::Row>>(self) -> TypedRowIter<RowT> {
-        self.into_iter().map(RowT::from)
+    fn into_typed<RowT: FromRow>(self) -> TypedRowIter<Result<RowT, FromRowError>> {
+        self.into_iter().map(RowT::from_row)
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 use tokio::net::{lookup_host, ToSocketAddrs};
 
+use crate::cql_to_rust::{FromRow, FromRowError};
 use crate::frame::response::result;
 use crate::frame::response::Response;
 use crate::frame::value::Value;
@@ -43,6 +44,38 @@ struct NodePool {
     // invariant: nonempty
     connections: HashMap<Shard, Arc<Connection>>,
     shard_info: Option<ShardInfo>,
+}
+
+// Trait used to implement Vec<result::Row>::into_typed<RowT>(self)
+// This is the only way to add custom method to Vec
+pub trait IntoTypedRows {
+    fn into_typed<RowT: FromRow>(self) -> TypedRowIter<RowT>;
+}
+
+// Adds method Vec<result::Row>::into_typed<RowT>(self)
+// It transforms the Vec into iterator mapping to custom row type
+impl IntoTypedRows for Vec<result::Row> {
+    fn into_typed<RowT: FromRow>(self) -> TypedRowIter<RowT> {
+        TypedRowIter {
+            row_iter: self.into_iter(),
+            phantom_data: Default::default(),
+        }
+    }
+}
+
+// Iterator that maps a Vec<result::Row> into custom RowType used by IntoTypedRows::into_typed
+// impl Trait doesn't compile so we have to be explicit
+pub struct TypedRowIter<RowT: FromRow> {
+    row_iter: std::vec::IntoIter<result::Row>,
+    phantom_data: std::marker::PhantomData<RowT>,
+}
+
+impl<RowT: FromRow> Iterator for TypedRowIter<RowT> {
+    type Item = Result<RowT, FromRowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.row_iter.next().map(RowT::from_row)
+    }
 }
 
 /// Represents a CQL session, which can be used to communicate

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -45,6 +45,25 @@ struct NodePool {
     shard_info: Option<ShardInfo>,
 }
 
+// Trait used to implement Vec<result::Row>::into_typed<RowT>(self)
+// This is the only way to add custom method to Vec
+pub trait IntoTypedRows {
+    fn into_typed<RowT: From<result::Row>>(self) -> TypedRowIter<RowT>;
+}
+
+// Adds method Vec<result::Row>::into_typed<RowT>(self)
+// It transforms the Vec into iterator mapping to custom row type
+impl IntoTypedRows for Vec<result::Row> {
+    fn into_typed<RowT: From<result::Row>>(self) -> TypedRowIter<RowT> {
+        self.into_iter().map(RowT::from)
+    }
+}
+
+// Iterator that maps a Vec<result::Row> into custom RowType used by IntoTypedRows::into_typed
+// impl Trait doesn't compile so we have to be explicit
+pub type TypedRowIter<RowT> =
+    std::iter::Map<std::vec::IntoIter<result::Row>, fn(result::Row) -> RowT>;
+
 /// Represents a CQL session, which can be used to communicate
 /// with the database
 impl Session {


### PR DESCRIPTION
This PR implements a way to parse rows returned by Session::query as strongly typed tuples or custom types.
For example:
```rust
    // Rows can be parsed as tuples
    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
        for (a, b, c) in rows.into_typed::<(i32, i32, String)>() {
            println!("a, b, c: {}, {}, {}", a, b, c);
        }
    }

    // Or as custom structs that derive FromRow
    #[derive(Debug, FromRow)]
    struct RowData {
        a: i32,
        b: Option<i32>,
        c: String,
    }

    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
        for row_data in rows.into_typed::<RowData>() {
            println!("row_data: {:?}", row_data);
        }
    }
```
API proposed in #99 turned out very verbose because each `SELECT` required specifying returned row type (Rust has no default generic arguments) and there were some additional issues with `impl Into<Query>`  when trying to explicitly define generic arguments.

This solution implements 
```rust
fn Vec::<Row>::into_typed::<RowT: From<Row>>(self) -> impl Iterator<Item = RowT> {
    self.into_iter().map(RowT::from)
}
```
to allow converting Vec<Row> into iterator of strongly typed rows