### PR TITLE
Remove sleeping to await schema agreement from tests

### DIFF
--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -78,8 +78,7 @@ async fn test_unprepared_statement() {
         )
         .await
         .unwrap();
-    // Wait for schema agreement
-    std::thread::sleep(std::time::Duration::from_millis(300));
+
     session
         .query(
             format!("INSERT INTO {}.t (a, b, c) VALUES (1, 2, 'abc')", ks),
@@ -182,8 +181,6 @@ async fn test_prepared_statement() {
         .query(format!("CREATE TABLE IF NOT EXISTS {}.complex_pk (a int, b int, c text, d int, e int, primary key ((a,b,c),d))", ks), &[])
         .await
         .unwrap();
-    // Wait for schema agreement
-    std::thread::sleep(std::time::Duration::from_millis(300));
 
     let prepared_statement = session
         .prepare(format!("SELECT a, b, c FROM {}.t2", ks))
@@ -376,9 +373,6 @@ async fn test_batch() {
         .await
         .unwrap();
 
-    // Wait for schema agreement
-    std::thread::sleep(std::time::Duration::from_millis(300));
-
     let prepared_statement = session
         .prepare(format!(
             "INSERT INTO {}.t_batch (a, b, c) VALUES (?, ?, ?)",
@@ -476,8 +470,7 @@ async fn test_token_calculation() {
         )
         .await
         .unwrap();
-    // Wait for schema agreement
-    std::thread::sleep(std::time::Duration::from_millis(300));
+
     let prepared_statement = session
         .prepare(format!("INSERT INTO {}.t3 (a) VALUES (?)", ks))
         .await


### PR DESCRIPTION
In one test there were leftover sleeps that were used to wait for schema agreement.

This isn't needed anymore, because after #460 the driver automatically awaits schema agreement whenever it's needed. The sleeps only slow down the tests.

Fixes: #464

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
