### PR TITLE
Implement client-side timeouts

### DIFF
--- a/docs/source/SUMMARY.md
+++ b/docs/source/SUMMARY.md
@@ -22,6 +22,7 @@
     - [Lightweight transaction query (LWT)](queries/lwt.md)
     - [USE keyspace](queries/usekeyspace.md)
     - [Schema agreement](queries/schema_agreement.md)
+    - [Client timeout](queries/client_timeout.md)
 
 - [Data Types](data-types/data-types.md)
     - [Bool, Tinyint, Smallint, Int, Bigint, Float, Double](data-types/primitive.md)

--- a/docs/source/queries/client_timeout.md
+++ b/docs/source/queries/client_timeout.md
@@ -1,0 +1,60 @@
+# Client timeouts
+
+In order to make sure that your application can handle network failures and other disasters, database queries issued by
+Scylla Rust Driver can time out on the client side, without waiting (potentially indefinitely) for a server to respond.
+
+## Per-session settings
+
+A default per-session client timeout is set to 30 seconds. This parameter can be modified via the query builder by using the `client_timeout` method:
+```rust
+# extern crate scylla;
+# extern crate tokio;
+use scylla::{Session, SessionBuilder};
+use std::error::Error;
+use std::time::Duration;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let uri = std::env::var("SCYLLA_URI")
+        .unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    let session: Session = SessionBuilder::new()
+        .known_node(uri)
+        .known_node("127.0.0.72:4321")
+        .known_node("localhost:8000")
+        .connection_timeout(Duration::from_secs(3))
+        .client_timeout(Duration::from_millis(1500))
+        .known_node_addr(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            9000,
+        ))
+        .build()
+        .await?;
+
+    Ok(())
+}
+```
+
+## Per-query settings
+
+Queries, prepared statements and batches can also have their own, unique client timeout parameter. That allows overriding the default session configuration and specifying a timeout for a single particular type of query. Example:
+
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use std::time::Duration;
+use scylla::query::Query;
+
+// Create a Query manually to change the client timeout
+let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?) IF NOT EXISTS".to_string());
+my_query.set_client_timeout(Some(Duration::from_secs(3)));
+
+// Insert a value into the table
+let to_insert: i32 = 12345;
+session.query(my_query, (to_insert,)).await?;
+# Ok(())
+# }
+```

--- a/docs/source/queries/queries.md
+++ b/docs/source/queries/queries.md
@@ -19,6 +19,8 @@ This driver supports all query types available in Scylla:
 Additionaly there is special functionality to enable `USE KEYSPACE` queries:
 [USE keyspace](usekeyspace.md)
 
+Queries can be subject to driver-side timeouts: [client timeout](client_timeout.md)
+
 Queries are fully asynchronous - you can run as many of them in parallel as you wish,
 but be mindful of the per-connection limit of 32768 limit per connection imposed
 by the CQL protocol.
@@ -37,4 +39,5 @@ by the CQL protocol.
    usekeyspace
    schema_agreement
    lwt
+   client_timeout
 ```

--- a/docs/source/queries/queries.md
+++ b/docs/source/queries/queries.md
@@ -4,7 +4,7 @@ This driver supports all query types available in Scylla:
 * [Simple queries](simple.md)
     * Easy to use
     * Poor performance
-    * Primitve load balancing
+    * Primitive load balancing
 * [Prepared queries](prepared.md)
     * Need to be prepared before use
     * Fast
@@ -19,7 +19,9 @@ This driver supports all query types available in Scylla:
 Additionaly there is special functionality to enable `USE KEYSPACE` queries:
 [USE keyspace](usekeyspace.md)
 
-Queries are fully asynchronous - you can run as many of them in parallel as you wish.
+Queries are fully asynchronous - you can run as many of them in parallel as you wish,
+but be mindful of the per-connection limit of 32768 limit per connection imposed
+by the CQL protocol.
 
 ```eval_rst
 .. toctree::

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -115,6 +115,19 @@ impl Batch {
     pub fn get_timestamp(&self) -> Option<i64> {
         self.config.timestamp
     }
+
+    /// Sets the client-side timeout for this statement.
+    /// If not None, the driver will stop waiting for the request
+    /// to finish after `timeout` passed.
+    /// Otherwise, default session client timeout will be applied.
+    pub fn set_client_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.config.client_timeout = timeout
+    }
+
+    /// Gets client timeout associated with this query
+    pub fn get_client_timeout(&mut self) -> Option<std::time::Duration> {
+        self.config.client_timeout
+    }
 }
 
 impl Default for Batch {

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -20,6 +20,7 @@ pub struct StatementConfig {
 
     pub tracing: bool,
     pub timestamp: Option<i64>,
+    pub client_timeout: Option<std::time::Duration>,
 }
 
 impl Default for StatementConfig {
@@ -32,6 +33,7 @@ impl Default for StatementConfig {
             speculative_execution_policy: None,
             tracing: false,
             timestamp: None,
+            client_timeout: None,
         }
     }
 }
@@ -49,6 +51,7 @@ impl Clone for StatementConfig {
             speculative_execution_policy: self.speculative_execution_policy.clone(),
             tracing: self.tracing,
             timestamp: self.timestamp,
+            client_timeout: self.client_timeout,
         }
     }
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -202,6 +202,19 @@ impl PreparedStatement {
     pub fn get_timestamp(&self) -> Option<i64> {
         self.config.timestamp
     }
+
+    /// Sets the client-side timeout for this statement.
+    /// If not None, the driver will stop waiting for the request
+    /// to finish after `timeout` passed.
+    /// Otherwise, default session client timeout will be applied.
+    pub fn set_client_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.config.client_timeout = timeout
+    }
+
+    /// Gets client timeout associated with this query
+    pub fn get_client_timeout(&mut self) -> Option<std::time::Duration> {
+        self.config.client_timeout
+    }
 }
 
 #[derive(Debug, Error, PartialEq, Eq, PartialOrd, Ord)]

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -117,6 +117,19 @@ impl Query {
     pub fn get_timestamp(&self) -> Option<i64> {
         self.config.timestamp
     }
+
+    /// Sets the client-side timeout for this statement.
+    /// If not None, the driver will stop waiting for the request
+    /// to finish after `timeout` passed.
+    /// Otherwise, default session client timeout will be applied.
+    pub fn set_client_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.config.client_timeout = timeout
+    }
+
+    /// Gets client timeout associated with this query
+    pub fn get_client_timeout(&mut self) -> Option<std::time::Duration> {
+        self.config.client_timeout
+    }
 }
 
 impl From<String> for Query {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -173,6 +173,7 @@ pub struct ConnectionConfig {
     pub auth_username: Option<String>,
     pub auth_password: Option<String>,
     pub connect_timeout: std::time::Duration,
+    pub client_timeout: std::time::Duration,
     // should be Some only in control connections,
     pub event_sender: Option<mpsc::Sender<Event>>,
     pub default_consistency: Consistency,
@@ -198,6 +199,7 @@ impl Default for ConnectionConfig {
             auth_password: None,
             connect_timeout: std::time::Duration::from_secs(5),
             default_consistency: Default::default(),
+            client_timeout: std::time::Duration::from_secs(30),
         }
     }
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -182,6 +182,7 @@ pub struct ConnectionConfig {
     pub auth_password: Option<String>,
     pub connect_timeout: std::time::Duration,
     pub client_timeout: std::time::Duration,
+    pub max_orphan_count: Option<u16>,
     // should be Some only in control connections,
     pub event_sender: Option<mpsc::Sender<Event>>,
     pub default_consistency: Consistency,
@@ -208,6 +209,7 @@ impl Default for ConnectionConfig {
             connect_timeout: std::time::Duration::from_secs(5),
             default_consistency: Default::default(),
             client_timeout: std::time::Duration::from_secs(30),
+            max_orphan_count: Some(1024),
         }
     }
 }
@@ -780,8 +782,8 @@ impl Connection {
         // across .await points. Therefore, it should not be too expensive.
         let handler_map = StdMutex::new(ResponseHandlerMap::new());
 
+        let w = Self::writer(write_half, &handler_map, receiver, config.max_orphan_count);
         let r = Self::reader(read_half, &handler_map, config);
-        let w = Self::writer(write_half, &handler_map, receiver);
 
         let result = futures::try_join!(r, w);
         let error: QueryError = match result {
@@ -857,6 +859,7 @@ impl Connection {
         mut write_half: (impl AsyncWrite + Unpin),
         handler_map: &StdMutex<ResponseHandlerMap>,
         mut task_receiver: mpsc::Receiver<Task>,
+        max_orphan_count: Option<u16>,
     ) -> Result<(), QueryError> {
         // When the Connection object is dropped, the sender half
         // of the channel will be dropped, this task will return an error
@@ -888,11 +891,13 @@ impl Connection {
                 }
                 Task::Orphan { stream_id } => {
                     let mut hmap = handler_map.try_lock().unwrap();
-                    if hmap.orphan_count() >= 1024 {
-                        //FIXME: make the orphan threshold configurable
+                    if max_orphan_count.is_some()
+                        && hmap.orphan_count() >= max_orphan_count.unwrap()
+                    {
                         warn!(
-                            "Too many orphaned stream ids: {}, dropping connection",
-                            hmap.orphan_count()
+                            "Too many orphaned stream ids: {}/{}, dropping connection",
+                            hmap.orphan_count(),
+                            max_orphan_count.unwrap(),
                         );
                         return Err(QueryError::TooManyOrphanedStreamIds(hmap.orphan_count()));
                     }

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -40,6 +40,9 @@ pub enum QueryError {
 
     #[error("Too many orphaned stream ids: {0}")]
     TooManyOrphanedStreamIds(u16),
+
+    #[error("Unable to allocate stream id")]
+    UnableToAllocStreamId,
 }
 
 /// An error sent from the database in response to a query
@@ -286,6 +289,9 @@ pub enum NewSessionError {
 
     #[error("Too many orphaned stream ids: {0}")]
     TooManyOrphanedStreamIds(u16),
+
+    #[error("Unable to allocate stream id")]
+    UnableToAllocStreamId,
 }
 
 /// Invalid keyspace name given to `Session::use_keyspace()`
@@ -359,6 +365,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::TooManyOrphanedStreamIds(ids) => {
                 NewSessionError::TooManyOrphanedStreamIds(ids)
             }
+            QueryError::UnableToAllocStreamId => NewSessionError::UnableToAllocStreamId,
         }
     }
 }

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -37,6 +37,9 @@ pub enum QueryError {
     /// Timeout error has occured, function didn't complete in time.
     #[error("Timeout Error")]
     TimeoutError,
+
+    #[error("Too many orphaned stream ids: {0}")]
+    TooManyOrphanedStreamIds(u16),
 }
 
 /// An error sent from the database in response to a query
@@ -280,6 +283,9 @@ pub enum NewSessionError {
     /// Timeout error has occured, couldn't connect to node in time.
     #[error("Timeout Error")]
     TimeoutError,
+
+    #[error("Too many orphaned stream ids: {0}")]
+    TooManyOrphanedStreamIds(u16),
 }
 
 /// Invalid keyspace name given to `Session::use_keyspace()`
@@ -350,6 +356,9 @@ impl From<QueryError> for NewSessionError {
             QueryError::InvalidMessage(m) => NewSessionError::InvalidMessage(m),
             QueryError::ClientTimeout(_m) => NewSessionError::TimeoutError,
             QueryError::TimeoutError => NewSessionError::TimeoutError,
+            QueryError::TooManyOrphanedStreamIds(ids) => {
+                NewSessionError::TooManyOrphanedStreamIds(ids)
+            }
         }
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -89,6 +89,7 @@ pub struct SessionConfig {
     pub schema_agreement_interval: Duration,
     pub connect_timeout: std::time::Duration,
     pub client_timeout: std::time::Duration,
+    pub max_orphan_count: Option<u16>,
 
     /// Size of the per-node connection pool, i.e. how many connections the driver should keep to each node.
     /// The default is `PerShard(1)`, which is the recommended setting for Scylla clusters.
@@ -142,6 +143,7 @@ impl SessionConfig {
             auth_password: None,
             connect_timeout: std::time::Duration::from_secs(5),
             client_timeout: std::time::Duration::from_secs(30),
+            max_orphan_count: Some(1024),
             connection_pool_size: Default::default(),
             disallow_shard_aware_port: false,
             default_consistency: Consistency::Quorum,
@@ -228,6 +230,7 @@ impl SessionConfig {
             event_sender: None,
             default_consistency: self.default_consistency,
             client_timeout: self.client_timeout,
+            max_orphan_count: self.max_orphan_count,
         }
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -88,6 +88,7 @@ pub struct SessionConfig {
 
     pub schema_agreement_interval: Duration,
     pub connect_timeout: std::time::Duration,
+    pub client_timeout: std::time::Duration,
 
     /// Size of the per-node connection pool, i.e. how many connections the driver should keep to each node.
     /// The default is `PerShard(1)`, which is the recommended setting for Scylla clusters.
@@ -140,6 +141,7 @@ impl SessionConfig {
             auth_username: None,
             auth_password: None,
             connect_timeout: std::time::Duration::from_secs(5),
+            client_timeout: std::time::Duration::from_secs(30),
             connection_pool_size: Default::default(),
             disallow_shard_aware_port: false,
             default_consistency: Consistency::Quorum,
@@ -225,6 +227,7 @@ impl SessionConfig {
             connect_timeout: self.connect_timeout,
             event_sender: None,
             default_consistency: self.default_consistency,
+            client_timeout: self.client_timeout,
         }
     }
 }

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -419,6 +419,27 @@ impl SessionBuilder {
         self
     }
 
+    /// Changes client-side timeout
+    /// The default is 30 seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use std::time::Duration;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .client_timeout(Duration::from_millis(500))
+    ///     .build() // Turns SessionBuilder into Session
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn client_timeout(mut self, duration: std::time::Duration) -> Self {
+        self.config.client_timeout = duration;
+        self
+    }
+
     /// Sets the per-node connection pool size.
     /// The default is one connection per shard, which is the recommended setting for Scylla.
     ///
@@ -632,6 +653,21 @@ mod tests {
         builder = builder.connection_timeout(std::time::Duration::from_secs(10));
         assert_eq!(
             builder.config.connect_timeout,
+            std::time::Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn client_timeout() {
+        let mut builder = SessionBuilder::new();
+        assert_eq!(
+            builder.config.client_timeout,
+            std::time::Duration::from_secs(30)
+        );
+
+        builder = builder.client_timeout(std::time::Duration::from_secs(10));
+        assert_eq!(
+            builder.config.client_timeout,
             std::time::Duration::from_secs(10)
         );
     }

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -440,6 +440,28 @@ impl SessionBuilder {
         self
     }
 
+    /// Changes the threshold for orphaned stream ids
+    /// until the connection is killed
+    /// The default is 1024.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use std::time::Duration;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .max_orphan_count(Some(16))
+    ///     .build() // Turns SessionBuilder into Session
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn max_orphan_count(mut self, count: Option<u16>) -> Self {
+        self.config.max_orphan_count = count;
+        self
+    }
+
     /// Sets the per-node connection pool size.
     /// The default is one connection per shard, which is the recommended setting for Scylla.
     ///
@@ -670,6 +692,15 @@ mod tests {
             builder.config.client_timeout,
             std::time::Duration::from_secs(10)
         );
+    }
+
+    #[test]
+    fn max_orphan_count() {
+        let mut builder = SessionBuilder::new();
+        assert_eq!(builder.config.max_orphan_count, Some(1024));
+
+        builder = builder.max_orphan_count(None);
+        assert_eq!(builder.config.max_orphan_count, None);
     }
 
     #[test]


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.

This pull request introduces client-side timeouts and a management layer for orphaned stream ids. Orphaned stream ids are the ones for which the client-side timeout already fired, but no response came from the server yet. In such scenario, a stream id cannot be released yet, because the response associated with the same id may still be received later. Instead, orphaned stream ids are tracked per connection, and once a threshold is reached, the connection is killed.

Fixes #304
Fixes #305