### PR TITLE
Update Rust Driver Docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Although optimized for ScyllaDB, the driver is also compatible with [Apache Cass
 **Note: this driver is officially supported but currently available in beta. Bug reports and pull requests are welcome!**
 
 ## Getting Started
-The [documentation book](https://cvybhu.github.io/scyllabook/index.html) is a good place to get started. Another useful resource is the Rust and Scylla [lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University.
+The [documentation book](https://rust-driver.docs.scylladb.com/stable/index.html) is a good place to get started. Another useful resource is the Rust and Scylla [lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University.
 
 ## Examples
 ```rust


### PR DESCRIPTION
Updated Rust Driver Docs link to https://rust-driver.docs.scylladb.com/stable/index.html