### PR TITLE
result: add support for custom CQL types

### DIFF
--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -41,6 +41,7 @@ pub struct TableSpec {
 
 #[derive(Debug, Clone)]
 enum ColumnType {
+    Custom(String),
     Ascii,
     Boolean,
     Blob,
@@ -355,6 +356,10 @@ fn deser_type(buf: &mut &[u8]) -> StdResult<ColumnType, ParseError> {
     use ColumnType::*;
     let id = types::read_short(buf)?;
     Ok(match id {
+        0x0000 => {
+            let type_str: String = types::read_string(buf)?.to_string();
+            Custom(type_str)
+        }
         0x0001 => Ascii,
         0x0002 => BigInt,
         0x0003 => Blob,
@@ -513,6 +518,12 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
     }
 
     Ok(match typ {
+        Custom(type_str) => {
+            return Err(ParseError::BadData(format!(
+                "Support for custom types is not yet implemented: {}",
+                type_str
+            )));
+        }
         Ascii => {
             if !buf.is_ascii() {
                 return Err(ParseError::BadData("String is not ascii!".to_string()));


### PR DESCRIPTION
CQL protocol allows sending custom types identified by their
string representation. One of the cases in which the trick is used
is when Cassandra returns duration columns to a CQLv4 client, which
is not supposed to know this type.

WIP: the actual implementation will be done once #363 is merged.

Refs #364

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ x I added appropriate `Fixes:` annotations to PR description.
