### PR TITLE
Allow SerialConsistency to be parsed from CQL errors

### DIFF
--- a/scylla/src/frame/response/error.rs
+++ b/scylla/src/frame/response/error.rs
@@ -82,6 +82,7 @@ impl From<Error> for QueryError {
 #[cfg(test)]
 mod tests {
     use super::Error;
+    use crate::frame::types::LegacyConsistency;
     use crate::statement::Consistency;
     use crate::transport::errors::{DbError, WriteType};
     use std::convert::TryInto;
@@ -137,7 +138,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::Unavailable {
-                consistency: Consistency::One,
+                consistency: LegacyConsistency::Regular(Consistency::One),
                 required: 2,
                 alive: 3,
             }
@@ -162,7 +163,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::WriteTimeout {
-                consistency: Consistency::Quorum,
+                consistency: LegacyConsistency::Regular(Consistency::Quorum),
                 received: -5, // Allow negative values when they don't make sense, it's better than crashing with ProtocolError
                 required: 100,
                 write_type: WriteType::Simple,
@@ -184,7 +185,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::ReadTimeout {
-                consistency: Consistency::Two,
+                consistency: LegacyConsistency::Regular(Consistency::Two),
                 received: 8,
                 required: 32,
                 data_present: false,
@@ -207,7 +208,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::ReadFailure {
-                consistency: Consistency::Three,
+                consistency: LegacyConsistency::Regular(Consistency::Three),
                 received: 4,
                 required: 5,
                 numfailures: 6,
@@ -275,7 +276,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::WriteFailure {
-                consistency: Consistency::Any,
+                consistency: LegacyConsistency::Regular(Consistency::Any),
                 received: 2,
                 required: 4,
                 numfailures: 8,

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -1,8 +1,8 @@
 //! This module contains various erros which can be returned by [`Session`](crate::Session)
 
 use crate::frame::frame_errors::{FrameError, ParseError};
+use crate::frame::types::LegacyConsistency;
 use crate::frame::value::SerializeValuesError;
-use crate::statement::Consistency;
 use std::io::ErrorKind;
 use std::sync::Arc;
 use thiserror::Error;
@@ -92,7 +92,7 @@ pub enum DbError {
     )]
     Unavailable {
         /// Consistency level of the query
-        consistency: Consistency,
+        consistency: LegacyConsistency,
         /// Number of nodes required to be alive to satisfy required consistency level
         required: i32,
         /// Found number of active nodes
@@ -116,7 +116,7 @@ pub enum DbError {
             (consistency: {consistency}, received: {received}, required: {required}, data_present: {data_present})")]
     ReadTimeout {
         /// Consistency level of the query
-        consistency: Consistency,
+        consistency: LegacyConsistency,
         /// Number of nodes that responded to the read request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -130,7 +130,7 @@ pub enum DbError {
             (consistency: {consistency}, received: {received}, required: {required}, write_type: {write_type})")]
     WriteTimeout {
         /// Consistency level of the query
-        consistency: Consistency,
+        consistency: LegacyConsistency,
         /// Number of nodes that responded to the write request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -147,7 +147,7 @@ pub enum DbError {
     )]
     ReadFailure {
         /// Consistency level of the query
-        consistency: Consistency,
+        consistency: LegacyConsistency,
         /// Number of nodes that responded to the read request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -166,7 +166,7 @@ pub enum DbError {
     )]
     WriteFailure {
         /// Consistency level of the query
-        consistency: Consistency,
+        consistency: LegacyConsistency,
         /// Number of ndoes that responded to the read request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -385,6 +385,7 @@ impl From<&str> for WriteType {
 #[cfg(test)]
 mod tests {
     use super::{DbError, QueryError, WriteType};
+    use crate::frame::types::LegacyConsistency;
     use crate::statement::Consistency;
 
     #[test]
@@ -416,7 +417,7 @@ mod tests {
     fn dberror_full_info() {
         // Test that DbError::Unavailable is displayed correctly
         let db_error = DbError::Unavailable {
-            consistency: Consistency::Three,
+            consistency: LegacyConsistency::Regular(Consistency::Three),
             required: 3,
             alive: 2,
         };

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc;
 use super::errors::QueryError;
 use crate::cql_to_rust::{FromRow, FromRowError};
 
+use crate::frame::types::LegacyConsistency;
 use crate::frame::{
     response::{
         result,
@@ -297,7 +298,7 @@ where
                 let query_info = QueryInfo {
                     error: &last_error,
                     is_idempotent: self.query_is_idempotent,
-                    consistency: self.query_consistency,
+                    consistency: LegacyConsistency::Regular(self.query_consistency),
                 };
 
                 match self.retry_session.decide_should_retry(query_info) {

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1,6 +1,7 @@
 //! `Session` is the main object used in the driver.\
 //! It manages all connections to the cluster and allows to perform queries.
 
+use crate::frame::types::LegacyConsistency;
 use bytes::Bytes;
 use futures::future::join_all;
 use futures::future::try_join_all;
@@ -1133,7 +1134,9 @@ impl Session {
                 let query_info = QueryInfo {
                     error: last_error.as_ref().unwrap(),
                     is_idempotent,
-                    consistency: consistency.unwrap_or(self.default_consistency),
+                    consistency: LegacyConsistency::Regular(
+                        consistency.unwrap_or(self.default_consistency),
+                    ),
                 };
 
                 match retry_session.decide_should_retry(query_info) {


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.

Commit bff127f introduced a regression while splitting consistency
enum into Consistency and SerialConsistency. Namely, our driver
lost the ability to parse SerialConsistency returned as an error
from CQL. The ability is now restored by wrapping the result
in an enum - LegacyConsistency, capable of representing both regular
and serial consistency values.

Fixes #369