### PR TITLE
Add a script to build clean documentation book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -28,5 +28,7 @@ jobs:
       run: cargo build --verbose --examples
     - name: Build the book
       run: mdbook build docs
+    - name: Build the book using the script
+      run: python3 docs/build_book.py
     - name: Run book tests
       run: SCYLLA_URI=scylladb:9042 mdbook test -L target/debug/deps docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,22 +46,36 @@ SCYLLA_URI="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla-
 ## Contributing to the book
 
 The documentation book is written using [mdbook](https://github.com/rust-lang/mdBook)  
-Book source is in `book/src`
+Book source is in `docs/source`  
+This source has to be compatible with `Sphinx` so it might sometimes contain chunks like:
+````
+```eval_rst
+something
+```
+````
+But they are removed when building the book
+
 
 `mdbook` can be installed using:
 ```shell
 cargo install mdbook
 ```
 
-Build the book:
+Build the book (simple method, contains `Sphinx` artifacts):
 ```bash
-mdbook build book
-# HTML will be in book/book
+mdbook build docs
+# HTML will be in docs/book
+```
+
+To build the release version use a script which automatically removes `Sphinx` chunks:
+```bash
+python3 docs/build_book.py
+# HTML will be in docs/book/scriptbuild/book
 ```
 
 Or serve it on a local http server (automatically refreshes on changes)
 ```bash
-mdbook serve
+mdbook serve docs
 ```
 
 Test code examples (requires a running scylla instance):
@@ -70,5 +84,5 @@ Test code examples (requires a running scylla instance):
 cargo clean
 cargo build --examples
 
-mdbook test -L target/debug/deps/ book
+mdbook test -L target/debug/deps/ docs
 ```

--- a/docs/build_book.py
+++ b/docs/build_book.py
@@ -1,0 +1,66 @@
+#!/bin/python3
+
+# A script which removes sphinx markdown and builds the documentation book
+# It copies all files to working directory, modifies the .md files
+# to remove all ```eval_rst parts and builds the book
+# The generated HTML will be in docs/book/scriptbuild/book
+
+import os
+import shutil
+import pathlib
+
+def remove_sphinx_markdown(md_file_text):
+    text_split = md_file_text.split("```eval_rst")
+    
+    result = text_split[0]
+
+    for i in range(1, len(text_split)):
+        cur_chunk = text_split[i]
+        result += cur_chunk[cur_chunk.find("```") + 3:]
+
+    return result
+
+# Working directory, normally book builds in docs/book
+# so we can make our a folder in this build directory
+work_dir = os.path.join("docs", "book", "scriptbuild")
+os.makedirs(work_dir, exist_ok = True)
+
+# All modified sources will be put in work_dir/source
+src_dir = os.path.join(work_dir, "source")
+os.makedirs(src_dir, exist_ok = True)
+
+# Generated HTML will be put in work_dir/book
+build_dir = os.path.join(work_dir, "book")
+
+
+
+# Copy all mdbook files to work_dir before modifying
+
+# Copy book.toml
+shutil.copyfile(os.path.join("docs", "book.toml"), os.path.join(work_dir, "book.toml"))
+
+# Go over all .md files, remove the ``` sphinx parts and put them in work_dir/source
+for mdfile_path in pathlib.Path(os.path.join("docs", "source")).rglob("*.md"):
+
+    # Path in the book structure ex. queries/queries.md instead of docs/source/queries/queries.md
+    relative_path = mdfile_path.relative_to(os.path.join("docs", "source"))
+
+    # Read the current file
+    mdfile = open(mdfile_path, "r").read()
+
+    # Remove sphinx markdown
+    new_mdfile = remove_sphinx_markdown(mdfile)
+
+    # Write the modified file to src_dir
+    new_mdfile_path = os.path.join(src_dir, relative_path)
+    os.makedirs(os.path.dirname(new_mdfile_path), exist_ok = True)
+    open(new_mdfile_path, "w").write(new_mdfile)
+
+build_result = os.system(f"mdbook build {work_dir}")
+
+if build_result == 0:
+    print(f"OK Done - rendered HTML is in {build_dir}")
+    exit(0)
+else:
+    print(f"ERROR: mdbook build returned: {build_result}")
+    exit(1)


### PR DESCRIPTION
Documentation is now compatible with Sphinx which means that it contains Sphinx-specific fragments like:
````
```eval_rst
something
```
````

To build mdbook without them a script is needed.

This script removes Sphinx-specific parts and builds clean mdbook HTML

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
