### PR TITLE
session_test: add a test for fetching keyspace info

### DIFF
--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -529,3 +529,16 @@ async fn test_raw_use_keyspace() {
         .await
         .is_ok());
 }
+
+#[tokio::test]
+async fn test_fetch_system_keyspace() {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = SessionBuilder::new().known_node(uri).build().await.unwrap();
+
+    let prepared_statement = session
+        .prepare("SELECT * FROM system_schema.keyspaces")
+        .await
+        .unwrap();
+
+    session.execute(&prepared_statement, &[]).await.unwrap();
+}


### PR DESCRIPTION
The test case indicates that we support enough CQL types to parse
schema keyspace information. The test used to fail before the latest merge of almost all CQL types.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
