### PR TITLE
CI: check compilation with MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  rust_min: 1.59.0 # <- Update this when bumping up MSRV
 
 jobs:
   build:
@@ -25,10 +27,27 @@ jobs:
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
-      run: cargo clippy --verbose --examples --tests -- -D warnings
+      run: cargo clippy --verbose --examples --tests
     - name: Cargo check without features
       run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
     - name: Build
       run: cargo build --verbose --examples
     - name: Run tests
       run: cargo test --verbose
+
+  # Tests that our current minimum supported rust version compiles everything sucessfully
+  min_rust:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust ${{ env.rust_min }}
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.rust_min }}
+        override: true
+    - name: Print Rust version
+      run: rustc --version
+    - name: MSRV cargo check with features
+      run: cargo check --verbose --examples --tests
+    - name: MSRV cargo check without features
+      run: cargo check --verbose --manifest-path "scylla/Cargo.toml"


### PR DESCRIPTION
As we are about to declare 1.59 as our minimum supported rust version,
this commit introduces a CI check that will help us enforce it. It runs
the `cargo check` command using the MSRV toolchain and verifies that it
passes with and without features enabled.

The check was inspired by tokio's CI configuration.

Refs: #444

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
