### PR TITLE
transport/session: do not serialize values twice

### DIFF
--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -688,15 +688,6 @@ impl<'b> ValueList for Cow<'b, SerializedValues> {
     }
 }
 
-impl<'b> ValueList for SerializedResult<'b> {
-    fn serialized(&self) -> SerializedResult<'_> {
-        match self {
-            Ok(ser_values_cow) => Ok(Cow::Borrowed(ser_values_cow.as_ref())),
-            Err(e) => Err(*e),
-        }
-    }
-}
-
 //
 // BatchValues impls
 //

--- a/scylla/src/frame/value_tests.rs
+++ b/scylla/src/frame/value_tests.rs
@@ -400,16 +400,6 @@ fn cow_serialized_values_value_list() {
 }
 
 #[test]
-fn serialized_result_value_list() {
-    let ser_result: SerializedResult = (1_i32,).serialized();
-    assert!(matches!(ser_result, Ok(Cow::Owned(_))));
-
-    let ser_ser_result: Cow<SerializedValues> = ser_result.serialized().unwrap();
-
-    assert!(matches!(ser_ser_result, Cow::Borrowed(_)));
-}
-
-#[test]
 fn slice_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -401,6 +401,7 @@ impl Session {
         paging_state: Option<Bytes>,
     ) -> Result<QueryResult, QueryError> {
         let query: Query = query.into();
+        let serialized_values = values.serialized()?;
 
         let response = self
             .run_query(
@@ -410,7 +411,7 @@ impl Session {
                 |connection: Arc<Connection>| {
                     // Needed to avoid moving query and values into async move block
                     let query_ref = &query;
-                    let values_ref = &values;
+                    let values_ref = &serialized_values;
                     let paging_state_ref = &paging_state;
 
                     async move {


### PR DESCRIPTION
👋  just a small PR.

- to not serialize the values twice, `values.serialized()` was called in `query_paged` then `query`
- to use try_join_all instead of `collect::<Vec<_>> + collect::<Result<Vec<_>>>`

**EDIT**: just saw that there was an impl of ValueList for Result<SerializedValues> means that the first item is wrong.
If it's ok for you I keep the PR open for the "correctness"

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
