### PR TITLE
Add more information to `FromRowError`

### DIFF
--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -17,7 +17,8 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
             #field_name: {
                 let (col_ix, col_value) = vals_iter
                     .next()
-                    .ok_or(FromRowError::RowTooShort)?;
+                    .unwrap(); // vals_iter size is checked before this code is reached, so
+                               // it is safe to unwrap
 
                 <#field_type as FromCqlVal<Option<CqlValue>>>::from_cql(col_value)
                     .map_err(|e| FromRowError::BadCqlVal {
@@ -28,6 +29,7 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
         }
     });
 
+    let fields_count = struct_fields.named.len();
     let generated = quote! {
         impl FromRow for #struct_name {
             fn from_row(row: scylla::frame::response::result::Row)
@@ -35,6 +37,12 @@ pub fn from_row_derive(tokens_input: TokenStream) -> TokenStream {
                 use scylla::frame::response::result::CqlValue;
                 use scylla::cql_to_rust::{FromCqlVal, FromRow, FromRowError};
 
+                if #fields_count != row.columns.len() {
+                    return Err(FromRowError::WrongRowSize {
+                        expected: #fields_count,
+                        actual: row.columns.len(),
+                    });
+                }
                 let mut vals_iter = row.columns.into_iter().enumerate();
 
                 Ok(#struct_name {


### PR DESCRIPTION
`FromRowError::BadCqlVal` was made more useful by adding a related column index.
Also, error messages were changed from "Bad CQL Value" to something like "Value is null in the column with index 2".


- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test. <- clippy changed
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #287
