### PR TITLE
Support more collection types

### DIFF
--- a/docs/source/data-types/collections.md
+++ b/docs/source/data-types/collections.md
@@ -11,9 +11,9 @@
 use scylla::IntoTypedRows;
 
 // Insert a list of ints into the table
-let to_insert: Vec<i32> = vec![1, 2, 3, 4, 5];
+let my_list: Vec<i32> = vec![1, 2, 3, 4, 5];
 session
-    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&to_insert,))
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&my_list,))
     .await?;
 
 // Read a list of ints from the table
@@ -27,7 +27,7 @@ if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.ro
 ```
 
 ## Set
-`Set` is represented as `Vec<T>`
+`Set` is represented as `Vec<T>`, `HashSet<T>` or `BTreeSet<T>`:
 
 ```rust
 # extern crate scylla;
@@ -37,9 +37,9 @@ if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.ro
 use scylla::IntoTypedRows;
 
 // Insert a set of ints into the table
-let to_insert: Vec<i32> = vec![1, 2, 3, 4, 5];
+let my_set: Vec<i32> = vec![1, 2, 3, 4, 5];
 session
-    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&to_insert,))
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&my_set,))
     .await?;
 
 // Read a set of ints from the table
@@ -52,8 +52,56 @@ if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.ro
 # }
 ```
 
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::IntoTypedRows;
+use std::collections::HashSet;
+
+// Insert a set of ints into the table
+let my_set: HashSet<i32> = vec![1, 2, 3, 4, 5].into_iter().collect();
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&my_set,))
+    .await?;
+
+// Read a set of ints from the table
+if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
+    for row in rows.into_typed::<(HashSet<i32>,)>() {
+        let (set_value,): (HashSet<i32>,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::IntoTypedRows;
+use std::collections::BTreeSet;
+
+// Insert a set of ints into the table
+let my_set: BTreeSet<i32> = vec![1, 2, 3, 4, 5].into_iter().collect();
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&my_set,))
+    .await?;
+
+// Read a set of ints from the table
+if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
+    for row in rows.into_typed::<(BTreeSet<i32>,)>() {
+        let (set_value,): (BTreeSet<i32>,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
 ## Map
-`Map` is represented as `std::collections::HashMap<K, V>`
+`Map` is represented as `HashMap<K, V>` or `BTreeMap<K, V>`
 
 ```rust
 # extern crate scylla;
@@ -64,17 +112,43 @@ use scylla::IntoTypedRows;
 use std::collections::HashMap;
 
 // Insert a map of text and int into the table
-let mut to_insert: HashMap<String, i32> = HashMap::new();
-to_insert.insert("abcd".to_string(), 16);
+let mut my_map: HashMap<String, i32> = HashMap::new();
+my_map.insert("abcd".to_string(), 16);
 
 session
-    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&to_insert,))
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&my_map,))
     .await?;
 
 // Read a map from the table
 if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
     for row in rows.into_typed::<(HashMap<String, i32>,)>() {
         let (map_value,): (HashMap<String, i32>,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::IntoTypedRows;
+use std::collections::BTreeMap;
+
+// Insert a map of text and int into the table
+let mut my_map: BTreeMap<String, i32> = BTreeMap::new();
+my_map.insert("abcd".to_string(), 16);
+
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (&my_map,))
+    .await?;
+
+// Read a map from the table
+if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
+    for row in rows.into_typed::<(BTreeMap<String, i32>,)>() {
+        let (map_value,): (BTreeMap<String, i32>,) = row?;
     }
 }
 # Ok(())

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -3,8 +3,7 @@ use crate::frame::value::Counter;
 use bigdecimal::BigDecimal;
 use chrono::{Duration, NaiveDate};
 use num_bigint::BigInt;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 use std::net::IpAddr;
 use thiserror::Error;
@@ -124,6 +123,17 @@ impl<T: FromCqlVal<CqlValue> + Eq + Hash> FromCqlVal<CqlValue> for HashSet<T> {
             .into_iter()
             .map(T::from_cql)
             .collect::<Result<HashSet<T>, FromCqlValError>>()
+    }
+}
+
+impl<T: FromCqlVal<CqlValue> + Ord> FromCqlVal<CqlValue> for BTreeSet<T> {
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+        cql_val
+            .into_vec()
+            .ok_or(FromCqlValError::BadCqlType)?
+            .into_iter()
+            .map(T::from_cql)
+            .collect::<Result<BTreeSet<T>, FromCqlValError>>()
     }
 }
 

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -43,6 +43,13 @@ pub trait FromRow: Sized {
     fn from_row(row: Row) -> Result<Self, FromRowError>;
 }
 
+// CqlValue can be converted to CqlValue
+impl FromCqlVal<CqlValue> for CqlValue {
+    fn from_cql(cql_val: CqlValue) -> Result<CqlValue, FromCqlValError> {
+        Ok(cql_val)
+    }
+}
+
 // Implement from_cql<Option<CqlValue>> for every type that has from_cql<CqlValue>
 // This tries to unwrap the option or fails with an error
 impl<T: FromCqlVal<CqlValue>> FromCqlVal<Option<CqlValue>> for T {

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -3,7 +3,7 @@ use crate::frame::value::Counter;
 use bigdecimal::BigDecimal;
 use chrono::{Duration, NaiveDate};
 use num_bigint::BigInt;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 use std::net::IpAddr;
 use thiserror::Error;
@@ -134,6 +134,19 @@ impl<T: FromCqlVal<CqlValue> + Ord> FromCqlVal<CqlValue> for BTreeSet<T> {
             .into_iter()
             .map(T::from_cql)
             .collect::<Result<BTreeSet<T>, FromCqlValError>>()
+    }
+}
+
+impl<K: FromCqlVal<CqlValue> + Ord, V: FromCqlVal<CqlValue>> FromCqlVal<CqlValue>
+    for BTreeMap<K, V>
+{
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+        let vec = cql_val.into_pair_vec().ok_or(FromCqlValError::BadCqlType)?;
+        let mut res = BTreeMap::new();
+        for (key, value) in vec {
+            res.insert(K::from_cql(key)?, V::from_cql(value)?);
+        }
+        Ok(res)
     }
 }
 

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use chrono::Duration;
 use num_bigint::BigInt;
 use std::borrow::Cow;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;
 use std::net::IpAddr;
 use thiserror::Error;
@@ -482,6 +482,12 @@ impl<K: Value, V: Value> Value for HashMap<K, V> {
 impl<V: Value> Value for BTreeSet<V> {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         serialize_list_or_set(self.iter(), self.len(), buf)
+    }
+}
+
+impl<K: Value, V: Value> Value for BTreeMap<K, V> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        serialize_map(self.iter(), self.len(), buf)
     }
 }
 

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use chrono::Duration;
 use num_bigint::BigInt;
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;
 use std::net::IpAddr;
 use thiserror::Error;
@@ -476,6 +476,12 @@ impl<V: Value> Value for HashSet<V> {
 impl<K: Value, V: Value> Value for HashMap<K, V> {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         serialize_map(self.iter(), self.len(), buf)
+    }
+}
+
+impl<V: Value> Value for BTreeSet<V> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        serialize_list_or_set(self.iter(), self.len(), buf)
     }
 }
 

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use chrono::Duration;
 use num_bigint::BigInt;
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::net::IpAddr;
 use thiserror::Error;
@@ -465,6 +465,12 @@ fn serialize_list_or_set<'a, V: 'a + Value>(
     buf[bytes_num_pos..(bytes_num_pos + 4)].copy_from_slice(&written_bytes_i32.to_be_bytes());
 
     Ok(())
+}
+
+impl<V: Value> Value for HashSet<V> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        serialize_list_or_set(self.iter(), self.len(), buf)
+    }
 }
 
 impl<K: Value, V: Value> Value for HashMap<K, V> {


### PR DESCRIPTION
This PR adds full support for using `HashSet`, `BTreeSet` and `BTreeMap` with the driver.
`HashSet` already had a `FromCqlVal` implementation, but it didn't have `Value`.

I rewrote `cql_collections_test` a bit to cover all these added types.

Fixes: #344

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
