### PR TITLE
examples: make cqlsh-rs more user-friendly

### DIFF
--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -2,8 +2,28 @@ use anyhow::Result;
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use scylla::transport::Compression;
-use scylla::{Session, SessionBuilder};
+use scylla::{QueryResult, Session, SessionBuilder};
 use std::env;
+
+fn print_result(result: &QueryResult) {
+    if result.rows.is_none() {
+        println!("OK");
+        return;
+    }
+    for row in result.rows.as_ref().unwrap() {
+        for column in &row.columns {
+            print!("|");
+            print!(
+                " {:16}",
+                match column {
+                    None => "null".to_owned(),
+                    Some(value) => format!("{:?}", value),
+                }
+            );
+        }
+        println!("|")
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -22,15 +42,19 @@ async fn main() -> Result<()> {
         let readline = rl.readline(">> ");
         match readline {
             Ok(line) => {
+                if line.is_empty() {
+                    continue;
+                }
                 rl.add_history_entry(line.as_str());
-                session.query(line, &[]).await.unwrap();
+                let maybe_res = session.query(line, &[]).await;
+                match maybe_res {
+                    Err(err) => println!("Error: {}", err),
+                    Ok(res) => print_result(&res),
+                }
             }
-            Err(ReadlineError::Interrupted) => break,
+            Err(ReadlineError::Interrupted) => continue,
             Err(ReadlineError::Eof) => break,
-            Err(err) => {
-                println!("Error: {:?}", err);
-                break;
-            }
+            Err(err) => println!("Error: {}", err),
         }
     }
     Ok(())


### PR DESCRIPTION
While the tool is still far away from cqlsh's friendliness,
the following issues are fixed:
 - errors are printed in a human-redable fashion
 - errors do not crash the process
 - return values of SELECT statements are printed (in a semi-raw form,
   but still readable)
 - Ctrl+C does not terminate the program, Ctrl+D does

The TODO list for this tool to be really usable is still huge.
Issues include:
 - no column names are printed, because there's no schema information
   to take them from
 - results are printed in a debug form, along with their type
 - no support for paging
 - no auth support
 - etc.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] <strike>I added relevant tests for new features and bug fixes. </strike>
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] <strike>I added appropriate `Fixes:` annotations to PR description.</strike>
