### PR TITLE
Update the book to 0.2.0

### DIFF
--- a/docs/source/queries/batch.md
+++ b/docs/source/queries/batch.md
@@ -64,7 +64,7 @@ session.batch(&batch, ((), )).await?;
 # }
 ```
 
-See [Batch API documentation](https://docs.rs/scylla/0.1.0/scylla/statement/batch/struct.Batch.html)
+See [Batch API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/batch/struct.Batch.html)
 for more options
 
 ### Batch values

--- a/docs/source/queries/prepared.md
+++ b/docs/source/queries/prepared.md
@@ -66,7 +66,7 @@ session.execute(&prepared, (to_insert,)).await?;
 # }
 ```
 
-See [PreparedStatement API documentation](https://docs.rs/scylla/0.1.0/scylla/statement/prepared_statement/struct.PreparedStatement.html) 
+See [PreparedStatement API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/prepared_statement/struct.PreparedStatement.html) 
 for more options
 
 ### Performance

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -40,7 +40,7 @@ session.query(my_query, (to_insert,)).await?;
 # Ok(())
 # }
 ```
-See [Query API documentation](https://docs.rs/scylla/0.1.0/scylla/statement/query/struct.Query.html) for more options
+See [Query API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/query/struct.Query.html) for more options
 
 ### Second argument - the values
 Query text is constant, but the values might change.

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "0.1.0"
+scylla = "0.2.0"
 tokio = { version = "1.1.0", features = ["full"] }
 futures = "0.3.6"
 uuid = "0.8.1"


### PR DESCRIPTION
Documentation book still contains refrences to the driver in version `0.1.0`

I changed all `0.1.0` to `0.2.0`

I already uploaded this updated version to the github page

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
