### PR TITLE
Allow to access PreparedMetadata

### DIFF
--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -236,6 +236,11 @@ impl PreparedStatement {
         }
     }
 
+    /// Access metadata about this prepared statement as returned by the database
+    pub fn get_prepared_metadata(&self) -> &PreparedMetadata {
+        &self.metadata
+    }
+
     /// Get the name of the partitioner used for this statement.
     pub(crate) fn get_partitioner_name(&self) -> &PartitionerName {
         &self.partitioner_name


### PR DESCRIPTION
After preparing a statement the database returns a bunch of metadata information that is kept in `PreparedStatement`.
This data isn't normally used by users of the driver so it's private.

While it might not be useful to regular users I was just debugging a problem with Scylla and needed to access it.
Let's make it accessible from outside to make life easier for database developers who use this driver.

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
