### PR TITLE
Add nodelay param

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -53,6 +53,7 @@ struct TaskResponse {
 #[derive(Clone)]
 pub struct ConnectionConfig {
     pub compression: Option<Compression>,
+    pub tcp_nodelay: bool,
     /*
     These configuration options will be added in the future:
 
@@ -62,7 +63,6 @@ pub struct ConnectionConfig {
     pub use_tls: bool,
     pub tls_certificate_path: Option<String>,
 
-    pub tcp_nodelay: bool,
     pub tcp_keepalive: bool,
 
     pub load_balancing: Option<String>,
@@ -83,6 +83,7 @@ impl Connection {
             None => TcpStream::connect(addr).await?,
         };
         let source_port = stream.local_addr()?.port();
+        stream.set_nodelay(config.tcp_nodelay)?;
 
         // TODO: What should be the size of the channel?
         let (sender, receiver) = mpsc::channel(128);

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -41,6 +41,7 @@ pub struct SessionConfig {
     /// Preferred compression algorithm to use on connections.  
     /// If it's not supported by database server Session will fall back to no compression.  
     pub compression: Option<Compression>,
+    pub tcp_nodelay: bool,
     /*
     These configuration options will be added in the future:
 
@@ -50,7 +51,6 @@ pub struct SessionConfig {
     pub use_tls: bool,
     pub tls_certificate_path: Option<String>,
 
-    pub tcp_nodelay: bool,
     pub tcp_keepalive: bool,
 
     pub load_balancing: Option<String>,
@@ -81,6 +81,7 @@ impl SessionConfig {
         SessionConfig {
             known_nodes: Vec::new(),
             compression: None,
+            tcp_nodelay: false,
         }
     }
 
@@ -144,6 +145,7 @@ impl SessionConfig {
     fn get_connection_config(&self) -> ConnectionConfig {
         ConnectionConfig {
             compression: self.compression,
+            tcp_nodelay: self.tcp_nodelay,
         }
     }
 }

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -133,6 +133,27 @@ impl SessionBuilder {
         self
     }
 
+    /// Set the nodelay TCP flag.  
+    /// The default is false.  
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use scylla::transport::Compression;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .tcp_nodelay(true)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tcp_nodelay(mut self, nodelay: bool) -> Self {
+        self.config.tcp_nodelay = nodelay;
+        self
+    }
+
     /// Builds the Session after setting all the options
     ///
     /// # Example
@@ -247,6 +268,18 @@ mod tests {
     }
 
     #[test]
+    fn tcp_nodelay() {
+        let mut builder = SessionBuilder::new();
+        assert_eq!(builder.config.tcp_nodelay, false);
+
+        builder = builder.tcp_nodelay(true);
+        assert_eq!(builder.config.tcp_nodelay, true);
+
+        builder = builder.tcp_nodelay(false);
+        assert_eq!(builder.config.tcp_nodelay, false);
+    }
+
+    #[test]
     fn all_features() {
         let mut builder = SessionBuilder::new();
 
@@ -259,6 +292,7 @@ mod tests {
         builder = builder.known_nodes(&["hostname_test1", "hostname_test2"]);
         builder = builder.known_nodes_addr(&[addr1, addr2]);
         builder = builder.compression(Some(Compression::Snappy));
+        builder = builder.tcp_nodelay(true);
 
         assert_eq!(
             builder.config.known_nodes,
@@ -273,5 +307,6 @@ mod tests {
         );
 
         assert_eq!(builder.config.compression, Some(Compression::Snappy));
+        assert_eq!(builder.config.tcp_nodelay, true);
     }
 }


### PR DESCRIPTION
This pull requests abstracts the connection options to a separate structure and adds a way of configuring `nodelay` parameter. It also makes the default to `true`, under the assumption that users expect low latency and are not interested in delaying the outgoing packets with Nagle's algorithm.