### PR TITLE
Improve I/O performance via buffering

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.6"
 histogram = "0.6.9"
 num_enum = "0.5"
 compress = "0.2.1"
-tokio = { version = "1.1.0", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
+tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = "0.8.1"
 rand = "0.8.3"

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -241,7 +241,7 @@ impl Connection {
         stream.set_nodelay(config.tcp_nodelay)?;
 
         // TODO: What should be the size of the channel?
-        let (sender, receiver) = mpsc::channel(128);
+        let (sender, receiver) = mpsc::channel(1024);
 
         let (error_sender, error_receiver) = tokio::sync::oneshot::channel();
 


### PR DESCRIPTION
This pull request combines a couple of changes made in order to measure their impact on overall performance in various environments. The changes include:

* increasing the internal channel size in the connection router
* adding a buffering layer to reads
* adding a buffering layer to writes
    
NOTICE: write buffering is done via `BufWriter`
due to the fact that Tokio does not yet expose write_all_vectored,
and its implementation of write_vectored does not fit our needs,
because it basically just sends one buffer at a time anyway.
Once write_all_vectored is solved, write buffering can be
simplified, and memory copying can be elided.

Experiments show the following improvements:
 * local write workload to Apache Cassandra 4.0 is able to achieve 200kops for a single connection, compared to 70kops before the change
 * remote, shard-aware write workload to Scylla is able to achieve 200kops compared to 160k before the change
 * read workloads showed similar boosts, both locally and remotely

Fixes #338