### PR TITLE
workflows: do not run clippy for tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
-      run: cargo clippy --verbose --examples --tests -- -D warnings
+      run: cargo clippy --verbose --examples -- -D warnings
     - name: Cargo check without features
       run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
     - name: Build
@@ -33,4 +33,3 @@ jobs:
     - name: Run tests
       # test threads must be one because else database tests will run in parallel and will result in flaky tests
       run: cargo test --verbose -- --test-threads=1
-      


### PR DESCRIPTION
Recent clippy warnings do not really help maintain good coding
habits, but instead just keep breaking builds with overly opinionated
warnings. In order to reduce the noise, tests are no longer
checked with clippy.