### PR TITLE
Add support for named bind markers

### DIFF
--- a/docs/source/queries/values.md
+++ b/docs/source/queries/values.md
@@ -12,8 +12,9 @@ or a custom struct which derives from `ValueList`.
 A few examples:
 ```rust
 # extern crate scylla;
-# use scylla::{Session, ValueList};
+# use scylla::{Session, ValueList, frame::response::result::CqlValue};
 # use std::error::Error;
+# use std::collections::HashMap;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 // Empty slice means that there are no values to send
 session.query("INSERT INTO ks.tab (a) VALUES(1)", &[]).await?;
@@ -55,6 +56,15 @@ session.query("INSERT INTO ks.tab (a) VALUES(?)", (2_i32,)).await?;
 session
     .query("INSERT INTO ks.tab (a, b) VALUES(?, ?)", &(&2_i32, &"Some text"))
     .await?;
+
+// A map of named values can also be provided:
+let mut vals: HashMap<&str, CqlValue> = HashMap::new();
+vals.insert("avalue", CqlValue::Text("hello".to_string()));
+vals.insert("bvalue", CqlValue::Int(17));
+session
+    .query("INSERT INTO ks.tab (a, b) VALUES(:avalue, :bvalue)", &vals)
+    .await?;
+
 # Ok(())
 # }
 ```

--- a/scylla/src/frame/request/query.rs
+++ b/scylla/src/frame/request/query.rs
@@ -15,7 +15,7 @@ const FLAG_PAGE_SIZE: u8 = 0x04;
 const FLAG_WITH_PAGING_STATE: u8 = 0x08;
 const FLAG_WITH_SERIAL_CONSISTENCY: u8 = 0x10;
 const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
-// const FLAG_WITH_NAMES_FOR_VALUES: u8 = 0x40;
+const FLAG_WITH_NAMES_FOR_VALUES: u8 = 0x40;
 
 pub struct Query<'a> {
     pub contents: &'a str,
@@ -77,6 +77,10 @@ impl QueryParameters<'_> {
 
         if self.timestamp.is_some() {
             flags |= FLAG_WITH_DEFAULT_TIMESTAMP;
+        }
+
+        if self.values.has_names() {
+            flags |= FLAG_WITH_NAMES_FOR_VALUES;
         }
 
         buf.put_u8(flags);

--- a/scylla/src/frame/types.rs
+++ b/scylla/src/frame/types.rs
@@ -161,7 +161,7 @@ pub fn write_short(v: i16, buf: &mut impl BufMut) {
     buf.put_i16(v);
 }
 
-fn read_short_length(buf: &mut &[u8]) -> Result<usize, ParseError> {
+pub(crate) fn read_short_length(buf: &mut &[u8]) -> Result<usize, ParseError> {
     let v = read_short(buf)?;
     let v: usize = v.try_into()?;
     Ok(v)

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -1,3 +1,4 @@
+use crate::frame::types;
 use bigdecimal::BigDecimal;
 use bytes::BufMut;
 use chrono::prelude::*;
@@ -56,14 +57,19 @@ pub struct Time(pub Duration);
 pub struct SerializedValues {
     serialized_values: Vec<u8>,
     values_num: i16,
+    contains_names: bool,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SerializeValuesError {
     #[error("Too many values to add, max 32 767 values can be sent in a request")]
     TooManyValues,
+    #[error("Mixing named and not named values is not allowed")]
+    MixingNamedAndNotNamedValues,
     #[error(transparent)]
     ValueTooBig(#[from] ValueTooBig),
+    #[error("Parsing serialized values failed")]
+    ParseError,
 }
 
 pub type SerializedResult<'a> = Result<Cow<'a, SerializedValues>, SerializeValuesError>;
@@ -104,6 +110,7 @@ impl SerializedValues {
         SerializedValues {
             serialized_values: Vec::new(),
             values_num: 0,
+            contains_names: false,
         }
     }
 
@@ -111,7 +118,12 @@ impl SerializedValues {
         SerializedValues {
             serialized_values: Vec::with_capacity(capacity),
             values_num: 0,
+            contains_names: false,
         }
+    }
+
+    pub fn has_names(&self) -> bool {
+        self.contains_names
     }
 
     /// A const empty instance, useful for taking references
@@ -119,6 +131,9 @@ impl SerializedValues {
 
     /// Serializes value and appends it to the list
     pub fn add_value(&mut self, val: &impl Value) -> Result<(), SerializeValuesError> {
+        if self.contains_names {
+            return Err(SerializeValuesError::MixingNamedAndNotNamedValues);
+        }
         if self.values_num == i16::max_value() {
             return Err(SerializeValuesError::TooManyValues);
         }
@@ -134,10 +149,38 @@ impl SerializedValues {
         Ok(())
     }
 
+    pub fn add_named_value(
+        &mut self,
+        name: &str,
+        val: &impl Value,
+    ) -> Result<(), SerializeValuesError> {
+        if self.values_num > 0 && !self.contains_names {
+            return Err(SerializeValuesError::MixingNamedAndNotNamedValues);
+        }
+        self.contains_names = true;
+        if self.values_num == i16::max_value() {
+            return Err(SerializeValuesError::TooManyValues);
+        }
+
+        let len_before_serialize: usize = self.serialized_values.len();
+
+        types::write_string(name, &mut self.serialized_values)
+            .map_err(|_| SerializeValuesError::ParseError)?;
+
+        if let Err(e) = val.serialize(&mut self.serialized_values) {
+            self.serialized_values.resize(len_before_serialize, 0);
+            return Err(SerializeValuesError::from(e));
+        }
+
+        self.values_num += 1;
+        Ok(())
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = Option<&[u8]>> {
         SerializedValuesIterator {
             serialized_values: &self.serialized_values,
             next_offset: 0,
+            contains_names: self.contains_names,
         }
     }
 
@@ -159,13 +202,23 @@ impl SerializedValues {
 pub struct SerializedValuesIterator<'a> {
     serialized_values: &'a [u8],
     next_offset: usize,
+    contains_names: bool,
 }
 
 impl<'a> Iterator for SerializedValuesIterator<'a> {
     type Item = Option<&'a [u8]>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Read next value's 4 byte size, return it, advance
+        // Read next value's 4 byte size, return it, advance.
+        // In case of named values, skip names
+        if self.contains_names {
+            if self.next_offset + 2 > self.serialized_values.len() {
+                return None;
+            }
+            let mut len_bytes = &self.serialized_values[self.next_offset..(self.next_offset + 2)];
+            let next_name_len: usize = types::read_short_length(&mut len_bytes).ok()?;
+            self.next_offset += 2 + next_name_len;
+        }
 
         if self.next_offset + 4 > self.serialized_values.len() {
             // Reached the end - nothing more to read
@@ -642,6 +695,27 @@ impl<T: Value> ValueList for Vec<T> {
         Ok(Cow::Owned(result))
     }
 }
+
+// Implement ValueList for maps, which serializes named values
+macro_rules! impl_value_list_for_map {
+    ($map_type:ident, $key_type:ty) => {
+        impl<T: Value> ValueList for $map_type<$key_type, T> {
+            fn serialized(&self) -> SerializedResult<'_> {
+                let mut result = SerializedValues::with_capacity(self.len());
+                for (key, val) in self {
+                    result.add_named_value(key, val)?;
+                }
+
+                Ok(Cow::Owned(result))
+            }
+        }
+    };
+}
+
+impl_value_list_for_map!(HashMap, String);
+impl_value_list_for_map!(HashMap, &str);
+impl_value_list_for_map!(BTreeMap, String);
+impl_value_list_for_map!(BTreeMap, &str);
 
 // Implement ValueList for tuples of Values of size up to 16
 


### PR DESCRIPTION
This commit adds support for CQL named bind markers,
i.e. markers in a form of ":name_here" instead of customary "?".
Named markers are not recommended due to the fact that they induce
more overhead than unnamed ones, but it's still part of the CQL
protocol, so we should support them.

Fixes #360