### PR TITLE
book: Update scylla version to 0.3.1

### DIFF
--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -10,7 +10,7 @@ It was chosen because [`rustls`](https://github.com/ctz/rustls) doesn't support 
 
 To enable the `tls` feature add in `Cargo.toml`:
 ```toml
-scylla = { version = "0.2.0", features = ["ssl"] }
+scylla = { version = "0.3.1", features = ["ssl"] }
 openssl = "0.10.32"
 ```
 

--- a/docs/source/queries/batch.md
+++ b/docs/source/queries/batch.md
@@ -64,7 +64,7 @@ session.batch(&batch, ((), )).await?;
 # }
 ```
 
-See [Batch API documentation](https://docs.rs/scylla/0.3.1/scylla/statement/batch/struct.Batch.html)
+See [Batch API documentation](https://docs.rs/scylla/latest/scylla/statement/batch/struct.Batch.html)
 for more options
 
 ### Batch values

--- a/docs/source/queries/batch.md
+++ b/docs/source/queries/batch.md
@@ -64,7 +64,7 @@ session.batch(&batch, ((), )).await?;
 # }
 ```
 
-See [Batch API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/batch/struct.Batch.html)
+See [Batch API documentation](https://docs.rs/scylla/0.3.1/scylla/statement/batch/struct.Batch.html)
 for more options
 
 ### Batch values

--- a/docs/source/queries/lwt.md
+++ b/docs/source/queries/lwt.md
@@ -28,5 +28,5 @@ session.query(my_query, (to_insert,)).await?;
 
 The rest of the API remains identical for LWT and non-LWT queries.
 
-See [Query API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/query/struct.Query.html) for more options
+See [Query API documentation](https://docs.rs/scylla/0.3.1/scylla/statement/query/struct.Query.html) for more options
 

--- a/docs/source/queries/lwt.md
+++ b/docs/source/queries/lwt.md
@@ -28,5 +28,5 @@ session.query(my_query, (to_insert,)).await?;
 
 The rest of the API remains identical for LWT and non-LWT queries.
 
-See [Query API documentation](https://docs.rs/scylla/0.3.1/scylla/statement/query/struct.Query.html) for more options
+See [Query API documentation](https://docs.rs/scylla/latest/scylla/statement/query/struct.Query.html) for more options
 

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -43,7 +43,7 @@ session.query(my_query, (to_insert,)).await?;
 # Ok(())
 # }
 ```
-See [Query API documentation](https://docs.rs/scylla/0.2.0/scylla/statement/query/struct.Query.html) for more options
+See [Query API documentation](https://docs.rs/scylla/0.3.1/scylla/statement/query/struct.Query.html) for more options
 
 ### Second argument - the values
 Query text is constant, but the values might change.

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -43,7 +43,7 @@ session.query(my_query, (to_insert,)).await?;
 # Ok(())
 # }
 ```
-See [Query API documentation](https://docs.rs/scylla/0.3.1/scylla/statement/query/struct.Query.html) for more options
+See [Query API documentation](https://docs.rs/scylla/latest/scylla/statement/query/struct.Query.html) for more options
 
 ### Second argument - the values
 Query text is constant, but the values might change.

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "0.2.0"
+scylla = "0.3.1"
 tokio = { version = "1.1.0", features = ["full"] }
 futures = "0.3.6"
 uuid = "0.8.1"


### PR DESCRIPTION
Documentation book referenced scylla in version 0.2.0, but 0.3.1 is already out.
Changed all references from 0.2.0 to 0.3.1.

Fixes: #345

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
