### PR TITLE
Add feature to use lz4_flex crate for compression

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 [features]
 defaults = []
 ssl = ["tokio-openssl", "openssl"]
-safe_lz4 = ["lz4_flex"]
 
 [dependencies]
 scylla-macros = { version = "0.1.1", path = "../scylla-macros"}
@@ -21,7 +20,6 @@ bytes = "1.0.1"
 futures = "0.3.6"
 histogram = "0.6.9"
 num_enum = "0.5"
-compress = "0.2.1"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = "0.8.1"
@@ -38,7 +36,7 @@ arc-swap = "1.3.0"
 dashmap = "4.0.2"
 strum = "0.23"
 strum_macros = "0.23"
-lz4_flex = { version = "0.9.2", optional = true }
+lz4_flex = { version = "0.9.2" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 [features]
 defaults = []
 ssl = ["tokio-openssl", "openssl"]
+safe_lz4 = ["lz4_flex"]
 
 [dependencies]
 scylla-macros = { version = "0.1.1", path = "../scylla-macros"}
@@ -37,6 +38,7 @@ arc-swap = "1.3.0"
 dashmap = "4.0.2"
 strum = "0.23"
 strum_macros = "0.23"
+lz4_flex = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/frame/frame_errors.rs
+++ b/scylla/src/frame/frame_errors.rs
@@ -9,6 +9,7 @@ pub enum FrameError {
     Parse(#[from] ParseError),
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,
+    #[cfg(not(feature = "safe_lz4"))]
     #[error("L4Z body decompression failed")]
     Lz4BodyDecompression,
     #[error("Received frame marked as coming from a client")]
@@ -25,6 +26,12 @@ pub enum FrameError {
     StdIoError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]
     TryFromPrimitiveError(#[from] num_enum::TryFromPrimitiveError<response::ResponseOpcode>),
+    #[cfg(feature = "safe_lz4")]
+    #[error("Error compressing lz4 data {0}")]
+    Lz4CompressError(#[from] lz4_flex::block::CompressError),
+    #[cfg(feature = "safe_lz4")]
+    #[error("Error decompressing lz4 data {0}")]
+    Lz4DecompressError(#[from] lz4_flex::block::DecompressError),
 }
 
 #[derive(Error, Debug)]

--- a/scylla/src/frame/frame_errors.rs
+++ b/scylla/src/frame/frame_errors.rs
@@ -9,9 +9,6 @@ pub enum FrameError {
     Parse(#[from] ParseError),
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,
-    #[cfg(not(feature = "safe_lz4"))]
-    #[error("L4Z body decompression failed")]
-    Lz4BodyDecompression,
     #[error("Received frame marked as coming from a client")]
     FrameFromClient,
     #[error("Received a frame from version {0}, but only 4 is supported")]
@@ -26,10 +23,8 @@ pub enum FrameError {
     StdIoError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]
     TryFromPrimitiveError(#[from] num_enum::TryFromPrimitiveError<response::ResponseOpcode>),
-    #[cfg(feature = "safe_lz4")]
     #[error("Error compressing lz4 data {0}")]
     Lz4CompressError(#[from] lz4_flex::block::CompressError),
-    #[cfg(feature = "safe_lz4")]
     #[error("Error decompressing lz4 data {0}")]
     Lz4DecompressError(#[from] lz4_flex::block::DecompressError),
 }

--- a/scylla/src/frame/mod.rs
+++ b/scylla/src/frame/mod.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 
 use std::convert::TryFrom;
 
+#[cfg(not(feature = "safe_lz4"))]
 use compress::lz4;
 use request::Request;
 use response::ResponseOpcode;
@@ -205,12 +206,22 @@ pub fn compress_append(
     out: &mut Vec<u8>,
 ) -> Result<(), FrameError> {
     match compression {
+        #[cfg(not(feature = "safe_lz4"))]
         Compression::Lz4 => {
             let uncomp_len = uncomp_body.len() as u32;
             let mut tmp =
                 Vec::with_capacity(lz4::compression_bound(uncomp_len).unwrap_or(0) as usize);
             lz4::encode_block(uncomp_body, &mut tmp);
 
+            out.reserve_exact(std::mem::size_of::<u32>() + tmp.len());
+            out.put_u32(uncomp_len);
+            out.extend_from_slice(&tmp[..]);
+            Ok(())
+        }
+        #[cfg(feature = "safe_lz4")]
+        Compression::Lz4 => {
+            let uncomp_len = uncomp_body.len() as u32;
+            let tmp = lz4_flex::compress(uncomp_body);
             out.reserve_exact(std::mem::size_of::<u32>() + tmp.len());
             out.put_u32(uncomp_len);
             out.extend_from_slice(&tmp[..]);
@@ -230,6 +241,7 @@ pub fn compress_append(
 
 pub fn decompress(mut comp_body: &[u8], compression: Compression) -> Result<Vec<u8>, FrameError> {
     match compression {
+        #[cfg(not(feature = "safe_lz4"))]
         Compression::Lz4 => {
             let uncomp_len = comp_body.get_u32() as usize;
             let mut uncomp_body = Vec::with_capacity(uncomp_len);
@@ -242,8 +254,44 @@ pub fn decompress(mut comp_body: &[u8], compression: Compression) -> Result<Vec<
                 Err(FrameError::Lz4BodyDecompression)
             }
         }
+        #[cfg(feature = "safe_lz4")]
+        Compression::Lz4 => {
+            let uncomp_len = comp_body.get_u32() as usize;
+            let uncomp_body = lz4_flex::decompress(comp_body, uncomp_len)?;
+            Ok(uncomp_body)
+        }
         Compression::Snappy => snap::raw::Decoder::new()
             .decompress_vec(comp_body)
             .map_err(|_| FrameError::FrameDecompression),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_lz4_compress() {
+        let mut out = Vec::from(&b"Hello"[..]);
+        let uncomp_body = b", World!";
+        let compression = Compression::Lz4;
+        let expect = vec![
+            72, 101, 108, 108, 111, 0, 0, 0, 8, 128, 44, 32, 87, 111, 114, 108, 100, 33,
+        ];
+
+        compress_append(uncomp_body, compression, &mut out).unwrap();
+        assert_eq!(expect, out);
+    }
+
+    #[test]
+    fn test_lz4_decompress() {
+        let mut comp_body = Vec::new();
+        let uncomp_body = b"Hello, World!";
+        let compression = Compression::Lz4;
+        compress_append(uncomp_body, compression, &mut comp_body).unwrap();
+        let result = decompress(&comp_body[..], compression).unwrap();
+        let expect = vec![72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
+        assert_eq!(&expect[..], &result[..]);
+        assert_eq!(&uncomp_body[..], &result[..]);
     }
 }


### PR DESCRIPTION
This crate does not use unsafe code by default,
additionally it fixes some edge cases where data
could not be compressed by the compress crate.

Fixes: #381

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
