### PR TITLE
Retry Policy

### DIFF
--- a/scylla/src/frame/response/error.rs
+++ b/scylla/src/frame/response/error.rs
@@ -1,10 +1,11 @@
 use crate::frame::frame_errors::ParseError;
 use crate::frame::types;
-use crate::transport::errors::{DBError, QueryError};
+use crate::transport::errors::{DBError, QueryError, WriteType};
+use byteorder::ReadBytesExt;
 
 #[derive(Debug)]
 pub struct Error {
-    pub code: i32,
+    pub error: DBError,
     pub reason: String,
 }
 
@@ -13,12 +14,301 @@ impl Error {
         let code = types::read_int(buf)?;
         let reason = types::read_string(buf)?.to_owned();
 
-        Ok(Error { code, reason })
+        let error: DBError = match code {
+            0x0000 => DBError::ServerError,
+            0x000A => DBError::ProtocolError,
+            0x0100 => DBError::AuthenticationError,
+            0x1000 => DBError::Unavailable {
+                consistency: types::read_consistency(buf)?,
+                required: types::read_int(buf)?,
+                alive: types::read_int(buf)?,
+            },
+            0x1001 => DBError::Overloaded,
+            0x1002 => DBError::IsBootstrapping,
+            0x1003 => DBError::TruncateError,
+            0x1100 => DBError::WriteTimeout {
+                consistency: types::read_consistency(buf)?,
+                received: types::read_int(buf)?,
+                required: types::read_int(buf)?,
+                write_type: WriteType::from(types::read_string(buf)?),
+            },
+            0x1200 => DBError::ReadTimeout {
+                consistency: types::read_consistency(buf)?,
+                received: types::read_int(buf)?,
+                required: types::read_int(buf)?,
+                data_present: buf.read_u8()? != 0,
+            },
+            0x1300 => DBError::ReadFailure {
+                consistency: types::read_consistency(buf)?,
+                received: types::read_int(buf)?,
+                required: types::read_int(buf)?,
+                numfailures: types::read_int(buf)?,
+                data_present: buf.read_u8()? != 0,
+            },
+            0x1400 => DBError::FunctionFailure {
+                keyspace: types::read_string(buf)?.to_string(),
+                function: types::read_string(buf)?.to_string(),
+                arg_types: types::read_string_list(buf)?,
+            },
+            0x1500 => DBError::WriteFailure {
+                consistency: types::read_consistency(buf)?,
+                received: types::read_int(buf)?,
+                required: types::read_int(buf)?,
+                numfailures: types::read_int(buf)?,
+                write_type: WriteType::from(types::read_string(buf)?),
+            },
+            0x2000 => DBError::SyntaxError,
+            0x2100 => DBError::Unauthorized,
+            0x2200 => DBError::Invalid,
+            0x2300 => DBError::ConfigError,
+            0x2400 => DBError::AlreadyExists {
+                keyspace: types::read_string(buf)?.to_string(),
+                table: types::read_string(buf)?.to_string(),
+            },
+            0x2500 => DBError::Unprepared,
+            _ => DBError::Other(code),
+        };
+
+        Ok(Error { error, reason })
     }
 }
 
 impl Into<QueryError> for Error {
     fn into(self) -> QueryError {
-        QueryError::DBError(DBError::ErrorMsg(self.code, self.reason))
+        QueryError::DBError(self.error, self.reason)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use crate::statement::Consistency;
+    use crate::transport::errors::{DBError, WriteType};
+    use std::convert::TryInto;
+
+    // Serializes the beginning of an ERROR response - error code and message
+    // All custom data depending on the error type is appended after these bytes
+    fn make_error_request_bytes(error_code: i32, message: &str) -> Vec<u8> {
+        let mut bytes: Vec<u8> = Vec::new();
+        let message_len: u16 = message.len().try_into().unwrap();
+
+        bytes.extend(&error_code.to_be_bytes());
+        bytes.extend(&message_len.to_be_bytes());
+        bytes.extend(message.as_bytes());
+
+        bytes
+    }
+
+    // Tests deserialization of all errors without and additional data
+    #[test]
+    fn deserialize_simple_errors() {
+        let simple_error_mappings: [(i32, DBError); 12] = [
+            (0x0000, DBError::ServerError),
+            (0x000A, DBError::ProtocolError),
+            (0x0100, DBError::AuthenticationError),
+            (0x1001, DBError::Overloaded),
+            (0x1002, DBError::IsBootstrapping),
+            (0x1003, DBError::TruncateError),
+            (0x2000, DBError::SyntaxError),
+            (0x2100, DBError::Unauthorized),
+            (0x2200, DBError::Invalid),
+            (0x2300, DBError::ConfigError),
+            (0x2500, DBError::Unprepared),
+            (0x1234, DBError::Other(0x1234)),
+        ];
+
+        for (error_code, expected_error) in &simple_error_mappings {
+            let bytes: Vec<u8> = make_error_request_bytes(*error_code, "simple message");
+            let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+            assert_eq!(error.error, *expected_error);
+            assert_eq!(error.reason, "simple message");
+        }
+    }
+
+    #[test]
+    fn deserialize_unavailable() {
+        let mut bytes = make_error_request_bytes(0x1000, "message 2");
+        bytes.extend(&1_i16.to_be_bytes());
+        bytes.extend(&2_i32.to_be_bytes());
+        bytes.extend(&3_i32.to_be_bytes());
+
+        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            error.error,
+            DBError::Unavailable {
+                consistency: Consistency::One,
+                required: 2,
+                alive: 3,
+            }
+        );
+        assert_eq!(error.reason, "message 2");
+    }
+
+    #[test]
+    fn deserialize_write_timeout() {
+        let mut bytes = make_error_request_bytes(0x1100, "message 2");
+        bytes.extend(&0x0004_i16.to_be_bytes());
+        bytes.extend(&(-5_i32).to_be_bytes());
+        bytes.extend(&100_i32.to_be_bytes());
+
+        let write_type_str = "SIMPLE";
+        let write_type_str_len: u16 = write_type_str.len().try_into().unwrap();
+        bytes.extend(&write_type_str_len.to_be_bytes());
+        bytes.extend(write_type_str.as_bytes());
+
+        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            error.error,
+            DBError::WriteTimeout {
+                consistency: Consistency::Quorum,
+                received: -5, // Allow negative values when they don't make sense, it's better than crashing with ProtocolError
+                required: 100,
+                write_type: WriteType::Simple,
+            }
+        );
+        assert_eq!(error.reason, "message 2");
+    }
+
+    #[test]
+    fn deserialize_read_timeout() {
+        let mut bytes = make_error_request_bytes(0x1200, "message 2");
+        bytes.extend(&0x0002_i16.to_be_bytes());
+        bytes.extend(&8_i32.to_be_bytes());
+        bytes.extend(&32_i32.to_be_bytes());
+        bytes.push(0_u8);
+
+        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            error.error,
+            DBError::ReadTimeout {
+                consistency: Consistency::Two,
+                received: 8,
+                required: 32,
+                data_present: false,
+            }
+        );
+        assert_eq!(error.reason, "message 2");
+    }
+
+    #[test]
+    fn deserialize_read_failure() {
+        let mut bytes = make_error_request_bytes(0x1300, "message 2");
+        bytes.extend(&0x0003_i16.to_be_bytes());
+        bytes.extend(&4_i32.to_be_bytes());
+        bytes.extend(&5_i32.to_be_bytes());
+        bytes.extend(&6_i32.to_be_bytes());
+        bytes.push(123_u8); // Any non-zero value means data_present is true
+
+        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            error.error,
+            DBError::ReadFailure {
+                consistency: Consistency::Three,
+                received: 4,
+                required: 5,
+                numfailures: 6,
+                data_present: true,
+            }
+        );
+        assert_eq!(error.reason, "message 2");
+    }
+
+    #[test]
+    fn deserialize_function_failure() {
+        let mut bytes = make_error_request_bytes(0x1400, "message 2");
+
+        let keyspace_name: &str = "keyspace_name";
+        let keyspace_name_len: u16 = keyspace_name.len().try_into().unwrap();
+
+        let function_name: &str = "function_name";
+        let function_name_len: u16 = function_name.len().try_into().unwrap();
+
+        let type1: &str = "type1";
+        let type1_len: u16 = type1.len().try_into().unwrap();
+
+        let type2: &str = "type2";
+        let type2_len: u16 = type1.len().try_into().unwrap();
+
+        bytes.extend(&keyspace_name_len.to_be_bytes());
+        bytes.extend(keyspace_name.as_bytes());
+        bytes.extend(&function_name_len.to_be_bytes());
+        bytes.extend(function_name.as_bytes());
+        bytes.extend(&2_i16.to_be_bytes());
+        bytes.extend(&type1_len.to_be_bytes());
+        bytes.extend(type1.as_bytes());
+        bytes.extend(&type2_len.to_be_bytes());
+        bytes.extend(type2.as_bytes());
+
+        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            error.error,
+            DBError::FunctionFailure {
+                keyspace: "keyspace_name".to_string(),
+                function: "function_name".to_string(),
+                arg_types: vec!["type1".to_string(), "type2".to_string()]
+            }
+        );
+        assert_eq!(error.reason, "message 2");
+    }
+
+    #[test]
+    fn deserialize_write_failure() {
+        let mut bytes = make_error_request_bytes(0x1500, "message 2");
+
+        bytes.extend(&0x0000_i16.to_be_bytes());
+        bytes.extend(&2_i32.to_be_bytes());
+        bytes.extend(&4_i32.to_be_bytes());
+        bytes.extend(&8_i32.to_be_bytes());
+
+        let write_type_str = "COUNTER";
+        let write_type_str_len: u16 = write_type_str.len().try_into().unwrap();
+        bytes.extend(&write_type_str_len.to_be_bytes());
+        bytes.extend(write_type_str.as_bytes());
+
+        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            error.error,
+            DBError::WriteFailure {
+                consistency: Consistency::Any,
+                received: 2,
+                required: 4,
+                numfailures: 8,
+                write_type: WriteType::Counter,
+            }
+        );
+        assert_eq!(error.reason, "message 2");
+    }
+
+    #[test]
+    fn deserialize_already_exists() {
+        let mut bytes = make_error_request_bytes(0x2400, "message 2");
+
+        let keyspace_name: &str = "keyspace_name";
+        let keyspace_name_len: u16 = keyspace_name.len().try_into().unwrap();
+
+        let table_name: &str = "table_name";
+        let table_name_len: u16 = table_name.len().try_into().unwrap();
+
+        bytes.extend(&keyspace_name_len.to_be_bytes());
+        bytes.extend(keyspace_name.as_bytes());
+        bytes.extend(&table_name_len.to_be_bytes());
+        bytes.extend(table_name.as_bytes());
+
+        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            error.error,
+            DBError::AlreadyExists {
+                keyspace: "keyspace_name".to_string(),
+                table: "table_name".to_string(),
+            }
+        );
+        assert_eq!(error.reason, "message 2");
     }
 }

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -32,6 +32,12 @@ impl Default for Consistency {
     }
 }
 
+impl std::fmt::Display for Consistency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl From<std::num::TryFromIntError> for ParseError {
     fn from(_err: std::num::TryFromIntError) -> Self {
         ParseError::BadData("Integer conversion out of range".to_string())

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -1,19 +1,21 @@
 use super::Consistency;
 use crate::frame::response::result::PreparedMetadata;
 use crate::frame::value::SerializedValues;
+use crate::transport::retry_policy::RetryPolicy;
 use bytes::{BufMut, Bytes, BytesMut};
 use std::convert::TryInto;
 use thiserror::Error;
 
 /// Represents a statement prepared on the server.
-#[derive(Debug, Clone)]
 pub struct PreparedStatement {
     id: Bytes,
     metadata: PreparedMetadata,
     statement: String,
     page_size: Option<i32>,
-    consistency: Consistency,
-    serial_consistency: Option<Consistency>,
+    pub consistency: Consistency,
+    pub serial_consistency: Option<Consistency>,
+    pub is_idempotent: bool,
+    pub retry_policy: Option<Box<dyn RetryPolicy + Send + Sync>>,
 }
 
 impl PreparedStatement {
@@ -25,6 +27,8 @@ impl PreparedStatement {
             page_size: None,
             consistency: Default::default(),
             serial_consistency: None,
+            is_idempotent: false,
+            retry_policy: None,
         }
     }
 
@@ -72,6 +76,31 @@ impl PreparedStatement {
     /// (Ignored unless the statement is an LWT)
     pub fn get_serial_consistency(&self) -> Option<Consistency> {
         self.serial_consistency
+    }
+
+    /// Sets the idempotence of this statement  
+    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application  
+    /// If set to `true` we can be sure that it is idempotent  
+    /// If set to `false` it is unknown whether it is idempotent  
+    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
+    pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
+        self.is_idempotent = is_idempotent;
+    }
+
+    /// Gets the idempotence of this statement
+    pub fn get_is_idempotent(&self) -> bool {
+        self.is_idempotent
+    }
+
+    /// Sets a custom [`RetryPolicy`] to be used with this statement  
+    /// By default Session's retry policy is used, this allows to use a custom retry policy
+    pub fn set_retry_policy(&mut self, retry_policy: Box<dyn RetryPolicy + Send + Sync>) {
+        self.retry_policy = Some(retry_policy);
+    }
+
+    /// Gets custom [`RetryPolicy`] used by this statement
+    pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy + Send + Sync>> {
+        &self.retry_policy
     }
 
     /// Computes the partition key of the target table from given values
@@ -144,4 +173,22 @@ pub enum PartitionKeyError {
     NoPkIndexValue(u16, i16),
     #[error("Value bytes too long to create partition key, max 65 535 allowed! value.len(): {0}")]
     ValueTooLong(usize),
+}
+
+impl Clone for PreparedStatement {
+    fn clone(&self) -> PreparedStatement {
+        PreparedStatement {
+            id: self.id.clone(),
+            metadata: self.metadata.clone(),
+            statement: self.statement.clone(),
+            page_size: self.page_size,
+            consistency: self.consistency,
+            serial_consistency: self.serial_consistency,
+            is_idempotent: self.is_idempotent,
+            retry_policy: self
+                .retry_policy
+                .as_ref()
+                .map(|policy| policy.clone_boxed()),
+        }
+    }
 }

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -1,14 +1,16 @@
 use super::Consistency;
+use crate::transport::retry_policy::RetryPolicy;
 
 /// CQL query statement.
 ///
 /// This represents a CQL query that can be executed on a server.
-#[derive(Clone)]
 pub struct Query {
     contents: String,
     page_size: Option<i32>,
-    consistency: Consistency,
-    serial_consistency: Option<Consistency>,
+    pub consistency: Consistency,
+    pub serial_consistency: Option<Consistency>,
+    pub is_idempotent: bool,
+    pub retry_policy: Option<Box<dyn RetryPolicy + Send + Sync>>,
 }
 
 impl Query {
@@ -19,6 +21,8 @@ impl Query {
             page_size: None,
             consistency: Default::default(),
             serial_consistency: None,
+            is_idempotent: false,
+            retry_policy: None,
         }
     }
 
@@ -64,6 +68,31 @@ impl Query {
     pub fn get_serial_consistency(&self) -> Option<Consistency> {
         self.serial_consistency
     }
+
+    /// Sets the idempotence of this query  
+    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application  
+    /// If set to `true` we can be sure that it is idempotent  
+    /// If set to `false` it is unknown whether it is idempotent  
+    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
+    pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
+        self.is_idempotent = is_idempotent;
+    }
+
+    /// Gets the idempotence of this statement
+    pub fn get_is_idempotent(&self) -> bool {
+        self.is_idempotent
+    }
+
+    /// Sets a custom [`RetryPolicy`] to be used with this statement  
+    /// By default Session's retry policy is used, this allows to use a custom retry policy
+    pub fn set_retry_policy(&mut self, retry_policy: Box<dyn RetryPolicy + Send + Sync>) {
+        self.retry_policy = Some(retry_policy);
+    }
+
+    /// Gets custom [`RetryPolicy`] used by this statement
+    pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy + Send + Sync>> {
+        &self.retry_policy
+    }
 }
 
 impl From<String> for Query {
@@ -75,5 +104,21 @@ impl From<String> for Query {
 impl<'a> From<&'a str> for Query {
     fn from(s: &'a str) -> Query {
         Query::new(s.to_owned())
+    }
+}
+
+impl Clone for Query {
+    fn clone(&self) -> Query {
+        Query {
+            contents: self.contents.clone(),
+            page_size: self.page_size,
+            consistency: self.consistency,
+            serial_consistency: self.serial_consistency,
+            is_idempotent: self.is_idempotent,
+            retry_policy: self
+                .retry_policy
+                .as_ref()
+                .map(|policy| policy.clone_boxed()),
+        }
     }
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -252,11 +252,7 @@ impl Connection {
         Ok(response)
     }
 
-    pub async fn batch(
-        &self,
-        batch: &Batch,
-        values: impl BatchValues,
-    ) -> Result<Response, QueryError> {
+    pub async fn batch(&self, batch: &Batch, values: impl BatchValues) -> Result<(), QueryError> {
         let statements_count = batch.get_statements().len();
         if statements_count != values.len() {
             return Err(QueryError::BadQuery(BadQuery::ValueLenMismatch(
@@ -283,7 +279,15 @@ impl Connection {
             serial_consistency: batch.get_serial_consistency(),
         };
 
-        self.send_request(&batch_frame, true).await
+        let response = self.send_request(&batch_frame, true).await?;
+
+        match response {
+            Response::Error(err) => Err(err.into()),
+            Response::Result(_) => Ok(()),
+            _ => Err(QueryError::ProtocolError(
+                "BATCH: Unexpected server response",
+            )),
+        }
     }
 
     pub async fn use_keyspace(

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -153,7 +153,16 @@ impl Connection {
         query: impl Into<Query>,
         values: impl ValueList,
     ) -> Result<Option<Vec<result::Row>>, QueryError> {
-        let result = self.query(&query.into(), values, None).await?;
+        let query: Query = query.into();
+        self.query_single_page_by_ref(&query, &values).await
+    }
+
+    pub async fn query_single_page_by_ref(
+        &self,
+        query: &Query,
+        values: &impl ValueList,
+    ) -> Result<Option<Vec<result::Row>>, QueryError> {
+        let result = self.query(query, values, None).await?;
         match result {
             Response::Error(err) => Err(err.into()),
             Response::Result(result::Result::Rows(rs)) => Ok(Some(rs.rows)),

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -247,8 +247,14 @@ where
                 };
 
                 match self.retry_policy.decide_should_retry(query_info) {
-                    RetryDecision::RetrySameNode => continue 'same_node_retries,
-                    RetryDecision::RetryNextNode => continue 'nodes_in_plan,
+                    RetryDecision::RetrySameNode => {
+                        self.metrics.inc_retries_num();
+                        continue 'same_node_retries;
+                    }
+                    RetryDecision::RetryNextNode => {
+                        self.metrics.inc_retries_num();
+                        continue 'nodes_in_plan;
+                    }
                     RetryDecision::DontRetry => break 'nodes_in_plan,
                 };
             }

--- a/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
+++ b/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
@@ -55,7 +55,7 @@ impl LoadBalancingPolicy for DCAwareRoundRobinPolicy {
         &self,
         _statement: &Statement,
         cluster: &'a ClusterData,
-    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
         let local_nodes = self.retrieve_local_nodes(cluster);
@@ -78,7 +78,10 @@ impl LoadBalancingPolicy for DCAwareRoundRobinPolicy {
 }
 
 impl ChildLoadBalancingPolicy for DCAwareRoundRobinPolicy {
-    fn apply_child_policy(&self, plan: Vec<Arc<Node>>) -> Box<dyn Iterator<Item = Arc<Node>>> {
+    fn apply_child_policy(
+        &self,
+        plan: Vec<Arc<Node>>,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
         let (local_nodes, remote_nodes): (Vec<_>, Vec<_>) = plan

--- a/scylla/src/transport/load_balancing/round_robin.rs
+++ b/scylla/src/transport/load_balancing/round_robin.rs
@@ -32,7 +32,7 @@ impl LoadBalancingPolicy for RoundRobinPolicy {
         &self,
         _statement: &Statement,
         cluster: &'a ClusterData,
-    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
         let nodes_count = cluster.all_nodes.len();
@@ -48,7 +48,10 @@ impl LoadBalancingPolicy for RoundRobinPolicy {
 }
 
 impl ChildLoadBalancingPolicy for RoundRobinPolicy {
-    fn apply_child_policy(&self, mut plan: Vec<Arc<Node>>) -> Box<dyn Iterator<Item = Arc<Node>>> {
+    fn apply_child_policy(
+        &self,
+        mut plan: Vec<Arc<Node>>,
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
         let len = plan.len(); // borrow checker forces making such a variable

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -107,7 +107,7 @@ impl LoadBalancingPolicy for TokenAwarePolicy {
         &self,
         statement: &Statement,
         cluster: &'a ClusterData,
-    ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
         match statement.token {
             Some(token) => {
                 let keyspace = statement.keyspace.and_then(|k| cluster.keyspaces.get(k));
@@ -407,7 +407,7 @@ mod tests {
             &self,
             _: &Statement,
             _: &'a ClusterData,
-        ) -> Box<dyn Iterator<Item = Arc<Node>> + 'a> {
+        ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
             let empty_node_list: Vec<Arc<Node>> = Vec::new();
 
             Box::new(empty_node_list.into_iter())
@@ -419,7 +419,10 @@ mod tests {
     }
 
     impl ChildLoadBalancingPolicy for DumbPolicy {
-        fn apply_child_policy(&self, plan: Vec<Arc<Node>>) -> Box<dyn Iterator<Item = Arc<Node>>> {
+        fn apply_child_policy(
+            &self,
+            plan: Vec<Arc<Node>>,
+        ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync> {
             Box::new(plan.into_iter())
         }
     }

--- a/scylla/src/transport/metrics.rs
+++ b/scylla/src/transport/metrics.rs
@@ -34,6 +34,7 @@ pub struct Metrics {
     queries_num: AtomicU64,
     errors_iter_num: AtomicU64,
     queries_iter_num: AtomicU64,
+    retries_num: AtomicU64,
     histogram: Arc<Mutex<Histogram>>,
 }
 
@@ -44,6 +45,7 @@ impl Metrics {
             queries_num: AtomicU64::new(0),
             errors_iter_num: AtomicU64::new(0),
             queries_iter_num: AtomicU64::new(0),
+            retries_num: AtomicU64::new(0),
             histogram: Arc::new(Mutex::new(Histogram::new())),
         }
     }
@@ -67,6 +69,11 @@ impl Metrics {
     /// If query_iter would return 4 pages then this counter should be incremented 4 times.
     pub fn inc_total_paged_queries(&self) {
         self.queries_iter_num.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Increments counter measuring how many times a retry policy has decided to retry a query
+    pub fn inc_retries_num(&self) {
+        self.retries_num.fetch_add(1, ORDER_TYPE);
     }
 
     /// Saves to histogram latency of completing single query.
@@ -115,6 +122,11 @@ impl Metrics {
     pub fn get_queries_iter_num(&self) -> u64 {
         self.queries_iter_num.load(ORDER_TYPE)
     }
+
+    /// Returns counter measuring how many times a retry policy has decided to retry a query
+    pub fn get_retries_num(&self) -> u64 {
+        self.retries_num.load(ORDER_TYPE)
+    }
 }
 
 pub struct MetricsView {
@@ -157,5 +169,10 @@ impl MetricsView {
     /// Returns counter for pages requested in paged queries
     pub fn get_queries_iter_num(&self) -> u64 {
         self.metrics.get_queries_iter_num()
+    }
+
+    /// Returns counter measuring how many times a retry policy has decided to retry a query
+    pub fn get_retries_num(&self) -> u64 {
+        self.metrics.get_retries_num()
     }
 }

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -3,6 +3,7 @@ pub mod connection;
 mod connection_keeper;
 pub mod load_balancing;
 mod node;
+pub mod retry_policy;
 pub mod session;
 pub mod session_builder;
 mod topology;

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -23,6 +23,9 @@ pub enum RetryDecision {
 pub trait RetryPolicy {
     fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision;
 
+    // Reset before using for the next query
+    fn reset(&mut self);
+
     fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync>;
 }
 
@@ -33,6 +36,8 @@ impl RetryPolicy for FallthroughRetryPolicy {
     fn decide_should_retry(&mut self, _query_info: QueryInfo) -> RetryDecision {
         RetryDecision::DontRetry
     }
+
+    fn reset(&mut self) {}
 
     fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync> {
         Box::new(FallthroughRetryPolicy)
@@ -128,6 +133,10 @@ impl RetryPolicy for DefaultRetryPolicy {
             // In all other cases propagate the error to the user
             _ => RetryDecision::DontRetry,
         }
+    }
+
+    fn reset(&mut self) {
+        *self = DefaultRetryPolicy::new();
     }
 
     fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync> {

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -1,0 +1,432 @@
+use crate::statement::Consistency;
+use crate::transport::errors::{DBError, QueryError, WriteType};
+
+/// Information about a failed query
+pub struct QueryInfo<'a> {
+    /// The error with which the query failed
+    pub error: &'a QueryError,
+    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application  
+    /// If set to `true` we can be sure that it is idempotent  
+    /// If set to `false` it is unknown whether it is idempotent
+    pub is_idempotent: bool,
+    /// Consistency with which the query failed
+    pub consistency: Consistency,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RetryDecision {
+    RetrySameNode,
+    RetryNextNode,
+    DontRetry,
+}
+
+pub trait RetryPolicy {
+    fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision;
+}
+
+/// Forwards all errors directly to the user, never retries
+pub struct FallthroughRetryPolicy;
+
+impl RetryPolicy for FallthroughRetryPolicy {
+    fn decide_should_retry(&mut self, _query_info: QueryInfo) -> RetryDecision {
+        RetryDecision::DontRetry
+    }
+}
+
+/// Default retry policy - retries when there is a high chance that a retry might help.  
+/// Behaviour based on [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/retries/)
+pub struct DefaultRetryPolicy {
+    was_unavailable_retry: bool,
+    was_read_timeout_retry: bool,
+    was_write_timeout_retry: bool,
+}
+
+impl DefaultRetryPolicy {
+    pub fn new() -> DefaultRetryPolicy {
+        DefaultRetryPolicy {
+            was_unavailable_retry: false,
+            was_read_timeout_retry: false,
+            was_write_timeout_retry: false,
+        }
+    }
+}
+
+impl RetryPolicy for DefaultRetryPolicy {
+    fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision {
+        match query_info.error {
+            // Basic errors - there are some problems on this node
+            // Retry on a different one if possible
+            QueryError::IOError(_)
+            | QueryError::DBError(DBError::Overloaded, _)
+            | QueryError::DBError(DBError::ServerError, _)
+            | QueryError::DBError(DBError::TruncateError, _) => {
+                if query_info.is_idempotent {
+                    RetryDecision::RetryNextNode
+                } else {
+                    RetryDecision::DontRetry
+                }
+            }
+            // Unavailable - the current node believes that not enough nodes
+            // are alive to satisfy specified consistency requirements.
+            // Maybe this node has network problems - try a different one.
+            // Perform at most one retry - it's unlikely that two nodes
+            // have network problems at the same time
+            QueryError::DBError(DBError::Unavailable { .. }, _) => {
+                if !self.was_unavailable_retry {
+                    self.was_unavailable_retry = true;
+                    RetryDecision::RetryNextNode
+                } else {
+                    RetryDecision::DontRetry
+                }
+            }
+            // ReadTimeout - coordinator didn't receive enough replies in time.
+            // Retry at most once and only if there were actually enough replies
+            // to satisfy consistency but they were all just checksums (data_present == true).
+            // This happens when the coordinator picked replicas that were overloaded/dying.
+            // Retried request should have some useful response because the node will detect
+            // that these replicas are dead.
+            QueryError::DBError(
+                DBError::ReadTimeout {
+                    received,
+                    required,
+                    data_present,
+                    ..
+                },
+                _,
+            ) => {
+                if !self.was_read_timeout_retry && received >= required && *data_present {
+                    self.was_read_timeout_retry = true;
+                    RetryDecision::RetrySameNode
+                } else {
+                    RetryDecision::DontRetry
+                }
+            }
+            // Write timeout - coordinator didn't receive enough replies in time.
+            // Retry at most once and only for BatchLog write.
+            // Coordinator probably didn't detect the nodes as dead.
+            // By the time we retry they should be detected as dead.
+            QueryError::DBError(DBError::WriteTimeout { write_type, .. }, _) => {
+                if !self.was_write_timeout_retry
+                    && query_info.is_idempotent
+                    && *write_type == WriteType::BatchLog
+                {
+                    self.was_write_timeout_retry = true;
+                    RetryDecision::RetrySameNode
+                } else {
+                    RetryDecision::DontRetry
+                }
+            }
+            // The node is still bootstrapping it can't execute the query, we should try another one
+            QueryError::DBError(DBError::IsBootstrapping, _) => RetryDecision::RetryNextNode,
+            // In all other cases propagate the error to the user
+            _ => RetryDecision::DontRetry,
+        }
+    }
+}
+
+impl Default for DefaultRetryPolicy {
+    fn default() -> DefaultRetryPolicy {
+        DefaultRetryPolicy::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DefaultRetryPolicy, QueryInfo, RetryDecision, RetryPolicy};
+    use crate::statement::Consistency;
+    use crate::transport::errors::{BadQuery, DBError, QueryError, WriteType};
+    use std::io::ErrorKind;
+    use std::sync::Arc;
+
+    fn make_query_info(error: &QueryError, is_idempotent: bool) -> QueryInfo<'_> {
+        QueryInfo {
+            error,
+            is_idempotent,
+            consistency: Consistency::One,
+        }
+    }
+
+    // Asserts that default policy never retries for this Error
+    fn default_policy_assert_never_retries(error: QueryError) {
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&error, false)),
+            RetryDecision::DontRetry
+        );
+
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&error, true)),
+            RetryDecision::DontRetry
+        );
+    }
+
+    #[test]
+    fn default_never_retries() {
+        let never_retried_dberrors = vec![
+            DBError::SyntaxError,
+            DBError::Invalid,
+            DBError::AlreadyExists {
+                keyspace: String::new(),
+                table: String::new(),
+            },
+            DBError::FunctionFailure {
+                keyspace: String::new(),
+                function: String::new(),
+                arg_types: vec![],
+            },
+            DBError::AuthenticationError,
+            DBError::Unauthorized,
+            DBError::ConfigError,
+            DBError::ReadFailure {
+                consistency: Consistency::Two,
+                received: 2,
+                required: 1,
+                numfailures: 1,
+                data_present: false,
+            },
+            DBError::WriteFailure {
+                consistency: Consistency::Two,
+                received: 1,
+                required: 2,
+                numfailures: 1,
+                write_type: WriteType::BatchLog,
+            },
+            DBError::Unprepared,
+            DBError::ProtocolError,
+            DBError::Other(0x124816),
+        ];
+
+        for dberror in never_retried_dberrors {
+            default_policy_assert_never_retries(QueryError::DBError(dberror, String::new()));
+        }
+
+        default_policy_assert_never_retries(QueryError::BadQuery(BadQuery::ValueLenMismatch(1, 2)));
+        default_policy_assert_never_retries(QueryError::ProtocolError("test"));
+    }
+
+    // Asserts that for this error policy retries on next on idempotent queries only
+    fn default_policy_assert_idempotent_next(error: QueryError) {
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&error, false)),
+            RetryDecision::DontRetry
+        );
+
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&error, true)),
+            RetryDecision::RetryNextNode
+        );
+    }
+
+    #[test]
+    fn default_idempotent_next_retries() {
+        let idempotent_next_errors = vec![
+            QueryError::DBError(DBError::Overloaded, String::new()),
+            QueryError::DBError(DBError::TruncateError, String::new()),
+            QueryError::DBError(DBError::ServerError, String::new()),
+            QueryError::IOError(Arc::new(std::io::Error::new(ErrorKind::Other, "test"))),
+        ];
+
+        for error in idempotent_next_errors {
+            default_policy_assert_idempotent_next(error);
+        }
+    }
+
+    // Always retry on next node if current one is bootstrapping
+    #[test]
+    fn default_bootstrapping() {
+        let error = QueryError::DBError(DBError::IsBootstrapping, String::new());
+
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&error, false)),
+            RetryDecision::RetryNextNode
+        );
+
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&error, true)),
+            RetryDecision::RetryNextNode
+        );
+    }
+
+    // On Unavailable error we retry one time no matter the idempotence
+    #[test]
+    fn default_unavailable() {
+        let error = QueryError::DBError(
+            DBError::Unavailable {
+                consistency: Consistency::Two,
+                required: 2,
+                alive: 1,
+            },
+            String::new(),
+        );
+
+        let mut policy_not_idempotent = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy_not_idempotent.decide_should_retry(make_query_info(&error, false)),
+            RetryDecision::RetryNextNode
+        );
+        assert_eq!(
+            policy_not_idempotent.decide_should_retry(make_query_info(&error, false)),
+            RetryDecision::DontRetry
+        );
+
+        let mut policy_idempotent = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy_idempotent.decide_should_retry(make_query_info(&error, true)),
+            RetryDecision::RetryNextNode
+        );
+        assert_eq!(
+            policy_idempotent.decide_should_retry(make_query_info(&error, true)),
+            RetryDecision::DontRetry
+        );
+    }
+
+    // On ReadTimeout we retry one time if there were enough responses and the data was present no matter the idempotence
+    #[test]
+    fn default_read_timeout() {
+        // Enough responses and data_present == true
+        let enough_responses_with_data = QueryError::DBError(
+            DBError::ReadTimeout {
+                consistency: Consistency::Two,
+                received: 2,
+                required: 2,
+                data_present: true,
+            },
+            String::new(),
+        );
+
+        // Not idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&enough_responses_with_data, false)),
+            RetryDecision::RetrySameNode
+        );
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&enough_responses_with_data, false)),
+            RetryDecision::DontRetry
+        );
+
+        // Idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&enough_responses_with_data, true)),
+            RetryDecision::RetrySameNode
+        );
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&enough_responses_with_data, true)),
+            RetryDecision::DontRetry
+        );
+
+        // Enough responses but data_present == false
+        let enough_responses_no_data = QueryError::DBError(
+            DBError::ReadTimeout {
+                consistency: Consistency::Two,
+                received: 2,
+                required: 2,
+                data_present: false,
+            },
+            String::new(),
+        );
+
+        // Not idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&enough_responses_no_data, false)),
+            RetryDecision::DontRetry
+        );
+
+        // Idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&enough_responses_no_data, true)),
+            RetryDecision::DontRetry
+        );
+
+        // Not enough responses, data_present == true
+        let not_enough_responses_with_data = QueryError::DBError(
+            DBError::ReadTimeout {
+                consistency: Consistency::Two,
+                received: 1,
+                required: 2,
+                data_present: true,
+            },
+            String::new(),
+        );
+
+        // Not idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&not_enough_responses_with_data, false)),
+            RetryDecision::DontRetry
+        );
+
+        // Idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&not_enough_responses_with_data, true)),
+            RetryDecision::DontRetry
+        );
+    }
+
+    // WriteTimeout will retry once when the query is idempotent and write_type == BatchLog
+    #[test]
+    fn default_write_timeout() {
+        // WriteType == BatchLog
+        let good_write_type = QueryError::DBError(
+            DBError::WriteTimeout {
+                consistency: Consistency::Two,
+                received: 1,
+                required: 2,
+                write_type: WriteType::BatchLog,
+            },
+            String::new(),
+        );
+
+        // Not idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&good_write_type, false)),
+            RetryDecision::DontRetry
+        );
+
+        // Idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&good_write_type, true)),
+            RetryDecision::RetrySameNode
+        );
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&good_write_type, true)),
+            RetryDecision::DontRetry
+        );
+
+        // WriteType != BatchLog
+        let bad_write_type = QueryError::DBError(
+            DBError::WriteTimeout {
+                consistency: Consistency::Two,
+                received: 4,
+                required: 2,
+                write_type: WriteType::Simple,
+            },
+            String::new(),
+        );
+
+        // Not idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&bad_write_type, false)),
+            RetryDecision::DontRetry
+        );
+
+        // Idempotent
+        let mut policy = DefaultRetryPolicy::new();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info(&bad_write_type, true)),
+            RetryDecision::DontRetry
+        );
+    }
+}

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -22,6 +22,8 @@ pub enum RetryDecision {
 
 pub trait RetryPolicy {
     fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision;
+
+    fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync>;
 }
 
 /// Forwards all errors directly to the user, never retries
@@ -31,10 +33,15 @@ impl RetryPolicy for FallthroughRetryPolicy {
     fn decide_should_retry(&mut self, _query_info: QueryInfo) -> RetryDecision {
         RetryDecision::DontRetry
     }
+
+    fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync> {
+        Box::new(FallthroughRetryPolicy)
+    }
 }
 
 /// Default retry policy - retries when there is a high chance that a retry might help.  
 /// Behaviour based on [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/retries/)
+#[derive(Clone)]
 pub struct DefaultRetryPolicy {
     was_unavailable_retry: bool,
     was_read_timeout_retry: bool,
@@ -121,6 +128,10 @@ impl RetryPolicy for DefaultRetryPolicy {
             // In all other cases propagate the error to the user
             _ => RetryDecision::DontRetry,
         }
+    }
+
+    fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync> {
+        Box::new(self.clone())
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1,4 +1,5 @@
 use futures::future::join_all;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -15,21 +16,22 @@ use crate::frame::value::{BatchValues, SerializedValues, ValueList};
 use crate::prepared_statement::{PartitionKeyError, PreparedStatement};
 use crate::query::Query;
 use crate::routing::{murmur3_token, Token};
+use crate::statement::Consistency;
 use crate::transport::{
     cluster::Cluster,
-    connection::{ConnectionConfig, VerifiedKeyspaceName},
+    connection::{Connection, ConnectionConfig, VerifiedKeyspaceName},
     iterator::RowIterator,
     load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, Statement, TokenAwarePolicy},
     metrics::{Metrics, MetricsView},
     node::Node,
-    retry_policy::{DefaultRetryPolicy, RetryPolicy},
+    retry_policy::{DefaultRetryPolicy, QueryInfo, RetryDecision, RetryPolicy},
     Compression,
 };
 
 pub struct Session {
     cluster: Cluster,
     load_balancer: Box<dyn LoadBalancingPolicy>,
-    _retry_policy: Box<dyn RetryPolicy + Send + Sync>,
+    retry_policy: Box<dyn RetryPolicy + Send + Sync>,
 
     metrics: Arc<Metrics>,
 }
@@ -242,7 +244,7 @@ impl Session {
         let session = Session {
             cluster,
             load_balancer: config.load_balancing,
-            _retry_policy: config.retry_policy,
+            retry_policy: config.retry_policy,
             metrics,
         };
 
@@ -270,23 +272,9 @@ impl Session {
         query: impl Into<Query>,
         values: impl ValueList,
     ) -> Result<Option<Vec<result::Row>>, QueryError> {
-        let now = Instant::now();
-        self.metrics.inc_total_nonpaged_queries();
-        let result = self.query_no_metrics(query, values).await;
-        match &result {
-            Ok(_) => self.log_latency(now.elapsed().as_millis() as u64),
-            Err(_) => self.metrics.inc_failed_nonpaged_queries(),
-        };
-        result
-    }
-
-    async fn query_no_metrics(
-        &self,
-        query: impl Into<Query>,
-        values: impl ValueList,
-    ) -> Result<Option<Vec<result::Row>>, QueryError> {
-        let query = query.into();
+        let mut query = query.into();
         let query_text = query.get_contents();
+        let serialized_values = values.serialized();
 
         // In case the user tried doing session.query("use keyspace ks") run session::use_keyspace
         if query_is_setting_keyspace(query_text) {
@@ -302,16 +290,28 @@ impl Session {
                 .map(|_| None);
         }
 
-        let statement_info = Statement {
-            token: None,
-            keyspace: None,
-        };
-        let node = self.load_balancing_plan(statement_info);
+        let retry_policy = query
+            .retry_policy
+            .take()
+            .unwrap_or_else(|| self.retry_policy.clone_boxed());
 
-        node.random_connection()
-            .await?
-            .query_single_page(query, values)
-            .await
+        // Needed to avoid moving query and values into async move block
+        let query_ref: &Query = &query;
+        let values_ref = &serialized_values;
+
+        self.run_query(
+            Statement::default(),
+            query.is_idempotent,
+            query.consistency,
+            retry_policy,
+            |node: Arc<Node>| async move { node.random_connection().await },
+            |connection: Arc<Connection>| async move {
+                connection
+                    .query_single_page_by_ref(query_ref, values_ref)
+                    .await
+            },
+        )
+        .await
     }
 
     pub async fn query_iter(
@@ -571,6 +571,72 @@ impl Session {
         let mut plan = self.load_balancer.plan(&statement_info, &cluster_info);
 
         plan.next().unwrap() // Plan returned by load balancing policies should never be empty
+    }
+
+    // This method allows to easily run a query using load balancing, retry policy etc.
+    // Requires some information about the query and two closures
+    // First closure is used to choose a connection
+    // - query will use node.random_connection()
+    // - execute will use node.connection_for_token()
+    // The second closure is used to do the query itself on a connection
+    // - query will use connection.query()
+    // - execute will use connection.execute()
+    // If this query closure fails with some errors retry policy is used to perform retries
+    // On success this query's result is returned
+    // I tried to make this closures take a reference instead of an Arc but failed
+    // maybe once async closures get stabilized this can be fixed
+    async fn run_query<'a, ConnFut, QueryFut, ResT>(
+        &'a self,
+        statement_info: Statement<'a>,
+        query_is_idempotent: bool,
+        query_consistency: Consistency,
+        mut retry_policy: Box<dyn RetryPolicy + Send + Sync>,
+        choose_connection: impl Fn(Arc<Node>) -> ConnFut,
+        do_query: impl Fn(Arc<Connection>) -> QueryFut,
+    ) -> Result<ResT, QueryError>
+    where
+        ConnFut: Future<Output = Result<Arc<Connection>, QueryError>>,
+        QueryFut: Future<Output = Result<ResT, QueryError>>,
+    {
+        let cluster_data = self.cluster.get_data();
+        let query_plan = self.load_balancer.plan(&statement_info, &cluster_data);
+
+        let mut last_error: QueryError =
+            QueryError::ProtocolError("Empty query plan - driver bug!");
+
+        'nodes_in_plan: for node in query_plan {
+            'same_node_retries: loop {
+                let connection: Arc<Connection> = match choose_connection(node.clone()).await {
+                    Ok(connection) => connection,
+                    Err(e) => {
+                        last_error = e;
+                        continue 'nodes_in_plan;
+                    }
+                };
+
+                let query_result: Result<ResT, QueryError> = do_query(connection).await;
+
+                last_error = match query_result {
+                    Ok(response) => return Ok(response),
+                    Err(e) => e, // TODO: metrics
+                };
+
+                // Use retry policy to decide what to do next
+                let query_info = QueryInfo {
+                    error: &last_error,
+                    is_idempotent: query_is_idempotent,
+                    consistency: query_consistency,
+                };
+
+                match retry_policy.decide_should_retry(query_info) {
+                    RetryDecision::RetrySameNode => continue 'same_node_retries,
+                    RetryDecision::RetryNextNode => continue 'nodes_in_plan,
+                    RetryDecision::DontRetry => return Err(last_error),
+                };
+            }
+        }
+
+        return Err(last_error);
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -589,8 +589,14 @@ impl Session {
                 };
 
                 match retry_policy.decide_should_retry(query_info) {
-                    RetryDecision::RetrySameNode => continue 'same_node_retries,
-                    RetryDecision::RetryNextNode => continue 'nodes_in_plan,
+                    RetryDecision::RetrySameNode => {
+                        self.metrics.inc_retries_num();
+                        continue 'same_node_retries;
+                    }
+                    RetryDecision::RetryNextNode => {
+                        self.metrics.inc_retries_num();
+                        continue 'nodes_in_plan;
+                    }
                     RetryDecision::DontRetry => return Err(last_error),
                 };
             }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use tokio::net::lookup_host;
 use tracing::warn;
 
-use super::errors::{BadQuery, NewSessionError, QueryError};
+use super::errors::{BadQuery, DBError, NewSessionError, QueryError};
 use crate::batch::Batch;
 use crate::cql_to_rust::FromRow;
 use crate::frame::response::cql_to_rust::FromRowError;
@@ -416,8 +416,8 @@ impl Session {
             .await?;
         match result {
             Response::Error(err) => {
-                match err.code {
-                    9472 => {
+                match err.error {
+                    DBError::Unprepared => {
                         // Repreparation of a statement is needed
                         let reprepared = connection.prepare(prepared.get_statement()).await?;
                         // Reprepared statement should keep its id - it's the md5 sum

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -4,6 +4,7 @@ use super::session::{Session, SessionConfig};
 use super::Compression;
 use crate::transport::retry_policy::RetryPolicy;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 /// SessionBuilder is used to create new Session instances
 /// # Example
@@ -187,16 +188,17 @@ impl SessionBuilder {
     /// # use scylla::{Session, SessionBuilder};
     /// # use scylla::transport::Compression;
     /// # use scylla::transport::load_balancing::RoundRobinPolicy;
+    /// # use std::sync::Arc;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let session: Session = SessionBuilder::new()
     ///     .known_node("127.0.0.1:9042")
-    ///     .load_balancing(Box::new(RoundRobinPolicy::new()))
+    ///     .load_balancing(Arc::new(RoundRobinPolicy::new()))
     ///     .build()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn load_balancing(mut self, policy: Box<dyn LoadBalancingPolicy>) -> Self {
+    pub fn load_balancing(mut self, policy: Arc<dyn LoadBalancingPolicy>) -> Self {
         self.config.load_balancing = policy;
         self
     }
@@ -258,6 +260,7 @@ mod tests {
     use crate::transport::session::KnownNode;
     use crate::transport::Compression;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
 
     #[test]
     fn default_session_builder() {
@@ -358,7 +361,7 @@ mod tests {
             "TokenAwarePolicy{child_policy: RoundRobinPolicy}".to_string()
         );
 
-        builder = builder.load_balancing(Box::new(RoundRobinPolicy::new()));
+        builder = builder.load_balancing(Arc::new(RoundRobinPolicy::new()));
         assert_eq!(
             builder.config.load_balancing.name(),
             "RoundRobinPolicy".to_string()
@@ -394,7 +397,7 @@ mod tests {
         builder = builder.known_nodes_addr(&[addr1, addr2]);
         builder = builder.compression(Some(Compression::Snappy));
         builder = builder.tcp_nodelay(true);
-        builder = builder.load_balancing(Box::new(RoundRobinPolicy::new()));
+        builder = builder.load_balancing(Arc::new(RoundRobinPolicy::new()));
         builder = builder.use_keyspace("ks_name", true);
 
         assert_eq!(

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -2,6 +2,7 @@ use super::errors::NewSessionError;
 use super::load_balancing::LoadBalancingPolicy;
 use super::session::{Session, SessionConfig};
 use super::Compression;
+use crate::transport::retry_policy::RetryPolicy;
 use std::net::SocketAddr;
 
 /// SessionBuilder is used to create new Session instances
@@ -197,6 +198,29 @@ impl SessionBuilder {
     /// ```
     pub fn load_balancing(mut self, policy: Box<dyn LoadBalancingPolicy>) -> Self {
         self.config.load_balancing = policy;
+        self
+    }
+
+    /// Sets the [`RetryPolicy`] to use by default on queries
+    /// The default is [DefaultRetryPolicy](crate::transport::retry_policy::DefaultRetryPolicy)
+    /// It is possible to implement a custom retry policy by implementing the trait [`RetryPolicy`]
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use scylla::transport::Compression;
+    /// use scylla::transport::retry_policy::DefaultRetryPolicy;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn retry_policy(mut self, retry_policy: Box<dyn RetryPolicy + Send + Sync>) -> Self {
+        self.config.retry_policy = retry_policy;
         self
     }
 


### PR DESCRIPTION
## Description
This PR adds support for `RetryPolicy` - when a query fails this `RetryPolicy` decides whether we should retry on this node, next node or don't retry at all.

All `RetryPolicies` implement the trait `RetryPolicy`:
```rust
pub trait RetryPolicy {
    fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision;

    // Reset before using for the next query
    fn reset(&mut self);

    fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync>;
}

/// Information about a failed query
pub struct QueryInfo<'a> {
    /// The error with which the query failed
    pub error: &'a QueryError,
    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application  
    /// If set to `true` we can be sure that it is idempotent  
    /// If set to `false` it is unknown whether it is idempotent
    pub is_idempotent: bool,
    /// Consistency with which the query failed
    pub consistency: Consistency,
}

#[derive(Debug, PartialEq, Eq)]
pub enum RetryDecision {
    RetrySameNode,
    RetryNextNode,
    DontRetry,
}
```
There are two retry policies implemented:
* `FallthroughRetryPolicy` - never retries, retruns errors straight to the user
* `DefaultRetryPolicy` - policy used by default, behaviour based on [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/retries/)

The user can implement their own `RetryPolicy` by implementing this trait.
iIt is also possible to use a different `RetryPolicy` for a single query.

In [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/retries/) there is also a `ConsistencyDowngradingRetryPolicy` - a policy that tries to perform the query with specified consistency but if it fails because consistency requirements can't be met, it chooses a lower consistency so that the query can be finished.

[DataStax C/C++ Driver](https://docs.datastax.com/en/developer/cpp-driver/2.15/topics/configuration/retry_policies/) deprecated this policy and asks users not to use it in new applications. Their argumentation is that if the query would be valid with lower consistency then it shouldn't be preformed with higher consistency in the first place.

I didn't implement this `RetryPolicy` because I'm not sure if we want to have it at all.

I didn't add any new metrics, should there be something new? Do we need a number of retries or something else?

## Notes
When parsing `DBError` I assume that fields are initialized in the order in which they are specified.
I belive this is true, there are some tests in `rust` repository for struct evaluation order: ([1](https://github.com/rust-lang/rust/blob/master/src/test/ui/structs-enums/struct-order-of-eval-1.rs) [2](https://github.com/rust-lang/rust/blob/master/src/test/ui/structs-enums/struct-order-of-eval-2.rs) [3](https://github.com/rust-lang/rust/blob/master/src/test/ui/structs-enums/struct-order-of-eval-3.rs) [4](https://github.com/rust-lang/rust/blob/master/src/test/ui/structs-enums/struct-order-of-eval-4.rs))
If this is a concern I can change it to explicit separate parsing but the code will be longer and uglier.

## Fixed issues: 
Fixes: #41


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
