### PR TITLE
Remove unnecessary `pub`

### DIFF
--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -208,7 +208,7 @@ impl SerializedValues {
 }
 
 #[derive(Clone, Copy)]
-pub struct SerializedValuesIterator<'a> {
+struct SerializedValuesIterator<'a> {
     serialized_values: &'a [u8],
     contains_names: bool,
 }


### PR DESCRIPTION
(non backwards-compatible)

Alternately we could make this return an explicit type so that it's expressable, but I doubt that would actually be necessary for anyone.
https://github.com/scylladb/scylla-rust-driver/blob/db8d52893bdef56977872a09f51fda2fa423168f/scylla-cql/src/frame/value.rs#L189