### PR TITLE
remove crate:: when use is already present

### DIFF
--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
 
     println!("Connecting to {} with cassandra superuser ...", uri);
 
-    let session = crate::SessionBuilder::new()
+    let session = SessionBuilder::new()
         .known_node(uri)
         .user("cassandra", "cassandra")
         .build()


### PR DESCRIPTION
- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] PR description sums up the changes and reasons why they should be introduced.

This PR is just to remove redudant import from crate:: when use:scylla is already present in auth.rs.