### PR TITLE
examples: add an example with allocation stats

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,8 @@ tracing-subscriber = "0.2.16"
 chrono = "0.4"
 uuid = "1.0"
 tower = "0.4"
+stats_alloc = "0.1"
+clap = { version = "3.2.4", features = ["derive"] }
 
 [[example]]
 name = "auth"
@@ -93,3 +95,7 @@ path = "custom_load_balancing_policy.rs"
 [[example]]
 name = "tower"
 path = "tower.rs"
+
+[[example]]
+name = "allocations"
+path = "allocations.rs"

--- a/examples/allocations.rs
+++ b/examples/allocations.rs
@@ -1,0 +1,175 @@
+use anyhow::Result;
+use scylla::{statement::prepared_statement::PreparedStatement, Session, SessionBuilder};
+use std::io::Write;
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+use stats_alloc::{Stats, StatsAlloc, INSTRUMENTED_SYSTEM};
+use std::alloc::System;
+
+use clap::{ArgEnum, Parser};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(arg_enum, value_parser, default_value = "all")]
+    mode: Mode,
+
+    #[clap(short, long, value_parser, default_value = "127.0.0.1:9042")]
+    node: String,
+
+    #[clap(short, long, value_parser, default_value_t = 256usize)]
+    parallelism: usize,
+
+    #[clap(short, long, value_parser, default_value_t = 100_000usize)]
+    requests: usize,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ArgEnum)]
+enum Mode {
+    All,
+    Insert,
+    Select,
+}
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+fn print_stats(stats: &stats_alloc::Stats, reqs: f64) {
+    println!(
+        "allocs/req:            {:9.2}",
+        stats.allocations as f64 / reqs
+    );
+    println!(
+        "reallocs/req:          {:9.2}",
+        stats.reallocations as f64 / reqs
+    );
+    println!(
+        "frees/req:             {:9.2}",
+        stats.deallocations as f64 / reqs
+    );
+    println!(
+        "bytes allocated/req:   {:9.2}",
+        stats.bytes_allocated as f64 / reqs
+    );
+    println!(
+        "bytes reallocated/req: {:9.2}",
+        stats.bytes_reallocated as f64 / reqs
+    );
+    println!(
+        "bytes freed/req:       {:9.2}",
+        stats.bytes_deallocated as f64 / reqs
+    );
+}
+
+async fn measure(
+    session: Arc<Session>,
+    prepared: Arc<PreparedStatement>,
+    sem: Arc<Semaphore>,
+    reqs: usize,
+    parallelism: usize,
+) -> Stats {
+    let initial_stats = GLOBAL.stats();
+
+    for i in 0..reqs {
+        if i % 10000 == 0 {
+            print!(".");
+            std::io::stdout().flush().unwrap();
+        }
+        let session = session.clone();
+        let prepared = prepared.clone();
+        let permit = sem.clone().acquire_owned().await;
+        tokio::task::spawn(async move {
+            let i = i;
+            session
+                .execute(&prepared, (i as i32, 2 * i as i32))
+                .await
+                .unwrap();
+
+            let _permit = permit;
+        });
+    }
+    println!();
+
+    // Wait for all in-flight requests to finish
+    for _ in 0..parallelism {
+        sem.acquire().await.unwrap().forget();
+    }
+
+    GLOBAL.stats() - initial_stats
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    println!("{:?}", args);
+
+    println!("Connecting to {} ...", args.node);
+
+    let session: Session = SessionBuilder::new().known_node(args.node).build().await?;
+    let session = Arc::new(session);
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.await_schema_agreement().await.unwrap();
+
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.alloc_test (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    session.await_schema_agreement().await.unwrap();
+
+    let prepared_inserts = Arc::new(
+        session
+            .prepare("INSERT INTO ks.alloc_test (a, b, c) VALUES (?, ?, 'abc')")
+            .await?,
+    );
+
+    let prepared_selects = Arc::new(
+        session
+            .prepare("SELECT * FROM ks.alloc_test WHERE a = ? and b = ?")
+            .await?,
+    );
+
+    let sem = Arc::new(Semaphore::new(args.parallelism));
+
+    if args.mode == Mode::All || args.mode == Mode::Insert {
+        print!("Sending {} inserts, hold tight ", args.requests);
+        let write_stats = measure(
+            session.clone(),
+            prepared_inserts.clone(),
+            sem.clone(),
+            args.requests,
+            args.parallelism,
+        )
+        .await;
+        println!("----------");
+        println!("Inserts:");
+        println!("----------");
+        print_stats(&write_stats, args.requests as f64);
+        println!("----------");
+        sem.add_permits(args.parallelism);
+    }
+
+    if args.mode == Mode::All || args.mode == Mode::Select {
+        print!("Sending {} selects, hold tight ", args.requests);
+        let read_stats = measure(
+            session.clone(),
+            prepared_selects.clone(),
+            sem.clone(),
+            args.requests,
+            args.parallelism,
+        )
+        .await;
+        println!("----------");
+        println!("Selects:");
+        println!("----------");
+        print_stats(&read_stats, args.requests as f64);
+        println!("----------");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The new example program, allocations.rs, counts how many
allocations, reallocations and frees were submitted
per request during our write path and read path, based on
prepared statements.
This example can be used to track potential performance regressions.

Example output:
```
[sarna@localhost scylla-rust-driver]$ cargo run --release --example allocations
    Finished release [optimized] target(s) in 0.07s
     Running `target/release/examples/allocations`
Args { mode: All, node: "127.0.0.1:9042", parallelism: 256, requests: 100000 }
Connecting to 127.0.0.1:9042 ...
Sending 100000 inserts, hold tight ..........
----------
Inserts:
----------
allocs/req:                15.01
reallocs/req:               9.00
frees/req:                 15.01
bytes allocated/req:     3496.39
bytes reallocated/req:    105.00
bytes freed/req:         3495.53
----------
Sending 100000 selects, hold tight ..........
----------
Selects:
----------
allocs/req:                28.00
reallocs/req:               9.00
frees/req:                 28.00
bytes allocated/req:     4355.00
bytes reallocated/req:    105.00
bytes freed/req:         4355.00
----------
```

Refs #457

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
