### PR TITLE
Fix sending/receiving Inet and Blob in queries

### DIFF
--- a/scylla/src/frame/cql_types_test.rs
+++ b/scylla/src/frame/cql_types_test.rs
@@ -628,7 +628,7 @@ async fn test_inet() {
             .unwrap();
 
         let (read_inet,): (IpAddr,) = session
-            .query("SELECT val from ks.inet_tests", &[])
+            .query("SELECT val from ks.inet_tests WHERE id = 0", &[])
             .await
             .unwrap()
             .unwrap()
@@ -646,7 +646,7 @@ async fn test_inet() {
             .unwrap();
 
         let (read_inet,): (IpAddr,) = session
-            .query("SELECT val from ks.inet_tests", &[])
+            .query("SELECT val from ks.inet_tests WHERE id = 0", &[])
             .await
             .unwrap()
             .unwrap()
@@ -702,7 +702,7 @@ async fn test_blob() {
             .unwrap();
 
         let (read_blob,): (Vec<u8>,) = session
-            .query("SELECT val from ks.blob_tests", &[])
+            .query("SELECT val from ks.blob_tests WHERE id = 0", &[])
             .await
             .unwrap()
             .unwrap()
@@ -720,7 +720,7 @@ async fn test_blob() {
             .unwrap();
 
         let (read_blob,): (Vec<u8>,) = session
-            .query("SELECT val from ks.blob_tests", &[])
+            .query("SELECT val from ks.blob_tests WHERE id = 0", &[])
             .await
             .unwrap()
             .unwrap()

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -83,6 +83,7 @@ impl_from_cql_val!(f32, as_float); // f32::from_cql<CqlValue>
 impl_from_cql_val!(f64, as_double); // f64::from_cql<CqlValue>
 impl_from_cql_val!(bool, as_boolean); // bool::from_cql<CqlValue>
 impl_from_cql_val!(String, into_string); // String::from_cql<CqlValue>
+impl_from_cql_val!(Vec<u8>, into_blob); // Vec<u8>::from_cql<CqlValue>
 impl_from_cql_val!(IpAddr, as_inet); // IpAddr::from_cql<CqlValue>
 impl_from_cql_val!(Uuid, as_uuid); // Uuid::from_cql<CqlValue>
 impl_from_cql_val!(BigDecimal, into_decimal); // BigDecimal::from_cql<CqlValue>

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -230,6 +230,13 @@ impl CqlValue {
         }
     }
 
+    pub fn into_blob(self) -> Option<Vec<u8>> {
+        match self {
+            Self::Blob(b) => Some(b),
+            _ => None,
+        }
+    }
+
     pub fn as_inet(&self) -> Option<IpAddr> {
         match self {
             Self::Inet(a) => Some(*a),

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -6,6 +6,7 @@ use num_bigint::BigInt;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::net::IpAddr;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -345,6 +346,23 @@ impl Value for Vec<u8> {
         buf.put_i32(val_len);
 
         buf.extend_from_slice(&self);
+
+        Ok(())
+    }
+}
+
+impl Value for IpAddr {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        match self {
+            IpAddr::V4(addr) => {
+                buf.put_i32(4);
+                buf.extend_from_slice(&addr.octets());
+            }
+            IpAddr::V6(addr) => {
+                buf.put_i32(16);
+                buf.extend_from_slice(&addr.octets());
+            }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Description
There were missing implementations for `IpAddr` and `Vec<u8>` which didn't allow to send/receive them in queries properly.

Added:
* `impl Value for IpAddr`
* `impl FromCQLVal for Vec<u8>`
* Tests for `Inet` and `Blob`

## Fixed issues:
Fixes: #201

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
