### PR TITLE
Query Builder 2.0

### DIFF
--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -63,3 +63,31 @@ impl<'a> From<&'a str> for Query {
         Query::new(s.to_owned())
     }
 }
+
+#[derive(Clone)]
+pub struct QueryBuilder(pub Query);
+
+impl QueryBuilder {
+    pub fn new(text: impl Into<String>) -> QueryBuilder {
+        QueryBuilder(Query::new(text.into()))
+    }
+
+    pub fn disable_paging(mut self) -> Self {
+        self.0.disable_paging();
+        self
+    }
+
+    pub fn page_size(mut self, page_size: i32) -> Self {
+        self.0.set_page_size(page_size);
+        self
+    }
+
+    pub fn consistency(mut self, consistency: Consistency) -> Self {
+        self.0.set_consistency(consistency);
+        self
+    }
+
+    pub fn build(self) -> Query {
+        self.0
+    }
+}

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -106,3 +106,37 @@ impl QueryBuilder {
         self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Query, QueryBuilder};
+    use crate::frame::types::Consistency;
+
+    #[test]
+    fn default_query_builder() {
+        let query: Query = QueryBuilder::new("query text").build();
+
+        assert_eq!(query.contents, "query text".to_string());
+        assert_eq!(query.page_size, None);
+        assert_eq!(query.consistency, Consistency::Quorum);
+    }
+
+    #[test]
+    fn query_builder_all_options() {
+        let query: Query = QueryBuilder::new("other query text")
+            .disable_paging()
+            .page_size(128)
+            .consistency(Consistency::LocalQuorum)
+            .build();
+
+        assert_eq!(query.contents, "other query text".to_string());
+        assert_eq!(query.page_size, Some(128));
+        assert_eq!(query.consistency, Consistency::LocalQuorum);
+    }
+
+    #[test]
+    #[should_panic]
+    fn query_builder_invalid_page_size() {
+        QueryBuilder::new("bad page size").page_size(-16);
+    }
+}

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -64,29 +64,44 @@ impl<'a> From<&'a str> for Query {
     }
 }
 
+/// `QueryBuilder` makes creating a [`Query`] convenient
+///
+/// # Example:
+/// ```rust
+/// # use scylla::query::{Query, QueryBuilder};
+/// # use scylla::frame::types::Consistency;
+/// let query: Query = QueryBuilder::new("SELECT * FROM keyspace.table")
+///     .consistency(Consistency::One)
+///     .build();
+/// ```
 #[derive(Clone)]
 pub struct QueryBuilder(pub Query);
 
 impl QueryBuilder {
+    /// Creates new QueryBuilder for a [`Query`] with given query text
     pub fn new(text: impl Into<String>) -> QueryBuilder {
         QueryBuilder(Query::new(text.into()))
     }
 
+    /// Disables paging for this CQL query.
     pub fn disable_paging(mut self) -> Self {
         self.0.disable_paging();
         self
     }
 
+    /// Sets the page size for this CQL query
     pub fn page_size(mut self, page_size: i32) -> Self {
         self.0.set_page_size(page_size);
         self
     }
 
+    /// Sets the consistency to be used when executing this query.
     pub fn consistency(mut self, consistency: Consistency) -> Self {
         self.0.set_consistency(consistency);
         self
     }
 
+    /// Builds the result Query, turns `QueryBuilder` into `Query`
     pub fn build(self) -> Query {
         self.0
     }


### PR DESCRIPTION
## Description
Old PR for `QueryBuilder` (#71) is dead, this is the new one.

It adds a `QueryBuilder` that makes creating `Query` convenient.
It can be used like this:
```rust
let query: Query = QueryBuilder::new("SELECT * FROM keyspace.table")
    .page_size(128)
    .consistency(Consistency::LocalQuorum)
    .build();
```

### Other possible features
I was thinking about other features, but I'm not sure if they are really needed.
We could allow running a query from `QueryBuilder` like this:
```rust
QueryBuilder::new("SELECT * FROM keyspace.table")
   .page_size(128)
   .consistency(Consistency::LocalQuorum)
   .run(&session, (1, "abc"))
   .await?;
```
And maybe preparing them too?
```rust
QueryBuilder::new("SELECT * FROM keyspace.table")
   .page_size(128)
   .consistency(Consistency::LocalQuorum)
   .prepare(&session, (1, "abc"))
   .await?;
````
Pros:
* Shorter code

Cons:
* Cyclic dependency `Query` <-> `Session`
* Two ways to do the same thing
* More complicated code

### Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.