### PR TITLE
Remove batch fields and added new initializer

### DIFF
--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,5 +1,4 @@
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
-use crate::transport::retry_policy::RetryPolicy;
 
 pub use super::Consistency;
 use super::StatementConfig;
@@ -10,93 +9,24 @@ pub use crate::frame::request::batch::BatchType;
 /// This represents a CQL batch that can be executed on a server.
 #[derive(Clone)]
 pub struct Batch {
-    pub(crate) config: StatementConfig,
-
-    statements: Vec<BatchStatement>,
-    batch_type: BatchType,
+    pub config: StatementConfig,
+    pub statements: Vec<BatchStatement>,
+    pub batch_type: BatchType,
 }
 
 impl Batch {
-    /// Creates a new, empty `Batch` of `batch_type` type.
-    pub fn new(batch_type: BatchType) -> Self {
-        Self {
-            batch_type,
-            ..Default::default()
+    /// Uses the default value for field `config`
+    pub fn new(statements: Vec<BatchStatement>, batch_type: BatchType) -> Batch {
+        Batch {
+            config: Default::default(),
+            statements,
+            batch_type
         }
     }
 
     /// Appends a new statement to the batch.
     pub fn append_statement(&mut self, statement: impl Into<BatchStatement>) {
         self.statements.push(statement.into());
-    }
-
-    /// Gets type of batch.
-    pub fn get_type(&self) -> BatchType {
-        self.batch_type
-    }
-
-    /// Returns statements contained in the batch.
-    pub fn get_statements(&self) -> &[BatchStatement] {
-        self.statements.as_ref()
-    }
-
-    /// Sets the consistency to be used when executing this batch.
-    pub fn set_consistency(&mut self, c: Consistency) {
-        self.config.consistency = c;
-    }
-
-    /// Gets the consistency to be used when executing this batch.
-    pub fn get_consistency(&self) -> Consistency {
-        self.config.consistency
-    }
-
-    /// Sets the serial consistency to be used when executing this batch.
-    /// (Ignored unless the batch is an LWT)
-    pub fn set_serial_consistency(&mut self, sc: Option<Consistency>) {
-        self.config.serial_consistency = sc;
-    }
-
-    /// Gets the serial consistency to be used when executing this batch.
-    /// (Ignored unless the batch is an LWT)
-    pub fn get_serial_consistency(&self) -> Option<Consistency> {
-        self.config.serial_consistency
-    }
-
-    /// Sets the idempotence of this batch
-    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
-    /// If set to `true` we can be sure that it is idempotent
-    /// If set to `false` it is unknown whether it is idempotent
-    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
-    pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
-        self.config.is_idempotent = is_idempotent;
-    }
-
-    /// Gets the idempotence of this batch
-    pub fn get_is_idempotent(&self) -> bool {
-        self.config.is_idempotent
-    }
-
-    /// Sets a custom [`RetryPolicy`] to be used with this batch
-    /// By default Session's retry policy is used, this allows to use a custom retry policy
-    pub fn set_retry_policy(&mut self, retry_policy: Box<dyn RetryPolicy>) {
-        self.config.retry_policy = Some(retry_policy);
-    }
-
-    /// Gets custom [`RetryPolicy`] used by this batch
-    pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy>> {
-        &self.config.retry_policy
-    }
-
-    /// Enable or disable CQL Tracing for this batch
-    /// If enabled session.batch() will return a BatchResult containing tracing_id
-    /// which can be used to query tracing information about the execution of this query
-    pub fn set_tracing(&mut self, should_trace: bool) {
-        self.config.tracing = should_trace;
-    }
-
-    /// Gets whether tracing is enabled for this batch
-    pub fn get_tracing(&self) -> bool {
-        self.config.tracing
     }
 }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -399,7 +399,7 @@ impl Connection {
         batch: &Batch,
         values: impl BatchValues,
     ) -> Result<BatchResult, QueryError> {
-        let statements_count = batch.get_statements().len();
+        let statements_count = batch.statements.len();
         if statements_count != values.len() {
             return Err(QueryError::BadQuery(BadQuery::ValueLenMismatch(
                 values.len(),
@@ -407,7 +407,7 @@ impl Connection {
             )));
         }
 
-        let statements_iter = batch.get_statements().iter().map(|s| match s {
+        let statements_iter = batch.statements.iter().map(|s| match s {
             BatchStatement::Query(q) => batch::BatchStatement::Query {
                 text: q.get_contents(),
             },
@@ -420,9 +420,9 @@ impl Connection {
             statements: statements_iter,
             statements_count,
             values,
-            batch_type: batch.get_type(),
-            consistency: batch.get_consistency(),
-            serial_consistency: batch.get_serial_consistency(),
+            batch_type: batch.batch_type,
+            consistency: batch.config.consistency,
+            serial_consistency: batch.config.serial_consistency,
         };
 
         let query_response = self


### PR DESCRIPTION
## Pre-review checklist

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes. -> Not needed
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I added appropriate `Fixes:` annotations to PR description.

I have some sort of wrapper around batch in which I have the batch statement vec already there, it would be a waste to call `append_statement` in a loop for that case. 

With the new initalizer, I can add them directly to the batch. 

I removed the getter/setter methods, I think those methods are cluttering up the code and users can access the config fields themself fairly easy. 