### PR TITLE
Restore clippy tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
-      run: cargo clippy --verbose --examples -- -D warnings
+      run: cargo clippy --verbose --examples --tests -- -D warnings
     - name: Cargo check without features
       run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
     - name: Build

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1123,7 +1123,7 @@ async fn test_prepared_config() {
 
     let prepared_statement = session.prepare(query).await.unwrap();
 
-    assert_eq!(prepared_statement.get_is_idempotent(), true);
+    assert!(prepared_statement.get_is_idempotent());
     assert_eq!(prepared_statement.get_page_size(), Some(42));
 }
 


### PR DESCRIPTION
This miniseries restores clippy checks for our tests.
Tests were excluded from clippy checks a while ago due to
ridiculous warnings, but these seem to be gone now with a new
clippy version. Hence, let's restore the additional checks.

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
