### PR TITLE
Add more checks to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
-      run: cargo clippy --verbose -- -D warnings
+      run: cargo clippy --verbose --examples --tests -- -D warnings
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --examples
     - name: Run tests
       run: cargo test --verbose

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,7 +6,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -6,7 +6,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 
@@ -36,8 +36,7 @@ async fn main() -> Result<()> {
             .query(format!("SELECT token(pk) FROM ks.t where pk = {}", pk), &[])
             .await?
             .unwrap()
-            .iter()
-            .next()
+            .get(0)
             .expect("token query no rows!")
             .columns[0]
             .as_ref()

--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -7,7 +7,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 

--- a/examples/parallel-prepared.rs
+++ b/examples/parallel-prepared.rs
@@ -7,7 +7,7 @@ use tokio::sync::Semaphore;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -7,7 +7,7 @@ use tokio::sync::Semaphore;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -5,7 +5,7 @@ use tokio::stream::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -6,7 +6,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let uri = env::var("SCYLLA_URI").unwrap_or("127.0.0.1:9042".to_string());
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -402,7 +402,7 @@ fn type_consistency() {
     let c2 = read_consistency(&mut &*buf).unwrap();
     assert_eq!(c, c2);
 
-    let c = 0x1234 as i16;
+    let c: i16 = 0x1234;
     buf.clear();
     buf.put_i16(c);
     let c_result = read_consistency(&mut &*buf);

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -261,8 +261,8 @@ impl Connection {
         let _ = futures::try_join!(r, w);
     }
 
-    async fn reader<'a>(
-        mut read_half: tcp::ReadHalf<'a>,
+    async fn reader(
+        mut read_half: tcp::ReadHalf<'_>,
         handler_map: &StdMutex<ResponseHandlerMap>,
     ) -> Result<(), TransportError> {
         loop {
@@ -306,8 +306,8 @@ impl Connection {
         }
     }
 
-    async fn writer<'a>(
-        mut write_half: tcp::WriteHalf<'a>,
+    async fn writer(
+        mut write_half: tcp::WriteHalf<'_>,
         handler_map: &StdMutex<ResponseHandlerMap>,
         mut task_receiver: mpsc::Receiver<Task>,
     ) -> Result<(), TransportError> {
@@ -329,9 +329,11 @@ impl Connection {
                 }
             };
 
-            let mut params = FrameParams::default();
-            params.stream = stream_id;
-            params.flags = task.request_flags;
+            let params = frame::FrameParams {
+                stream: stream_id,
+                flags: task.request_flags,
+                ..Default::default()
+            };
 
             frame::write_request_frame(
                 &mut write_half,

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -183,12 +183,12 @@ async fn test_batch() {
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session
-        .query("DROP TABLE IF EXISTS ks.t;", &[])
+        .query("DROP TABLE IF EXISTS ks.t_batch;", &[])
         .await
         .unwrap();
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS ks.t_batch (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await
@@ -198,7 +198,7 @@ async fn test_batch() {
     std::thread::sleep(std::time::Duration::from_millis(300));
 
     let prepared_statement = session
-        .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)")
+        .prepare("INSERT INTO ks.t_batch (a, b, c) VALUES (?, ?, ?)")
         .await
         .unwrap();
 
@@ -206,8 +206,8 @@ async fn test_batch() {
     // to avoid problem of statements/values count mismatch
     use crate::batch::Batch;
     let mut batch: Batch = Default::default();
-    batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)");
-    batch.append_statement("INSERT INTO ks.t (a, b, c) VALUES (7, 11, '')");
+    batch.append_statement("INSERT INTO ks.t_batch (a, b, c) VALUES (?, ?, ?)");
+    batch.append_statement("INSERT INTO ks.t_batch (a, b, c) VALUES (7, 11, '')");
     batch.append_statement(prepared_statement);
 
     let values = ((1_i32, 2_i32, "abc"), (), (1_i32, 4_i32, "hello"));
@@ -215,7 +215,7 @@ async fn test_batch() {
     session.batch(&batch, values).await.unwrap();
 
     let rs = session
-        .query("SELECT a, b, c FROM ks.t", &[])
+        .query("SELECT a, b, c FROM ks.t_batch", &[])
         .await
         .unwrap()
         .unwrap();


### PR DESCRIPTION
* Add `--examples` and `--tests` flags to `cargo clippy` to make it check examples and tests
* Add `--examples` to `cargo build` to also build examples

Before these changes it was possible to submit an example that doesn't compile and CI would pass