### PR TITLE
docs: Replace double trailing space with backslash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ SCYLLA_URI="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla-
 
 ## Contributing to the book
 
-The documentation book is written using [mdbook](https://github.com/rust-lang/mdBook)  
-Book source is in `docs/source`  
+The documentation book is written using [mdbook](https://github.com/rust-lang/mdBook)\
+Book source is in `docs/source`\
 This source has to be compatible with `Sphinx` so it might sometimes contain chunks like:
 ````
 ```eval_rst

--- a/docs/source/connecting/compression.md
+++ b/docs/source/connecting/compression.md
@@ -1,7 +1,7 @@
 # Compression
 
-By default the driver does not use any compression on connections.  
-It's possible to specify a preferred compression algorithm.   
+By default the driver does not use any compression on connections.\
+It's possible to specify a preferred compression algorithm. \
 The driver will try using it, but if the database doesn't support it, it will fall back to no compression.
 
 Available compression algorithms:

--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -1,6 +1,6 @@
 # TLS
 
-Driver uses the [`openssl`](https://github.com/sfackler/rust-openssl) crate for TLS functionality.  
+Driver uses the [`openssl`](https://github.com/sfackler/rust-openssl) crate for TLS functionality.\
 It was chosen because [`rustls`](https://github.com/ctz/rustls) doesn't support certificates for ip addresses
 (see [issue](https://github.com/briansmith/webpki/issues/54)), which is a common use case for Scylla.
 

--- a/docs/source/data-types/counter.md
+++ b/docs/source/data-types/counter.md
@@ -1,5 +1,5 @@
 # Counter
-`Counter` is represented as `struct Counter(pub i64)`  
+`Counter` is represented as `struct Counter(pub i64)`\
 `Counter` can't be inserted, it can only be read or updated.
 
 ```rust

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -5,7 +5,7 @@ to achieve seamless sending and receiving of CQL values.
 
 See the following chapters for examples on how to send and receive each data type.
 
-See [Query values](../queries/values.md) for more information about sending values in queries.  
+See [Query values](../queries/values.md) for more information about sending values in queries.\
 See [Query result](../queries/result.md) for more information about reading values from queries
 
 Database types and their Rust equivalents:

--- a/docs/source/data-types/date.md
+++ b/docs/source/data-types/date.md
@@ -1,7 +1,7 @@
 # Date
 
 For most use cases `Date` can be represented as 
-[`chrono::NaiveDate`](https://docs.rs/chrono/0.4.19/chrono/naive/struct.NaiveDate.html).  
+[`chrono::NaiveDate`](https://docs.rs/chrono/0.4.19/chrono/naive/struct.NaiveDate.html).\
 `NaiveDate` supports dates from -262145-1-1 to 262143-12-31.
 
 For dates outside of this range you can use the raw `u32` representation.

--- a/docs/source/data-types/tuple.md
+++ b/docs/source/data-types/tuple.md
@@ -18,7 +18,7 @@ session
 if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
     for row in rows.into_typed::<((i32, String),)>() {
         let (tuple_value,): ((i32, String),) = row?;
-        
+
         let int_value: i32 = tuple_value.0;
         let string_value: String = tuple_value.1;
     }

--- a/docs/source/data-types/udt.md
+++ b/docs/source/data-types/udt.md
@@ -1,5 +1,5 @@
 # User defined types
-Scylla allows users to define their own data types with named fields.  
+Scylla allows users to define their own data types with named fields.\
 The driver supports this by allowing to create a custom struct with derived functionality.
 
 For example let's say `my_type` was created using this query:

--- a/docs/source/load-balancing/dc-robin.md
+++ b/docs/source/load-balancing/dc-robin.md
@@ -1,7 +1,7 @@
 # DC Aware Round robin
 
 This is a more sophisticated version of [Round robin policy](robin.md).
-It takes all nodes in the local datacenter and uses them one after another.  
+It takes all nodes in the local datacenter and uses them one after another.\
 If no nodes from the local datacenter are available it will fall back to other nodes.
 
 For example if there are two datacenters:

--- a/docs/source/load-balancing/load-balancing.md
+++ b/docs/source/load-balancing/load-balancing.md
@@ -1,6 +1,6 @@
 # Load balancing
 
-There are multiple load balancing strategies that the driver can use.  
+There are multiple load balancing strategies that the driver can use.\
 Load balancing can be configured for the whole `Session` during creation.
 
 Basic load balancing strategies:
@@ -9,10 +9,10 @@ Basic load balancing strategies:
 
 Each of these basic load balancing strategies can be wrapped in `TokenAwarePolicy` to enable token awareness.
 
-> **Note**  
+> **Note**\
 > Only [prepared queries](../queries/prepared.md) use token aware load balancing
 
-All queries are shard aware, there is no way to turn off shard awareness.  
+All queries are shard aware, there is no way to turn off shard awareness.\
 If a token is available the query is sent to the correct shard, otherwise to a random one.
 
 So, the available load balancing policies are:

--- a/docs/source/load-balancing/robin.md
+++ b/docs/source/load-balancing/robin.md
@@ -1,6 +1,6 @@
 # Round robin
-The simplest load balancing policy available.  
-Takes all nodes in the cluster and uses them one after another.  
+The simplest load balancing policy available.\
+Takes all nodes in the cluster and uses them one after another.\
 
 For example if there are nodes `A`, `B`, `C` in the cluster, 
 this policy will use `A`, `B`, `C`, `A`, `B`, ...

--- a/docs/source/load-balancing/token-dc-robin.md
+++ b/docs/source/load-balancing/token-dc-robin.md
@@ -1,6 +1,6 @@
 # Token aware DC Aware Round robin
 
-This policy will try to calculate a token to find replica nodes in which queried data is stored.  
+This policy will try to calculate a token to find replica nodes in which queried data is stored.\
 After finding the replicas it chooses the ones from the local datacenter and performs a round robin on them.
 
 ### Example

--- a/docs/source/load-balancing/token-robin.md
+++ b/docs/source/load-balancing/token-robin.md
@@ -1,6 +1,6 @@
 # Token aware Round robin
 
-This policy will try to calculate a token to find replica nodes in which queried data is stored.  
+This policy will try to calculate a token to find replica nodes in which queried data is stored.\
 After finding the replicas it performs a round robin on them.
 
 ### Example

--- a/docs/source/logging/logging.md
+++ b/docs/source/logging/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-The driver uses the [tracing](https://github.com/tokio-rs/tracing) crate for all logs.  
+The driver uses the [tracing](https://github.com/tokio-rs/tracing) crate for all logs.\
 To view the logs you have to create a `tracing` subscriber to which all logs will be written.
 
 To just print the logs you can use the default subscriber:

--- a/docs/source/queries/batch.md
+++ b/docs/source/queries/batch.md
@@ -1,7 +1,7 @@
 # Batch statement
 
-A batch statement allows to run many queries at once.  
-These queries can be [simple queries](simple.md) or [prepared queries](prepared.md).  
+A batch statement allows to run many queries at once.\
+These queries can be [simple queries](simple.md) or [prepared queries](prepared.md).\
 Only queries like `INSERT` or `UPDATE` can be in a batch, batch doesn't return any rows.
 
 ```rust
@@ -41,7 +41,7 @@ session.batch(&batch, batch_values).await?;
 ```
 
 ### Batch options
-You can set various options by operating on the `Batch` object.  
+You can set various options by operating on the `Batch` object.\
 For example to change consistency:
 ```rust
 # extern crate scylla;
@@ -70,11 +70,11 @@ for more options
 ### Batch values
 Batch takes a tuple of values specified just like in [simple](simple.md) or [prepared](prepared.md) queries.
 
-Length of batch values must be equal to the number of statements in a batch.  
+Length of batch values must be equal to the number of statements in a batch.\
 Each query must have its values specified, even if they are empty.
 
-Values passed to `Session::batch` must implement the trait `BatchValues`.  
-By default this includes tuples `()` and slices `&[]` of tuples and slices which implement `ValueList`.  
+Values passed to `Session::batch` must implement the trait `BatchValues`.\
+By default this includes tuples `()` and slices `&[]` of tuples and slices which implement `ValueList`.\
 
 Example:
 ```rust

--- a/docs/source/queries/paged.md
+++ b/docs/source/queries/paged.md
@@ -139,5 +139,5 @@ let res2 = session
 ```
 
 ### Performance
-Performance is the same as in non-paged variants.  
+Performance is the same as in non-paged variants.\
 For the best performance use [prepared queries](prepared.md).

--- a/docs/source/queries/result.md
+++ b/docs/source/queries/result.md
@@ -72,7 +72,7 @@ if let Some(rows) = session.query("SELECT a, b from ks.tab", &[]).await?.rows {
 ```
 
 ### Parsing row as a custom struct
-It is possible to receive row as a struct with fields matching the columns.  
+It is possible to receive row as a struct with fields matching the columns.\
 The struct must:
 * have the same number of fields as the number of queried columns
 * have field types matching the columns being received

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -15,15 +15,15 @@ session
 # }
 ```
 
-> ***Warning***  
-> Don't use simple query to receive large amounts of data.  
-> By default the query is unpaged and might cause heavy load on the cluster.  
-> In such cases set a page size and use [paged query](paged.md) instead.  
+> ***Warning***\
+> Don't use simple query to receive large amounts of data.\
+> By default the query is unpaged and might cause heavy load on the cluster.\
+> In such cases set a page size and use [paged query](paged.md) instead.\
 > 
 > When page size is set, `query` will return only the first page of results.
 
 ### First argument - the query
-As the first argument `Session::query` takes anything implementing `Into<Query>`.  
+As the first argument `Session::query` takes anything implementing `Into<Query>`.\
 You can create a query manually to set custom options. For example to change query consistency:
 ```rust
 # extern crate scylla;
@@ -47,7 +47,7 @@ See [Query API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/quer
 
 ### Second argument - the values
 Query text is constant, but the values might change.
-You can pass changing values to a query by specifying a list of variables as bound values.  
+You can pass changing values to a query by specifying a list of variables as bound values.\
 Each `?` in query text will be filled with the matching value. 
 
 The easiest way is to pass values using a tuple:
@@ -69,7 +69,7 @@ Here the first `?` will be filled with `2` and the second with `"Some text"`.
 See [Query values](values.md) for more information about sending values in queries
 
 ### Query result
-`Session::query` returns `QueryResult` with rows represented as `Option<Vec<Row>>`.  
+`Session::query` returns `QueryResult` with rows represented as `Option<Vec<Row>>`.\
 Each row can be parsed as a tuple of rust types using `into_typed`:
 ```rust
 # extern crate scylla;
@@ -89,15 +89,15 @@ if let Some(rows) = session.query("SELECT a FROM ks.tab", &[]).await?.rows {
 # Ok(())
 # }
 ```
-> In cases where page size is set, simple query returns only a single page of results.  
-> To receive all pages use a [paged query](paged.md) instead.  
+> In cases where page size is set, simple query returns only a single page of results.\
+> To receive all pages use a [paged query](paged.md) instead.\
 
 See [Query result](result.md) for more information about handling query results
 
 ### Performance
-Simple queries should not be used in places where performance matters.  
+Simple queries should not be used in places where performance matters.\
 If perfomance matters use a [Prepared query](prepared.md) instead.
 
-With simple query the database has to parse query text each time it's executed, which worsens performance.  
+With simple query the database has to parse query text each time it's executed, which worsens performance.\
 
 Additionaly token and shard aware load balancing does not work with simple queries. They are sent to random nodes.

--- a/docs/source/queries/usekeyspace.md
+++ b/docs/source/queries/usekeyspace.md
@@ -46,7 +46,7 @@ session
 # }
 ```
 
-The first argument is the keyspace name.  
+The first argument is the keyspace name.\
 The second argument states whether this name is case sensitive.
 
 It is also possible to send raw use keyspace query using `Session::query` instead of `Session::use_keyspace` such as:
@@ -68,8 +68,8 @@ This could end up with half of connections using one keyspace and the other half
 
 ### Case sensitivity
 
-In CQL a keyspace name can be case insensitive (without `"`) or case sensitive (with `"`).  
-If the second argument to `use_keyspace` is set to `true` this keyspace name will be wrapped in `"`.  
+In CQL a keyspace name can be case insensitive (without `"`) or case sensitive (with `"`).\
+If the second argument to `use_keyspace` is set to `true` this keyspace name will be wrapped in `"`.\
 It is best to avoid the problem altogether and just not create two keyspaces with the same name but different cases.
 
 Let's see what happens when there are two keyspaces with the same name but different cases: `my_keyspace` and `MY_KEYSPACE`:

--- a/docs/source/queries/values.md
+++ b/docs/source/queries/values.md
@@ -1,11 +1,11 @@
 # Query values
 Query text is constant, but the values might change.
-You can pass changing values to a query by specifying a list of variables as bound values.  
+You can pass changing values to a query by specifying a list of variables as bound values.\
 Each `?` in query text will be filled with the matching value. 
 
 > **Never** pass values by adding strings, this could lead to [SQL Injection](https://en.wikipedia.org/wiki/SQL_injection)
 
-Each list of values to send in a query must implement the trait `ValueList`.  
+Each list of values to send in a query must implement the trait `ValueList`.\
 By default this can be a slice `&[]`, a tuple `()` (max 16 elements) of values to send,
 or a custom struct which derives from `ValueList`.
 
@@ -75,7 +75,7 @@ session
 ```
 
 ### `Unset` values
-When performing an insert with values which might be `NULL`, it's better to use `Unset`.  
+When performing an insert with values which might be `NULL`, it's better to use `Unset`.\
 Database treats inserting `NULL` as a delete operation and will generate a tombstone.
 Using `Unset` results in better performance:
 

--- a/docs/source/quickstart/scylla-docker.md
+++ b/docs/source/quickstart/scylla-docker.md
@@ -1,6 +1,6 @@
 # Running Scylla using Docker
 
-To make queries we will need a running Scylla instance. The easiest way is to use a [Docker](https://www.docker.com/) image.  
+To make queries we will need a running Scylla instance. The easiest way is to use a [Docker](https://www.docker.com/) image.\
 Please [install Docker](https://docs.docker.com/engine/install) if it's not installed.
 
 ### Running scylla

--- a/docs/source/retry-policy/default.md
+++ b/docs/source/retry-policy/default.md
@@ -1,5 +1,5 @@
 # Default retry policy
-This is the retry policy used by default. It retries when there is a high chance that it might help.  
+This is the retry policy used by default. It retries when there is a high chance that it might help.\
 This policy is based on the one in [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.11/manual/core/retries/).
 The behaviour is the same.
 

--- a/docs/source/tracing/paged.md
+++ b/docs/source/tracing/paged.md
@@ -1,6 +1,6 @@
 # Tracing a paged query
 
-A paged query performs multiple simple/prepared queries to query subsequent pages.  
+A paged query performs multiple simple/prepared queries to query subsequent pages.\
 If tracing is enabled the row iterator will contain a list of tracing ids for all performed queries.
 
 

--- a/docs/source/tracing/tracing.md
+++ b/docs/source/tracing/tracing.md
@@ -12,8 +12,8 @@ Queries that support tracing:
 * [`Session::batch()`](batch.md)
 * [`Session::prepare()`](prepare.md)
 
-After obtaining the tracing id you can use `Session::get_tracing_info()` to query tracing information.  
-`TracingInfo` contains values that are the same in Scylla and Cassandra®.  
+After obtaining the tracing id you can use `Session::get_tracing_info()` to query tracing information.\
+`TracingInfo` contains values that are the same in Scylla and Cassandra®.\
 If `TracingInfo` does not contain some needed value it's possible to query it manually from the tables
 `system_traces.sessions` and `system_traces.events`
 

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -2,7 +2,7 @@
 //! Although optimized for Scylla, the driver is also compatible with [Apache Cassandra®](https://cassandra.apache.org/).
 //!
 //! # Documentation book
-//! The best source to learn about this driver is the [documentation book](https://cvybhu.github.io/scyllabook/index.html).  
+//! The best source to learn about this driver is the [documentation book](https://cvybhu.github.io/scyllabook/index.html).\
 //! This page contains mainly API documentation
 //!
 //! # Other documentation
@@ -13,7 +13,7 @@
 //!
 //! # Driver overview
 //! ### Connecting
-//! All driver activity revolves around the [Session](crate::Session)  
+//! All driver activity revolves around the [Session](crate::Session)\
 //! `Session` is created by specifying a few known nodes and connecting to them:
 //!
 //! ```rust,no_run
@@ -31,11 +31,11 @@
 //!    Ok(())
 //! }
 //! ```
-//! `Session` is usually created using the [SessionBuilder](crate::SessionBuilder).  
+//! `Session` is usually created using the [SessionBuilder](crate::SessionBuilder).\
 //! All configuration options for a `Session` can be specified while building.
 //!
 //! ### Making queries
-//! After succesfully connecting to the cluster we can make queries.  
+//! After succesfully connecting to the cluster we can make queries.\
 //! The driver supports multiple query types:
 //! * [Simple](crate::Session::query)
 //! * [Simple paged](crate::Session::query_iter)
@@ -82,7 +82,7 @@
 //!
 //! if let Some(rows) = rows_opt {
 //!     for row in rows.into_typed::<(i32, String)>() {
-//!         // Parse row as int and text   
+//!         // Parse row as int and text \
 //!         let (int_val, text_val): (i32, String) = row?;
 //!     }
 //! }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -79,7 +79,7 @@ pub struct QueryResponse {
     pub warnings: Vec<String>,
 }
 
-/// Result of a single query  
+/// Result of a single query\
 /// Contains all rows returned by the database and some more information
 #[derive(Default, Debug)]
 pub struct QueryResult {
@@ -104,9 +104,9 @@ impl QueryResult {
             .find(|(_id, spec)| spec.name == name)
     }
 
-    /// This function is used to merge results of multiple paged queries into one.  
-    /// other is the result of a new paged query.  
-    /// It is merged with current result kept in self.  
+    /// This function is used to merge results of multiple paged queries into one.\
+    /// other is the result of a new paged query.\
+    /// It is merged with current result kept in self.\
     pub(crate) fn merge_with_next_page_res(&mut self, other: QueryResult) {
         if let Some(other_rows) = other.rows {
             match &mut self.rows {

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -36,7 +36,7 @@ pub enum QueryError {
 }
 
 /// An error sent from the database in response to a query
-/// as described in the [specification](https://github.com/apache/cassandra/blob/5ed5e84613ef0e9664a774493db7d2604e3596e0/doc/native_protocol_v4.spec#L1029)  
+/// as described in the [specification](https://github.com/apache/cassandra/blob/5ed5e84613ef0e9664a774493db7d2604e3596e0/doc/native_protocol_v4.spec#L1029)\
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum DbError {
     /// The submitted query has a syntax error

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -34,7 +34,7 @@ use crate::transport::node::Node;
 use crate::transport::retry_policy::{QueryInfo, RetryDecision, RetrySession};
 use uuid::Uuid;
 
-/// Iterator over rows returned by paged queries  
+/// Iterator over rows returned by paged queries\
 /// Allows to easily access rows without worrying about handling multiple pages
 pub struct RowIterator {
     current_row_idx: usize,
@@ -59,7 +59,7 @@ pub(crate) struct PreparedIteratorConfig {
     pub metrics: Arc<Metrics>,
 }
 
-/// Fetching pages is asynchronous so `RowIterator` does not implement the `Iterator` trait.  
+/// Fetching pages is asynchronous so `RowIterator` does not implement the `Iterator` trait.\
 /// Instead it uses the asynchronous `Stream` trait
 impl Stream for RowIterator {
     type Item = Result<Row, QueryError>;
@@ -352,7 +352,7 @@ where
 }
 
 /// Iterator over rows returned by paged queries
-/// where each row is parsed as the given type  
+/// where each row is parsed as the given type\
 /// Returned by `RowIterator::into_typed`
 pub struct TypedRowIterator<RowT> {
     row_iterator: RowIterator,
@@ -378,7 +378,7 @@ pub enum NextRowError {
     FromRowError(#[from] FromRowError),
 }
 
-/// Fetching pages is asynchronous so `TypedRowIterator` does not implement the `Iterator` trait.  
+/// Fetching pages is asynchronous so `TypedRowIterator` does not implement the `Iterator` trait.\
 /// Instead it uses the asynchronous `Stream` trait
 impl<RowT: FromRow> Stream for TypedRowIterator<RowT> {
     type Item = Result<RowT, NextRowError>;

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -1,6 +1,6 @@
-//! Load balancing configurations  
-//! `Session` can use any load balancing policy which implements the `LoadBalancingPolicy` trait  
-//! Policies which implement the `ChildLoadBalancingPolicy` can be wrapped in some other policies  
+//! Load balancing configurations\
+//! `Session` can use any load balancing policy which implements the `LoadBalancingPolicy` trait\
+//! Policies which implement the `ChildLoadBalancingPolicy` can be wrapped in some other policies\
 //! See [the book](https://cvybhu.github.io/scyllabook/load-balancing/load-balancing.html) for more information
 
 use super::{cluster::ClusterData, node::Node};

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -1,4 +1,4 @@
-//! Query retries configurations  
+//! Query retries configurations\
 //! To decide when to retry a query the `Session` can use any object which implements
 //! the `RetryPolicy` trait
 
@@ -9,8 +9,8 @@ use crate::transport::errors::{DbError, QueryError, WriteType};
 pub struct QueryInfo<'a> {
     /// The error with which the query failed
     pub error: &'a QueryError,
-    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application  
-    /// If set to `true` we can be sure that it is idempotent  
+    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application\
+    /// If set to `true` we can be sure that it is idempotent\
     /// If set to `false` it is unknown whether it is idempotent
     pub is_idempotent: bool,
     /// Consistency with which the query failed
@@ -83,7 +83,7 @@ impl RetrySession for FallthroughRetrySession {
     fn reset(&mut self) {}
 }
 
-/// Default retry policy - retries when there is a high chance that a retry might help.  
+/// Default retry policy - retries when there is a high chance that a retry might help.\
 /// Behaviour based on [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/retries/)
 pub struct DefaultRetryPolicy;
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1,4 +1,4 @@
-//! `Session` is the main object used in the driver.  
+//! `Session` is the main object used in the driver.\
 //! It manages all connections to the cluster and allows to perform queries.
 
 use bytes::Bytes;
@@ -253,7 +253,7 @@ impl IntoTypedRows for Vec<result::Row> {
     }
 }
 
-/// Iterator over rows parsed as the given type  
+/// Iterator over rows parsed as the given type\
 /// Returned by `rows.into_typed::<(...)>()`
 pub struct TypedRowIter<RowT: FromRow> {
     row_iter: std::vec::IntoIter<result::Row>,
@@ -338,7 +338,7 @@ impl Session {
         Ok(session)
     }
 
-    /// Sends a query to the database and receives a response.  
+    /// Sends a query to the database and receives a response.\
     /// Returns only a single page of results, to receive multiple pages use [query_iter](Session::query_iter)
     ///
     /// This is the easiest way to make a query, but performance is worse than that of prepared queries.
@@ -377,7 +377,7 @@ impl Session {
     ///
     /// if let Some(rows) = rows_opt {
     ///     for row in rows.into_typed::<(i32, String)>() {
-    ///         // Parse row as int and text   
+    ///         // Parse row as int and text \
     ///         let (int_val, text_val): (i32, String) = row?;
     ///     }
     /// }
@@ -447,10 +447,10 @@ impl Session {
         Ok(())
     }
 
-    /// Run a simple query with paging  
-    /// This method will query all pages of the result  
+    /// Run a simple query with paging\
+    /// This method will query all pages of the result\
     ///
-    /// Returns an async iterator (stream) over all received rows  
+    /// Returns an async iterator (stream) over all received rows\
     /// Page size can be specified in the [Query](crate::query::Query) passed to the function
     ///
     /// See [the book](https://cvybhu.github.io/scyllabook/queries/paged.html) for more information
@@ -511,7 +511,7 @@ impl Session {
     /// * Database doesn't need to parse the query
     /// * They are properly load balanced using token aware routing
     ///
-    /// > ***Warning***  
+    /// > ***Warning***\
     /// > For token/shard aware load balancing to work properly, all partition key values
     /// > must be sent as bound values
     /// > (see [performance section](https://cvybhu.github.io/scyllabook/queries/prepared.html#performance))
@@ -583,14 +583,14 @@ impl Session {
     }
 
     /// Execute a prepared query. Requires a [PreparedStatement](crate::prepared_statement::PreparedStatement)
-    /// generated using [`Session::prepare`](Session::prepare)  
+    /// generated using [`Session::prepare`](Session::prepare)\
     /// Returns only a single page of results, to receive multiple pages use [execute_iter](Session::execute_iter)
     ///
     /// Prepared queries are much faster than simple queries:
     /// * Database doesn't need to parse the query
     /// * They are properly load balanced using token aware routing
     ///
-    /// > ***Warning***  
+    /// > ***Warning***\
     /// > For token/shard aware load balancing to work properly, all partition key values
     /// > must be sent as bound values
     /// > (see [performance section](https://cvybhu.github.io/scyllabook/queries/prepared.html#performance))
@@ -667,10 +667,10 @@ impl Session {
         response.into_query_result()
     }
 
-    /// Run a prepared query with paging  
-    /// This method will query all pages of the result  
+    /// Run a prepared query with paging\
+    /// This method will query all pages of the result\
     ///
-    /// Returns an async iterator (stream) over all received rows  
+    /// Returns an async iterator (stream) over all received rows\
     /// Page size can be specified in the [PreparedStatement](crate::prepared_statement::PreparedStatement)
     /// passed to the function
     ///
@@ -737,8 +737,8 @@ impl Session {
         ))
     }
 
-    /// Perform a batch query  
-    /// Batch contains many `simple` or `prepared` queries which are executed at once  
+    /// Perform a batch query\
+    /// Batch contains many `simple` or `prepared` queries which are executed at once\
     /// Batch doesn't return any rows
     ///
     /// Batch values must contain values for each of the queries
@@ -793,13 +793,13 @@ impl Session {
         .await
     }
 
-    /// Sends `USE <keyspace_name>` request on all connections  
-    /// This allows to write `SELECT * FROM table` instead of `SELECT * FROM keyspace.table`  
+    /// Sends `USE <keyspace_name>` request on all connections\
+    /// This allows to write `SELECT * FROM table` instead of `SELECT * FROM keyspace.table`\
     ///
     /// Note that even failed `use_keyspace` can change currently used keyspace - the request is sent on all connections and
     /// can overwrite previously used keyspace.
     ///
-    /// Call only one `use_keyspace` at a time.  
+    /// Call only one `use_keyspace` at a time.\
     /// Trying to do two `use_keyspace` requests simultaneously with different names
     /// can end with some connections using one keyspace and the rest using the other.
     ///
@@ -844,7 +844,7 @@ impl Session {
         Ok(())
     }
 
-    /// Manually trigger a topology refresh  
+    /// Manually trigger a topology refresh\
     /// The driver will fetch current nodes in the cluster and update its topology information
     ///
     /// Normally this is not needed,
@@ -853,7 +853,7 @@ impl Session {
         self.cluster.refresh_topology().await
     }
 
-    /// Access metrics collected by the driver  
+    /// Access metrics collected by the driver\
     /// Driver collects various metrics like number of queries or query latencies.
     /// They can be read using this method
     pub fn get_metrics(&self) -> Arc<Metrics> {
@@ -869,7 +869,7 @@ impl Session {
             .await
     }
 
-    /// Queries tracing info with custom retry settings.  
+    /// Queries tracing info with custom retry settings.\
     /// Tracing info might not be available immediately on queried node -
     /// that's why the driver performs a few attempts with sleeps in between.
     /// [`GetTracingConfig`] allows to specify a custom querying strategy.

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -201,8 +201,8 @@ impl SessionBuilder {
         self
     }
 
-    /// Set keyspace to be used on all connections.  
-    /// Each connection will send `"USE <keyspace_name>"` before sending any requests.  
+    /// Set keyspace to be used on all connections.\
+    /// Each connection will send `"USE <keyspace_name>"` before sending any requests.\
     /// This can be later changed with [`Session::use_keyspace`]
     ///
     /// # Example
@@ -224,8 +224,8 @@ impl SessionBuilder {
         self
     }
 
-    /// Set username and password for authentication.  
-    /// If the database server will require authentication  
+    /// Set username and password for authentication.\
+    /// If the database server will require authentication\
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
In markdown to make a new line we can write:
```
First line<space><space>
Second line.
```

Without the double space both lines would be rendered in the same line.
It acts like `<br>` in HTML
We use this in our documentation.

However there is also another way to specify a newline:
```
First line\
Second line
```

In my opinion the second way is better:
* It is more visible when writing the markdown
* Contributors remove trailing spaces, because they think it is a mistake
* Some editors automatically remove trailing spaces

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
