### PR TITLE
docs: remove stray hashes from rust-driver.docs.scylladb.com

### DIFF
--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -2,6 +2,7 @@
 
 # Copy contents
 mkdir gh-pages
+python ./docs/_utils/drop_hashes.py
 cp -r ./docs/_build/dirhtml/. gh-pages
 
 # Create gh-pages branch

--- a/docs/_utils/drop_hashes.py
+++ b/docs/_utils/drop_hashes.py
@@ -1,0 +1,24 @@
+#!/bin/python3
+
+# A script which removes mdbook's # notation, which sphinx cannot handle.
+
+import os
+import shutil
+import pathlib
+
+def remove_hashes(md_file_text):
+    text_split = md_file_text.split('\n')
+    result = ''
+    for line in text_split:
+        err_idx = line.find('<span class="err">')
+        if err_idx == -1:
+            result += line + '\n'
+        elif err_idx > 0:
+            result += line[:err_idx] + '\n'
+
+    return result[:-1] if len(result) > 0 else result
+
+for mdfile_path in pathlib.Path("docs/_build/dirhtml").rglob("*.html"):
+    mdfile = open(mdfile_path, "r").read()
+    new_mdfile = remove_hashes(mdfile)
+    open(mdfile_path, "w").write(new_mdfile)


### PR DESCRIPTION
Sphinx, the framework used for publishing docs on
rust-driver.docs.scylladb.com, can't handle mdbook's comments
starting with '#', which results in broken docs pages.
A simple heuristics for removing incorrectly generated snippets
is added to the deploy script - it will work as long as sphinx
generates HTML the same way, so it may need to be revamped
in the future.
