### PR TITLE
session: automatically wait for schema agreement

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -158,6 +158,13 @@ impl QueryResponse {
         }
     }
 
+    pub fn as_schema_change(&self) -> Option<&result::SchemaChange> {
+        match &self.response {
+            Response::Result(result::Result::SchemaChange(sc)) => Some(sc),
+            _ => None,
+        }
+    }
+
     pub fn into_query_result(self) -> Result<QueryResult, QueryError> {
         let (rows, paging_state, col_specs) = match self.response {
             Response::Error(err) => return Err(err.into()),

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -500,6 +500,46 @@ impl SessionBuilder {
         self.config.keepalive_interval = Some(interval);
         self
     }
+
+    /// Enables automatic wait for schema agreement and sets the timeout for it.
+    /// By default, it is enabled and the timeout is 60 seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .auto_schema_agreement_timeout(std::time::Duration::from_secs(120))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn auto_schema_agreement_timeout(mut self, timeout: Duration) -> Self {
+        self.config.auto_await_schema_agreement_timeout = Some(timeout);
+        self
+    }
+
+    /// Disables automatic wait for schema agreement.
+    /// By default, it is enabled and the timeout is 60 seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .no_auto_schema_agreement()
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn no_auto_schema_agreement(mut self) -> Self {
+        self.config.auto_await_schema_agreement_timeout = None;
+        self
+    }
 }
 
 /// Creates a [`SessionBuilder`] with default configuration, same as [`SessionBuilder::new`]


### PR DESCRIPTION
Now, the session automatically waits for schema agreement after
executing a statement which modifies the schema. The rationale for this
change is that, previously, it was the user's responsibility to wait for
schema agreement and it was easy to forget about this check.

The automatic wait for schema agreement is never a bug, although it can
slow down some programs which do a lot of schema changes in a short
succession. Those applications can opt-out of this feature by disabling
the feature in the configuration and can still wait for schema agreement
manually.

The session will wait for schema agreement for a configured amount of
time, and then - if the agreement is not reached - it will return
a TimeoutError.

Fixes: #459

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] ~I have split my patch into logically separate commits.~
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
