### PR TITLE
Make ConnectionKeeper keep the connection open

### DIFF
--- a/scylla/src/transport/connection_keeper.rs
+++ b/scylla/src/transport/connection_keeper.rs
@@ -3,16 +3,18 @@ use crate::routing::ShardInfo;
 use crate::transport::errors::QueryError;
 use crate::transport::{
     connection,
-    connection::{Connection, ConnectionConfig, ErrorReceiver, VerifiedKeyspaceName},
+    connection::{Connection, ConnectionConfig, VerifiedKeyspaceName},
 };
 
 use futures::{future::RemoteHandle, FutureExt};
+use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 /// ConnectionKeeper keeps a Connection to some address and works to keep it open
 pub struct ConnectionKeeper {
     conn_state_receiver: tokio::sync::watch::Receiver<ConnectionState>,
+    use_keyspace_channel: tokio::sync::mpsc::Sender<UseKeyspaceRequest>,
     _worker_handle: RemoteHandle<()>,
 }
 
@@ -32,11 +34,20 @@ struct ConnectionKeeperWorker {
     shard_info_sender: Option<ShardInfoSender>,
     conn_state_sender: tokio::sync::watch::Sender<ConnectionState>,
 
+    // Channel used to receive use keyspace requests
+    use_keyspace_channel: tokio::sync::mpsc::Receiver<UseKeyspaceRequest>,
+
     // Keyspace send in "USE <keyspace name>" when opening each connection
     used_keyspace: Option<VerifiedKeyspaceName>,
 }
 
 pub type ShardInfoSender = Arc<std::sync::Mutex<tokio::sync::watch::Sender<Option<ShardInfo>>>>;
+
+#[derive(Debug)]
+struct UseKeyspaceRequest {
+    keyspace_name: VerifiedKeyspaceName,
+    response_chan: tokio::sync::oneshot::Sender<Result<(), QueryError>>,
+}
 
 impl ConnectionKeeper {
     /// Creates new ConnectionKeeper that starts a connection in the background
@@ -56,12 +67,15 @@ impl ConnectionKeeper {
         let (conn_state_sender, conn_state_receiver) =
             tokio::sync::watch::channel(ConnectionState::Initializing);
 
+        let (use_keyspace_sender, use_keyspace_receiver) = tokio::sync::mpsc::channel(1);
+
         let worker = ConnectionKeeperWorker {
             address,
             config,
             shard_info,
             shard_info_sender,
             conn_state_sender,
+            use_keyspace_channel: use_keyspace_receiver,
             used_keyspace: keyspace_name,
         };
 
@@ -70,6 +84,7 @@ impl ConnectionKeeper {
 
         ConnectionKeeper {
             conn_state_receiver,
+            use_keyspace_channel: use_keyspace_sender,
             _worker_handle: worker_handle,
         }
     }
@@ -113,60 +128,113 @@ impl ConnectionKeeper {
 
     pub async fn use_keyspace(
         &self,
-        keyspace_name: &VerifiedKeyspaceName,
+        keyspace_name: VerifiedKeyspaceName,
     ) -> Result<(), QueryError> {
-        // ConnectionKeeper doesn't have reconnecting yet so this will be ok for now
-        // TODO: Modify once ConnectionKeeper gets reconnecting
+        let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
 
-        self.get_connection()
-            .await?
-            .use_keyspace(keyspace_name)
+        self.use_keyspace_channel
+            .send(UseKeyspaceRequest {
+                keyspace_name,
+                response_chan: response_sender,
+            })
             .await
+            .expect("Bug in ConnectionKeeper::use_keyspace sending");
+        // Other end of this channel is in the Worker, can't be dropped while we have &self to _worker_handle
+
+        response_receiver.await.unwrap() // ConnectionKeeperWorker always responds
     }
 }
 
 impl ConnectionKeeperWorker {
-    pub async fn work(self) {
-        let connect_result = self.open_new_connection().await;
+    pub async fn work(mut self) {
+        // Reconnect at most every 8 seconds
+        let reconnect_cooldown = tokio::time::Duration::from_secs(8);
+        let mut last_reconnect_time;
 
-        match connect_result {
-            Ok((conn, _error_receiver)) => {
-                let _ = self
-                    .conn_state_sender
-                    .send(ConnectionState::Connected(conn.clone()));
+        loop {
+            last_reconnect_time = tokio::time::Instant::now();
 
-                let new_shard_info: Option<ShardInfo> = conn.get_shard_info().clone();
+            // Connect and wait for error
+            let current_error: QueryError = self.run_connection().await;
 
-                if let Some(sender) = &self.shard_info_sender {
-                    // Ignore sending error
-                    // If no one wants to get shard_info that's OK
-                    // If lock is poisoned do nothing
-                    if let Ok(sender_locked) = sender.lock() {
-                        let _ = sender_locked.send(new_shard_info);
-                    }
-                }
-            }
-            Err(e) => {
-                let _ = self.conn_state_sender.send(ConnectionState::Broken(e));
-            } // TODO: Wait for connection to fail, then create new, loop it
-        };
+            // Mark the connection as broken, wait cooldown and reconnect
+            let _ = self
+                .conn_state_sender
+                .send(ConnectionState::Broken(current_error));
+
+            let next_reconnect_time = last_reconnect_time
+                .checked_add(reconnect_cooldown)
+                .unwrap_or_else(tokio::time::Instant::now);
+
+            tokio::time::sleep_until(next_reconnect_time).await;
+        }
     }
 
-    async fn open_new_connection(&self) -> Result<(Arc<Connection>, ErrorReceiver), QueryError> {
+    // Opens a new connection and waits until some fatal error occurs
+    async fn run_connection(&mut self) -> QueryError {
+        // If shard is specified choose random source port
         let mut source_port: Option<u16> = None;
         if let Some(info) = &self.shard_info {
             source_port = Some(info.draw_source_port_for_shard(info.shard.into()));
         }
 
-        let (new_conn, error_receiver) =
-            connection::open_connection(self.address, source_port, self.config.clone()).await?;
+        // Connect to the node
+        let connect_result =
+            connection::open_connection(self.address, source_port, self.config.clone()).await;
 
+        let (connection, mut error_receiver) = match connect_result {
+            Ok((connection, error_receiver)) => (Arc::new(connection), error_receiver),
+            Err(e) => return e,
+        };
+
+        // Mark connection as Connected
+        let _ = self
+            .conn_state_sender
+            .send(ConnectionState::Connected(connection.clone()));
+
+        // Notify about new shard info
+        if let Some(sender) = &self.shard_info_sender {
+            let new_shard_info: Option<ShardInfo> = connection.get_shard_info().clone();
+
+            // Ignore sending error
+            // If no one wants to get shard_info that's OK
+            // If lock is poisoned do nothing
+            if let Ok(sender_locked) = sender.lock() {
+                let _ = sender_locked.send(new_shard_info);
+            }
+        }
+
+        // Use the specified keyspace
         if let Some(keyspace_name) = &self.used_keyspace {
-            let _ = new_conn.use_keyspace(&keyspace_name).await;
+            let _ = connection.use_keyspace(&keyspace_name).await;
             // Ignore the error, used_keyspace could be set a long time ago and then deleted
             // user gets all errors from session.use_keyspace()
         }
 
-        Ok((Arc::new(new_conn), error_receiver))
+        let connection_closed_error = QueryError::IOError(Arc::new(std::io::Error::new(
+            ErrorKind::Other,
+            "Connection closed",
+        )));
+
+        // Wait for events - a use keyspace request or a fatal error
+        loop {
+            tokio::select! {
+                recv_res = self.use_keyspace_channel.recv() => {
+                    match recv_res {
+                        Some(request) => {
+                            self.used_keyspace = Some(request.keyspace_name.clone());
+
+                            // Send USE KEYSPACE request, send result if channel wasn't closed
+                            let res = connection.use_keyspace(&request.keyspace_name).await;
+                            let _ = request.response_chan.send(res);
+                        },
+                        None => return connection_closed_error,
+                    }
+                },
+                connection_error = &mut error_receiver => {
+                    return connection_error.unwrap_or(connection_closed_error);
+                }
+            }
+        }
     }
 }

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -274,12 +274,12 @@ impl NodeWorker {
 
         match &*node_conns {
             NodeConnections::Single(conn_keeper) => {
-                let fut = conn_keeper.use_keyspace(keyspace_name);
+                let fut = conn_keeper.use_keyspace(keyspace_name.clone());
                 use_keyspace_futures.push(fut);
             }
             NodeConnections::Sharded { shard_conns, .. } => {
                 for conn_keeper in shard_conns {
-                    let fut = conn_keeper.use_keyspace(keyspace_name);
+                    let fut = conn_keeper.use_keyspace(keyspace_name.clone());
                     use_keyspace_futures.push(fut);
                 }
             }


### PR DESCRIPTION
## Description
This PR makes `ConnectionKeeper` detect when the connection breaks and reopen it in a loop.
Reopening is on an 8 second cooldown to not spam the network with reconnects.

Additionally `ConnectionKeeper` is now able to detect that a source port collision has occured and will retry on a different port.
First a random port is chosen, then we add `nr_shards` and wrap around until we check all possible ports (just like piodul described in #149).

## Fixed issues
Fixes: #149 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
