### PR TITLE
Allow passing driver name via CQL startup message

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -370,6 +370,21 @@ pub async fn open_connection(
     source_port: Option<u16>,
     compression: Option<Compression>,
 ) -> Result<Connection, TransportError> {
+    open_named_connection(
+        addr,
+        source_port,
+        compression,
+        Some("scylla-rust-driver".to_string()),
+    )
+    .await
+}
+
+pub async fn open_named_connection(
+    addr: SocketAddr,
+    source_port: Option<u16>,
+    compression: Option<Compression>,
+    driver_name: Option<String>,
+) -> Result<Connection, TransportError> {
     // TODO: shouldn't all this logic be in Connection::new?
     let mut connection = Connection::new(addr, source_port, compression).await?;
 
@@ -398,6 +413,9 @@ pub async fn open_connection(
 
     let mut options = HashMap::new();
     options.insert("CQL_VERSION".to_string(), "4.0.0".to_string()); // FIXME: hardcoded values
+    if let Some(name) = driver_name {
+        options.insert("DRIVER_NAME".to_string(), name);
+    }
     if let Some(compression) = &compression {
         let compression_str = compression.to_string();
         if supported_compression.iter().any(|c| c == &compression_str) {

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -11,7 +11,7 @@ use tokio::time;
 
 use crate::frame::response::result;
 use crate::routing::*;
-use crate::transport::connection::{open_connection, Connection};
+use crate::transport::connection::{open_connection, open_named_connection, Connection};
 
 const UPDATER_CRASHED: &str = "the topology updater thread has crashed. Need to restart it.";
 
@@ -90,7 +90,13 @@ impl TopologyReader {
     pub async fn new(n: Node) -> Result<(Self, Topology), TransportError> {
         // TODO: use compression? maybe not necessarily, since the communicated objects are
         // small and the communication doesn't happen often?
-        let conn = open_connection(n.addr, None, None).await?;
+        let conn = open_named_connection(
+            n.addr,
+            None,
+            None,
+            Some("scylla-rust-driver:control-connection".to_string()),
+        )
+        .await?;
 
         // TODO: When querying system.local of `n` or system.peers of other nodes, we might find
         // that the address of `n` is different than `n.addr` (`n` might have multiple addresses).


### PR DESCRIPTION
With the driver name explicitly passed, scylla-rust-driver connections can be easily recognized via CQL:
```cql
cassandra@cqlsh> select address, port, client_type, driver_name from system.clients ;

 address   | port  | client_type | driver_name
-----------+-------+-------------+---------------------------------------
 127.0.0.1 | 43376 |         cql |                                  null
 127.0.0.1 | 43378 |         cql |                                  null
 127.0.0.1 | 44072 |         cql |                    scylla-rust-driver
 127.0.0.1 | 44074 |         cql | scylla-rust-driver:control-connection
```