### PR TITLE
topology: use rpc_address instead of peer when fetching addrs

### DIFF
--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -373,7 +373,8 @@ async fn query_metadata(
 }
 
 async fn query_peers(conn: &Connection, connect_port: u16) -> Result<Vec<Peer>, QueryError> {
-    let mut peers_query = Query::new("select peer, data_center, rack, tokens from system.peers");
+    let mut peers_query =
+        Query::new("select rpc_address, data_center, rack, tokens from system.peers");
     peers_query.set_page_size(1024);
     let peers_query_future = conn.query_all(&peers_query, &[]);
 


### PR DESCRIPTION
When fetching node addresses from system tables, `peer` column
is not the right choice - the address available for clients
is generally stored in `rpc_address` column.
Technically, a full solution should also fetch `broadcast_rpc_address`
and use it if `rpc_address` is incorrect or set to 0.0.0.0,
but this quick fix is enough to work for most configurations.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
