### PR TITLE
Add support for User Defined Types (Issue #98, #105)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -33,3 +33,7 @@ path = "compare-tokens.rs"
 [[example]]
 name = "select-paging"
 path = "select-paging.rs"
+
+[[example]]
+name = "user-defined-type"
+path = "user-defined-type.rs"

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+use scylla::cql_to_rust::FromCQLVal;
+use scylla::macros::{FromUserType, IntoUserType};
+use scylla::transport::session::{IntoTypedRows, Session};
+use scylla::try_values;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session = Session::connect(uri, None).await?;
+    session.refresh_topology().await?;
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session
+        .query(
+            "CREATE TYPE IF NOT EXISTS ks.my_type (int_val int, text_val text)",
+            &[],
+        )
+        .await?;
+
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.udt_tab (k int, my my_type, primary key (k))",
+            &[],
+        )
+        .await?;
+
+    // Define custom struct that matches User Defined Type created earlier
+    // wrapping field in Option will gracefully handle null field values
+    #[derive(Debug, IntoUserType, FromUserType)]
+    struct MyType {
+        int_val: i32,
+        text_val: Option<String>,
+    }
+
+    let to_insert = MyType {
+        int_val: 17,
+        text_val: Some("Some string".to_string()),
+    };
+
+    // It can be inserted like a normal value
+    session
+        .query(
+            "INSERT INTO ks.udt_tab (k, my) VALUES (5, ?)",
+            &(try_values!(to_insert)?),
+        )
+        .await?;
+
+    // And read like any normal value
+    if let Some(rows) = session.query("SELECT my FROM ks.udt_tab", &[]).await? {
+        for row in rows.into_typed::<(MyType,)>() {
+            let (my_val,) = row?;
+            println!("{:?}", my_val)
+        }
+    }
+
+    println!("Ok.");
+
+    Ok(())
+}

--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -1,0 +1,53 @@
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
+
+/// #[derive(FromRow)] derives FromRow for struct
+/// Works only on simple structs without generics etc
+pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(tokens_input as DeriveInput);
+
+    let struct_name = &input.ident;
+
+    let struct_fields = match &input.data {
+        Data::Struct(data) => {
+            match &data.fields {
+                Fields::Named(named_fields) => named_fields,
+                _ => panic!("derive(FromRow) works only for structs with named fields. Tuples don't need derive."),
+            }
+        },
+        _ => panic!("derive(FromRow) works only on structs!")
+    };
+
+    // Generates tokens for field_name: field_type::from_cql(vals_iter.next().ok_or(...)?), ...
+    let set_fields_code = struct_fields.named.iter().map(|field| {
+        let field_name = &field.ident;
+        let field_type = &field.ty;
+
+        quote_spanned! {field.span() =>
+            #field_name: <#field_type as FromCQLVal<Option<CQLValue>>>::from_cql(
+                vals_iter
+                .next()
+                .ok_or(FromRowError::RowTooShort) ?
+            ) ?,
+        }
+    });
+
+    let generated = quote! {
+        impl FromRow for #struct_name {
+            fn from_row(row: scylla::frame::response::result::Row)
+            -> Result<Self, scylla::cql_to_rust::FromRowError> {
+                use scylla::frame::response::result::CQLValue;
+                use scylla::cql_to_rust::{FromCQLVal, FromRow, FromRowError};
+
+                let mut vals_iter = row.columns.into_iter();
+
+                Ok(#struct_name {
+                    #(#set_fields_code)*
+                })
+            }
+        }
+    };
+
+    TokenStream::from(generated)
+}

--- a/scylla-macros/src/from_user_type.rs
+++ b/scylla-macros/src/from_user_type.rs
@@ -1,0 +1,65 @@
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
+
+/// #[derive(FromUserType)] allows to parse a struct as User Defined Type
+/// Works only on simple structs without generics etc
+pub fn from_user_type_derive(tokens_input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(tokens_input as DeriveInput);
+
+    let struct_name = &input.ident;
+
+    let struct_fields = match &input.data {
+        Data::Struct(data) => {
+            match &data.fields {
+                Fields::Named(named_fields) => named_fields,
+                _ => panic!("derive(FromUserType) works only for structs with named fields. Tuples don't need derive."),
+            }
+        },
+        _ => panic!("derive(FromUserType) works only on structs!")
+    };
+
+    // Generates tokens for field_name: field_type::from_cql(fields.remove(stringify!(#field_name)).unwrap_or(None)) ?, ...
+    let set_fields_code = struct_fields.named.iter().map(|field| {
+        let field_name = &field.ident;
+        let field_type = &field.ty;
+
+        quote_spanned! {field.span() =>
+            #field_name: <#field_type as FromCQLVal<Option<CQLValue>>>::from_cql(
+                // Take value with key #field_name out of fields map, if none found then return NULL
+                fields.remove(stringify!(#field_name)).unwrap_or(None)
+            ) ?,
+        }
+    });
+
+    let generated = quote! {
+        impl FromCQLVal<scylla::frame::response::result::CQLValue> for #struct_name {
+            fn from_cql(cql_val: scylla::frame::response::result::CQLValue)
+            -> Result<Self, scylla::cql_to_rust::FromCQLValError> {
+                use std::collections::HashMap;
+                use scylla::cql_to_rust::{FromCQLVal, FromCQLValError};
+                use scylla::frame::response::result::CQLValue;
+
+                // Interpret CQLValue as CQlValue::UserDefinedType
+                let mut fields: HashMap<String, Option<CQLValue>> = match cql_val {
+                    CQLValue::UserDefinedType{fields, ..} => fields,
+                    _ => return Err(FromCQLValError::BadCQLType),
+                };
+
+                // Parse struct using values from fields
+                let result = #struct_name {
+                    #(#set_fields_code)*
+                };
+
+                // There should be no unused fields when reading user defined type
+                if !fields.is_empty() {
+                    return Err(FromCQLValError::BadCQLType);
+                }
+
+                return Ok(result);
+            }
+        }
+    };
+
+    TokenStream::from(generated)
+}

--- a/scylla-macros/src/into_user_type.rs
+++ b/scylla-macros/src/into_user_type.rs
@@ -1,0 +1,63 @@
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
+
+/// #[derive(IntoUserType)] allows to parse a struct as User Defined Type
+/// Works only on simple structs without generics etc
+pub fn into_user_type_derive(tokens_input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(tokens_input as DeriveInput);
+
+    let struct_name = &input.ident;
+
+    let struct_fields = match &input.data {
+        Data::Struct(data) => {
+            match &data.fields {
+                Fields::Named(named_fields) => named_fields,
+                _ => panic!("derive(IntoUserType) works only for structs with named fields. Tuples don't need derive."),
+            }
+        },
+        _ => panic!("derive(IntoUserType) works only on structs!")
+    };
+
+    let convert_code = struct_fields.named.iter().map(|field| {
+        let field_name = &field.ident;
+        let field_type = &field.ty;
+
+        quote_spanned! {field.span() =>
+            // Convert field to scylla Value
+            let #field_name: Value = <#field_type as TryIntoValue>::try_into_value(self.#field_name) ?;
+            // Convert scylla Value to Bytes
+            let #field_name: Bytes = <Value as ::std::convert::TryInto<Bytes>>::try_into(#field_name) ?;
+            result_size += #field_name.len();
+        }
+    });
+
+    let set_result_code = struct_fields.named.iter().map(|field| {
+        let field_name = &field.ident;
+
+        quote_spanned! {field.span() =>
+            result_bytes.put(#field_name);
+        }
+    });
+
+    let generated = quote! {
+        impl scylla::frame::value::TryIntoValue for #struct_name {
+            fn try_into_value(self) -> Result<scylla::frame::value::Value, scylla::frame::value::ValueTooBig> {
+                use scylla::frame::value::{Value, ValueTooBig, TryIntoValue};
+                use scylla::macros::{Bytes, BytesMut, BufMut};
+
+                let mut result_size: usize = 0;
+
+                #(#convert_code)*
+
+                let mut result_bytes = BytesMut::with_capacity(result_size);
+
+                #(#set_result_code)*
+
+                Ok(Value::Val(result_bytes.into()))
+            }
+        }
+    };
+
+    TokenStream::from(generated)
+}

--- a/scylla/src/frame/request/batch.rs
+++ b/scylla/src/frame/request/batch.rs
@@ -79,7 +79,7 @@ impl BatchStatementWithValues<'_> {
         self.statement.serialize(buf)?;
 
         // Serializing values bound to statement
-        types::write_values(&self.values, buf);
+        types::write_values(&self.values, buf)?;
 
         Ok(())
     }

--- a/scylla/src/frame/request/query.rs
+++ b/scylla/src/frame/request/query.rs
@@ -70,7 +70,7 @@ impl QueryParameters<'_> {
         buf.put_u8(flags);
 
         if !self.values.is_empty() {
-            types::write_values(&self.values, buf);
+            types::write_values(&self.values, buf)?;
         }
 
         if let Some(page_size) = self.page_size {

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::BufMut;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::str;
 use uuid::Uuid;
 
@@ -345,17 +346,19 @@ fn type_uuid() {
     assert_eq!(u, u2);
 }
 
-pub fn write_values(values: &[Value], buf: &mut impl BufMut) {
-    buf.put_i16(values.len() as i16);
+pub fn write_values(values: &[Value], buf: &mut impl BufMut) -> Result<()> {
+    buf.put_i16(values.len().try_into()?);
 
     for value in values {
         match value {
             Value::Val(v) => {
-                write_int(v.len() as i32, buf);
+                write_int(v.len().try_into()?, buf);
                 buf.put_slice(&v[..]);
             }
             Value::Null => write_int(-1, buf),
             Value::NotSet => write_int(-2, buf),
         }
     }
+
+    Ok(())
 }

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -1,4 +1,5 @@
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
+use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -7,17 +8,103 @@ pub enum Value {
     NotSet,
 }
 
+pub trait TryIntoValue {
+    fn try_into_value(self) -> Result<Value, ValueTooBig>;
+}
+
+pub struct ValueTooBig {}
+
+impl std::fmt::Debug for ValueTooBig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Value is too big to be sent in a request, max 2GiB allowed"
+        )
+    }
+}
+
+impl std::fmt::Display for ValueTooBig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Value is too big to be sent in a request, max 2GiB allowed"
+        )
+    }
+}
+
+impl std::error::Error for ValueTooBig {}
+
+impl TryInto<Bytes> for Value {
+    type Error = ValueTooBig;
+
+    fn try_into(self) -> Result<Bytes, ValueTooBig> {
+        const MIN_1: &[u8] = &(-1_i32).to_be_bytes();
+        const MIN_2: &[u8] = &(-2_i32).to_be_bytes();
+
+        match self {
+            Value::Val(bytes) => {
+                let bytes_len_int: i32 = match bytes.len().try_into() {
+                    Ok(int_len) => int_len,
+                    Err(_) => return Err(ValueTooBig {}),
+                };
+
+                let mut result = BytesMut::with_capacity(4 + bytes.len());
+
+                result.put_i32(bytes_len_int);
+                result.put(bytes);
+                Ok(result.into())
+            }
+            Value::Null => Ok(Bytes::from_static(MIN_1)),
+            Value::NotSet => Ok(Bytes::from_static(MIN_2)),
+        }
+    }
+}
+
+impl<T: TryIntoValue> TryIntoValue for Option<T> {
+    fn try_into_value(self) -> Result<Value, ValueTooBig> {
+        match self {
+            Some(val) => Ok(<T as TryIntoValue>::try_into_value(val)?),
+            None => Ok(Value::Null),
+        }
+    }
+}
+
+impl<T: Into<Value>> Into<Value> for Option<T> {
+    fn into(self) -> Value {
+        match self {
+            Some(val) => <T as Into<Value>>::into(val),
+            None => Value::Null,
+        }
+    }
+}
+
+// Given a type that implements Into<Value> implement TryIntoValue for it
+// trying to do that with generics fails because TryIntoValue<Option<_>> is ambiguous
+macro_rules! impl_try_into_for_into {
+    ($t:ty) => {
+        impl TryIntoValue for $t {
+            fn try_into_value(self) -> Result<Value, ValueTooBig> {
+                Ok(self.into())
+            }
+        }
+    };
+}
+
 impl Into<Value> for String {
     fn into(self) -> Value {
         Value::Val(self.into())
     }
 }
 
-impl<'a> Into<Value> for &'a str {
+impl_try_into_for_into!(String);
+
+impl Into<Value> for &str {
     fn into(self) -> Value {
         Value::Val(self.to_owned().into())
     }
 }
+
+impl_try_into_for_into!(&str);
 
 impl Into<Value> for i8 {
     fn into(self) -> Value {
@@ -25,11 +112,15 @@ impl Into<Value> for i8 {
     }
 }
 
+impl_try_into_for_into!(i8);
+
 impl Into<Value> for i16 {
     fn into(self) -> Value {
         Value::Val(self.to_be_bytes().to_vec().into())
     }
 }
+
+impl_try_into_for_into!(i16);
 
 impl Into<Value> for i32 {
     fn into(self) -> Value {
@@ -37,11 +128,15 @@ impl Into<Value> for i32 {
     }
 }
 
+impl_try_into_for_into!(i32);
+
 impl Into<Value> for i64 {
     fn into(self) -> Value {
         Value::Val(self.to_be_bytes().to_vec().into())
     }
 }
+
+impl_try_into_for_into!(i64);
 
 impl Into<Value> for u8 {
     fn into(self) -> Value {
@@ -49,11 +144,15 @@ impl Into<Value> for u8 {
     }
 }
 
+impl_try_into_for_into!(u8);
+
 impl Into<Value> for u16 {
     fn into(self) -> Value {
         Value::Val(self.to_be_bytes().to_vec().into())
     }
 }
+
+impl_try_into_for_into!(u16);
 
 impl Into<Value> for u32 {
     fn into(self) -> Value {
@@ -61,8 +160,12 @@ impl Into<Value> for u32 {
     }
 }
 
+impl_try_into_for_into!(u32);
+
 impl Into<Value> for u64 {
     fn into(self) -> Value {
         Value::Val(self.to_be_bytes().to_vec().into())
     }
 }
+
+impl_try_into_for_into!(u64);

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -12,7 +12,7 @@ pub trait TryIntoValue {
     fn try_into_value(self) -> Result<Value, ValueTooBig>;
 }
 
-pub struct ValueTooBig {}
+pub struct ValueTooBig;
 
 impl std::fmt::Debug for ValueTooBig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -45,7 +45,7 @@ impl TryInto<Bytes> for Value {
             Value::Val(bytes) => {
                 let bytes_len_int: i32 = match bytes.len().try_into() {
                     Ok(int_len) => int_len,
-                    Err(_) => return Err(ValueTooBig {}),
+                    Err(_) => return Err(ValueTooBig),
                 };
 
                 let mut result = BytesMut::with_capacity(4 + bytes.len());

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -4,12 +4,21 @@ macro_rules! values {
     ($($value:expr),*) => {
         {
             use $crate::frame::value::Value;
-            use ::std::vec::Vec;
-            let mut values: Vec<Value> = Vec::new();
-            $(
-                values.push(::std::convert::Into::into($value));
-            )*
-            values
+            [$(<_ as ::std::convert::Into<Value>>::into($value)),*]
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! try_values {
+    ($($value:expr),*) => {
+        {
+            use $crate::frame::value::{Value, ValueTooBig, TryIntoValue};
+            let lambda = || -> Result<_, ValueTooBig> {
+                Ok([$(<_ as TryIntoValue>::try_into_value($value) ?),*])
+            };
+
+            lambda()
         }
     };
 }
@@ -17,3 +26,14 @@ macro_rules! values {
 /// #[derive(FromRow)] derives FromRow for struct
 /// Works only on simple structs without generics etc
 pub use scylla_macros::FromRow;
+
+/// #[derive(FromUserType)] allows to parse struct as a User Defined Type
+/// Works only on simple structs without generics etc
+pub use scylla_macros::FromUserType;
+
+/// #[derive(IntoUserType)] allows to pass struct a User Defined Type Value in queries
+/// Works only on simple structs without generics etc
+pub use scylla_macros::IntoUserType;
+
+// Reexports for derive(IntoUserType)
+pub use bytes::{BufMut, Bytes, BytesMut};

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -200,13 +200,13 @@ async fn test_batch() {
     batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (7, 11, '')");
     batch.append_statement(prepared_statement);
 
-    let values = [
-        values!(1_i32, 2_i32, "abc"),
-        Vec::new(),
-        values!(1_i32, 4_i32, "hello"),
+    let values: &[&[_]] = &[
+        &values!(1_i32, 2_i32, "abc"),
+        &[],
+        &values!(1_i32, 4_i32, "hello"),
     ];
 
-    session.batch(&batch, &values).await.unwrap();
+    session.batch(&batch, values).await.unwrap();
 
     let rs = session
         .query("SELECT a, b, c FROM ks.t", &[])


### PR DESCRIPTION
This PR implements support for using User Defined Types that can be used like this:
```rust
// CREATE TYPE IF NOT EXISTS ks.my_type (int_val int, text_val text)

// Define custom struct that matches User Defined Type created earlier
// wrapping field in Option will gracefully handle null field values
#[derive(Debug, IntoUserType, FromUserType)]
struct MyType {
    int_val: i32,
    text_val: Option<String>,
}

let to_insert = MyType {
    int_val: 17,
    text_val: Some("Some string".to_string()),
};

// It can be inserted like a normal value
session
    .query(
        "INSERT INTO ks.udt_tab (k, my) VALUES (5, ?)",
        &(try_values!(to_insert)?),
    )
    .await?;

// And read like any normal value
if let Some(rows) = session.query("SELECT my FROM ks.udt_tab", &[]).await? {
    for row in rows.into_typed::<(MyType,)>() {
        let (my_val,) = row?;
        println!("{:?}", my_val)
    }
}
```
Fixes #105
Fixes #98

The main challenge introduced by UDT is that creating a `Value` from user struct can fail if the resulting value would be bigger than 2GiB. This PR deals with this by implementing `TryIntoValue` for user structs with corresponding `try_values!`. 
Maybe the `values!` API could be kept if we changed public query APIs to take `ValueIn` instead of `Value` where `ValueIn` would be something like:
```rust
pub enum ValueIn {
    Value(value::Value),
    Invalid
}
```
and we would return an error when sending a request with `Invalid` values.
But that would introduce more complexity in query code, maybe we could wait with such refactor until implementing named values as they are gonna require a redesign anyway?

Another issue is that currently serializing struct into value is not very efficient - fields get recursively converted into values with one allocation for every field. This could be avoided by adding a serialization trait that would write each type into `BufMut` as binary `Value`. But adding such trait would make current Value struct not needed - we could just have `Bytes` and value would be just `Bytes` created using serialization trait.

This PR implements UDTs using current Value api, I'm not sure if full redesign of Value api should be included in this, maybe we could create a separate issue for this? Also there might be additional issues that are gonna come to light when implementing the rest of CQL types, so maybe we could wait to get the full picture and then start refactoring.

EDIT:
I have moved refactoring `Value` api into #114 