### PR TITLE
session: fix a doc reference

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -345,7 +345,7 @@ impl Session {
     /// Executes a previously prepared statement
     /// # Arguments
     ///
-    /// * `prepared` - a statement prepared with [prepare](crate::transport::session::prepare)
+    /// * `prepared` - a statement prepared with [prepare](crate::transport::session::Session::prepare)
     /// * `values` - values bound to the query
     pub async fn execute(
         &self,


### PR DESCRIPTION
When generating docs, a warning showed that one of the refs
was outdated, so it's hereby updated.

