### PR TITLE
session: route prepared queries without pk index like unprepared queries

### DIFF
--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -72,6 +72,13 @@ impl PreparedStatement {
         &self.prepare_tracing_ids
     }
 
+    /// Returns true if the prepared statement has necessary information
+    /// to be routed in a token-aware manner. If false, the query
+    /// will always be sent to a random node/shard.
+    pub fn is_token_aware(&self) -> bool {
+        !self.metadata.pk_indexes.is_empty()
+    }
+
     /// Computes the partition key of the target table from given values —
     /// it assumes that all partition key columns are passed in values.
     /// Partition keys have a specific serialization rules.


### PR DESCRIPTION
Not all prepared statements can be routed in a token-aware manner.
Sometimes the token cannot be computed by the driver based on the bound
query values - if this is the case, PREPARE will return metadata with
empty pk_index (which tells the driver how to compute the token).
However, the driver interprets empty pk_index as valid information and
computes a dummy token which is then used to route the statement to the
same node/shard every time.

This commit changes the execute logic so that it detects when the
prepared statement has empty pk_index and routes it in the same way as
unprepared queries.

Tested by modifying the `parallel-prepared` test so that it does not have bind markers in partition key, running it and observing the request distribution in metrics.

Fixes: #453

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
