### PR TITLE
topology: always update known_peers on refresh

### DIFF
--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -92,8 +92,9 @@ impl TopologyReader {
     /// Fetches current topology info from the cluster
     pub async fn read_topology_info(&mut self) -> Result<TopologyInfo, QueryError> {
         let mut result = self.fetch_topology_info().await;
-        if result.is_ok() {
-            return result;
+        if let Ok(topology_info) = result {
+            self.update_known_peers(&topology_info);
+            return Ok(topology_info);
         }
 
         // shuffle known_peers to iterate through them in random order later


### PR DESCRIPTION
Currently, the TopologyReader is responsible for maintaining the control
connection. When the control connection breaks, it attempts to
re-establish by trying nodes from the `known_peers` list in random
order.

The `known_peers` list is modified only in two situations:

- It is initialized from the known nodes list from the session's
  configuration,
- When topology refresh is requested, current control connection breaks
  and is successfully reconnected, the `known_peers` list is
  reinitialized from fetched topology info.

However, this is not enough. If only known node is provided in the
session configuration and the node is removed from the cluster, the
TopologyReader won't be able to reconnect the control connection because
the only node from the `known_peers` list has just been removed.

The solution to this is to update the `known_peers` list on each
topology refresh. This way, the `known_peers` list will be up-to-date
and the TopologyReader will consider all nodes in the cluster when
re-establishing the control connection.

Fixes #269

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
