### PR TITLE
Made built-in tracing broader and OTel compliant

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,6 +14,9 @@ scylla = {path = "../scylla", features = ["ssl", "cloud"]}
 tokio = {version = "1.1.0", features = ["full"]}
 tracing = "0.1.25"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+tracing-opentelemetry = "0.18.0"
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
+opentelemetry-zipkin = { version = "0.16.0", features = ["reqwest-client"], default-features = false }
 chrono = "0.4"
 uuid = "1.0"
 tower = "0.4"
@@ -107,6 +110,11 @@ path = "allocations.rs"
 [[example]]
 name = "query_history"
 path = "query_history.rs"
+
+[[example]]
+name = "otel_tracing"
+path = "otel_tracing.rs"
+
 
 [[example]]
 name = "cloud"

--- a/examples/otel_tracing.rs
+++ b/examples/otel_tracing.rs
@@ -1,0 +1,130 @@
+use anyhow::Result;
+use opentelemetry::global::shutdown_tracer_provider;
+use scylla::macros::FromRow;
+use scylla::transport::session::{IntoTypedRows, Session};
+use scylla::SessionBuilder;
+use std::env;
+use tracing::instrument::WithSubscriber;
+
+use tracing::{error, trace_span, Instrument};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Registry;
+
+async fn example() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    session
+        .query("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)", (3, 4, "def"))
+        .await?;
+
+    session
+        .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')", &[])
+        .await?;
+
+    let prepared = session
+        .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, 7, ?)")
+        .await?;
+    session
+        .execute(&prepared, (42_i32, "I'm prepared!"))
+        .await?;
+    session
+        .execute(&prepared, (43_i32, "I'm prepared 2!"))
+        .await?;
+    session
+        .execute(&prepared, (44_i32, "I'm prepared 3!"))
+        .await?;
+
+    // Rows can be parsed as tuples
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+        for row in rows.into_typed::<(i32, i32, String)>() {
+            let (a, b, c) = row?;
+            println!("a, b, c: {}, {}, {}", a, b, c);
+        }
+    }
+
+    // Or as custom structs that derive FromRow
+    #[derive(Debug, FromRow)]
+    struct RowData {
+        _a: i32,
+        _b: Option<i32>,
+        _c: String,
+    }
+
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+        for row_data in rows.into_typed::<RowData>() {
+            let row_data = row_data?;
+            println!("row_data: {:?}", row_data);
+        }
+    }
+
+    // Or simply as untyped rows
+    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+        for row in rows {
+            let a = row.columns[0].as_ref().unwrap().as_int().unwrap();
+            let b = row.columns[1].as_ref().unwrap().as_int().unwrap();
+            let c = row.columns[2].as_ref().unwrap().as_text().unwrap();
+            println!("a, b, c: {}, {}, {}", a, b, c);
+
+            // Alternatively each row can be parsed individually
+            // let (a2, b2, c2) = row.into_typed::<(i32, i32, String)>() ?;
+        }
+    }
+
+    let metrics = session.get_metrics();
+    println!("Queries requested: {}", metrics.get_queries_num());
+    println!("Iter queries requested: {}", metrics.get_queries_iter_num());
+    println!("Errors occurred: {}", metrics.get_errors_num());
+    println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
+    println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
+    println!(
+        "99.9 latency percentile: {}",
+        metrics.get_latency_percentile_ms(99.9).unwrap()
+    );
+
+    println!("Ok.");
+
+    Ok(())
+}
+
+/* This test requires Zipkin instance running on localhost, on its default port (9411) */
+#[tokio::main]
+async fn main() -> Result<()> {
+    let tracer = opentelemetry_zipkin::new_pipeline()
+        .with_service_name("otel-trace-demo")
+        .install_batch(opentelemetry::runtime::Tokio)?;
+
+    // Create a tracing layer with the configured tracer
+    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    // Use the tracing subscriber `Registry`, or any other subscriber
+    // that impls `LookupSpan`
+    let subscriber = Registry::default().with(telemetry);
+
+    let res = async {
+        // Spans will be sent to the configured OpenTelemetry exporter
+        let root = trace_span!("example's root span");
+        {
+            root.in_scope(|| {
+                error!("Error triggered on purpose.");
+            });
+            example().instrument(root).await
+        }
+    }
+    .with_subscriber(subscriber)
+    .await;
+    shutdown_tracer_provider();
+    res
+}

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -28,6 +28,22 @@ pub enum Consistency {
     LocalOne = 0x000A,
 }
 
+impl Consistency {
+    pub fn name(&self) -> &str {
+        match self {
+            Consistency::Any => "Any",
+            Consistency::One => "One",
+            Consistency::Two => "Two",
+            Consistency::Three => "Three",
+            Consistency::Quorum => "Quorum",
+            Consistency::All => "All",
+            Consistency::LocalQuorum => "LocalQuorum",
+            Consistency::EachQuorum => "EachQuorum",
+            Consistency::LocalOne => "LocalOne",
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "SCREAMING_SNAKE_CASE"))]

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -35,6 +35,10 @@ impl RetryPolicy for DowngradingConsistencyRetryPolicy {
     fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
         Box::new(DowngradingConsistencyRetryPolicy)
     }
+
+    fn name(&self) -> &'static str {
+        "DowngradingConsistencyRetryPolicy"
+    }
 }
 
 pub struct DowngradingConsistencyRetrySession {

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -32,6 +32,8 @@ pub trait RetryPolicy: std::fmt::Debug + Send + Sync {
 
     /// Used to clone this RetryPolicy
     fn clone_boxed(&self) -> Box<dyn RetryPolicy>;
+
+    fn name(&self) -> &'static str;
 }
 
 impl Clone for Box<dyn RetryPolicy> {
@@ -75,6 +77,10 @@ impl RetryPolicy for FallthroughRetryPolicy {
     fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
         Box::new(FallthroughRetryPolicy)
     }
+
+    fn name(&self) -> &'static str {
+        "FallthroughRetryPolicy"
+    }
 }
 
 impl RetrySession for FallthroughRetrySession {
@@ -109,6 +115,10 @@ impl RetryPolicy for DefaultRetryPolicy {
 
     fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
         Box::new(DefaultRetryPolicy)
+    }
+
+    fn name(&self) -> &'static str {
+        "DefaultRetryPolicy"
     }
 }
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -2605,6 +2605,9 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
         fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
             Box::new(MyRetryPolicy(self.0.clone()))
         }
+        fn name(&self) -> &'static str {
+            "MyRetryPolicy"
+        }
     }
 
     struct MyRetrySession(Arc<AtomicBool>);

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -21,6 +21,8 @@ pub trait SpeculativeExecutionPolicy: std::fmt::Debug + Send + Sync {
 
     /// The delay between each speculative execution
     fn retry_interval(&self, context: &Context) -> Duration;
+
+    fn name(&self) -> &'static str;
 }
 
 /// A SpeculativeExecutionPolicy that schedules a given number of speculative
@@ -56,6 +58,10 @@ impl SpeculativeExecutionPolicy for SimpleSpeculativeExecutionPolicy {
     fn retry_interval(&self, _: &Context) -> Duration {
         self.retry_interval
     }
+
+    fn name(&self) -> &'static str {
+        "SimpleSpeculativeExecutionPolicy"
+    }
 }
 
 impl SpeculativeExecutionPolicy for PercentileSpeculativeExecutionPolicy {
@@ -76,6 +82,10 @@ impl SpeculativeExecutionPolicy for PercentileSpeculativeExecutionPolicy {
             }
         };
         Duration::from_millis(ms)
+    }
+
+    fn name(&self) -> &'static str {
+        "PercentileSpeculativeExecutionPolicy"
     }
 }
 

--- a/scylla/src/utils/mod.rs
+++ b/scylla/src/utils/mod.rs
@@ -1,3 +1,91 @@
 pub(crate) mod parse;
 
 pub mod test_utils;
+
+use std::error::Error;
+
+use tracing::{error, field::display, Span};
+
+/// Constructs an OpenTelemetry span at the trace level.
+///
+/// Basically does the same as [tracing::trace_span!], only adding two (empty) fields:
+/// `otel.status_code` and `otel.status_message`.
+#[macro_export]
+macro_rules! otel_span {
+    (parent: $parent:expr, $name:expr, $($field:tt)*) => {
+        tracing::trace_span!(
+            target: module_path!(),
+            parent: $parent,
+            $name,
+            $($field)*
+            otel.status_code = tracing::field::Empty,
+            otel.status_message = tracing::field::Empty,
+        )
+    };
+    ($name:expr, $($field:tt)*) => {
+        tracing::trace_span!(
+            target: module_path!(),
+            $name,
+            $($field)*
+            otel.status_code = tracing::field::Empty,
+            otel.status_message = tracing::field::Empty,
+        )
+    };
+    (parent: $parent:expr, $name:expr) => {
+        $crate::otel_span!(parent: $parent, $name,)
+    };
+    ($name:expr) => {
+        $crate::otel_span!($name,)
+    };
+}
+
+pub(crate) trait RecordError {
+    fn record_error(self, span: &Span) -> Self;
+}
+
+impl<T, E> RecordError for Result<T, E>
+where
+    E: Error,
+{
+    fn record_error(self, span: &Span) -> Self {
+        if let Err(ref err) = self {
+            span.record_error(err);
+        }
+        self
+    }
+}
+
+pub(crate) trait SpanExt {
+    fn record_error(&self, error: &impl Error);
+
+    fn record_none_explicitly<Q, V>(&self, field: &Q, value: Option<V>)
+    where
+        Q: ?Sized + tracing::field::AsField,
+        V: tracing::field::Value;
+}
+
+impl SpanExt for Span {
+    fn record_error(&self, error: &impl Error) {
+        self.record("otel.status_code", "ERROR");
+        self.record("otel.status_message", display(error));
+        self.in_scope(|| error!("{}", "Finished with error"));
+    }
+
+    fn record_none_explicitly<Q, V>(&self, field: &Q, value: Option<V>)
+    where
+        Q: ?Sized + tracing::field::AsField,
+        V: tracing::field::Value,
+    {
+        match &value {
+            Some(v) => self.record(field, v),
+            None => self.record(field, "<None>"),
+        };
+    }
+}
+
+#[macro_export]
+macro_rules! scylladb_tag {
+    ($suffix:literal) => {
+        concat!("db.scylladb.", $suffix)
+    };
+}

--- a/scylla/tests/execution_profiles.rs
+++ b/scylla/tests/execution_profiles.rs
@@ -93,6 +93,10 @@ impl<const NODE: u8> RetryPolicy for BoundToPredefinedNodePolicy<NODE> {
     fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
         Box::new(self.clone())
     }
+
+    fn name(&self) -> &'static str {
+        "BoundToPredefinedNodePolicy"
+    }
 }
 
 impl<const NODE: u8> RetrySession for BoundToPredefinedNodePolicy<NODE> {

--- a/scylla/tests/execution_profiles.rs
+++ b/scylla/tests/execution_profiles.rs
@@ -120,6 +120,10 @@ impl<const NODE: u8> SpeculativeExecutionPolicy for BoundToPredefinedNodePolicy<
         self.report_node(Report::SpeculativeExecution);
         std::time::Duration::from_millis(200)
     }
+
+    fn name(&self) -> &'static str {
+        "BoundToPredefinedNodePolicy"
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
In effort of increasing Scylla drivers' observability, I instrumented this one with OpenTelemetry compliant tracing. The solution utilises the `tokio-tracing` already present in the driver, however adding more spans and tags to them. The structure and content of those are expected to be roughly consistent among various drivers, so I kept close to Java driver's implementation. For converting `tokio-tracing` traces into OTel traces, I've used `tracing_opentelemetry` compatibility layer.

## Considerations yet to be done
- configurable Verbosity Level,
- whether we should turn the new tracing features (including possibly heavy data transfers upon creating spans and filling them with tags) on only when explicitly requested,
- how we can extend `Value` and `ValueList` so that they enable putting their string representation into `bound_values` and `partition_key` tags.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
