### PR TITLE
connection_keeper: try another source port on permission denied error

### DIFF
--- a/scylla/src/transport/connection_keeper.rs
+++ b/scylla/src/transport/connection_keeper.rs
@@ -271,7 +271,7 @@ impl ConnectionKeeperWorker {
                 connection::open_connection(self.address, Some(port), self.config.clone()).await;
 
             match connect_result {
-                Err(err) if err.is_address_in_use() => continue, // If port collision happened try next port
+                Err(err) if err.is_address_unavailable_for_use() => continue, // If we can't use this port, try the next one
                 result => return result,
             }
         }


### PR DESCRIPTION
Currently, when connecting to a particular shard on the shard-aware
port, we need to choose a source port whose number equals the shard ID
modulo the shard count. We draw a random source port in range
49152-65535 which satisfies the conditions and try to bind to it. If
binding fails due to the address being in use, we try the next suitable
port in the range, possibly wrapping around if the end of the range is
reached. If binding/connecting fails due to other errors, we consider
the connection attempt a failure and the ConnectionKeeper retries
connecting after a delay.

However, it appears that there is another bind error which we didn't
consider but should be handled in a similar way as the "address in use
case": some ports/addresses might be reserved either by the OS or
processes with higher privileges, which may cause attempts to bind to
this port fail with a "permission denied" error. Notably, Docker for
Windows which I use in order to run Scylla for tests reserves some
ports in the 49152-65535 range.

To account for reserved ports, this commit modifies the port selection
logic so that it does not treat PermissionDenied as a serious error but
instead retries connecting with a different source port.

Fixes #205

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
