### PR TITLE
Add first steps to cached prepared statements

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -34,6 +34,7 @@ chrono = "0.4"
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
 arc-swap = "1.3.0"
+dashmap = "4.0.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/frame/request/query.rs
+++ b/scylla/src/frame/request/query.rs
@@ -18,7 +18,7 @@ const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
 // const FLAG_WITH_NAMES_FOR_VALUES: u8 = 0x40;
 
 pub struct Query<'a> {
-    pub contents: String,
+    pub contents: &'a str,
     pub parameters: QueryParameters<'a>,
 }
 
@@ -26,7 +26,7 @@ impl Request for Query<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Query;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
-        types::write_long_string(&self.contents, buf)?;
+        types::write_long_string(self.contents, buf)?;
         self.parameters.serialize(buf)?;
         Ok(())
     }

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -108,6 +108,7 @@ pub use statement::query;
 pub use frame::response::cql_to_rust;
 pub use frame::response::cql_to_rust::FromRow;
 
+pub use transport::caching_session::CachingSession;
 pub use transport::connection::{BatchResult, QueryResult};
 pub use transport::session::{IntoTypedRows, Session, SessionConfig};
 pub use transport::session_builder::SessionBuilder;

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -9,7 +9,7 @@ use crate::transport::retry_policy::RetryPolicy;
 pub struct Query {
     pub(crate) config: StatementConfig,
 
-    contents: String,
+    pub contents: String,
     page_size: Option<i32>,
 }
 
@@ -27,11 +27,6 @@ impl Query {
     pub fn with_page_size(mut self, page_size: i32) -> Self {
         self.page_size = Some(page_size);
         self
-    }
-
-    /// Returns the string representation of the CQL query.
-    pub fn get_contents(&self) -> &str {
-        &self.contents
     }
 
     /// Sets the page size for this CQL query.

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -1,0 +1,272 @@
+use bytes::Bytes;
+use dashmap::DashMap;
+use itertools::Either;
+use crate::frame::value::ValueList;
+use crate::prepared_statement::PreparedStatement;
+use crate::query::Query;
+use crate::{QueryResult, Session};
+use crate::transport::errors::{DbError, QueryError};
+use crate::transport::iterator::RowIterator;
+
+/// Provides auto caching while executing queries
+pub struct CachingSession {
+    pub session: Session,
+    /// The prepared statement cache size
+    /// If a prepared statement is added while the limit is reached, the oldest prepared statement
+    /// is removed from the cache
+    pub max_capacity: usize,
+    pub cache: DashMap<String, PreparedStatement>,
+}
+
+impl CachingSession {
+    pub fn from(session: Session, cache_size: usize) -> Self {
+        Self {
+            session,
+            max_capacity: cache_size,
+            cache: Default::default(),
+        }
+    }
+
+    /// Does the same thing as [`Session::execute`] but uses the prepared statement cache
+    pub async fn execute(
+        &self,
+        query: impl Into<Query>,
+        values: &impl ValueList,
+    ) -> Result<QueryResult, QueryError> {
+        let query = query.into();
+        let prepared = self.add_prepared_statement(&query).await?;
+        let values = values.serialized()?;
+        let result = self.session.execute(&prepared, values.clone()).await;
+
+        match self.post_execute_prepared_statement(&query, result).await? {
+            Either::Left(result) => Ok(result),
+            Either::Right(new_prepared_statement) => {
+                self.session.execute(&new_prepared_statement, values).await
+            }
+        }
+    }
+
+
+    /// Does the same thing as [`Session::execute_iter`] but uses the prepared statement cache
+    pub async fn execute_iter(
+        &self,
+        query: impl Into<Query>,
+        values: impl ValueList,
+    ) -> Result<RowIterator, QueryError> {
+        let query = query.into();
+        let prepared = self.add_prepared_statement(&query).await?;
+        let values = values.serialized()?;
+        let result = self.session.execute_iter(prepared, values.clone()).await;
+
+        match self.post_execute_prepared_statement(&query, result).await? {
+            Either::Left(result) => Ok(result),
+            Either::Right(new_prepared_statement) => {
+                self.session.execute_iter(new_prepared_statement, values).await
+            }
+        }
+    }
+
+    /// Does the same thing as [`Session::execute_paged`] but uses the prepared statement cache
+    pub async fn execute_paged(
+        &self,
+        query: impl Into<Query>,
+        values: impl ValueList,
+        paging_state: Option<Bytes>,
+    ) -> Result<QueryResult, QueryError> {
+        let query = query.into();
+        let prepared = self.add_prepared_statement(&query).await?;
+        let values = values.serialized()?;
+        let result = self
+            .session
+            .execute_paged(&prepared, values.clone(), paging_state.clone())
+            .await;
+
+        match self.post_execute_prepared_statement(&query, result).await? {
+            Either::Left(result) => Ok(result),
+            Either::Right(new_prepared_statement) => {
+                self
+                    .session
+                    .execute_paged(&new_prepared_statement, values, paging_state)
+                    .await
+            }
+        }
+    }
+
+    /// Adds a prepared statement to the cache
+    pub async fn add_prepared_statement(
+        &self,
+        query: impl Into<&Query>,
+    ) -> Result<PreparedStatement, QueryError> {
+        let query = query.into();
+
+        if let Some(prepared) = self.cache.get(&query.contents) {
+            // Clone, because else the value is mutably borrowed and the execute method gives a compile error
+            Ok(prepared.clone())
+        } else {
+            let prepared = self.session.prepare(query.clone()).await?;
+
+            if self.max_capacity
+                == self.cache.len()
+            {
+                // Cache is full, remove the first entry
+                // Don't delete while holding the key, this could deadlock
+                // Instead, store the raw string in a variable and remove it later on when there
+                // are no more references to the cache
+                let mut query = "".to_string();
+
+                // There is no easy way to just get a random/first element
+                #[allow(clippy::never_loop)]
+                for first in self.cache.iter() {
+                    query = first.key().clone();
+
+                    // Only the first entry is important
+                    break;
+                }
+
+                self.cache.remove(&query);
+            }
+
+            self.cache.insert(query.contents.clone(), prepared.clone());
+
+            Ok(prepared)
+        }
+    }
+
+    /// This method is called after a cached prepared statement
+    /// It returns:
+    ///     - a success result, nothing has to be done: [`Either::Left`]
+    ///     - a new prepared statement in which the caller should retry the query: [`Either::Right`].
+    ///     - [`QueryError`] when an error occurred
+    async fn post_execute_prepared_statement<T>(
+        &self,
+        query: &Query,
+        result: Result<T, QueryError>,
+    ) -> Result<Either<T, PreparedStatement>, QueryError> {
+        match result {
+            Ok(qr) => Ok(Either::Left(qr)),
+            Err(err) => {
+                // Check if the 'Unprepare; error is thrown
+                // In that case, re-prepare it and send it again
+                // In all other cases, just return the error
+                match err {
+                    QueryError::DbError(db_error, message) => match db_error {
+                        DbError::Unprepared => {
+                            self.cache.remove(&query.contents);
+
+                            let prepared = self.add_prepared_statement(query).await?;
+
+                            Ok(Either::Right(prepared))
+                        }
+                        _ => Err(QueryError::DbError(db_error, message)),
+                    },
+                    _ => Err(err),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use crate::{CachingSession, SessionBuilder};
+
+    async fn create_caching_session() -> CachingSession {
+        let session = CachingSession::from(SessionBuilder::new_for_test().await, 2);
+
+        // Add a row, this makes it easier to check if the caching works combined with the regular execute fn on Session
+        session.execute("insert into test_table(a, b) values (1, 2)", &[]).await.unwrap();
+
+        // Clear the cache because it now contains an insert
+        assert_eq!(session.cache.len(), 1);
+
+        session.cache.clear();
+
+        session
+    }
+
+    /// Test that when the cache is full and a different query comes in, that query will be added
+    /// to the cache and a random query is removed
+    #[tokio::test]
+    async fn test_full() {
+        let session = create_caching_session().await;
+
+        let first_query = "select * from test_table";
+        let middle_query = "insert into test_table(a, b) values (?, ?)";
+        let last_query = "update test_table set b = ? where a = 1";
+
+        session.add_prepared_statement(&first_query.into()).await.unwrap();
+        session.add_prepared_statement(&middle_query.into()).await.unwrap();
+        session.add_prepared_statement(&last_query.into()).await.unwrap();
+
+        assert_eq!(2, session.cache.len());
+
+        // This query should be in the cache
+        assert!(session.cache.get(last_query).is_some());
+
+        // Either the first or middle query should be removed
+        let first_query_removed = session.cache.get(first_query).is_none();
+        let middle_query_removed = session.cache.get(middle_query).is_none();
+
+        assert!(first_query_removed || middle_query_removed);
+    }
+
+    /// Checks that the same prepared statement is reused when executing the same query twice
+    #[tokio::test]
+    async fn test_execute_cached() {
+        let session = create_caching_session().await;
+        let result = session
+            .execute("select * from test_table", &[])
+            .await
+            .unwrap();
+
+        assert_eq!(1, session.cache.len());
+        assert_eq!(1, result.rows.unwrap().len());
+
+        let result = session
+            .execute("select * from test_table", &[])
+            .await
+            .unwrap();
+
+        assert_eq!(1, session.cache.len());
+        assert_eq!(1, result.rows.unwrap().len());
+    }
+
+    /// Checks that caching works with execute_iter
+    #[tokio::test]
+    async fn test_execute_iter_cached() {
+        let session = create_caching_session().await;
+
+        assert!(session.cache.is_empty());
+
+        let mut iter = session
+            .execute_iter("select * from test_table", &[])
+            .await
+            .unwrap();
+
+        let mut rows = 0;
+
+        while let Some(_) = iter.next().await {
+            rows += 1;
+        }
+
+        assert_eq!(1, rows);
+        assert_eq!(1, session.cache.len());
+    }
+
+    /// Checks that caching works with execute_paged
+    #[tokio::test]
+    async fn test_execute_paged_cached() {
+        let session = create_caching_session().await;
+
+        assert!(session.cache.is_empty());
+
+        let result = session
+            .execute_paged("select * from test_table", &[], None)
+            .await
+            .unwrap();
+
+        assert_eq!(1, session.cache.len());
+        assert_eq!(1, result.rows.unwrap().len());
+    }
+}

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -278,7 +278,7 @@ impl Connection {
         let query_response = self
             .send_request(
                 &request::Prepare {
-                    query: query.get_contents(),
+                    query: &query.contents,
                 },
                 true,
                 query.config.tracing,
@@ -290,7 +290,7 @@ impl Connection {
             Response::Result(result::Result::Prepared(p)) => PreparedStatement::new(
                 p.id,
                 p.prepared_metadata,
-                query.get_contents().to_owned(),
+                query.contents.clone(),
                 query.get_page_size(),
             ),
             _ => {
@@ -353,7 +353,7 @@ impl Connection {
         let serialized_values = values.serialized()?;
 
         let query_frame = query::Query {
-            contents: query.get_contents().to_owned(),
+            contents: &query.contents,
             parameters: query::QueryParameters {
                 consistency: query.get_consistency(),
                 serial_consistency: query.get_serial_consistency(),
@@ -516,7 +516,7 @@ impl Connection {
 
         let statements_iter = batch.statements.iter().map(|s| match s {
             BatchStatement::Query(q) => batch::BatchStatement::Query {
-                text: q.get_contents(),
+                text: &q.contents,
             },
             BatchStatement::PreparedStatement(s) => {
                 batch::BatchStatement::Prepared { id: s.get_id() }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -515,9 +515,7 @@ impl Connection {
         }
 
         let statements_iter = batch.statements.iter().map(|s| match s {
-            BatchStatement::Query(q) => batch::BatchStatement::Query {
-                text: &q.contents,
-            },
+            BatchStatement::Query(q) => batch::BatchStatement::Query { text: &q.contents },
             BatchStatement::PreparedStatement(s) => {
                 batch::BatchStatement::Prepared { id: s.get_id() }
             }

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -5,6 +5,7 @@ pub mod load_balancing;
 mod node;
 pub mod retry_policy;
 pub mod session;
+pub(crate) mod caching_session;
 pub mod session_builder;
 pub mod speculative_execution;
 mod topology;

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod caching_session;
 mod cluster;
 pub(crate) mod connection;
 mod connection_pool;
@@ -5,7 +6,6 @@ pub mod load_balancing;
 mod node;
 pub mod retry_policy;
 pub mod session;
-pub(crate) mod caching_session;
 pub mod session_builder;
 pub mod speculative_execution;
 mod topology;

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -753,8 +753,10 @@ impl Session {
     /// TODO: write more docs
     pub async fn add_prepared_statement(
         &self,
-        query: &Query,
+        query: impl Into<&Query>,
     ) -> Result<PreparedStatement, QueryError> {
+        let query = query.into();
+
         if let Some(prepared) = self.prepared_statement_cache.cache.get(&query.contents) {
             // Clone, because else the value is mutably borrowed and the execute method gives a compile error
             Ok(prepared.clone())
@@ -808,7 +810,7 @@ impl Session {
                                 self.prepared_statement_cache.cache.remove(&query.contents);
 
                                 let prepared =
-                                    self.add_prepared_statement(&query).await?;
+                                    self.add_prepared_statement(query).await?;
 
                                 Ok(Either::Right(prepared))
                             }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -751,7 +751,7 @@ impl Session {
     }
 
     /// TODO: write more docs
-    async fn add_prepared_statement(
+    pub async fn add_prepared_statement(
         &self,
         query: &Query,
     ) -> Result<PreparedStatement, QueryError> {

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -10,6 +10,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::transport::errors::QueryError;
+use crate::QueryResult;
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
 
@@ -41,6 +43,36 @@ impl SessionBuilder {
         SessionBuilder {
             config: SessionConfig::new(),
         }
+    }
+
+    #[cfg(test)]
+    pub async fn new_for_test() -> Session {
+        let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+        let session = SessionBuilder::new()
+            .known_node(uri)
+            .build()
+            .await
+            .expect("Could not create session");
+
+        session
+            .query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[])
+            .await
+            .expect("Could not create keyspace");
+
+        session
+            .query(
+                "CREATE TABLE IF NOT EXISTS ks.test_table (a int primary key, b int)",
+                &[],
+            )
+            .await
+            .expect("Could not create table");
+
+        session
+            .use_keyspace("ks", false)
+            .await
+            .expect("Could not set keyspace");
+
+        session
     }
 
     /// Add a known node with a hostname

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -10,8 +10,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::transport::errors::QueryError;
-use crate::QueryResult;
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
 


### PR DESCRIPTION
- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I added appropriate `Fixes:` annotations to PR description.

This is a PR to add cached prepared statements. I added a lot of TODO's since I am not sure if this is the correct way. I just added a simple cache mechanism on top of the existing methods. Fixes https://github.com/scylladb/scylla-rust-driver/issues/151