### PR TITLE
Fix authentication for Cassandra

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,10 @@ chrono = "0.4"
 uuid = "0.8.1"
 
 [[example]]
+name = "auth"
+path = "auth.rs"
+
+[[example]]
 name = "basic"
 path = "basic.rs"
 

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use scylla::SessionBuilder;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} with cassandra superuser ...", uri);
+
+    let session = crate::SessionBuilder::new()
+        .known_node(uri)
+        .user("cassandra", "cassandra")
+        .build()
+        .await
+        .unwrap();
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
+    session
+        .query("DROP TABLE IF EXISTS ks.t;", &[])
+        .await
+        .unwrap();
+
+    println!("Ok.");
+
+    Ok(())
+}

--- a/scylla/src/frame/request/auth_response.rs
+++ b/scylla/src/frame/request/auth_response.rs
@@ -1,5 +1,6 @@
 use crate::frame::frame_errors::ParseError;
 use bytes::BufMut;
+use std::convert::TryInto;
 
 use crate::frame::request::{Request, RequestOpcode};
 use crate::transport::Authenticator;
@@ -23,18 +24,14 @@ impl Request for AuthResponse {
         let username_as_bytes = self.username.as_ref().unwrap().as_bytes();
         let password_as_bytes = self.password.as_ref().unwrap().as_bytes();
 
-        let buf_size = 2 + (username_as_bytes.len() as u8) + (password_as_bytes.len() as u8);
-
-        buf.put_u8(buf_size);
+        // The body of AuthResponse is a single [bytes] value (i32 length and then contents)
+        let buf_size = 2 + username_as_bytes.len() + password_as_bytes.len();
+        buf.put_i32(buf_size.try_into()?);
 
         buf.put_u8(0);
-        for byte in username_as_bytes {
-            buf.put_u8(*byte);
-        }
+        buf.put_slice(username_as_bytes);
         buf.put_u8(0);
-        for byte in password_as_bytes {
-            buf.put_u8(*byte);
-        }
+        buf.put_slice(password_as_bytes);
         Ok(())
     }
 }

--- a/scylla/src/frame/response/authenticate.rs
+++ b/scylla/src/frame/response/authenticate.rs
@@ -30,12 +30,12 @@ impl AuthSuccess {
 
 #[derive(Debug)]
 pub struct AuthChallenge {
-    pub authenticate_message: String,
+    pub authenticate_message: Option<Vec<u8>>,
 }
 
 impl AuthChallenge {
     pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let authenticate_message = types::read_string(buf)?.to_string();
+        let authenticate_message = types::read_bytes_opt(buf)?.map(|b| b.to_owned());
 
         Ok(AuthChallenge {
             authenticate_message,

--- a/scylla/src/frame/response/authenticate.rs
+++ b/scylla/src/frame/response/authenticate.rs
@@ -17,12 +17,12 @@ impl Authenticate {
 
 #[derive(Debug)]
 pub struct AuthSuccess {
-    pub success_message: String,
+    pub success_message: Option<Vec<u8>>,
 }
 
 impl AuthSuccess {
     pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let success_message = types::read_string(buf)?.to_string();
+        let success_message = types::read_bytes_opt(buf)?.map(|b| b.to_owned());
 
         Ok(AuthSuccess { success_message })
     }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -859,7 +859,7 @@ pub async fn open_named_connection(
                     )
                 }
                 Response::AuthSuccess(_authenticate_success) => {
-                    return Ok((connection, error_receiver));
+                    // OK, continue
                 }
                 Response::Error(err) => {
                     return Err(err.into());

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -853,7 +853,10 @@ pub async fn open_named_connection(
             match auth_result.response {
                 Response::AuthChallenge(authenticate_challenge) => {
                     let challenge_message = authenticate_challenge.authenticate_message;
-                    unimplemented!("Auth Challenge not implemented yet, {}", challenge_message)
+                    unimplemented!(
+                        "Auth Challenge not implemented yet, {:?}",
+                        challenge_message
+                    )
                 }
                 Response::AuthSuccess(_authenticate_success) => {
                     return Ok((connection, error_receiver));


### PR DESCRIPTION
This PR fixes a small number of bugs in password authentication logic, mostly related to frame (de)serialization. Despite those bugs, authentication in Scylla worked - however, Cassandra behaves a little differently and incorrectly read/written frames prevent the authentication flow from working.

Refs: #272

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
