### PR TITLE
Optimize PreparedStatement::compute_partition_key

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -37,6 +37,7 @@ dashmap = "4.0.2"
 strum = "0.23"
 strum_macros = "0.23"
 lz4_flex = { version = "0.9.2" }
+smallvec = "1.8.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -342,15 +342,15 @@ pub struct ResultMetadata {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct PKIndex {
-    pub index: u16,
-    pub sequence: u16,
+pub struct PartitionKeyIndex {
+    pub index: u16,    // index in the serialized values
+    pub sequence: u16, // sequence number in partition key
 }
 
 #[derive(Debug, Clone)]
 pub struct PreparedMetadata {
     pub col_count: usize,
-    pub pk_indexes: Vec<PKIndex>,
+    pub pk_indexes: Vec<PartitionKeyIndex>,
     pub col_specs: Vec<ColumnSpec>,
 }
 
@@ -527,11 +527,10 @@ fn deser_prepared_metadata(buf: &mut &[u8]) -> StdResult<PreparedMetadata, Parse
     let col_count = types::read_int_length(buf)? as usize;
 
     let pk_count: usize = types::read_int(buf)?.try_into()?;
-    assert!(pk_count <= u16::MAX as usize);
 
     let mut pk_indexes = Vec::with_capacity(pk_count);
     for i in 0..pk_count {
-        pk_indexes.push(PKIndex {
+        pk_indexes.push(PartitionKeyIndex {
             index: types::read_short(buf)? as u16,
             sequence: i as u16,
         });

--- a/scylla/src/frame/response/result.rs
+++ b/scylla/src/frame/response/result.rs
@@ -343,13 +343,17 @@ pub struct ResultMetadata {
 
 #[derive(Debug, Copy, Clone)]
 pub struct PartitionKeyIndex {
-    pub index: u16,    // index in the serialized values
-    pub sequence: u16, // sequence number in partition key
+    /// index in the serialized values
+    pub index: u16,
+    /// sequence number in partition key
+    pub sequence: u16,
 }
 
 #[derive(Debug, Clone)]
 pub struct PreparedMetadata {
     pub col_count: usize,
+    /// pk_indexes are sorted by `index` and can be reordered in partition key order
+    /// using `sequence` field
     pub pk_indexes: Vec<PartitionKeyIndex>,
     pub col_specs: Vec<ColumnSpec>,
 }


### PR DESCRIPTION
In PreparedMetadata initialization, PK indexes are associated to their
sequence number, and then sorted by the index value. It allows iterating on
bounded_values in order, because indexes can then be reordered thanks to
sequence number.

Also, buf size is computed during iteration in order to be reserved before
writing to it, preventing buffer reallocation at each write.

Last but not least, an array is used instead of a vector when the size of
pk_indexes is not too big, saving the allocation cost.

Quick benchmark using `complex_pk` table of `test_prepared_statement` shows a
performance improvement from 200ns to at 130ns.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ x] I have split my patch into logically separate commits.
- [ x] All commit messages clearly explain what they change and why.
- [ x] I added relevant tests for new features and bug fixes.
- [ x] All commits compile, pass static checks and pass test.
- [ x] PR description sums up the changes and reasons why they should be introduced.
- [ x] I added appropriate `Fixes:` annotations to PR description.
