### PR TITLE
Client-side timestamps

### DIFF
--- a/scylla/src/frame/request/batch.rs
+++ b/scylla/src/frame/request/batch.rs
@@ -10,6 +10,7 @@ use crate::frame::{
 
 // Batch flags
 const FLAG_WITH_SERIAL_CONSISTENCY: u8 = 0x10;
+const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
 
 pub struct Batch<'a, StatementsIter, Values>
 where
@@ -21,6 +22,7 @@ where
     pub batch_type: BatchType,
     pub consistency: types::Consistency,
     pub serial_consistency: Option<types::Consistency>,
+    pub timestamp: Option<i64>,
     pub values: Values,
 }
 
@@ -65,11 +67,17 @@ where
         if self.serial_consistency.is_some() {
             flags |= FLAG_WITH_SERIAL_CONSISTENCY;
         }
+        if self.timestamp.is_some() {
+            flags |= FLAG_WITH_DEFAULT_TIMESTAMP;
+        }
 
         buf.put_u8(flags);
 
         if let Some(serial_consistency) = self.serial_consistency {
             types::write_consistency(serial_consistency, buf);
+        }
+        if let Some(timestamp) = self.timestamp {
+            types::write_long(timestamp, buf);
         }
 
         Ok(())

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -98,6 +98,18 @@ impl Batch {
     pub fn get_tracing(&self) -> bool {
         self.config.tracing
     }
+
+    /// Sets the default timestamp for this batch in microseconds.
+    /// If not None, it will replace the server side assigned timestamp as default timestamp for
+    /// all the statements contained in the batch.
+    pub fn set_timestamp(&mut self, timestamp: Option<i64>) {
+        self.config.timestamp = timestamp
+    }
+
+    /// Gets the default timestamp for this batch in microseconds.
+    pub fn get_timestamp(&self) -> Option<i64> {
+        self.config.timestamp
+    }
 }
 
 impl Default for Batch {

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -19,6 +19,7 @@ pub struct StatementConfig {
     pub speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
 
     pub tracing: bool,
+    pub timestamp: Option<i64>,
 }
 
 impl Default for StatementConfig {
@@ -30,6 +31,7 @@ impl Default for StatementConfig {
             retry_policy: None,
             speculative_execution_policy: None,
             tracing: false,
+            timestamp: None,
         }
     }
 }
@@ -46,6 +48,7 @@ impl Clone for StatementConfig {
                 .map(|policy| policy.clone_boxed()),
             speculative_execution_policy: self.speculative_execution_policy.clone(),
             tracing: self.tracing,
+            timestamp: self.timestamp,
         }
     }
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -188,6 +188,19 @@ impl PreparedStatement {
     pub fn get_tracing(&self) -> bool {
         self.config.tracing
     }
+
+    /// Sets the default timestamp for this statement in microseconds.
+    /// If not None, it will replace the server side assigned timestamp as default timestamp
+    /// If a statement contains a `USING TIMESTAMP` clause, calling this method won't change
+    /// anything
+    pub fn set_timestamp(&mut self, timestamp: Option<i64>) {
+        self.config.timestamp = timestamp
+    }
+
+    /// Gets the default timestamp for this statement in microseconds.
+    pub fn get_timestamp(&self) -> Option<i64> {
+        self.config.timestamp
+    }
 }
 
 #[derive(Debug, Error, PartialEq, Eq, PartialOrd, Ord)]

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -108,6 +108,19 @@ impl Query {
     pub fn get_tracing(&self) -> bool {
         self.config.tracing
     }
+
+    /// Sets the default timestamp for this statement in microseconds.
+    /// If not None, it will replace the server side assigned timestamp as default timestamp
+    /// If a statement contains a `USING TIMESTAMP` clause, calling this method won't change
+    /// anything
+    pub fn set_timestamp(&mut self, timestamp: Option<i64>) {
+        self.config.timestamp = timestamp
+    }
+
+    /// Gets the default timestamp for this statement in microseconds.
+    pub fn get_timestamp(&self) -> Option<i64> {
+        self.config.timestamp
+    }
 }
 
 impl From<String> for Query {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -331,6 +331,7 @@ impl Connection {
                 values: &serialized_values,
                 page_size: query.get_page_size(),
                 paging_state,
+                timestamp: query.get_timestamp(),
             },
         };
 
@@ -364,6 +365,7 @@ impl Connection {
                 serial_consistency: prepared_statement.get_serial_consistency(),
                 values: &serialized_values,
                 page_size: prepared_statement.get_page_size(),
+                timestamp: prepared_statement.get_timestamp(),
                 paging_state,
             },
         };
@@ -423,6 +425,7 @@ impl Connection {
             batch_type: batch.get_type(),
             consistency: batch.get_consistency(),
             serial_consistency: batch.get_serial_consistency(),
+            timestamp: batch.get_timestamp(),
         };
 
         let query_response = self

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -913,3 +913,111 @@ async fn test_await_timed_schema_agreement() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn test_timestamp() {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = SessionBuilder::new().known_node(uri).build().await.unwrap();
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
+    session
+        .query("DROP TABLE IF EXISTS ks.t_timestamp;", &[])
+        .await
+        .unwrap();
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t_timestamp (a text, b text, primary key (a))",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    session.await_schema_agreement().await.unwrap();
+
+    let query_str = "INSERT INTO ks.t_timestamp (a, b) VALUES (?, ?)";
+
+    // test regular query timestamps
+
+    let mut regular_query = Query::new(query_str.to_string());
+
+    regular_query.set_timestamp(Some(420));
+    session
+        .query(regular_query.clone(), ("regular query", "higher timestamp"))
+        .await
+        .unwrap();
+
+    regular_query.set_timestamp(Some(42));
+    session
+        .query(regular_query.clone(), ("regular query", "lower timestamp"))
+        .await
+        .unwrap();
+
+    // test prepared statement timestamps
+
+    let mut prepared_statement = session.prepare(query_str).await.unwrap();
+
+    prepared_statement.set_timestamp(Some(420));
+    session
+        .execute(&prepared_statement, ("prepared query", "higher timestamp"))
+        .await
+        .unwrap();
+
+    prepared_statement.set_timestamp(Some(42));
+    session
+        .execute(&prepared_statement, ("prepared query", "lower timestamp"))
+        .await
+        .unwrap();
+
+    // test batch statement timestamps
+
+    let mut batch: Batch = Default::default();
+    batch.append_statement(regular_query);
+    batch.append_statement(prepared_statement);
+
+    batch.set_timestamp(Some(420));
+    session
+        .batch(
+            &batch,
+            (
+                ("first query in batch", "higher timestamp"),
+                ("second query in batch", "higher timestamp"),
+            ),
+        )
+        .await
+        .unwrap();
+
+    batch.set_timestamp(Some(42));
+    session
+        .batch(
+            &batch,
+            (
+                ("first query in batch", "lower timestamp"),
+                ("second query in batch", "lower timestamp"),
+            ),
+        )
+        .await
+        .unwrap();
+
+    let mut results = session
+        .query("SELECT a, b, WRITETIME(b) FROM ks.t_timestamp", &[])
+        .await
+        .unwrap()
+        .rows
+        .unwrap()
+        .into_typed::<(String, String, i64)>()
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    results.sort();
+
+    let expected_results = [
+        ("first query in batch", "higher timestamp", 420),
+        ("prepared query", "higher timestamp", 420),
+        ("regular query", "higher timestamp", 420),
+        ("second query in batch", "higher timestamp", 420),
+    ]
+    .iter()
+    .map(|(x, y, t)| (x.to_string(), y.to_string(), *t))
+    .collect::<Vec<_>>();
+
+    assert_eq!(results, expected_results);
+}


### PR DESCRIPTION
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.

This pull request adds support for specifying client-side timestamps for a given query.
```rust
let mut regular_query = Query::new(query_str.to_string());
regular_query.set_timestamp(Some(42));
session.query(regular_query, (,)).await?;
```
Refs: #262 (not saying fixes, because issue is resolved partially - there are no generators implemented, only programmatically setting the timestamp for queries)
