### PR TITLE
docs: Add back newlines that were removed in PR #347

### DIFF
--- a/docs/source/queries/prepared.md
+++ b/docs/source/queries/prepared.md
@@ -22,12 +22,12 @@ session.execute(&prepared, (to_insert,)).await?;
 # }
 ```
 
-> ***Warning***
+> ***Warning***\
 > For token/shard aware load balancing to work properly, all partition key values
 > must be sent as bound values (see [performance section](#performance))
 
-> ***Warning***
-> Don't use `execute` to receive large amounts of data.
+> ***Warning***\
+> Don't use `execute` to receive large amounts of data.\
 > By default the query is unpaged and might cause heavy load on the cluster.
 > In such cases set a page size and use a [paged query](paged.md) instead.
 >


### PR DESCRIPTION
PR #347 accidentally removed some newlines from the documentation.
Add them back to make the documentation look nicer.

Before:
![image](https://user-images.githubusercontent.com/36861778/143455532-f4722529-28ae-4687-bfb9-7d976bafc1fc.png)

After:
![image](https://user-images.githubusercontent.com/36861778/143455648-618c99ae-6ca8-4c67-9a95-7718685f3392.png)


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
