### PR TITLE
Add getting column spec for RowIterator

### DIFF
--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -326,7 +326,7 @@ impl Row {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Rows {
     pub metadata: ResultMetadata,
     rows_count: usize,

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -18,7 +18,7 @@ use crate::cql_to_rust::{FromRow, FromRowError};
 use crate::frame::{
     response::{
         result,
-        result::{Row, Rows},
+        result::{ColumnSpec, Row, Rows},
         Response,
     },
     value::SerializedValues,
@@ -211,6 +211,11 @@ impl RowIterator {
         &self.tracing_ids
     }
 
+    /// Returns specification of row columns
+    pub fn get_column_specs(&self) -> &[ColumnSpec] {
+        &self.current_page.metadata.col_specs
+    }
+
     fn is_current_page_exhausted(&self) -> bool {
         self.current_row_idx >= self.current_page.rows.len()
     }
@@ -363,6 +368,11 @@ impl<RowT> TypedRowIterator<RowT> {
     /// If tracing was enabled returns tracing ids of all finished page queries
     pub fn get_tracing_ids(&self) -> &[Uuid] {
         self.row_iterator.get_tracing_ids()
+    }
+
+    /// Returns specification of row columns
+    pub fn get_column_specs(&self) -> &[ColumnSpec] {
+        self.row_iterator.get_column_specs()
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -493,7 +493,7 @@ impl Session {
             None => self.retry_policy.new_session(),
         };
 
-        Ok(RowIterator::new_for_query(
+        RowIterator::new_for_query(
             query,
             serialized_values.into_owned(),
             self.default_consistency,
@@ -501,7 +501,8 @@ impl Session {
             self.load_balancer.clone(),
             self.cluster.get_data(),
             self.metrics.clone(),
-        ))
+        )
+        .await
     }
 
     /// Prepares a statement on the server side and returns a prepared statement,
@@ -723,18 +724,17 @@ impl Session {
             None => self.retry_policy.new_session(),
         };
 
-        Ok(RowIterator::new_for_prepared_statement(
-            PreparedIteratorConfig {
-                prepared,
-                values: serialized_values.into_owned(),
-                default_consistency: self.default_consistency,
-                token,
-                retry_session,
-                load_balancer: self.load_balancer.clone(),
-                cluster_data: self.cluster.get_data(),
-                metrics: self.metrics.clone(),
-            },
-        ))
+        RowIterator::new_for_prepared_statement(PreparedIteratorConfig {
+            prepared,
+            values: serialized_values.into_owned(),
+            default_consistency: self.default_consistency,
+            token,
+            retry_session,
+            load_balancer: self.load_balancer.clone(),
+            cluster_data: self.cluster.get_data(),
+            metrics: self.metrics.clone(),
+        })
+        .await
     }
 
     /// Perform a batch query  

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -75,6 +75,14 @@ async fn test_unprepared_statement() {
             (7, 11, &String::from(""))
         ]
     );
+    let query_result = session
+        .query_iter("SELECT a, b, c FROM ks.t", &[])
+        .await
+        .unwrap();
+    for (spec, name) in query_result.get_column_specs().iter().zip(["a", "b", "c"]) {
+        assert_eq!(spec.name, name); // Check column name.
+        assert_eq!(spec.table_spec.ks_name, "ks");
+    }
     let mut results_from_manual_paging: Vec<Row> = vec![];
     let query = Query::new("SELECT a, b, c FROM ks.t").with_page_size(1);
     let mut paging_state: Option<Bytes> = None;
@@ -121,6 +129,14 @@ async fn test_prepared_statement() {
         .unwrap();
     // Wait for schema agreement
     std::thread::sleep(std::time::Duration::from_millis(300));
+
+    let prepared_statement = session.prepare("SELECT a, b, c FROM ks.t2").await.unwrap();
+    let query_result = session.execute_iter(prepared_statement, &[]).await.unwrap();
+    for (spec, name) in query_result.get_column_specs().iter().zip(["a", "b", "c"]) {
+        assert_eq!(spec.name, name); // Check column name.
+        assert_eq!(spec.table_spec.ks_name, "ks");
+    }
+
     let prepared_statement = session
         .prepare("INSERT INTO ks.t2 (a, b, c) VALUES (?, ?, ?)")
         .await

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -79,7 +79,9 @@ async fn test_unprepared_statement() {
         .query_iter("SELECT a, b, c FROM ks.t", &[])
         .await
         .unwrap();
-    for (spec, name) in query_result.get_column_specs().iter().zip(["a", "b", "c"]) {
+    let specs = query_result.get_column_specs();
+    assert_eq!(specs.len(), 3);
+    for (spec, name) in specs.iter().zip(["a", "b", "c"]) {
         assert_eq!(spec.name, name); // Check column name.
         assert_eq!(spec.table_spec.ks_name, "ks");
     }
@@ -132,7 +134,9 @@ async fn test_prepared_statement() {
 
     let prepared_statement = session.prepare("SELECT a, b, c FROM ks.t2").await.unwrap();
     let query_result = session.execute_iter(prepared_statement, &[]).await.unwrap();
-    for (spec, name) in query_result.get_column_specs().iter().zip(["a", "b", "c"]) {
+    let specs = query_result.get_column_specs();
+    assert_eq!(specs.len(), 3);
+    for (spec, name) in specs.iter().zip(["a", "b", "c"]) {
         assert_eq!(spec.name, name); // Check column name.
         assert_eq!(spec.table_spec.ks_name, "ks");
     }


### PR DESCRIPTION
Fixes: #336 
We add a getter for `ColumnSpec` for `*_iter` query methods. 
Enables users to learn about column names when they are using `*_iter` methods.
I took implementation from [cvybhu@6bf7182](https://github.com/cvybhu/scylla-rust-driver/commit/6bf71829821a1969a8c19f05b43eadba17242040) and made tests for it.
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
