### PR TITLE
Update documentation book after release 0.1.0

### DIFF
--- a/book/src/connecting/authentication.md
+++ b/book/src/connecting/authentication.md
@@ -1,3 +1,22 @@
 # Authentication
 
-Authentication is still in development, see pull request [#177](https://github.com/scylladb/scylla-rust-driver/pull/177)
+Driver supports authentication by username and password.
+
+To specify credentials use the `user` method in `SessionBuilder`:
+
+```rust
+# extern crate scylla;
+# extern crate tokio;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::{Session, SessionBuilder};
+
+let session: Session = SessionBuilder::new()
+    .known_node("127.0.0.1:9042")
+    .user("myusername", "mypassword")
+    .build()
+    .await?;
+
+# Ok(())
+# }
+```

--- a/book/src/connecting/tls.md
+++ b/book/src/connecting/tls.md
@@ -10,7 +10,7 @@ It was chosen because [`rustls`](https://github.com/ctz/rustls) doesn't support 
 
 To enable the `tls` feature add in `Cargo.toml`:
 ```toml
-scylla = { git = "https://github.com/...", branch = "main", features = ["ssl"] }
+scylla = { version = "0.1.0", features = ["ssl"] }
 openssl = "0.10.32"
 ```
 

--- a/book/src/load-balancing/load-balancing.md
+++ b/book/src/load-balancing/load-balancing.md
@@ -12,6 +12,9 @@ Each of these basic load balancing strategies can be wrapped in `TokenAwarePolic
 > **Note**  
 > Only [prepared queries](../queries/prepared.md) use token aware load balancing
 
+All queries are shard aware, there is no way to turn off shard awareness.  
+If a token is available the query is sent to the correct shard, otherwise to a random one.
+
 So, the available load balancing policies are:
 * [Round robin](robin.md)
 * [DC Aware Round robin](dc-robin.md)

--- a/book/src/queries/batch.md
+++ b/book/src/queries/batch.md
@@ -64,6 +64,9 @@ session.batch(&batch, ((), )).await?;
 # }
 ```
 
+See [Batch API documentation](https://docs.rs/scylla/0.1.0/scylla/statement/batch/struct.Batch.html)
+for more options
+
 ### Batch values
 Batch takes a tuple of values specified just like in [simple](simple.md) or [prepared](prepared.md) queries.
 

--- a/book/src/queries/prepared.md
+++ b/book/src/queries/prepared.md
@@ -66,6 +66,9 @@ session.execute(&prepared, (to_insert,)).await?;
 # }
 ```
 
+See [PreparedStatement API documentation](https://docs.rs/scylla/0.1.0/scylla/statement/prepared_statement/struct.PreparedStatement.html) 
+for more options
+
 ### Performance
 Prepared queries have good performance, much better than simple queries.  
 By default they use shard/token aware load balancing.

--- a/book/src/queries/simple.md
+++ b/book/src/queries/simple.md
@@ -40,7 +40,7 @@ session.query(my_query, (to_insert,)).await?;
 # Ok(())
 # }
 ```
-See [Query API documentation (TODO)]() for more options
+See [Query API documentation](https://docs.rs/scylla/0.1.0/scylla/statement/query/struct.Query.html) for more options
 
 ### Second argument - the values
 Query text is constant, but the values might change.

--- a/book/src/quickstart/create-project.md
+++ b/book/src/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver", branch = "main" }
+scylla = "0.1.0"
 tokio = { version = "1.1.0", features = ["full"] }
 futures = "0.3.6"
 uuid = "0.8.1"
@@ -17,8 +17,6 @@ num-bigint = "0.3"
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 ```
-> Note that when specifying a dependency as a git link, updates will not be automatically pulled.
-> Running `cargo update` will update the git dependency manually.
 
 In `main.rs` put:
 ```rust

--- a/book/src/title-page.md
+++ b/book/src/title-page.md
@@ -5,7 +5,7 @@ Although optimized for Scylla, the driver is also compatible with [Apache Cassan
 
 ### Other documentation
 * [Examples](https://github.com/scylladb/scylla-rust-driver/tree/main/examples)
-*  *API documentation* (Coming soon, for now download the [repo](https://github.com/scylladb/scylla-rust-driver) and run `cargo doc`)
+* [API documentation](https://docs.rs/scylla)
 * [Scylla documentation](https://docs.scylladb.com)
 * [Cassandra® documentation](https://cassandra.apache.org/doc/latest/)
 


### PR DESCRIPTION
After release to crates.io the book needs some updates:
* Changed github links in Cargo.toml to crates.io crate
* Added links to API documentation on docs.rs
* Added chapter about authenticatoin
* Improved load balancing section

I already updated the hosted html to make sure that no one mistakenly adds the gitihub link in their Cargo.toml

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
