### PR TITLE
Use connection address instead of rpc_address in system.local

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -32,6 +32,7 @@ use crate::transport::Compression;
 pub struct Connection {
     submit_channel: mpsc::Sender<Task>,
     _worker_handle: RemoteHandle<()>,
+    connect_address: SocketAddr,
     source_port: u16,
     shard_info: Option<ShardInfo>,
     config: ConnectionConfig,
@@ -98,6 +99,7 @@ impl Connection {
             submit_channel: sender,
             _worker_handle,
             source_port,
+            connect_address: addr,
             shard_info: None,
             config,
             is_shard_aware: false,
@@ -408,6 +410,10 @@ impl Connection {
 
     fn set_is_shard_aware(&mut self, is_shard_aware: bool) {
         self.is_shard_aware = is_shard_aware;
+    }
+
+    pub fn get_connect_address(&self) -> SocketAddr {
+        self.connect_address
     }
 }
 


### PR DESCRIPTION
## Description
When fetching topology information from the cluster we used to query `rpc_address` from `system.local` to find local node's address.
This was a mistake - unless SNI is enabled we should just use the existing connection's address.
In #154 it was mentioned that this is what DataStax driver does.

## Fixed issues
Probably #171, but I have a hard time recreating the exact setup in which the bug occured

## Pre-review checklist
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~ I'm not sure how to test this but I looked manually at the address we connect to
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
