### PR TITLE
Fix compilation without ssl feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
       run: cargo clippy --verbose --examples --tests -- -D warnings
+    - name: Cargo check without features
+      run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
     - name: Build
       run: cargo build --verbose --examples
     - name: Run tests

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -598,7 +598,6 @@ impl Connection {
         receiver: mpsc::Receiver<Task>,
         error_sender: tokio::sync::oneshot::Sender<QueryError>,
     ) -> Result<RemoteHandle<()>, std::io::Error> {
-        let _config = config;
         Ok(Self::run_router_spawner(
             stream,
             receiver,


### PR DESCRIPTION
The driver doesn't compile when the ssl feature is not enabled because we use `config` after move:
```rust
// connection.rs:594  
#[cfg(not(feature = "ssl"))]
async fn run_router(
    config: ConnectionConfig,
    stream: TcpStream,
    receiver: mpsc::Receiver<Task>,
    error_sender: tokio::sync::oneshot::Sender<QueryError>,
) -> Result<RemoteHandle<()>, std::io::Error> {
    let _config = config;
    Ok(Self::run_router_spawner(
        stream,
        receiver,
        error_sender,
        config,
    ))
}
```

This PR fixes the error and adds a check in the CI to ensure this doesn't happen again.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
