### PR TITLE
Implement `Value` for `slice[T]`

### DIFF
--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -550,6 +550,12 @@ impl<T: Value> Value for Vec<T> {
     }
 }
 
+impl<T: Value> Value for &[T] {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        serialize_list_or_set(self.iter(), self.len(), buf)
+    }
+}
+
 fn serialize_tuple<V: Value>(
     elem_iter: impl Iterator<Item = V>,
     buf: &mut Vec<u8>,


### PR DESCRIPTION
## Pre-review checklist

Adds the ability to serialize slices of `T: Value`. Used to prevent having to use `Vec<T>` and saves allocations.

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
