### PR TITLE
Stop parsing UDT fields when buffer is empty.

### DIFF
--- a/scylla/src/frame/cql_types_test.rs
+++ b/scylla/src/frame/cql_types_test.rs
@@ -4,7 +4,7 @@ use crate::frame::response::result::CqlValue;
 use crate::frame::value::Counter;
 use crate::frame::value::Value;
 use crate::frame::value::{Date, Time, Timestamp};
-use crate::macros::{IntoUserType,FromUserType};
+use crate::macros::{FromUserType, IntoUserType};
 use crate::transport::session::IntoTypedRows;
 use crate::transport::session::Session;
 use crate::SessionBuilder;
@@ -807,7 +807,7 @@ async fn test_udt_after_schema_update() {
         pub second: bool,
     };
 
-    let v1 = UdtV1{
+    let v1 = UdtV1 {
         first: 123,
         second: true,
     };
@@ -846,7 +846,7 @@ async fn test_udt_after_schema_update() {
         )
         .await
         .unwrap();
-    
+
     let (read_udt,): (UdtV1,) = session
         .query(
             format!("SELECT val from ks.{} WHERE id = 0", table_name),
@@ -891,7 +891,7 @@ async fn test_udt_after_schema_update() {
 
     assert_eq!(
         read_udt,
-        UdtV2{
+        UdtV2 {
             first: 123,
             second: true,
             third: None,

--- a/scylla/src/frame/cql_types_test.rs
+++ b/scylla/src/frame/cql_types_test.rs
@@ -15,6 +15,8 @@ use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use uuid::Uuid;
+use crate as scylla;
+use crate::macros::{IntoUserType,FromUserType};
 
 // Used to prepare a table for test
 // Creates keyspace ks
@@ -746,4 +748,153 @@ async fn test_blob() {
 
         assert_eq!(read_blob, *blob);
     }
+}
+
+
+#[tokio::test]
+async fn test_udt_after_schema_update() {
+    let table_name = "udt_tests";
+    let type_name = "usertype1";
+
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+    let session: Session = SessionBuilder::new().known_node(uri).build().await.unwrap();
+
+    session
+        .query(
+            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = \
+            {'class' : 'SimpleStrategy', 'replication_factor' : 1}",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    session
+        .query(format!("DROP TABLE IF EXISTS ks.{}", table_name), &[])
+        .await
+        .unwrap();
+    
+    session
+        .query(format!("DROP TYPE IF EXISTS ks.{}", type_name), &[])
+        .await
+        .unwrap();
+
+    session
+        .query(
+            format!(
+                "CREATE TYPE IF NOT EXISTS ks.{} (first int, second boolean)",
+                type_name
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    session
+        .query(
+            format!(
+                "CREATE TABLE IF NOT EXISTS ks.{} (id int PRIMARY KEY, val ks.{})",
+                table_name, type_name
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    #[derive(IntoUserType, FromUserType, Debug, PartialEq)]
+    struct UdtV1 {
+        pub first: i32,
+        pub second: bool
+    };
+
+    let v1 = UdtV1{
+        first: 123,
+        second: true
+    };
+
+    session
+        .query(
+            format!(
+                "INSERT INTO ks.{}(id,val) VALUES (0, {})",
+                table_name, "{first: 123, second: true}"
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+    
+    let (read_udt,): (UdtV1,) = session
+        .query(format!("SELECT val from ks.{} WHERE id = 0", table_name), &[])
+        .await
+        .unwrap()
+        .rows
+        .unwrap()
+        .into_typed::<(UdtV1,)>()
+        .next()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(read_udt, v1);
+
+    session
+        .query(
+            format!(
+                "INSERT INTO ks.{}(id,val) VALUES (0, ?)",
+                table_name
+            ),
+            &(&v1,),
+        )
+        .await
+        .unwrap();
+    
+    let (read_udt,): (UdtV1,) = session
+        .query(format!("SELECT val from ks.{} WHERE id = 0", table_name), &[])
+        .await
+        .unwrap()
+        .rows
+        .unwrap()
+        .into_typed::<(UdtV1,)>()
+        .next()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(read_udt, v1);
+
+    session
+        .query(
+            format!(
+                "ALTER TYPE ks.{} ADD third text;",
+                type_name
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+
+
+    #[derive(FromUserType, Debug, PartialEq)]
+    struct UdtV2 {
+        pub first: i32,
+        pub second: bool,
+        pub third: Option<String>
+    };
+
+
+    let (read_udt,): (UdtV2,) = session
+        .query(format!("SELECT val from ks.{} WHERE id = 0", table_name), &[])
+        .await
+        .unwrap()
+        .rows
+        .unwrap()
+        .into_typed::<(UdtV2,)>()
+        .next()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(read_udt, UdtV2{
+        first: 123,
+        second: true,
+        third: None
+    });
 }

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -706,6 +706,13 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
             let mut fields: BTreeMap<String, Option<CqlValue>> = BTreeMap::new();
 
             for (field_name, field_type) in field_types {
+                // If a field is added to a UDT and we read an old (frozen ?) version of it, 
+                // the driver will fail to parse the whole UDT.
+                // This is why we break the parsing after we reach the end of the serialized UDT.
+                if buf.is_empty() {
+                    break
+                }
+
                 let mut field_value: Option<CqlValue> = None;
                 if let Some(mut field_val_bytes) = types::read_bytes_opt(buf)? {
                     field_value = Some(deser_cql_value(field_type, &mut field_val_bytes)?);

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -706,11 +706,11 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
             let mut fields: BTreeMap<String, Option<CqlValue>> = BTreeMap::new();
 
             for (field_name, field_type) in field_types {
-                // If a field is added to a UDT and we read an old (frozen ?) version of it, 
+                // If a field is added to a UDT and we read an old (frozen ?) version of it,
                 // the driver will fail to parse the whole UDT.
                 // This is why we break the parsing after we reach the end of the serialized UDT.
                 if buf.is_empty() {
-                    break
+                    break;
                 }
 
                 let mut field_value: Option<CqlValue> = None;


### PR DESCRIPTION
When you create an User Defined Type, then insert a frozen udt into a table, then add a field to this UDT (on both Scylla schema and Rust code) the driver will fail to parse the UDT with the error: "Invalid message: Error parsing message: failed to fill whole buffer".
This is because the driver tries to read the new field from the buffer but it reached the end of it.
This fix simply stop parsing UDT fields when buffer is empty.

Fixes: Stop parsing UDT fields when buffer is empty.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
