### PR TITLE
Remove needless refresh_topology()

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,7 +11,6 @@ async fn main() -> Result<()> {
     println!("Connecting to {} ...", uri);
 
     let session = Session::connect(uri, None).await?;
-    session.refresh_topology().await?;
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
 

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -11,7 +11,6 @@ async fn main() -> Result<()> {
     println!("Connecting to {} ...", uri);
 
     let session = Session::connect(uri, None).await?;
-    session.refresh_topology().await?;
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
 

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -10,7 +10,6 @@ async fn main() -> Result<()> {
     println!("Connecting to {} ...", uri);
 
     let session = Session::connect(uri, None).await?;
-    session.refresh_topology().await?;
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
 

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -11,7 +11,6 @@ async fn main() -> Result<()> {
     println!("Connecting to {} ...", uri);
 
     let session = Session::connect(uri, None).await?;
-    session.refresh_topology().await?;
 
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
 


### PR DESCRIPTION
`Session::connect()` now does `refresh_topology()` on startup so we call it twice in examples, which is not needed.