### PR TITLE
CQL Tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ let uri = "127.0.0.1:9042";
 
 let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
+if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
     for row in rows.into_typed::<(i32, i32, String)>() {
         let (a, b, c) = row?;
         println!("a, b, c: {}, {}, {}", a, b, c);

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,6 +14,7 @@ tokio = {version = "1.1.0", features = ["full"]}
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 chrono = "0.4"
+uuid = "0.8.1"
 
 [[example]]
 name = "basic"
@@ -54,3 +55,8 @@ path = "user-defined-type.rs"
 [[example]]
 name = "cql-time-types"
 path = "cql-time-types.rs"
+
+[[example]]
+name = "tracing"
+path = "tracing.rs"
+

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
         for row in rows.into_typed::<(i32, i32, String)>() {
             let (a, b, c) = row?;
             println!("a, b, c: {}, {}, {}", a, b, c);
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
         c: String,
     }
 
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
         for row_data in rows.into_typed::<RowData>() {
             let row_data = row_data?;
             println!("row_data: {:?}", row_data);
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
     }
 
     // Or simply as untyped rows
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
         for row in rows {
             let a = row.columns[0].as_ref().unwrap().as_int().unwrap();
             let b = row.columns[1].as_ref().unwrap().as_int().unwrap();

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -34,6 +34,7 @@ async fn main() -> Result<()> {
         let qt = session
             .query(format!("SELECT token(pk) FROM ks.t where pk = {}", pk), &[])
             .await?
+            .rows
             .unwrap()
             .get(0)
             .expect("token query no rows!")

--- a/examples/cql-time-types.rs
+++ b/examples/cql-time-types.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
         .query("INSERT INTO ks.dates (d) VALUES (?)", (example_date,))
         .await?;
 
-    if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await? {
+    if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await?.rows {
         for row in rows.into_typed::<(NaiveDate,)>() {
             let (read_date,): (NaiveDate,) = match row {
                 Ok(read_date) => read_date,
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
         .query("INSERT INTO ks.dates (d) VALUES (?)", (example_big_date,))
         .await?;
 
-    if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await? {
+    if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await?.rows {
         for row in rows {
             let read_days: u32 = match row.columns[0] {
                 Some(CqlValue::Date(days)) => days,
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
         .query("INSERT INTO ks.times (t) VALUES (?)", (Time(example_time),))
         .await?;
 
-    if let Some(rows) = session.query("SELECT t from ks.times", &[]).await? {
+    if let Some(rows) = session.query("SELECT t from ks.times", &[]).await?.rows {
         for row in rows.into_typed::<(Duration,)>() {
             let (read_time,): (Duration,) = row?;
 
@@ -105,7 +105,11 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    if let Some(rows) = session.query("SELECT t from ks.timestamps", &[]).await? {
+    if let Some(rows) = session
+        .query("SELECT t from ks.timestamps", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(Duration,)>() {
             let (read_time,): (Duration,) = row?;
 

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await? {
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
         for row in rows.into_typed::<(i32, i32, String)>() {
             let (a, b, c) = row?;
             println!("a, b, c: {}, {}, {}", a, b, c);

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,0 +1,76 @@
+// CQL Tracing allows to see each step during execution of a query
+// query() prepare() and execute() can be traced
+
+use anyhow::{anyhow, Result};
+use scylla::statement::{prepared_statement::PreparedStatement, query::Query, Consistency};
+use scylla::tracing::{GetTracingConfig, TracingInfo};
+use scylla::QueryResult;
+use scylla::{Session, SessionBuilder};
+use std::env;
+use std::num::NonZeroU32;
+use std::time::Duration;
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.tracing_example (val text primary key)",
+            &[],
+        )
+        .await?;
+
+    // QUERY
+    // Create a simple query and enable tracing for it
+    let mut query: Query = Query::new("SELECT val from ks.tracing_example".to_string());
+    query.set_tracing(true);
+
+    // QueryResult will contain a tracing_id which can be used to query tracing information
+    let query_result: QueryResult = session.query(query.clone(), &[]).await?;
+    let query_tracing_id: Uuid = query_result
+        .tracing_id
+        .ok_or_else(|| anyhow!("Tracing id is None!"))?;
+
+    // Get tracing information for this query and print it
+    let tracing_info: TracingInfo = session.get_tracing_info(&query_tracing_id).await?;
+    println!("Query tracing info: {:#?}\n", tracing_info);
+
+    // PREPARE
+    // Now prepare a query - query to be prepared has tracing set so the prepare will be traced
+    let mut prepared: PreparedStatement = session.prepare(query).await?;
+
+    // prepared.prepare_tracing_id contains tracing ids of all prepare requests
+    let prepare_ids: &Vec<Uuid> = &prepared.prepare_tracing_ids;
+    println!("Prepare tracing ids: {:?}\n", prepare_ids);
+
+    // EXECUTE
+    // To trace execution of a prepared statement tracing must be enabled for it
+    prepared.set_tracing(true);
+
+    let execute_result: QueryResult = session.execute(&prepared, &[]).await?;
+    println!("Execute tracing id: {:?}", execute_result.tracing_id);
+
+    // CUSTOM
+    // GetTracingConfig allows to specify a custom settings for querying tracing info
+    // Tracing info might not immediately be available on queried node
+    // so the driver performs a few attempts with sleeps in between.
+
+    let custom_config: GetTracingConfig = GetTracingConfig {
+        attempts: NonZeroU32::new(8).unwrap(),
+        interval: Duration::from_millis(100),
+        consistency: Consistency::One,
+    };
+
+    let _custom_info: TracingInfo = session
+        .get_tracing_info_custom(&query_tracing_id, &custom_config)
+        .await?;
+
+    Ok(())
+}

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
         .await?;
 
     // And read like any normal value
-    if let Some(rows) = session.query("SELECT my FROM ks.udt_tab", &[]).await? {
+    if let Some(rows) = session.query("SELECT my FROM ks.udt_tab", &[]).await?.rows {
         for row in rows.into_typed::<(MyType,)>() {
             let (my_val,) = row?;
             println!("{:?}", my_val)

--- a/scylla/src/frame/cql_collections_test.rs
+++ b/scylla/src/frame/cql_collections_test.rs
@@ -50,6 +50,7 @@ async fn test_cql_collections() {
         .query("SELECT team FROM ks.teams", &[])
         .await
         .unwrap()
+        .rows
     {
         for row in rows.into_typed::<(HashMap<i32, String>,)>() {
             let teams: HashMap<i32, String> = row.unwrap().0;
@@ -83,6 +84,7 @@ async fn test_cql_collections() {
         .query("SELECT tags FROM ks.images", &[])
         .await
         .unwrap()
+        .rows
     {
         for row in rows.into_typed::<(Vec<String>,)>() {
             let tag: Vec<String> = row.unwrap().0;
@@ -101,6 +103,7 @@ async fn test_cql_collections() {
         .query("SELECT tags FROM ks.images", &[])
         .await
         .unwrap()
+        .rows
     {
         for row in rows.into_typed::<(Vec<String>,)>() {
             let tag: Vec<String> = row.unwrap().0;
@@ -130,6 +133,7 @@ async fn test_cql_collections() {
         .query("SELECT scores FROM ks.plays", &[])
         .await
         .unwrap()
+        .rows
     {
         for row in rows.into_typed::<(Vec<i32>,)>() {
             let scores: Vec<i32> = row.unwrap().0;
@@ -151,6 +155,7 @@ async fn test_cql_collections() {
         .query("SELECT scores FROM ks.plays", &[])
         .await
         .unwrap()
+        .rows
     {
         for row in rows.into_typed::<(Vec<i32>,)>() {
             let scores: Vec<i32> = row.unwrap().0;
@@ -180,6 +185,7 @@ async fn test_cql_collections() {
         .query("SELECT duration FROM ks.durations", &[])
         .await
         .unwrap()
+        .rows
     {
         for row in rows.into_typed::<((i32, String),)>() {
             let duration = row.unwrap().0;

--- a/scylla/src/frame/cql_types_test.rs
+++ b/scylla/src/frame/cql_types_test.rs
@@ -89,6 +89,7 @@ where
             .query(select_values, &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(T,)>()
             .map(Result::unwrap)
@@ -178,6 +179,7 @@ async fn test_counter() {
             .query(select_values, (i as i32,))
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Counter,)>()
             .map(Result::unwrap)
@@ -233,6 +235,7 @@ async fn test_naive_date() {
             .query("SELECT val from ks.naive_date", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(NaiveDate,)>()
             .next()
@@ -256,6 +259,7 @@ async fn test_naive_date() {
                 .query("SELECT val from ks.naive_date", &[])
                 .await
                 .unwrap()
+                .rows
                 .unwrap()
                 .into_typed::<(NaiveDate,)>()
                 .next()
@@ -313,6 +317,7 @@ async fn test_date() {
             .query("SELECT val from ks.date_tests", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()[0]
             .columns[0]
             .as_ref()
@@ -361,6 +366,7 @@ async fn test_time() {
             .query("SELECT val from ks.time_tests", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Duration,)>()
             .next()
@@ -382,6 +388,7 @@ async fn test_time() {
             .query("SELECT val from ks.time_tests", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Duration,)>()
             .next()
@@ -467,6 +474,7 @@ async fn test_timestamp() {
             .query("SELECT val from ks.timestamp_tests", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Duration,)>()
             .next()
@@ -488,6 +496,7 @@ async fn test_timestamp() {
             .query("SELECT val from ks.timestamp_tests", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Duration,)>()
             .next()
@@ -541,6 +550,7 @@ async fn test_timeuuid() {
             .query("SELECT val from ks.timeuuid_tests", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Uuid,)>()
             .next()
@@ -563,6 +573,7 @@ async fn test_timeuuid() {
             .query("SELECT val from ks.timeuuid_tests", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Uuid,)>()
             .next()
@@ -631,6 +642,7 @@ async fn test_inet() {
             .query("SELECT val from ks.inet_tests WHERE id = 0", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(IpAddr,)>()
             .next()
@@ -649,6 +661,7 @@ async fn test_inet() {
             .query("SELECT val from ks.inet_tests WHERE id = 0", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(IpAddr,)>()
             .next()
@@ -705,6 +718,7 @@ async fn test_blob() {
             .query("SELECT val from ks.blob_tests WHERE id = 0", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Vec<u8>,)>()
             .next()
@@ -723,6 +737,7 @@ async fn test_blob() {
             .query("SELECT val from ks.blob_tests WHERE id = 0", &[])
             .await
             .unwrap()
+            .rows
             .unwrap()
             .into_typed::<(Vec<u8>,)>()
             .next()

--- a/scylla/src/frame/mod.rs
+++ b/scylla/src/frame/mod.rs
@@ -124,6 +124,7 @@ pub struct RequestBodyWithExtensions {
 pub fn prepare_request_body_with_extensions(
     body_with_ext: RequestBodyWithExtensions,
     compression: Option<Compression>,
+    tracing: bool,
 ) -> Result<(u8, Bytes), FrameError> {
     let mut flags = 0;
 
@@ -131,6 +132,10 @@ pub fn prepare_request_body_with_extensions(
     if let Some(compression) = compression {
         flags |= FLAG_COMPRESSION;
         body = compress(&body, compression)?.into();
+    }
+
+    if tracing {
+        flags |= FLAG_TRACING;
     }
 
     Ok((flags, body))

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -15,5 +15,6 @@ pub use statement::query;
 
 pub use frame::response::cql_to_rust;
 
+pub use transport::connection::QueryResult;
 pub use transport::session::{IntoTypedRows, Session, SessionConfig};
 pub use transport::session_builder::SessionBuilder;

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -6,6 +6,7 @@ pub mod macros;
 pub mod frame;
 pub mod routing;
 pub mod statement;
+pub mod tracing;
 pub mod transport;
 
 pub use macros::*;

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -16,6 +16,6 @@ pub use statement::query;
 
 pub use frame::response::cql_to_rust;
 
-pub use transport::connection::QueryResult;
+pub use transport::connection::{BatchResult, QueryResult};
 pub use transport::session::{IntoTypedRows, Session, SessionConfig};
 pub use transport::session_builder::SessionBuilder;

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -14,6 +14,7 @@ pub struct Batch {
     pub serial_consistency: Option<Consistency>,
     pub is_idempotent: bool,
     pub retry_policy: Option<Box<dyn RetryPolicy + Send + Sync>>,
+    pub tracing: bool,
 }
 
 impl Batch {
@@ -86,6 +87,18 @@ impl Batch {
     pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy + Send + Sync>> {
         &self.retry_policy
     }
+
+    /// Enable or disable CQL Tracing for this batch  
+    /// If enabled session.batch() will return a BatchResult containing tracing_id
+    /// which can be used to query tracing information about the execution of this query
+    pub fn set_tracing(&mut self, should_trace: bool) {
+        self.tracing = should_trace;
+    }
+
+    /// Gets whether tracing is enabled for this batch
+    pub fn get_tracing(&self) -> bool {
+        self.tracing
+    }
 }
 
 impl Default for Batch {
@@ -97,6 +110,7 @@ impl Default for Batch {
             serial_consistency: None,
             is_idempotent: false,
             retry_policy: None,
+            tracing: false,
         }
     }
 }
@@ -138,6 +152,7 @@ impl Clone for Batch {
                 .retry_policy
                 .as_ref()
                 .map(|policy| policy.clone_boxed()),
+            tracing: self.tracing,
         }
     }
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -5,12 +5,14 @@ use crate::transport::retry_policy::RetryPolicy;
 use bytes::{BufMut, Bytes, BytesMut};
 use std::convert::TryInto;
 use thiserror::Error;
+use uuid::Uuid;
 
 /// Represents a statement prepared on the server.
 pub struct PreparedStatement {
     id: Bytes,
     metadata: PreparedMetadata,
     statement: String,
+    pub prepare_tracing_ids: Vec<Uuid>,
     page_size: Option<i32>,
     pub consistency: Consistency,
     pub serial_consistency: Option<Consistency>,
@@ -25,6 +27,7 @@ impl PreparedStatement {
             id,
             metadata,
             statement,
+            prepare_tracing_ids: Vec::new(),
             page_size: None,
             consistency: Default::default(),
             serial_consistency: None,
@@ -117,6 +120,11 @@ impl PreparedStatement {
         self.tracing
     }
 
+    /// Gets tracing ids of queries used to prepare this statement
+    pub fn get_prepare_tracing_ids(&self) -> &[Uuid] {
+        &self.prepare_tracing_ids
+    }
+
     /// Computes the partition key of the target table from given values
     /// Partition keys have a specific serialization rules.
     /// Ref: https://github.com/scylladb/scylla/blob/40adf38915b6d8f5314c621a94d694d172360833/compound_compat.hh#L33-L47
@@ -195,6 +203,7 @@ impl Clone for PreparedStatement {
             id: self.id.clone(),
             metadata: self.metadata.clone(),
             statement: self.statement.clone(),
+            prepare_tracing_ids: self.prepare_tracing_ids.clone(),
             page_size: self.page_size,
             consistency: self.consistency,
             serial_consistency: self.serial_consistency,

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -16,6 +16,7 @@ pub struct PreparedStatement {
     pub serial_consistency: Option<Consistency>,
     pub is_idempotent: bool,
     pub retry_policy: Option<Box<dyn RetryPolicy + Send + Sync>>,
+    pub tracing: bool,
 }
 
 impl PreparedStatement {
@@ -29,6 +30,7 @@ impl PreparedStatement {
             serial_consistency: None,
             is_idempotent: false,
             retry_policy: None,
+            tracing: false,
         }
     }
 
@@ -101,6 +103,18 @@ impl PreparedStatement {
     /// Gets custom [`RetryPolicy`] used by this statement
     pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy + Send + Sync>> {
         &self.retry_policy
+    }
+
+    /// Enable or disable CQL Tracing for this prepared statement  
+    /// If enabled session.execute() will return QueryResult containing tracing_id
+    /// which can be used to query tracing information about the execution of this statement
+    pub fn set_tracing(&mut self, should_trace: bool) {
+        self.tracing = should_trace;
+    }
+
+    /// Gets whether tracing is enabled for this prepared statement
+    pub fn get_tracing(&self) -> bool {
+        self.tracing
     }
 
     /// Computes the partition key of the target table from given values
@@ -189,6 +203,7 @@ impl Clone for PreparedStatement {
                 .retry_policy
                 .as_ref()
                 .map(|policy| policy.clone_boxed()),
+            tracing: self.tracing,
         }
     }
 }

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -11,6 +11,7 @@ pub struct Query {
     pub serial_consistency: Option<Consistency>,
     pub is_idempotent: bool,
     pub retry_policy: Option<Box<dyn RetryPolicy + Send + Sync>>,
+    pub tracing: bool,
 }
 
 impl Query {
@@ -23,6 +24,7 @@ impl Query {
             serial_consistency: None,
             is_idempotent: false,
             retry_policy: None,
+            tracing: false,
         }
     }
 
@@ -93,6 +95,18 @@ impl Query {
     pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy + Send + Sync>> {
         &self.retry_policy
     }
+
+    /// Enable or disable CQL Tracing for this query  
+    /// If enabled session.query() will return QueryResult containing tracing_id
+    /// which can be used to query tracing information about the execution of this query
+    pub fn set_tracing(&mut self, should_trace: bool) {
+        self.tracing = should_trace;
+    }
+
+    /// Gets whether tracing is enabled for this query
+    pub fn get_tracing(&self) -> bool {
+        self.tracing
+    }
 }
 
 impl From<String> for Query {
@@ -119,6 +133,7 @@ impl Clone for Query {
                 .retry_policy
                 .as_ref()
                 .map(|policy| policy.clone_boxed()),
+            tracing: self.tracing,
         }
     }
 }

--- a/scylla/src/tracing.rs
+++ b/scylla/src/tracing.rs
@@ -1,0 +1,91 @@
+use chrono::Duration;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use uuid::Uuid;
+
+use crate::cql_to_rust::{FromRow, FromRowError};
+use crate::frame::response::result::Row;
+
+/// Tracing info retrieved from `system_traces.sessions`
+/// with all events from `system_traces.events`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TracingInfo {
+    pub client: Option<IpAddr>,
+    pub command: Option<String>,
+    pub coordinator: Option<IpAddr>,
+    pub duration: Option<i32>,
+    pub parameters: Option<HashMap<String, String>>,
+    pub request: Option<String>,
+    /// started_at is a timestamp - time since unix epoch
+    pub started_at: Option<Duration>,
+
+    pub events: Vec<TracingEvent>,
+}
+
+/// A single event happening during a traced query
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TracingEvent {
+    pub event_id: Uuid,
+    pub activity: Option<String>,
+    pub source: Option<IpAddr>,
+    pub source_elapsed: Option<i32>,
+    pub thread: Option<String>,
+}
+
+// A query used to query TracingInfo from system_traces.sessions
+pub(crate) const TRACES_SESSION_QUERY_STR: &str =
+    "SELECT client, command, coordinator, duration, parameters, request, started_at \
+    FROM system_traces.sessions WHERE session_id = ?";
+
+// A query used to query TracingEvent from system_traces.events
+pub(crate) const TRACES_EVENTS_QUERY_STR: &str =
+    "SELECT event_id, activity, source, source_elapsed, thread \
+    FROM system_traces.events WHERE session_id = ?";
+
+// Converts a row received by performing TRACES_SESSION_QUERY_STR to TracingInfo
+impl FromRow for TracingInfo {
+    fn from_row(row: Row) -> Result<TracingInfo, FromRowError> {
+        let (client, command, coordinator, duration, parameters, request, started_at) =
+            <(
+                Option<IpAddr>,
+                Option<String>,
+                Option<IpAddr>,
+                Option<i32>,
+                Option<HashMap<String, String>>,
+                Option<String>,
+                Option<Duration>,
+            )>::from_row(row)?;
+
+        Ok(TracingInfo {
+            client,
+            command,
+            coordinator,
+            duration,
+            parameters,
+            request,
+            started_at,
+            events: Vec::new(),
+        })
+    }
+}
+
+// Converts a row received by performing TRACES_SESSION_QUERY_STR to TracingInfo
+impl FromRow for TracingEvent {
+    fn from_row(row: Row) -> Result<TracingEvent, FromRowError> {
+        let (event_id, activity, source, source_elapsed, thread) = <(
+            Uuid,
+            Option<String>,
+            Option<IpAddr>,
+            Option<i32>,
+            Option<String>,
+        )>::from_row(row)?;
+
+        Ok(TracingEvent {
+            event_id,
+            activity,
+            source,
+            source_elapsed,
+            thread,
+        })
+    }
+}

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -272,7 +272,9 @@ impl Connection {
             },
         };
 
-        let query_response = self.send_request(&execute_frame, true, false).await?;
+        let query_response = self
+            .send_request(&execute_frame, true, prepared_statement.tracing)
+            .await?;
 
         if let Response::Error(err) = &query_response.response {
             if err.error == DbError::Unprepared {
@@ -286,7 +288,9 @@ impl Connection {
                     ));
                 }
 
-                return self.send_request(&execute_frame, true, false).await;
+                return self
+                    .send_request(&execute_frame, true, prepared_statement.tracing)
+                    .await;
             }
         }
 

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -149,9 +149,10 @@ impl RowIterator {
                 |node: Arc<Node>| async move { node.connection_for_token(token).await };
 
             let page_query = |connection: Arc<Connection>, paging_state: Option<Bytes>| async move {
-                connection
+                Ok(connection
                     .execute(prepared_ref, values_ref, paging_state)
-                    .await
+                    .await?
+                    .response)
             };
 
             let worker = RowIteratorWorker {

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -94,7 +94,10 @@ impl RowIterator {
             let choose_connection = |node: Arc<Node>| async move { node.random_connection().await };
 
             let page_query = |connection: Arc<Connection>, paging_state: Option<Bytes>| async move {
-                connection.query(query_ref, values_ref, paging_state).await
+                Ok(connection
+                    .query(query_ref, values_ref, paging_state)
+                    .await?
+                    .response)
             };
 
             let worker = RowIteratorWorker {

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -19,7 +19,7 @@ use crate::statement::Consistency;
 use crate::tracing::{GetTracingConfig, TracingEvent, TracingInfo};
 use crate::transport::{
     cluster::Cluster,
-    connection::{Connection, ConnectionConfig, QueryResult, VerifiedKeyspaceName},
+    connection::{BatchResult, Connection, ConnectionConfig, QueryResult, VerifiedKeyspaceName},
     iterator::RowIterator,
     load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, Statement, TokenAwarePolicy},
     metrics::{Metrics, MetricsView},
@@ -464,7 +464,11 @@ impl Session {
     ///
     /// * `batch` - batch to be performed
     /// * `values` - values bound to the query
-    pub async fn batch(&self, batch: &Batch, values: impl BatchValues) -> Result<(), QueryError> {
+    pub async fn batch(
+        &self,
+        batch: &Batch,
+        values: impl BatchValues,
+    ) -> Result<BatchResult, QueryError> {
         let values_ref = &values;
 
         let retry_session = match &batch.retry_policy {

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -17,7 +17,7 @@ use crate::routing::{murmur3_token, Token};
 use crate::statement::Consistency;
 use crate::transport::{
     cluster::Cluster,
-    connection::{Connection, ConnectionConfig, VerifiedKeyspaceName},
+    connection::{Connection, ConnectionConfig, QueryResult, VerifiedKeyspaceName},
     iterator::RowIterator,
     load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, Statement, TokenAwarePolicy},
     metrics::{Metrics, MetricsView},
@@ -278,7 +278,7 @@ impl Session {
         &self,
         query: impl Into<Query>,
         values: impl ValueList,
-    ) -> Result<Option<Vec<result::Row>>, QueryError> {
+    ) -> Result<QueryResult, QueryError> {
         let query: Query = query.into();
         let query_text: &str = query.get_contents();
         let serialized_values = values.serialized();
@@ -294,7 +294,7 @@ impl Session {
             return self
                 .use_keyspace(keyspace_name, case_sensitive)
                 .await
-                .map(|_| None);
+                .map(|_| QueryResult::default());
         }
 
         let retry_session = match &query.retry_policy {

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -395,7 +395,7 @@ impl Session {
         &self,
         prepared: &PreparedStatement,
         values: impl ValueList,
-    ) -> Result<Option<Vec<result::Row>>, QueryError> {
+    ) -> Result<QueryResult, QueryError> {
         let serialized_values = values.serialized()?;
         let values_ref = &serialized_values;
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -712,29 +712,8 @@ async fn test_get_tracing_info(session: &Session) {
     let tracing_id: Uuid = traced_query_result.tracing_id.unwrap();
 
     // Getting tracing info from session using this uuid works
-    // Tracing info might not be immediately available
-    // Perform 8 retries with a 32ms wait in between
-    let mut last_error = None;
-
-    for _ in 0..8_u32 {
-        let tracing_info_res: Result<TracingInfo, _> = session.get_tracing_info(&tracing_id).await;
-
-        match tracing_info_res {
-            Ok(tracing_info) => {
-                assert!(!tracing_info.events.is_empty()); // Ok
-                return;
-            }
-            Err(e) => last_error = Some(e), // Retry
-        };
-
-        // Sleep before retry
-        tokio::time::sleep(std::time::Duration::from_millis(32)).await;
-    }
-
-    panic!(
-        "Failed to perform session.get_tracing_info(): {:?}",
-        last_error
-    );
+    let tracing_info: TracingInfo = session.get_tracing_info(&tracing_id).await.unwrap();
+    assert!(!tracing_info.events.is_empty());
 }
 
 async fn assert_in_tracing_table(session: &Session, tracing_uuid: Uuid) {

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -39,6 +39,7 @@ async fn test_unprepared_statement() {
         .query("SELECT a, b, c FROM ks.t", &[])
         .await
         .unwrap()
+        .rows
         .unwrap();
 
     let mut results: Vec<(i32, i32, &String)> = rs
@@ -112,6 +113,7 @@ async fn test_prepared_statement() {
             .query("SELECT token(a) FROM ks.t2", &[])
             .await
             .unwrap()
+            .rows
             .unwrap();
         let token: i64 = rs.first().unwrap().columns[0]
             .as_ref()
@@ -131,6 +133,7 @@ async fn test_prepared_statement() {
             .query("SELECT token(a,b,c) FROM ks.complex_pk", &[])
             .await
             .unwrap()
+            .rows
             .unwrap();
         let token: i64 = rs.first().unwrap().columns[0]
             .as_ref()
@@ -152,6 +155,7 @@ async fn test_prepared_statement() {
             .query("SELECT a,b,c FROM ks.t2", &[])
             .await
             .unwrap()
+            .rows
             .unwrap();
         let r = rs.first().unwrap();
         let a = r.columns[0].as_ref().unwrap().as_int().unwrap();
@@ -164,6 +168,7 @@ async fn test_prepared_statement() {
             .query("SELECT a,b,c,d,e FROM ks.complex_pk", &[])
             .await
             .unwrap()
+            .rows
             .unwrap();
         let r = rs.first().unwrap();
         let a = r.columns[0].as_ref().unwrap().as_int().unwrap();
@@ -218,6 +223,7 @@ async fn test_batch() {
         .query("SELECT a, b, c FROM ks.t_batch", &[])
         .await
         .unwrap()
+        .rows
         .unwrap();
 
     let mut results: Vec<(i32, i32, &String)> = rs
@@ -276,6 +282,7 @@ async fn test_token_calculation() {
             .query("SELECT token(a) FROM ks.t3 WHERE a = ?", &values)
             .await
             .unwrap()
+            .rows
             .unwrap();
         let token: i64 = rs.first().unwrap().columns[0]
             .as_ref()
@@ -331,6 +338,7 @@ async fn test_use_keyspace() {
         .query("SELECT * FROM tab", &[])
         .await
         .unwrap()
+        .rows
         .unwrap()
         .into_typed::<(String,)>()
         .map(|res| res.unwrap().0)
@@ -381,6 +389,7 @@ async fn test_use_keyspace() {
         .query("SELECT * FROM tab", &[])
         .await
         .unwrap()
+        .rows
         .unwrap()
         .into_typed::<(String,)>()
         .map(|res| res.unwrap().0)
@@ -447,6 +456,7 @@ async fn test_use_keyspace_case_sensitivity() {
         .query("SELECT * from tab", &[])
         .await
         .unwrap()
+        .rows
         .unwrap()
         .into_typed::<(String,)>()
         .map(|row| row.unwrap().0)
@@ -462,6 +472,7 @@ async fn test_use_keyspace_case_sensitivity() {
         .query("SELECT * from tab", &[])
         .await
         .unwrap()
+        .rows
         .unwrap()
         .into_typed::<(String,)>()
         .map(|row| row.unwrap().0)
@@ -511,6 +522,7 @@ async fn test_raw_use_keyspace() {
         .query("SELECT * FROM tab", &[])
         .await
         .unwrap()
+        .rows
         .unwrap()
         .into_typed::<(String,)>()
         .map(|res| res.unwrap().0)

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -168,11 +168,11 @@ async fn query_peers(conn: &Connection, connect_port: u16) -> Result<Vec<Peer>, 
 
     let (peers_res, local_res) = tokio::try_join!(peers_query, local_query)?;
 
-    let peers_rows = peers_res.ok_or(QueryError::ProtocolError(
+    let peers_rows = peers_res.rows.ok_or(QueryError::ProtocolError(
         "system.peers query response was not Rows",
     ))?;
 
-    let local_rows = local_res.ok_or(QueryError::ProtocolError(
+    let local_rows = local_res.rows.ok_or(QueryError::ProtocolError(
         "system.local query response was not Rows",
     ))?;
 
@@ -222,6 +222,7 @@ async fn query_keyspaces(conn: &Connection) -> Result<HashMap<String, Keyspace>,
             &[],
         )
         .await?
+        .rows
         .ok_or(QueryError::ProtocolError(
             "system_schema.keyspaces query response was not Rows",
         ))?;


### PR DESCRIPTION
## Description
This PR adds support for CQL tracing.
Tracing can be used like this:
```rust
// Create a simple query and enable tracing for it
let mut query: Query = Query::new("SELECT peer from system.peers".to_string());
query.set_tracing(true);

// QueryResult will contain a tracing_id which can be used to query tracing information
let query_result: QueryResult = session.query(query.clone(), &[]).await?;
let query_tracing_id: Uuid = query_result
    .tracing_id
    .ok_or_else(|| anyhow!("Tracing id is None!"))?;

// Get tracing information for this query and print it
let tracing_info: TracingInfo = session.get_tracing_info(&query_tracing_id).await?;
println!("Query tracing info: {:#?}\n", tracing_info);
```
Queries that support tracing are:
* `Session::query()`
* `Session::prepare()`
* `Session::execute()`
* `Session::batch()`
* `Session::query_iter()`
* `Session::execute_iter()`

~~In the [specification](https://github.com/apache/cassandra/blob/28e8632c9793f8d77247fc40f2c5003810df16f9/doc/native_protocol_v4.spec#L116) it's written that only QUERY, PREPARE and EXECUTE queries support tracing so `Session::batch()` doesn't support it.~~

## Notes
`TracingInfo` contains columns from `system_traces` that are the same in Cassandra and Scylla. Scylla has some scylla specific entries that the user can query themselves if they really need to.

Retrying tracing info queries and its configuration is based on [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.0/manual/core/tracing/)

## Fixed issues
Fixes: #189

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
