### PR TITLE
Allow creating multiple sessions with a single SessionBuilder

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -64,3 +64,7 @@ path = "tracing.rs"
 name = "schema_agreement"
 path = "schema_agreement.rs"
 
+[[example]]
+name = "clone"
+path = "clone.rs"
+

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use futures::future::join_all;
+use scylla::transport::session::Session;
+use scylla::SessionBuilder;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session_builder = SessionBuilder::new().known_node(uri);
+
+    let sessions: Vec<Session> = join_all(
+        (0..100)
+            .map(|_: usize| async { session_builder.build().await.unwrap() })
+            .collect::<Vec<_>>(),
+    )
+    .await;
+
+    sessions[0].query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    sessions[0]
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    for (i, session) in sessions.iter().enumerate().take(100) {
+        session.await_schema_agreement().await.unwrap();
+        session
+            .query(
+                "INSERT INTO ks.t (a,b,c) VALUES (?,?,?)",
+                (i as i32, i as i32, "hello"),
+            )
+            .await
+            .unwrap();
+    }
+
+    if let Some(rows) = sessions[42]
+        .query("SELECT a, b, c FROM ks.t", &[])
+        .await?
+        .rows
+    {
+        println!("Read {} rows", rows.len());
+    }
+
+    Ok(())
+}

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -33,6 +33,12 @@ pub trait RetryPolicy {
     fn clone_boxed(&self) -> Box<dyn RetryPolicy + Send + Sync>;
 }
 
+impl Clone for Box<dyn RetryPolicy + Send + Sync> {
+    fn clone(&self) -> Box<dyn RetryPolicy + Send + Sync> {
+        self.clone_boxed()
+    }
+}
+
 /// Used throughout a single query to decide when to retry it
 /// After this query is finished it is destroyed or reset
 pub trait RetrySession {

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -50,6 +50,7 @@ pub struct Session {
 /// Configuration options for [`Session`].
 /// Can be created manually, but usually it's easier to use
 /// [SessionBuilder](super::session_builder::SessionBuilder)
+#[derive(Clone)]
 pub struct SessionConfig {
     /// List of database servers known on Session startup.
     /// Session will connect to these nodes to retrieve information about other nodes in the cluster.

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -321,8 +321,8 @@ impl SessionBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn build(self) -> Result<Session, NewSessionError> {
-        Session::connect(self.config).await
+    pub async fn build(&self) -> Result<Session, NewSessionError> {
+        Session::connect(self.config.clone()).await
     }
 
     /// Changes connection timeout


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.

This commit changes SessionBuilder::build(), so that it can be called multiple times and produce a valid session with given configuration each time it's called. The target use case is to prepare the configuration once and then spawn multiple sessions in order to do work in parallel.

Tested with the included example.

Refs #216 