### PR TITLE
Add a default value for serial consistency: LocalSerial

### DIFF
--- a/docs/source/SUMMARY.md
+++ b/docs/source/SUMMARY.md
@@ -19,6 +19,7 @@
     - [Prepared query](queries/prepared.md)
     - [Batch statement](queries/batch.md)
     - [Paged query](queries/paged.md)
+    - [Lightweight transaction query (LWT)](queries/lwt.md)
     - [USE keyspace](queries/usekeyspace.md)
     - [Schema agreement](queries/schema_agreement.md)
 

--- a/docs/source/queries/lwt.md
+++ b/docs/source/queries/lwt.md
@@ -1,0 +1,32 @@
+# Lightweight transaction (LWT) query
+
+A lightweight transaction query can be expressed just like any other query, via `Session`, with the notable difference of having an additional consistency level parameter - the `serial_consistency_level`.
+
+
+### Format of the query
+A lightweight transaction query is not a separate type - it can be expressed just like any other queries: via `SimpleQuery`, `PreparedStatement`, batches, and so on. The difference lays in the query string itself - when it contains a condition (e.g. `IF NOT EXISTS`), it becomes a lightweight transaction. It's important to remember that CQL specification requires a separate, additional consistency level to be defined for LWT queries - `serial_consistency_level`. The serial consistency level can only be set to two values: `SerialConsistency::Serial` or `SerialConsistency::LocalSerial`. The "local" variant makes the transaction consistent only within the same datacenter. For convenience, Scylla Rust Driver sets the default consistency level to `LocalSerial`, as it's more commonly used. For cross-datacenter consistency, please remember to always override the default with `SerialConsistency::Serial`.
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::query::Query;
+use scylla::statement::{Consistency, SerialConsistency};
+
+// Create a Query manually to change the Consistency to ONE
+let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?) IF NOT EXISTS".to_string());
+my_query.set_consistency(Consistency::One);
+// Use cross-datacenter serial consistency
+my_query.set_serial_consistency(Some(SerialConsistency::Serial));
+
+// Insert a value into the table
+let to_insert: i32 = 12345;
+session.query(my_query, (to_insert,)).await?;
+# Ok(())
+# }
+```
+
+The rest of the API remains identical for LWT and non-LWT queries.
+
+See [Query API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/query/struct.Query.html) for more options
+

--- a/docs/source/queries/queries.md
+++ b/docs/source/queries/queries.md
@@ -34,4 +34,5 @@ Queries are fully asynchronous - you can run as many of them in parallel as you 
    paged
    usekeyspace
    schema_agreement
+   lwt
 ```

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -4,7 +4,9 @@
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
 use scylla::batch::Batch;
-use scylla::statement::{prepared_statement::PreparedStatement, query::Query, Consistency};
+use scylla::statement::{
+    prepared_statement::PreparedStatement, query::Query, Consistency, SerialConsistency,
+};
 use scylla::tracing::{GetTracingConfig, TracingInfo};
 use scylla::transport::iterator::RowIterator;
 use scylla::{BatchResult, QueryResult};
@@ -34,6 +36,7 @@ async fn main() -> Result<()> {
     // Create a simple query and enable tracing for it
     let mut query: Query = Query::new("SELECT val from ks.tracing_example".to_string());
     query.set_tracing(true);
+    query.set_serial_consistency(Some(SerialConsistency::LocalSerial));
 
     // QueryResult will contain a tracing_id which can be used to query tracing information
     let query_result: QueryResult = session.query(query.clone(), &[]).await?;

--- a/scylla/src/frame/request/batch.rs
+++ b/scylla/src/frame/request/batch.rs
@@ -21,7 +21,7 @@ where
     pub statements_count: usize,
     pub batch_type: BatchType,
     pub consistency: types::Consistency,
-    pub serial_consistency: Option<types::Consistency>,
+    pub serial_consistency: Option<types::SerialConsistency>,
     pub timestamp: Option<i64>,
     pub values: Values,
 }
@@ -74,7 +74,7 @@ where
         buf.put_u8(flags);
 
         if let Some(serial_consistency) = self.serial_consistency {
-            types::write_consistency(serial_consistency, buf);
+            types::write_serial_consistency(serial_consistency, buf);
         }
         if let Some(timestamp) = self.timestamp {
             types::write_long(timestamp, buf);

--- a/scylla/src/frame/request/query.rs
+++ b/scylla/src/frame/request/query.rs
@@ -34,7 +34,7 @@ impl Request for Query<'_> {
 
 pub struct QueryParameters<'a> {
     pub consistency: types::Consistency,
-    pub serial_consistency: Option<types::Consistency>,
+    pub serial_consistency: Option<types::SerialConsistency>,
     pub timestamp: Option<i64>,
     pub page_size: Option<i32>,
     pub paging_state: Option<Bytes>,
@@ -94,7 +94,7 @@ impl QueryParameters<'_> {
         }
 
         if let Some(serial_consistency) = self.serial_consistency {
-            types::write_consistency(serial_consistency, buf);
+            types::write_serial_consistency(serial_consistency, buf);
         }
 
         if let Some(timestamp) = self.timestamp {

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -23,9 +23,14 @@ pub enum Consistency {
     All = 0x0005,
     LocalQuorum = 0x0006,
     EachQuorum = 0x0007,
+    LocalOne = 0x000A,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
+#[repr(i16)]
+pub enum SerialConsistency {
     Serial = 0x0008,
     LocalSerial = 0x0009,
-    LocalOne = 0x000A,
 }
 
 impl Default for Consistency {
@@ -401,6 +406,10 @@ pub fn read_consistency(buf: &mut &[u8]) -> Result<Consistency, ParseError> {
 }
 
 pub fn write_consistency(c: Consistency, buf: &mut impl BufMut) {
+    write_short(c as i16, buf);
+}
+
+pub fn write_serial_consistency(c: SerialConsistency, buf: &mut impl BufMut) {
     write_short(c as i16, buf);
 }
 

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,8 +1,8 @@
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
 use crate::transport::retry_policy::RetryPolicy;
 
-pub use super::Consistency;
 use super::StatementConfig;
+pub use super::{Consistency, SerialConsistency};
 pub use crate::frame::request::batch::BatchType;
 
 /// CQL batch statement.
@@ -56,13 +56,13 @@ impl Batch {
 
     /// Sets the serial consistency to be used when executing this batch.
     /// (Ignored unless the batch is an LWT)
-    pub fn set_serial_consistency(&mut self, sc: Option<Consistency>) {
+    pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
         self.config.serial_consistency = sc;
     }
 
     /// Gets the serial consistency to be used when executing this batch.
     /// (Ignored unless the batch is an LWT)
-    pub fn get_serial_consistency(&self) -> Option<Consistency> {
+    pub fn get_serial_consistency(&self) -> Option<SerialConsistency> {
         self.config.serial_consistency
     }
 

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -7,11 +7,11 @@ pub mod batch;
 pub mod prepared_statement;
 pub mod query;
 
-pub use crate::frame::types::Consistency;
+pub use crate::frame::types::{Consistency, SerialConsistency};
 
 pub struct StatementConfig {
     pub consistency: Consistency,
-    pub serial_consistency: Option<Consistency>,
+    pub serial_consistency: Option<SerialConsistency>,
 
     pub is_idempotent: bool,
 

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -26,7 +26,7 @@ impl Default for StatementConfig {
     fn default() -> Self {
         Self {
             consistency: Default::default(),
-            serial_consistency: None,
+            serial_consistency: Some(SerialConsistency::LocalSerial),
             is_idempotent: false,
             retry_policy: None,
             speculative_execution_policy: None,

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use super::StatementConfig;
 use crate::frame::response::result::PreparedMetadata;
-use crate::frame::types::Consistency;
+use crate::frame::types::{Consistency, SerialConsistency};
 use crate::frame::value::SerializedValues;
 use crate::transport::retry_policy::RetryPolicy;
 
@@ -142,13 +142,13 @@ impl PreparedStatement {
 
     /// Sets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
-    pub fn set_serial_consistency(&mut self, sc: Option<Consistency>) {
+    pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
         self.config.serial_consistency = sc;
     }
 
     /// Gets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
-    pub fn get_serial_consistency(&self) -> Option<Consistency> {
+    pub fn get_serial_consistency(&self) -> Option<SerialConsistency> {
         self.config.serial_consistency
     }
 

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -1,5 +1,5 @@
 use super::StatementConfig;
-use crate::frame::types::Consistency;
+use crate::frame::types::{Consistency, SerialConsistency};
 use crate::transport::retry_policy::RetryPolicy;
 
 /// CQL query statement.
@@ -62,13 +62,13 @@ impl Query {
 
     /// Sets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
-    pub fn set_serial_consistency(&mut self, sc: Option<Consistency>) {
+    pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
         self.config.serial_consistency = sc;
     }
 
     /// Gets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
-    pub fn get_serial_consistency(&self) -> Option<Consistency> {
+    pub fn get_serial_consistency(&self) -> Option<SerialConsistency> {
         self.config.serial_consistency
     }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -20,7 +20,7 @@ use crate::frame::value::{BatchValues, SerializedValues, ValueList};
 use crate::prepared_statement::{PartitionKeyError, PreparedStatement};
 use crate::query::Query;
 use crate::routing::{murmur3_token, Token};
-use crate::statement::Consistency;
+use crate::statement::{Consistency, SerialConsistency};
 use crate::tracing::{GetTracingConfig, TracingEvent, TracingInfo};
 use crate::transport::{
     cluster::Cluster,
@@ -1181,7 +1181,7 @@ impl Session {
         let info = Statement::default();
         let config = StatementConfig {
             is_idempotent: true,
-            serial_consistency: Some(Consistency::One),
+            serial_consistency: Some(SerialConsistency::LocalSerial),
             ..Default::default()
         };
 


### PR DESCRIPTION
This series adds a default serial consistency level for queries - `LocalSerial`. The decision is based on the fact that `LocalSerial` is the one that provides acceptable performance. Users interested in strong, cross-dc consistency - which could also cause prohibitive latencies - should override to `Local`.

The series also comes with a doc entry which briefly explains LWT queries (they weren't mentioned at all so far), as well as an extra validation layer which would prevent users from setting a wrong consistency level, without introducing any backward incompatible changes.

This series introduces a breaking change - serial consistency is now defined as a separate enum. Fixing the existing aplications is trivial and consists of replacing all occurrences of `Consistency::LocalSerial` to `SerialConsistency::LocalSerial` and `Consistency::Serial` to `SerialConsistency::Serial`.

Fixes #277

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
