### PR TITLE
Load balancing fallback

### DIFF
--- a/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
+++ b/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
@@ -119,6 +119,7 @@ mod tests {
     use super::*;
 
     use crate::transport::load_balancing::tests;
+    use std::collections::HashSet;
 
     #[tokio::test]
     async fn test_dc_aware_round_robin_policy() {
@@ -127,7 +128,7 @@ mod tests {
         let local_dc = "eu".to_string();
         let policy = DcAwareRoundRobinPolicy::new(local_dc);
 
-        let plans = (0..4)
+        let plans = (0..32)
             .map(|_| {
                 tests::get_plan_and_collect_node_identifiers(
                     &policy,
@@ -135,15 +136,19 @@ mod tests {
                     &cluster,
                 )
             })
-            .collect::<Vec<_>>();
+            .collect::<HashSet<_>>();
 
         let expected_plans = vec![
             vec![1, 2, 3, 4, 5],
-            vec![2, 3, 1, 5, 4],
-            vec![3, 1, 2, 4, 5],
             vec![1, 2, 3, 5, 4],
-        ];
+            vec![2, 3, 1, 5, 4],
+            vec![2, 3, 1, 4, 5],
+            vec![3, 1, 2, 4, 5],
+            vec![3, 1, 2, 5, 4],
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
 
-        assert_eq!(plans, expected_plans);
+        assert_eq!(expected_plans, plans);
     }
 }

--- a/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
+++ b/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
@@ -1,4 +1,4 @@
-use super::{ChildLoadBalancingPolicy, LoadBalancingPolicy, Statement};
+use super::{ChildLoadBalancingPolicy, LoadBalancingPolicy, Plan, Statement};
 use crate::transport::{cluster::ClusterData, node::Node};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -51,11 +51,7 @@ const EMPTY_NODE_LIST: &Vec<Arc<Node>> = &vec![];
 const ORDER_TYPE: Ordering = Ordering::Relaxed;
 
 impl LoadBalancingPolicy for DcAwareRoundRobinPolicy {
-    fn plan<'a>(
-        &self,
-        _statement: &Statement,
-        cluster: &'a ClusterData,
-    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
+    fn plan<'a>(&self, _statement: &Statement, cluster: &'a ClusterData) -> Plan<'a> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
         let local_nodes = self.retrieve_local_nodes(cluster);

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -23,6 +23,15 @@ pub struct Statement<'a> {
     pub keyspace: Option<&'a str>,
 }
 
+impl<'a> Statement<'a> {
+    fn empty() -> Self {
+        Self {
+            token: None,
+            keyspace: None,
+        }
+    }
+}
+
 pub type Plan<'a> = Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a>;
 
 /// Policy that decides which nodes to contact for each query

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -6,7 +6,7 @@
 use super::{cluster::ClusterData, node::Node};
 use crate::routing::Token;
 
-use std::sync::Arc;
+use std::{collections::hash_map::DefaultHasher, hash::Hasher, sync::Arc};
 
 mod dc_aware_round_robin;
 mod round_robin;
@@ -53,10 +53,21 @@ pub trait ChildLoadBalancingPolicy: LoadBalancingPolicy {
     ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync>;
 }
 
-// Does safe modulo
-fn compute_rotation(index: usize, count: usize) -> usize {
-    if count != 0 {
-        index % count
+// Hashing round robin's index is a mitigation to problems that occur when a
+// `RoundRobin::apply_child_policy()` is called twice by a parent policy.
+fn round_robin_index_hash(index: usize) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    hasher.write_usize(index);
+
+    hasher.finish()
+}
+
+// Does safe modulo and additionally hashes the index
+fn compute_rotation(round_robin_index: usize, sequence_length: usize) -> usize {
+    if sequence_length > 1 {
+        let hash = round_robin_index_hash(round_robin_index);
+
+        (hash % sequence_length as u64) as usize
     } else {
         0
     }

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -23,14 +23,12 @@ pub struct Statement<'a> {
     pub keyspace: Option<&'a str>,
 }
 
+pub type Plan<'a> = Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a>;
+
 /// Policy that decides which nodes to contact for each query
 pub trait LoadBalancingPolicy: Send + Sync {
     /// It is used for each query to find which nodes to query first
-    fn plan<'a>(
-        &self,
-        statement: &Statement,
-        cluster: &'a ClusterData,
-    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a>;
+    fn plan<'a>(&self, statement: &Statement, cluster: &'a ClusterData) -> Plan<'a>;
 
     /// Returns name of load balancing policy
     fn name(&self) -> String;

--- a/scylla/src/transport/load_balancing/round_robin.rs
+++ b/scylla/src/transport/load_balancing/round_robin.rs
@@ -1,4 +1,4 @@
-use super::{ChildLoadBalancingPolicy, LoadBalancingPolicy, Statement};
+use super::{ChildLoadBalancingPolicy, LoadBalancingPolicy, Plan, Statement};
 use crate::transport::{cluster::ClusterData, node::Node};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -28,11 +28,7 @@ impl Default for RoundRobinPolicy {
 const ORDER_TYPE: Ordering = Ordering::Relaxed;
 
 impl LoadBalancingPolicy for RoundRobinPolicy {
-    fn plan<'a>(
-        &self,
-        _statement: &Statement,
-        cluster: &'a ClusterData,
-    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
+    fn plan<'a>(&self, _statement: &Statement, cluster: &'a ClusterData) -> Plan<'a> {
         let index = self.index.fetch_add(1, ORDER_TYPE);
 
         let nodes_count = cluster.all_nodes.len();

--- a/scylla/src/transport/load_balancing/round_robin.rs
+++ b/scylla/src/transport/load_balancing/round_robin.rs
@@ -71,6 +71,7 @@ mod tests {
     use super::*;
 
     use crate::transport::load_balancing::tests;
+    use std::collections::HashSet;
 
     // ConnectionKeeper (which lives in Node) requires context of Tokio runtime
     #[tokio::test]
@@ -79,7 +80,7 @@ mod tests {
 
         let policy = RoundRobinPolicy::new();
 
-        let plans = (0..6)
+        let plans = (0..16)
             .map(|_| {
                 tests::get_plan_and_collect_node_identifiers(
                     &policy,
@@ -87,17 +88,19 @@ mod tests {
                     &cluster,
                 )
             })
-            .collect::<Vec<_>>();
+            .collect::<HashSet<_>>();
 
+        // Check if `plans` contains all possible round robin plans
         let expected_plans = vec![
             vec![1, 2, 3, 4, 5],
             vec![2, 3, 4, 5, 1],
             vec![3, 4, 5, 1, 2],
             vec![4, 5, 1, 2, 3],
             vec![5, 1, 2, 3, 4],
-            vec![1, 2, 3, 4, 5],
-        ];
+        ]
+        .into_iter()
+        .collect::<HashSet<Vec<_>>>();
 
-        assert_eq!(plans, expected_plans);
+        assert_eq!(expected_plans, plans);
     }
 }

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -1,4 +1,4 @@
-use super::{ChildLoadBalancingPolicy, LoadBalancingPolicy, Statement};
+use super::{ChildLoadBalancingPolicy, LoadBalancingPolicy, Plan, Statement};
 use crate::routing::Token;
 use crate::transport::topology::Strategy;
 use crate::transport::{cluster::ClusterData, node::Node};
@@ -103,11 +103,7 @@ impl TokenAwarePolicy {
 }
 
 impl LoadBalancingPolicy for TokenAwarePolicy {
-    fn plan<'a>(
-        &self,
-        statement: &Statement,
-        cluster: &'a ClusterData,
-    ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
+    fn plan<'a>(&self, statement: &Statement, cluster: &'a ClusterData) -> Plan<'a> {
         match statement.token {
             Some(token) => {
                 let keyspace = statement.keyspace.and_then(|k| cluster.keyspaces.get(k));
@@ -422,11 +418,7 @@ mod tests {
     struct DumbPolicy {}
 
     impl LoadBalancingPolicy for DumbPolicy {
-        fn plan<'a>(
-            &self,
-            _: &Statement,
-            _: &'a ClusterData,
-        ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
+        fn plan<'a>(&self, _: &Statement, _: &'a ClusterData) -> Plan<'a> {
             let empty_node_list: Vec<Arc<Node>> = Vec::new();
 
             Box::new(empty_node_list.into_iter())


### PR DESCRIPTION
## Description

This PR adds a load balancing fallback mechanism.

Fallback policies have to implement `FallbackPolicy` trait. They are very similar to load balancing policies, in fact every `LoadBalancingPolicy` implements `FallbackPolicy` implicitly.

Query plans produced by fallback policies are lazily chained to primary load balancing plans.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #161