### PR TITLE
frame: allow deserializing timestamps into i64

### DIFF
--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -395,6 +395,12 @@ mod tests {
             timestamp_duration,
             Duration::from_cql(CqlValue::Timestamp(timestamp_duration)).unwrap(),
         );
+
+        let timestamp_i64 = 997;
+        assert_eq!(
+            timestamp_i64,
+            i64::from_cql(CqlValue::Timestamp(Duration::milliseconds(timestamp_i64))).unwrap()
+        )
     }
 
     #[test]

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -188,6 +188,7 @@ impl CqlValue {
     pub fn as_bigint(&self) -> Option<i64> {
         match self {
             Self::BigInt(i) => Some(*i),
+            Self::Timestamp(d) => Some(d.num_milliseconds()),
             _ => None,
         }
     }


### PR DESCRIPTION
Timestamps can already be serialized with an i64, so it's only
natural to allow deserializing them as an integer as well.

Fixes #419

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
