### PR TITLE
frame: make StdIoError transparent

### DIFF
--- a/scylla/src/frame/frame_errors.rs
+++ b/scylla/src/frame/frame_errors.rs
@@ -19,7 +19,7 @@ pub enum FrameError {
     FrameDecompression,
     #[error("Frame compression failed.")]
     FrameCompression,
-    #[error("std io error encountered while processing")]
+    #[error(transparent)]
     StdIoError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]
     TryFromPrimitiveError(#[from] num_enum::TryFromPrimitiveError<response::ResponseOpcode>),


### PR DESCRIPTION
Shadowing the actual error message with a static string is harmful,
let's just show the full original error instead.

Fixes #392

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] <strike>I added relevant tests for new features and bug fixes.</strike>
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
