### PR TITLE
Remove cargo clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Format check
       run: cargo fmt --verbose --all -- --check
+    - name: Clippy check
+      run: cargo clippy --verbose -- -D warnings
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/scylla/src/frame/mod.rs
+++ b/scylla/src/frame/mod.rs
@@ -6,7 +6,6 @@ pub mod value;
 use crate::transport::Compression;
 use anyhow::Result;
 use bytes::{Buf, BufMut, Bytes};
-use snappy;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use uuid::Uuid;
 

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -354,7 +354,7 @@ fn deser_rows(buf: &mut &[u8]) -> AResult<Rows> {
             };
             columns.push(v);
         }
-        rows.push(Row { columns: columns });
+        rows.push(Row { columns });
     }
     Ok(Rows {
         metadata,

--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -1,4 +1,3 @@
-use anyhow;
 use anyhow::Result;
 use bytes::{Buf, Bytes};
 use rand::Rng;
@@ -36,8 +35,10 @@ pub struct ShardInfo {
     msb_ignore: u8,
 }
 
-impl Token {
-    pub fn from_str(s: &str) -> Result<Token> {
+impl std::str::FromStr for Token {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Token> {
         Ok(Token { value: s.parse()? })
     }
 }
@@ -70,7 +71,7 @@ impl ShardInfo {
     pub fn shard_of(&self, token: Token) -> Shard {
         let mut biased_token = (token.value as u64).wrapping_add(1u64 << 63);
         biased_token <<= self.msb_ignore;
-        return (((biased_token as u128) * (self.nr_shards as u128)) >> 64) as Shard;
+        (((biased_token as u128) * (self.nr_shards as u128)) >> 64) as Shard
     }
 
     /// If we connect to Scylla using Scylla's shard aware port, then Scylla assigns a shard to the
@@ -181,7 +182,7 @@ pub fn hash3_x64_128(mut data: &[u8]) -> i128 {
         h2 ^= k2;
     }
 
-    if data.len() > 0 {
+    if !data.is_empty() {
         for i in (0..std::cmp::min(8, data.len())).rev() {
             k1 ^= Wrapping(data[i] as i8 as i64) << (i * 8);
         }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -87,10 +87,10 @@ impl Connection {
         self.send_request(&request::Prepare { query }, true).await
     }
 
-    pub async fn query_single_page<'a>(
+    pub async fn query_single_page(
         &self,
         query: impl Into<Query>,
-        values: &'a [Value],
+        values: &[Value],
     ) -> Result<Option<Vec<result::Row>>> {
         let result = self.query(&query.into(), values, None).await?;
         match result {
@@ -101,10 +101,10 @@ impl Connection {
         }
     }
 
-    pub async fn query<'a>(
+    pub async fn query(
         &self,
         query: &Query,
-        values: &'a [Value],
+        values: &[Value],
         paging_state: Option<Bytes>,
     ) -> Result<Response> {
         let query_frame = query::Query {
@@ -120,10 +120,10 @@ impl Connection {
         self.send_request(&query_frame, true).await
     }
 
-    pub async fn execute<'a>(
+    pub async fn execute(
         &self,
         prepared_statement: &PreparedStatement,
-        values: &'a [Value],
+        values: &[Value],
         paging_state: Option<Bytes>,
     ) -> Result<Response> {
         let execute_frame = execute::Execute {

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -91,10 +91,10 @@ impl Session {
     ///
     /// * `query` - query to be performed
     /// * `values` - values bound to the query
-    pub async fn query<'a>(
+    pub async fn query(
         &self,
         query: impl Into<Query>,
-        values: &'a [Value],
+        values: &[Value],
     ) -> Result<Option<Vec<result::Row>>> {
         self.any_connection()?
             .query_single_page(query, values)
@@ -124,7 +124,7 @@ impl Session {
                 p.prepared_metadata,
                 query.to_owned(),
             )),
-            _ => return Err(anyhow!("Unexpected frame received")),
+            _ => Err(anyhow!("Unexpected frame received")),
         }
     }
 
@@ -133,10 +133,10 @@ impl Session {
     ///
     /// * `prepared` - a statement prepared with [prepare](crate::transport::session::prepare)
     /// * `values` - values bound to the query
-    pub async fn execute<'a>(
+    pub async fn execute(
         &self,
         prepared: &PreparedStatement,
-        values: &'a [Value],
+        values: &[Value],
     ) -> Result<Option<Vec<result::Row>>> {
         // FIXME: Prepared statement ids are local to a node, so we must make sure
         // that prepare() sends to all nodes and keeps all ids.

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 use tokio::sync::{mpsc, oneshot};


### PR DESCRIPTION
Currently running `cargo clippy` produces 12 warnings which makes it hard to notice tips for newly written code.
This PR applies clippy's suggestions to remove the warnings.

Clippy is buggy and might show no output when ran on already build project
Running `touch $(find ./scylla) && cargo clippy` allows to refresh the build and clippy works ok