### PR TITLE
Add support for custom hashing in CachingSession

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -41,6 +41,7 @@ smallvec = "1.8.0"
 
 [dev-dependencies]
 criterion = "0.3"
+fxhash = "0.2.1"
 
 [[bench]]
 name = "benchmark"

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -1,12 +1,13 @@
-use crate::frame::value::ValueList;
+use crate::frame::value::{BatchValues, ValueList};
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::transport::errors::{DbError, QueryError};
 use crate::transport::iterator::RowIterator;
-use crate::{QueryResult, Session};
+use crate::{BatchResult, QueryResult, Session};
 use bytes::Bytes;
 use dashmap::DashMap;
 use itertools::Either;
+use crate::batch::{Batch, BatchStatement};
 
 /// Provides auto caching while executing queries
 pub struct CachingSession {
@@ -89,6 +90,59 @@ impl CachingSession {
                     .execute_paged(&new_prepared_statement, values, paging_state)
                     .await
             }
+        }
+    }
+
+    /// Does the same thing as [`Session::batch`] but uses the prepared statement cache
+    pub async fn batch(
+        &self,
+        mut batch: Batch,
+        values: impl BatchValues,
+    ) -> Result<BatchResult, QueryError> {
+        // Replace all of the `Query`s with `PreparedStatement`s
+        for statement in batch.statements.iter_mut() {
+            if let BatchStatement::Query(query) = statement {
+                let prepared = self.add_prepared_statement(&*query).await?;
+                *statement = BatchStatement::PreparedStatement(prepared);
+            }
+        }
+
+        let result = self
+            .session
+            .batch(&batch, &values)
+            .await;
+
+        // If one of the statements is Unprepared, we need to remove it from the cache,
+        // re-prepare it, and retry the batch execution
+        match result {
+            r @ Ok(_) => r,
+            Err( QueryError::DbError(DbError::Unprepared { ref statement_id }, _message)) => {
+                let unprepared_statement = batch.statements.iter_mut().find_map(|statement| {
+                    if let BatchStatement::PreparedStatement(statement) = statement {
+                        if statement.get_id() == statement_id {
+                            return Some(statement)
+                        }
+                    }
+                    None
+                });
+                // Remove the query from the cache, re-prepare the statement, and
+                // overwrite the previous unprepared_statement with the newly prepared
+                // statement.
+                match unprepared_statement {
+                    Some(unprepared_statement) => {
+                        self.cache.remove(unprepared_statement.get_statement());
+                        let prepared = self.add_prepared_statement(
+                            &Query::new(unprepared_statement.get_statement())
+                        ).await?;
+                        *unprepared_statement = prepared;
+                        self.session.batch(&batch, values).await
+                    }
+                    None => Err(QueryError::ProtocolError(
+                        "Prepared statement Id did not match any known statement Id",
+                    ))
+                }
+            },
+            e @ Err(_) => e,
         }
     }
 

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -204,6 +204,7 @@ impl<S> CachingSession<S>
 mod tests {
     use crate::{CachingSession, Session, SessionBuilder};
     use futures::TryStreamExt;
+    use fxhash::FxBuildHasher;
 
     async fn new_for_test() -> Session {
         let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
@@ -343,5 +344,13 @@ mod tests {
 
         assert_eq!(1, session.cache.len());
         assert_eq!(1, result.rows.unwrap().len());
+    }
+
+    /// This test checks that we can construct a CachingSession with custom HashBuilder implementations
+    #[tokio::test]
+    async fn test_custom_hasher() {
+        let _session: CachingSession::<std::collections::hash_map::RandomState> = CachingSession::from(new_for_test().await, 2);
+        let _session: CachingSession::<FxBuildHasher> = CachingSession::from(new_for_test().await, 2);
+        let _session: CachingSession::<FxBuildHasher> = CachingSession::with_hasher(new_for_test().await, 2, FxBuildHasher::default());
     }
 }


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
There are no Fixes: here, unless you want me to open up an issue or something.

I added a test, which required adding the `fxhash` crate (I just chose that because I knew of it). All the test does is ensure that the code compiles when using a custom hasher and the new method I created.

*Summary*

Currently `CachingSession` does not allow one to specify a custom hash algorithm even though `DashMap` supports this. Rust's default hash algorithm is sip13 with a random seed (that gets incremented with every HashMap creation). This is to ensure that, *when an attacker controls your keys*, you aren't susceptible to a DOS via quadratic performance. That's a fine default, but it's unlikely to be the case for the Scylla driver - if your attacker controls the entire query you're probably in trouble already.

This PR:
1. adds a new generic parameter `S` to CachingSession and sets it to the default of `RandomState` (the default for Rust's hashmap). 

2. Moves the `CachingSession::from` impl into its own block that specifies `S: Default + BuildHasher + Clone` (as `Default` is used only in this one place).

3. Adds new methods `with_hasher`, `with_capacity_and_hasher`, and `with_capacity`.

4. Adds a single test, `test_custom_hasher`. This test is *extremely* simple. All it is doing is ensuring that the code compiles, there's no business logic here - I'm assuming that Scylla does not care about the the Hasher implementation and that the only possible bugs here would be with regards to type inference, so that's all this test tries to exercise.

This mirrors the std::collections::HashMap and DashMap APIs.