### PR TITLE
No retries on error response bug fix

### DIFF
--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -26,7 +26,6 @@ pub enum ResponseOpcode {
 
 #[derive(Debug)]
 pub enum Response {
-    Error(Error),
     Ready,
     Result(result::Result),
     Authenticate(authenticate::Authenticate),
@@ -37,22 +36,25 @@ pub enum Response {
 }
 
 impl Response {
-    pub fn deserialize(opcode: ResponseOpcode, buf: &mut &[u8]) -> Result<Response, ParseError> {
+    pub fn deserialize(
+        opcode: ResponseOpcode,
+        buf: &mut &[u8],
+    ) -> Result<Result<Response, Error>, ParseError> {
         let response = match opcode {
-            ResponseOpcode::Error => Response::Error(Error::deserialize(buf)?),
-            ResponseOpcode::Ready => Response::Ready,
-            ResponseOpcode::Authenticate => {
-                Response::Authenticate(authenticate::Authenticate::deserialize(buf)?)
-            }
-            ResponseOpcode::Supported => Response::Supported(Supported::deserialize(buf)?),
-            ResponseOpcode::Result => Response::Result(result::deserialize(buf)?),
-            ResponseOpcode::Event => Response::Event(event::Event::deserialize(buf)?),
-            ResponseOpcode::AuthChallenge => {
-                Response::AuthChallenge(authenticate::AuthChallenge::deserialize(buf)?)
-            }
-            ResponseOpcode::AuthSuccess => {
-                Response::AuthSuccess(authenticate::AuthSuccess::deserialize(buf)?)
-            }
+            ResponseOpcode::Error => Err(Error::deserialize(buf)?),
+            ResponseOpcode::Ready => Ok(Response::Ready),
+            ResponseOpcode::Authenticate => Ok(Response::Authenticate(
+                authenticate::Authenticate::deserialize(buf)?,
+            )),
+            ResponseOpcode::Supported => Ok(Response::Supported(Supported::deserialize(buf)?)),
+            ResponseOpcode::Result => Ok(Response::Result(result::deserialize(buf)?)),
+            ResponseOpcode::Event => Ok(Response::Event(event::Event::deserialize(buf)?)),
+            ResponseOpcode::AuthChallenge => Ok(Response::AuthChallenge(
+                authenticate::AuthChallenge::deserialize(buf)?,
+            )),
+            ResponseOpcode::AuthSuccess => Ok(Response::AuthSuccess(
+                authenticate::AuthSuccess::deserialize(buf)?,
+            )),
         };
 
         Ok(response)

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -412,10 +412,6 @@ where
                     // Query succeeded, reset retry policy for future retries
                     self.retry_session.reset();
                 }
-                Response::Error(err) => {
-                    self.metrics.inc_failed_paged_queries();
-                    return Err(err.into());
-                }
                 _ => {
                     self.metrics.inc_failed_paged_queries();
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1274,7 +1274,7 @@ impl Session {
             .map_or(Ok(false), |res| res.and(Ok(true)))
     }
 
-    async fn schema_agreement_auxilary<ResT, QueryFut>(
+    async fn schema_agreement_auxiliary<ResT, QueryFut>(
         &self,
         do_query: impl Fn(Arc<Connection>) -> QueryFut,
     ) -> Result<ResT, QueryError>
@@ -1309,7 +1309,7 @@ impl Session {
     }
 
     pub async fn fetch_schema_version(&self) -> Result<Uuid, QueryError> {
-        self.schema_agreement_auxilary(|connection: Arc<Connection>| async move {
+        self.schema_agreement_auxiliary(|connection: Arc<Connection>| async move {
             connection.fetch_schema_version().await
         })
         .await


### PR DESCRIPTION
As described in #501, due to a bug in `Session::execute_query()`, no retries were performed if Scylla returned Response::Error. This was because such response was considered to be an `Ok()` variant and not `Err()` one. This patch removes `Response::Error` enum variant completely and rewrites the logic in a way such that the information about such errors is passed as `Err(QueryError)` variant. This way, errors from Scylla finally trigger retries instead of instant fallthrough to the user.
Fixes: #501

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
