### PR TITLE
Allow multithreaded tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,5 +31,4 @@ jobs:
     - name: Build
       run: cargo build --verbose --examples
     - name: Run tests
-      # test threads must be one because else database tests will run in parallel and will result in flaky tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose

--- a/scylla/src/transport/authenticate_test.rs
+++ b/scylla/src/transport/authenticate_test.rs
@@ -11,12 +11,11 @@ async fn authenticate_superuser() {
         .build()
         .await
         .unwrap();
+    let ks = crate::transport::session_test::unique_name();
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
-    session
-        .query("DROP TABLE IF EXISTS ks.t;", &[])
-        .await
-        .unwrap();
+    session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 1}}", ks), &[]).await.unwrap();
+    session.use_keyspace(ks, false).await.unwrap();
+    session.query("DROP TABLE IF EXISTS t;", &[]).await.unwrap();
 
     println!("Ok.");
 }

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -17,7 +17,7 @@ pub mod topology;
 #[cfg(test)]
 mod authenticate_test;
 #[cfg(test)]
-mod session_test;
+pub(crate) mod session_test;
 
 pub use cluster::ClusterData;
 pub use node::Node;

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -44,36 +44,6 @@ impl SessionBuilder {
         }
     }
 
-    #[cfg(test)]
-    pub async fn new_for_test() -> Session {
-        let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
-        let session = SessionBuilder::new()
-            .known_node(uri)
-            .build()
-            .await
-            .expect("Could not create session");
-
-        session
-            .query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[])
-            .await
-            .expect("Could not create keyspace");
-
-        session
-            .query(
-                "CREATE TABLE IF NOT EXISTS ks.test_table (a int primary key, b int)",
-                &[],
-            )
-            .await
-            .expect("Could not create table");
-
-        session
-            .use_keyspace("ks", false)
-            .await
-            .expect("Could not set keyspace");
-
-        session
-    }
-
     /// Add a known node with a hostname
     /// # Examples
     /// ```


### PR DESCRIPTION
By providing unique keyspace names, the test suite is now capable
of running with multiple threads. In other words, one no longer
has to pass `-- --test-threads 1` for the tests to pass.

This series also removes the now unneeded `-- --test-threads 1` from our CI workflow.

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
