### PR TITLE
Make error message propagation more robust

### DIFF
--- a/scylla/src/frame/frame_errors.rs
+++ b/scylla/src/frame/frame_errors.rs
@@ -29,7 +29,7 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
-    #[error("Bad data - couldn't serialize. Error msg: {0}")]
+    #[error("Could not serialize frame: {0}")]
     BadData(String),
     #[error(transparent)]
     IoError(#[from] std::io::Error),

--- a/scylla/src/frame/frame_errors.rs
+++ b/scylla/src/frame/frame_errors.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum FrameError {
-    #[error("Type parsing failed")]
+    #[error(transparent)]
     Parse(#[from] ParseError),
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,

--- a/scylla/src/frame/request/auth_response.rs
+++ b/scylla/src/frame/request/auth_response.rs
@@ -18,7 +18,7 @@ impl Request for AuthResponse {
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
         if self.username.is_none() || self.password.is_none() {
             return Err(ParseError::BadData(
-                "Bad credentials given - username and password shouldn't be none".to_string(),
+                "Bad credentials: username or password missing. You can use SessionBuilder::user(\"user\", \"pass\") to provide credentials.".to_string(),
             ));
         }
         let username_as_bytes = self.username.as_ref().unwrap().as_bytes();

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -22,9 +22,13 @@ pub enum QueryError {
     #[error("IO Error: {0}")]
     IoError(Arc<std::io::Error>),
 
-    /// Unexpected or invalid message received
+    /// Unexpected message received
     #[error("Protocol Error: {0}")]
     ProtocolError(&'static str),
+
+    /// Invalid message received
+    #[error("Invalid message: {0}")]
+    InvalidMessage(String),
 
     /// Timeout error has occured, function didn't complete in time.
     #[error("Timeout Error")]
@@ -261,9 +265,13 @@ pub enum NewSessionError {
     #[error("IO Error: {0}")]
     IoError(Arc<std::io::Error>),
 
-    /// Unexpected or invalid message received
+    /// Unexpected message received
     #[error("Protocol Error: {0}")]
     ProtocolError(&'static str),
+
+    /// Invalid message received
+    #[error("Invalid message: {0}")]
+    InvalidMessage(String),
 
     /// Timeout error has occured, couldn't connect to node in time.
     #[error("Timeout Error")]
@@ -305,14 +313,14 @@ impl From<SerializeValuesError> for QueryError {
 }
 
 impl From<ParseError> for QueryError {
-    fn from(_parse_error: ParseError) -> QueryError {
-        QueryError::ProtocolError("Error parsing message")
+    fn from(parse_error: ParseError) -> QueryError {
+        QueryError::InvalidMessage(format!("Error parsing message: {}", parse_error))
     }
 }
 
 impl From<FrameError> for QueryError {
-    fn from(_frame_error: FrameError) -> QueryError {
-        QueryError::ProtocolError("Error parsing message frame")
+    fn from(frame_error: FrameError) -> QueryError {
+        QueryError::InvalidMessage(format!("Error parsing message frame: {}", frame_error))
     }
 }
 
@@ -329,6 +337,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::BadQuery(e) => NewSessionError::BadQuery(e),
             QueryError::IoError(e) => NewSessionError::IoError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
+            QueryError::InvalidMessage(m) => NewSessionError::InvalidMessage(m),
             QueryError::TimeoutError => NewSessionError::TimeoutError,
         }
     }

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -320,7 +320,7 @@ impl From<ParseError> for QueryError {
 
 impl From<FrameError> for QueryError {
     fn from(frame_error: FrameError) -> QueryError {
-        QueryError::InvalidMessage(format!("Error parsing message frame: {}", frame_error))
+        QueryError::InvalidMessage(format!("Frame error: {}", frame_error))
     }
 }
 


### PR DESCRIPTION
This series reworks error messages in order to avoid losing their context and improve their readability. It was tested manually based on the authentication error case described in #243 - where failing to provide username or password in the session builde resulted in a very cryptic (and incorrect) message:
```
Error parsing message frame
```

After the series is applied, the same scenario returns the following:
```
Invalid message: Frame error: Could not serialize frame: Bad credentials: username or password missing. You can use SessionBuilder::user("user", "pass") to provide credentials.
```

Fixes #244 
Refs #272 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] <strike>I added relevant tests for new features and bug fixes.</strike>
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
