### PR TITLE
Support USE statement (Issue #109)

### DIFF
--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -13,7 +13,7 @@ use std::str;
 
 #[derive(Debug)]
 pub struct SetKeyspace {
-    // TODO
+    pub keyspace_name: String,
 }
 
 #[derive(Debug)]
@@ -423,8 +423,10 @@ fn deser_rows(buf: &mut &[u8]) -> StdResult<Rows, ParseError> {
     })
 }
 
-fn deser_set_keyspace(_buf: &mut &[u8]) -> StdResult<SetKeyspace, ParseError> {
-    Ok(SetKeyspace {}) // TODO
+fn deser_set_keyspace(buf: &mut &[u8]) -> StdResult<SetKeyspace, ParseError> {
+    let keyspace_name: String = types::read_string(buf)?.to_string();
+
+    Ok(SetKeyspace { keyspace_name })
 }
 
 fn deser_prepared(buf: &mut &[u8]) -> StdResult<Prepared, ParseError> {

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -424,7 +424,7 @@ fn deser_rows(buf: &mut &[u8]) -> StdResult<Rows, ParseError> {
 }
 
 fn deser_set_keyspace(buf: &mut &[u8]) -> StdResult<SetKeyspace, ParseError> {
-    let keyspace_name: String = types::read_string(buf)?.to_string();
+    let keyspace_name = types::read_string(buf)?.to_string();
 
     Ok(SetKeyspace { keyspace_name })
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Mutex as StdMutex;
 
-use super::transport_errors::{InternalDriverError, PrepareError, TransportError};
+use super::transport_errors::{BadKeyspaceName, InternalDriverError, PrepareError, TransportError};
 
 use crate::batch::{Batch, BatchStatement};
 use crate::frame::{
@@ -195,15 +195,18 @@ impl Connection {
     }
 
     // Please ensure keyspace_name is valid before calling this method
-    pub async fn use_keyspace(&self, keyspace_name: &str) -> Result<(), TransportError> {
+    pub async fn use_keyspace(
+        &self,
+        keyspace_name: &VerifiedKeyspaceName,
+    ) -> Result<(), TransportError> {
         // Trying to pass keyspace_name as bound value doesn't work
         // We have to send "USE " + keyspace_name
-        let query: Query = format!("USE \"{}\"", keyspace_name).into();
+        let query: Query = format!("USE \"{}\"", keyspace_name.as_str()).into();
         let query_response = self.query(&query, (), None).await?;
 
         match query_response {
             Response::Result(result::Result::SetKeyspace(set_keyspace)) => {
-                if set_keyspace.keyspace_name != keyspace_name {
+                if set_keyspace.keyspace_name != keyspace_name.as_str() {
                     return Err(TransportError::InternalDriverError(
                         InternalDriverError::UnexpectedResponse,
                     ));
@@ -539,5 +542,57 @@ impl StreamIDSet {
         let block_id = stream_id as usize / 64;
         let off = stream_id as usize % 64;
         self.used_bitmap[block_id] &= !(1 << off);
+    }
+}
+
+/// This type can only hold a valid keyspace name
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VerifiedKeyspaceName(String);
+
+impl VerifiedKeyspaceName {
+    pub fn new(keyspace_name: String) -> Result<Self, BadKeyspaceName> {
+        Self::verify_keyspace_name_is_valid(&keyspace_name)?;
+
+        Ok(VerifiedKeyspaceName(keyspace_name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    // "Keyspace names can have up to 48 alpha-numeric characters and contain underscores;
+    // only letters and numbers are supported as the first character."
+    // https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/cqlCreateKeyspace.html
+    // Despite that cassandra accepts undesrcore as first character so we do too
+    // https://github.com/scylladb/scylla/blob/62551b3bd382c7c47371eb3fc38173bd0cfed44d/test/cql-pytest/test_keyspace.py#L58
+    // https://github.com/scylladb/scylla/blob/fd1dd0eac7a303ceaa9f3ff643c4848506b0c85c/thrift/thrift_validation.cc#L76
+    fn verify_keyspace_name_is_valid(keyspace_name: &str) -> Result<(), BadKeyspaceName> {
+        if keyspace_name.is_empty() {
+            return Err(BadKeyspaceName::Empty);
+        }
+
+        // Verify that length <= 48
+        let keyspace_name_len: usize = keyspace_name.chars().count(); // Only ascii allowed so it's equal to .len()
+        if keyspace_name_len > 48 {
+            return Err(BadKeyspaceName::TooLong(
+                keyspace_name.to_string(),
+                keyspace_name_len,
+            ));
+        }
+
+        // Verify all chars are alpha-numeric or underscore
+        for character in keyspace_name.chars() {
+            match character {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '_' => {}
+                _ => {
+                    return Err(BadKeyspaceName::IllegalCharacter(
+                        keyspace_name.to_string(),
+                        character,
+                    ))
+                }
+            };
+        }
+
+        Ok(())
     }
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -194,7 +194,6 @@ impl Connection {
         self.send_request(&batch_frame, true).await
     }
 
-    // Please ensure keyspace_name is valid before calling this method
     pub async fn use_keyspace(
         &self,
         keyspace_name: &VerifiedKeyspaceName,

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1,6 +1,6 @@
 use crate::frame::value::ValueList;
 use crate::routing::hash3_x64_128;
-use crate::transport::session::Session;
+use crate::transport::session::{IntoTypedRows, Session};
 
 // TODO: Requires a running local Scylla instance
 #[tokio::test]
@@ -289,4 +289,69 @@ async fn test_token_calculation() {
         ) as i64;
         assert_eq!(token, expected_token)
     }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_use_keyspace() {
+    use super::transport_errors::{BadKeyspaceName, TransportError};
+
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session = Session::connect(uri, None).await.unwrap();
+    session.refresh_topology().await.unwrap();
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS use_ks_test WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
+
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS use_ks_test.tab (a text primary key)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    session
+        .query("INSERT INTO use_ks_test.tab (a) VALUES ('test1')", &[])
+        .await
+        .unwrap();
+
+    session.use_keyspace("use_ks_test").await.unwrap();
+
+    session
+        .query("INSERT INTO tab (a) VALUES ('test2')", &[])
+        .await
+        .unwrap();
+
+    let mut rows: Vec<String> = session
+        .query("SELECT * FROM tab", &[])
+        .await
+        .unwrap()
+        .unwrap()
+        .into_typed::<(String,)>()
+        .map(|res| res.unwrap().0)
+        .collect();
+
+    rows.sort();
+
+    assert_eq!(rows, vec!["test1".to_string(), "test2".to_string()]);
+
+    // Test that invalid keyspaces get rejected
+    assert!(matches!(
+        session.use_keyspace("").await,
+        Err(TransportError::BadKeyspaceName(BadKeyspaceName::Empty))
+    ));
+
+    let long_name: String = vec!['a'; 49].iter().collect();
+    assert!(matches!(
+        session.use_keyspace(long_name).await,
+        Err(TransportError::BadKeyspaceName(BadKeyspaceName::TooLong(_, _)))
+    ));
+
+    assert!(matches!(
+        session.use_keyspace("abcd;dfdsf").await,
+        Err(TransportError::BadKeyspaceName(BadKeyspaceName::IllegalCharacter(_, ';')))
+    ));
 }

--- a/scylla/src/transport/transport_errors.rs
+++ b/scylla/src/transport/transport_errors.rs
@@ -65,6 +65,16 @@ pub enum DBError {
     ErrorMsg(i32, String),
 }
 
+#[derive(Debug, Error)]
+pub enum BadKeyspaceName {
+    #[error("Keyspace name is empty")]
+    Empty,
+    #[error("Keyspace name too long, must be up to 48 characters, found {1} characters. Bad keyspace name: '{0}'")]
+    TooLong(String, usize),
+    #[error("Illegal character found: '{1}', only alpha-numeric and underscores allowed. Bad keyspace name: '{0}'")]
+    IllegalCharacter(String, char),
+}
+
 #[derive(Error, Debug)]
 pub enum TransportError {
     #[error("Task queue closed")]
@@ -107,4 +117,6 @@ pub enum TransportError {
     SerializeValuesError(#[from] SerializeValuesError),
     #[error(transparent)]
     PartitionKeyError(#[from] PartitionKeyError),
+    #[error(transparent)]
+    BadKeyspaceName(#[from] BadKeyspaceName),
 }


### PR DESCRIPTION
Fixes #109 

We can now perform `"USE <keyspace name>"` in session like this:
```rust
session.use_keyspace("ks").await ?;
```
This is propagated to all active and future connections.

Session gets a new field:
```rust
struct Session {
    current_keyspace: AsyncRwLock<Option<String>>,
    // ...
}
```
While this lock is locked current keyspace can't change so all operations adding new connections should lock it when manipulating `pool`.

`pick_connection` is a bit complex but I don't see any easy way to fix it and it will probably get rewritten soon when #118 gets implemented.