### PR TITLE
Load balancing (Issue #121, #122, #123, #124)

### DIFF
--- a/scylla/src/transport/load_balancing.rs
+++ b/scylla/src/transport/load_balancing.rs
@@ -10,14 +10,15 @@ use std::{
     },
 };
 
-const ORDER_TYPE: Ordering = Ordering::Relaxed;
-
+/// Represents info about statement that can be used by load balancing policies.
 pub struct Statement {
     pub token: Option<Token>,
     pub keyspace: Option<String>,
 }
 
+/// Policy that decides which nodes to contact for each query
 pub trait LoadBalancingPolicy: Send + Sync {
+    /// It is used for each query to find which nodes to query first
     fn plan<'a>(
         &self,
         statement: &Statement,
@@ -25,26 +26,32 @@ pub trait LoadBalancingPolicy: Send + Sync {
     ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a>;
 }
 
-pub trait InternalLoadBalancingPolicy: LoadBalancingPolicy {
-    fn apply_policy_for_plan(
+/// This trait is used to apply policy to plan made by parent policy.
+///
+/// For example, this enables RoundRobinPolicy to process plan made by TokenAwarePolicy.
+pub trait ChildLoadBalancingPolicy: LoadBalancingPolicy {
+    fn apply_child_policy(
         &self,
         plan: &mut dyn Iterator<Item = Arc<Node>>,
     ) -> Box<dyn Iterator<Item = Arc<Node>>>;
 }
 
-pub struct RoundRobin {
+/// A Round-robin load balancing policy.
+pub struct RoundRobinPolicy {
     index: AtomicUsize,
 }
 
-impl RoundRobin {
+impl RoundRobinPolicy {
     pub fn new() -> Self {
-        RoundRobin {
+        Self {
             index: AtomicUsize::new(0),
         }
     }
 }
 
-impl LoadBalancingPolicy for RoundRobin {
+const ORDER_TYPE: Ordering = Ordering::Relaxed;
+
+impl LoadBalancingPolicy for RoundRobinPolicy {
     fn plan<'a>(
         &self,
         _statement: &Statement,
@@ -52,47 +59,42 @@ impl LoadBalancingPolicy for RoundRobin {
     ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
-        let number_of_nodes = cluster.known_peers.len();
+        let nodes_count = cluster.all_nodes.len();
+        let rotation = compute_rotation(index, nodes_count);
+        let rotated_nodes = slice_rotated_left(&cluster.all_nodes, rotation).cloned();
 
-        let iter = cluster
-            .known_peers
-            .values()
-            .cloned()
-            .cycle()
-            .skip(index % number_of_nodes)
-            .take(number_of_nodes);
-
-        Box::new(iter)
+        Box::new(rotated_nodes)
     }
 }
 
-impl InternalLoadBalancingPolicy for RoundRobin {
-    fn apply_policy_for_plan(
+impl ChildLoadBalancingPolicy for RoundRobinPolicy {
+    fn apply_child_policy(
         &self,
         plan: &mut dyn Iterator<Item = Arc<Node>>,
     ) -> Box<dyn Iterator<Item = Arc<Node>>> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
         // `plan` iterator is not cloneable, because of this we can't
-        // call plan.cycle(), and do a cyclic shift
+        // call iter_rotated_left()
         let mut vec: VecDeque<Arc<Node>> = plan.collect();
-        vec.rotate_right(index % vec.len());
+        vec.rotate_right(compute_rotation(index, vec.len()));
 
         Box::new(vec.into_iter())
     }
 }
 
-pub struct TokenAware {
-    internal_policy: Box<dyn InternalLoadBalancingPolicy>,
+/// A wrapper load balancing policy that adds token awareness to a child policy.
+pub struct TokenAwarePolicy {
+    child_policy: Box<dyn ChildLoadBalancingPolicy>,
 }
 
-impl TokenAware {
-    pub fn new(internal_policy: Box<dyn InternalLoadBalancingPolicy>) -> Self {
-        Self { internal_policy }
+impl TokenAwarePolicy {
+    pub fn new(child_policy: Box<dyn ChildLoadBalancingPolicy>) -> Self {
+        Self { child_policy }
     }
 }
 
-impl LoadBalancingPolicy for TokenAware {
+impl LoadBalancingPolicy for TokenAwarePolicy {
     fn plan<'a>(
         &self,
         statement: &Statement,
@@ -109,10 +111,150 @@ impl LoadBalancingPolicy for TokenAware {
                     .chain(cluster.ring.values().cloned())
                     .take(1);
 
-                self.internal_policy.apply_policy_for_plan(&mut owner)
+                self.child_policy.apply_child_policy(&mut owner)
             }
-            // fallback to internal policy
-            None => Box::new(self.internal_policy.plan(statement, cluster)),
+            // fallback to child policy
+            None => Box::new(self.child_policy.plan(statement, cluster)),
         }
+    }
+}
+
+/// A data-center aware Round-robin load balancing policy.
+pub struct DCAwareRoundRobinPolicy {
+    index: AtomicUsize,
+    local_dc: String,
+}
+
+impl DCAwareRoundRobinPolicy {
+    pub fn new(local_dc: String) -> Self {
+        Self {
+            index: AtomicUsize::new(0),
+            local_dc,
+        }
+    }
+
+    fn is_local_node(node: &Node, local_dc: &String) -> bool {
+        match &node.datacenter {
+            Some(dc) => (dc == local_dc),
+            None => false,
+        }
+    }
+
+    fn retrieve_local_nodes<'a>(&self, cluster: &'a ClusterData) -> &'a Vec<Arc<Node>> {
+        cluster
+            .datacenters
+            .get(&self.local_dc)
+            .unwrap_or(EMPTY_NODE_LIST)
+    }
+
+    fn retrieve_remote_nodes<'a>(
+        &self,
+        cluster: &'a ClusterData,
+    ) -> impl Iterator<Item = Arc<Node>> + Clone + 'a {
+        // local_dc is moved into filter closure so clone is needed
+        let local_dc = self.local_dc.clone();
+
+        cluster
+            .all_nodes
+            .iter()
+            .cloned()
+            .filter(move |node| !DCAwareRoundRobinPolicy::is_local_node(node, &local_dc))
+    }
+}
+
+const EMPTY_NODE_LIST: &Vec<Arc<Node>> = &vec![];
+
+impl LoadBalancingPolicy for DCAwareRoundRobinPolicy {
+    fn plan<'a>(
+        &self,
+        _statement: &Statement,
+        cluster: &'a ClusterData,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+        let index = self.index.fetch_add(1, ORDER_TYPE);
+
+        let local_nodes = self.retrieve_local_nodes(cluster);
+        let local_nodes_rotation = compute_rotation(index, local_nodes.len());
+        let rotated_local_nodes = slice_rotated_left(local_nodes, local_nodes_rotation).cloned();
+
+        let remote_nodes = self.retrieve_remote_nodes(cluster);
+        let remote_nodes_count = cluster.all_nodes.len() - local_nodes.len();
+        let remote_nodes_rotation = compute_rotation(index, remote_nodes_count);
+        let rotated_remote_nodes = iter_rotated_left(remote_nodes, remote_nodes_rotation);
+
+        let plan = rotated_local_nodes.chain(rotated_remote_nodes);
+        Box::new(plan)
+    }
+}
+
+impl ChildLoadBalancingPolicy for DCAwareRoundRobinPolicy {
+    fn apply_child_policy(
+        &self,
+        plan: &mut dyn Iterator<Item = Arc<Node>>,
+    ) -> Box<dyn Iterator<Item = Arc<Node>>> {
+        let index = self.index.fetch_add(1, ORDER_TYPE);
+
+        let (local_nodes, remote_nodes): (Vec<_>, Vec<_>) =
+            plan.partition(|node| DCAwareRoundRobinPolicy::is_local_node(node, &self.local_dc));
+
+        let local_nodes_rotation = compute_rotation(index, local_nodes.len());
+        let rotated_local_nodes = slice_rotated_left(&local_nodes, local_nodes_rotation);
+
+        let remote_nodes_rotation = compute_rotation(index, remote_nodes.len());
+        let rotated_remote_nodes = slice_rotated_left(&remote_nodes, remote_nodes_rotation);
+
+        let plan = rotated_local_nodes
+            .chain(rotated_remote_nodes)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter();
+        Box::new(plan)
+    }
+}
+
+// Does safe modulo
+fn compute_rotation(index: usize, count: usize) -> usize {
+    if count != 0 {
+        index % count
+    } else {
+        0
+    }
+}
+
+// similar to slice::rotate_left, but works on iterators
+fn iter_rotated_left<'a, T>(
+    iter: impl Iterator<Item = T> + Clone + 'a,
+    mid: usize,
+) -> impl Iterator<Item = T> + Clone + 'a {
+    let begin = iter.clone().skip(mid);
+    let end = iter.take(mid);
+    begin.chain(end)
+}
+
+// similar to slice::rotate_left, but it returns an iterator, doesn't mutate input
+fn slice_rotated_left<'a, T>(slice: &'a [T], mid: usize) -> impl Iterator<Item = &T> + 'a {
+    let begin = &slice[mid..];
+    let end = &slice[..mid];
+    begin.iter().chain(end.iter())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slice_rotation() {
+        let a = [1, 2, 3, 4, 5];
+        let a_rotated = slice_rotated_left(&a, 2).cloned().collect::<Vec<i32>>();
+
+        assert_eq!(vec![3, 4, 5, 1, 2], a_rotated);
+    }
+
+    #[test]
+    fn test_iter_rotation() {
+        let a = [1, 2, 3, 4, 5];
+        let a_iter = a.iter().cloned();
+        let a_rotated = iter_rotated_left(a_iter, 2).collect::<Vec<i32>>();
+
+        assert_eq!(vec![3, 4, 5, 1, 2], a_rotated);
     }
 }

--- a/scylla/src/transport/load_balancing.rs
+++ b/scylla/src/transport/load_balancing.rs
@@ -1,0 +1,121 @@
+use super::{cluster::ClusterData, node::Node};
+use crate::routing::Token;
+
+use core::ops::Bound::{Included, Unbounded};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+const ORDER_TYPE: Ordering = Ordering::Relaxed;
+
+pub struct Statement {
+    pub token: Option<Token>,
+    pub keyspace: Option<String>,
+}
+
+pub trait LoadBalancingPolicy: Send + Sync {
+    fn plan<'a>(
+        &self,
+        statement: &Statement,
+        cluster: &'a ClusterData,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a>;
+}
+
+pub trait InternalLoadBalancingPolicy: LoadBalancingPolicy {
+    fn apply_for_plan<'a>(
+        &self,
+        plan: Box<dyn Iterator<Item = Arc<Node>> + 'a>,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a>;
+}
+
+pub struct RoundRobin {
+    index: AtomicUsize,
+}
+
+impl RoundRobin {
+    pub fn new() -> Self {
+        RoundRobin {
+            index: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl LoadBalancingPolicy for RoundRobin {
+    fn plan<'a>(
+        &self,
+        _statement: &Statement,
+        cluster: &'a ClusterData,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+        let index = self.index.fetch_add(1, ORDER_TYPE);
+
+        let number_of_nodes = cluster.known_peers.len();
+
+        let iter = cluster
+            .known_peers
+            .values()
+            .cloned()
+            .cycle()
+            .skip(index % number_of_nodes)
+            .take(number_of_nodes);
+
+        Box::new(iter)
+    }
+}
+
+impl InternalLoadBalancingPolicy for RoundRobin {
+    fn apply_for_plan<'a>(
+        &self,
+        plan: Box<dyn Iterator<Item = Arc<Node>> + 'a>,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+        let index = self.index.fetch_add(1, ORDER_TYPE);
+
+        // `plan` iterator is not cloneable, because of this we can't
+        // simply call plan.cycle()
+        // collecting into vector is a sort of workaround
+        // in future this could be speed up by using smallvec crate
+        let vec: Vec<Arc<Node>> = plan.collect();
+        let number_of_nodes = vec.len();
+
+        let iter = vec
+            .into_iter()
+            .cycle()
+            .skip(index % number_of_nodes)
+            .take(number_of_nodes);
+
+        Box::new(iter)
+    }
+}
+
+pub struct TokenAware {
+    internal_policy: Box<dyn InternalLoadBalancingPolicy>,
+}
+
+impl TokenAware {
+    pub fn new(internal_policy: Box<dyn InternalLoadBalancingPolicy>) -> Self {
+        Self { internal_policy }
+    }
+}
+
+impl LoadBalancingPolicy for TokenAware {
+    fn plan<'a>(
+        &self,
+        statement: &Statement,
+        cluster: &'a ClusterData,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+        match statement.token {
+            Some(token) => {
+                // FIXME add replica calculation
+                let owner = cluster
+                    .ring
+                    .range((Included(token), Unbounded))
+                    .map(|(_token, node)| node.clone())
+                    .take(1)
+                    .chain(cluster.ring.values().cloned())
+                    .take(1);
+
+                self.internal_policy.apply_for_plan(Box::new(owner))
+            }
+            // fallback to internal policy
+            None => Box::new(self.internal_policy.plan(statement, cluster)),
+        }
+    }
+}

--- a/scylla/src/transport/load_balancing.rs
+++ b/scylla/src/transport/load_balancing.rs
@@ -102,7 +102,9 @@ impl LoadBalancingPolicy for TokenAwarePolicy {
     ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
         match statement.token {
             Some(token) => {
-                // FIXME add replica calculation
+                // TODO: we try only the owner of the range (vnode) that the token lies in
+                // we should calculate the *set* of replicas for this token, using the replication strategy
+                // of the table being queried.
                 let mut owner = cluster
                     .ring
                     .range((Included(token), Unbounded))

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -1,6 +1,7 @@
 mod cluster;
 pub mod connection;
 mod connection_keeper;
+pub mod load_balancing;
 mod node;
 pub mod session;
 pub mod session_builder;

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -20,7 +20,7 @@ use crate::transport::{
     cluster::{Cluster, ClusterData},
     connection::{Connection, ConnectionConfig},
     iterator::RowIterator,
-    load_balancing::{LoadBalancingPolicy, RoundRobin, Statement, TokenAware},
+    load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, Statement, TokenAwarePolicy},
     metrics::{Metrics, MetricsView},
     node::Node,
     Compression,
@@ -89,7 +89,7 @@ impl SessionConfig {
             known_nodes: Vec::new(),
             compression: None,
             tcp_nodelay: false,
-            load_balancing: Box::new(TokenAware::new(Box::new(RoundRobin::new()))),
+            load_balancing: Box::new(TokenAwarePolicy::new(Box::new(RoundRobinPolicy::new()))),
         }
     }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -487,7 +487,7 @@ impl Session {
         let cluster_info = self.cluster.get_data();
         let mut plan = self.load_balancer.plan(&statement_info, &cluster_info);
 
-        plan.next().unwrap() // TODO add error handling?
+        plan.next().unwrap() // Plan returned by load balancing policies should never be empty
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -16,32 +16,39 @@ use crate::frame::value::{BatchValues, SerializedValues, ValueList};
 use crate::prepared_statement::{PartitionKeyError, PreparedStatement};
 use crate::query::Query;
 use crate::routing::{murmur3_token, Token};
-use crate::transport::cluster::{Cluster, ClusterData};
-use crate::transport::connection::{Connection, ConnectionConfig};
-use crate::transport::iterator::RowIterator;
-use crate::transport::metrics::{Metrics, MetricsView};
-use crate::transport::node::Node;
-use crate::transport::Compression;
+use crate::transport::{
+    cluster::{Cluster, ClusterData},
+    connection::{Connection, ConnectionConfig},
+    iterator::RowIterator,
+    load_balancing::{LoadBalancingPolicy, RoundRobin, Statement, TokenAware},
+    metrics::{Metrics, MetricsView},
+    node::Node,
+    Compression,
+};
 
 pub struct Session {
     cluster: Cluster,
+    load_balancer: Box<dyn LoadBalancingPolicy>,
 
     metrics: Arc<Metrics>,
 }
 
-/// Configuration options for [`Session`].  
+/// Configuration options for [`Session`].
 /// Can be created manually, but usually it's easier to use
 /// [SessionBuilder](super::session_builder::SessionBuilder)
 pub struct SessionConfig {
-    /// List of database servers known on Session startup.  
-    /// Session will connect to these nodes to retrieve information about other nodes in the cluster.  
-    /// Each node can be represented as a hostname or an IP address.  
+    /// List of database servers known on Session startup.
+    /// Session will connect to these nodes to retrieve information about other nodes in the cluster.
+    /// Each node can be represented as a hostname or an IP address.
     pub known_nodes: Vec<KnownNode>,
 
-    /// Preferred compression algorithm to use on connections.  
-    /// If it's not supported by database server Session will fall back to no compression.  
+    /// Preferred compression algorithm to use on connections.
+    /// If it's not supported by database server Session will fall back to no compression.
     pub compression: Option<Compression>,
     pub tcp_nodelay: bool,
+
+    /// Load balancing policy used by Session
+    pub load_balancing: Box<dyn LoadBalancingPolicy>,
     /*
     These configuration options will be added in the future:
 
@@ -53,7 +60,6 @@ pub struct SessionConfig {
 
     pub tcp_keepalive: bool,
 
-    pub load_balancing: Option<String>,
     pub retry_policy: Option<String>,
 
     pub default_consistency: Option<String>,
@@ -71,6 +77,7 @@ impl SessionConfig {
     /// Creates a [`SessionConfig`] with default configuration
     /// # Default configuration
     /// * Compression: None
+    /// * Load balancing policy: Token-aware Round-robin
     ///
     /// # Example
     /// ```
@@ -82,6 +89,7 @@ impl SessionConfig {
             known_nodes: Vec::new(),
             compression: None,
             tcp_nodelay: false,
+            load_balancing: Box::new(TokenAware::new(Box::new(RoundRobin::new()))),
         }
     }
 
@@ -224,7 +232,11 @@ impl Session {
         let cluster = Cluster::new(&node_addresses, config.get_connection_config()).await?;
         let metrics = Arc::new(Metrics::new());
 
-        Ok(Session { cluster, metrics })
+        Ok(Session {
+            cluster,
+            load_balancer: config.load_balancing,
+            metrics,
+        })
     }
 
     // TODO: Should return an iterator over results
@@ -350,7 +362,22 @@ impl Session {
         let serialized_values = values.serialized()?;
 
         let token = calculate_token(prepared, &serialized_values)?;
-        let connection = self.pick_connection(token).await?;
+
+        let plan = {
+            let statemet_info = Statement {
+                token: Some(token),
+                keyspace: None, // TODO retrieve info about keyspace
+            };
+
+            let cluster_info = self.cluster.get_data();
+            let mut iter = self.load_balancer.plan(&statemet_info, &cluster_info);
+
+            iter.next()
+        };
+
+        let node = plan.unwrap(); // TODO add error handling?
+
+        let connection = node.connection_for_token(token).await?;
         let result = connection
             .execute(prepared, &serialized_values, None)
             .await?;


### PR DESCRIPTION
This pull request adds configurable load balancing.

There are 3 composable policies:
- Round robin (`RoundRobinPolicy`) Fixes #122
- DC aware round robin (`DCAwareRoundRobinPolicy`) Fixes #123
- Token aware (`TokenAwarePolicy`, wraps another policy) Fixes #124

All policies implement trait `LoadBalancingPolicy`. Session constructor accepts optional specification of load balancing policy (by passing `Option<Box<dyn LoadBalancingPolicy>>`). Session's default policy is token aware round robin. Fixes #121

Each policy has a method `plan(statement_info, &cluster)`, which inspects statement info, and returns an iterator designating the order of nodes in a query plan.

In order to support being a child policy, `RoundRobinPolicy` &  `DCAwareRoundRobinPolicy` also implement trait `ChildLoadBalancingPolicy`. Thus, it is possible to have token aware round robin: `Box::new(TokenAwarePolicy::new(Box::new(RoundRobinPolicy::new())))`.