### PR TITLE
scylla/transport/topology: accept shorter topology names

### DIFF
--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -324,7 +324,7 @@ fn strategy_from_string_map(
         ))?;
 
     let strategy: Strategy = match strategy_name.as_str() {
-        "org.apache.cassandra.locator.SimpleStrategy" => {
+        "org.apache.cassandra.locator.SimpleStrategy" | "SimpleStrategy" => {
             let rep_factor_str: String =
                 strategy_map
                     .remove("replication_factor")
@@ -338,7 +338,7 @@ fn strategy_from_string_map(
 
             Strategy::SimpleStrategy { replication_factor }
         }
-        "org.apache.cassandra.locator.NetworkTopologyStrategy" => {
+        "org.apache.cassandra.locator.NetworkTopologyStrategy" | "NetworkTopologyStrategy" => {
             let mut datacenter_repfactors: HashMap<String, usize> =
                 HashMap::with_capacity(strategy_map.len());
 
@@ -355,7 +355,7 @@ fn strategy_from_string_map(
                 datacenter_repfactors,
             }
         }
-        "org.apache.cassandra.locator.LocalStrategy" => Strategy::LocalStrategy,
+        "org.apache.cassandra.locator.LocalStrategy" | "LocalStrategy" => Strategy::LocalStrategy,
         _ => Strategy::Other {
             name: strategy_name,
             data: strategy_map,


### PR DESCRIPTION
this patch handles shorter topology names, otherwise the
strategy is considered as `Other` and the default behavior in this case with
a TokenAwarePolicy is to override RF to 1.

see https://github.com/scylladb/scylla-rust-driver/blob/main/scylla/src/transport/load_balancing/token_aware.rs#L128-L132 and https://docs.scylladb.com/getting-started/ddl/#create-keyspace-statement


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
