### PR TITLE
Enhanced CI cluster: now 3-node instead of 1-node

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,16 +14,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      scylladb:
-        image: scylladb/scylla
-        ports:
-          - 9042:9042
-        options: --health-cmd "cqlsh --debug" --health-interval 5s --health-retries 10
-        volumes:
-          - ${{ github.workspace }}:/workspace
     steps:
     - uses: actions/checkout@v2
+    - name: Setup 3-node Scylla cluster
+      run: |
+        sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+        GITHUB_WORKSPACE=${{ github.workspace }} docker-compose -f test/docker-compose.yml up -d
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
@@ -33,7 +29,9 @@ jobs:
     - name: Build
       run: cargo build --verbose --examples
     - name: Run tests
-      run: cargo test --verbose
+      run: SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose
+    - name: Stop cluster
+      run: GITHUB_WORKSPACE=${{ github.workspace }} docker-compose -f test/docker-compose.yml down
 
   # Tests that our current minimum supported rust version compiles everything sucessfully
   min_rust:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.7"
+
+networks:
+  public:
+    name: scylla_rust_driver_public
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.42.0.0/16
+services:
+  scylla1:
+    image: scylladb/scylla
+    volumes:
+      - ${GITHUB_WORKSPACE}:/workspace
+    networks:
+      public:
+        ipv4_address: 172.42.0.2
+    command: --rpc-address 172.42.0.2 --listen-address 172.42.0.2 --seeds 172.42.0.2 --skip-wait-for-gossip-to-settle 0
+  scylla2:
+    image: scylladb/scylla
+    volumes:
+      - ${GITHUB_WORKSPACE}:/workspace
+    networks:
+      public:
+        ipv4_address: 172.42.0.3
+    command: --rpc-address 172.42.0.3 --listen-address 172.42.0.3 --seeds 172.42.0.2 --skip-wait-for-gossip-to-settle 0
+  scylla3:
+    image: scylladb/scylla
+    volumes:
+      - ${GITHUB_WORKSPACE}:/workspace
+    networks:
+      public:
+        ipv4_address: 172.42.0.4
+    command: --rpc-address 172.42.0.4 --listen-address 172.42.0.4 --seeds 172.42.0.2,172.42.0.3 --skip-wait-for-gossip-to-settle 0


### PR DESCRIPTION
As it enables testing more sophisticated scenarios such as retries
and speculative executions, we made the cluster in CI consist
of 3 nodes. The existing tests pass seamlessly on such cluster.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
