### PR TITLE
Switch to Rust edition 2021

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,7 +7,7 @@ multilingual = false
 src = "source"
 
 [rust]
-edition = "2018"
+edition = "2021"
 
 [output.html]
 default-theme = "ayu"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "examples"
 publish = false
 version = "0.0.0"

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scylla-macros"
 version = "0.1.1"
-edition = "2018"
+edition = "2021"
 description = "proc macros for scylla async CQL driver"
 repository = "https://github.com/scylladb/scylla-rust-driver"
 readme = "../README.md"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scylla"
 version = "0.4.5"
-edition = "2018"
+edition = "2021"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"
 repository = "https://github.com/scylladb/scylla-rust-driver"
 readme = "../README.md"


### PR DESCRIPTION
Rust edition 2021 has some nice features, for example arrays got an `into_iter()` implementation, which means that we can do things like:
```rust
let my_set: BTreeSet<String> = [
    "doggie".to_string(),
    "doge".to_string(),
    "doggo".to_string(),
]
.into_iter()
.collect();
```

Updating to 2021 shouldn't cause any issues. According to the documentation crates with edition 2018 can still use our crate, even if it's in edition 2021:
https://doc.rust-lang.org/nightly/edition-guide/editions/index.html
> This ensures that the decision to migrate to a newer edition is a "private one" that the crate can make without affecting others.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
