### PR TITLE
caching_session: execute: Take ValueList by value

### DIFF
--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -31,7 +31,7 @@ impl CachingSession {
     pub async fn execute(
         &self,
         query: impl Into<Query>,
-        values: &impl ValueList,
+        values: impl ValueList,
     ) -> Result<QueryResult, QueryError> {
         let query = query.into();
         let prepared = self.add_prepared_statement(&query).await?;


### PR DESCRIPTION
`CachingSession::execute` takes the value list argument as:
```rust
values: &impl ValueList,
```

This is an unnecessary limitation. `Session` has:
```rust
values: impl ValueList,
```


This forces the user to pass values as a reference, so instead of writing:
```rust
session.execute(..., (1, 2, 3))
```
They have to write:
```rust
session.execute(...., &(1, 2, 3))
```

There is a generic impl that makes every reference to `ValueList` also implement `ValueList`:
```rust
impl<T: ValueList> ValueList for &T {
     ...
}
```

This means that this is not a breaking change. All existing code will work without any modifications (the tests didn't need to be modified). It just enables the user to write cleaner code.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
