### PR TITLE
Refactor: change deprecating const methods ::max_value() and ::min_value() into type constants ::MAX and ::MIN respectively

### DIFF
--- a/examples/cql-time-types.rs
+++ b/examples/cql-time-types.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     }
 
     // Dates outside this range must be represented in the raw form - an u32 describing days since -5877641-06-23
-    let example_big_date: Date = Date(u32::max_value());
+    let example_big_date: Date = Date(u32::MAX);
     session
         .query("INSERT INTO ks.dates (d) VALUES (?)", (example_big_date,))
         .await?;

--- a/scylla/src/frame/cql_types_test.rs
+++ b/scylla/src/frame/cql_types_test.rs
@@ -307,7 +307,7 @@ async fn test_date() {
         ("1970-01-31", Date(2_u32.pow(31) + 30)),
         ("-5877641-06-23", Date(0)),
         // NOTICE: dropped for Cassandra 4 compatibility
-        //("5881580-07-11", Date(u32::max_value())),
+        //("5881580-07-11", Date(u32::MAX)),
     ];
 
     for (date_text, date) in &tests {
@@ -447,14 +447,8 @@ async fn test_timestamp() {
 
     let tests = [
         ("0", Duration::milliseconds(0)),
-        (
-            "9223372036854775807",
-            Duration::milliseconds(i64::max_value()),
-        ),
-        (
-            "-9223372036854775808",
-            Duration::milliseconds(i64::min_value()),
-        ),
+        ("9223372036854775807", Duration::milliseconds(i64::MAX)),
+        ("-9223372036854775808", Duration::milliseconds(i64::MIN)),
         // NOTICE: dropped for Cassandra 4 compatibility
         //("1970-01-01", Duration::milliseconds(0)),
         //("2020-03-08", after_epoch_offset),

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -387,7 +387,7 @@ mod tests {
         let min_date: CqlValue = CqlValue::Date(0);
         assert!(NaiveDate::from_cql(min_date).is_err());
 
-        let max_date: CqlValue = CqlValue::Date(u32::max_value());
+        let max_date: CqlValue = CqlValue::Date(u32::MAX);
         assert!(NaiveDate::from_cql(max_date).is_err());
     }
 
@@ -399,7 +399,7 @@ mod tests {
             Duration::from_cql(CqlValue::Time(time_duration)).unwrap(),
         );
 
-        let timestamp_duration = Duration::milliseconds(i64::min_value());
+        let timestamp_duration = Duration::milliseconds(i64::MIN);
         assert_eq!(
             timestamp_duration,
             Duration::from_cql(CqlValue::Timestamp(timestamp_duration)).unwrap(),

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -1194,13 +1194,11 @@ mod tests {
             super::deser_cql_value(&ColumnType::Date, &mut four_bytes.as_ref()).unwrap();
         assert_eq!(date, CqlValue::Date(u32::from_be_bytes(four_bytes)));
 
-        // Date is parsed as u32 not i32, u32::max_value() is u32::max_value()
-        let date: CqlValue = super::deser_cql_value(
-            &ColumnType::Date,
-            &mut u32::max_value().to_be_bytes().as_ref(),
-        )
-        .unwrap();
-        assert_eq!(date, CqlValue::Date(u32::max_value()));
+        // Date is parsed as u32 not i32, u32::MAX is u32::MAX
+        let date: CqlValue =
+            super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
+                .unwrap();
+        assert_eq!(date, CqlValue::Date(u32::MAX));
 
         // Trying to parse a 0, 3 or 5 byte array fails
         super::deser_cql_value(&ColumnType::Date, &mut [].as_ref()).unwrap();
@@ -1235,7 +1233,7 @@ mod tests {
 
         assert_eq!(date.as_date().unwrap(), after_epoch);
 
-        // 0 and u32::max_value() is out of NaiveDate range, fails with an error, not panics
+        // 0 and u32::MAX is out of NaiveDate range, fails with an error, not panics
         assert!(
             super::deser_cql_value(&ColumnType::Date, &mut 0_u32.to_be_bytes().as_ref())
                 .unwrap()
@@ -1243,13 +1241,12 @@ mod tests {
                 .is_none()
         );
 
-        assert!(super::deser_cql_value(
-            &ColumnType::Date,
-            &mut u32::max_value().to_be_bytes().as_ref()
-        )
-        .unwrap()
-        .as_date()
-        .is_none());
+        assert!(
+            super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
+                .unwrap()
+                .as_date()
+                .is_none()
+        );
 
         // It's hard to test NaiveDate more because it involves calculating days between calendar dates
         // There are more tests using database queries that should cover it
@@ -1273,7 +1270,7 @@ mod tests {
 
         // Negative values cause an error
         // Values bigger than 86399999999999 cause an error
-        for test_val in [-1, i64::min_value(), max_time + 1, i64::max_value()].iter() {
+        for test_val in [-1, i64::MIN, max_time + 1, i64::MAX].iter() {
             let bytes: [u8; 8] = test_val.to_be_bytes();
             super::deser_cql_value(&ColumnType::Time, &mut &bytes[..]).unwrap_err();
         }
@@ -1297,15 +1294,7 @@ mod tests {
         // Timestamp is an i64 - milliseconds since unix epoch
 
         // Check that test values are deserialized correctly
-        for test_val in &[
-            0,
-            -1,
-            1,
-            74568745,
-            -4584658,
-            i64::min_value(),
-            i64::max_value(),
-        ] {
+        for test_val in &[0, -1, 1, 74568745, -4584658, i64::MIN, i64::MAX] {
             let bytes: [u8; 8] = test_val.to_be_bytes();
             let cql_value: CqlValue =
                 super::deser_cql_value(&ColumnType::Timestamp, &mut &bytes[..]).unwrap();

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -143,7 +143,7 @@ impl SerializedValues {
         if self.contains_names {
             return Err(SerializeValuesError::MixingNamedAndNotNamedValues);
         }
-        if self.values_num == i16::max_value() {
+        if self.values_num == i16::MAX {
             return Err(SerializeValuesError::TooManyValues);
         }
 
@@ -167,7 +167,7 @@ impl SerializedValues {
             return Err(SerializeValuesError::MixingNamedAndNotNamedValues);
         }
         self.contains_names = true;
-        if self.values_num == i16::max_value() {
+        if self.values_num == i16::MAX {
             return Err(SerializeValuesError::TooManyValues);
         }
 

--- a/scylla/src/frame/value_tests.rs
+++ b/scylla/src/frame/value_tests.rs
@@ -57,7 +57,7 @@ fn naive_date_serialization() {
 fn date_serialization() {
     assert_eq!(serialized(Date(0)), vec![0, 0, 0, 4, 0, 0, 0, 0]);
     assert_eq!(
-        serialized(Date(u32::max_value())),
+        serialized(Date(u32::MAX)),
         vec![0, 0, 0, 4, 255, 255, 255, 255]
     );
 }
@@ -84,7 +84,7 @@ fn time_serialization() {
     }
 
     // Durations so long that nanoseconds don't fit in i64 cause an error
-    let long_time = Time(Duration::milliseconds(i64::max_value()));
+    let long_time = Time(Duration::milliseconds(i64::MAX));
     assert_eq!(long_time.serialize(&mut Vec::new()), Err(ValueTooBig));
 }
 
@@ -92,15 +92,7 @@ fn time_serialization() {
 fn timestamp_serialization() {
     // Timestamp is milliseconds since unix epoch represented as i64
 
-    for test_val in &[
-        0,
-        -1,
-        1,
-        -45345346,
-        453451,
-        i64::min_value(),
-        i64::max_value(),
-    ] {
+    for test_val in &[0, -1, 1, -45345346, 453451, i64::MIN, i64::MAX] {
         let test_timestamp: Timestamp = Timestamp(Duration::milliseconds(*test_val));
         let bytes: Vec<u8> = serialized(test_timestamp);
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1273,7 +1273,7 @@ fn calculate_token(
         Err(PartitionKeyError::ValueTooLong(values_len)) => {
             return Err(QueryError::BadQuery(BadQuery::ValuesTooLongForKey(
                 values_len,
-                u16::max_value().into(),
+                u16::MAX.into(),
             )))
         }
     };


### PR DESCRIPTION
Methods such as `i64::max_value()` will get deprecated so we may as well get rid of them now - my IDE will be happier and `i64::MAX` is shorter anyway.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
