### PR TITLE
Fix RetryPolicy not retrying on Response::Error

### DIFF
--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -5,7 +5,7 @@ pub mod event;
 pub mod result;
 pub mod supported;
 
-use crate::frame::frame_errors::ParseError;
+use crate::{errors::QueryError, frame::frame_errors::ParseError};
 use num_enum::TryFromPrimitive;
 
 pub use error::Error;
@@ -57,4 +57,29 @@ impl Response {
 
         Ok(response)
     }
+
+    pub fn into_non_error_response(self) -> Result<NonErrorResponse, QueryError> {
+        Ok(match self {
+            Response::Error(err) => return Err(QueryError::from(err)),
+            Response::Ready => NonErrorResponse::Ready,
+            Response::Result(res) => NonErrorResponse::Result(res),
+            Response::Authenticate(auth) => NonErrorResponse::Authenticate(auth),
+            Response::AuthSuccess(auth_succ) => NonErrorResponse::AuthSuccess(auth_succ),
+            Response::AuthChallenge(auth_chal) => NonErrorResponse::AuthChallenge(auth_chal),
+            Response::Supported(sup) => NonErrorResponse::Supported(sup),
+            Response::Event(eve) => NonErrorResponse::Event(eve),
+        })
+    }
+}
+
+// A Response which can not be Response::Error
+#[derive(Debug)]
+pub enum NonErrorResponse {
+    Ready,
+    Result(result::Result),
+    Authenticate(authenticate::Authenticate),
+    AuthSuccess(authenticate::AuthSuccess),
+    AuthChallenge(authenticate::AuthChallenge),
+    Supported(Supported),
+    Event(event::Event),
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -32,7 +32,7 @@ use crate::batch::{Batch, BatchStatement};
 use crate::frame::{
     self,
     request::{self, batch, execute, query, register, Request},
-    response::{event::Event, result, Response, ResponseOpcode},
+    response::{event::Event, result, NonErrorResponse, Response, ResponseOpcode},
     server_event_type::EventType,
     value::{BatchValues, ValueList},
     FrameParams, SerializedRequest,
@@ -142,6 +142,13 @@ pub struct QueryResponse {
     pub warnings: Vec<String>,
 }
 
+// A QueryResponse in which response can not be Response::Error
+pub struct NonErrorQueryResponse {
+    pub response: NonErrorResponse,
+    pub tracing_id: Option<Uuid>,
+    pub warnings: Vec<String>,
+}
+
 /// Result of Session::batch(). Contains no rows, only some useful information.
 pub struct BatchResult {
     /// Warnings returned by the database
@@ -165,15 +172,28 @@ impl QueryResponse {
         }
     }
 
+    pub fn into_non_error_query_response(self) -> Result<NonErrorQueryResponse, QueryError> {
+        Ok(NonErrorQueryResponse {
+            response: self.response.into_non_error_response()?,
+            tracing_id: self.tracing_id,
+            warnings: self.warnings,
+        })
+    }
+
+    pub fn into_query_result(self) -> Result<QueryResult, QueryError> {
+        self.into_non_error_query_response()?.into_query_result()
+    }
+}
+
+impl NonErrorQueryResponse {
     pub fn into_query_result(self) -> Result<QueryResult, QueryError> {
         let (rows, paging_state, col_specs) = match self.response {
-            Response::Error(err) => return Err(err.into()),
-            Response::Result(result::Result::Rows(rs)) => (
+            NonErrorResponse::Result(result::Result::Rows(rs)) => (
                 Some(rs.rows),
                 rs.metadata.paging_state,
                 rs.metadata.col_specs,
             ),
-            Response::Result(_) => (None, None, vec![]),
+            NonErrorResponse::Result(_) => (None, None, vec![]),
             _ => {
                 return Err(QueryError::ProtocolError(
                     "Unexpected server response, expected Result or Error",

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -158,20 +158,6 @@ pub struct BatchResult {
 }
 
 impl QueryResponse {
-    pub fn as_set_keyspace(&self) -> Option<&result::SetKeyspace> {
-        match &self.response {
-            Response::Result(result::Result::SetKeyspace(sk)) => Some(sk),
-            _ => None,
-        }
-    }
-
-    pub fn as_schema_change(&self) -> Option<&result::SchemaChange> {
-        match &self.response {
-            Response::Result(result::Result::SchemaChange(sc)) => Some(sc),
-            _ => None,
-        }
-    }
-
     pub fn into_non_error_query_response(self) -> Result<NonErrorQueryResponse, QueryError> {
         Ok(NonErrorQueryResponse {
             response: self.response.into_non_error_response()?,
@@ -186,6 +172,20 @@ impl QueryResponse {
 }
 
 impl NonErrorQueryResponse {
+    pub fn as_set_keyspace(&self) -> Option<&result::SetKeyspace> {
+        match &self.response {
+            NonErrorResponse::Result(result::Result::SetKeyspace(sk)) => Some(sk),
+            _ => None,
+        }
+    }
+
+    pub fn as_schema_change(&self) -> Option<&result::SchemaChange> {
+        match &self.response {
+            NonErrorResponse::Result(result::Result::SchemaChange(sc)) => Some(sc),
+            _ => None,
+        }
+    }
+
     pub fn into_query_result(self) -> Result<QueryResult, QueryError> {
         let (rows, paging_state, col_specs) = match self.response {
             NonErrorResponse::Result(result::Result::Rows(rs)) => (


### PR DESCRIPTION
This is an alternative to #510.
`run_query` takes as a paramter a closure used to run a single query ona connection.
Result of such a query is `Result<ResT, QueryResult>`.

In Case of Result::Err the retry policy decides whether to retry the query based on the error type.

There was a bug - in a few cases `ResT` was of type `QueryResponse`, which has an `Error` variant. Such errors weren't detected by `RetryPolicy` and were never retried.

This PR fixes the bug by making the closure return `NonErrorQueryResponse`. All errors will be collected in a single `QueryResult` and detected by `RetryPolicy`.

Additionally to prevent such mistakes from happening a new trait is introduced that defines which types can be used as `ResT` in `run_query`:
```rust
pub trait AllowedRunQueryResTType {}

impl AllowedRunQueryResTType for Uuid {}
impl AllowedRunQueryResTType for BatchResult {}
impl AllowedRunQueryResTType for NonErrorQueryResponse {}
```

Fixes: #501

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
