### PR TITLE
frame: allow using Time struct as CqlValue

### DIFF
--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -97,6 +97,15 @@ impl_from_cql_val!(Uuid, as_uuid); // Uuid::from_cql<CqlValue>
 impl_from_cql_val!(BigDecimal, into_decimal); // BigDecimal::from_cql<CqlValue>
 impl_from_cql_val!(Duration, as_duration); // Duration::from_cql<CqlValue>
 
+impl FromCqlVal<CqlValue> for crate::frame::value::Time {
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+        match cql_val {
+            CqlValue::Time(d) => Ok(Self(d)),
+            _ => Err(FromCqlValError::BadCqlType),
+        }
+    }
+}
+
 // Vec<T>::from_cql<CqlValue>
 impl<T: FromCqlVal<CqlValue>> FromCqlVal<CqlValue> for Vec<T> {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
@@ -394,6 +403,16 @@ mod tests {
         assert_eq!(
             timestamp_duration,
             Duration::from_cql(CqlValue::Timestamp(timestamp_duration)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn time_from_cql() {
+        use crate::frame::value::Time;
+        let time_duration = Duration::nanoseconds(86399999999999);
+        assert_eq!(
+            time_duration,
+            Time::from_cql(CqlValue::Time(time_duration)).unwrap().0,
         );
     }
 


### PR DESCRIPTION
It's particularly useful in IntoUserType and FromUserType macros
to be able to express that a column has CQL Time type.
For that we need a wrapper, and a perfect candidate for that
is scylla::frame::value::Time, which is already a thin wrapper over
chrono::Duration. This patch simply implements FromCqlVal for this
struct, which will allow using it for serialization and deserialization.

Fixes #421

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
