### PR TITLE
Fix spelling typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Although optimized for ScyllaDB, the driver is also compatible with [Apache Cass
 **Note: this driver is officially supported but currently available in beta. Bug reports and pull requests are welcome!**
 
 ## Getting Started
-The [documentation book](https://cvybhu.github.io/scyllabook/index.html) is a good place to get started. Another useful resource is the Rust and Scylla [lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla Univeristy. 
+The [documentation book](https://cvybhu.github.io/scyllabook/index.html) is a good place to get started. Another useful resource is the Rust and Scylla [lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University.
 
 ## Examples
 ```rust

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 
-After succesfully connecting to some specified node the driver will fetch topology information about
+After successfully connecting to some specified node the driver will fetch topology information about
 other nodes in this cluster and connect to them as well.
 
 ```eval_rst

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -22,8 +22,8 @@ let metrics = session.get_metrics();
 
 println!("Queries requested: {}", metrics.get_queries_num());
 println!("Iter queries requested: {}", metrics.get_queries_iter_num());
-println!("Errors occured: {}", metrics.get_errors_num());
-println!("Iter errors occured: {}", metrics.get_errors_iter_num());
+println!("Errors occurred: {}", metrics.get_errors_num());
+println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
 println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
 println!(
     "99.9 latency percentile: {}",

--- a/docs/source/queries/prepared.md
+++ b/docs/source/queries/prepared.md
@@ -35,7 +35,7 @@ session.execute(&prepared, (to_insert,)).await?;
 
 ### `Session::prepare`
 `Session::prepare` takes query text and prepares the query on all nodes and shards.
-If at least one succeds returns success.
+If at least one succeeds returns success.
 
 ### `Session::execute`
 `Session::execute` takes a prepared query and bound values and runs the query.

--- a/docs/source/queries/queries.md
+++ b/docs/source/queries/queries.md
@@ -4,7 +4,7 @@ This driver supports all query types available in Scylla:
 * [Simple queries](simple.md)
     * Easy to use
     * Poor performance
-    * Primitve load balancing
+    * Primitive load balancing
 * [Prepared queries](prepared.md)
     * Need to be prepared before use
     * Fast
@@ -16,7 +16,7 @@ This driver supports all query types available in Scylla:
     * Allows to read result in multiple pages when it doesn't fit in a single response
     * Can be prepared for better performance and load balancing
 
-Additionaly there is special functionality to enable `USE KEYSPACE` queries:
+Additionally there is special functionality to enable `USE KEYSPACE` queries:
 [USE keyspace](usekeyspace.md)
 
 Queries are fully asynchronous - you can run as many of them in parallel as you wish.

--- a/docs/source/queries/schema_agreement.md
+++ b/docs/source/queries/schema_agreement.md
@@ -32,7 +32,7 @@ session.await_schema_agreement().await?;
 ```
 
 ### Awaiting with timeout
-We can also set timeout in miliseconds with `Session::await_timed_schema_agreement`.
+We can also set timeout in milliseconds with `Session::await_timed_schema_agreement`.
 It takes one argument, an `std::time::Duration` value that tells how long our driver should await for schema agreement. If the timeout is met the return value is `false` otherwise it is `true`.
 
 ```rust
@@ -51,7 +51,7 @@ if session.await_timed_schema_agreement(Duration::from_secs(5)).await? { // wait
 ```
 
 ### Checking for schema interval
-If schema is not agreed driver sleeps for a duration before checking it again. Default value is 200 miliseconds but it can be changed with `SessionBuilder::schema_agreement_interval`.
+If schema is not agreed driver sleeps for a duration before checking it again. Default value is 200 milliseconds but it can be changed with `SessionBuilder::schema_agreement_interval`.
 
 
 ```rust

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -96,8 +96,8 @@ See [Query result](result.md) for more information about handling query results
 
 ### Performance
 Simple queries should not be used in places where performance matters.\
-If perfomance matters use a [Prepared query](prepared.md) instead.
+If performance matters use a [Prepared query](prepared.md) instead.
 
 With simple query the database has to parse query text each time it's executed, which worsens performance.\
 
-Additionaly token and shard aware load balancing does not work with simple queries. They are sent to random nodes.
+Additionally token and shard aware load balancing does not work with simple queries. They are sent to random nodes.

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -81,8 +81,8 @@ async fn main() -> Result<()> {
     let metrics = session.get_metrics();
     println!("Queries requested: {}", metrics.get_queries_num());
     println!("Iter queries requested: {}", metrics.get_queries_iter_num());
-    println!("Errors occured: {}", metrics.get_errors_num());
-    println!("Iter errors occured: {}", metrics.get_errors_iter_num());
+    println!("Errors occurred: {}", metrics.get_errors_num());
+    println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
     println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
     println!(
         "99.9 latency percentile: {}",

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -27,7 +27,7 @@ use openssl::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
 // Set verification mode
 // if SslVerifyMode::PEER with self-signed certificate you have to
 // use set_ca_file method with path to your ca.crt file as an argument
-// if SslVerifyMode::NONE you don't need to use any aditional methods
+// if SslVerifyMode::NONE you don't need to use any additional methods
 //
 // Build it and add to scylla-rust-driver's SessionBuilder
 

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -719,7 +719,7 @@ impl_value_list_for_map!(BTreeMap, &str);
 
 // Implement ValueList for tuples of Values of size up to 16
 
-// Here is an example implemetation for (T0, )
+// Here is an example implementation for (T0, )
 // Further variants are done using a macro
 impl<T0: Value> ValueList for (T0,) {
     fn serialized(&self) -> SerializedResult<'_> {
@@ -824,7 +824,7 @@ impl<T: ValueList> BatchValues for Vec<T> {
     }
 }
 
-// Here is an example implemetation for (T0, )
+// Here is an example implementation for (T0, )
 // Further variants are done using a macro
 impl<T0: ValueList> BatchValues for (T0,) {
     fn len(&self) -> usize {

--- a/scylla/src/frame/value_tests.rs
+++ b/scylla/src/frame/value_tests.rs
@@ -206,7 +206,7 @@ fn serialized_values() {
         );
     }
 
-    // Add a value thats too big, recover gracefully
+    // Add a value that's too big, recover gracefully
     struct TooBigValue;
     impl Value for TooBigValue {
         fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -35,7 +35,7 @@
 //! All configuration options for a `Session` can be specified while building.
 //!
 //! ### Making queries
-//! After succesfully connecting to the cluster we can make queries.\
+//! After successfully connecting to the cluster we can make queries.\
 //! The driver supports multiple query types:
 //! * [Simple](crate::Session::query)
 //! * [Simple paged](crate::Session::query_iter)

--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -93,7 +93,7 @@ impl Sharder {
 
     /// Returns iterator over source ports `p` such that `shard == shard_of_source_port(p)`.
     /// Starts at a random port and goes forward by `nr_shards`. After reaching maximum wraps back around.
-    /// Stops once all possibile ports have been returned
+    /// Stops once all possible ports have been returned
     pub fn iter_source_ports_for_shard(&self, shard: Shard) -> impl Iterator<Item = u16> {
         assert!(shard < self.nr_shards.get() as u32);
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -918,7 +918,7 @@ impl Connection {
                         params.stream
                     );
                     return Err(QueryError::ProtocolError(
-                        "Received reponse with unexpected StreamId",
+                        "Received response with unexpected StreamId",
                     ));
                 }
                 Orphaned => {
@@ -1391,7 +1391,7 @@ impl VerifiedKeyspaceName {
         self.name.as_str()
     }
 
-    // "Keyspace names can have up to 48 alpha-numeric characters and contain underscores;
+    // "Keyspace names can have up to 48 alphanumeric characters and contain underscores;
     // only letters and numbers are supported as the first character."
     // https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/cqlCreateKeyspace.html
     // Despite that cassandra accepts underscore as first character so we do too
@@ -1411,7 +1411,7 @@ impl VerifiedKeyspaceName {
             ));
         }
 
-        // Verify all chars are alpha-numeric or underscore
+        // Verify all chars are alphanumeric or underscore
         for character in keyspace_name.chars() {
             match character {
                 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' => {}

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -1,4 +1,4 @@
-//! This module contains various erros which can be returned by [`Session`](crate::Session)
+//! This module contains various errors which can be returned by [`Session`](crate::Session)
 
 use crate::frame::frame_errors::{FrameError, ParseError};
 use crate::frame::types::LegacyConsistency;
@@ -8,7 +8,7 @@ use std::io::ErrorKind;
 use std::sync::Arc;
 use thiserror::Error;
 
-/// Error that occured during query execution
+/// Error that occurred during query execution
 #[derive(Error, Debug, Clone)]
 pub enum QueryError {
     /// Database sent a response containing some error with a message
@@ -19,7 +19,7 @@ pub enum QueryError {
     #[error(transparent)]
     BadQuery(#[from] BadQuery),
 
-    /// Input/Output error has occured, connection broken etc.
+    /// Input/Output error has occurred, connection broken etc.
     #[error("IO Error: {0}")]
     IoError(Arc<std::io::Error>),
 
@@ -31,7 +31,7 @@ pub enum QueryError {
     #[error("Invalid message: {0}")]
     InvalidMessage(String),
 
-    /// Timeout error has occured, function didn't complete in time.
+    /// Timeout error has occurred, function didn't complete in time.
     #[error("Timeout Error")]
     TimeoutError,
 
@@ -184,9 +184,9 @@ pub enum DbError {
         write_type: WriteType,
     },
 
-    /// Tried to execute a prepared statement that is not prepared. Driver shoud prepare it again
+    /// Tried to execute a prepared statement that is not prepared. Driver should prepare it again
     #[error(
-        "Tried to execute a prepared statement that is not prepared. Driver shoud prepare it again"
+        "Tried to execute a prepared statement that is not prepared. Driver should prepare it again"
     )]
     Unprepared {
         /// Statement id of the requested prepared query
@@ -211,20 +211,20 @@ pub enum DbError {
 pub enum WriteType {
     /// Non-batched non-counter write
     Simple,
-    /// Logged batch write. If this type is received, it means the batch log has been succesfully written
+    /// Logged batch write. If this type is received, it means the batch log has been successfully written
     /// (otherwise BatchLog type would be present)
     Batch,
     /// Unlogged batch. No batch log write has been attempted.
     UnloggedBatch,
     /// Counter write (batched or not)
     Counter,
-    /// Timeout occured during the write to the batch log when a logged batch was requested
+    /// Timeout occurred during the write to the batch log when a logged batch was requested
     BatchLog,
-    /// Timeout occured during Compare And Set write/update
+    /// Timeout occurred during Compare And Set write/update
     Cas,
     /// Write involves VIEW update and failure to acquire local view(MV) lock for key within timeout
     View,
-    /// Timeout occured  when a cdc_total_space_in_mb is exceeded when doing a write to data tracked by cdc
+    /// Timeout occurred  when a cdc_total_space_in_mb is exceeded when doing a write to data tracked by cdc
     Cdc,
     /// Other type not specified in the specification
     Other(String),
@@ -242,8 +242,8 @@ pub enum BadQuery {
     #[error("Length of provided values ({0}) must be equal to number of batch statements ({1})")]
     ValueLenMismatch(usize, usize),
 
-    /// Serialized values are too long to compute parition key
-    #[error("Serialized values are too long to compute parition key! Length: {0}, Max allowed length: {1}")]
+    /// Serialized values are too long to compute partition key
+    #[error("Serialized values are too long to compute partition key! Length: {0}, Max allowed length: {1}")]
     ValuesTooLongForKey(usize, usize),
 
     /// Passed invalid keyspace name to use
@@ -251,7 +251,7 @@ pub enum BadQuery {
     BadKeyspaceName(#[from] BadKeyspaceName),
 }
 
-/// Error that occured during session creation
+/// Error that occurred during session creation
 #[derive(Error, Debug, Clone)]
 pub enum NewSessionError {
     /// Failed to resolve hostname passed in Session creation
@@ -271,7 +271,7 @@ pub enum NewSessionError {
     #[error(transparent)]
     BadQuery(#[from] BadQuery),
 
-    /// Input/Output error has occured, connection broken etc.
+    /// Input/Output error has occurred, connection broken etc.
     #[error("IO Error: {0}")]
     IoError(Arc<std::io::Error>),
 
@@ -283,7 +283,7 @@ pub enum NewSessionError {
     #[error("Invalid message: {0}")]
     InvalidMessage(String),
 
-    /// Timeout error has occured, couldn't connect to node in time.
+    /// Timeout error has occurred, couldn't connect to node in time.
     #[error("Timeout Error")]
     TimeoutError,
 
@@ -305,8 +305,8 @@ pub enum BadKeyspaceName {
     #[error("Keyspace name too long, must be up to 48 characters, found {1} characters. Bad keyspace name: '{0}'")]
     TooLong(String, usize),
 
-    /// Illegal character - only alpha-numeric and underscores allowed.
-    #[error("Illegal character found: '{1}', only alpha-numeric and underscores allowed. Bad keyspace name: '{0}'")]
+    /// Illegal character - only alphanumeric and underscores allowed.
+    #[error("Illegal character found: '{1}', only alphanumeric and underscores allowed. Bad keyspace name: '{0}'")]
     IllegalCharacter(String, char),
 }
 

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -352,7 +352,7 @@ where
                         return Ok(());
                     }
 
-                    // Query succeded, reset retry policy for future retries
+                    // Query succeeded, reset retry policy for future retries
                     self.retry_session.reset();
                 }
                 Response::Error(err) => {

--- a/scylla/src/transport/metrics.rs
+++ b/scylla/src/transport/metrics.rs
@@ -50,7 +50,7 @@ impl Metrics {
         }
     }
 
-    /// Increments counter for errors that occured in nonpaged queries.
+    /// Increments counter for errors that occurred in nonpaged queries.
     pub(crate) fn inc_failed_nonpaged_queries(&self) {
         self.errors_num.fetch_add(1, ORDER_TYPE);
     }
@@ -60,7 +60,7 @@ impl Metrics {
         self.queries_num.fetch_add(1, ORDER_TYPE);
     }
 
-    /// Increments counter for errors that occured in paged queries.
+    /// Increments counter for errors that occurred in paged queries.
     pub(crate) fn inc_failed_paged_queries(&self) {
         self.errors_iter_num.fetch_add(1, ORDER_TYPE);
     }
@@ -103,7 +103,7 @@ impl Metrics {
         Ok(histogram_unlocked.percentile(percentile)?)
     }
 
-    /// Returns counter for errors occured in nonpaged queries
+    /// Returns counter for errors occurred in nonpaged queries
     pub fn get_errors_num(&self) -> u64 {
         self.errors_num.load(ORDER_TYPE)
     }
@@ -113,7 +113,7 @@ impl Metrics {
         self.queries_num.load(ORDER_TYPE)
     }
 
-    /// Returns counter for errors occured in paged queries
+    /// Returns counter for errors occurred in paged queries
     pub fn get_errors_iter_num(&self) -> u64 {
         self.errors_iter_num.load(ORDER_TYPE)
     }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -564,7 +564,7 @@ impl Session {
         let handles = connections.iter().map(|c| c.prepare(&query));
         let mut results = join_all(handles).await;
 
-        // If at least one prepare was succesfull prepare returns Ok
+        // If at least one prepare was successful prepare returns Ok
 
         // Find first result that is Ok, or Err if all failed
         let mut first_ok: Option<Result<PreparedStatement, QueryError>> = None;
@@ -823,7 +823,7 @@ impl Session {
     /// # Arguments
     ///
     /// * `keyspace_name` - keyspace name to use,
-    /// keyspace names can have up to 48 alpha-numeric characters and contain underscores
+    /// keyspace names can have up to 48 alphanumeric characters and contain underscores
     /// * `case_sensitive` - if set to true the generated query will put keyspace name in quotes
     /// # Example
     /// ```rust
@@ -914,7 +914,7 @@ impl Session {
 
         Err(QueryError::ProtocolError(
             "All tracing queries returned an empty result, \
-            maybe information didnt reach this node yet. \
+            maybe information didn't reach this node yet. \
             Consider using get_tracing_info_custom with \
             bigger interval in GetTracingConfig",
         ))

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -67,7 +67,7 @@ impl SessionBuilder {
     }
 
     /// Specify a default consistency to be used for queries.
-    /// It's possible to override it by explictly setting a consistency on the chosen query.
+    /// It's possible to override it by explicitly setting a consistency on the chosen query.
     pub fn default_consistency(mut self, consistency: Consistency) -> Self {
         self.config.default_consistency = consistency;
         self
@@ -218,7 +218,7 @@ impl SessionBuilder {
     }
 
     /// Set the delay for schema agreement check. How often driver should ask if schema is in agreement
-    /// The default is 200 miliseconds.
+    /// The default is 200 milliseconds.
     ///
     /// # Example
     /// ```

--- a/test/tls/scylla.yaml
+++ b/test/tls/scylla.yaml
@@ -27,7 +27,7 @@ num_tokens: 256
 
 # Directory where Scylla should store all its files, which are commitlog,
 # data, hints, view_hints and saved_caches subdirectories. All of these
-# subs can be overriden by the respective options below.
+# subs can be overridden by the respective options below.
 # If unset, the value defaults to /var/lib/scylla
 # workdir: /var/lib/scylla
 
@@ -373,7 +373,7 @@ commitlog_total_space_in_mb: -1
 # Increase if your rows are large, or if you have a very large
 # number of rows per partition.  The competing goals are these:
 #   1) a smaller granularity means more index entries are generated
-#      and looking up rows withing the partition by collation column
+#      and looking up rows within the partition by collation column
 #      is faster
 #   2) but, Scylla will keep the collation index in memory for hot
 #      rows (as part of the key cache), so a larger granularity means


### PR DESCRIPTION
Documentation, code comments and user reported messages contain some spelling typos to be fixed.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
