### PR TITLE
CI: don't use a prebuilt container in the "Book" workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,7 +12,6 @@ env:
 
 jobs:
   build:
-    container: scylladb/rust-mdbook
     runs-on: ubuntu-latest
     services:
       scylladb:
@@ -24,6 +23,8 @@ jobs:
           - ${{ github.workspace }}:/workspace
     steps:
     - uses: actions/checkout@v2
+    - name: Install mdbook
+      run: cargo install mdbook --no-default-features
     - name: Build the project
       run: cargo build --verbose --examples
     - name: Build the book
@@ -31,4 +32,4 @@ jobs:
     - name: Build the book using the script
       run: python3 docs/build_book.py
     - name: Run book tests
-      run: SCYLLA_URI=scylladb:9042 mdbook test -L target/debug/deps docs
+      run: mdbook test -L target/debug/deps docs


### PR DESCRIPTION
The "Book" workflow uses a prebuilt Docker image "scylla-mdbook" which,
in addition to the usual Rust compilation tools, contains a `cargo
mdbook` command installed. The problem with this approach is that the
container should be rebuilt regularly in order to update the Rust
version within - however, nobody remembers to do that and after 10
months the compiler became so outdated that it no longer recognises some
of the newly introduced changes to the language.

This commit changes the "Book" workflow so that it bases on
`ubuntu-latest` which is updated regularly, and the `cargo mdbook` tool
is installed as the first step. Although this is extra work on each CI
run compared to the previous approach, it requires less maintenance and
is less likely to break in the future.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
