### PR TITLE
examples: make tracing info human-readable

### DIFF
--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -46,7 +46,23 @@ async fn main() -> Result<()> {
 
     // Get tracing information for this query and print it
     let tracing_info: TracingInfo = session.get_tracing_info(&query_tracing_id).await?;
-    println!("Query tracing info: {:#?}\n", tracing_info);
+    println!(
+        "Tracing command {} performed by {:?}, which took {}µs total",
+        tracing_info.command.as_deref().unwrap_or("?"),
+        tracing_info.client,
+        tracing_info.duration.unwrap_or(0)
+    );
+    println!("│  UUID   │ Elapsed  │ Command");
+    println!("├─────────┼──────────┼──────────────────");
+    for event in tracing_info.events {
+        println!(
+            "│{} │ {:6}µs │ {}",
+            &event.event_id.to_string()[0..8],
+            event.source_elapsed.unwrap_or(0),
+            event.activity.as_deref().unwrap_or("?"),
+        );
+    }
+    println!("└─────────┴──────────┴──────────────────");
 
     // PREPARE
     // Now prepare a query - query to be prepared has tracing set so the prepare will be traced


### PR DESCRIPTION
Tracing info used to be printed in its debug form,
which isn't very human readable. The new format shows
the output as a table:

```
Tracing command QUERY performed by Some(127.0.0.1), which took 375ms total
│  UUID   │ Elapsed  │ Command
├─────────┼──────────┼──────────────────
│6caa2aa9 │      0ms │ Parsing a statement
│6caa2f0a │    112ms │ Processing a statement
│6caa30f2 │    161ms │ read_data: querying locally
│6caa3136 │    168ms │ Start querying token range (-inf, {minimum token, end}]
│6caa322c │    193ms │ Creating shard reader on shard: 0
│6caa32ce │    209ms │ Scanning cache for range (-inf, {minimum token, end}] and slice {(-inf, +inf)}
│6caa341b │    242ms │ Page stats: 0 partition(s), 0 static row(s) (0 live, 0 dead), 0 clustering row(s) (0 live, 0 dead) and 0 range tombstone(s)
│6caa3518 │    267ms │ Querying is done
│6caa3588 │    279ms │ read_data: querying locally
│6caa35a3 │    281ms │ Start querying token range ({minimum token, end}, +inf)
│6caa35e2 │    288ms │ Creating shard reader on shard: 0
│6caa3628 │    295ms │ Scanning cache for range ({minimum token, end}, +inf) and slice {(-inf, +inf)}
│6caa37d3 │    337ms │ Page stats: 1 partition(s), 0 static row(s) (0 live, 0 dead), 1 clustering row(s) (1 live, 0 dead) and 0 range tombstone(s)
│6caa3811 │    343ms │ Querying is done
│6caa38ce │    362ms │ Done processing - preparing a result
└─────────┴──────────┴──────────────────
```
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] <strike>I added relevant tests for new features and bug fixes.</strike>
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] <strike>I added appropriate `Fixes:` annotations to PR description.</strike>
