### PR TITLE
Bump `uuid` and `dashmap` dependencies.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ tokio = {version = "1.1.0", features = ["full"]}
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 chrono = "0.4"
-uuid = "1.0.0"
+uuid = "1.0"
 tower = "0.4"
 
 [[example]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ tokio = {version = "1.1.0", features = ["full"]}
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 chrono = "0.4"
-uuid = "0.8.1"
+uuid = "1.0.0"
 tower = "0.4"
 
 [[example]]

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2018"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"
 repository = "https://github.com/scylladb/scylla-rust-driver"
@@ -22,7 +22,7 @@ histogram = "0.6.9"
 num_enum = "0.5"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
-uuid = "0.8.1"
+uuid = "1.0.0"
 rand = "0.8.3"
 thiserror = "1.0"
 itertools = "0.10.0"
@@ -33,7 +33,7 @@ chrono = "0.4"
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
 arc-swap = "1.3.0"
-dashmap = "4.0.2"
+dashmap = "5.2.0"
 strum = "0.23"
 strum_macros = "0.23"
 lz4_flex = { version = "0.9.2" }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "0.5.0"
+version = "0.4.4"
 edition = "2018"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"
 repository = "https://github.com/scylladb/scylla-rust-driver"
@@ -22,7 +22,7 @@ histogram = "0.6.9"
 num_enum = "0.5"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
-uuid = "1.0.0"
+uuid = "1.0"
 rand = "0.8.3"
 thiserror = "1.0"
 itertools = "0.10.0"
@@ -33,7 +33,7 @@ chrono = "0.4"
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
 arc-swap = "1.3.0"
-dashmap = "5.2.0"
+dashmap = "5.2"
 strum = "0.23"
 strum_macros = "0.23"
 lz4_flex = { version = "0.9.2" }


### PR DESCRIPTION
What it says on the cover.

- Bumps `uuid` version to 1.0.0 (which may break downstream code due to mismatching versions, but doesn't break the API).
- Bumps `dashmap` for relevant speedups.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
