### PR TITLE
Expose schema metadata

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -18,6 +18,8 @@ jobs:
         image: cassandra
         ports:
           - 9042:9042
+    env:
+      CDC: 'disabled'
     steps:
     - uses: actions/checkout@v2
       # A separate step for building to separate measuring time of compilation and testing

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -35,6 +35,8 @@ openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
 arc-swap = "1.3.0"
 dashmap = "4.0.2"
+strum = "0.23"
+strum_macros = "0.23"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -81,6 +81,7 @@ impl Cluster {
     pub async fn new(
         initial_peers: &[SocketAddr],
         pool_config: PoolConfig,
+        fetch_schema_metadata: bool,
     ) -> Result<Cluster, QueryError> {
         let cluster_data = Arc::new(ArcSwap::from(Arc::new(ClusterData {
             known_peers: HashMap::new(),
@@ -101,6 +102,7 @@ impl Cluster {
                 initial_peers,
                 pool_config.connection_config.clone(),
                 server_events_sender,
+                fetch_schema_metadata,
             ),
             pool_config,
 

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -5,7 +5,7 @@ use crate::transport::connection::{Connection, VerifiedKeyspaceName};
 use crate::transport::connection_pool::PoolConfig;
 use crate::transport::errors::QueryError;
 use crate::transport::node::Node;
-use crate::transport::topology::{Keyspace, TopologyInfo, TopologyReader};
+use crate::transport::topology::{Keyspace, Metadata, MetadataReader};
 
 use arc_swap::ArcSwap;
 use futures::future::join_all;
@@ -50,7 +50,7 @@ struct ClusterWorker {
     cluster_data: Arc<ArcSwap<ClusterData>>,
 
     // Cluster connections
-    topology_reader: TopologyReader,
+    metadata_reader: MetadataReader,
     pool_config: PoolConfig,
 
     // To listen for refresh requests
@@ -97,7 +97,7 @@ impl Cluster {
         let worker = ClusterWorker {
             cluster_data: cluster_data.clone(),
 
-            topology_reader: TopologyReader::new(
+            metadata_reader: MetadataReader::new(
                 initial_peers,
                 pool_config.connection_config.clone(),
                 server_events_sender,
@@ -121,7 +121,7 @@ impl Cluster {
             _worker_handle: worker_handle,
         };
 
-        result.refresh_topology().await?;
+        result.refresh_metadata().await?;
 
         Ok(result)
     }
@@ -130,7 +130,7 @@ impl Cluster {
         self.data.load_full()
     }
 
-    pub async fn refresh_topology(&self) -> Result<(), QueryError> {
+    pub async fn refresh_metadata(&self) -> Result<(), QueryError> {
         let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
 
         self.refresh_channel
@@ -138,12 +138,12 @@ impl Cluster {
                 response_chan: response_sender,
             })
             .await
-            .expect("Bug in Cluster::refresh_topology sending");
+            .expect("Bug in Cluster::refresh_metadata sending");
         // Other end of this channel is in ClusterWorker, can't be dropped while we have &self to Cluster with _worker_handle
 
         response_receiver
             .await
-            .expect("Bug in Cluster::refresh_topology receiving")
+            .expect("Bug in Cluster::refresh_metadata receiving")
         // ClusterWorker always responds
     }
 
@@ -217,22 +217,22 @@ impl ClusterData {
         }
     }
 
-    /// Creates new ClusterData using information about topology held in `info`.
+    /// Creates new ClusterData using information about topology held in `metadata`.
     /// Uses provided `known_peers` hashmap to recycle nodes if possible.
     pub fn new(
-        info: TopologyInfo,
+        metadata: Metadata,
         pool_config: &PoolConfig,
         known_peers: &HashMap<SocketAddr, Arc<Node>>,
         used_keyspace: &Option<VerifiedKeyspaceName>,
     ) -> Self {
         // Create new updated known_peers and ring
         let mut new_known_peers: HashMap<SocketAddr, Arc<Node>> =
-            HashMap::with_capacity(info.peers.len());
+            HashMap::with_capacity(metadata.peers.len());
         let mut ring: BTreeMap<Token, Arc<Node>> = BTreeMap::new();
         let mut datacenters: HashMap<String, Datacenter> = HashMap::new();
-        let mut all_nodes: Vec<Arc<Node>> = Vec::with_capacity(info.peers.len());
+        let mut all_nodes: Vec<Arc<Node>> = Vec::with_capacity(metadata.peers.len());
 
-        for peer in info.peers {
+        for peer in metadata.peers {
             // Take existing Arc<Node> if possible, otherwise create new one
             // Changing rack/datacenter but not ip address seems improbable
             // so we can just create new node and connections then
@@ -276,7 +276,7 @@ impl ClusterData {
         ClusterData {
             known_peers: new_known_peers,
             ring,
-            keyspaces: info.keyspaces,
+            keyspaces: metadata.keyspaces,
             all_nodes,
             datacenters,
         }
@@ -427,12 +427,12 @@ impl ClusterWorker {
     }
 
     async fn perform_refresh(&mut self) -> Result<(), QueryError> {
-        // Read latest TopologyInfo
-        let topo_info = self.topology_reader.read_topology_info().await?;
+        // Read latest Metadata
+        let metadata = self.metadata_reader.read_metadata().await?;
         let cluster_data: Arc<ClusterData> = self.cluster_data.load_full();
 
         let new_cluster_data = Arc::new(ClusterData::new(
-            topo_info,
+            metadata,
             &self.pool_config,
             &cluster_data.known_peers,
             &self.used_keyspace,

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -281,6 +281,13 @@ impl ClusterData {
             datacenters,
         }
     }
+
+    /// Access keyspaces details collected by the driver
+    /// Driver collects various schema details like tables, partitioners, columns, types.
+    /// They can be read using this method
+    pub fn get_keyspace_info(&self) -> &HashMap<String, Keyspace> {
+        &self.keyspaces
+    }
 }
 
 impl ClusterWorker {

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -84,8 +84,8 @@ impl Default for Statement<'_> {
 mod tests {
     use super::*;
 
+    use crate::transport::topology::Metadata;
     use crate::transport::topology::Peer;
-    use crate::transport::topology::TopologyInfo;
     use std::collections::HashMap;
     use std::net::SocketAddr;
 
@@ -134,7 +134,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let info = TopologyInfo {
+        let info = Metadata {
             peers,
             keyspaces: HashMap::new(),
         };

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -153,9 +153,9 @@ mod tests {
 
     use crate::transport::load_balancing::tests;
     use crate::transport::topology::Keyspace;
+    use crate::transport::topology::Metadata;
     use crate::transport::topology::Peer;
     use crate::transport::topology::Strategy;
-    use crate::transport::topology::Metadata;
     use std::collections::HashMap;
 
     // ConnectionKeeper (which lives in Node) requires context of Tokio runtime
@@ -287,6 +287,7 @@ mod tests {
                     strategy: Strategy::SimpleStrategy {
                         replication_factor: 2,
                     },
+                    tables: HashMap::new(),
                 },
             ),
             (
@@ -295,6 +296,7 @@ mod tests {
                     strategy: Strategy::SimpleStrategy {
                         replication_factor: 3,
                     },
+                    tables: HashMap::new(),
                 },
             ),
         ]
@@ -384,6 +386,7 @@ mod tests {
                         .cloned()
                         .collect::<HashMap<_, _>>(),
                 },
+                tables: HashMap::new(),
             },
         )]
         .iter()

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -155,7 +155,7 @@ mod tests {
     use crate::transport::topology::Keyspace;
     use crate::transport::topology::Peer;
     use crate::transport::topology::Strategy;
-    use crate::transport::topology::TopologyInfo;
+    use crate::transport::topology::Metadata;
     use std::collections::HashMap;
 
     // ConnectionKeeper (which lives in Node) requires context of Tokio runtime
@@ -302,7 +302,7 @@ mod tests {
         .cloned()
         .collect();
 
-        let info = TopologyInfo {
+        let info = Metadata {
             peers: Vec::from(peers),
             keyspaces,
         };
@@ -390,7 +390,7 @@ mod tests {
         .cloned()
         .collect();
 
-        let info = TopologyInfo {
+        let info = Metadata {
             peers: Vec::from(peers),
             keyspaces,
         };

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -288,6 +288,7 @@ mod tests {
                         replication_factor: 2,
                     },
                     tables: HashMap::new(),
+                    user_defined_types: HashMap::new(),
                 },
             ),
             (
@@ -297,6 +298,7 @@ mod tests {
                         replication_factor: 3,
                     },
                     tables: HashMap::new(),
+                    user_defined_types: HashMap::new(),
                 },
             ),
         ]
@@ -387,6 +389,7 @@ mod tests {
                         .collect::<HashMap<_, _>>(),
                 },
                 tables: HashMap::new(),
+                user_defined_types: HashMap::new(),
             },
         )]
         .iter()

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -9,6 +9,7 @@ pub mod session;
 pub mod session_builder;
 pub mod speculative_execution;
 mod topology;
+pub use cluster::ClusterData;
 
 pub mod errors;
 pub mod iterator;

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -844,13 +844,13 @@ impl Session {
         Ok(())
     }
 
-    /// Manually trigger a topology refresh\
-    /// The driver will fetch current nodes in the cluster and update its topology information
+    /// Manually trigger a metadata refresh\
+    /// The driver will fetch current nodes in the cluster and update its metadata
     ///
     /// Normally this is not needed,
-    /// the driver should automatically detect all topology changes in the cluster
-    pub async fn refresh_topology(&self) -> Result<(), QueryError> {
-        self.cluster.refresh_topology().await
+    /// the driver should automatically detect all metadata changes in the cluster
+    pub async fn refresh_metadata(&self) -> Result<(), QueryError> {
+        self.cluster.refresh_metadata().await
     }
 
     /// Access metrics collected by the driver\

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -102,6 +102,9 @@ pub struct SessionConfig {
     pub disallow_shard_aware_port: bool,
 
     pub default_consistency: Consistency,
+
+    /// If true, full schema is fetched with every metadata refresh.
+    pub fetch_schema_metadata: bool,
     /*
     These configuration options will be added in the future:
 
@@ -147,6 +150,7 @@ impl SessionConfig {
             connection_pool_size: Default::default(),
             disallow_shard_aware_port: false,
             default_consistency: Consistency::LocalQuorum,
+            fetch_schema_metadata: true,
         }
     }
 
@@ -321,7 +325,12 @@ impl Session {
 
         node_addresses.extend(resolved);
 
-        let cluster = Cluster::new(&node_addresses, config.get_pool_config()).await?;
+        let cluster = Cluster::new(
+            &node_addresses,
+            config.get_pool_config(),
+            config.fetch_schema_metadata,
+        )
+        .await?;
 
         let session = Session {
             cluster,

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -482,6 +482,26 @@ impl SessionBuilder {
         self.config.disallow_shard_aware_port = disallow;
         self
     }
+
+    /// Set the fetch schema metadata flag.
+    /// The default is true.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .fetch_schema_metadata(true)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn fetch_schema_metadata(mut self, fetch: bool) -> Self {
+        self.config.fetch_schema_metadata = fetch;
+        self
+    }
 }
 
 /// Creates a [`SessionBuilder`] with default configuration, same as [`SessionBuilder::new`]
@@ -637,6 +657,18 @@ mod tests {
     }
 
     #[test]
+    fn fetch_schema_metadata() {
+        let mut builder = SessionBuilder::new();
+        assert!(builder.config.fetch_schema_metadata);
+
+        builder = builder.fetch_schema_metadata(false);
+        assert!(!builder.config.fetch_schema_metadata);
+
+        builder = builder.fetch_schema_metadata(true);
+        assert!(builder.config.fetch_schema_metadata);
+    }
+
+    #[test]
     fn all_features() {
         let mut builder = SessionBuilder::new();
 
@@ -652,6 +684,7 @@ mod tests {
         builder = builder.tcp_nodelay(true);
         builder = builder.load_balancing(Arc::new(RoundRobinPolicy::new()));
         builder = builder.use_keyspace("ks_name", true);
+        builder = builder.fetch_schema_metadata(false);
 
         assert_eq!(
             builder.config.known_nodes,
@@ -675,5 +708,6 @@ mod tests {
         assert_eq!(builder.config.used_keyspace, Some("ks_name".to_string()));
 
         assert!(builder.config.keyspace_case_sensitive);
+        assert!(!builder.config.fetch_schema_metadata);
     }
 }


### PR DESCRIPTION
This pull request introduces an insight into the schema of the cluster. From now on it is possible to access keyspace elements such as tables, their columns, types, kinds (regular, static, clustering, partition_key), ordering of partition key and clustering columns, UDTs, partitioner which are stored in `Metadata` structure (former `TopologyInfo`). The client has a way to disable this feature using a proper flag in `SessionConfig`.

This pull request introduces new external dependency namely strum.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #346 