### PR TITLE
Support USE statement

### DIFF
--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -12,7 +12,7 @@ use std::{
 
 #[derive(Debug)]
 pub struct SetKeyspace {
-    // TODO
+    pub keyspace_name: String,
 }
 
 #[derive(Debug)]
@@ -479,9 +479,10 @@ fn deser_rows(buf: &mut &[u8]) -> StdResult<Rows, ParseError> {
     })
 }
 
-#[allow(clippy::unnecessary_wraps)]
-fn deser_set_keyspace(_buf: &mut &[u8]) -> StdResult<SetKeyspace, ParseError> {
-    Ok(SetKeyspace {}) // TODO
+fn deser_set_keyspace(buf: &mut &[u8]) -> StdResult<SetKeyspace, ParseError> {
+    let keyspace_name = types::read_string(buf)?.to_string();
+
+    Ok(SetKeyspace { keyspace_name })
 }
 
 fn deser_prepared(buf: &mut &[u8]) -> StdResult<Prepared, ParseError> {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -596,13 +596,13 @@ impl StreamIDSet {
 
 /// This type can only hold a valid keyspace name
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct VerifiedKeyspaceName(String);
+pub struct VerifiedKeyspaceName(Arc<String>);
 
 impl VerifiedKeyspaceName {
     pub fn new(keyspace_name: String) -> Result<Self, BadKeyspaceName> {
         Self::verify_keyspace_name_is_valid(&keyspace_name)?;
 
-        Ok(VerifiedKeyspaceName(keyspace_name))
+        Ok(VerifiedKeyspaceName(Arc::new(keyspace_name)))
     }
 
     pub fn as_str(&self) -> &str {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -14,7 +14,7 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr},
 };
 
-use super::errors::{BadQuery, QueryError};
+use super::errors::{BadKeyspaceName, BadQuery, QueryError};
 
 use crate::batch::{Batch, BatchStatement};
 use crate::frame::{
@@ -217,6 +217,32 @@ impl Connection {
         };
 
         self.send_request(&batch_frame, true).await
+    }
+
+    pub async fn use_keyspace(
+        &self,
+        keyspace_name: &VerifiedKeyspaceName,
+    ) -> Result<(), QueryError> {
+        // Trying to pass keyspace_name as bound value doesn't work
+        // We have to send "USE " + keyspace_name
+        let query: Query = format!("USE \"{}\"", keyspace_name.as_str()).into();
+        let query_response = self.query(&query, (), None).await?;
+
+        match query_response {
+            Response::Result(result::Result::SetKeyspace(set_keyspace)) => {
+                if set_keyspace.keyspace_name != keyspace_name.as_str() {
+                    return Err(QueryError::ProtocolError(
+                        "USE <keyspace_name> returned response with different keyspace name",
+                    ));
+                }
+
+                Ok(())
+            }
+            Response::Error(err) => Err(err.into()),
+            _ => Err(QueryError::ProtocolError(
+                "USE <keyspace_name> returned unexpected response",
+            )),
+        }
     }
 
     // TODO: Return the response associated with that frame
@@ -565,5 +591,57 @@ impl StreamIDSet {
         let block_id = stream_id as usize / 64;
         let off = stream_id as usize % 64;
         self.used_bitmap[block_id] &= !(1 << off);
+    }
+}
+
+/// This type can only hold a valid keyspace name
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VerifiedKeyspaceName(String);
+
+impl VerifiedKeyspaceName {
+    pub fn new(keyspace_name: String) -> Result<Self, BadKeyspaceName> {
+        Self::verify_keyspace_name_is_valid(&keyspace_name)?;
+
+        Ok(VerifiedKeyspaceName(keyspace_name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    // "Keyspace names can have up to 48 alpha-numeric characters and contain underscores;
+    // only letters and numbers are supported as the first character."
+    // https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/cqlCreateKeyspace.html
+    // Despite that cassandra accepts underscore as first character so we do too
+    // https://github.com/scylladb/scylla/blob/62551b3bd382c7c47371eb3fc38173bd0cfed44d/test/cql-pytest/test_keyspace.py#L58
+    // https://github.com/scylladb/scylla/blob/718976e794790253c4b24e2c78208e11f24e7502/cql3/statements/create_keyspace_statement.cc#L75
+    fn verify_keyspace_name_is_valid(keyspace_name: &str) -> Result<(), BadKeyspaceName> {
+        if keyspace_name.is_empty() {
+            return Err(BadKeyspaceName::Empty);
+        }
+
+        // Verify that length <= 48
+        let keyspace_name_len: usize = keyspace_name.chars().count(); // Only ascii allowed so it's equal to .len()
+        if keyspace_name_len > 48 {
+            return Err(BadKeyspaceName::TooLong(
+                keyspace_name.to_string(),
+                keyspace_name_len,
+            ));
+        }
+
+        // Verify all chars are alpha-numeric or underscore
+        for character in keyspace_name.chars() {
+            match character {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '_' => {}
+                _ => {
+                    return Err(BadKeyspaceName::IllegalCharacter(
+                        keyspace_name.to_string(),
+                        character,
+                    ))
+                }
+            };
+        }
+
+        Ok(())
     }
 }

--- a/scylla/src/transport/connection_keeper.rs
+++ b/scylla/src/transport/connection_keeper.rs
@@ -3,7 +3,7 @@ use crate::routing::ShardInfo;
 use crate::transport::errors::QueryError;
 use crate::transport::{
     connection,
-    connection::{Connection, ConnectionConfig},
+    connection::{Connection, ConnectionConfig, VerifiedKeyspaceName},
 };
 
 use futures::{future::RemoteHandle, FutureExt};
@@ -104,6 +104,19 @@ impl ConnectionKeeper {
             ConnectionState::Broken(e) => Err(e),
             _ => unreachable!(),
         }
+    }
+
+    pub async fn use_keyspace(
+        &self,
+        keyspace_name: &VerifiedKeyspaceName,
+    ) -> Result<(), QueryError> {
+        // ConnectionKeeper doesn't have reconnecting yet so this will be ok for now
+        // TODO: Modify once ConnectionKeeper gets reconnecting
+
+        self.get_connection()
+            .await?
+            .use_keyspace(keyspace_name)
+            .await
     }
 }
 

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -63,6 +63,10 @@ pub enum NewSessionError {
     #[error("Empty known nodes list")]
     EmptyKnownNodesList,
 
+    /// Passed invalid keyspace name to use
+    #[error(transparent)]
+    BadKeyspaceName(#[from] BadKeyspaceName),
+
     /// Database sent a response containing some error
     #[error(transparent)]
     DBError(#[from] DBError),
@@ -81,7 +85,7 @@ pub enum NewSessionError {
 }
 
 /// Invalid keyspace name given to `Session::use_keyspace()`
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum BadKeyspaceName {
     /// Keyspace name is empty
     #[error("Keyspace name is empty")]
@@ -153,6 +157,17 @@ impl From<QueryError> for NewSessionError {
             QueryError::BadQuery(e) => NewSessionError::BadQuery(e),
             QueryError::IOError(e) => NewSessionError::IOError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
+        }
+    }
+}
+
+impl From<UseKeyspaceError> for NewSessionError {
+    fn from(use_ks_error: UseKeyspaceError) -> NewSessionError {
+        match use_ks_error {
+            UseKeyspaceError::BadKeyspaceName(e) => NewSessionError::BadKeyspaceName(e),
+            UseKeyspaceError::DBError(e) => NewSessionError::DBError(e),
+            UseKeyspaceError::IOError(e) => NewSessionError::IOError(e),
+            UseKeyspaceError::ProtocolError(e) => NewSessionError::ProtocolError(e),
         }
     }
 }

--- a/scylla/src/transport/load_balancing.rs
+++ b/scylla/src/transport/load_balancing.rs
@@ -295,6 +295,7 @@ mod tests {
             },
             datacenter,
             None,
+            None,
         );
 
         Arc::new(node)

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -1,14 +1,15 @@
 /// Node represents a cluster node along with it's data and connections
 use crate::routing::{Shard, ShardInfo, Token};
+use crate::transport::connection::VerifiedKeyspaceName;
 use crate::transport::connection::{Connection, ConnectionConfig};
 use crate::transport::connection_keeper::{ConnectionKeeper, ShardInfoSender};
 use crate::transport::errors::QueryError;
+use futures::future::join_all;
 
 use futures::{future::RemoteHandle, FutureExt};
 use rand::Rng;
 use std::net::SocketAddr;
-use std::sync::Arc;
-use tokio::sync::RwLock as AsyncRwLock;
+use std::sync::{Arc, RwLock};
 
 /// Node represents a cluster node along with it's data and connections
 pub struct Node {
@@ -16,7 +17,9 @@ pub struct Node {
     pub datacenter: Option<String>,
     pub rack: Option<String>,
 
-    pub connections: Arc<AsyncRwLock<NodeConnections>>,
+    pub connections: Arc<RwLock<Arc<NodeConnections>>>,
+
+    use_keyspace_channel: tokio::sync::mpsc::Sender<UseKeyspaceRequest>,
 
     _worker_handle: RemoteHandle<()>,
 }
@@ -34,12 +37,21 @@ pub enum NodeConnections {
 
 // Works in the background to detect ShardInfo changes and keep node connections updated
 struct NodeWorker {
-    node_conns: Arc<AsyncRwLock<NodeConnections>>,
+    node_conns: Arc<RwLock<Arc<NodeConnections>>>,
     node_addr: SocketAddr,
     connection_config: ConnectionConfig,
 
     shard_info_sender: ShardInfoSender,
     shard_info_receiver: tokio::sync::watch::Receiver<Option<ShardInfo>>,
+
+    // Channel used to receive use keyspace requests
+    use_keyspace_channel: tokio::sync::mpsc::Receiver<UseKeyspaceRequest>,
+}
+
+#[derive(Debug)]
+struct UseKeyspaceRequest {
+    keyspace_name: VerifiedKeyspaceName,
+    response_chan: tokio::sync::oneshot::Sender<Result<(), QueryError>>,
 }
 
 impl Node {
@@ -60,14 +72,16 @@ impl Node {
 
         let shard_info_sender = Arc::new(std::sync::Mutex::new(shard_info_sender));
 
-        let connections = Arc::new(AsyncRwLock::new(NodeConnections::Single(
+        let (use_keyspace_sender, use_keyspace_receiver) = tokio::sync::mpsc::channel(32);
+
+        let connections = Arc::new(RwLock::new(Arc::new(NodeConnections::Single(
             ConnectionKeeper::new(
                 address,
                 connection_config.clone(),
                 None,
                 Some(shard_info_sender.clone()),
             ),
-        )));
+        ))));
 
         let worker = NodeWorker {
             node_conns: connections.clone(),
@@ -75,6 +89,7 @@ impl Node {
             connection_config,
             shard_info_sender,
             shard_info_receiver,
+            use_keyspace_channel: use_keyspace_receiver,
         };
 
         let (fut, worker_handle) = worker.work().remote_handle();
@@ -85,15 +100,16 @@ impl Node {
             datacenter,
             rack,
             connections,
+            use_keyspace_channel: use_keyspace_sender,
             _worker_handle: worker_handle,
         }
     }
 
     /// Get connection which should be used to connect using given token
     pub async fn connection_for_token(&self, token: Token) -> Result<Arc<Connection>, QueryError> {
-        let connections = &*self.connections.read().await;
+        let connections: Arc<NodeConnections> = self.connections.read().unwrap().clone();
 
-        match connections {
+        match &*connections {
             NodeConnections::Single(conn_keeper) => conn_keeper.get_connection().await,
             NodeConnections::Sharded {
                 shard_info,
@@ -109,9 +125,9 @@ impl Node {
 
     /// Get random connection
     pub async fn random_connection(&self) -> Result<Arc<Connection>, QueryError> {
-        let connections = &*self.connections.read().await;
+        let connections: Arc<NodeConnections> = self.connections.read().unwrap().clone();
 
-        match connections {
+        match &*connections {
             NodeConnections::Single(conn_keeper) => conn_keeper.get_connection().await,
             NodeConnections::Sharded {
                 shard_info,
@@ -123,6 +139,24 @@ impl Node {
             }
         }
     }
+
+    pub async fn use_keyspace(
+        &self,
+        keyspace_name: VerifiedKeyspaceName,
+    ) -> Result<(), QueryError> {
+        let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
+
+        self.use_keyspace_channel
+            .send(UseKeyspaceRequest {
+                keyspace_name,
+                response_chan: response_sender,
+            })
+            .await
+            .expect("Bug in Node::use_keyspace sending");
+        // Other end of this channel is in NodeWorker, can't be dropped while we have &self to Node with _worker_handle
+
+        response_receiver.await.unwrap() // NodeWorker always responds
+    }
 }
 
 impl NodeWorker {
@@ -130,12 +164,28 @@ impl NodeWorker {
         let mut cur_shard_info: Option<ShardInfo> = self.shard_info_receiver.borrow().clone();
 
         loop {
-            // Wait for current shard_info to change
-            // We own one sending end of this channel so it can't return None
-            self.shard_info_receiver
-                .changed()
-                .await
-                .expect("Bug in NodeWorker::work");
+            tokio::select! {
+                // Wait for current shard_info to change
+                changed_res = self.shard_info_receiver.changed() => {
+                    // We own one sending end of this channel so it can't return None
+                    changed_res.expect("Bug in NodeWorker::work")
+                    // Then go to resharding update
+                },
+                // Wait for a use_keyspace request
+                recv_res = self.use_keyspace_channel.recv() => {
+                    match recv_res {
+                        Some(request) => {
+                            let node_conns = self.node_conns.read().unwrap().clone();
+                            let use_keyspace_future = Self::handle_use_keyspace_request(node_conns, request);
+                            tokio::spawn(use_keyspace_future);
+                        },
+                        None => return,
+                    }
+
+                    continue; // Don't go to resharding update, wait for the next event
+                },
+            }
+
             let new_shard_info: Option<ShardInfo> = self.shard_info_receiver.borrow().clone();
 
             // See if the node has resharded
@@ -155,7 +205,7 @@ impl NodeWorker {
             // We received updated node ShardInfo
             // Create new node connections. It will happen rarely so we can probably afford it
             // TODO: Maybe save some connections instead of recreating?
-            let mut new_connections: NodeConnections = match &cur_shard_info {
+            let new_connections: NodeConnections = match &cur_shard_info {
                 None => NodeConnections::Single(ConnectionKeeper::new(
                     self.node_addr,
                     self.connection_config.clone(),
@@ -185,11 +235,72 @@ impl NodeWorker {
                 }
             };
 
+            let mut new_connections_to_swap = Arc::new(new_connections);
+
             // Update node.connections
             // Use std::mem::swap to minimalize time spent holding write lock
-            let mut node_conns_lock = self.node_conns.write().await;
-            std::mem::swap(&mut *node_conns_lock, &mut new_connections);
+            let mut node_conns_lock = self.node_conns.write().unwrap();
+            std::mem::swap(&mut *node_conns_lock, &mut new_connections_to_swap);
             drop(node_conns_lock);
         }
+    }
+
+    async fn handle_use_keyspace_request(
+        node_conns: Arc<NodeConnections>,
+        request: UseKeyspaceRequest,
+    ) {
+        let result = Self::send_use_keyspace(node_conns, &request.keyspace_name).await;
+
+        // Don't care if nobody wants request result
+        let _ = request.response_chan.send(result);
+    }
+
+    async fn send_use_keyspace(
+        node_conns: Arc<NodeConnections>,
+        keyspace_name: &VerifiedKeyspaceName,
+    ) -> Result<(), QueryError> {
+        let mut use_keyspace_futures = Vec::new();
+
+        match &*node_conns {
+            NodeConnections::Single(conn_keeper) => {
+                let fut = conn_keeper.use_keyspace(keyspace_name);
+                use_keyspace_futures.push(fut);
+            }
+            NodeConnections::Sharded { shard_conns, .. } => {
+                for conn_keeper in shard_conns {
+                    let fut = conn_keeper.use_keyspace(keyspace_name);
+                    use_keyspace_futures.push(fut);
+                }
+            }
+        }
+
+        let use_keyspace_results: Vec<Result<(), QueryError>> =
+            join_all(use_keyspace_futures).await;
+
+        // If there was at least one Ok and the rest were IOErrors we can return Ok
+        // keyspace name is correct and will be used on broken connection on the next reconnect
+
+        // If there were only IOErrors then return IOError
+        // If there was an error different than IOError return this error - something is wrong
+
+        let mut was_ok: bool = false;
+        let mut io_error: Option<Arc<std::io::Error>> = None;
+
+        for result in use_keyspace_results {
+            match result {
+                Ok(()) => was_ok = true,
+                Err(err) => match err {
+                    QueryError::IOError(io_err) => io_error = Some(io_err),
+                    _ => return Err(err),
+                },
+            }
+        }
+
+        if was_ok {
+            return Ok(());
+        }
+
+        // We can unwrap io_error because use_keyspace_futures must be nonempty
+        return Err(QueryError::IOError(io_error.unwrap()));
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -476,9 +476,11 @@ impl Session {
         // Trying to pass keyspace as bound value in "USE ?" doesn't work
         // So we have to create a string for query: "USE " + new_keyspace
         // To avoid any possible CQL injections it's good to verify that the name is valid
-        let _verified_ks_name = VerifiedKeyspaceName::new(keyspace_name.into())?;
+        let verified_ks_name = VerifiedKeyspaceName::new(keyspace_name.into())?;
 
-        unimplemented!();
+        self.cluster.use_keyspace(verified_ks_name).await?;
+
+        Ok(())
     }
 
     pub async fn refresh_topology(&self) -> Result<(), QueryError> {

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -155,6 +155,28 @@ impl SessionBuilder {
         self
     }
 
+    /// Set keyspace to be used on all connections.  
+    /// Each connection will send `"USE <keyspace_name>"` before sending any requests.  
+    /// This can be later changed with [`Session::use_keyspace`]
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use scylla::transport::Compression;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .use_keyspace("my_keyspace_name")
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn use_keyspace(mut self, keyspace_name: impl Into<String>) -> Self {
+        self.config.used_keyspace = Some(keyspace_name.into());
+        self
+    }
+
     /// Set the load balancing policy
     /// The default is Token-aware Round-robin.
     ///

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -63,7 +63,7 @@ impl TopologyReader {
         for address in known_peers {
             control_connections.insert(
                 *address,
-                ConnectionKeeper::new(*address, connection_config.clone(), None, None),
+                ConnectionKeeper::new(*address, connection_config.clone(), None, None, None),
             );
         }
 
@@ -111,7 +111,13 @@ impl TopologyReader {
                 .control_connections
                 .remove(&peer.address)
                 .unwrap_or_else(|| {
-                    ConnectionKeeper::new(peer.address, self.connection_config.clone(), None, None)
+                    ConnectionKeeper::new(
+                        peer.address,
+                        self.connection_config.clone(),
+                        None,
+                        None,
+                        None,
+                    )
                 });
 
             new_control_connections.insert(peer.address, cur_connection);


### PR DESCRIPTION
## Description
This PR allows to perform `USE keyspace_name` queries on the database.
Like this:
```rust
session.use_keyspace("my_keyspace").await?;
```
Or during session creation:
```rust
let session: Session = SessionBuilder::new()
    .known_node("127.0.0.1:9042")
    .use_keyspace("use_ks_test")
    .build()
    .await?;
```
## Design
New keyspace to use is being sent using channels to `ClusterWorker` and then to `NodeWorker`.
Those workers do an async `select` on their work and use keyspace requests.
This ensures that no new `Nodes`/`ConnectionKeepers` are created when keyspace is changed.
Each worker keeps `used_keyspace` and later passes it when creating `Nodes`/`ConnectionKeepers`.
I used channels because they were much easier to reason about than mutexes. Mutexes could easily have race conditions when creating new `Nodes`/`ConnectionKeepers`.

`use_keyspace` succeds if at least one node responds with `Ok`.
IO Errors are ignored - If we lost connection then we will perform `use_keyspace` on reconnect later when reconnecting is added.
Any other error causes the whole thing to fail with this error.

I thought about handling `Overloaded` errors but I'm not sure if this is a good idea.
To stay correct we would have to block all requests until the node is not overloaded anymore and then send use_keyspace and unlock all requests.
This seems complicated, I think for now we can just return `Overloaded` errors to the user.

## Fixed issues
Fixes #109

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
