### PR TITLE
Removed warning in benchmarks

### DIFF
--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -29,7 +29,7 @@ fn types_benchmark(c: &mut Criterion) {
     c.bench_function("string", |b| {
         b.iter(|| {
             buf.clear();
-            types::write_string("hello, world", &mut buf);
+            types::write_string("hello, world", &mut buf).unwrap();
             types::read_string(&mut &buf[..]).unwrap();
         })
     });


### PR DESCRIPTION
One value was not unwrapped, and the compiler has been warning
about unused result while checking target benchmarks.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x]  All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
