### PR TITLE
Pull materialized view information when fetching schema

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -27,4 +27,4 @@ jobs:
       run: cargo build --verbose --tests
     - name: Run tests on cassandra
       # test threads must be one because else database tests will run in parallel and will result in flaky tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose -- --test-threads=1 --skip test_views_in_schema_info

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -312,6 +312,7 @@ mod tests {
                         replication_factor: 2,
                     },
                     tables: HashMap::new(),
+                    views: HashMap::new(),
                     user_defined_types: HashMap::new(),
                 },
             ),
@@ -322,6 +323,7 @@ mod tests {
                         replication_factor: 3,
                     },
                     tables: HashMap::new(),
+                    views: HashMap::new(),
                     user_defined_types: HashMap::new(),
                 },
             ),
@@ -413,6 +415,7 @@ mod tests {
                         .collect::<HashMap<_, _>>(),
                 },
                 tables: HashMap::new(),
+                views: HashMap::new(),
                 user_defined_types: HashMap::new(),
             },
         )]


### PR DESCRIPTION
In order to keep information about materialized views too,
system_schema.views system table is queried, instead of fetching
the info only from system_schema.tables.

Fixes #506 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
