### PR TITLE
Add batch support to CachingSession, Add Session::prepare_batch

### DIFF
--- a/docs/source/queries/batch.md
+++ b/docs/source/queries/batch.md
@@ -40,6 +40,34 @@ session.batch(&batch, batch_values).await?;
 # }
 ```
 
+### Preparing a batch
+Instead of preparing each query individually, it's possible to prepare a whole batch at once:
+
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::batch::Batch;
+
+// Create a batch statement with unprepared statements
+let mut batch: Batch = Default::default();
+batch.append_statement("INSERT INTO ks.simple_unprepared1 VALUES(?, ?)");
+batch.append_statement("INSERT INTO ks.simple_unprepared2 VALUES(?, ?)");
+
+// Prepare all statements in the batch at once
+let prepared_batch: Batch = session.prepare_batch(&batch).await?;
+
+// Specify bound values to use with each query
+let batch_values = ((1_i32, 2_i32),
+                    (3_i32, 4_i32));
+
+// Run the prepared batch
+session.batch(&prepared_batch, batch_values).await?;
+# Ok(())
+# }
+```
+
 ### Batch options
 You can set various options by operating on the `Batch` object.\
 For example to change consistency:

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1,7 +1,8 @@
 use crate as scylla;
-use crate::batch::Batch;
+use crate::batch::{Batch, BatchStatement};
 use crate::frame::response::result::Row;
 use crate::frame::value::ValueList;
+use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::routing::Token;
 use crate::statement::Consistency;
@@ -19,6 +20,7 @@ use assert_matches::assert_matches;
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
+use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashMap};
 use tokio::net::TcpListener;
 use uuid::Uuid;
@@ -2086,4 +2088,121 @@ async fn test_views_in_schema_info() {
         views_base_table,
         std::collections::HashSet::from([&"t".to_string()])
     )
+}
+
+async fn assert_test_batch_table_rows_contain(sess: &Session, expected_rows: &[(i32, i32)]) {
+    let selected_rows: BTreeSet<(i32, i32)> = sess
+        .query("SELECT a, b FROM test_batch_table", ())
+        .await
+        .unwrap()
+        .rows_typed::<(i32, i32)>()
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    for expected_row in expected_rows.iter() {
+        if !selected_rows.contains(expected_row) {
+            panic!(
+                "Expected {:?} to contain row: {:?}, but they didnt",
+                selected_rows, expected_row
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_prepare_batch() {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let session = SessionBuilder::new().known_node(uri).build().await.unwrap();
+
+    let ks = unique_keyspace_name();
+    session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 1}}", ks), &[]).await.unwrap();
+    session.use_keyspace(ks.clone(), false).await.unwrap();
+
+    session
+        .query(
+            "CREATE TABLE test_batch_table (a int, b int, primary key (a, b))",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let unprepared_insert_a_b: &str = "insert into test_batch_table (a, b) values (?, ?)";
+    let unprepared_insert_a_7: &str = "insert into test_batch_table (a, b) values (?, 7)";
+    let unprepared_insert_8_b: &str = "insert into test_batch_table (a, b) values (8, ?)";
+    let prepared_insert_a_b: PreparedStatement =
+        session.prepare(unprepared_insert_a_b).await.unwrap();
+    let prepared_insert_a_7: PreparedStatement =
+        session.prepare(unprepared_insert_a_7).await.unwrap();
+    let prepared_insert_8_b: PreparedStatement =
+        session.prepare(unprepared_insert_8_b).await.unwrap();
+
+    let assert_batch_prepared = |b: &Batch| {
+        for stmt in &b.statements {
+            match stmt {
+                BatchStatement::PreparedStatement(_) => {}
+                _ => panic!("Unprepared statement in prepared batch!"),
+            }
+        }
+    };
+
+    {
+        let mut unprepared_batch: Batch = Default::default();
+        unprepared_batch.append_statement(unprepared_insert_a_b);
+        unprepared_batch.append_statement(unprepared_insert_a_7);
+        unprepared_batch.append_statement(unprepared_insert_8_b);
+
+        let prepared_batch: Batch = session.prepare_batch(&unprepared_batch).await.unwrap();
+        assert_batch_prepared(&prepared_batch);
+
+        session
+            .batch(&prepared_batch, ((10, 20), (10,), (20,)))
+            .await
+            .unwrap();
+        assert_test_batch_table_rows_contain(&session, &[(10, 20), (10, 7), (8, 20)]).await;
+    }
+
+    {
+        let mut partially_prepared_batch: Batch = Default::default();
+        partially_prepared_batch.append_statement(unprepared_insert_a_b);
+        partially_prepared_batch.append_statement(prepared_insert_a_7.clone());
+        partially_prepared_batch.append_statement(unprepared_insert_8_b);
+
+        let prepared_batch: Batch = session
+            .prepare_batch(&partially_prepared_batch)
+            .await
+            .unwrap();
+        assert_batch_prepared(&prepared_batch);
+
+        session
+            .batch(&prepared_batch, ((30, 40), (30,), (40,)))
+            .await
+            .unwrap();
+        assert_test_batch_table_rows_contain(&session, &[(30, 40), (30, 7), (8, 40)]).await;
+    }
+
+    {
+        let mut fully_prepared_batch: Batch = Default::default();
+        fully_prepared_batch.append_statement(prepared_insert_a_b);
+        fully_prepared_batch.append_statement(prepared_insert_a_7);
+        fully_prepared_batch.append_statement(prepared_insert_8_b);
+
+        let prepared_batch: Batch = session.prepare_batch(&fully_prepared_batch).await.unwrap();
+        assert_batch_prepared(&prepared_batch);
+
+        session
+            .batch(&prepared_batch, ((50, 60), (50,), (60,)))
+            .await
+            .unwrap();
+
+        assert_test_batch_table_rows_contain(&session, &[(50, 60), (50, 7), (8, 60)]).await;
+    }
+
+    {
+        let mut bad_batch: Batch = Default::default();
+        bad_batch.append_statement(unprepared_insert_a_b);
+        bad_batch.append_statement("This isnt even CQL");
+        bad_batch.append_statement(unprepared_insert_8_b);
+
+        assert!(session.prepare_batch(&bad_batch).await.is_err());
+    }
 }


### PR DESCRIPTION
This PR adds a `batch` method on `CachingSession` which allows it to execute batches.
The batch is taken by reference to stay consistent with `Session` and to make it possible not to copy batches that are already prepared.

Apart from that I also added a `prepare_batch` method to both `Session` and `CachingSession`. It's more convenient to create a batch and then prepare all statements within that it's to prepare each of them one by one. Both changes are in one PR because the code is very similar and it's easier to review both at once.

Fixes: #469, thanks to [colin-grapl](https://github.com/colin-grapl) for the initial code

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
