### PR TITLE
Run all tests on Cassandra in CI

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -1,0 +1,28 @@
+# This workflow runs all tests on cassandra to ensure full compatibility
+name: Cassandra tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      cassandra:
+        image: cassandra
+        ports:
+          - 9042:9042
+    steps:
+    - uses: actions/checkout@v2
+      # A separate step for building to separate measuring time of compilation and testing
+    - name: Build the project
+      run: cargo build --verbose --tests
+    - name: Run tests on cassandra
+      # test threads must be one because else database tests will run in parallel and will result in flaky tests
+      run: cargo test --verbose -- --test-threads=1


### PR DESCRIPTION
Adds a workflow in which all tests are run using a Cassandra instance to ensure full compatibility.

I am not sure if the flag `--test-threads=1` is really needed, all tests are written in a way that allows to run them in parallel.
I made a test in #192 but there was no real time gained by removing it, majority of time is spent compiling the project, tests take only a small amount of time. I left it in, doesn't really hurt and is consistent with `rust.yml`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
