### PR TITLE
Make control connections more persistent

### DIFF
--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -190,15 +190,9 @@ impl MetadataReader {
         // shuffle known_peers to iterate through them in random order later
         self.known_peers.shuffle(&mut thread_rng());
 
-        let address_of_failed_control_connection = self.control_connection_address;
-        let filtered_known_peers = self
-            .known_peers
-            .iter()
-            .filter(|&peer| peer != &address_of_failed_control_connection);
-
         // if fetching metadata on current control connection failed,
         // try to fetch metadata from other known peer
-        for peer in filtered_known_peers {
+        for peer in self.known_peers.iter().cycle() {
             let err = match result {
                 Ok(_) => break,
                 Err(err) => err,

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -189,6 +189,14 @@ impl MetadataReader {
 
         // shuffle known_peers to iterate through them in random order later
         self.known_peers.shuffle(&mut thread_rng());
+        debug!(
+            "Known peers: {}",
+            self.known_peers
+                .iter()
+                .map(std::net::SocketAddr::to_string)
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
 
         // if fetching metadata on current control connection failed,
         // try to fetch metadata from other known peer
@@ -210,6 +218,10 @@ impl MetadataReader {
                 self.connection_config.clone(),
             );
 
+            debug!(
+                "Retrying to establish the control connection on {}",
+                self.control_connection_address
+            );
             result = self.fetch_metadata().await;
         }
 


### PR DESCRIPTION
topology: make control connection more persistent

After this series, trying to read topology metadata does
not ever end on its own - instead, the function retries
in an infinite loop. It's the caller's responsibility to
eventually stop waiting and abort - right now it is done
after 60 seconds (our hardcoded refresh period), but we
should also consider making it configurable.

Fixes #398
Tested manually by providing bogus known addresses and observing logs.

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
