### PR TITLE
statement: preserve query configuration during prepare()

### DIFF
--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -22,11 +22,12 @@ pub struct PreparedStatement {
 }
 
 impl PreparedStatement {
-    pub fn new(
+    pub(crate) fn new(
         id: Bytes,
         metadata: PreparedMetadata,
         statement: String,
         page_size: Option<i32>,
+        config: StatementConfig,
     ) -> Self {
         Self {
             id,
@@ -34,7 +35,7 @@ impl PreparedStatement {
             statement,
             prepare_tracing_ids: Vec::new(),
             page_size,
-            config: Default::default(),
+            config,
         }
     }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -293,6 +293,7 @@ impl Connection {
                 p.prepared_metadata,
                 query.contents.clone(),
                 query.get_page_size(),
+                query.config.clone(),
             ),
             _ => {
                 return Err(QueryError::ProtocolError(

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1058,3 +1058,18 @@ async fn test_timestamp() {
 
     assert_eq!(results, expected_results);
 }
+
+#[tokio::test]
+async fn test_prepared_config() {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = SessionBuilder::new().known_node(uri).build().await.unwrap();
+
+    let mut query = Query::new("SELECT * FROM system_schema.tables");
+    query.set_is_idempotent(true);
+    query.set_page_size(42);
+
+    let prepared_statement = session.prepare(query).await.unwrap();
+
+    assert_eq!(prepared_statement.get_is_idempotent(), true);
+    assert_eq!(prepared_statement.get_page_size(), Some(42));
+}


### PR DESCRIPTION
When preparing a statement based on a Query instance, we should
preserve the whole configuration. It's especially important
for CachingSession users, because prepare() happens implicitly
in this case, so there's no other way to customize the configuration
for a particular query.

Fixes #340

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
