### PR TITLE
treewide: make tcp_nodelay default to true

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -152,7 +152,7 @@ impl Default for ConnectionConfig {
     fn default() -> Self {
         Self {
             compression: None,
-            tcp_nodelay: false,
+            tcp_nodelay: true,
             event_sender: None,
             #[cfg(feature = "ssl")]
             ssl_context: None,

--- a/scylla/src/transport/connection_keeper.rs
+++ b/scylla/src/transport/connection_keeper.rs
@@ -306,7 +306,7 @@ mod tests {
 
         let connection_config = ConnectionConfig {
             compression: None,
-            tcp_nodelay: false,
+            tcp_nodelay: true,
             #[cfg(feature = "ssl")]
             ssl_context: None,
             ..Default::default()

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -110,7 +110,7 @@ impl SessionConfig {
         SessionConfig {
             known_nodes: Vec::new(),
             compression: None,
-            tcp_nodelay: false,
+            tcp_nodelay: true,
             schema_agreement_interval: Duration::from_millis(200),
             load_balancing: Arc::new(TokenAwarePolicy::new(Box::new(RoundRobinPolicy::new()))),
             used_keyspace: None,

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -143,7 +143,7 @@ impl SessionBuilder {
     }
 
     /// Set the nodelay TCP flag.
-    /// The default is false.
+    /// The default is true.
     ///
     /// # Example
     /// ```
@@ -446,13 +446,13 @@ mod tests {
     #[test]
     fn tcp_nodelay() {
         let mut builder = SessionBuilder::new();
-        assert_eq!(builder.config.tcp_nodelay, false);
-
-        builder = builder.tcp_nodelay(true);
         assert_eq!(builder.config.tcp_nodelay, true);
 
         builder = builder.tcp_nodelay(false);
         assert_eq!(builder.config.tcp_nodelay, false);
+
+        builder = builder.tcp_nodelay(true);
+        assert_eq!(builder.config.tcp_nodelay, true);
     }
 
     #[test]


### PR DESCRIPTION
Scylla is generally assumed to be used for latency-sensitive
workloads, in which case it always makes sense to turn off
Nagle's algorithm. Thus, tcp_nodelay parameter is now true
by default and can be turned off manually when building
a new session.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] <strike>I added appropriate `Fixes:` annotations to PR description.</strike>
