### PR TITLE
Apply suggestions from clippy 1.51

### DIFF
--- a/examples/cql-time-types.rs
+++ b/examples/cql-time-types.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use chrono::{Duration, NaiveDate};
-use scylla::frame::response::result::CQLValue;
+use scylla::frame::response::result::CqlValue;
 use scylla::frame::value::{Date, Time, Timestamp};
 use scylla::transport::session::{IntoTypedRows, Session};
 use scylla::SessionBuilder;
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
     if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await? {
         for row in rows {
             let read_days: u32 = match row.columns[0] {
-                Some(CQLValue::Date(days)) => days,
+                Some(CqlValue::Date(days)) => days,
                 _ => panic!("oh no"),
             };
 

--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
 
     let session: Session = SessionBuilder::new()
         .known_node(uri)
-        .compression(Some(Compression::LZ4))
+        .compression(Some(Compression::Lz4))
         .build()
         .await?;
 

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use scylla::cql_to_rust::FromCQLVal;
+use scylla::cql_to_rust::FromCqlVal;
 use scylla::macros::{FromUserType, IntoUserType};
 use scylla::{IntoTypedRows, Session, SessionBuilder};
 use std::env;

--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -14,7 +14,7 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
         let field_type = &field.ty;
 
         quote_spanned! {field.span() =>
-            #field_name: <#field_type as FromCQLVal<Option<CQLValue>>>::from_cql(
+            #field_name: <#field_type as FromCqlVal<Option<CqlValue>>>::from_cql(
                 vals_iter
                 .next()
                 .ok_or(FromRowError::RowTooShort) ?
@@ -26,8 +26,8 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
         impl FromRow for #struct_name {
             fn from_row(row: scylla::frame::response::result::Row)
             -> Result<Self, scylla::cql_to_rust::FromRowError> {
-                use scylla::frame::response::result::CQLValue;
-                use scylla::cql_to_rust::{FromCQLVal, FromRow, FromRowError};
+                use scylla::frame::response::result::CqlValue;
+                use scylla::cql_to_rust::{FromCqlVal, FromRow, FromRowError};
 
                 let mut vals_iter = row.columns.into_iter();
 

--- a/scylla-macros/src/from_user_type.rs
+++ b/scylla-macros/src/from_user_type.rs
@@ -14,7 +14,7 @@ pub fn from_user_type_derive(tokens_input: TokenStream) -> TokenStream {
         let field_type = &field.ty;
 
         quote_spanned! {field.span() =>
-            #field_name: <#field_type as FromCQLVal<Option<CQLValue>>>::from_cql(
+            #field_name: <#field_type as FromCqlVal<Option<CqlValue>>>::from_cql(
                 // Take value with key #field_name out of fields map, if none found then return NULL
                 fields.remove(stringify!(#field_name)).unwrap_or(None)
             ) ?,
@@ -22,17 +22,17 @@ pub fn from_user_type_derive(tokens_input: TokenStream) -> TokenStream {
     });
 
     let generated = quote! {
-        impl FromCQLVal<scylla::frame::response::result::CQLValue> for #struct_name {
-            fn from_cql(cql_val: scylla::frame::response::result::CQLValue)
-            -> Result<Self, scylla::cql_to_rust::FromCQLValError> {
+        impl FromCqlVal<scylla::frame::response::result::CqlValue> for #struct_name {
+            fn from_cql(cql_val: scylla::frame::response::result::CqlValue)
+            -> Result<Self, scylla::cql_to_rust::FromCqlValError> {
                 use std::collections::BTreeMap;
-                use scylla::cql_to_rust::{FromCQLVal, FromCQLValError};
-                use scylla::frame::response::result::CQLValue;
+                use scylla::cql_to_rust::{FromCqlVal, FromCqlValError};
+                use scylla::frame::response::result::CqlValue;
 
-                // Interpret CQLValue as CQlValue::UserDefinedType
-                let mut fields: BTreeMap<String, Option<CQLValue>> = match cql_val {
-                    CQLValue::UserDefinedType{fields, ..} => fields,
-                    _ => return Err(FromCQLValError::BadCQLType),
+                // Interpret CqlValue as CQlValue::UserDefinedType
+                let mut fields: BTreeMap<String, Option<CqlValue>> = match cql_val {
+                    CqlValue::UserDefinedType{fields, ..} => fields,
+                    _ => return Err(FromCqlValError::BadCqlType),
                 };
 
                 // Parse struct using values from fields
@@ -42,7 +42,7 @@ pub fn from_user_type_derive(tokens_input: TokenStream) -> TokenStream {
 
                 // There should be no unused fields when reading user defined type
                 if !fields.is_empty() {
-                    return Err(FromCQLValError::BadCQLType);
+                    return Err(FromCqlValError::BadCqlType);
                 }
 
                 return Ok(result);

--- a/scylla/src/frame/cql_types_test.rs
+++ b/scylla/src/frame/cql_types_test.rs
@@ -1,5 +1,5 @@
-use crate::cql_to_rust::FromCQLVal;
-use crate::frame::response::result::CQLValue;
+use crate::cql_to_rust::FromCqlVal;
+use crate::frame::response::result::CqlValue;
 use crate::frame::value::Counter;
 use crate::frame::value::Value;
 use crate::frame::value::{Date, Time, Timestamp};
@@ -62,7 +62,7 @@ async fn init_test(table_name: &str, type_name: &str) -> Session {
 // Expected values and bound values are computed using T::from_str
 async fn run_tests<T>(tests: &[&str], type_name: &str)
 where
-    T: Value + FromCQLVal<CQLValue> + FromStr + Debug + Clone + PartialEq,
+    T: Value + FromCqlVal<CqlValue> + FromStr + Debug + Clone + PartialEq,
 {
     let session: Session = init_test(type_name, type_name).await;
 
@@ -316,7 +316,7 @@ async fn test_date() {
             .columns[0]
             .as_ref()
             .map(|cql_val| match cql_val {
-                CQLValue::Date(days) => Date(*days),
+                CqlValue::Date(days) => Date(*days),
                 _ => panic!(),
             })
             .unwrap();

--- a/scylla/src/frame/frame_errors.rs
+++ b/scylla/src/frame/frame_errors.rs
@@ -1,5 +1,5 @@
 use super::response;
-use crate::cql_to_rust::CQLTypeError;
+use crate::cql_to_rust::CqlTypeError;
 use crate::frame::value::SerializeValuesError;
 use thiserror::Error;
 
@@ -10,7 +10,7 @@ pub enum FrameError {
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,
     #[error("L4Z body decompression failed")]
-    LZ4BodyDecompression,
+    Lz4BodyDecompression,
     #[error("Received frame marked as coming from a client")]
     FrameFromClient,
     #[error("Received a frame from version {0}, but only 4 is supported")]
@@ -22,7 +22,7 @@ pub enum FrameError {
     #[error("Frame compression failed.")]
     FrameCompression,
     #[error("std io error encountered while processing")]
-    StdIOError(#[from] std::io::Error),
+    StdIoError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]
     TryFromPrimitiveError(#[from] num_enum::TryFromPrimitiveError<response::ResponseOpcode>),
 }
@@ -38,5 +38,5 @@ pub enum ParseError {
     #[error(transparent)]
     SerializeValuesError(#[from] SerializeValuesError),
     #[error(transparent)]
-    CQLTypeError(#[from] CQLTypeError),
+    CqlTypeError(#[from] CqlTypeError),
 }

--- a/scylla/src/frame/mod.rs
+++ b/scylla/src/frame/mod.rs
@@ -194,11 +194,11 @@ pub fn parse_response_body_extensions(
 
 pub fn compress(uncomp_body: &[u8], compression: Compression) -> Result<Vec<u8>, FrameError> {
     match compression {
-        Compression::LZ4 => {
+        Compression::Lz4 => {
             let uncomp_len = uncomp_body.len() as u32;
             let mut tmp =
                 Vec::with_capacity(lz4::compression_bound(uncomp_len).unwrap_or(0) as usize);
-            lz4::encode_block(&uncomp_body[..], &mut tmp);
+            lz4::encode_block(uncomp_body, &mut tmp);
 
             let mut comp_body = Vec::with_capacity(std::mem::size_of::<u32>() + tmp.len());
             comp_body.put_u32(uncomp_len);
@@ -213,16 +213,16 @@ pub fn compress(uncomp_body: &[u8], compression: Compression) -> Result<Vec<u8>,
 
 pub fn decompress(mut comp_body: &[u8], compression: Compression) -> Result<Vec<u8>, FrameError> {
     match compression {
-        Compression::LZ4 => {
+        Compression::Lz4 => {
             let uncomp_len = comp_body.get_u32() as usize;
             let mut uncomp_body = Vec::with_capacity(uncomp_len);
             if uncomp_len == 0 {
                 return Ok(uncomp_body);
             }
-            if lz4::decode_block(&comp_body[..], &mut uncomp_body) > 0 {
+            if lz4::decode_block(comp_body, &mut uncomp_body) > 0 {
                 Ok(uncomp_body)
             } else {
-                Err(FrameError::LZ4BodyDecompression)
+                Err(FrameError::Lz4BodyDecompression)
             }
         }
         Compression::Snappy => snap::raw::Decoder::new()

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -1,4 +1,4 @@
-use super::result::{CQLValue, Row};
+use super::result::{CqlValue, Row};
 use crate::frame::value::Counter;
 use bigdecimal::BigDecimal;
 use chrono::{Duration, NaiveDate};
@@ -12,28 +12,28 @@ use uuid::Uuid;
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum FromRowError {
     #[error("Bad CQL value")]
-    BadCQLVal(#[from] FromCQLValError),
+    BadCqlVal(#[from] FromCqlValError),
     #[error("Row too short")]
     RowTooShort,
 }
 
 #[derive(Error, Debug, PartialEq, Eq)]
-pub enum CQLTypeError {
+pub enum CqlTypeError {
     #[error("Invalid number of set elements: {0}")]
     InvalidNumberOfElements(i32),
 }
 
-/// This trait defines a way to convert CQLValue or Option<CQLValue> into some rust type
-// We can't use From trait because impl From<Option<CQLValue>> for String {...}
+/// This trait defines a way to convert CqlValue or Option<CqlValue> into some rust type
+// We can't use From trait because impl From<Option<CqlValue>> for String {...}
 // is forbidden since neither From nor String are defined in this crate
-pub trait FromCQLVal<T>: Sized {
-    fn from_cql(cql_val: T) -> Result<Self, FromCQLValError>;
+pub trait FromCqlVal<T>: Sized {
+    fn from_cql(cql_val: T) -> Result<Self, FromCqlValError>;
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
-pub enum FromCQLValError {
+pub enum FromCqlValError {
     #[error("Bad CQL type")]
-    BadCQLType,
+    BadCqlType,
     #[error("Value is null")]
     ValIsNull,
 }
@@ -43,68 +43,68 @@ pub trait FromRow: Sized {
     fn from_row(row: Row) -> Result<Self, FromRowError>;
 }
 
-// Implement from_cql<Option<CQLValue>> for every type that has from_cql<CQLValue>
+// Implement from_cql<Option<CqlValue>> for every type that has from_cql<CqlValue>
 // This tries to unwrap the option or fails with an error
-impl<T: FromCQLVal<CQLValue>> FromCQLVal<Option<CQLValue>> for T {
-    fn from_cql(cql_val_opt: Option<CQLValue>) -> Result<Self, FromCQLValError> {
-        T::from_cql(cql_val_opt.ok_or(FromCQLValError::ValIsNull)?)
+impl<T: FromCqlVal<CqlValue>> FromCqlVal<Option<CqlValue>> for T {
+    fn from_cql(cql_val_opt: Option<CqlValue>) -> Result<Self, FromCqlValError> {
+        T::from_cql(cql_val_opt.ok_or(FromCqlValError::ValIsNull)?)
     }
 }
 
-// Implement from_cql<Option<CQLValue>> for Option<T> for every type that has from_cql<CQLValue>
-// Value inside Option gets mapped from CQLValue to T
-impl<T: FromCQLVal<CQLValue>> FromCQLVal<Option<CQLValue>> for Option<T> {
-    fn from_cql(cql_val_opt: Option<CQLValue>) -> Result<Self, FromCQLValError> {
+// Implement from_cql<Option<CqlValue>> for Option<T> for every type that has from_cql<CqlValue>
+// Value inside Option gets mapped from CqlValue to T
+impl<T: FromCqlVal<CqlValue>> FromCqlVal<Option<CqlValue>> for Option<T> {
+    fn from_cql(cql_val_opt: Option<CqlValue>) -> Result<Self, FromCqlValError> {
         match cql_val_opt {
             Some(cql_val) => Ok(Some(T::from_cql(cql_val)?)),
             None => Ok(None),
         }
     }
 }
-// This macro implements FromCQLVal given a type and method of CQLValue that returns this type
+// This macro implements FromCqlVal given a type and method of CqlValue that returns this type
 macro_rules! impl_from_cql_val {
     ($T:ty, $convert_func:ident) => {
-        impl FromCQLVal<CQLValue> for $T {
-            fn from_cql(cql_val: CQLValue) -> Result<$T, FromCQLValError> {
-                cql_val.$convert_func().ok_or(FromCQLValError::BadCQLType)
+        impl FromCqlVal<CqlValue> for $T {
+            fn from_cql(cql_val: CqlValue) -> Result<$T, FromCqlValError> {
+                cql_val.$convert_func().ok_or(FromCqlValError::BadCqlType)
             }
         }
     };
 }
 
-impl_from_cql_val!(i32, as_int); // i32::from_cql<CQLValue>
-impl_from_cql_val!(i64, as_bigint); // i64::from_cql<CQLValue>
-impl_from_cql_val!(Counter, as_counter); // Counter::from_cql<CQLValue>
-impl_from_cql_val!(i16, as_smallint); // i16::from_cql<CQLValue>
-impl_from_cql_val!(BigInt, into_varint); // BigInt::from_cql<CQLValue>
-impl_from_cql_val!(i8, as_tinyint); // i8::from_cql<CQLValue>
-impl_from_cql_val!(NaiveDate, as_date); // NaiveDate::from_cql<CQLValue>
-impl_from_cql_val!(f32, as_float); // f32::from_cql<CQLValue>
-impl_from_cql_val!(f64, as_double); // f64::from_cql<CQLValue>
-impl_from_cql_val!(bool, as_boolean); // bool::from_cql<CQLValue>
-impl_from_cql_val!(String, into_string); // String::from_cql<CQLValue>
-impl_from_cql_val!(IpAddr, as_inet); // IpAddr::from_cql<CQLValue>
-impl_from_cql_val!(Uuid, as_uuid); // Uuid::from_cql<CQLValue>
-impl_from_cql_val!(BigDecimal, into_decimal); // BigDecimal::from_cql<CQLValue>
-impl_from_cql_val!(Duration, as_duration); // Duration::from_cql<CQLValue>
+impl_from_cql_val!(i32, as_int); // i32::from_cql<CqlValue>
+impl_from_cql_val!(i64, as_bigint); // i64::from_cql<CqlValue>
+impl_from_cql_val!(Counter, as_counter); // Counter::from_cql<CqlValue>
+impl_from_cql_val!(i16, as_smallint); // i16::from_cql<CqlValue>
+impl_from_cql_val!(BigInt, into_varint); // BigInt::from_cql<CqlValue>
+impl_from_cql_val!(i8, as_tinyint); // i8::from_cql<CqlValue>
+impl_from_cql_val!(NaiveDate, as_date); // NaiveDate::from_cql<CqlValue>
+impl_from_cql_val!(f32, as_float); // f32::from_cql<CqlValue>
+impl_from_cql_val!(f64, as_double); // f64::from_cql<CqlValue>
+impl_from_cql_val!(bool, as_boolean); // bool::from_cql<CqlValue>
+impl_from_cql_val!(String, into_string); // String::from_cql<CqlValue>
+impl_from_cql_val!(IpAddr, as_inet); // IpAddr::from_cql<CqlValue>
+impl_from_cql_val!(Uuid, as_uuid); // Uuid::from_cql<CqlValue>
+impl_from_cql_val!(BigDecimal, into_decimal); // BigDecimal::from_cql<CqlValue>
+impl_from_cql_val!(Duration, as_duration); // Duration::from_cql<CqlValue>
 
-// Vec<T>::from_cql<CQLValue>
-impl<T: FromCQLVal<CQLValue>> FromCQLVal<CQLValue> for Vec<T> {
-    fn from_cql(cql_val: CQLValue) -> Result<Self, FromCQLValError> {
+// Vec<T>::from_cql<CqlValue>
+impl<T: FromCqlVal<CqlValue>> FromCqlVal<CqlValue> for Vec<T> {
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         cql_val
             .into_vec()
-            .ok_or(FromCQLValError::BadCQLType)?
+            .ok_or(FromCqlValError::BadCqlType)?
             .into_iter()
             .map(T::from_cql)
-            .collect::<Result<Vec<T>, FromCQLValError>>()
+            .collect::<Result<Vec<T>, FromCqlValError>>()
     }
 }
 
-impl<T1: FromCQLVal<CQLValue> + Eq + Hash, T2: FromCQLVal<CQLValue>> FromCQLVal<CQLValue>
+impl<T1: FromCqlVal<CqlValue> + Eq + Hash, T2: FromCqlVal<CqlValue>> FromCqlVal<CqlValue>
     for HashMap<T1, T2>
 {
-    fn from_cql(cql_val: CQLValue) -> Result<Self, FromCQLValError> {
-        let vec = cql_val.into_pair_vec().ok_or(FromCQLValError::BadCQLType)?;
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+        let vec = cql_val.into_pair_vec().ok_or(FromCqlValError::BadCqlType)?;
         let mut res = HashMap::with_capacity(vec.len());
         for (key, value) in vec {
             res.insert(T1::from_cql(key)?, T2::from_cql(value)?);
@@ -113,12 +113,12 @@ impl<T1: FromCQLVal<CQLValue> + Eq + Hash, T2: FromCQLVal<CQLValue>> FromCQLVal<
     }
 }
 
-// This macro implements FromRow for tuple of types that have FromCQLVal
+// This macro implements FromRow for tuple of types that have FromCqlVal
 macro_rules! impl_tuple_from_row {
     ( $($Ti:tt),+ ) => {
         impl<$($Ti),+> FromRow for ($($Ti,)+)
         where
-            $($Ti: FromCQLVal<Option<CQLValue>>),+
+            $($Ti: FromCqlVal<Option<CqlValue>>),+
         {
             fn from_row(row: Row) -> Result<Self, FromRowError> {
                 let mut vals_iter = row.columns.into_iter();
@@ -156,21 +156,21 @@ impl_tuple_from_row!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 macro_rules! impl_tuple_from_cql {
     ( $($Ti:tt),+ ) => {
-        impl<$($Ti),+> FromCQLVal<CQLValue> for ($($Ti,)+)
+        impl<$($Ti),+> FromCqlVal<CqlValue> for ($($Ti,)+)
         where
-            $($Ti: FromCQLVal<CQLValue>),+
+            $($Ti: FromCqlVal<CqlValue>),+
         {
-            fn from_cql(cql_val: CQLValue) -> Result<Self, FromCQLValError> {
+            fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
                 let tuple_fields = match cql_val {
-                    CQLValue::Tuple(fields) => fields,
-                    _ => return Err(FromCQLValError::BadCQLType)
+                    CqlValue::Tuple(fields) => fields,
+                    _ => return Err(FromCqlValError::BadCqlType)
                 };
 
                 let mut tuple_fields_iter = tuple_fields.into_iter();
 
                 Ok((
                     $(
-                        $Ti::from_cql(tuple_fields_iter.next().ok_or(FromCQLValError::BadCQLType) ?) ?
+                        $Ti::from_cql(tuple_fields_iter.next().ok_or(FromCqlValError::BadCqlType) ?) ?
                     ,)+
                 ))
             }
@@ -197,7 +197,7 @@ impl_tuple_from_cql!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 #[cfg(test)]
 mod tests {
-    use super::{CQLValue, FromCQLVal, FromCQLValError, FromRow, FromRowError, Row};
+    use super::{CqlValue, FromCqlVal, FromCqlValError, FromRow, FromRowError, Row};
     use crate as scylla;
     use crate::frame::value::Counter;
     use crate::macros::FromRow;
@@ -210,54 +210,54 @@ mod tests {
 
     #[test]
     fn i32_from_cql() {
-        assert_eq!(Ok(1234), i32::from_cql(CQLValue::Int(1234)));
+        assert_eq!(Ok(1234), i32::from_cql(CqlValue::Int(1234)));
     }
 
     #[test]
     fn bool_from_cql() {
-        assert_eq!(Ok(true), bool::from_cql(CQLValue::Boolean(true)));
-        assert_eq!(Ok(false), bool::from_cql(CQLValue::Boolean(false)));
+        assert_eq!(Ok(true), bool::from_cql(CqlValue::Boolean(true)));
+        assert_eq!(Ok(false), bool::from_cql(CqlValue::Boolean(false)));
     }
 
     #[test]
     fn floatingpoints_from_cql() {
         let float: f32 = 2.13;
         let double: f64 = 4.26;
-        assert_eq!(Ok(float), f32::from_cql(CQLValue::Float(float)));
-        assert_eq!(Ok(double), f64::from_cql(CQLValue::Double(double)));
+        assert_eq!(Ok(float), f32::from_cql(CqlValue::Float(float)));
+        assert_eq!(Ok(double), f64::from_cql(CqlValue::Double(double)));
     }
 
     #[test]
     fn i64_from_cql() {
-        assert_eq!(Ok(1234), i64::from_cql(CQLValue::BigInt(1234)));
+        assert_eq!(Ok(1234), i64::from_cql(CqlValue::BigInt(1234)));
     }
 
     #[test]
     fn i8_from_cql() {
-        assert_eq!(Ok(6), i8::from_cql(CQLValue::TinyInt(6)));
+        assert_eq!(Ok(6), i8::from_cql(CqlValue::TinyInt(6)));
     }
 
     #[test]
     fn i16_from_cql() {
-        assert_eq!(Ok(16), i16::from_cql(CQLValue::SmallInt(16)));
+        assert_eq!(Ok(16), i16::from_cql(CqlValue::SmallInt(16)));
     }
 
     #[test]
     fn string_from_cql() {
         assert_eq!(
             Ok("ascii_test".to_string()),
-            String::from_cql(CQLValue::Ascii("ascii_test".to_string()))
+            String::from_cql(CqlValue::Ascii("ascii_test".to_string()))
         );
         assert_eq!(
             Ok("text_test".to_string()),
-            String::from_cql(CQLValue::Text("text_test".to_string()))
+            String::from_cql(CqlValue::Text("text_test".to_string()))
         );
     }
 
     #[test]
     fn ip_addr_from_cql() {
         let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        assert_eq!(Ok(ip_addr), IpAddr::from_cql(CQLValue::Inet(ip_addr)));
+        assert_eq!(Ok(ip_addr), IpAddr::from_cql(CqlValue::Inet(ip_addr)));
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod tests {
         let big_int = 0.to_bigint().unwrap();
         assert_eq!(
             Ok(big_int),
-            BigInt::from_cql(CQLValue::Varint(0.to_bigint().unwrap()))
+            BigInt::from_cql(CqlValue::Varint(0.to_bigint().unwrap()))
         );
     }
 
@@ -274,40 +274,40 @@ mod tests {
         let decimal = BigDecimal::from_str("123.4").unwrap();
         assert_eq!(
             Ok(decimal.clone()),
-            BigDecimal::from_cql(CQLValue::Decimal(decimal))
+            BigDecimal::from_cql(CqlValue::Decimal(decimal))
         );
     }
 
     #[test]
     fn counter_from_cql() {
         let counter = Counter(1);
-        assert_eq!(Ok(counter), Counter::from_cql(CQLValue::Counter(counter)));
+        assert_eq!(Ok(counter), Counter::from_cql(CqlValue::Counter(counter)));
     }
 
     #[test]
     fn naive_date_from_cql() {
-        let unix_epoch: CQLValue = CQLValue::Date(2_u32.pow(31));
+        let unix_epoch: CqlValue = CqlValue::Date(2_u32.pow(31));
         assert_eq!(
             Ok(NaiveDate::from_ymd(1970, 1, 1)),
             NaiveDate::from_cql(unix_epoch)
         );
 
-        let before_epoch: CQLValue = CQLValue::Date(2_u32.pow(31) - 30);
+        let before_epoch: CqlValue = CqlValue::Date(2_u32.pow(31) - 30);
         assert_eq!(
             Ok(NaiveDate::from_ymd(1969, 12, 2)),
             NaiveDate::from_cql(before_epoch)
         );
 
-        let after_epoch: CQLValue = CQLValue::Date(2_u32.pow(31) + 30);
+        let after_epoch: CqlValue = CqlValue::Date(2_u32.pow(31) + 30);
         assert_eq!(
             Ok(NaiveDate::from_ymd(1970, 1, 31)),
             NaiveDate::from_cql(after_epoch)
         );
 
-        let min_date: CQLValue = CQLValue::Date(0);
+        let min_date: CqlValue = CqlValue::Date(0);
         assert!(NaiveDate::from_cql(min_date).is_err());
 
-        let max_date: CQLValue = CQLValue::Date(u32::max_value());
+        let max_date: CqlValue = CqlValue::Date(u32::max_value());
         assert!(NaiveDate::from_cql(max_date).is_err());
     }
 
@@ -316,13 +316,13 @@ mod tests {
         let time_duration = Duration::nanoseconds(86399999999999);
         assert_eq!(
             time_duration,
-            Duration::from_cql(CQLValue::Time(time_duration)).unwrap(),
+            Duration::from_cql(CqlValue::Time(time_duration)).unwrap(),
         );
 
         let timestamp_duration = Duration::milliseconds(i64::min_value());
         assert_eq!(
             timestamp_duration,
-            Duration::from_cql(CQLValue::Timestamp(timestamp_duration)).unwrap(),
+            Duration::from_cql(CqlValue::Timestamp(timestamp_duration)).unwrap(),
         );
     }
 
@@ -332,18 +332,18 @@ mod tests {
 
         assert_eq!(
             test_uuid,
-            Uuid::from_cql(CQLValue::Uuid(test_uuid)).unwrap()
+            Uuid::from_cql(CqlValue::Uuid(test_uuid)).unwrap()
         );
 
         assert_eq!(
             test_uuid,
-            Uuid::from_cql(CQLValue::Timeuuid(test_uuid)).unwrap()
+            Uuid::from_cql(CqlValue::Timeuuid(test_uuid)).unwrap()
         );
     }
 
     #[test]
     fn vec_from_cql() {
-        let cql_val = CQLValue::Set(vec![CQLValue::Int(1), CQLValue::Int(2), CQLValue::Int(3)]);
+        let cql_val = CqlValue::Set(vec![CqlValue::Int(1), CqlValue::Int(2), CqlValue::Int(3)]);
         assert_eq!(Ok(vec![1, 2, 3]), Vec::<i32>::from_cql(cql_val));
     }
 
@@ -351,8 +351,8 @@ mod tests {
     fn tuple_from_row() {
         let row = Row {
             columns: vec![
-                Some(CQLValue::Int(1)),
-                Some(CQLValue::Text("some_text".to_string())),
+                Some(CqlValue::Int(1)),
+                Some(CqlValue::Text("some_text".to_string())),
                 None,
             ],
         };
@@ -363,7 +363,7 @@ mod tests {
         assert_eq!(c, None);
 
         let row2 = Row {
-            columns: vec![Some(CQLValue::Int(1)), Some(CQLValue::Int(2))],
+            columns: vec![Some(CqlValue::Int(1)), Some(CqlValue::Int(2))],
         };
 
         let (d,) = <(i32,)>::from_row(row2).unwrap();
@@ -372,14 +372,14 @@ mod tests {
 
     #[test]
     fn from_cql_null() {
-        assert_eq!(i32::from_cql(None), Err(FromCQLValError::ValIsNull));
+        assert_eq!(i32::from_cql(None), Err(FromCqlValError::ValIsNull));
     }
 
     #[test]
     fn from_cql_wrong_type() {
         assert_eq!(
-            i32::from_cql(CQLValue::BigInt(1234)),
-            Err(FromCQLValError::BadCQLType)
+            i32::from_cql(CqlValue::BigInt(1234)),
+            Err(FromCqlValError::BadCqlType)
         );
     }
 
@@ -391,26 +391,26 @@ mod tests {
 
         assert_eq!(
             <(i32,)>::from_row(row),
-            Err(FromRowError::BadCQLVal(FromCQLValError::ValIsNull))
+            Err(FromRowError::BadCqlVal(FromCqlValError::ValIsNull))
         );
     }
 
     #[test]
     fn from_row_wrong_type() {
         let row = Row {
-            columns: vec![Some(CQLValue::Int(1234))],
+            columns: vec![Some(CqlValue::Int(1234))],
         };
 
         assert_eq!(
             <(String,)>::from_row(row),
-            Err(FromRowError::BadCQLVal(FromCQLValError::BadCQLType))
+            Err(FromRowError::BadCqlVal(FromCqlValError::BadCqlType))
         );
     }
 
     #[test]
     fn from_row_too_short() {
         let row = Row {
-            columns: vec![Some(CQLValue::Int(1234))],
+            columns: vec![Some(CqlValue::Int(1234))],
         };
 
         assert_eq!(<(i32, i32)>::from_row(row), Err(FromRowError::RowTooShort));
@@ -427,9 +427,9 @@ mod tests {
 
         let row = Row {
             columns: vec![
-                Some(CQLValue::Int(16)),
+                Some(CqlValue::Int(16)),
                 None,
-                Some(CQLValue::Set(vec![CQLValue::Int(1), CQLValue::Int(2)])),
+                Some(CqlValue::Set(vec![CqlValue::Int(1), CqlValue::Int(2)])),
             ],
         };
 

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -321,10 +321,12 @@ pub fn write_string_list(v: &[String], buf: &mut impl BufMut) -> Result<(), Pars
 
 #[test]
 fn type_string_list() {
-    let mut val = Vec::new();
-    val.push("".to_owned());
-    val.push("CQL_VERSION".to_owned());
-    val.push("THROW_ON_OVERLOAD".to_owned());
+    let val = vec![
+        "".to_owned(),
+        "CQL_VERSION".to_owned(),
+        "THROW_ON_OVERLOAD".to_owned(),
+    ];
+
     let mut buf = Vec::new();
     write_string_list(&val, &mut buf).unwrap();
     assert_eq!(read_string_list(&mut &buf[..]).unwrap(), val);

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -355,11 +355,11 @@ impl ClusterWorker {
         let use_keyspace_results: Vec<Result<(), QueryError>> =
             join_all(use_keyspace_futures).await;
 
-        // If there was at least one Ok and the rest were IOErrors we can return Ok
+        // If there was at least one Ok and the rest were IoErrors we can return Ok
         // keyspace name is correct and will be used on broken connection on the next reconnect
 
-        // If there were only IOErrors then return IOError
-        // If there was an error different than IOError return this error - something is wrong
+        // If there were only IoErrors then return IoError
+        // If there was an error different than IoError return this error - something is wrong
 
         let mut was_ok: bool = false;
         let mut io_error: Option<Arc<std::io::Error>> = None;
@@ -368,7 +368,7 @@ impl ClusterWorker {
             match result {
                 Ok(()) => was_ok = true,
                 Err(err) => match err {
-                    QueryError::IOError(io_err) => io_error = Some(io_err),
+                    QueryError::IoError(io_err) => io_error = Some(io_err),
                     _ => return Err(err),
                 },
             }
@@ -379,7 +379,7 @@ impl ClusterWorker {
         }
 
         // We can unwrap io_error because use_keyspace_futures must be nonempty
-        return Err(QueryError::IOError(io_error.unwrap()));
+        return Err(QueryError::IoError(io_error.unwrap()));
     }
 
     async fn perform_refresh(&mut self) -> Result<(), QueryError> {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -15,7 +15,7 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr},
 };
 
-use super::errors::{BadKeyspaceName, BadQuery, DBError, QueryError};
+use super::errors::{BadKeyspaceName, BadQuery, DbError, QueryError};
 
 use crate::batch::{Batch, BatchStatement};
 use crate::frame::{
@@ -234,7 +234,7 @@ impl Connection {
         let response = self.send_request(&execute_frame, true).await?;
 
         if let Response::Error(err) = &response {
-            if err.error == DBError::Unprepared {
+            if err.error == DbError::Unprepared {
                 // Repreparation of a statement is needed
                 let reprepared = self.prepare(prepared_statement.get_statement()).await?;
                 // Reprepared statement should keep its id - it's the md5 sum
@@ -349,14 +349,14 @@ impl Connection {
             })
             .await
             .map_err(|_| {
-                QueryError::IOError(Arc::new(std::io::Error::new(
+                QueryError::IoError(Arc::new(std::io::Error::new(
                     ErrorKind::Other,
                     "Connection broken",
                 )))
             })?;
 
         let task_response = receiver.await.map_err(|_| {
-            QueryError::IOError(Arc::new(std::io::Error::new(
+            QueryError::IoError(Arc::new(std::io::Error::new(
                 ErrorKind::Other,
                 "Connection broken",
             )))
@@ -638,14 +638,14 @@ async fn connect_with_source_port(
 }
 
 struct ResponseHandlerMap {
-    stream_set: StreamIDSet,
+    stream_set: StreamIdSet,
     handlers: HashMap<i16, ResponseHandler>,
 }
 
 impl ResponseHandlerMap {
     pub fn new() -> Self {
         Self {
-            stream_set: StreamIDSet::new(),
+            stream_set: StreamIdSet::new(),
             handlers: HashMap::new(),
         }
     }
@@ -669,11 +669,11 @@ impl ResponseHandlerMap {
     }
 }
 
-struct StreamIDSet {
+struct StreamIdSet {
     used_bitmap: Box<[u64]>,
 }
 
-impl StreamIDSet {
+impl StreamIdSet {
     pub fn new() -> Self {
         const BITMAP_SIZE: usize = (std::i16::MAX as usize + 1) / 64;
         Self {

--- a/scylla/src/transport/connection_keeper.rs
+++ b/scylla/src/transport/connection_keeper.rs
@@ -222,7 +222,7 @@ impl ConnectionKeeperWorker {
             // user gets all errors from session.use_keyspace()
         }
 
-        let connection_closed_error = QueryError::IOError(Arc::new(std::io::Error::new(
+        let connection_closed_error = QueryError::IoError(Arc::new(std::io::Error::new(
             ErrorKind::Other,
             "Connection closed",
         )));
@@ -277,7 +277,7 @@ impl ConnectionKeeperWorker {
         }
 
         // Tried all source ports for that shard, give up
-        return Err(QueryError::IOError(Arc::new(std::io::Error::new(
+        return Err(QueryError::IoError(Arc::new(std::io::Error::new(
             std::io::ErrorKind::AddrInUse,
             "Could not find free source port for shard",
         ))));

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -7,7 +7,7 @@ mod dc_aware_round_robin;
 mod round_robin;
 mod token_aware;
 
-pub use dc_aware_round_robin::DCAwareRoundRobinPolicy;
+pub use dc_aware_round_robin::DcAwareRoundRobinPolicy;
 pub use round_robin::RoundRobinPolicy;
 pub use token_aware::TokenAwarePolicy;
 
@@ -104,11 +104,11 @@ mod tests {
     #[test]
     fn test_names() {
         let local_dc = "eu".to_string();
-        let policy = TokenAwarePolicy::new(Box::new(DCAwareRoundRobinPolicy::new(local_dc)));
+        let policy = TokenAwarePolicy::new(Box::new(DcAwareRoundRobinPolicy::new(local_dc)));
 
         assert_eq!(
             policy.name(),
-            "TokenAwarePolicy{child_policy: DCAwareRoundRobinPolicy}".to_string()
+            "TokenAwarePolicy{child_policy: DcAwareRoundRobinPolicy}".to_string()
         );
     }
 

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -166,7 +166,7 @@ mod tests {
         struct Test<'a> {
             statement: Statement<'a>,
             expected_plan: Vec<u16>,
-        };
+        }
 
         let tests = [
             Test {

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -19,7 +19,7 @@ mod session_test;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Compression {
     /// LZ4 compression algorithm.
-    LZ4,
+    Lz4,
     /// Snappy compression algorithm.
     Snappy,
 }
@@ -27,7 +27,7 @@ pub enum Compression {
 impl ToString for Compression {
     fn to_string(&self) -> String {
         match self {
-            Compression::LZ4 => "lz4".to_owned(),
+            Compression::Lz4 => "lz4".to_owned(),
             Compression::Snappy => "snappy".to_owned(),
         }
     }

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -333,11 +333,11 @@ impl NodeWorker {
         let use_keyspace_results: Vec<Result<(), QueryError>> =
             join_all(use_keyspace_futures).await;
 
-        // If there was at least one Ok and the rest were IOErrors we can return Ok
+        // If there was at least one Ok and the rest were IoErrors we can return Ok
         // keyspace name is correct and will be used on broken connection on the next reconnect
 
-        // If there were only IOErrors then return IOError
-        // If there was an error different than IOError return this error - something is wrong
+        // If there were only IoErrors then return IoError
+        // If there was an error different than IoError return this error - something is wrong
 
         let mut was_ok: bool = false;
         let mut io_error: Option<Arc<std::io::Error>> = None;
@@ -346,7 +346,7 @@ impl NodeWorker {
             match result {
                 Ok(()) => was_ok = true,
                 Err(err) => match err {
-                    QueryError::IOError(io_err) => io_error = Some(io_err),
+                    QueryError::IoError(io_err) => io_error = Some(io_err),
                     _ => return Err(err),
                 },
             }
@@ -357,6 +357,6 @@ impl NodeWorker {
         }
 
         // We can unwrap io_error because use_keyspace_futures must be nonempty
-        return Err(QueryError::IOError(io_error.unwrap()));
+        return Err(QueryError::IoError(io_error.unwrap()));
     }
 }

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -331,8 +331,8 @@ mod tests {
         let mut builder = SessionBuilder::new();
         assert_eq!(builder.config.compression, None);
 
-        builder = builder.compression(Some(Compression::LZ4));
-        assert_eq!(builder.config.compression, Some(Compression::LZ4));
+        builder = builder.compression(Some(Compression::Lz4));
+        assert_eq!(builder.config.compression, Some(Compression::Lz4));
 
         builder = builder.compression(Some(Compression::Snappy));
         assert_eq!(builder.config.compression, Some(Compression::Snappy));

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1,6 +1,6 @@
 use crate::frame::value::ValueList;
 use crate::routing::hash3_x64_128;
-use crate::transport::errors::{BadKeyspaceName, BadQuery, DBError, QueryError};
+use crate::transport::errors::{BadKeyspaceName, BadQuery, DbError, QueryError};
 use crate::{IntoTypedRows, Session, SessionBuilder};
 
 #[tokio::test]
@@ -552,21 +552,21 @@ async fn test_db_errors() {
     // SyntaxError on bad query
     assert!(matches!(
         session.query("gibberish", &[]).await,
-        Err(QueryError::DBError(DBError::SyntaxError, _))
+        Err(QueryError::DbError(DbError::SyntaxError, _))
     ));
 
     // AlreadyExists when creating a keyspace for the second time
     session.query("CREATE KEYSPACE IF NOT EXISTS db_errors_ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
 
     let create_keyspace_res = session.query("CREATE KEYSPACE db_errors_ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await;
-    let keyspace_exists_error: DBError = match create_keyspace_res {
-        Err(QueryError::DBError(e, _)) => e,
+    let keyspace_exists_error: DbError = match create_keyspace_res {
+        Err(QueryError::DbError(e, _)) => e,
         _ => panic!("Second CREATE KEYSPACE didn't return an error!"),
     };
 
     assert_eq!(
         keyspace_exists_error,
-        DBError::AlreadyExists {
+        DbError::AlreadyExists {
             keyspace: "db_errors_ks".to_string(),
             table: "".to_string()
         }
@@ -584,14 +584,14 @@ async fn test_db_errors() {
     let create_table_res = session
         .query("CREATE TABLE db_errors_ks.tab (a text primary key)", &[])
         .await;
-    let create_tab_error: DBError = match create_table_res {
-        Err(QueryError::DBError(e, _)) => e,
+    let create_tab_error: DbError = match create_table_res {
+        Err(QueryError::DbError(e, _)) => e,
         _ => panic!("Second CREATE TABLE didn't return an error!"),
     };
 
     assert_eq!(
         create_tab_error,
-        DBError::AlreadyExists {
+        DbError::AlreadyExists {
             keyspace: "db_errors_ks".to_string(),
             table: "tab".to_string()
         }


### PR DESCRIPTION
## Description
After update to Rust 1.51 cargo clippy shows more suggestions.
We need to apply them in order to pass the CI.

## Changes:
* All abbreviations changed so that only the first letter is uppercase (`LZ4` -> `Lz4`, `CQL` -> `Cql`, etc...)
* Removed some redundant slicings (`&slice[..]` -> `slice`)
* `Vec::new(); vec.push()` changed to `vec![]`
* Changed `Into` to `From`
* Removed redundant `;`

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
