### PR TITLE
Optional address translation added

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -38,6 +38,7 @@ strum = "0.23"
 strum_macros = "0.23"
 lz4_flex = { version = "0.9.2" }
 smallvec = "1.8.0"
+async-trait = "0.1.56"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, warn};
 
+use super::session::AddressTranslator;
+
 /// Cluster manages up to date information and connections to database nodes.
 /// All data can be accessed by cloning Arc<ClusterData> in the `data` field
 pub struct Cluster {
@@ -43,6 +45,7 @@ pub struct ClusterData {
     pub(crate) keyspaces: HashMap<String, Keyspace>,
     pub(crate) all_nodes: Vec<Arc<Node>>,
     pub(crate) datacenters: HashMap<String, Datacenter>,
+    pub(crate) address_translator: Option<Arc<dyn AddressTranslator>>,
 }
 
 // Works in the background to keep the cluster updated
@@ -83,6 +86,7 @@ impl Cluster {
         initial_peers: &[SocketAddr],
         pool_config: PoolConfig,
         fetch_schema_metadata: bool,
+        address_translator: &Option<Arc<dyn AddressTranslator>>,
     ) -> Result<Cluster, QueryError> {
         let (refresh_sender, refresh_receiver) = tokio::sync::mpsc::channel(32);
         let (use_keyspace_sender, use_keyspace_receiver) = tokio::sync::mpsc::channel(32);
@@ -94,10 +98,18 @@ impl Cluster {
             pool_config.keepalive_interval,
             server_events_sender,
             fetch_schema_metadata,
+            address_translator,
         );
 
         let metadata = metadata_reader.read_metadata(true).await?;
-        let cluster_data = ClusterData::new(metadata, &pool_config, &HashMap::new(), &None);
+        let cluster_data = ClusterData::new(
+            metadata,
+            &pool_config,
+            &HashMap::new(),
+            &None,
+            address_translator,
+        )
+        .await;
         cluster_data.wait_until_all_pools_are_initialized().await;
         let cluster_data: Arc<ArcSwap<ClusterData>> =
             Arc::new(ArcSwap::from(Arc::new(cluster_data)));
@@ -221,11 +233,12 @@ impl ClusterData {
 
     /// Creates new ClusterData using information about topology held in `metadata`.
     /// Uses provided `known_peers` hashmap to recycle nodes if possible.
-    pub(crate) fn new(
+    pub(crate) async fn new(
         metadata: Metadata,
         pool_config: &PoolConfig,
         known_peers: &HashMap<SocketAddr, Arc<Node>>,
         used_keyspace: &Option<VerifiedKeyspaceName>,
+        address_translator: &Option<Arc<dyn AddressTranslator>>,
     ) -> Self {
         // Create new updated known_peers and ring
         let mut new_known_peers: HashMap<SocketAddr, Arc<Node>> =
@@ -235,15 +248,26 @@ impl ClusterData {
         let mut all_nodes: Vec<Arc<Node>> = Vec::with_capacity(metadata.peers.len());
 
         for peer in metadata.peers {
+            let translated_peer_address = match address_translator {
+                Some(ref translator) => match translator.translate_address(&peer).await {
+                    Ok(addr) => addr,
+                    Err(err) => {
+                        warn!("Could not translate address; TranslationError: {:?}; node therefore skipped.", err);
+                        continue;
+                    }
+                },
+                None => peer.address,
+            };
             // Take existing Arc<Node> if possible, otherwise create new one
             // Changing rack/datacenter but not ip address seems improbable
             // so we can just create new node and connections then
-            let node: Arc<Node> = match known_peers.get(&peer.address) {
+            let node: Arc<Node> = match known_peers.get(&translated_peer_address) {
                 Some(node) if node.datacenter == peer.datacenter && node.rack == peer.rack => {
                     node.clone()
                 }
                 _ => Arc::new(Node::new(
                     peer.address,
+                    translated_peer_address,
                     pool_config.clone(),
                     peer.datacenter,
                     peer.rack,
@@ -251,7 +275,7 @@ impl ClusterData {
                 )),
             };
 
-            new_known_peers.insert(peer.address, node.clone());
+            new_known_peers.insert(translated_peer_address, node.clone());
 
             if let Some(dc) = &node.datacenter {
                 match datacenters.get_mut(dc) {
@@ -281,6 +305,7 @@ impl ClusterData {
             keyspaces: metadata.keyspaces,
             all_nodes,
             datacenters,
+            address_translator: address_translator.clone(),
         }
     }
 
@@ -389,7 +414,12 @@ impl ClusterWorker {
     fn change_node_down_marker(&mut self, addr: SocketAddr, is_down: bool) {
         let cluster_data = self.cluster_data.load_full();
 
-        let node = match cluster_data.known_peers.get(&addr) {
+        let node = match cluster_data
+            .known_peers
+            .iter()
+            .filter_map(|(_addr, node)| (node.untranslated_address == addr).then(|| node))
+            .next()
+        {
             Some(node) => node,
             None => {
                 warn!("Unknown node address {}", addr);
@@ -456,12 +486,16 @@ impl ClusterWorker {
         let metadata = self.metadata_reader.read_metadata(false).await?;
         let cluster_data: Arc<ClusterData> = self.cluster_data.load_full();
 
-        let new_cluster_data = Arc::new(ClusterData::new(
-            metadata,
-            &self.pool_config,
-            &cluster_data.known_peers,
-            &self.used_keyspace,
-        ));
+        let new_cluster_data = Arc::new(
+            ClusterData::new(
+                metadata,
+                &self.pool_config,
+                &cluster_data.known_peers,
+                &self.used_keyspace,
+                &cluster_data.address_translator,
+            )
+            .await,
+        );
 
         new_cluster_data
             .wait_until_all_pools_are_initialized()

--- a/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
+++ b/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
@@ -123,7 +123,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dc_aware_round_robin_policy() {
-        let cluster = tests::mock_cluster_data_for_round_robin_tests();
+        let cluster = tests::mock_cluster_data_for_round_robin_tests().await;
 
         let local_dc = "eu".to_string();
         let policy = DcAwareRoundRobinPolicy::new(local_dc);

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -133,7 +133,7 @@ mod tests {
 
     // creates ClusterData with info about 5 nodes living in 2 different datacenters
     // ring field is empty
-    pub fn mock_cluster_data_for_round_robin_tests() -> ClusterData {
+    pub async fn mock_cluster_data_for_round_robin_tests() -> ClusterData {
         let peers = [("eu", 1), ("eu", 2), ("eu", 3), ("us", 4), ("us", 5)]
             .iter()
             .map(|(dc, id)| Peer {
@@ -149,7 +149,7 @@ mod tests {
             keyspaces: HashMap::new(),
         };
 
-        ClusterData::new(info, &Default::default(), &HashMap::new(), &None)
+        ClusterData::new(info, &Default::default(), &HashMap::new(), &None, &None).await
     }
 
     pub const EMPTY_STATEMENT: Statement = Statement {

--- a/scylla/src/transport/load_balancing/round_robin.rs
+++ b/scylla/src/transport/load_balancing/round_robin.rs
@@ -76,7 +76,7 @@ mod tests {
     // ConnectionKeeper (which lives in Node) requires context of Tokio runtime
     #[tokio::test]
     async fn test_round_robin_policy() {
-        let cluster = tests::mock_cluster_data_for_round_robin_tests();
+        let cluster = tests::mock_cluster_data_for_round_robin_tests().await;
 
         let policy = RoundRobinPolicy::new();
 

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -185,7 +185,7 @@ mod tests {
     // ConnectionKeeper (which lives in Node) requires context of Tokio runtime
     #[tokio::test]
     async fn test_token_aware_policy() {
-        let cluster = mock_cluster_data_for_token_aware_tests();
+        let cluster = mock_cluster_data_for_token_aware_tests().await;
 
         struct Test<'a> {
             statement: Statement<'a>,
@@ -241,7 +241,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_token_aware_policy_with_nts() {
-        let cluster = mock_cluster_data_for_nts_token_aware_tests();
+        let cluster = mock_cluster_data_for_nts_token_aware_tests().await;
 
         let policy = TokenAwarePolicy::new(Box::new(DumbPolicy {}));
 
@@ -257,7 +257,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_token_aware_fallback_policy() {
-        let cluster = mock_cluster_data_for_token_aware_tests();
+        let cluster = mock_cluster_data_for_token_aware_tests().await;
 
         let policy = TokenAwarePolicy::new(Box::new(DumbPolicy {}));
 
@@ -274,7 +274,7 @@ mod tests {
     // ring field is populated as follows:
     // ring tokens:            50 100 150 200 250 300 400 500
     // corresponding node ids: 2  1   2   3   1   2   3   1
-    fn mock_cluster_data_for_token_aware_tests() -> ClusterData {
+    async fn mock_cluster_data_for_token_aware_tests() -> ClusterData {
         let peers = [
             Peer {
                 datacenter: Some("eu".into()),
@@ -335,7 +335,7 @@ mod tests {
             keyspaces,
         };
 
-        ClusterData::new(info, &Default::default(), &HashMap::new(), &None)
+        ClusterData::new(info, &Default::default(), &HashMap::new(), &None, &None).await
     }
 
     // creates ClusterData with info about 8 nodes living in two different datacenters
@@ -351,7 +351,7 @@ mod tests {
     // datacenter:       her
     // nodes in rack r3: 5 6
     // nodes in rack r4: 7 8
-    fn mock_cluster_data_for_nts_token_aware_tests() -> ClusterData {
+    async fn mock_cluster_data_for_nts_token_aware_tests() -> ClusterData {
         let peers = [
             Peer {
                 datacenter: Some("waw".into()),
@@ -425,7 +425,7 @@ mod tests {
             keyspaces,
         };
 
-        ClusterData::new(info, &Default::default(), &HashMap::new(), &None)
+        ClusterData::new(info, &Default::default(), &HashMap::new(), &None, &None).await
     }
 
     // Used as child policy for TokenAwarePolicy tests

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -16,6 +16,7 @@ use std::{
 
 /// Node represents a cluster node along with it's data and connections
 pub struct Node {
+    pub untranslated_address: SocketAddr,
     pub address: SocketAddr,
     pub datacenter: Option<String>,
     pub rack: Option<String>,
@@ -28,12 +29,14 @@ pub struct Node {
 impl Node {
     /// Creates new node which starts connecting in the background
     /// # Arguments
-    ///
+    /// `untranslated_address` - address received with topology metadata;
+    ///                          may be different than `address`
     /// `address` - address to connect to
     /// `compression` - preferred compression to use
     /// `datacenter` - optional datacenter name
     /// `rack` - optional rack name
     pub(crate) fn new(
+        untranslated_address: SocketAddr,
         address: SocketAddr,
         pool_config: PoolConfig,
         datacenter: Option<String>,
@@ -44,6 +47,7 @@ impl Node {
             NodeConnectionPool::new(address.ip(), address.port(), pool_config, keyspace_name);
 
         Node {
+            untranslated_address,
             address,
             datacenter,
             rack,

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -2,11 +2,14 @@
 //! It manages all connections to the cluster and allows to perform queries.
 
 use crate::frame::types::LegacyConsistency;
+use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::join_all;
 use futures::future::try_join_all;
+use std::collections::HashMap;
 use std::future::Future;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::lookup_host;
@@ -16,6 +19,7 @@ use uuid::Uuid;
 
 use super::connection::QueryResponse;
 use super::errors::{BadQuery, NewSessionError, QueryError};
+use super::topology::Peer;
 use crate::cql_to_rust::FromRow;
 use crate::frame::response::cql_to_rust::FromRowError;
 use crate::frame::response::result;
@@ -52,6 +56,44 @@ pub use crate::transport::connection_pool::PoolSize;
 
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
+
+#[derive(Debug, Copy, Clone)]
+pub enum TranslationError {
+    NoRuleForAddress,
+    InvalidAddressInRule,
+}
+
+#[async_trait]
+pub trait AddressTranslator: Send + Sync {
+    async fn translate_address(&self, peer: &Peer) -> Result<SocketAddr, TranslationError>;
+}
+
+#[async_trait]
+impl AddressTranslator for HashMap<SocketAddr, SocketAddr> {
+    async fn translate_address(&self, peer: &Peer) -> Result<SocketAddr, TranslationError> {
+        match self.get(&peer.address) {
+            Some(&translated_addr) => Ok(translated_addr),
+            None => Err(TranslationError::NoRuleForAddress),
+        }
+    }
+}
+
+#[async_trait]
+// Notice: this is unefficient, but what else can we do with such poor representation as str?
+// After all, the cluster size is small enough to make this irrelevant.
+impl AddressTranslator for HashMap<&'static str, &'static str> {
+    async fn translate_address(&self, peer: &Peer) -> Result<SocketAddr, TranslationError> {
+        for (&rule_addr_str, &translated_addr_str) in self.iter() {
+            if let Ok(rule_addr) = SocketAddr::from_str(rule_addr_str) {
+                if rule_addr == peer.address {
+                    return SocketAddr::from_str(translated_addr_str)
+                        .map_err(|_| TranslationError::InvalidAddressInRule);
+                }
+            }
+        }
+        Err(TranslationError::NoRuleForAddress)
+    }
+}
 
 /// `Session` manages connections to the cluster and allows to perform queries
 pub struct Session {
@@ -118,6 +160,8 @@ pub struct SessionConfig {
     /// Controls the timeout for the automatic wait for schema agreement after sending a schema-altering statement.
     /// If `None`, the automatic schema agreement is disabled.
     pub auto_await_schema_agreement_timeout: Option<Duration>,
+
+    pub address_translator: Option<Arc<dyn AddressTranslator>>,
 }
 
 /// Describes database server known on Session startup.
@@ -160,6 +204,7 @@ impl SessionConfig {
             fetch_schema_metadata: true,
             keepalive_interval: None,
             auto_await_schema_agreement_timeout: Some(std::time::Duration::from_secs(60)),
+            address_translator: None,
         }
     }
 
@@ -339,6 +384,7 @@ impl Session {
             &node_addresses,
             config.get_pool_config(),
             config.fetch_schema_metadata,
+            &config.address_translator,
         )
         .await?;
 

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -4,9 +4,10 @@ use crate::statement::query::Query;
 use crate::transport::connection::{Connection, ConnectionConfig};
 use crate::transport::connection_pool::{NodeConnectionPool, PoolConfig, PoolSize};
 use crate::transport::errors::{DbError, QueryError};
-use crate::transport::session::IntoTypedRows;
+use crate::transport::session::{AddressTranslator, IntoTypedRows};
 use crate::utils::parse::{ParseErrorCause, ParseResult, ParserState};
 
+use futures::future::join_all;
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use std::borrow::BorrowMut;
@@ -16,6 +17,7 @@ use std::fmt::Formatter;
 use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 use strum_macros::EnumString;
 use tokio::sync::mpsc;
@@ -32,6 +34,8 @@ pub(crate) struct MetadataReader {
     // when control connection fails, MetadataReader tries to connect to one of known_peers
     known_peers: Vec<SocketAddr>,
     fetch_schema: bool,
+
+    address_translator: Option<Arc<dyn AddressTranslator>>,
 }
 
 /// Describes all metadata retrieved from the cluster
@@ -199,6 +203,7 @@ impl MetadataReader {
         keepalive_interval: Option<Duration>,
         server_event_sender: mpsc::Sender<Event>,
         fetch_schema: bool,
+        address_translator: &Option<Arc<dyn AddressTranslator>>,
     ) -> Self {
         let control_connection_address = *known_peers
             .choose(&mut thread_rng())
@@ -222,6 +227,7 @@ impl MetadataReader {
             connection_config,
             known_peers: known_peers.into(),
             fetch_schema,
+            address_translator: address_translator.clone(),
         }
     }
 
@@ -229,7 +235,7 @@ impl MetadataReader {
     pub async fn read_metadata(&mut self, initial: bool) -> Result<Metadata, QueryError> {
         let mut result = self.fetch_metadata(initial).await;
         if let Ok(metadata) = result {
-            self.update_known_peers(&metadata);
+            self.update_known_peers(&metadata).await;
             return Ok(metadata);
         }
 
@@ -280,7 +286,7 @@ impl MetadataReader {
 
         match &result {
             Ok(metadata) => {
-                self.update_known_peers(metadata);
+                self.update_known_peers(metadata).await;
                 debug!("Fetched new metadata");
             }
             Err(error) => error!(
@@ -320,8 +326,25 @@ impl MetadataReader {
         res
     }
 
-    fn update_known_peers(&mut self, metadata: &Metadata) {
-        self.known_peers = metadata.peers.iter().map(|peer| peer.address).collect();
+    async fn update_known_peers(&mut self, metadata: &Metadata) {
+        self.known_peers = join_all(metadata.peers.iter().map(|peer| async {
+            let res: Result<Option<SocketAddr>, ()> = match self.address_translator {
+                Some(ref translator) => match translator.translate_address(peer).await {
+                    Ok(translated_addr) => Ok(Some(translated_addr)),
+                    Err(err) => {
+                        warn!("Could not translate address; TranslationError: {:?}", err);
+                        Ok(None)
+                    }
+                },
+                None => Ok(Some(peer.address)),
+            };
+            res
+        }))
+        .await
+        .into_iter()
+        .flatten()
+        .flatten()
+        .collect();
     }
 
     fn make_control_connection_pool(
@@ -397,12 +420,8 @@ async fn query_peers(conn: &Connection, connect_port: u16) -> Result<Vec<Peer>, 
     let typed_peers_rows =
         peers_rows.into_typed::<(IpAddr, Option<String>, Option<String>, Option<Vec<String>>)>();
 
-    // For the local node we should use connection's address instead of rpc_address unless SNI is enabled (TODO)
-    // Replace address in local_rows with connection's address
-    let local_address: IpAddr = conn.get_connect_address().ip();
-    let typed_local_rows = local_rows
-        .into_typed::<(IpAddr, Option<String>, Option<String>, Option<Vec<String>>)>()
-        .map(|res| res.map(|(_addr, dc, rack, tokens)| (local_address, dc, rack, tokens)));
+    let typed_local_rows =
+        local_rows.into_typed::<(IpAddr, Option<String>, Option<String>, Option<Vec<String>>)>();
 
     for row in typed_peers_rows.chain(typed_local_rows) {
         let (ip_address, datacenter, rack, tokens) = row.map_err(|_| {


### PR DESCRIPTION
Added AddressTranslator trait and an ability to provide a struct
implementing it to the session builder. When done so, every address
fetched as cluster metadata will be translated using the rules defined
by the trait implementor.
The reasons are described in the related issue.
Reverts: #173
Fixes #470
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
