### PR TITLE
Add SCYLLA_URI parameter to session tests

### DIFF
--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -6,7 +6,8 @@ use crate::transport::session::Session;
 #[tokio::test]
 #[ignore]
 async fn test_unprepared_statement() {
-    let session = Session::connect("127.0.0.1:9042", None).await.unwrap();
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = Session::connect(uri, None).await.unwrap();
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session
@@ -64,7 +65,8 @@ async fn test_unprepared_statement() {
 #[tokio::test]
 #[ignore]
 async fn test_prepared_statement() {
-    let session = Session::connect("127.0.0.1:9042", None).await.unwrap();
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = Session::connect(uri, None).await.unwrap();
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session
@@ -179,7 +181,8 @@ async fn test_prepared_statement() {
 #[tokio::test]
 #[ignore]
 async fn test_batch() {
-    let session = Session::connect("127.0.0.1:9042", None).await.unwrap();
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = Session::connect(uri, None).await.unwrap();
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session
@@ -243,7 +246,8 @@ async fn test_batch() {
 #[tokio::test]
 #[ignore]
 async fn test_token_calculation() {
-    let session = Session::connect("127.0.0.1:9042", None).await.unwrap();
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = Session::connect(uri, None).await.unwrap();
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session


### PR DESCRIPTION
Currently all tests in `session_test.rs` connect to `127.0.0.1:9042`

This PR adds an option to specify a different uri using an environment variable, like in the examples.
Tests can then be run like this:
```bash
SCYLLA_URI=172.17.0.3:9042 cargo test -- --ignored
```