### PR TITLE
Driver-side metrics (Issue #75)

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -82,6 +82,17 @@ async fn main() -> Result<()> {
         }
     }
 
+    let metrics = session.get_metrics();
+    println!("Queries requested: {}", metrics.get_queries_num());
+    println!("Iter queries requested: {}", metrics.get_queries_iter_num());
+    println!("Errors occured: {}", metrics.get_errors_num());
+    println!("Iter errors occured: {}", metrics.get_errors_iter_num());
+    println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
+    println!(
+        "99.9 latency percentile: {}",
+        metrics.get_latency_percentile_ms(99.9).unwrap()
+    );
+
     println!("Ok.");
 
     Ok(())

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.33"
 byteorder = "1.3.4"
 bytes = "0.6.0"
 futures = "0.3.6"
+histogram = "0.6.9"
 num_enum = "0.5"
 compress = "0.2.1"
 tokio = { version = "0.3.0", features = ["net", "time", "io-util", "sync", "rt", "macros"] }

--- a/scylla/src/transport/metrics.rs
+++ b/scylla/src/transport/metrics.rs
@@ -1,0 +1,161 @@
+use histogram::Histogram;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+const ORDER_TYPE: Ordering = Ordering::Relaxed;
+
+#[derive(Debug)]
+pub enum MetricsError<'a> {
+    Poison(PoisonError<MutexGuard<'a, Histogram>>),
+    Histogram(&'static str),
+}
+
+impl<'a> From<PoisonError<MutexGuard<'a, Histogram>>> for MetricsError<'a> {
+    fn from(err: PoisonError<MutexGuard<'_, Histogram>>) -> MetricsError {
+        MetricsError::Poison(err)
+    }
+}
+
+impl From<&'static str> for MetricsError<'_> {
+    fn from(err: &'static str) -> MetricsError {
+        MetricsError::Histogram(err)
+    }
+}
+
+impl std::fmt::Display for MetricsError<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Default)]
+pub struct Metrics {
+    errors_num: AtomicU64,
+    queries_num: AtomicU64,
+    errors_iter_num: AtomicU64,
+    queries_iter_num: AtomicU64,
+    histogram: Arc<Mutex<Histogram>>,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        Self {
+            errors_num: AtomicU64::new(0),
+            queries_num: AtomicU64::new(0),
+            errors_iter_num: AtomicU64::new(0),
+            queries_iter_num: AtomicU64::new(0),
+            histogram: Arc::new(Mutex::new(Histogram::new())),
+        }
+    }
+
+    /// Increments counter for errors that occured in nonpaged queries.
+    pub fn inc_failed_nonpaged_queries(&self) {
+        self.errors_num.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Increments counter for nonpaged queries.
+    pub fn inc_total_nonpaged_queries(&self) {
+        self.queries_num.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Increments counter for errors that occured in paged queries.
+    pub fn inc_failed_paged_queries(&self) {
+        self.errors_iter_num.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Increments counter for page queries in paged queries.
+    /// If query_iter would return 4 pages then this counter should be incremented 4 times.
+    pub fn inc_total_paged_queries(&self) {
+        self.queries_iter_num.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Saves to histogram latency of completing single query.
+    /// For paged queries it should log latency for every page.
+    ///
+    /// # Arguments
+    ///
+    /// * `latency` - time in milliseconds that should be logged
+    pub fn log_query_latency(&self, latency: u64) -> Result<(), MetricsError> {
+        let mut histogram_unlocked = self.histogram.lock()?;
+        histogram_unlocked.increment(latency)?;
+        Ok(())
+    }
+
+    /// Returns average latency in milliseconds
+    pub fn get_latency_avg_ms(&self) -> Result<u64, MetricsError> {
+        let histogram_unlocked = self.histogram.lock()?;
+        Ok(histogram_unlocked.mean()?)
+    }
+
+    /// Returns latency from histogram for a given percentile
+    /// # Arguments
+    ///
+    /// * `percentile` - float value (0.0 - 100.0)
+    pub fn get_latency_percentile_ms(&self, percentile: f64) -> Result<u64, MetricsError> {
+        let histogram_unlocked = self.histogram.lock()?;
+        Ok(histogram_unlocked.percentile(percentile)?)
+    }
+
+    /// Returns counter for errors occured in nonpaged queries
+    pub fn get_errors_num(&self) -> u64 {
+        self.errors_num.load(ORDER_TYPE)
+    }
+
+    /// Returns counter for nonpaged queries
+    pub fn get_queries_num(&self) -> u64 {
+        self.queries_num.load(ORDER_TYPE)
+    }
+
+    /// Returns counter for errors occured in paged queries
+    pub fn get_errors_iter_num(&self) -> u64 {
+        self.errors_iter_num.load(ORDER_TYPE)
+    }
+
+    /// Returns counter for pages requested in paged queries
+    pub fn get_queries_iter_num(&self) -> u64 {
+        self.queries_iter_num.load(ORDER_TYPE)
+    }
+}
+
+pub struct MetricsView {
+    metrics: Arc<Metrics>,
+}
+
+impl MetricsView {
+    pub fn new(metrics: Arc<Metrics>) -> Self {
+        Self { metrics }
+    }
+
+    /// Returns average latency in milliseconds
+    pub fn get_latency_avg_ms(&self) -> Result<u64, MetricsError> {
+        self.metrics.get_latency_avg_ms()
+    }
+
+    /// Returns latency from histogram for a given percentile
+    /// # Arguments
+    ///
+    /// * `percentile` - float value (0.0 - 100.0)
+    pub fn get_latency_percentile_ms(&self, percentile: f64) -> Result<u64, MetricsError> {
+        self.metrics.get_latency_percentile_ms(percentile)
+    }
+
+    /// Returns counter for errors occured in nonpaged queries
+    pub fn get_errors_num(&self) -> u64 {
+        self.metrics.get_errors_num()
+    }
+
+    /// Returns counter for nonpaged queries
+    pub fn get_queries_num(&self) -> u64 {
+        self.metrics.get_queries_num()
+    }
+
+    /// Returns counter for errors occured in paged queries
+    pub fn get_errors_iter_num(&self) -> u64 {
+        self.metrics.get_errors_iter_num()
+    }
+
+    /// Returns counter for pages requested in paged queries
+    pub fn get_queries_iter_num(&self) -> u64 {
+        self.metrics.get_queries_iter_num()
+    }
+}

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -1,5 +1,6 @@
 pub mod connection;
 pub mod iterator;
+mod metrics;
 pub mod session;
 mod topology;
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 use tokio::net::{lookup_host, ToSocketAddrs};
 
 use crate::batch::Batch;
@@ -17,6 +18,7 @@ use crate::query::Query;
 use crate::routing::{murmur3_token, Node, Shard, ShardInfo, Token};
 use crate::transport::connection::{open_connection, Connection};
 use crate::transport::iterator::RowIterator;
+use crate::transport::metrics::{Metrics, MetricsView};
 use crate::transport::topology::{Topology, TopologyReader};
 use crate::transport::Compression;
 
@@ -34,6 +36,8 @@ pub struct Session {
 
     topology: Topology,
     _topology_reader_handle: RemoteHandle<()>,
+
+    metrics: Arc<Metrics>,
 }
 
 // Pool of connections for a single node.
@@ -107,11 +111,14 @@ impl Session {
                 .collect(),
         ));
 
+        let metrics = Arc::new(Metrics::new());
+
         Ok(Session {
             pool,
             compression,
             topology,
             _topology_reader_handle,
+            metrics,
         })
     }
 
@@ -130,6 +137,21 @@ impl Session {
         query: impl Into<Query>,
         values: &[Value],
     ) -> Result<Option<Vec<result::Row>>> {
+        let now = Instant::now();
+        self.metrics.inc_total_nonpaged_queries();
+        let result = self.query_no_metrics(query, values).await;
+        match &result {
+            Ok(_) => self.log_latency(now.elapsed().as_millis() as u64),
+            Err(_) => self.metrics.inc_failed_nonpaged_queries(),
+        };
+        result
+    }
+
+    async fn query_no_metrics(
+        &self,
+        query: impl Into<Query>,
+        values: &[Value],
+    ) -> Result<Option<Vec<result::Row>>> {
         self.any_connection()?
             .query_single_page(query, values)
             .await
@@ -140,6 +162,7 @@ impl Session {
             self.any_connection()?,
             query.into(),
             values.to_owned(),
+            self.metrics.clone(),
         ))
     }
 
@@ -168,6 +191,21 @@ impl Session {
     /// * `prepared` - a statement prepared with [prepare](crate::transport::session::prepare)
     /// * `values` - values bound to the query
     pub async fn execute(
+        &self,
+        prepared: &PreparedStatement,
+        values: &[Value],
+    ) -> Result<Option<Vec<result::Row>>> {
+        let now = Instant::now();
+        self.metrics.inc_total_nonpaged_queries();
+        let result = self.execute_no_metrics(prepared, values).await;
+        match &result {
+            Ok(_) => self.log_latency(now.elapsed().as_millis() as u64),
+            Err(_) => self.metrics.inc_failed_nonpaged_queries(),
+        };
+        result
+    }
+
+    async fn execute_no_metrics(
         &self,
         prepared: &PreparedStatement,
         values: &[Value],
@@ -224,6 +262,7 @@ impl Session {
             self.any_connection()?,
             prepared.into(),
             values.to_owned(),
+            self.metrics.clone(),
         ))
     }
 
@@ -356,6 +395,16 @@ impl Session {
             .next()
             .ok_or_else(|| anyhow!("fatal error, broken invariant: no connections available"))?
             .any_connection()?)
+    }
+
+    pub fn get_metrics(&self) -> MetricsView {
+        MetricsView::new(self.metrics.clone())
+    }
+
+    fn log_latency(&self, latency: u64) {
+        let _ = self // silent fail if mutex is poisoned
+            .metrics
+            .log_query_latency(latency);
     }
 }
 


### PR DESCRIPTION
This PR implements driver-side metrics.
We log number of: normal queries, iter queries, errors at normal queries and errors at iter queries.
We also log latency using Histogram where we can get average latency or percentile of latency.

From example:
```rust
    println!("Queries requested: {}", session.queries_num());
    println!("Iter queries requested: {}", session.queries_iter_num());
    println!("Errors occured: {}", session.errors_num());
    println!("Iter errors occured: {}", session.errors_iter_num());
    println!("Average latency: {}", session.latency_avg ());
    println!("87,1 latency percentile: {}", session.latency_percentile(87.1));
```