### PR TITLE
Repreprare evicted statements in batch queries.

### DIFF
--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -201,6 +201,12 @@ pub fn read_bytes<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], ParseError> {
     Ok(v)
 }
 
+pub fn read_short_bytes<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], ParseError> {
+    let len = read_short_length(buf)?;
+    let v = read_raw_bytes(len, buf)?;
+    Ok(v)
+}
+
 pub fn write_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), ParseError> {
     write_int_length(v.len(), buf)?;
     buf.put_slice(v);

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -142,7 +142,7 @@ impl CachingSession {
                 // In all other cases, just return the error
                 match err {
                     QueryError::DbError(db_error, message) => match db_error {
-                        DbError::Unprepared => {
+                        DbError::Unprepared { .. } => {
                             self.cache.remove(&query.contents);
 
                             let prepared = self.add_prepared_statement(query).await?;

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -449,7 +449,7 @@ impl Connection {
             .await?;
 
         if let Response::Error(err) = &query_response.response {
-            if err.error == DbError::Unprepared {
+            if let DbError::Unprepared { .. } = err.error {
                 // Repreparation of a statement is needed
                 let reprepare_query: Query = prepared_statement.get_statement().into();
                 let reprepared = self.prepare(&reprepare_query).await?;

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -539,19 +539,45 @@ impl Connection {
             timestamp: batch.get_timestamp(),
         };
 
-        let query_response = self
-            .send_request(&batch_frame, true, batch.config.tracing)
-            .await?;
+        loop {
+            let query_response = self
+                .send_request(&batch_frame, true, batch.config.tracing)
+                .await?;
 
-        match query_response.response {
-            Response::Error(err) => Err(err.into()),
-            Response::Result(_) => Ok(BatchResult {
-                warnings: query_response.warnings,
-                tracing_id: query_response.tracing_id,
-            }),
-            _ => Err(QueryError::ProtocolError(
-                "BATCH: Unexpected server response",
-            )),
+            return match query_response.response {
+                Response::Error(err) => match err.error {
+                    DbError::Unprepared { statement_id } => {
+                        let prepared_statement = batch.statements.iter().find_map(|s| match s {
+                            BatchStatement::PreparedStatement(s) if *s.get_id() == statement_id => {
+                                Some(s)
+                            }
+                            _ => None,
+                        });
+                        if let Some(p) = prepared_statement {
+                            let reprepare_query: Query = p.get_statement().into();
+                            let reprepared = self.prepare(&reprepare_query).await?;
+                            if reprepared.get_id() != p.get_id() {
+                                return Err(QueryError::ProtocolError(
+                                    "Prepared statement Id changed, md5 sum should stay the same",
+                                ));
+                            }
+                            continue;
+                        } else {
+                            return Err(QueryError::ProtocolError(
+                                "The server returned a prepared statement Id that did not exist in the batch",
+                            ));
+                        }
+                    }
+                    _ => Err(err.into()),
+                },
+                Response::Result(_) => Ok(BatchResult {
+                    warnings: query_response.warnings,
+                    tracing_id: query_response.tracing_id,
+                }),
+                _ => Err(QueryError::ProtocolError(
+                    "BATCH: Unexpected server response",
+                )),
+            };
         }
     }
 

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -3,6 +3,7 @@
 use crate::frame::frame_errors::{FrameError, ParseError};
 use crate::frame::types::LegacyConsistency;
 use crate::frame::value::SerializeValuesError;
+use bytes::Bytes;
 use std::io::ErrorKind;
 use std::sync::Arc;
 use thiserror::Error;
@@ -181,7 +182,10 @@ pub enum DbError {
     #[error(
         "Tried to execute a prepared statement that is not prepared. Driver shoud prepare it again"
     )]
-    Unprepared,
+    Unprepared {
+        /// Statement id of the requested prepared query
+        statement_id: Bytes,
+    },
 
     /// Internal server error. This indicates a server-side bug
     #[error("Internal server error. This indicates a server-side bug")]

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -214,6 +214,7 @@ mod tests {
     use crate::frame::types::LegacyConsistency;
     use crate::statement::Consistency;
     use crate::transport::errors::{BadQuery, DbError, QueryError, WriteType};
+    use bytes::Bytes;
     use std::io::ErrorKind;
     use std::sync::Arc;
 
@@ -271,7 +272,9 @@ mod tests {
                 numfailures: 1,
                 write_type: WriteType::BatchLog,
             },
-            DbError::Unprepared,
+            DbError::Unprepared {
+                statement_id: Bytes::from_static(b"deadbeef"),
+            },
             DbError::ProtocolError,
             DbError::Other(0x124816),
         ];


### PR DESCRIPTION
This PR does 2 things: 

1. Changes the `DbError::Unprepared` enum to include the statement ID that was found to not be prepared. 
2. In the `batch` execution function, if a prepared statement comes back as unprepared, it reprepares that query. This happens in a loop so that if multiple queries are not prepared, it will reprepare all of them. Theoretically you could end up in an infinite loop if for some reason the prepared query get immediately evicted before the query is executed again; however this is roughly the same behavior the [gocql](https://github.com/gocql/gocql) driver would have if that Scylla server acted maliciously. 

*WRT Tests*: I'm not sure how to write this test; as it would somehow involve evicted the prepared query in the Scylla database.

Fixes #342 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.


