### PR TITLE
Switch to using "snap" crate instead of "snappy"

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -17,7 +17,7 @@ histogram = "0.6.9"
 num_enum = "0.5"
 compress = "0.2.1"
 tokio = { version = "0.3.0", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
-snappy = "0.4.0"
+snap = "1.0"
 uuid = "0.8.1"
 rand = "0.7.3"
 thiserror = "1.0"

--- a/scylla/src/frame/frame_errors.rs
+++ b/scylla/src/frame/frame_errors.rs
@@ -18,6 +18,8 @@ pub enum FrameError {
     ConnectionClosed(usize, usize),
     #[error("Frame decompression failed.")]
     FrameDecompression,
+    #[error("Frame compression failed.")]
+    FrameCompression,
     #[error("std io error encountered while processing")]
     StdIOError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -205,7 +205,7 @@ impl Connection {
         let body_with_ext = RequestBodyWithExtensions { body };
 
         let (flags, raw_request) =
-            frame::prepare_request_body_with_extensions(body_with_ext, compression);
+            frame::prepare_request_body_with_extensions(body_with_ext, compression)?;
 
         let (sender, receiver) = oneshot::channel();
 


### PR DESCRIPTION
Currently, we are using the "snappy" crate for compression/decompression
of frames. This crate is just a binding to the C++ snappy library, and
therefore requires it to already be installed when building the crate.

This commit removes "snappy" crate as a dependency; now, the "snap"
crate is used, which is a pure Rust implementation of the snappy
algorithm with performance comparable to the C++ library. Now, the C++
library doesn't have to be installed when compiling the driver.

This change makes the driver compile and pass all units test on my
Windows installation.

Fixes #129