### PR TITLE
Support batches (Fixes: #74)

### DIFF
--- a/scylla/src/frame/request/batch.rs
+++ b/scylla/src/frame/request/batch.rs
@@ -7,35 +7,83 @@ use crate::{
     frame::value::Value,
 };
 
-pub enum BatchedQuery {
+pub struct Batch<'a> {
+    pub statements: Vec<BatchStatementWithValues<'a>>,
+    pub batch_type: BatchType,
+    pub consistency: i16,
+}
+
+pub struct BatchStatementWithValues<'a> {
+    pub statement: BatchStatement,
+    pub values: &'a [Value],
+}
+
+pub enum BatchStatement {
     QueryContents(String),
     PreparedStatementID(Bytes),
 }
 
-impl BatchedQuery {
-    pub fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
-        match self {
-            BatchedQuery::QueryContents(s) => {
-                buf.put_u8(0);
-                types::write_long_string(s, buf)?;
-            }
-            BatchedQuery::PreparedStatementID(id) => {
-                buf.put_u8(1);
-                types::write_short_bytes(&id[..], buf)?;
-            }
+#[derive(Clone, Copy)]
+pub enum BatchType {
+    Logged = 0,
+    Unlogged = 1,
+    Counter = 2,
+}
+
+impl Request for Batch<'_> {
+    const OPCODE: RequestOpcode = RequestOpcode::Batch;
+
+    fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
+        // Serializing type of batch
+        buf.put_u8(self.batch_type as u8);
+
+        // Serializing queries
+        types::write_short(self.statements.len() as i16, buf);
+        for statement in &self.statements {
+            statement.serialize(buf)?;
         }
+
+        // Serializing consistency
+        types::write_short(self.consistency, buf);
+
+        // Serializing flags
+        // FIXME: consider other flag values than 0
+        buf.put_u8(0);
+
         Ok(())
     }
 }
 
-pub struct BatchedQueryWithValues<'a> {
-    pub query: BatchedQuery,
-    pub values: &'a [Value],
+impl Default for Batch<'_> {
+    fn default() -> Self {
+        Self {
+            statements: Vec::new(),
+            batch_type: BatchType::Logged,
+            consistency: 1,
+        }
+    }
 }
 
-impl BatchedQueryWithValues<'_> {
-    pub fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
-        self.query.serialize(buf)?;
+impl BatchStatement {
+    fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
+        match self {
+            BatchStatement::QueryContents(s) => {
+                buf.put_u8(0);
+                types::write_long_string(s, buf)?;
+            }
+            BatchStatement::PreparedStatementID(id) => {
+                buf.put_u8(1);
+                types::write_short_bytes(&id[..], buf)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl BatchStatementWithValues<'_> {
+    fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
+        self.statement.serialize(buf)?;
         types::write_short(self.values.len() as i16, buf);
 
         for value in self.values {
@@ -48,43 +96,6 @@ impl BatchedQueryWithValues<'_> {
                 Value::NotSet => types::write_int(-2, buf),
             }
         }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-pub enum BatchType {
-    Logged = 0,
-    Unlogged = 1,
-    Counter = 2,
-}
-
-pub struct Batch<'a> {
-    pub queries: Vec<BatchedQueryWithValues<'a>>,
-    pub batch_type: BatchType,
-    pub consistency: i16,
-}
-
-impl Request for Batch<'_> {
-    const OPCODE: RequestOpcode = RequestOpcode::Batch;
-
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
-        // Serializing type of batch
-        buf.put_u8(self.batch_type as u8);
-
-        // Serializing queries
-        types::write_short(self.queries.len() as i16, buf);
-        for query in &self.queries {
-            query.serialize(buf)?;
-        }
-
-        // Serializing consistency
-        types::write_short(self.consistency, buf);
-
-        // Serializing flags
-        // FIXME: consider other flag values than 0
-        buf.put_u8(0);
 
         Ok(())
     }

--- a/scylla/src/frame/request/batch.rs
+++ b/scylla/src/frame/request/batch.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use bytes::{BufMut, Bytes};
 
-use crate::{
-    frame::request::{Request, RequestOpcode},
-    frame::types,
-    frame::value::Value,
+use crate::frame::{
+    request::{Request, RequestOpcode},
+    types,
+    value::Value,
 };
 
 pub struct Batch<'a> {
@@ -23,6 +23,7 @@ pub enum BatchStatement {
     PreparedStatementID(Bytes),
 }
 
+/// The type of a batch.
 #[derive(Clone, Copy)]
 pub enum BatchType {
     Logged = 0,
@@ -83,9 +84,11 @@ impl BatchStatement {
 
 impl BatchStatementWithValues<'_> {
     fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
+        // Serializing statement
         self.statement.serialize(buf)?;
-        types::write_short(self.values.len() as i16, buf);
 
+        // Serializing values bound to statement
+        types::write_short(self.values.len() as i16, buf);
         for value in self.values {
             match value {
                 Value::Val(v) => {

--- a/scylla/src/frame/request/batch.rs
+++ b/scylla/src/frame/request/batch.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use bytes::{BufMut, Bytes};
+
+use crate::{
+    frame::request::{Request, RequestOpcode},
+    frame::types,
+    frame::value::Value,
+};
+
+pub enum BatchedQuery {
+    QueryContents(String),
+    PreparedStatementID(Bytes),
+}
+
+impl BatchedQuery {
+    pub fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
+        match self {
+            BatchedQuery::QueryContents(s) => {
+                buf.put_u8(0);
+                types::write_long_string(s, buf)?;
+            }
+            BatchedQuery::PreparedStatementID(id) => {
+                buf.put_u8(1);
+                types::write_short_bytes(&id[..], buf)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct BatchedQueryWithValues<'a> {
+    pub query: BatchedQuery,
+    pub values: &'a [Value],
+}
+
+impl BatchedQueryWithValues<'_> {
+    pub fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
+        self.query.serialize(buf)?;
+        types::write_short(self.values.len() as i16, buf);
+
+        for value in self.values {
+            match value {
+                Value::Val(v) => {
+                    types::write_int(v.len() as i32, buf);
+                    buf.put_slice(&v[..]);
+                }
+                Value::Null => types::write_int(-1, buf),
+                Value::NotSet => types::write_int(-2, buf),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum BatchType {
+    Logged = 0,
+    Unlogged = 1,
+    Counter = 2,
+}
+
+pub struct Batch<'a> {
+    pub queries: Vec<BatchedQueryWithValues<'a>>,
+    pub batch_type: BatchType,
+    pub consistency: i16,
+}
+
+impl Request for Batch<'_> {
+    const OPCODE: RequestOpcode = RequestOpcode::Batch;
+
+    fn serialize(&self, buf: &mut impl BufMut) -> Result<()> {
+        // Serializing type of batch
+        buf.put_u8(self.batch_type as u8);
+
+        // Serializing queries
+        types::write_short(self.queries.len() as i16, buf);
+        for query in &self.queries {
+            query.serialize(buf)?;
+        }
+
+        // Serializing consistency
+        types::write_short(self.consistency, buf);
+
+        // Serializing flags
+        // FIXME: consider other flag values than 0
+        buf.put_u8(0);
+
+        Ok(())
+    }
+}

--- a/scylla/src/frame/request/mod.rs
+++ b/scylla/src/frame/request/mod.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use bytes::{BufMut, Bytes};
 use num_enum::TryFromPrimitive;
 
+pub use batch::Batch;
 pub use options::Options;
 pub use prepare::Prepare;
 pub use query::Query;

--- a/scylla/src/frame/request/mod.rs
+++ b/scylla/src/frame/request/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch;
 pub mod execute;
 pub mod options;
 pub mod prepare;

--- a/scylla/src/frame/request/query.rs
+++ b/scylla/src/frame/request/query.rs
@@ -70,18 +70,7 @@ impl QueryParameters<'_> {
         buf.put_u8(flags);
 
         if !self.values.is_empty() {
-            buf.put_i16(self.values.len() as i16);
-
-            for value in self.values {
-                match value {
-                    Value::Val(v) => {
-                        types::write_int(v.len() as i32, buf);
-                        buf.put_slice(&v[..]);
-                    }
-                    Value::Null => types::write_int(-1, buf),
-                    Value::NotSet => types::write_int(-2, buf),
-                }
-            }
+            types::write_values(&self.values, buf);
         }
 
         if let Some(page_size) = self.page_size {

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::str;
 use uuid::Uuid;
 
+use crate::frame::value::Value;
+
 fn read_raw_bytes<'a>(count: usize, buf: &mut &'a [u8]) -> Result<&'a [u8]> {
     if buf.len() < count {
         return Err(anyhow!(
@@ -341,4 +343,19 @@ fn type_uuid() {
     write_uuid(&u, &mut buf);
     let u2 = read_uuid(&mut &*buf).unwrap();
     assert_eq!(u, u2);
+}
+
+pub fn write_values(values: &[Value], buf: &mut impl BufMut) {
+    buf.put_i16(values.len() as i16);
+
+    for value in values {
+        match value {
+            Value::Val(v) => {
+                write_int(v.len() as i32, buf);
+                buf.put_slice(&v[..]);
+            }
+            Value::Null => write_int(-1, buf),
+            Value::NotSet => write_int(-2, buf),
+        }
+    }
 }

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -12,6 +12,7 @@ pub mod statement;
 pub mod transport;
 
 pub use macros::*;
+pub use statement::batch;
 pub use statement::prepared_statement;
 pub use statement::query;
 

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -8,19 +8,15 @@ pub struct Batch {
 }
 
 impl Batch {
-    pub fn new<E: Into<BatchStatement> + Clone>(statements: &[E], batch_type: BatchType) -> Self {
+    pub fn new(batch_type: BatchType) -> Self {
         Self {
-            statements: statements.iter().map(|e| e.clone().into()).collect(),
             batch_type,
+            ..Default::default()
         }
     }
 
     pub fn append_statement(&mut self, statement: impl Into<BatchStatement>) {
         self.statements.push(statement.into());
-    }
-
-    pub fn clear_statements(&mut self) {
-        self.statements.clear();
     }
 
     pub fn get_type(&self) -> BatchType {
@@ -45,6 +41,12 @@ impl Default for Batch {
 pub enum BatchStatement {
     Query(Query),
     PreparedStatement(PreparedStatement),
+}
+
+impl From<&str> for BatchStatement {
+    fn from(s: &str) -> Self {
+        BatchStatement::Query(Query::from(s))
+    }
 }
 
 impl From<Query> for BatchStatement {

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -2,12 +2,17 @@ use crate::statement::{prepared_statement::PreparedStatement, query::Query};
 
 pub use crate::frame::request::batch::BatchType;
 
+/// CQL batch statement.
+///
+/// This represents a CQL batch that can be executed on a server.
+#[derive(Clone)]
 pub struct Batch {
     statements: Vec<BatchStatement>,
     batch_type: BatchType,
 }
 
 impl Batch {
+    /// Creates a new, empty `Batch` of `batch_type` type.
     pub fn new(batch_type: BatchType) -> Self {
         Self {
             batch_type,
@@ -15,14 +20,17 @@ impl Batch {
         }
     }
 
+    /// Appends a new statement to the batch.
     pub fn append_statement(&mut self, statement: impl Into<BatchStatement>) {
         self.statements.push(statement.into());
     }
 
+    /// Gets type of batch.
     pub fn get_type(&self) -> BatchType {
         self.batch_type
     }
 
+    /// Returns statements contained in the batch.
     pub fn get_statements(&self) -> &[BatchStatement] {
         self.statements.as_ref()
     }
@@ -37,6 +45,7 @@ impl Default for Batch {
     }
 }
 
+/// This enum represents a CQL statement, that can be part of batch.
 #[derive(Clone)]
 pub enum BatchStatement {
     Query(Query),

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,10 +1,60 @@
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
 
-pub enum Batched {
+pub use crate::frame::request::batch::BatchType;
+
+pub struct Batch {
+    statements: Vec<BatchStatement>,
+    batch_type: BatchType,
+}
+
+impl Batch {
+    pub fn new<E: Into<BatchStatement> + Clone>(statements: &[E], batch_type: BatchType) -> Self {
+        Self {
+            statements: statements.iter().map(|e| e.clone().into()).collect(),
+            batch_type,
+        }
+    }
+
+    pub fn append_statement(&mut self, statement: impl Into<BatchStatement>) {
+        self.statements.push(statement.into());
+    }
+
+    pub fn clear_statements(&mut self) {
+        self.statements.clear();
+    }
+
+    pub fn get_type(&self) -> BatchType {
+        self.batch_type
+    }
+
+    pub fn get_statements(&self) -> &[BatchStatement] {
+        self.statements.as_ref()
+    }
+}
+
+impl Default for Batch {
+    fn default() -> Self {
+        Self {
+            statements: Vec::new(),
+            batch_type: BatchType::Logged,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum BatchStatement {
     Query(Query),
     PreparedStatement(PreparedStatement),
 }
 
-pub struct Batch {
-    queries: Vec<Batched>,
+impl From<Query> for BatchStatement {
+    fn from(q: Query) -> Self {
+        BatchStatement::Query(q)
+    }
+}
+
+impl From<PreparedStatement> for BatchStatement {
+    fn from(p: PreparedStatement) -> Self {
+        BatchStatement::PreparedStatement(p)
+    }
 }

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,0 +1,10 @@
+use crate::statement::{prepared_statement::PreparedStatement, query::Query};
+
+pub enum Batched {
+    Query(Query),
+    PreparedStatement(PreparedStatement),
+}
+
+pub struct Batch {
+    queries: Vec<Batched>,
+}

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,2 +1,3 @@
+pub mod batch;
 pub mod prepared_statement;
 pub mod query;

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -142,10 +142,12 @@ impl Connection {
     }
 
     pub async fn batch(&self, batch: &Batch, values: &[impl AsRef<[Value]>]) -> Result<Response> {
-        let num_of_statements = batch.get_statements().len();
-        if num_of_statements != values.len() {
+        let statements_count = batch.get_statements().len();
+        if statements_count != values.len() {
             return Err(anyhow!(
-                "Length of provided values must be equal to number of batch statements"
+                "Length of provided values ({}) must be equal to number of batch statements ({})",
+                values.len(),
+                statements_count
             ));
         }
 
@@ -167,7 +169,7 @@ impl Connection {
 
         let batch_frame = batch::Batch {
             statements,
-            num_of_statements,
+            statements_count,
             batch_type: batch.get_type(),
             consistency: 1, // TODO something else than hardcoded value
         };

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -141,7 +141,7 @@ impl Connection {
         self.send_request(&execute_frame, true).await
     }
 
-    pub async fn batch<V: AsRef<[Value]>>(&self, batch: &Batch, values: &[V]) -> Result<Response> {
+    pub async fn batch(&self, batch: &Batch, values: &[impl AsRef<[Value]>]) -> Result<Response> {
         if batch.get_statements().len() != values.len() {
             return Err(anyhow!(
                 "Length of provided values must be equal to number of batch statements"

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Mutex as StdMutex;
 
+use crate::batch::Batch;
 use crate::frame::{
     self,
     request::{self, execute, query, Request, RequestOpcode},
@@ -137,6 +138,23 @@ impl Connection {
         };
 
         self.send_request(&execute_frame, true).await
+    }
+
+    pub async fn batch<V: AsRef<[Value]>>(&self, batch: &Batch, values: &[V]) -> Result<Response> {
+        /*
+        let batch_frame = query::Query {
+            contents: query.get_contents().to_owned(),
+            parameters: query::QueryParameters {
+                values,
+                page_size: query.get_page_size(),
+                paging_state,
+                ..Default::default()
+            },
+        };
+
+        self.send_request(&query_frame, true).await
+        */
+        Ok(Response::Ready)
     }
 
     // TODO: Return the response associated with that frame

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -227,10 +227,15 @@ impl Session {
         ))
     }
 
-    pub async fn batch<V: AsRef<[Value]>>(
+    /// Sends a batch to the database.
+    /// # Arguments
+    ///
+    /// * `batch` - batch to be performed
+    /// * `values` - values bound to the query
+    pub async fn batch(
         &self,
         batch: impl Into<Batch>,
-        values: &[V],
+        values: &[impl AsRef<[Value]>],
     ) -> Result<()> {
         // FIXME: Prepared statement ids are local to a node
         // this method does not handle this

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -232,14 +232,10 @@ impl Session {
     ///
     /// * `batch` - batch to be performed
     /// * `values` - values bound to the query
-    pub async fn batch(
-        &self,
-        batch: impl Into<Batch>,
-        values: &[impl AsRef<[Value]>],
-    ) -> Result<()> {
+    pub async fn batch(&self, batch: &Batch, values: &[impl AsRef<[Value]>]) -> Result<()> {
         // FIXME: Prepared statement ids are local to a node
         // this method does not handle this
-        let response = self.any_connection()?.batch(&batch.into(), values).await?;
+        let response = self.any_connection()?.batch(&batch, values).await?;
         match response {
             Response::Error(err) => Err(err.into()),
             Response::Result(_) => Ok(()),

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -192,6 +192,8 @@ async fn test_batch() {
         .await
         .unwrap();
 
+    // TODO: Add API, that supports binding values to statements in batch creation process,
+    // to avoid problem of statements/values count mismatch
     use crate::batch::Batch;
     let mut batch: Batch = Default::default();
     batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)");

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -168,6 +168,71 @@ async fn test_prepared_statement() {
 
 #[tokio::test]
 #[ignore]
+async fn test_batch() {
+    let session = Session::connect("127.0.0.1:9042", None).await.unwrap();
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
+    session
+        .query("DROP TABLE IF EXISTS ks.t;", &[])
+        .await
+        .unwrap();
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Wait for schema agreement
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    use crate::batch::Batch;
+    use crate::batch::BatchType;
+    use crate::query::Query;
+
+    let batch = Batch::new::<Query>(
+        &[
+            "INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')".into(),
+            "INSERT INTO ks.t (a, b, c) VALUES (7, 11, '')".into(),
+            "INSERT INTO ks.t (a, b, c) VALUES (1, 4, 'hello')".into(),
+        ],
+        BatchType::Logged,
+    );
+
+    let mut v = Vec::<Vec<crate::frame::value::Value>>::new();
+    v.resize(batch.get_statements().len(), Default::default());
+
+    session.batch(batch, &v).await.unwrap();
+
+    let rs = session
+        .query("SELECT a, b, c FROM ks.t", &[])
+        .await
+        .unwrap()
+        .unwrap();
+
+    let mut results: Vec<(i32, i32, &String)> = rs
+        .iter()
+        .map(|r| {
+            let a = r.columns[0].as_ref().unwrap().as_int().unwrap();
+            let b = r.columns[1].as_ref().unwrap().as_int().unwrap();
+            let c = r.columns[2].as_ref().unwrap().as_text().unwrap();
+            (a, b, c)
+        })
+        .collect();
+    results.sort();
+    assert_eq!(
+        results,
+        vec![
+            (1, 2, &String::from("abc")),
+            (1, 4, &String::from("hello")),
+            (7, 11, &String::from(""))
+        ]
+    );
+}
+
+#[tokio::test]
+#[ignore]
 async fn test_token_calculation() {
     let session = Session::connect("127.0.0.1:9042", None).await.unwrap();
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -188,17 +188,11 @@ async fn test_batch() {
     std::thread::sleep(std::time::Duration::from_millis(300));
 
     use crate::batch::Batch;
-    use crate::batch::BatchType;
-    use crate::query::Query;
 
-    let batch = Batch::new::<Query>(
-        &[
-            "INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')".into(),
-            "INSERT INTO ks.t (a, b, c) VALUES (7, 11, '')".into(),
-            "INSERT INTO ks.t (a, b, c) VALUES (1, 4, 'hello')".into(),
-        ],
-        BatchType::Logged,
-    );
+    let mut batch: Batch = Default::default();
+    batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')");
+    batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (7, 11, '')");
+    batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (1, 4, 'hello')");
 
     let mut v = Vec::<Vec<crate::frame::value::Value>>::new();
     v.resize(batch.get_statements().len(), Default::default());


### PR DESCRIPTION
This PR implements basic support for sending multiple statements at once using the BATCH request (issue [#74 ](https://github.com/scylladb/scylla-rust-driver/issues/74)). Prepared statements might not work properly (because prepared statement ids are local to a node).
Usage preview:
```rust
use crate::batch::Batch;

let mut batch: Batch = Default::default();
batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)");
batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (7, 11, '')");
batch.append_statement(prepared_statement);

let values = [
    values!(1_i32, 2_i32, "abc"),
    Vec::new(),
    values!(1_i32, 4_i32, "hello"),
];

session.batch(&batch, &values).await.unwrap();
```