### PR TITLE
frame/response: consider empty payload as valid value

### DIFF
--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -56,6 +56,7 @@ impl<T: FromCqlVal<CqlValue>> FromCqlVal<Option<CqlValue>> for T {
 impl<T: FromCqlVal<CqlValue>> FromCqlVal<Option<CqlValue>> for Option<T> {
     fn from_cql(cql_val_opt: Option<CqlValue>) -> Result<Self, FromCqlValError> {
         match cql_val_opt {
+            Some(CqlValue::Empty) => Ok(None),
             Some(cql_val) => Ok(Some(T::from_cql(cql_val)?)),
             None => Ok(None),
         }
@@ -401,6 +402,16 @@ mod tests {
             i32::from_cql(CqlValue::BigInt(1234)),
             Err(FromCqlValError::BadCqlType)
         );
+    }
+
+    #[test]
+    fn from_cql_empty_value() {
+        assert_eq!(
+            i32::from_cql(CqlValue::Empty),
+            Err(FromCqlValError::BadCqlType)
+        );
+
+        assert_eq!(<Option<i32>>::from_cql(Some(CqlValue::Empty)), Ok(None));
     }
 
     #[test]

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -83,6 +83,7 @@ pub enum CqlValue {
     /// Can be converted to chrono::NaiveDate (-262145-1-1 to 262143-12-31) using as_date
     Date(u32),
     Double(f64),
+    Empty,
     Float(f32),
     Int(i32),
     BigInt(i64),
@@ -499,6 +500,16 @@ fn deser_prepared_metadata(buf: &mut &[u8]) -> StdResult<PreparedMetadata, Parse
 
 fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, ParseError> {
     use ColumnType::*;
+
+    if buf.is_empty() {
+        match typ {
+            Ascii | Blob | Text => {
+                // can't be empty
+            }
+            _ => return Ok(CqlValue::Empty),
+        }
+    }
+
     Ok(match typ {
         Ascii => {
             if !buf.is_ascii() {
@@ -1087,7 +1098,7 @@ mod tests {
         assert_eq!(date, CqlValue::Date(u32::max_value()));
 
         // Trying to parse a 0, 3 or 5 byte array fails
-        super::deser_cql_value(&ColumnType::Date, &mut [].as_ref()).unwrap_err();
+        super::deser_cql_value(&ColumnType::Date, &mut [].as_ref()).unwrap();
         super::deser_cql_value(&ColumnType::Date, &mut [1, 2, 3].as_ref()).unwrap_err();
         super::deser_cql_value(&ColumnType::Date, &mut [1, 2, 3, 4, 5].as_ref()).unwrap_err();
 
@@ -1203,6 +1214,49 @@ mod tests {
                 Duration::milliseconds(*test_val).num_milliseconds(),
                 *test_val
             );
+        }
+    }
+    #[test]
+    fn test_deserialize_empty_payload() {
+        for (test_type, res_cql) in [
+            (ColumnType::Ascii, CqlValue::Ascii("".to_owned())),
+            (ColumnType::Boolean, CqlValue::Empty),
+            (ColumnType::Blob, CqlValue::Blob(vec![])),
+            (ColumnType::Counter, CqlValue::Empty),
+            (ColumnType::Date, CqlValue::Empty),
+            (ColumnType::Decimal, CqlValue::Empty),
+            (ColumnType::Double, CqlValue::Empty),
+            (ColumnType::Float, CqlValue::Empty),
+            (ColumnType::Int, CqlValue::Empty),
+            (ColumnType::BigInt, CqlValue::Empty),
+            (ColumnType::Text, CqlValue::Text("".to_owned())),
+            (ColumnType::Timestamp, CqlValue::Empty),
+            (ColumnType::Inet, CqlValue::Empty),
+            (ColumnType::List(Box::new(ColumnType::Int)), CqlValue::Empty),
+            (
+                ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::Int)),
+                CqlValue::Empty,
+            ),
+            (ColumnType::Set(Box::new(ColumnType::Int)), CqlValue::Empty),
+            (
+                ColumnType::UserDefinedType {
+                    type_name: "".to_owned(),
+                    keyspace: "".to_owned(),
+                    field_types: vec![],
+                },
+                CqlValue::Empty,
+            ),
+            (ColumnType::SmallInt, CqlValue::Empty),
+            (ColumnType::TinyInt, CqlValue::Empty),
+            (ColumnType::Time, CqlValue::Empty),
+            (ColumnType::Timeuuid, CqlValue::Empty),
+            (ColumnType::Tuple(vec![]), CqlValue::Empty),
+            (ColumnType::Uuid, CqlValue::Empty),
+            (ColumnType::Varint, CqlValue::Empty),
+        ] {
+            let cql_value: CqlValue = super::deser_cql_value(&test_type, &mut &[][..]).unwrap();
+
+            assert_eq!(cql_value, res_cql);
         }
     }
 


### PR DESCRIPTION
👋 

This PR introduces a new CqlValue value Empty to handle the empty payload.

Empty value can happen for timestamp written by the gocql driver.
https://github.com/gocql/gocql/pull/441
https://github.com/gocql/gocql/pull/441/files#diff-86b8b79c186e030c418e5b4843749915abbd25a8b34108a9982aa48811046cbfR842-R847

Fixes: #316

```rust
      .into_typed::<(Duration, )>(); // will fail with CqlBadType
      .into_typed::<(Option<Duration>, )>(); // will return None
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
