### PR TITLE
connection: propagate authentication failure error to user

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -858,6 +858,9 @@ pub async fn open_named_connection(
                 Response::AuthSuccess(_authenticate_success) => {
                     return Ok((connection, error_receiver));
                 }
+                Response::Error(err) => {
+                    return Err(err.into());
+                }
                 _ => {
                     return Err(QueryError::ProtocolError(
                         "Unexpected response to Authenticate Response message",


### PR DESCRIPTION
Currently, during authentication, the "ERROR" frame is treated as
unexpected and an error with the following message is returned to the
user:

    Unexpected response to Authenticate Response message

This commit causes the error from the "ERROR" frame to be propagated to
the user in case of authentication failure. For example, if bad
username/password combination is provided, Scylla will return the
following message:

    Username and/or password are incorrect

which is much more helpful.

Fixes #257

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
