### PR TITLE
Local control connection should be using rpc_address instead of listen address

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::ErrorKind;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{SocketAddr};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -490,11 +490,11 @@ async fn connect_with_source_port(
 ) -> Result<TcpStream, std::io::Error> {
     if addr.is_ipv4() {
         let socket = TcpSocket::new_v4().unwrap();
-        socket.bind(format!("{}:{}", addr, source_port).parse().unwrap())?;
+        socket.bind(format!("{}:{}", addr.ip(), source_port).parse().unwrap())?;
         Ok(socket.connect(addr).await?)
     } else if addr.is_ipv6() {
         let socket = TcpSocket::new_v6().unwrap();
-        socket.bind(format!("[{}]:{}", addr, source_port).parse().unwrap())?;
+        socket.bind(format!("[{}]:{}", addr.ip(), source_port).parse().unwrap())?;
         Ok(socket.connect(addr).await?)
     } else {
         Err(std::io::Error::new(ErrorKind::Other, "invalid ip address").into())

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -488,16 +488,17 @@ async fn connect_with_source_port(
     addr: SocketAddr,
     source_port: u16,
 ) -> Result<TcpStream, std::io::Error> {
-    if addr.is_ipv4() {
-        let socket = TcpSocket::new_v4().unwrap();
-        socket.bind(format!("{}:{}", addr.ip(), source_port).parse().unwrap())?;
-        Ok(socket.connect(addr).await?)
-    } else if addr.is_ipv6() {
-        let socket = TcpSocket::new_v6().unwrap();
-        socket.bind(format!("[{}]:{}", addr.ip(), source_port).parse().unwrap())?;
-        Ok(socket.connect(addr).await?)
-    } else {
-        Err(std::io::Error::new(ErrorKind::Other, "invalid ip address"))
+    match addr {
+        SocketAddr::V4(_) => {
+            let socket = TcpSocket::new_v4()?;
+            socket.bind(format!("0.0.0.0:{}", source_port).parse().unwrap())?;
+            Ok(socket.connect(addr).await?)
+        }
+        SocketAddr::V6(_) => {
+            let socket = TcpSocket::new_v6()?;
+            socket.bind(format!("[::/0]:{}", source_port).parse().unwrap())?;
+            Ok(socket.connect(addr).await?)
+        }
     }
 }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::{
     cmp::Ordering,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{Ipv4Addr, Ipv6Addr},
 };
 
 use super::errors::{BadQuery, QueryError};

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -497,7 +497,7 @@ async fn connect_with_source_port(
         socket.bind(format!("[{}]:{}", addr.ip(), source_port).parse().unwrap())?;
         Ok(socket.connect(addr).await?)
     } else {
-        Err(std::io::Error::new(ErrorKind::Other, "invalid ip address").into())
+        Err(std::io::Error::new(ErrorKind::Other, "invalid ip address"))
     }
 }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -3,13 +3,16 @@ use futures::{future::RemoteHandle, FutureExt};
 use tokio::net::{tcp, TcpSocket, TcpStream};
 use tokio::sync::{mpsc, oneshot};
 
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::{
+    cmp::Ordering,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
 
 use super::errors::{BadQuery, QueryError};
 
@@ -491,12 +494,18 @@ async fn connect_with_source_port(
     match addr {
         SocketAddr::V4(_) => {
             let socket = TcpSocket::new_v4()?;
-            socket.bind(format!("0.0.0.0:{}", source_port).parse().unwrap())?;
+            socket.bind(SocketAddr::new(
+                Ipv4Addr::new(0, 0, 0, 0).into(),
+                source_port,
+            ))?;
             Ok(socket.connect(addr).await?)
         }
         SocketAddr::V6(_) => {
             let socket = TcpSocket::new_v6()?;
-            socket.bind(format!("[::/0]:{}", source_port).parse().unwrap())?;
+            socket.bind(SocketAddr::new(
+                Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).into(),
+                source_port,
+            ))?;
             Ok(socket.connect(addr).await?)
         }
     }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::ErrorKind;
-use std::net::{SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 


### PR DESCRIPTION
DataStax (nodejs driver) claims that you shouldn't use system.local's rpc_address unless the client specifies SNI in the options. For now I have omitted that and will use rpc_address which is meant for clients to receive. DataStax defaults to using the initial connections address for the control connection (Which we could expose from conn) but I've left a comment explaining for now.

Also cleaned up parsing of ipv6 in the connection with port function.