### PR TITLE
Made PreparedStatement drop tracing ids on clone

### DIFF
--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -12,7 +12,6 @@ use crate::transport::partitioner::PartitionerName;
 use crate::transport::retry_policy::RetryPolicy;
 
 /// Represents a statement prepared on the server.
-#[derive(Clone)]
 pub struct PreparedStatement {
     pub(crate) config: StatementConfig,
     pub prepare_tracing_ids: Vec<Uuid>,
@@ -22,6 +21,20 @@ pub struct PreparedStatement {
     statement: String,
     page_size: Option<i32>,
     partitioner_name: PartitionerName,
+}
+
+impl Clone for PreparedStatement {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            prepare_tracing_ids: Vec::new(),
+            id: self.id.clone(),
+            metadata: self.metadata.clone(),
+            statement: self.statement.clone(),
+            page_size: self.page_size,
+            partitioner_name: self.partitioner_name.clone(),
+        }
+    }
 }
 
 impl PreparedStatement {


### PR DESCRIPTION
As cloning a vector of tracing ids while cloning a `PreparedStatement` is redundant and conflicts with the general rule that cloning should be cheap, we drop it.
Fixes: #504

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
