### PR TITLE
frame: allow using Timestamp struct as CqlValue

### DIFF
--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -437,7 +437,9 @@ mod tests {
         let timestamp_duration = Duration::milliseconds(86399999999999);
         assert_eq!(
             timestamp_duration,
-            Timestamp::from_cql(CqlValue::Timestamp(timestamp_duration)).unwrap().0,
+            Timestamp::from_cql(CqlValue::Timestamp(timestamp_duration))
+                .unwrap()
+                .0,
         );
     }
 

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -106,6 +106,15 @@ impl FromCqlVal<CqlValue> for crate::frame::value::Time {
     }
 }
 
+impl FromCqlVal<CqlValue> for crate::frame::value::Timestamp {
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+        match cql_val {
+            CqlValue::Timestamp(d) => Ok(Self(d)),
+            _ => Err(FromCqlValError::BadCqlType),
+        }
+    }
+}
+
 // Vec<T>::from_cql<CqlValue>
 impl<T: FromCqlVal<CqlValue>> FromCqlVal<CqlValue> for Vec<T> {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
@@ -419,6 +428,16 @@ mod tests {
         assert_eq!(
             time_duration,
             Time::from_cql(CqlValue::Time(time_duration)).unwrap().0,
+        );
+    }
+
+    #[test]
+    fn timestamp_from_cql() {
+        use crate::frame::value::Timestamp;
+        let timestamp_duration = Duration::milliseconds(86399999999999);
+        assert_eq!(
+            timestamp_duration,
+            Timestamp::from_cql(CqlValue::Timestamp(timestamp_duration)).unwrap().0,
         );
     }
 


### PR DESCRIPTION
FromCqlVal implementation has been added to frame::value::Time in #422,
but frame::value::Timestamp should have been included too.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
