### PR TITLE
Update `DefaultRetrySession`'s retry conditions

### DIFF
--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -198,6 +198,8 @@ impl RetrySession for DefaultRetrySession {
             }
             // The node is still bootstrapping it can't execute the query, we should try another one
             QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode,
+            // Connection to the contacted node is overloaded, try another one
+            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode,
             // In all other cases propagate the error to the user
             _ => RetryDecision::DontRetry,
         }


### PR DESCRIPTION
## Description

Adds a `RetryNextNode` decision for the `QueryError::UnableToAllocStreamId`. This error happens when a request cannot be send to Scylla because the chosen connection is overloaded. It is desired for a retry session to retry on the next node when seeing this error as the next node's connections may not be overloaded.

Fixes: #407

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
