### PR TITLE
fix link from top menu

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,7 +110,7 @@ html_style = ''
 
 html_theme_options = {
     'header_links': [
-    ('Scylla Rust Driver', 'https://scylladb.github.io/rust-driver/'),
+    ('Scylla Rust Driver', 'https://rust-driver.docs.scylladb.com/'),
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],


### PR DESCRIPTION
Fix https://github.com/scylladb/scylla-rust-driver/issues/289