### PR TITLE
Include ssl functions on docs.rs

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 defaults = []

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["database", "scylla", "cql", "cassandra"]
 categories = ["database"]
 license = "MIT OR Apache-2.0"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 defaults = []
 ssl = ["tokio-openssl", "openssl"]

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -91,6 +91,8 @@
 //! ```
 //! See the [book](https://rust-driver.docs.scylladb.com/stable/queries/result.html) for more receiving methods
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 pub use scylla_cql::frame;
 pub use scylla_cql::macros::{self, *};
 


### PR DESCRIPTION
## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.


By default docs.rs builds crates with all features disabled, this results in the ssl methods not being included in places such as: https://docs.rs/scylla/latest/scylla/transport/session_builder/struct.SessionBuilder.html
To resolve this we set docs.rs metadata as documented here: https://docs.rs/about/metadata

Additionally we use `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to make use of https://doc.rust-lang.org/beta/unstable-book/language-features/doc-auto-cfg.html which is what gives us the nice "only available on..." badge underneath:
![image](https://user-images.githubusercontent.com/5120858/184044665-89f515cd-2a1d-40d7-868c-f72d058b8c01.png)


You can use the command: `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features` to test the changes locally.