### PR TITLE
adding connection_timeout to SessionBuilder

### DIFF
--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -7,6 +7,7 @@ When creating a `Session` you can specify a few known nodes to which the driver 
 # extern crate tokio;
 use scylla::{Session, SessionBuilder};
 use std::error::Error;
+use std::time::Duration;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 #[tokio::main]
@@ -18,6 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .known_node(uri)
         .known_node("127.0.0.72:4321")
         .known_node("localhost:8000")
+        .connection_timeout(Duration::from_secs(3))
         .known_node_addr(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             9000,

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -25,6 +25,10 @@ pub enum QueryError {
     /// Unexpected or invalid message received
     #[error("Protocol Error: {0}")]
     ProtocolError(&'static str),
+
+    /// Timeout error has occured, function didn't complete in time.
+    #[error("Timeout Error")]
+    TimeoutError,
 }
 
 /// An error sent from the database in response to a query
@@ -260,6 +264,10 @@ pub enum NewSessionError {
     /// Unexpected or invalid message received
     #[error("Protocol Error: {0}")]
     ProtocolError(&'static str),
+
+    /// Timeout error has occured, couldn't connect to node in time.
+    #[error("Timeout Error")]
+    TimeoutError,
 }
 
 /// Invalid keyspace name given to `Session::use_keyspace()`
@@ -321,6 +329,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::BadQuery(e) => NewSessionError::BadQuery(e),
             QueryError::IoError(e) => NewSessionError::IoError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
+            QueryError::TimeoutError => NewSessionError::TimeoutError,
         }
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -77,6 +77,7 @@ pub struct SessionConfig {
     pub auth_password: Option<String>,
 
     pub schema_agreement_interval: Duration,
+    pub connect_timeout: std::time::Duration,
     /*
     These configuration options will be added in the future:
 
@@ -119,6 +120,7 @@ impl SessionConfig {
             ssl_context: None,
             auth_username: None,
             auth_password: None,
+            connect_timeout: std::time::Duration::from_secs(5),
         }
     }
 
@@ -187,6 +189,7 @@ impl SessionConfig {
             ssl_context: self.ssl_context.clone(),
             auth_username: self.auth_username.to_owned(),
             auth_password: self.auth_password.to_owned(),
+            connect_timeout: self.connect_timeout,
             ..Default::default()
         }
     }

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -324,6 +324,26 @@ impl SessionBuilder {
     pub async fn build(self) -> Result<Session, NewSessionError> {
         Session::connect(self.config).await
     }
+
+    /// Changes connection timeout
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use std::time::Duration;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .set_connect_timeout(Duration::from_secs(30))
+    ///     .build() // Turns SessionBuilder into Session
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn set_connect_timeout(mut self, duration: std::time::Duration) -> Self {
+        self.config.connect_timeout = duration;
+        self
+    }
 }
 
 /// Creates a [`SessionBuilder`] with default configuration, same as [`SessionBuilder::new`]

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -486,6 +486,15 @@ mod tests {
     }
 
     #[test]
+    fn connection_timeout() {
+        let mut builder = SessionBuilder::new();
+        assert_eq!(builder.config.connect_timeout, std::time::Duration::from_secs(5));
+
+        builder = builder.connection_timeout(std::time::Duration::from_secs(10));
+        assert_eq!(builder.config.connect_timeout, std::time::Duration::from_secs(10));
+    }
+
+    #[test]
     fn all_features() {
         let mut builder = SessionBuilder::new();
 

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -326,6 +326,8 @@ impl SessionBuilder {
     }
 
     /// Changes connection timeout
+    /// The default is 5 seconds.
+    /// If it's higher than underlying os's default connection timeout it won't effect.
     ///
     /// # Example
     /// ```
@@ -334,13 +336,13 @@ impl SessionBuilder {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let session: Session = SessionBuilder::new()
     ///     .known_node("127.0.0.1:9042")
-    ///     .set_connect_timeout(Duration::from_secs(30))
+    ///     .connection_timeout(Duration::from_secs(30))
     ///     .build() // Turns SessionBuilder into Session
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set_connect_timeout(mut self, duration: std::time::Duration) -> Self {
+    pub fn connection_timeout(mut self, duration: std::time::Duration) -> Self {
         self.config.connect_timeout = duration;
         self
     }

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -488,10 +488,16 @@ mod tests {
     #[test]
     fn connection_timeout() {
         let mut builder = SessionBuilder::new();
-        assert_eq!(builder.config.connect_timeout, std::time::Duration::from_secs(5));
+        assert_eq!(
+            builder.config.connect_timeout,
+            std::time::Duration::from_secs(5)
+        );
 
         builder = builder.connection_timeout(std::time::Duration::from_secs(10));
-        assert_eq!(builder.config.connect_timeout, std::time::Duration::from_secs(10));
+        assert_eq!(
+            builder.config.connect_timeout,
+            std::time::Duration::from_secs(10)
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Description
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/234 currently library doesn't have any timeout on creating connection and even one unreachable node makes library sluggish.
With this commit we use `SessionBuilder`'s `connection_timeout` function to change connect timeout (5s default).
Tests aren't added yet.
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
