### PR TITLE
treewide: replace all book links in the comments with rust driver docs links

### DIFF
--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -2,11 +2,11 @@
 //! Although optimized for Scylla, the driver is also compatible with [Apache Cassandra®](https://cassandra.apache.org/).
 //!
 //! # Documentation book
-//! The best source to learn about this driver is the [documentation book](https://cvybhu.github.io/scyllabook/index.html).\
+//! The best source to learn about this driver is the [documentation book](https://rust-driver.docs.scylladb.com/).\
 //! This page contains mainly API documentation
 //!
 //! # Other documentation
-//! * [Documentation book](https://cvybhu.github.io/scyllabook/index.html)
+//! * [Documentation book](https://rust-driver.docs.scylladb.com/)
 //! * [Examples](https://github.com/scylladb/scylla-rust-driver/tree/main/examples)
 //! * [Scylla documentation](https://docs.scylladb.com)
 //! * [Cassandra® documentation](https://cassandra.apache.org/doc/latest/)
@@ -89,7 +89,7 @@
 //! # Ok(())
 //! # }
 //! ```
-//! See the [book](https://cvybhu.github.io/scyllabook/queries/result.html) for more receiving methods
+//! See the [book](https://rust-driver.docs.scylladb.com/stable/queries/result.html) for more receiving methods
 
 #[macro_use]
 pub mod macros;

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -1,7 +1,7 @@
 //! Load balancing configurations\
 //! `Session` can use any load balancing policy which implements the `LoadBalancingPolicy` trait\
 //! Policies which implement the `ChildLoadBalancingPolicy` can be wrapped in some other policies\
-//! See [the book](https://cvybhu.github.io/scyllabook/load-balancing/load-balancing.html) for more information
+//! See [the book](https://rust-driver.docs.scylladb.com/stable/load-balancing/load-balancing.html) for more information
 
 use super::{cluster::ClusterData, node::Node};
 use crate::routing::Token;

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -358,7 +358,7 @@ impl Session {
     ///
     /// This is the easiest way to make a query, but performance is worse than that of prepared queries.
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/queries/simple.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/simple.html) for more information
     /// # Arguments
     /// * `query` - query to perform, can be just a `&str` or the [Query](crate::query::Query) struct.
     /// * `values` - values bound to the query, easiest way is to use a tuple of bound values
@@ -470,7 +470,7 @@ impl Session {
     /// Returns an async iterator (stream) over all received rows\
     /// Page size can be specified in the [Query](crate::query::Query) passed to the function
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/queries/paged.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/paged.html) for more information
     ///
     /// # Arguments
     /// * `query` - query to perform, can be just a `&str` or the [Query](crate::query::Query) struct.
@@ -534,9 +534,9 @@ impl Session {
     /// > ***Warning***\
     /// > For token/shard aware load balancing to work properly, all partition key values
     /// > must be sent as bound values
-    /// > (see [performance section](https://cvybhu.github.io/scyllabook/queries/prepared.html#performance))
+    /// > (see [performance section](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html#performance))
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/queries/prepared.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html) for more information
     ///
     /// # Arguments
     /// * `query` - query to prepare, can be just a `&str` or the [Query](crate::query::Query) struct.
@@ -613,9 +613,9 @@ impl Session {
     /// > ***Warning***\
     /// > For token/shard aware load balancing to work properly, all partition key values
     /// > must be sent as bound values
-    /// > (see [performance section](https://cvybhu.github.io/scyllabook/queries/prepared.html#performance))
+    /// > (see [performance section](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html#performance))
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/queries/prepared.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html) for more information
     ///
     /// # Arguments
     /// * `prepared` - the prepared statement to execute, generated using [`Session::prepare`](Session::prepare)
@@ -699,7 +699,7 @@ impl Session {
     /// Page size can be specified in the [PreparedStatement](crate::prepared_statement::PreparedStatement)
     /// passed to the function
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/queries/paged.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/paged.html) for more information
     ///
     /// # Arguments
     /// * `prepared` - the prepared statement to execute, generated using [`Session::prepare`](Session::prepare)
@@ -772,7 +772,7 @@ impl Session {
     ///
     /// Batch values must contain values for each of the queries
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/queries/batch.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/batch.html) for more information
     ///
     /// # Arguments
     /// * `batch` - [Batch](crate::batch::Batch) to be performed
@@ -833,7 +833,7 @@ impl Session {
     /// Trying to do two `use_keyspace` requests simultaneously with different names
     /// can end with some connections using one keyspace and the rest using the other.
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/queries/usekeyspace.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/usekeyspace.html) for more information
     ///
     /// # Arguments
     ///
@@ -899,7 +899,7 @@ impl Session {
 
     /// Get [`TracingInfo`] of a traced query performed earlier
     ///
-    /// See [the book](https://cvybhu.github.io/scyllabook/tracing/tracing.html)
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/tracing/tracing.html)
     /// for more information about query tracing
     pub async fn get_tracing_info(&self, tracing_id: &Uuid) -> Result<TracingInfo, QueryError> {
         self.get_tracing_info_custom(tracing_id, &GetTracingConfig::default())


### PR DESCRIPTION
All occurrences of the old scyllabook link now point to official
driver docs.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
