### PR TITLE
Add retrieving keyspace replication factor and strategy (Issue #107)

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -21,6 +21,7 @@ snap = "1.0"
 uuid = "0.8.1"
 rand = "0.7.3"
 thiserror = "1.0"
+serde_json = "1.0.60"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -8,7 +8,7 @@ use std::num::Wrapping;
 use std::ops::Bound::{Included, Unbounded};
 use thiserror::Error;
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub struct Node {
     // TODO: potentially a node may have multiple addresses, remember them?
     // but we need an Ord instance on Node
@@ -33,6 +33,31 @@ pub struct ShardInfo {
     shard: u16,
     nr_shards: u16,
     msb_ignore: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Keyspace {
+    // TODO - are those required for each keyspace? Maybe Option is not needed
+    pub replication_factor: Option<usize>,
+    pub strategy_class: Option<Strategy>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Strategy {
+    SimpleStrategy,
+    LocalStrategy,
+    // TODO - add more strategies
+    WithName(String),
+}
+
+impl Strategy {
+    pub fn from_string(strategy_string: String) -> Strategy {
+        match strategy_string.as_str() {
+            "org.apache.cassandra.locator.SimpleStrategy" => Strategy::SimpleStrategy,
+            "org.apache.cassandra.locator.LocalStrategy" => Strategy::LocalStrategy,
+            _ => Strategy::WithName(strategy_string),
+        }
+    }
 }
 
 impl std::str::FromStr for Token {

--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -35,34 +35,28 @@ pub struct ShardInfo {
     msb_ignore: u8,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Keyspace {
-    // replication_factor might be None ex. with NetworkTopologyStrategy
-    pub replication_factor: Option<usize>,
-    // TODO - is strategy_class required for each keyspace to exist? Maybe Option is not needed
-    pub strategy_class: Option<Strategy>,
+    pub strategy: Strategy,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Strategy {
-    SimpleStrategy,
-    LocalStrategy,
-    NetworkTopologyStrategy,
-    // TODO - add more strategies
-    WithName(String),
-}
-
-impl Strategy {
-    pub fn from_string(strategy_string: String) -> Strategy {
-        match strategy_string.as_str() {
-            "org.apache.cassandra.locator.SimpleStrategy" => Strategy::SimpleStrategy,
-            "org.apache.cassandra.locator.LocalStrategy" => Strategy::LocalStrategy,
-            "org.apache.cassandra.locator.NetworkTopologyStrategy" => {
-                Strategy::NetworkTopologyStrategy
-            }
-            _ => Strategy::WithName(strategy_string),
-        }
-    }
+    SimpleStrategy {
+        replication_factor: usize,
+    },
+    NetworkTopologyStrategy {
+        // Replication factors of datacenters with given names
+        datacenter_repfactors: HashMap<String, usize>,
+    },
+    LocalStrategy {
+        // TODO - is LocalStrategy required to have a replication_factor?
+        replication_factor: Option<usize>,
+    },
+    Other {
+        name: String,
+        data: HashMap<String, String>,
+    },
 }
 
 impl std::str::FromStr for Token {

--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -37,8 +37,9 @@ pub struct ShardInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Keyspace {
-    // TODO - are those required for each keyspace? Maybe Option is not needed
+    // replication_factor might be None ex. with NetworkTopologyStrategy
     pub replication_factor: Option<usize>,
+    // TODO - is strategy_class required for each keyspace to exist? Maybe Option is not needed
     pub strategy_class: Option<Strategy>,
 }
 
@@ -46,6 +47,7 @@ pub struct Keyspace {
 pub enum Strategy {
     SimpleStrategy,
     LocalStrategy,
+    NetworkTopologyStrategy,
     // TODO - add more strategies
     WithName(String),
 }
@@ -55,6 +57,9 @@ impl Strategy {
         match strategy_string.as_str() {
             "org.apache.cassandra.locator.SimpleStrategy" => Strategy::SimpleStrategy,
             "org.apache.cassandra.locator.LocalStrategy" => Strategy::LocalStrategy,
+            "org.apache.cassandra.locator.NetworkTopologyStrategy" => {
+                Strategy::NetworkTopologyStrategy
+            }
             _ => Strategy::WithName(strategy_string),
         }
     }

--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -49,10 +49,7 @@ pub enum Strategy {
         // Replication factors of datacenters with given names
         datacenter_repfactors: HashMap<String, usize>,
     },
-    LocalStrategy {
-        // TODO - is LocalStrategy required to have a replication_factor?
-        replication_factor: Option<usize>,
-    },
+    LocalStrategy, // replication_factor == 1
     Other {
         name: String,
         data: HashMap<String, String>,

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -22,6 +22,3 @@ impl ToString for Compression {
         }
     }
 }
-
-#[cfg(test)]
-mod session_test;

--- a/scylla/src/transport/session/mod.rs
+++ b/scylla/src/transport/session/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod session_test;
+
 use futures::{
     future::{try_join_all, RemoteHandle},
     FutureExt,

--- a/scylla/src/transport/session/session_test.rs
+++ b/scylla/src/transport/session/session_test.rs
@@ -303,8 +303,10 @@ async fn test_keyspaces() {
     let session = Session::connect(uri, None).await.unwrap();
     session.refresh_topology().await.unwrap();
 
+    // Creates keyspaces for Topology_test_keyspace_1, 2, 3 ...
     session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks1 WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks2 WITH REPLICATION = {'class' : 'LocalStrategy', 'replication_factor' : 3}", &[]).await.unwrap();
+    session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks3 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy'}", &[]).await.unwrap();
 
     session.refresh_topology().await.unwrap();
 
@@ -329,6 +331,18 @@ async fn test_keyspaces() {
         Keyspace {
             replication_factor: Some(3),
             strategy_class: Some(Strategy::LocalStrategy),
+        }
+    );
+
+    assert_eq!(
+        session
+            .topology
+            .get_keyspace("top_test_ks3")
+            .unwrap()
+            .unwrap(),
+        Keyspace {
+            replication_factor: None,
+            strategy_class: Some(Strategy::NetworkTopologyStrategy),
         }
     );
 }

--- a/scylla/src/transport/session/session_test.rs
+++ b/scylla/src/transport/session/session_test.rs
@@ -305,8 +305,8 @@ async fn test_keyspaces() {
     session.refresh_topology().await.unwrap();
 
     // Creates keyspaces for Topology_test_keyspace_1, 2, 3 ...
-    session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks1 WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
-    session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks2 WITH REPLICATION = {'class' : 'LocalStrategy', 'replication_factor' : 3}", &[]).await.unwrap();
+    session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks1 WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3}", &[]).await.unwrap();
+    session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks2 WITH REPLICATION = {'class' : 'LocalStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session.query("CREATE KEYSPACE IF NOT EXISTS top_test_ks3 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'DC1': 2, 'dc2': 3}", &[]).await.unwrap();
 
     session.refresh_topology().await.unwrap();
@@ -320,7 +320,7 @@ async fn test_keyspaces() {
             .unwrap(),
         Keyspace {
             strategy: Strategy::SimpleStrategy {
-                replication_factor: 1,
+                replication_factor: 3,
             },
         }
     );
@@ -333,9 +333,7 @@ async fn test_keyspaces() {
             .get("top_test_ks2")
             .unwrap(),
         Keyspace {
-            strategy: Strategy::LocalStrategy {
-                replication_factor: Some(3),
-            },
+            strategy: Strategy::LocalStrategy
         }
     );
 

--- a/scylla/src/transport/transport_errors.rs
+++ b/scylla/src/transport/transport_errors.rs
@@ -26,6 +26,9 @@ pub enum TopologyError {
     #[error("Expected rows result when querying system.peers")]
     PeersRowError,
 
+    #[error("Bad query result when querying system_schema.keyspaces: {0}")]
+    BadKeyspacesQuery(String),
+
     #[error("Expected rows result when querying system.local")]
     LocalExpectedRowResults,
     #[error("system.local query result empty")]


### PR DESCRIPTION
Fixes #107 
`Topology` refresh now includes refreshing information about known keyspaces. For each keyspace we keep the replication strategy.

```rust
pub struct Keyspace {
    pub strategy: Strategy,
}

pub enum Strategy {
    SimpleStrategy {
        replication_factor: usize,
    },
    NetworkTopologyStrategy {
        // Replication factors of datacenters with given names
        datacenter_repfactors: HashMap<String, usize>,
    },
    LocalStrategy, // replication_factor == 1
    Other {
        name: String,
        data: HashMap<String, String>,
    },
}
```
Keyspace data can be accessed using `Topology::read_keyspaces`

I'm not sure what strategies should be added here but they could be easily implemented when we get to using them in load balancing.

For now query parses db response as json because we can't parse a map due to #104 

I had to move `session_test` to a submodule of `session` to access private field `session.topology` in tests.
Moved `session.rs -> session/mod.rs` and `session_test.rs -> session/session_test.rs`

`refresh_peers` is a copy-pasted chunk of code + replacing `continue` with `return Err` but github diff doesn't see this :/