### PR TITLE
examples: add example tower::Service trait implementation

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,6 +16,7 @@ tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 chrono = "0.4"
 uuid = "0.8.1"
+tower = "0.4"
 
 [[example]]
 name = "auth"
@@ -88,3 +89,7 @@ path = "value_list.rs"
 [[example]]
 name = "custom_load_balancing_policy"
 path = "custom_load_balancing_policy.rs"
+
+[[example]]
+name = "tower"
+path = "tower.rs"

--- a/examples/tower.rs
+++ b/examples/tower.rs
@@ -1,0 +1,70 @@
+use std::env;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use tower::Service;
+
+struct SessionService {
+    session: Arc<scylla::Session>,
+}
+
+// A trivial service implementation for sending parameterless simple string requests to Scylla.
+impl Service<scylla::query::Query> for SessionService {
+    type Response = scylla::QueryResult;
+    type Error = scylla::transport::errors::QueryError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: scylla::query::Query) -> Self::Future {
+        let session = self.session.clone();
+        Box::pin(async move { session.query(req, &[]).await })
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+    let mut session: SessionService = SessionService {
+        session: Arc::new(
+            scylla::SessionBuilder::new()
+                .known_node(uri)
+                .build()
+                .await?,
+        ),
+    };
+
+    let resp = session
+        .call("SELECT keyspace_name, table_name FROM system_schema.tables;".into())
+        .await?;
+
+    let print_text = |t: &Option<scylla::frame::response::result::CqlValue>| {
+        t.as_ref()
+            .unwrap_or(&scylla::frame::response::result::CqlValue::Text(
+                "<null>".to_string(),
+            ))
+            .as_text()
+            .unwrap_or(&"<null>".to_string())
+            .clone()
+    };
+
+    println!(
+        "Tables:\n{}",
+        resp.rows()?
+            .into_iter()
+            .map(|r| format!(
+                "\t{}.{}",
+                print_text(&r.columns[0]),
+                print_text(&r.columns[1])
+            ))
+            .collect::<Vec<String>>()
+            .join("\n")
+    );
+    Ok(())
+}


### PR DESCRIPTION
This commit provides a simple example on how to wrap a Scylla session
into a tower::Service, which gives such a session all the benefits
of tower - composability, universal API, etc.
The example provides a very trivial service which is only capable
of sending unprepared, parameterless queries, but it's educational
nonetheless. By implementing a service on top of CachingSession
wrapped with a list of parameters, a full-fledged service can be
easily implemented.

Refs #425

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
