### PR TITLE
Run CI database tests in parallel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,8 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run tests
-      # test threads must be one because else database tests will run in parallel and will result in flaky tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,5 +40,5 @@ Execute the commands below to run the tests:
 docker run --name scylla-ci -d scylladb/scylla
 
 # Run all tests
-SCYLLA_URI="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla-ci):19042" cargo test -- --test-threads=1
+SCYLLA_URI="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla-ci):19042" cargo test
 ```


### PR DESCRIPTION
@Jasperav added a flag to run tests sequentially one after another in CI in #170, but I think it's not really needed.
All tests are written in a way that allows them to be run in parallel without any conflicts, I don't see any reason why something would break.

Running them in prallel could improve CI times - currently a single CI run takes 5 minutes out of which 3 minutes is spent running tests.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
