### PR TITLE
Integration with logging library

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ futures = "0.3.6"
 rustyline = "6.3.0"
 scylla = {path = "../scylla"}
 tokio = {version = "1.1.0", features = ["full"]}
-tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing = "0.1.25"
+tracing-subscriber = "0.2.16"
 
 [[example]]
 name = "basic"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,10 +10,16 @@ futures = "0.3.6"
 rustyline = "6.3.0"
 scylla = {path = "../scylla"}
 tokio = {version = "1.1.0", features = ["full"]}
+tracing = "0.1"
+tracing-subscriber = "0.2"
 
 [[example]]
 name = "basic"
 path = "basic.rs"
+
+[[example]]
+name = "logging"
+path = "logging.rs"
 
 [[example]]
 name = "cqlsh-rs"

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use scylla::transport::session::Session;
+use scylla::SessionBuilder;
+use std::env;
+use tracing::info;
+
+// To run this example, and view logged messages, RUST_LOG env var needs to be set
+// This can be done using shell command presented below
+// RUST_LOG=info cargo run --example logging
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Install global collector configured based on RUST_LOG env var
+    // This collector will receive logs from the driver
+    tracing_subscriber::fmt::init();
+
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    info!("Connecting to {}", uri);
+
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    // This query should generate a warning message
+    session.query("USE ks", &[]).await?;
+
+    Ok(())
+}

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0"
 itertools = "0.10.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
+tracing = "0.1.25"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use futures::{future::RemoteHandle, FutureExt};
 use tokio::net::{tcp, TcpSocket, TcpStream};
 use tokio::sync::{mpsc, oneshot};
-use tracing::warn;
+use tracing::{error, warn};
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -435,7 +435,7 @@ impl Connection {
                 } else {
                     // TODO: Handle this error better, for now we drop this
                     // request and return an error to the receiver
-                    warn!("Could not allocate stream id");
+                    error!("Could not allocate stream id");
                     continue;
                 }
             };

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::net::lookup_host;
+use tracing::warn;
 
 use super::errors::{BadQuery, NewSessionError, QueryError};
 use crate::batch::Batch;
@@ -285,8 +286,7 @@ impl Session {
 
         // In case the user tried doing session.query("use keyspace ks") run session::use_keyspace
         if query_is_setting_keyspace(query_text) {
-            // TODO: replace with log library in https://github.com/scylladb/scylla-rust-driver/issues/158
-            eprintln!("Warning: Raw USE KEYSPACE queries are experimental, please use session::use_keyspace instead");
+            warn!("Raw USE KEYSPACE queries are experimental, please use session::use_keyspace instead");
 
             let keyspace_name = &query_text["use ".len()..].trim_end_matches(';').trim();
             let case_sensitive = keyspace_name.starts_with('"');


### PR DESCRIPTION
## Description

This pull request adds integration with logging library [tracing](https://crates.io/crates/tracing) (actual logging is abstracted, consumer of our driver can choose a suitable logging implementation).

Calls to `eprintln!` have been replaced with `warn!` event emission. I think It's a good idea to log more events in the future, but as for now, only warnings that existed before are logged (except for stream allocation failure warning in connection.rs, that's new).

I have also added new example, that uses `tracing-subscriber` to log events to stdout.

Fixes: #158

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
