### PR TITLE
Add a method to query data using multiple paged queries

### DIFF
--- a/docs/source/queries/batch.md
+++ b/docs/source/queries/batch.md
@@ -20,7 +20,7 @@ let mut batch: Batch = Default::default();
 batch.append_statement("INSERT INTO ks.tab(a, b) VALUES(?, ?)");
 
 // Add a simple query created manually to the batch
-let simple: Query = Query::new("INSERT INTO ks.tab (a, b) VALUES(3, 4)".to_string());
+let simple: Query = Query::new("INSERT INTO ks.tab (a, b) VALUES(3, 4)");
 batch.append_statement(simple);
 
 // Add a prepared query to the batch

--- a/docs/source/queries/paged.md
+++ b/docs/source/queries/paged.md
@@ -70,7 +70,7 @@ On a `Query`:
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
 
-let mut query: Query = Query::new("SELECT a, b FROM ks.t".to_string());
+let mut query: Query = Query::new("SELECT a, b FROM ks.t");
 query.set_page_size(16);
 
 let _ = session.query_iter(query, &[]).await?; // ...
@@ -110,7 +110,7 @@ On a `Query`:
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
 
-let paged_query = Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(6);
+let paged_query = Query::new("SELECT a, b, c FROM ks.t").with_page_size(6);
 let res1 = session.query(paged_query.clone(), &[]).await?;
 let res2 = session
     .query_paged(paged_query.clone(), &[], res1.paging_state)
@@ -128,7 +128,7 @@ On a `PreparedStatement`:
 use scylla::query::Query;
 
 let paged_prepared = session
-    .prepare(Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(7))
+    .prepare(Query::new("SELECT a, b, c FROM ks.t").with_page_size(7))
     .await?;
 let res1 = session.execute(&paged_prepared, &[]).await?;
 let res2 = session

--- a/docs/source/queries/prepared.md
+++ b/docs/source/queries/prepared.md
@@ -27,8 +27,11 @@ session.execute(&prepared, (to_insert,)).await?;
 > must be sent as bound values (see [performance section](#performance))
 
 > ***Warning***  
-> Prepared query returns only a single page of results.
-> If number of rows might exceed single page size use a [paged query](paged.md) instead.
+> Don't use `execute` to receive large amounts of data.  
+> By default the query is unpaged and might cause heavy load on the cluster.
+> In such cases set a page size and use a [paged query](paged.md) instead.
+> 
+> When page size is set, `execute` will return only the first page of results.
 
 ### `Session::prepare`
 `Session::prepare` takes query text and prepares the query on all nodes and shards.

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -31,7 +31,7 @@ use scylla::query::Query;
 use scylla::statement::Consistency;
 
 // Create a Query manually to change the Consistency to ONE
-let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)".to_string());
+let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
 my_query.set_consistency(Consistency::One);
 
 // Insert a value into the table

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -16,8 +16,11 @@ session
 ```
 
 > ***Warning***  
-> Simple query returns only a single page of results.
-> If number of rows might exceed single page size use a [paged query](paged.md) instead.  
+> Don't use simple query to receive large amounts of data.  
+> By default the query is unpaged and might cause heavy load on the cluster.  
+> In such cases set a page size and use [paged query](paged.md) instead.  
+> 
+> When page size is set, `query` will return only the first page of results.
 
 ### First argument - the query
 As the first argument `Session::query` takes anything implementing `Into<Query>`.  
@@ -86,8 +89,8 @@ if let Some(rows) = session.query("SELECT a FROM ks.tab", &[]).await?.rows {
 # Ok(())
 # }
 ```
-> Simple query returns only a single page of results.
-> If number of rows might exceed single page size use a [paged query](paged.md) instead.  
+> In cases where page size is set, simple query returns only a single page of results.  
+> To receive all pages use a [paged query](paged.md) instead.  
 
 See [Query result](result.md) for more information about handling query results
 

--- a/docs/source/retry-policy/default.md
+++ b/docs/source/retry-policy/default.md
@@ -32,7 +32,7 @@ use scylla::query::Query;
 use scylla::transport::retry_policy::DefaultRetryPolicy;
 
 // Create a Query manually and set the retry policy
-let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)".to_string());
+let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
 my_query.set_retry_policy(Box::new(DefaultRetryPolicy::new()));
 
 // Run the query using this retry policy

--- a/docs/source/retry-policy/fallthrough.md
+++ b/docs/source/retry-policy/fallthrough.md
@@ -31,7 +31,7 @@ use scylla::query::Query;
 use scylla::transport::retry_policy::FallthroughRetryPolicy;
 
 // Create a Query manually and set the retry policy
-let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)".to_string());
+let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
 my_query.set_retry_policy(Box::new(FallthroughRetryPolicy::new()));
 
 // Run the query using this retry policy

--- a/docs/source/retry-policy/retry-policy.md
+++ b/docs/source/retry-policy/retry-policy.md
@@ -26,7 +26,7 @@ use scylla::query::Query;
 use scylla::prepared_statement::PreparedStatement;
 
 // Specify that a Query is idempotent
-let mut my_query: Query = Query::new("SELECT a FROM ks.tab".to_string());
+let mut my_query: Query = Query::new("SELECT a FROM ks.tab");
 my_query.set_is_idempotent(true);
 
 

--- a/docs/source/tracing/paged.md
+++ b/docs/source/tracing/paged.md
@@ -19,7 +19,7 @@ use futures::StreamExt;
 use uuid::Uuid;
 
 // Create a Query manually and enable tracing
-let mut query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(4)".to_string());
+let mut query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(4)");
 query.set_tracing(true);
 
 // Create a paged query iterator and fetch pages

--- a/docs/source/tracing/prepare.md
+++ b/docs/source/tracing/prepare.md
@@ -14,7 +14,7 @@ use scylla::tracing::TracingInfo;
 use uuid::Uuid;
 
 // Prepare the query with tracing enabled
-let mut to_prepare: Query = Query::new("SELECT a FROM ks.tab".to_string());
+let mut to_prepare: Query = Query::new("SELECT a FROM ks.tab");
 to_prepare.set_tracing(true);
 
 let mut prepared: PreparedStatement = session

--- a/docs/source/tracing/simple-prepared.md
+++ b/docs/source/tracing/simple-prepared.md
@@ -16,7 +16,7 @@ use scylla::tracing::TracingInfo;
 use uuid::Uuid;
 
 // Create a Query manually and enable tracing
-let mut query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(4)".to_string());
+let mut query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(4)");
 query.set_tracing(true);
 
 let res: QueryResult = session.query(query, &[]).await?;

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
         println!("a, b, c: {}, {}, {}", a, b, c);
     }
 
-    let paged_query = Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(6);
+    let paged_query = Query::new("SELECT a, b, c FROM ks.t").with_page_size(6);
     let res1 = session.query(paged_query.clone(), &[]).await?;
     println!(
         "Paging state: {:#?} ({} rows)",
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
     );
 
     let paged_prepared = session
-        .prepare(Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(7))
+        .prepare(Query::new("SELECT a, b, c FROM ks.t").with_page_size(7))
         .await?;
     let res4 = session.execute(&paged_prepared, &[]).await?;
     println!(

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
 
     // QUERY
     // Create a simple query and enable tracing for it
-    let mut query: Query = Query::new("SELECT val from ks.tracing_example".to_string());
+    let mut query: Query = Query::new("SELECT val from ks.tracing_example");
     query.set_tracing(true);
     query.set_serial_consistency(Some(SerialConsistency::LocalSerial));
 

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -15,9 +15,9 @@ pub struct Query {
 
 impl Query {
     /// Creates a new `Query` from a CQL query string.
-    pub fn new(contents: String) -> Self {
+    pub fn new(query_text: impl Into<String>) -> Self {
         Self {
-            contents,
+            contents: query_text.into(),
             page_size: None,
             config: Default::default(),
         }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -896,13 +896,11 @@ impl Session {
         consistency: Consistency,
     ) -> Result<Option<TracingInfo>, QueryError> {
         // Query system_traces.sessions for TracingInfo
-        let mut traces_session_query =
-            Query::new(crate::tracing::TRACES_SESSION_QUERY_STR.to_string());
+        let mut traces_session_query = Query::new(crate::tracing::TRACES_SESSION_QUERY_STR);
         traces_session_query.config.consistency = consistency;
 
         // Query system_traces.events for TracingEvents
-        let mut traces_events_query =
-            Query::new(crate::tracing::TRACES_EVENTS_QUERY_STR.to_string());
+        let mut traces_events_query = Query::new(crate::tracing::TRACES_EVENTS_QUERY_STR);
         traces_events_query.config.consistency = Consistency::One;
         traces_events_query.config.consistency = consistency;
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -898,11 +898,13 @@ impl Session {
         // Query system_traces.sessions for TracingInfo
         let mut traces_session_query = Query::new(crate::tracing::TRACES_SESSION_QUERY_STR);
         traces_session_query.config.consistency = consistency;
+        traces_session_query.set_page_size(1024);
 
         // Query system_traces.events for TracingEvents
         let mut traces_events_query = Query::new(crate::tracing::TRACES_EVENTS_QUERY_STR);
         traces_events_query.config.consistency = Consistency::One;
         traces_events_query.config.consistency = consistency;
+        traces_events_query.set_page_size(1024);
 
         let (traces_session_res, traces_events_res) = tokio::try_join!(
             self.query(traces_session_query, (tracing_id,)),

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -76,7 +76,7 @@ async fn test_unprepared_statement() {
         ]
     );
     let mut results_from_manual_paging: Vec<Row> = vec![];
-    let query = Query::new("SELECT a, b, c FROM ks.t".to_owned()).with_page_size(1);
+    let query = Query::new("SELECT a, b, c FROM ks.t").with_page_size(1);
     let mut paging_state: Option<Bytes> = None;
     let mut watchdog = 0;
     loop {
@@ -196,7 +196,7 @@ async fn test_prepared_statement() {
         assert_eq!((a, b, c), (17, 16, &String::from("I'm prepared!!!")));
 
         let mut results_from_manual_paging: Vec<Row> = vec![];
-        let query = Query::new("SELECT a, b, c FROM ks.t2".to_owned()).with_page_size(1);
+        let query = Query::new("SELECT a, b, c FROM ks.t2").with_page_size(1);
         let prepared_paged = session.prepare(query).await.unwrap();
         let mut paging_state: Option<Bytes> = None;
         let mut watchdog = 0;
@@ -724,13 +724,13 @@ async fn test_tracing() {
 
 async fn test_tracing_query(session: &Session) {
     // A query without tracing enabled has no tracing uuid in result
-    let untraced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab".to_string());
+    let untraced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab");
     let untraced_query_result: QueryResult = session.query(untraced_query, &[]).await.unwrap();
 
     assert!(untraced_query_result.tracing_id.is_none());
 
     // A query with tracing enabled has a tracing uuid in result
-    let mut traced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab".to_string());
+    let mut traced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab");
     traced_query.config.tracing = true;
 
     let traced_query_result: QueryResult = session.query(traced_query, &[]).await.unwrap();
@@ -777,7 +777,7 @@ async fn test_tracing_prepare(session: &Session) {
     assert!(untraced_prepared.prepare_tracing_ids.is_empty());
 
     // Preparing a statement with tracing enabled has tracing uuids in result
-    let mut to_prepare_traced = Query::new("SELECT * FROM test_tracing_ks.tab".to_string());
+    let mut to_prepare_traced = Query::new("SELECT * FROM test_tracing_ks.tab");
     to_prepare_traced.config.tracing = true;
 
     let traced_prepared = session.prepare(to_prepare_traced).await.unwrap();
@@ -791,7 +791,7 @@ async fn test_tracing_prepare(session: &Session) {
 
 async fn test_get_tracing_info(session: &Session) {
     // A query with tracing enabled has a tracing uuid in result
-    let mut traced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab".to_string());
+    let mut traced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab");
     traced_query.config.tracing = true;
 
     let traced_query_result: QueryResult = session.query(traced_query, &[]).await.unwrap();
@@ -804,7 +804,7 @@ async fn test_get_tracing_info(session: &Session) {
 
 async fn test_tracing_query_iter(session: &Session) {
     // A query without tracing enabled has no tracing ids
-    let untraced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab".to_string());
+    let untraced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab");
 
     let mut untraced_row_iter = session.query_iter(untraced_query, &[]).await.unwrap();
     while let Some(_row) = untraced_row_iter.next().await {
@@ -818,7 +818,7 @@ async fn test_tracing_query_iter(session: &Session) {
     assert!(untraced_typed_row_iter.get_tracing_ids().is_empty());
 
     // A query with tracing enabled has a tracing ids in result
-    let mut traced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab".to_string());
+    let mut traced_query: Query = Query::new("SELECT * FROM test_tracing_ks.tab");
     traced_query.config.tracing = true;
 
     let mut traced_row_iter = session.query_iter(traced_query, &[]).await.unwrap();
@@ -898,8 +898,7 @@ async fn test_tracing_batch(session: &Session) {
 }
 
 async fn assert_in_tracing_table(session: &Session, tracing_uuid: Uuid) {
-    let mut traces_query =
-        Query::new("SELECT * FROM system_traces.sessions WHERE session_id = ?".to_string());
+    let mut traces_query = Query::new("SELECT * FROM system_traces.sessions WHERE session_id = ?");
     traces_query.config.consistency = Consistency::One;
 
     // Tracing info might not be immediately available


### PR DESCRIPTION
## Description
This PR adds new methods: `query_all` and `execute_all`.  
They use multiple paged queries to fetch results, and then merge all those results into one.  
`page_size` must be set on the query that is passed to those methods.

Currently we use a single unpaged query to fetch data, but this might cause stalls (#298).
It's better to use many smaller queries and merge results locally.

```rust
Connection::query_all(
        &self,
        query: &Query,
        values: impl ValueList,
    ) -> Result<QueryResult, QueryError>;

Connection::execute_all(
        &self,
        prepared_statement: &PreparedStatement,
        values: impl ValueList,
    ) -> Result<QueryResult, QueryError>;
```

## Fixed Issues
Fixes: #298

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
