### PR TITLE
Add per-statement load balancing policy

### DIFF
--- a/examples/custom_load_balancing_policy.rs
+++ b/examples/custom_load_balancing_policy.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use scylla::{
-    load_balancing::{LoadBalancingPolicy, Statement},
+    load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, Statement},
+    query::Query,
     transport::{ClusterData, Node},
     Session, SessionBuilder,
 };
 use std::{env, sync::Arc};
+use tracing::info;
 
 /// Example load balancing policy that prefers nodes from favorite datacenter
 struct CustomLoadBalancingPolicy {
@@ -17,6 +19,7 @@ impl LoadBalancingPolicy for CustomLoadBalancingPolicy {
         _statement: &Statement,
         cluster: &'a ClusterData,
     ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync + 'a> {
+        info!("Yay, picking my favorite DC again!");
         let fav_dc_info = cluster
             .get_datacenters_info()
             .get(&self.fav_datacenter_name);
@@ -35,17 +38,45 @@ impl LoadBalancingPolicy for CustomLoadBalancingPolicy {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    let custom_load_balancing = CustomLoadBalancingPolicy {
+    let custom_load_balancing = Arc::new(CustomLoadBalancingPolicy {
         fav_datacenter_name: "PL".to_string(),
-    };
+    });
 
-    let _session: Session = SessionBuilder::new()
+    let session: Session = SessionBuilder::new()
         .known_node(uri)
-        .load_balancing(Arc::new(custom_load_balancing))
+        .load_balancing(custom_load_balancing.clone())
         .build()
         .await?;
+
+    session
+        .query("SELECT host_id FROM system.local", &[])
+        .await
+        .unwrap();
+
+    let mut config = scylla::statement::StatementConfig {
+        load_balancing_policy: Some(Arc::new(RoundRobinPolicy::new())),
+        ..Default::default()
+    };
+
+    session
+        .query(
+            Query::with_config("SELECT host_id FROM system.local", config.clone()),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    config.load_balancing_policy = Some(custom_load_balancing);
+    session
+        .query(
+            Query::with_config("SELECT host_id FROM system.local", config),
+            &[],
+        )
+        .await
+        .unwrap();
 
     Ok(())
 }

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::transport::load_balancing::LoadBalancingPolicy;
 use crate::transport::retry_policy::RetryPolicy;
 use crate::transport::speculative_execution::SpeculativeExecutionPolicy;
 
@@ -17,6 +18,7 @@ pub struct StatementConfig {
 
     pub retry_policy: Option<Box<dyn RetryPolicy>>,
     pub speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
+    pub load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
 
     pub tracing: bool,
     pub timestamp: Option<i64>,
@@ -30,6 +32,7 @@ impl Default for StatementConfig {
             is_idempotent: false,
             retry_policy: None,
             speculative_execution_policy: None,
+            load_balancing_policy: None,
             tracing: false,
             timestamp: None,
         }
@@ -47,6 +50,7 @@ impl Clone for StatementConfig {
                 .as_ref()
                 .map(|policy| policy.clone_boxed()),
             speculative_execution_policy: self.speculative_execution_policy.clone(),
+            load_balancing_policy: self.load_balancing_policy.clone(),
             tracing: self.tracing,
             timestamp: self.timestamp,
         }

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -23,6 +23,15 @@ impl Query {
         }
     }
 
+    /// Creates a new `Query` from a CQL query string and custom config
+    pub fn with_config(query_text: impl Into<String>, config: StatementConfig) -> Self {
+        Self {
+            contents: query_text.into(),
+            page_size: None,
+            config,
+        }
+    }
+
     /// Returns self with page size set to the given value
     pub fn with_page_size(mut self, page_size: i32) -> Self {
         self.page_size = Some(page_size);


### PR DESCRIPTION
This series adds load balancing policy as a new field in `StatementConfig`. Thanks to that, users are able to specify a load balancing policy in statement configuration, and such a policy takes precedence over the default session load balancing policy.
This series was tested manually via observing the logs from extended custom_load_balancing_policy example.

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
