### PR TITLE
topology: drop the serde_json dependency

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -25,7 +25,6 @@ tokio = { version = "1.1.0", features = ["net", "time", "io-util", "sync", "rt",
 snap = "1.0"
 uuid = "0.8.1"
 rand = "0.8.3"
-serde_json = "1.0.60"
 thiserror = "1.0"
 itertools = "0.10.0"
 bigdecimal = "0.2.0"


### PR DESCRIPTION
At the time when the logic responsible for querying keyspace metadata
was implemented, there was no support for map datatypes, which was
needed to parse the `replication` parameters of a keyspace. To work
around that, the `toJson` function was used so that Scylla returns the
parameters encoded as a JSON string. The serde_json library was added to
dependencies solely for the purpose of parsing the encoded json map.

Support for direct deserialization of map types has been merged some
time ago, so there is no need to involve JSON as an intermediate step.

This commit removes the logic responsible for parsing the `replication`
map from JSON representation and now the map is parsed directly from its
CQL representation. Additionally, the serde_json crate is removed from
dependencies.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
