### PR TITLE
Add resuming paging

### DIFF
--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -40,22 +40,55 @@ async fn main() -> Result<()> {
         println!("a, b, c: {}, {}, {}", a, b, c);
     }
 
-    let paged_query = Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(1);
-    let paging_state = session.query(paged_query, &[]).await?.paging_state;
-    println!("Paging state: {:#?}", paging_state);
-
-    let paged_prepared = session
-        .prepare(Query::with_page_size(
-            "SELECT a, b, c FROM ks.t".to_owned(),
-            1,
-        ))
-        .await?;
-    let paging_state_from_prepared = session.execute(&paged_prepared, &[]).await?.paging_state;
+    let paged_query = Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(6);
+    let res1 = session.query(paged_query.clone(), &[]).await?;
     println!(
-        "Paging state from the prepared statement execution: {:#?}",
-        paging_state_from_prepared
+        "Paging state: {:#?} ({} rows)",
+        res1.paging_state,
+        res1.rows.unwrap().len()
+    );
+    let res2 = session
+        .query_paged(paged_query.clone(), &[], res1.paging_state)
+        .await?;
+    println!(
+        "Paging state: {:#?} ({} rows)",
+        res2.paging_state,
+        res2.rows.unwrap().len()
+    );
+    let res3 = session
+        .query_paged(paged_query.clone(), &[], res2.paging_state)
+        .await?;
+    println!(
+        "Paging state: {:#?} ({} rows)",
+        res3.paging_state,
+        res3.rows.unwrap().len()
     );
 
+    let paged_prepared = session
+        .prepare(Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(7))
+        .await?;
+    let res4 = session.execute(&paged_prepared, &[]).await?;
+    println!(
+        "Paging state from the prepared statement execution: {:#?} ({} rows)",
+        res4.paging_state,
+        res4.rows.unwrap().len()
+    );
+    let res5 = session
+        .execute_paged(&paged_prepared, &[], res4.paging_state)
+        .await?;
+    println!(
+        "Paging state from the second prepared statement execution: {:#?} ({} rows)",
+        res5.paging_state,
+        res5.rows.unwrap().len()
+    );
+    let res6 = session
+        .execute_paged(&paged_prepared, &[], res5.paging_state)
+        .await?;
+    println!(
+        "Paging state from the third prepared statement execution: {:#?} ({} rows)",
+        res6.paging_state,
+        res6.rows.unwrap().len()
+    );
     println!("Ok.");
 
     Ok(())

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -44,6 +44,18 @@ async fn main() -> Result<()> {
     let paging_state = session.query(paged_query, &[]).await?.paging_state;
     println!("Paging state: {:#?}", paging_state);
 
+    let paged_prepared = session
+        .prepare(Query::with_page_size(
+            "SELECT a, b, c FROM ks.t".to_owned(),
+            1,
+        ))
+        .await?;
+    let paging_state_from_prepared = session.execute(&paged_prepared, &[]).await?.paging_state;
+    println!(
+        "Paging state from the prepared statement execution: {:#?}",
+        paging_state_from_prepared
+    );
+
     println!("Ok.");
 
     Ok(())

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use futures::stream::StreamExt;
-use scylla::{Session, SessionBuilder};
+use scylla::{query::Query, Session, SessionBuilder};
 use std::env;
 
 #[tokio::main]
@@ -39,6 +39,10 @@ async fn main() -> Result<()> {
         let (a, b, c) = next_row_res?;
         println!("a, b, c: {}, {}, {}", a, b, c);
     }
+
+    let paged_query = Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(1);
+    let paging_state = session.query(paged_query, &[]).await?.paging_state;
+    println!("Paging state: {:#?}", paging_state);
 
     println!("Ok.");
 

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -310,7 +310,7 @@ pub struct PreparedMetadata {
     pub col_specs: Vec<ColumnSpec>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Row {
     pub columns: Vec<Option<CqlValue>>,
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -22,13 +22,18 @@ pub struct PreparedStatement {
 }
 
 impl PreparedStatement {
-    pub fn new(id: Bytes, metadata: PreparedMetadata, statement: String) -> Self {
+    pub fn new(
+        id: Bytes,
+        metadata: PreparedMetadata,
+        statement: String,
+        page_size: Option<i32>,
+    ) -> Self {
         Self {
             id,
             metadata,
             statement,
             prepare_tracing_ids: Vec::new(),
-            page_size: None,
+            page_size,
             consistency: Default::default(),
             serial_consistency: None,
             is_idempotent: false,

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -28,6 +28,12 @@ impl Query {
         }
     }
 
+    /// Returns self with page size set to the given value
+    pub fn with_page_size(mut self, page_size: i32) -> Self {
+        self.page_size = Some(page_size);
+        self
+    }
+
     /// Returns the string representation of the CQL query.
     pub fn get_contents(&self) -> &str {
         &self.contents

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -91,6 +91,8 @@ pub struct QueryResult {
     pub warnings: Vec<String>,
     /// CQL Tracing uuid - can only be Some if tracing is enabled for this query
     pub tracing_id: Option<Uuid>,
+    /// Paging state returned from the server
+    pub paging_state: Option<Bytes>,
 }
 
 /// Result of Session::batch(). Contains no rows, only some useful information.
@@ -103,10 +105,10 @@ pub struct BatchResult {
 
 impl QueryResponse {
     pub fn into_query_result(self) -> Result<QueryResult, QueryError> {
-        let rows: Option<Vec<result::Row>> = match self.response {
+        let (rows, paging_state) = match self.response {
             Response::Error(err) => return Err(err.into()),
-            Response::Result(result::Result::Rows(rs)) => Some(rs.rows),
-            Response::Result(_) => None,
+            Response::Result(result::Result::Rows(rs)) => (Some(rs.rows), rs.metadata.paging_state),
+            Response::Result(_) => (None, None),
             _ => {
                 return Err(QueryError::ProtocolError(
                     "Unexpected server response, expected Result or Error",
@@ -118,6 +120,7 @@ impl QueryResponse {
             rows,
             warnings: self.warnings,
             tracing_id: self.tracing_id,
+            paging_state,
         })
     }
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -277,8 +277,11 @@ impl Connection {
         &self,
         query: &Query,
         values: &impl ValueList,
+        paging_state: Option<Bytes>,
     ) -> Result<QueryResult, QueryError> {
-        self.query(query, values, None).await?.into_query_result()
+        self.query(query, values, paging_state)
+            .await?
+            .into_query_result()
     }
 
     pub async fn query(

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -227,9 +227,12 @@ impl Connection {
 
         let mut prepared_statement = match query_response.response {
             Response::Error(err) => return Err(err.into()),
-            Response::Result(result::Result::Prepared(p)) => {
-                PreparedStatement::new(p.id, p.prepared_metadata, query.get_contents().to_owned())
-            }
+            Response::Result(result::Result::Prepared(p)) => PreparedStatement::new(
+                p.id,
+                p.prepared_metadata,
+                query.get_contents().to_owned(),
+                query.get_page_size(),
+            ),
             _ => {
                 return Err(QueryError::ProtocolError(
                     "PREPARE: Unexpected server response",

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -307,8 +307,9 @@ impl Connection {
         &self,
         prepared_statement: &PreparedStatement,
         values: impl ValueList,
+        paging_state: Option<Bytes>,
     ) -> Result<QueryResult, QueryError> {
-        self.execute(prepared_statement, values, None)
+        self.execute(prepared_statement, values, paging_state)
             .await?
             .into_query_result()
     }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1,6 +1,7 @@
 //! `Session` is the main object used in the driver.  
 //! It manages all connections to the cluster and allows to perform queries.
 
+use bytes::Bytes;
 use futures::future::join_all;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -571,8 +572,24 @@ impl Session {
         prepared: &PreparedStatement,
         values: impl ValueList,
     ) -> Result<QueryResult, QueryError> {
+        self.execute_paged(prepared, values, None).await
+    }
+
+    /// Executes a previously prepared statement with previously received paging state
+    /// # Arguments
+    ///
+    /// * `prepared` - a statement prepared with [prepare](crate::transport::session::Session::prepare)
+    /// * `values` - values bound to the query
+    /// * `paging_state` - paging state from the previous query or None
+    pub async fn execute_paged(
+        &self,
+        prepared: &PreparedStatement,
+        values: impl ValueList,
+        paging_state: Option<Bytes>,
+    ) -> Result<QueryResult, QueryError> {
         let serialized_values = values.serialized()?;
         let values_ref = &serialized_values;
+        let paging_state_ref = &paging_state;
 
         let token = calculate_token(prepared, &serialized_values)?;
 
@@ -593,7 +610,9 @@ impl Session {
             retry_session,
             |node: Arc<Node>| async move { node.connection_for_token(token).await },
             |connection: Arc<Connection>| async move {
-                connection.execute_single_page(prepared, values_ref).await
+                connection
+                    .execute_single_page(prepared, values_ref, paging_state_ref.clone())
+                    .await
             },
         )
         .await


### PR DESCRIPTION
This draft adds a way of resuming queries from previously received paging state. The paging state can be extracted from query results and passed to new queries to let them resume execution from where the previous query left off. It's an alternative way of querying to the existing `query_iter` mechanism.

This series is marked as a draft because of the following TODO list:
 - [x] Add tests for CI.
 - [x] Add documentation.
 - [ ] <strike>Currently the paging state is copied underneath. Consider optimizing this copying out - it's not likely to be a performance killer because it is expected to fit into a single cacheline, but eliding copies is good practice anyway. That would likely require some changes in function prototypes. Perhaps a good candidate for a follow-up patch.</strike>

Fixes #219

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
