### PR TITLE
Upgrade Tokio in examples so that they compile and run

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,7 +24,7 @@ name = "parallel"
 path = "parallel.rs"
 
 [[example]]
-name = "parallel-prep"
+name = "parallel-prepared"
 path = "parallel-prepared.rs"
 
 [[example]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
-name = "examples"
-version = "0.0.0"
-publish = false
 edition = "2018"
+name = "examples"
+publish = false
+version = "0.0.0"
 
 [dev-dependencies]
 anyhow = "1.0.33"
-scylla = { path = "../scylla" }
-tokio = { version = "0.3.0", features = ["full"] }
+futures = "0.3.6"
 rustyline = "6.3.0"
+scylla = {path = "../scylla"}
+tokio = {version = "1.1.0", features = ["full"]}
 
 [[example]]
 name = "basic"

--- a/examples/parallel-prepared.rs
+++ b/examples/parallel-prepared.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
 
     // Wait for all in-flight requests to finish
     for _ in 0..parallelism {
-        sem.acquire().await.forget();
+        sem.acquire().await.unwrap().forget();
     }
 
     println!("Ok.");

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
 
     // Wait for all in-flight requests to finish
     for _ in 0..parallelism {
-        sem.acquire().await.forget();
+        sem.acquire().await.unwrap().forget();
     }
 
     println!("Ok.");

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
+use futures::stream::StreamExt;
 use scylla::{Session, SessionBuilder};
 use std::env;
-use tokio::stream::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
The examples used a different version of Tokio than the driver itself - this PR upgrades Tokio in examples, too. Additionally, name of one of the examples was changed (parallel-prep -> parallel-prepared).