### PR TITLE
Address translation with exception for hosts on current control connection

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -43,6 +43,7 @@ strum = "0.23"
 strum_macros = "0.23"
 lz4_flex = { version = "0.9.2" }
 smallvec = "1.8.0"
+async-trait = "0.1.56"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -141,6 +141,7 @@ mod tests {
                 rack: None,
                 address: tests::id_to_invalid_addr(*id),
                 tokens: Vec::new(),
+                untranslated_address: Some(tests::id_to_invalid_addr(*id)),
             })
             .collect::<Vec<_>>();
 

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -290,6 +290,7 @@ mod tests {
                     Token { value: 250 },
                     Token { value: 500 },
                 ],
+                untranslated_address: Some(tests::id_to_invalid_addr(1)),
             },
             Peer {
                 datacenter: Some("eu".into()),
@@ -300,12 +301,14 @@ mod tests {
                     Token { value: 150 },
                     Token { value: 300 },
                 ],
+                untranslated_address: Some(tests::id_to_invalid_addr(2)),
             },
             Peer {
                 datacenter: Some("us".into()),
                 rack: None,
                 address: tests::id_to_invalid_addr(3),
                 tokens: vec![Token { value: 200 }, Token { value: 400 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(3)),
             },
         ];
 
@@ -365,48 +368,56 @@ mod tests {
                 rack: Some("r1".into()),
                 address: tests::id_to_invalid_addr(1),
                 tokens: vec![Token { value: 50 }, Token { value: 200 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(1)),
             },
             Peer {
                 datacenter: Some("waw".into()),
                 rack: Some("r1".into()),
                 address: tests::id_to_invalid_addr(2),
                 tokens: vec![Token { value: 150 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(2)),
             },
             Peer {
                 datacenter: Some("waw".into()),
                 rack: Some("r2".into()),
                 address: tests::id_to_invalid_addr(3),
                 tokens: vec![Token { value: 510 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(3)),
             },
             Peer {
                 datacenter: Some("waw".into()),
                 rack: Some("r2".into()),
                 address: tests::id_to_invalid_addr(4),
                 tokens: vec![Token { value: 300 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(4)),
             },
             Peer {
                 datacenter: Some("her".into()),
                 rack: Some("r3".into()),
                 address: tests::id_to_invalid_addr(5),
                 tokens: vec![Token { value: 100 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(5)),
             },
             Peer {
                 datacenter: Some("her".into()),
                 rack: Some("r3".into()),
                 address: tests::id_to_invalid_addr(6),
                 tokens: vec![Token { value: 250 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(6)),
             },
             Peer {
                 datacenter: Some("her".into()),
                 rack: Some("r4".into()),
                 address: tests::id_to_invalid_addr(7),
                 tokens: vec![Token { value: 500 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(7)),
             },
             Peer {
                 datacenter: Some("her".into()),
                 rack: Some("r4".into()),
                 address: tests::id_to_invalid_addr(8),
                 tokens: vec![Token { value: 400 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(8)),
             },
         ];
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -201,6 +201,8 @@ pub struct SessionConfig {
     /// Controls the client-side timeout for queries.
     /// If `None`, the queries have no timeout (the driver will block indefinitely).
     pub request_timeout: Option<Duration>,
+
+    pub address_translator: Option<Arc<dyn AddressTranslator>>,
 }
 
 /// Describes database server known on Session startup.
@@ -244,6 +246,7 @@ impl SessionConfig {
             keepalive_interval: None,
             auto_await_schema_agreement_timeout: Some(std::time::Duration::from_secs(60)),
             request_timeout: Some(Duration::from_secs(30)),
+            address_translator: None,
         }
     }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -431,6 +431,7 @@ impl Session {
             &node_addresses,
             config.get_pool_config(),
             config.fetch_schema_metadata,
+            &config.address_translator,
         )
         .await?;
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -4,12 +4,15 @@
 use crate::frame::types::LegacyConsistency;
 use crate::history;
 use crate::history::HistoryListener;
+use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::join_all;
 use futures::future::try_join_all;
 use scylla_cql::frame::response::NonErrorResponse;
+use std::collections::HashMap;
 use std::future::Future;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::lookup_host;
@@ -20,6 +23,7 @@ use uuid::Uuid;
 use super::connection::NonErrorQueryResponse;
 use super::connection::QueryResponse;
 use super::errors::{BadQuery, NewSessionError, QueryError};
+use super::topology::UntranslatedPeer;
 use crate::cql_to_rust::FromRow;
 use crate::frame::response::cql_to_rust::FromRowError;
 use crate::frame::response::result;
@@ -56,6 +60,53 @@ pub use crate::transport::connection_pool::PoolSize;
 
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
+
+#[derive(Debug, Copy, Clone)]
+pub enum TranslationError {
+    NoRuleForAddress,
+    InvalidAddressInRule,
+}
+
+#[async_trait]
+pub trait AddressTranslator: Send + Sync {
+    async fn translate_address(
+        &self,
+        untranslated_peer: &UntranslatedPeer,
+    ) -> Result<SocketAddr, TranslationError>;
+}
+
+#[async_trait]
+impl AddressTranslator for HashMap<SocketAddr, SocketAddr> {
+    async fn translate_address(
+        &self,
+        untranslated_peer: &UntranslatedPeer,
+    ) -> Result<SocketAddr, TranslationError> {
+        match self.get(&untranslated_peer.untranslated_address) {
+            Some(&translated_addr) => Ok(translated_addr),
+            None => Err(TranslationError::NoRuleForAddress),
+        }
+    }
+}
+
+#[async_trait]
+// Notice: this is unefficient, but what else can we do with such poor representation as str?
+// After all, the cluster size is small enough to make this irrelevant.
+impl AddressTranslator for HashMap<&'static str, &'static str> {
+    async fn translate_address(
+        &self,
+        untranslated_peer: &UntranslatedPeer,
+    ) -> Result<SocketAddr, TranslationError> {
+        for (&rule_addr_str, &translated_addr_str) in self.iter() {
+            if let Ok(rule_addr) = SocketAddr::from_str(rule_addr_str) {
+                if rule_addr == untranslated_peer.untranslated_address {
+                    return SocketAddr::from_str(translated_addr_str)
+                        .map_err(|_| TranslationError::InvalidAddressInRule);
+                }
+            }
+        }
+        Err(TranslationError::NoRuleForAddress)
+    }
+}
 
 /// `Session` manages connections to the cluster and allows to perform queries
 pub struct Session {

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -2,7 +2,7 @@
 
 use super::errors::NewSessionError;
 use super::load_balancing::LoadBalancingPolicy;
-use super::session::{Session, SessionConfig};
+use super::session::{AddressTranslator, Session, SessionConfig};
 use super::speculative_execution::SpeculativeExecutionPolicy;
 use super::Compression;
 use crate::transport::{connection_pool::PoolSize, retry_policy::RetryPolicy};
@@ -560,6 +560,65 @@ impl SessionBuilder {
     /// ```
     pub fn request_timeout(mut self, duration: Option<std::time::Duration>) -> Self {
         self.config.request_timeout = duration;
+        self
+    }
+
+    /// Uses a custom address translator for peer addresses retrieved from the cluster.
+    /// By default, no translation is performed.
+    ///
+    /// # Example
+    /// ```
+    /// # use async_trait::async_trait;
+    /// # use std::net::SocketAddr;
+    /// # use std::sync::Arc;
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use scylla::transport::session::{AddressTranslator, TranslationError};
+    /// # use scylla::transport::topology::UntranslatedPeer;
+    /// struct IdentityTranslator;
+    ///
+    /// #[async_trait]
+    /// impl AddressTranslator for IdentityTranslator {
+    ///     async fn translate_address(
+    ///         &self,
+    ///         untranslated_peer: &UntranslatedPeer
+    ///     ) -> Result<SocketAddr, TranslationError> {
+    ///         Ok(untranslated_peer.untranslated_address)
+    ///     }
+    /// }
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .address_translator(Arc::new(IdentityTranslator))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// /// # Example
+    /// ```
+    /// # use std::net::SocketAddr;
+    /// # use std::sync::Arc;
+    /// # use std::collections::HashMap;
+    /// # use std::str::FromStr;
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use scylla::transport::session::{AddressTranslator, TranslationError};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let mut translation_rules = HashMap::new();
+    ///     let addr_before_translation = SocketAddr::from_str("192.168.0.42").unwrap();
+    ///     let addr_after_translation = SocketAddr::from_str("157.123.12.42").unwrap();
+    ///     translation_rules.insert(addr_before_translation, addr_after_translation);
+    ///     let session: Session = SessionBuilder::new()
+    ///         .known_node("127.0.0.1:9042")
+    ///         .address_translator(Arc::new(translation_rules))
+    ///         .build()
+    ///         .await?;
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn address_translator(mut self, translator: Arc<dyn AddressTranslator>) -> Self {
+        self.config.address_translator = Some(translator);
         self
     }
 }

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -4,9 +4,10 @@ use crate::statement::query::Query;
 use crate::transport::connection::{Connection, ConnectionConfig};
 use crate::transport::connection_pool::{NodeConnectionPool, PoolConfig, PoolSize};
 use crate::transport::errors::{DbError, QueryError};
-use crate::transport::session::IntoTypedRows;
+use crate::transport::session::{AddressTranslator, IntoTypedRows};
 use crate::utils::parse::{ParseErrorCause, ParseResult, ParserState};
 
+use futures::future::try_join_all;
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use std::borrow::BorrowMut;
@@ -16,6 +17,7 @@ use std::fmt::Formatter;
 use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 use strum_macros::EnumString;
 use tokio::sync::mpsc;
@@ -32,6 +34,8 @@ pub(crate) struct MetadataReader {
     // when control connection fails, MetadataReader tries to connect to one of known_peers
     known_peers: Vec<SocketAddr>,
     fetch_schema: bool,
+
+    address_translator: Option<Arc<dyn AddressTranslator>>,
 }
 
 /// Describes all metadata retrieved from the cluster
@@ -214,6 +218,7 @@ impl MetadataReader {
         keepalive_interval: Option<Duration>,
         server_event_sender: mpsc::Sender<Event>,
         fetch_schema: bool,
+        address_translator: &Option<Arc<dyn AddressTranslator>>,
     ) -> Self {
         let control_connection_address = *known_peers
             .choose(&mut thread_rng())
@@ -237,6 +242,7 @@ impl MetadataReader {
             connection_config,
             known_peers: known_peers.into(),
             fetch_schema,
+            address_translator: address_translator.clone(),
         }
     }
 
@@ -315,6 +321,7 @@ impl MetadataReader {
         let res = query_metadata(
             conn,
             self.control_connection_address.port(),
+            self.address_translator.as_deref(),
             self.fetch_schema,
         )
         .await;
@@ -363,9 +370,10 @@ impl MetadataReader {
 async fn query_metadata(
     conn: &Connection,
     connect_port: u16,
+    address_translator: Option<&dyn AddressTranslator>,
     fetch_schema: bool,
 ) -> Result<Metadata, QueryError> {
-    let peers_query = query_peers(conn, connect_port);
+    let peers_query = query_peers(conn, connect_port, address_translator);
     let keyspaces_query = query_keyspaces(conn, fetch_schema);
 
     let (peers, keyspaces) = tokio::try_join!(peers_query, keyspaces_query)?;
@@ -387,7 +395,11 @@ async fn query_metadata(
     Ok(Metadata { peers, keyspaces })
 }
 
-async fn query_peers(conn: &Connection, connect_port: u16) -> Result<Vec<Peer>, QueryError> {
+async fn query_peers(
+    conn: &Connection,
+    connect_port: u16,
+    address_translator: Option<&dyn AddressTranslator>,
+) -> Result<Vec<Peer>, QueryError> {
     let mut peers_query =
         Query::new("select rpc_address, data_center, rack, tokens from system.peers");
     peers_query.set_page_size(1024);
@@ -408,26 +420,54 @@ async fn query_peers(conn: &Connection, connect_port: u16) -> Result<Vec<Peer>, 
         "system.local query response was not Rows",
     ))?;
 
-    let mut result: Vec<Peer> = Vec::with_capacity(peers_rows.len() + 1);
-
     let typed_peers_rows =
         peers_rows.into_typed::<(IpAddr, Option<String>, Option<String>, Option<Vec<String>>)>();
 
-    // For the local node we should use connection's address instead of rpc_address unless SNI is enabled (TODO)
-    // Replace address in local_rows with connection's address
-    let local_address: IpAddr = conn.get_connect_address().ip();
-    let typed_local_rows = local_rows
-        .into_typed::<(IpAddr, Option<String>, Option<String>, Option<Vec<String>>)>()
-        .map(|res| res.map(|(_addr, dc, rack, tokens)| (local_address, dc, rack, tokens)));
+    let local_ip: IpAddr = conn.get_connect_address().ip();
+    let local_address = SocketAddr::new(local_ip, connect_port);
 
-    for row in typed_peers_rows.chain(typed_local_rows) {
-        let (ip_address, datacenter, rack, tokens) = row.map_err(|_| {
-            QueryError::ProtocolError("system.peers or system.local has invalid column type")
-        })?;
+    let typed_local_rows =
+        local_rows.into_typed::<(IpAddr, Option<String>, Option<String>, Option<Vec<String>>)>();
+
+    let untranslated_rows = typed_peers_rows
+        .map(|res| res.map(|peer_row| (false, peer_row)))
+        .chain(typed_local_rows.map(|res| res.map(|local_row| (true, local_row))));
+
+    let translated_peers_futures = untranslated_rows.map(|untranslated_row| async {
+        let (is_local, (untranslated_ip_addr, datacenter, rack, tokens)) = untranslated_row.map_err(
+            |_| QueryError::ProtocolError("system.peers or system.local has invalid column type")
+        )?;
+        let untranslated_address = SocketAddr::new(untranslated_ip_addr, connect_port);
+
+        let (untranslated_address, address) = match (is_local, address_translator) {
+            (true, None) => {
+                // We need to replace rpc_address with control connection address.
+                (Some(untranslated_address), local_address)
+            },
+            (true, Some(_)) => {
+                // The address we used to connect is most likely different and we just don't know.
+                (None, local_address)
+            },
+            (false, None) => {
+                // The usual case - no translation.
+                (Some(untranslated_address), untranslated_address)
+            },
+            (false, Some(translator)) => {
+                // We use the provided translator and skip the peer if there is no rule for translating it.
+                (Some(untranslated_address),
+                    match translator.translate_address(&UntranslatedPeer {untranslated_address}).await {
+                        Ok(address) => address,
+                        Err(err) => {
+                            warn!("Could not translate address {}; TranslationError: {:?}; node therefore skipped.",
+                                    untranslated_address, err);
+                            return Ok::<Option<Peer>, QueryError>(None);
+                        }
+                    }
+                )
+            }
+        };
 
         let tokens_str: Vec<String> = tokens.unwrap_or_default();
-
-        let address = SocketAddr::new(ip_address, connect_port);
 
         // Parse string representation of tokens as integer values
         let tokens: Vec<Token> = match tokens_str
@@ -447,16 +487,18 @@ async fn query_peers(conn: &Connection, connect_port: u16) -> Result<Vec<Peer>, 
                 }]
             }
         };
-        result.push(Peer {
+
+        Ok(Some(Peer {
+            untranslated_address,
             address,
             tokens,
             datacenter,
             rack,
-            untranslated_address: Some(address),
-        });
-    }
+        }))
+    });
 
-    Ok(result)
+    let peers = try_join_all(translated_peers_futures).await?;
+    Ok(peers.into_iter().flatten().collect())
 }
 
 async fn query_keyspaces(

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -42,9 +42,15 @@ pub struct Metadata {
 
 pub struct Peer {
     pub address: SocketAddr,
+    pub untranslated_address: Option<SocketAddr>,
     pub tokens: Vec<Token>,
     pub datacenter: Option<String>,
     pub rack: Option<String>,
+}
+
+#[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
+pub struct UntranslatedPeer {
+    pub untranslated_address: SocketAddr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -188,6 +194,7 @@ impl Metadata {
                     }],
                     datacenter: None,
                     rack: None,
+                    untranslated_address: None,
                 }
             })
             .collect();
@@ -445,6 +452,7 @@ async fn query_peers(conn: &Connection, connect_port: u16) -> Result<Vec<Peer>, 
             tokens,
             datacenter,
             rack,
+            untranslated_address: Some(address),
         });
     }
 


### PR DESCRIPTION
To be consistent with other drivers' behaviour, as well as to mitigate the _possibly empty rpc_address_ problem, we turned off address translation for hosts that serve as metadata providers on current control connection. 
This re-reverts #471 and provides necessary fixes not to cause #487.
Fixes: #490 #487 #470 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
