### PR TITLE
Receive server events

### DIFF
--- a/scylla/src/frame/mod.rs
+++ b/scylla/src/frame/mod.rs
@@ -1,6 +1,7 @@
 pub mod frame_errors;
 pub mod request;
 pub mod response;
+pub mod server_event_type;
 pub mod types;
 pub mod value;
 

--- a/scylla/src/frame/request/mod.rs
+++ b/scylla/src/frame/request/mod.rs
@@ -4,6 +4,7 @@ pub mod execute;
 pub mod options;
 pub mod prepare;
 pub mod query;
+pub mod register;
 pub mod startup;
 
 use crate::frame::frame_errors::ParseError;

--- a/scylla/src/frame/request/register.rs
+++ b/scylla/src/frame/request/register.rs
@@ -1,17 +1,11 @@
 use bytes::BufMut;
-use std::fmt;
 
 use crate::frame::{
     frame_errors::ParseError,
     request::{Request, RequestOpcode},
+    server_event_type::EventType,
     types,
 };
-
-pub enum EventType {
-    TopologyChange,
-    StatusChange,
-    SchemaChange,
-}
 
 pub struct Register {
     pub event_types_to_register_for: Vec<EventType>,
@@ -29,17 +23,5 @@ impl Request for Register {
 
         types::write_string_list(&event_types_list, buf)?;
         Ok(())
-    }
-}
-
-impl fmt::Display for EventType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match &self {
-            Self::TopologyChange => "TOPOLOGY_CHANGE",
-            Self::StatusChange => "STATUS_CHANGE",
-            Self::SchemaChange => "SCHEMA_CHANGE",
-        };
-
-        write!(f, "{}", s)
     }
 }

--- a/scylla/src/frame/request/register.rs
+++ b/scylla/src/frame/request/register.rs
@@ -1,0 +1,45 @@
+use bytes::BufMut;
+use std::fmt;
+
+use crate::frame::{
+    frame_errors::ParseError,
+    request::{Request, RequestOpcode},
+    types,
+};
+
+pub enum EventType {
+    TopologyChange,
+    StatusChange,
+    SchemaChange,
+}
+
+pub struct Register {
+    pub event_types_to_register_for: Vec<EventType>,
+}
+
+impl Request for Register {
+    const OPCODE: RequestOpcode = RequestOpcode::Register;
+
+    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+        let event_types_list = self
+            .event_types_to_register_for
+            .iter()
+            .map(|event| event.to_string())
+            .collect::<Vec<_>>();
+
+        types::write_string_list(&event_types_list, buf)?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match &self {
+            Self::TopologyChange => "TOPOLOGY_CHANGE",
+            Self::StatusChange => "STATUS_CHANGE",
+            Self::SchemaChange => "SCHEMA_CHANGE",
+        };
+
+        write!(f, "{}", s)
+    }
+}

--- a/scylla/src/frame/response/event.rs
+++ b/scylla/src/frame/response/event.rs
@@ -1,0 +1,71 @@
+use crate::frame::frame_errors::ParseError;
+use crate::frame::server_event_type::EventType;
+use crate::frame::types;
+use std::net::SocketAddr;
+
+#[derive(Debug)]
+pub enum Event {
+    TopologyChange(TopologyChangeEvent),
+    StatusChange(StatusChangeEvent),
+    SchemaChange, // TODO specify
+}
+
+#[derive(Debug)]
+pub enum TopologyChangeEvent {
+    NewNode(SocketAddr),
+    RemovedNode(SocketAddr),
+}
+
+#[derive(Debug)]
+pub enum StatusChangeEvent {
+    Up(SocketAddr),
+    Down(SocketAddr),
+}
+
+impl Event {
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
+        let event_type: EventType = types::read_string(buf)?.parse()?;
+        match event_type {
+            EventType::TopologyChange => {
+                Ok(Self::TopologyChange(TopologyChangeEvent::deserialize(buf)?))
+            }
+            EventType::StatusChange => Ok(Self::StatusChange(StatusChangeEvent::deserialize(buf)?)),
+            EventType::SchemaChange => {
+                // TODO implement deserialization of SchemaChange
+                Ok(Self::SchemaChange)
+            }
+        }
+    }
+}
+
+impl TopologyChangeEvent {
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
+        let type_of_change = types::read_string(buf)?;
+        let addr = types::read_inet(buf)?;
+
+        match type_of_change {
+            "NEW_NODE" => Ok(Self::NewNode(addr)),
+            "REMOVED_NODE" => Ok(Self::RemovedNode(addr)),
+            _ => Err(ParseError::BadData(format!(
+                "Invalid type of change ({}) in TopologyChangeEvent",
+                type_of_change
+            ))),
+        }
+    }
+}
+
+impl StatusChangeEvent {
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
+        let type_of_change = types::read_string(buf)?;
+        let addr = types::read_inet(buf)?;
+
+        match type_of_change {
+            "UP" => Ok(Self::Up(addr)),
+            "DOWN" => Ok(Self::Down(addr)),
+            _ => Err(ParseError::BadData(format!(
+                "Invalid type of status change ({}) in StatusChangeEvent",
+                type_of_change
+            ))),
+        }
+    }
+}

--- a/scylla/src/frame/response/mod.rs
+++ b/scylla/src/frame/response/mod.rs
@@ -33,6 +33,7 @@ pub enum Response {
     AuthSuccess(authenticate::AuthSuccess),
     AuthChallenge(authenticate::AuthChallenge),
     Supported(Supported),
+    Event(event::Event),
 }
 
 impl Response {
@@ -45,7 +46,7 @@ impl Response {
             }
             ResponseOpcode::Supported => Response::Supported(Supported::deserialize(buf)?),
             ResponseOpcode::Result => Response::Result(result::deserialize(buf)?),
-            ResponseOpcode::Event => unimplemented!(),
+            ResponseOpcode::Event => Response::Event(event::Event::deserialize(buf)?),
             ResponseOpcode::AuthChallenge => {
                 Response::AuthChallenge(authenticate::AuthChallenge::deserialize(buf)?)
             }

--- a/scylla/src/frame/response/mod.rs
+++ b/scylla/src/frame/response/mod.rs
@@ -1,6 +1,7 @@
 pub mod authenticate;
 pub mod cql_to_rust;
 pub mod error;
+pub mod event;
 pub mod result;
 pub mod supported;
 

--- a/scylla/src/frame/server_event_type.rs
+++ b/scylla/src/frame/server_event_type.rs
@@ -1,0 +1,37 @@
+use crate::frame::frame_errors::ParseError;
+use std::fmt;
+use std::str::FromStr;
+
+pub enum EventType {
+    TopologyChange,
+    StatusChange,
+    SchemaChange,
+}
+
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match &self {
+            Self::TopologyChange => "TOPOLOGY_CHANGE",
+            Self::StatusChange => "STATUS_CHANGE",
+            Self::SchemaChange => "SCHEMA_CHANGE",
+        };
+
+        write!(f, "{}", s)
+    }
+}
+
+impl FromStr for EventType {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TOPOLOGY_CHANGE" => Ok(Self::TopologyChange),
+            "STATUS_CHANGE" => Ok(Self::StatusChange),
+            "SCHEMA_CHANGE" => Ok(Self::SchemaChange),
+            _ => Err(ParseError::BadData(format!(
+                "Invalid type event type: {}",
+                s
+            ))),
+        }
+    }
+}

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -232,7 +232,6 @@ impl Connection {
         if let Some(tracing_id) = query_response.tracing_id {
             prepared_statement.prepare_tracing_ids.push(tracing_id);
         }
-
         Ok(prepared_statement)
     }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -189,15 +189,6 @@ impl Connection {
             is_shard_aware: false,
         };
 
-        if connection.config.event_sender.is_some() {
-            let all_event_types = vec![
-                EventType::TopologyChange,
-                EventType::StatusChange,
-                EventType::SchemaChange,
-            ];
-            connection.register(all_event_types).await?;
-        }
-
         Ok((connection, error_receiver))
     }
 
@@ -859,6 +850,15 @@ pub async fn open_named_connection(
                 "Unexpected response to STARTUP message",
             ))
         }
+    }
+
+    if connection.config.event_sender.is_some() {
+        let all_event_types = vec![
+            EventType::TopologyChange,
+            EventType::StatusChange,
+            EventType::SchemaChange,
+        ];
+        connection.register(all_event_types).await?;
     }
 
     Ok((connection, error_receiver))

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -29,8 +29,9 @@ use super::errors::{BadKeyspaceName, BadQuery, DbError, QueryError};
 use crate::batch::{Batch, BatchStatement};
 use crate::frame::{
     self,
-    request::{self, batch, execute, query, register, register::EventType, Request, RequestOpcode},
-    response::{result, Response, ResponseOpcode},
+    request::{self, batch, execute, query, register, Request, RequestOpcode},
+    response::{event::Event, result, Response, ResponseOpcode},
+    server_event_type::EventType,
     value::{BatchValues, ValueList},
     FrameParams, RequestBodyWithExtensions,
 };
@@ -43,11 +44,6 @@ use crate::transport::Authenticator::{
     PasswordAuthenticator, ScyllaTransitionalAuthenticator,
 };
 use crate::transport::Compression;
-
-// TODO add more events
-pub enum Event {
-    TopologyChange,
-}
 
 pub struct Connection {
     submit_channel: mpsc::Sender<Task>,
@@ -439,7 +435,7 @@ impl Connection {
 
     async fn register(
         &self,
-        event_types_to_register_for: Vec<register::EventType>,
+        event_types_to_register_for: Vec<EventType>,
     ) -> Result<(), QueryError> {
         let register_frame = register::Register {
             event_types_to_register_for,

--- a/scylla/src/transport/connection_keeper.rs
+++ b/scylla/src/transport/connection_keeper.rs
@@ -309,8 +309,7 @@ mod tests {
             tcp_nodelay: false,
             #[cfg(feature = "ssl")]
             ssl_context: None,
-            auth_password: None,
-            auth_username: None,
+            ..Default::default()
         };
 
         // Get shard info from a single connection, all connections will open to this shard

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -176,6 +176,7 @@ impl SessionConfig {
             ssl_context: self.ssl_context.clone(),
             auth_username: self.auth_username.to_owned(),
             auth_password: self.auth_password.to_owned(),
+            ..Default::default()
         }
     }
 }

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -105,13 +105,14 @@ impl TopologyReader {
         // if fetching topology info on current control connection failed,
         // try to fetch topology info from other known peer
         for peer in filtered_known_peers {
-            if result.is_ok() {
-                break;
-            }
+            let err = match result {
+                Ok(_) => break,
+                Err(err) => err,
+            };
 
             warn!(
                 control_connection_address = self.control_connection_address.to_string().as_str(),
-                error = result.as_ref().err().unwrap().to_string().as_str(),
+                error = err.to_string().as_str(),
                 "Falied to fetch topology info using current control connection"
             );
 
@@ -138,7 +139,7 @@ impl TopologyReader {
             ),
         }
 
-        return result;
+        result
     }
 
     async fn fetch_topology_info(&self) -> Result<TopologyInfo, QueryError> {

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -92,6 +92,9 @@ impl TopologyReader {
     /// Fetches current topology info from the cluster
     pub async fn read_topology_info(&mut self) -> Result<TopologyInfo, QueryError> {
         let mut result = self.fetch_topology_info().await;
+        if result.is_ok() {
+            return result;
+        }
 
         // shuffle known_peers to iterate through them in random order later
         self.known_peers.shuffle(&mut thread_rng());


### PR DESCRIPTION
## Description

- Reduced control connection count to 1
- Added `Register` and `Event` frames
- Modified connection to allow sending `REGISTER` message
- Added mechanism to receive events and propagate them to cluster module
- Made cluster react to `TOPOLOGY_CHANGE` and `STATUS_CHANGE` events (and trigger topology metadata refresh Fixes: #85) 

## Design

`TopologyReader` creates control connections using special `ConnectionConfig` in which a sender half of mpsc channel is embedded. Control connection sends `REGISTER` message to a server and pushes every received event into its mpsc sender. `ClusterWorker` holds other half of this channel and processes events pushed by connection (triggers topology info refresh or deletes down nodes from associated `ClusterData`).

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] <s> I added relevant tests for new features and bug fixes. </s>
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
