### PR TITLE
Remove #[ignore] from connection keeper test

### DIFF
--- a/scylla/src/transport/connection_keeper.rs
+++ b/scylla/src/transport/connection_keeper.rs
@@ -294,7 +294,6 @@ mod tests {
     // Port collision should occur
     // If they are not handled this test will most likely fail
     #[tokio::test]
-    #[ignore]
     async fn many_connections() {
         let connections_number = 512;
 


### PR DESCRIPTION
I forgot to remove `#[ignore]` from a test again, when rebasing `ConnectionKeeper`.
The only `#[ignore]` left in the codebase in in `cql_types_test` but this will soon be overwritten by a PR.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
