### PR TITLE
Splitted "BadData" into ser/deser separately

### DIFF
--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -32,7 +32,9 @@ pub enum FrameError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error("Could not serialize frame: {0}")]
-    BadData(String),
+    BadDataToSerialize(String),
+    #[error("Could not deserialize frame: {0}")]
+    BadIncomingData(String),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error("type not yet implemented, id: {0}")]

--- a/scylla-cql/src/frame/request/auth_response.rs
+++ b/scylla-cql/src/frame/request/auth_response.rs
@@ -17,7 +17,7 @@ impl Request for AuthResponse {
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
         if self.username.is_none() || self.password.is_none() {
-            return Err(ParseError::BadData(
+            return Err(ParseError::BadDataToSerialize(
                 "Bad credentials: username or password missing. You can use SessionBuilder::user(\"user\", \"pass\") to provide credentials.".to_string(),
             ));
         }

--- a/scylla-cql/src/frame/response/event.rs
+++ b/scylla-cql/src/frame/response/event.rs
@@ -142,7 +142,7 @@ impl SchemaChangeEvent {
                 })
             }
 
-            _ => Err(ParseError::BadData(format!(
+            _ => Err(ParseError::BadIncomingData(format!(
                 "Invalid type of schema change ({}) in SchemaChangeEvent",
                 target
             ))),
@@ -158,7 +158,7 @@ impl TopologyChangeEvent {
         match type_of_change {
             "NEW_NODE" => Ok(Self::NewNode(addr)),
             "REMOVED_NODE" => Ok(Self::RemovedNode(addr)),
-            _ => Err(ParseError::BadData(format!(
+            _ => Err(ParseError::BadIncomingData(format!(
                 "Invalid type of change ({}) in TopologyChangeEvent",
                 type_of_change
             ))),
@@ -174,7 +174,7 @@ impl StatusChangeEvent {
         match type_of_change {
             "UP" => Ok(Self::Up(addr)),
             "DOWN" => Ok(Self::Down(addr)),
-            _ => Err(ParseError::BadData(format!(
+            _ => Err(ParseError::BadIncomingData(format!(
                 "Invalid type of status change ({}) in StatusChangeEvent",
                 type_of_change
             ))),

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -570,20 +570,22 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
 
     Ok(match typ {
         Custom(type_str) => {
-            return Err(ParseError::BadData(format!(
+            return Err(ParseError::BadIncomingData(format!(
                 "Support for custom types is not yet implemented: {}",
                 type_str
             )));
         }
         Ascii => {
             if !buf.is_ascii() {
-                return Err(ParseError::BadData("String is not ascii!".to_string()));
+                return Err(ParseError::BadIncomingData(
+                    "String is not ascii!".to_string(),
+                ));
             }
             CqlValue::Ascii(str::from_utf8(buf)?.to_owned())
         }
         Boolean => {
             if buf.len() != 1 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 1 not {}",
                     buf.len()
                 )));
@@ -593,7 +595,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         Blob => CqlValue::Blob(buf.to_vec()),
         Date => {
             if buf.len() != 4 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 4 not {}",
                     buf.len()
                 )));
@@ -604,7 +606,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         Counter => {
             if buf.len() != 8 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 8 not {}",
                     buf.len()
                 )));
@@ -620,7 +622,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         Double => {
             if buf.len() != 8 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 8 not {}",
                     buf.len()
                 )));
@@ -629,7 +631,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         Float => {
             if buf.len() != 4 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 4 not {}",
                     buf.len()
                 )));
@@ -638,7 +640,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         Int => {
             if buf.len() != 4 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 4 not {}",
                     buf.len()
                 )));
@@ -647,7 +649,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         SmallInt => {
             if buf.len() != 2 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 2 not {}",
                     buf.len()
                 )));
@@ -657,7 +659,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         TinyInt => {
             if buf.len() != 1 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 1 not {}",
                     buf.len()
                 )));
@@ -666,7 +668,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         BigInt => {
             if buf.len() != 8 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 8 not {}",
                     buf.len()
                 )));
@@ -676,7 +678,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         Text => CqlValue::Text(str::from_utf8(buf)?.to_owned()),
         Timestamp => {
             if buf.len() != 8 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 8 not {}",
                     buf.len()
                 )));
@@ -687,7 +689,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         Time => {
             if buf.len() != 8 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 8 not {}",
                     buf.len()
                 )));
@@ -696,7 +698,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
 
             // Valid values are in the range 0 to 86399999999999
             if !(0..=86399999999999).contains(&nanoseconds) {
-                return Err(ParseError::BadData(format! {
+                return Err(ParseError::BadIncomingData(format! {
                     "Invalid time value only 0 to 86399999999999 allowed: {}.", nanoseconds
                 }));
             }
@@ -705,7 +707,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }
         Timeuuid => {
             if buf.len() != 16 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 16 not {}",
                     buf.len()
                 )));
@@ -736,7 +738,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
                 ret
             }
             v => {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Invalid inet bytes length: {}",
                     v
                 )));
@@ -744,7 +746,7 @@ fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue, Par
         }),
         Uuid => {
             if buf.len() != 16 {
-                return Err(ParseError::BadData(format!(
+                return Err(ParseError::BadIncomingData(format!(
                     "Buffer length should be 16 not {}",
                     buf.len()
                 )));
@@ -893,7 +895,7 @@ pub fn deserialize(buf: &mut &[u8]) -> StdResult<Result, ParseError> {
         0x0004 => Prepared(deser_prepared(buf)?),
         0x0005 => SchemaChange(deser_schema_change(buf)?),
         k => {
-            return Err(ParseError::BadData(format!(
+            return Err(ParseError::BadIncomingData(format!(
                 "Unknown query result id: {}",
                 k
             )))

--- a/scylla-cql/src/frame/server_event_type.rs
+++ b/scylla-cql/src/frame/server_event_type.rs
@@ -28,7 +28,7 @@ impl FromStr for EventType {
             "TOPOLOGY_CHANGE" => Ok(Self::TopologyChange),
             "STATUS_CHANGE" => Ok(Self::StatusChange),
             "SCHEMA_CHANGE" => Ok(Self::SchemaChange),
-            _ => Err(ParseError::BadData(format!(
+            _ => Err(ParseError::BadIncomingData(format!(
                 "Invalid type event type: {}",
                 s
             ))),


### PR DESCRIPTION
As described in the related issue, serialization and deserialization
error were both covered by one ParseError variant, which caused
misleading messages. Now, there are separate variants for both cases.
Fixes:  #478

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
