### PR TITLE
Remove #[ignore] from keyspace tests

### DIFF
--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -292,7 +292,6 @@ async fn test_token_calculation() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_use_keyspace() {
     let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
     let session = SessionBuilder::new()
@@ -393,7 +392,6 @@ async fn test_use_keyspace() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_use_keyspace_case_sensitivity() {
     let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
     let session = SessionBuilder::new()
@@ -473,7 +471,6 @@ async fn test_use_keyspace_case_sensitivity() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_raw_use_keyspace() {
     let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
     let session = SessionBuilder::new()


### PR DESCRIPTION
I forgot to remove `#[ignore]` from keyspace tests in the original PR.
They should be removed because we now run all tests in CI.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
