### PR TITLE
Fix misleading getter/setter doc comments in the statement module

### DIFF
--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -62,7 +62,7 @@ impl Batch {
         self.config.serial_consistency
     }
 
-    /// Sets the idempotence of this statement
+    /// Sets the idempotence of this batch
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
     /// If set to `true` we can be sure that it is idempotent
     /// If set to `false` it is unknown whether it is idempotent
@@ -71,18 +71,18 @@ impl Batch {
         self.config.is_idempotent = is_idempotent;
     }
 
-    /// Gets the idempotence of this statement
+    /// Gets the idempotence of this batch
     pub fn get_is_idempotent(&self) -> bool {
         self.config.is_idempotent
     }
 
-    /// Sets a custom [`RetryPolicy`] to be used with this statement
+    /// Sets a custom [`RetryPolicy`] to be used with this batch
     /// By default Session's retry policy is used, this allows to use a custom retry policy
     pub fn set_retry_policy(&mut self, retry_policy: Box<dyn RetryPolicy>) {
         self.config.retry_policy = Some(retry_policy);
     }
 
-    /// Gets custom [`RetryPolicy`] used by this statement
+    /// Gets custom [`RetryPolicy`] used by this batch
     pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy>> {
         &self.config.retry_policy
     }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -130,24 +130,24 @@ impl PreparedStatement {
             .map(|col_spec| col_spec.table_spec.ks_name.as_str())
     }
 
-    /// Sets the consistency to be used when executing this batch.
+    /// Sets the consistency to be used when executing this statement.
     pub fn set_consistency(&mut self, c: Consistency) {
         self.config.consistency = c;
     }
 
-    /// Gets the consistency to be used when executing this batch.
+    /// Gets the consistency to be used when executing this statement.
     pub fn get_consistency(&self) -> Consistency {
         self.config.consistency
     }
 
-    /// Sets the serial consistency to be used when executing this batch.
-    /// (Ignored unless the batch is an LWT)
+    /// Sets the serial consistency to be used when executing this statement.
+    /// (Ignored unless the statement is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<Consistency>) {
         self.config.serial_consistency = sc;
     }
 
-    /// Gets the serial consistency to be used when executing this batch.
-    /// (Ignored unless the batch is an LWT)
+    /// Gets the serial consistency to be used when executing this statement.
+    /// (Ignored unless the statement is an LWT)
     pub fn get_serial_consistency(&self) -> Option<Consistency> {
         self.config.serial_consistency
     }
@@ -177,14 +177,14 @@ impl PreparedStatement {
         &self.config.retry_policy
     }
 
-    /// Enable or disable CQL Tracing for this batch
-    /// If enabled session.batch() will return a BatchResult containing tracing_id
+    /// Enable or disable CQL Tracing for this statement
+    /// If enabled session.execute() will return a QueryResult containing tracing_id
     /// which can be used to query tracing information about the execution of this query
     pub fn set_tracing(&mut self, should_trace: bool) {
         self.config.tracing = should_trace;
     }
 
-    /// Gets whether tracing is enabled for this batch
+    /// Gets whether tracing is enabled for this statement
     pub fn get_tracing(&self) -> bool {
         self.config.tracing
     }

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -50,24 +50,24 @@ impl Query {
         self.page_size
     }
 
-    /// Sets the consistency to be used when executing this batch.
+    /// Sets the consistency to be used when executing this statement.
     pub fn set_consistency(&mut self, c: Consistency) {
         self.config.consistency = c;
     }
 
-    /// Gets the consistency to be used when executing this batch.
+    /// Gets the consistency to be used when executing this statement.
     pub fn get_consistency(&self) -> Consistency {
         self.config.consistency
     }
 
-    /// Sets the serial consistency to be used when executing this batch.
-    /// (Ignored unless the batch is an LWT)
+    /// Sets the serial consistency to be used when executing this statement.
+    /// (Ignored unless the statement is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<Consistency>) {
         self.config.serial_consistency = sc;
     }
 
-    /// Gets the serial consistency to be used when executing this batch.
-    /// (Ignored unless the batch is an LWT)
+    /// Gets the serial consistency to be used when executing this statement.
+    /// (Ignored unless the statement is an LWT)
     pub fn get_serial_consistency(&self) -> Option<Consistency> {
         self.config.serial_consistency
     }
@@ -97,14 +97,14 @@ impl Query {
         &self.config.retry_policy
     }
 
-    /// Enable or disable CQL Tracing for this batch
-    /// If enabled session.batch() will return a BatchResult containing tracing_id
+    /// Enable or disable CQL Tracing for this statement
+    /// If enabled session.query() will return a QueryResult containing tracing_id
     /// which can be used to query tracing information about the execution of this query
     pub fn set_tracing(&mut self, should_trace: bool) {
         self.config.tracing = should_trace;
     }
 
-    /// Gets whether tracing is enabled for this batch
+    /// Gets whether tracing is enabled for this statement
     pub fn get_tracing(&self) -> bool {
         self.config.tracing
     }


### PR DESCRIPTION
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~

This pull request fixes some copy-paste errors in the statement module's getter/setter doc comments.