### PR TITLE
workflows: migrate to official scylladb docker images

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       scylladb:
-        image: cvybhu/scylla-passauth
+        image: scylladb/scylla-passauth
         ports:
           - 9042:9042
         options: --health-cmd "cqlsh --username cassandra --password cassandra --debug" --health-interval 5s --health-retries 30

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    container: cvybhu/rust-mdbook
+    container: scylladb/rust-mdbook
     runs-on: ubuntu-latest
     services:
       scylladb:

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       scylladb:
-        image: kejmer/scylla-tls
+        image: scylladb/scylla-tls
         ports:
           - 9042:9042
           - 9142:9142


### PR DESCRIPTION
Now that the driver is officially released, the temporary docker images are moved to the official account.