### PR TITLE
Fixed missing tokio feature in scylla-cql

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
       run: cargo clippy --verbose --examples --tests
     - name: Cargo check without features
       run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
+    - name: Build scylla-cql
+      run: cargo build --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml"
     - name: Build
       run: cargo build --verbose --examples
     - name: Run tests
@@ -49,3 +51,5 @@ jobs:
       run: cargo check --verbose --examples --tests
     - name: MSRV cargo check without features
       run: cargo check --verbose --manifest-path "scylla/Cargo.toml"
+    - name: MSRV cargo check scylla-cql
+      run: cargo check --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "examples",
     "scylla",
     "scylla-macros",
+    "scylla-cql",
 ]

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -14,7 +14,7 @@ scylla-macros = { version = "0.1.1", path = "../scylla-macros"}
 byteorder = "1.3.4"
 bytes = "1.0.1"
 num_enum = "0.5"
-tokio = "1.12"
+tokio = { version = "1.12", features = ["io-util"] }
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
Contrary to previous assumptions, tokio feature "io-util" is required
for `scylla-cql` crate to build. Moreover, I added the new crate
to Cargo workspace.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
