### PR TITLE
Remove locking in Cluster

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -34,6 +34,7 @@ tracing = "0.1.25"
 chrono = "0.4"
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
+arc-swap = "1.3.0"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
## Description

Recent benchmarks showed, that a significant amount of time is being spent waiting on Cluster's rw-lock protecting ClusterData structure. Thanks to the fact that we already use the rcu mechanism to update ClusterData, it was possible to remove RwLock and replace it with ArcSwap from arc-swap crate.

I also run few benchmarks and noticed ~1% performance  improvement (it can be bigger on machines more efficient than my pc).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
