### PR TITLE
Remove useles fields from CqlValue::UserDefinedType

### DIFF
--- a/scylla-macros/src/from_user_type.rs
+++ b/scylla-macros/src/from_user_type.rs
@@ -50,7 +50,7 @@ pub fn from_user_type_derive(tokens_input: TokenStream) -> TokenStream {
 
                 // Interpret CqlValue as CQlValue::UserDefinedType
                 let mut fields_iter = match cql_val {
-                    CqlValue::UserDefinedType{fields, ..} => fields.into_iter().peekable(),
+                    CqlValue::UserDefinedType(fields) => fields.into_iter().peekable(),
                     _ => return Err(FromCqlValError::BadCqlType),
                 };
 

--- a/scylla/src/frame/value.rs
+++ b/scylla/src/frame/value.rs
@@ -587,7 +587,7 @@ impl Value for CqlValue {
 
             // A UDT value is composed of successive [bytes] values, one for each field of the UDT
             // value (in the order defined by the type), so they serialize in a same way tuples do.
-            CqlValue::UserDefinedType { fields, .. } => {
+            CqlValue::UserDefinedType(fields) => {
                 serialize_tuple(fields.iter().map(|(_, value)| value), buf)
             }
 

--- a/scylla/src/frame/value_tests.rs
+++ b/scylla/src/frame/value_tests.rs
@@ -685,14 +685,10 @@ async fn test_cqlvalue_udt() {
         .await
         .unwrap();
 
-    let udt_cql_value = CqlValue::UserDefinedType {
-        keyspace: ks,
-        type_name: "cqlvalue_udt_type".to_string(),
-        fields: vec![
-            ("int_val".to_string(), Some(CqlValue::Int(42))),
-            ("text_val".to_string(), Some(CqlValue::Text("hi".into()))),
-        ],
-    };
+    let udt_cql_value = CqlValue::UserDefinedType(vec![
+        ("int_val".to_string(), Some(CqlValue::Int(42))),
+        ("text_val".to_string(), Some(CqlValue::Text("hi".into()))),
+    ]);
 
     session
         .query(


### PR DESCRIPTION
Solves #433 

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
