### PR TITLE
Make Topology module public.

### DIFF
--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -8,7 +8,7 @@ pub mod retry_policy;
 pub mod session;
 pub mod session_builder;
 pub mod speculative_execution;
-mod topology;
+pub mod topology;
 pub use cluster::ClusterData;
 
 pub mod errors;

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 
 /// Allows to read current metadata from the cluster
-pub struct MetadataReader {
+pub(crate) struct MetadataReader {
     connection_config: ConnectionConfig,
     control_connection_address: SocketAddr,
     control_connection: NodeConnectionPool,


### PR DESCRIPTION
Schema metadata exposed in #349 was not public, so the structures defined there couldn't be used outside of the crate. Now all structures representing metadata are public, except for the `MetadataReader`.
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
