### PR TITLE
frame,transport: change default consistency to LocalQuorum

### DIFF
--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -35,7 +35,7 @@ pub enum SerialConsistency {
 
 impl Default for Consistency {
     fn default() -> Self {
-        Consistency::Quorum
+        Consistency::LocalQuorum
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -142,7 +142,7 @@ impl SessionConfig {
             connect_timeout: std::time::Duration::from_secs(5),
             connection_pool_size: Default::default(),
             disallow_shard_aware_port: false,
-            default_consistency: Consistency::Quorum,
+            default_consistency: Consistency::LocalQuorum,
         }
     }
 


### PR DESCRIPTION
Originally the default consistency level was QUORUM,
but it might be detrimental to performance on multi-dc clusters.
Let's switch the default to LOCAL_QUORUM, which also has an additional
benefit of making the driver work out-of-the-box for Amazon Keyspaces,
which does not allow QUORUM consistency level.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] <strike>I added relevant tests for new features and bug fixes.</strike>
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] <strike>I added appropriate `Fixes:` annotations to PR description.</strike>
