### PR TITLE
Added DowngradingConsistencyPolicy

### DIFF
--- a/docs/source/SUMMARY.md
+++ b/docs/source/SUMMARY.md
@@ -48,6 +48,7 @@
 - [Retry policy configuration](retry-policy/retry-policy.md)
     - [Fallthrough retry policy](retry-policy/fallthrough.md)
     - [Default retry policy](retry-policy/default.md)
+    - [Downgrading consistency policy](retry-policy/downgrading_consistency.md)
 
 - [Speculative execution](speculative-execution/speculative.md)
     - [Simple](speculative-execution/simple.md)

--- a/docs/source/retry-policy/downgrading_consistency.md
+++ b/docs/source/retry-policy/downgrading_consistency.md
@@ -1,0 +1,107 @@
+# Downgrading consistency retry policy
+
+A retry policy that sometimes retries with a lower consistency level than the one initially
+requested.
+**BEWARE**: this policy may retry queries using a lower consistency level than the one
+initially requested. By doing so, it may break consistency guarantees. In other words, if you use
+this retry policy, there are cases (documented below) where a read at `Consistency::Quorum` **may
+not** see a preceding write at `Consistency::Quorum`. Do not use this policy unless you have
+understood the cases where this can happen and are ok with that. It is also highly recommended to
+always log the occurrences of such consistency breaks.
+This policy implements the same retries than the [DefaultRetryPolicy](default.md) policy. But on top
+of that, it also retries in the following cases:
+  - On a read timeout: if the number of replicas that responded is greater than one, but lower
+    than is required by the requested consistency level, the operation is retried at a lower
+    consistency level.
+  - On a write timeout: if the operation is a `WriteType::UnloggedBatch` and at least one
+    replica acknowledged the write, the operation is retried at a lower consistency level.
+    Furthermore, for other operations, if at least one replica acknowledged the write, the
+    timeout is ignored.
+  - On an unavailable exception: if at least one replica is alive, the operation is retried at
+    a lower consistency level.
+
+The lower consistency level to use for retries is determined by the following rules:
+  - if more than 3 replicas responded, use `Consistency::Three`.
+  - if 1, 2 or 3 replicas responded, use the corresponding level `Consistency::One`, `Consistency::Two` or
+      `Consistency::Three`.
+
+Note that if the initial consistency level was `Consistency::EachQuorum`, Scylla returns the number
+of live replicas _in the datacenter that failed to reach consistency_, not the overall
+number in the cluster. Therefore if this number is 0, we still retry at `Consistency::One`, on the
+assumption that a host may still be up in another datacenter.
+The reasoning being this retry policy is the following one. If, based on the information the
+Scylla coordinator node returns, retrying the operation with the initially requested
+consistency has a chance to succeed, do it. Otherwise, if based on this information we know
+**the initially requested consistency level cannot be achieved currently**, then:
+  - For writes, ignore the exception (thus silently failing the consistency requirement) if we
+    know the write has been persisted on at least one replica.
+  - For reads, try reading at a lower consistency level (thus silently failing the consistency
+    requirement).
+In other words, this policy implements the idea that if the requested consistency level cannot be
+achieved, the next best thing for writes is to make sure the data is persisted, and that reading
+something is better than reading nothing, even if there is a risk of reading stale data.
+
+This policy is based on the one in [DataStax Java Driver](https://docs.datastax.com/en/drivers/java/3.11/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.html).
+The behaviour is the same.
+
+### Examples
+To use in `Session`:
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::{Session, SessionBuilder};
+use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
+
+let session: Session = SessionBuilder::new()
+    .known_node("127.0.0.1:9042")
+    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .build()
+    .await?;
+# Ok(())
+# }
+```
+
+To use in a [simple query](../queries/simple.md):
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::query::Query;
+use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
+
+// Create a Query manually and set the retry policy
+let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
+my_query.set_retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()));
+
+// Run the query using this retry policy
+let to_insert: i32 = 12345;
+session.query(my_query, (to_insert,)).await?;
+# Ok(())
+# }
+```
+
+To use in a [prepared query](../queries/prepared.md):
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::prepared_statement::PreparedStatement;
+use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
+
+// Create PreparedStatement manually and set the retry policy
+let mut prepared: PreparedStatement = session
+    .prepare("INSERT INTO ks.tab (a) VALUES(?)")
+    .await?;
+
+prepared.set_retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()));
+
+// Run the query using this retry policy
+let to_insert: i32 = 12345;
+session.execute(&prepared, (to_insert,)).await?;
+# Ok(())
+# }
+```

--- a/docs/source/retry-policy/retry-policy.md
+++ b/docs/source/retry-policy/retry-policy.md
@@ -4,9 +4,11 @@ After a query fails the driver might decide to retry it based on its `Retry Poli
 Retry policy can be configured for `Session` or just for a single query.
 
 ### Retry policies
-By default there are two retry policies:
+By default there are three retry policies:
 * [Fallthrough Retry Policy](fallthrough.md) - never retries, returns all errors straight to the user
 * [Default Retry Policy](default.md) - used by default, might retry if there is a high chance of success
+* [Downgrading Consistency Retry Policy](downgrading_consistency.md) - behaves as [Default Retry Policy](default.md), but also,
+    in some more cases, it retries **with lower `Consistency`**.
 
 It's possible to implement a custom `Retry Policy` by implementing the traits `RetryPolicy` and `RetrySession`.
 
@@ -47,5 +49,6 @@ prepared.set_is_idempotent(true);
 
    fallthrough
    default
+   downgrading_consistency
 
 ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ rustyline-derive = "0.6"
 scylla = {path = "../scylla", features = ["ssl"]}
 tokio = {version = "1.1.0", features = ["full"]}
 tracing = "0.1.25"
-tracing-subscriber = "0.2.16"
+tracing-subscriber = "0.3.14"
 chrono = "0.4"
 uuid = "1.0"
 tower = "0.4"

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -54,8 +54,8 @@ pub enum DbError {
     #[error("The submitted query has a syntax error")]
     SyntaxError,
 
-    /// The query is syntatically correct but invalid
-    #[error("The query is syntatically correct but invalid")]
+    /// The query is syntactically correct but invalid
+    #[error("The query is syntactically correct but invalid")]
     Invalid,
 
     /// Attempted to create a keyspace or a table that was already existing
@@ -178,7 +178,7 @@ pub enum DbError {
     WriteFailure {
         /// Consistency level of the query
         consistency: LegacyConsistency,
-        /// Number of ndoes that responded to the read request
+        /// Number of nodes that responded to the read request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
         required: i32,
@@ -451,7 +451,7 @@ mod tests {
     // - displays error description
     // - displays error parameters
     // - displays error message
-    // - indented multiline strings dont cause whitespace gaps
+    // - indented multiline strings don't cause whitespace gaps
     #[test]
     fn dberror_full_info() {
         // Test that DbError::Unavailable is displayed correctly

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -253,6 +253,10 @@ pub enum BadQuery {
     /// Passed invalid keyspace name to use
     #[error("Passed invalid keyspace name to use: {0}")]
     BadKeyspaceName(#[from] BadKeyspaceName),
+
+    /// Other reasons of bad query
+    #[error("{0}")]
+    Other(String),
 }
 
 /// Error that occurred during session creation

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -168,3 +168,495 @@ impl RetrySession for DowngradingConsistencyRetrySession {
         *self = DowngradingConsistencyRetrySession::new();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{io::ErrorKind, sync::Arc};
+
+    use bytes::Bytes;
+    use scylla_cql::errors::BadQuery;
+
+    use super::*;
+
+    const CONSISTENCY_LEVELS: &[Consistency] = &[
+        Consistency::All,
+        Consistency::Any,
+        Consistency::EachQuorum,
+        Consistency::LocalOne,
+        Consistency::LocalQuorum,
+        Consistency::One,
+        Consistency::Quorum,
+        Consistency::Three,
+        Consistency::Two,
+    ];
+
+    fn make_query_info_with_cl(
+        error: &QueryError,
+        is_idempotent: bool,
+        cl: Consistency,
+    ) -> QueryInfo<'_> {
+        QueryInfo {
+            error,
+            is_idempotent,
+            consistency: LegacyConsistency::Regular(cl),
+        }
+    }
+
+    // Asserts that downgrading consistency policy never retries for this Error
+    fn downgrading_consistency_policy_assert_never_retries(error: QueryError, cl: Consistency) {
+        let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info_with_cl(&error, false, cl)),
+            RetryDecision::DontRetry
+        );
+
+        let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info_with_cl(&error, true, cl)),
+            RetryDecision::DontRetry
+        );
+    }
+
+    #[test]
+    fn downgrading_consistency_never_retries() {
+        let never_retried_dberrors = vec![
+            DbError::SyntaxError,
+            DbError::Invalid,
+            DbError::AlreadyExists {
+                keyspace: String::new(),
+                table: String::new(),
+            },
+            DbError::FunctionFailure {
+                keyspace: String::new(),
+                function: String::new(),
+                arg_types: vec![],
+            },
+            DbError::AuthenticationError,
+            DbError::Unauthorized,
+            DbError::ConfigError,
+            DbError::ReadFailure {
+                consistency: LegacyConsistency::Regular(Consistency::Two),
+                received: 1,
+                required: 2,
+                numfailures: 1,
+                data_present: false,
+            },
+            DbError::WriteFailure {
+                consistency: LegacyConsistency::Regular(Consistency::Two),
+                received: 1,
+                required: 2,
+                numfailures: 1,
+                write_type: WriteType::BatchLog,
+            },
+            DbError::Unprepared {
+                statement_id: Bytes::from_static(b"deadbeef"),
+            },
+            DbError::ProtocolError,
+            DbError::Other(0x124816),
+        ];
+
+        for &cl in CONSISTENCY_LEVELS {
+            for dberror in never_retried_dberrors.clone() {
+                downgrading_consistency_policy_assert_never_retries(
+                    QueryError::DbError(dberror, String::new()),
+                    cl,
+                );
+            }
+
+            downgrading_consistency_policy_assert_never_retries(
+                QueryError::BadQuery(BadQuery::ValueLenMismatch(1, 2)),
+                cl,
+            );
+            downgrading_consistency_policy_assert_never_retries(
+                QueryError::ProtocolError("test"),
+                cl,
+            );
+        }
+    }
+
+    // Asserts that for this error policy retries on next on idempotent queries only
+    fn downgrading_consistency_policy_assert_idempotent_next(error: QueryError, cl: Consistency) {
+        let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info_with_cl(&error, false, cl)),
+            RetryDecision::DontRetry
+        );
+
+        let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+        assert_eq!(
+            policy.decide_should_retry(make_query_info_with_cl(&error, true, cl)),
+            RetryDecision::RetryNextNode(cl)
+        );
+    }
+
+    fn max_likely_to_work_cl(known_ok: i32, current_cl: Consistency) -> RetryDecision {
+        if known_ok >= 3 {
+            RetryDecision::RetrySameNode(Consistency::Three)
+        } else if known_ok == 2 {
+            RetryDecision::RetrySameNode(Consistency::Two)
+        } else if known_ok == 1 || current_cl == Consistency::EachQuorum {
+            // JAVA-1005: EACH_QUORUM does not report a global number of alive replicas
+            // so even if we get 0 alive replicas, there might be
+            // a node up in some other datacenter
+            RetryDecision::RetrySameNode(Consistency::One)
+        } else {
+            RetryDecision::DontRetry
+        }
+    }
+
+    #[test]
+    fn downgrading_consistency_idempotent_next_retries() {
+        let idempotent_next_errors = vec![
+            QueryError::DbError(DbError::Overloaded, String::new()),
+            QueryError::DbError(DbError::TruncateError, String::new()),
+            QueryError::DbError(DbError::ServerError, String::new()),
+            QueryError::IoError(Arc::new(std::io::Error::new(ErrorKind::Other, "test"))),
+        ];
+
+        for &cl in CONSISTENCY_LEVELS {
+            for error in idempotent_next_errors.clone() {
+                downgrading_consistency_policy_assert_idempotent_next(error, cl);
+            }
+        }
+    }
+
+    // Always retry on next node if current one is bootstrapping
+    #[test]
+    fn downgrading_consistency_bootstrapping() {
+        let error = QueryError::DbError(DbError::IsBootstrapping, String::new());
+
+        for &cl in CONSISTENCY_LEVELS {
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(&error, false, cl)),
+                RetryDecision::RetryNextNode(cl)
+            );
+
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(&error, true, cl)),
+                RetryDecision::RetryNextNode(cl)
+            );
+        }
+    }
+
+    // On Unavailable error we retry one time no matter the idempotence
+    #[test]
+    fn downgrading_consistency_unavailable() {
+        let alive = 1;
+        let error = QueryError::DbError(
+            DbError::Unavailable {
+                consistency: LegacyConsistency::Regular(Consistency::Two),
+                required: 2,
+                alive,
+            },
+            String::new(),
+        );
+
+        for &cl in CONSISTENCY_LEVELS {
+            let mut policy_not_idempotent = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy_not_idempotent
+                    .decide_should_retry(make_query_info_with_cl(&error, false, cl)),
+                max_likely_to_work_cl(alive, cl)
+            );
+            assert_eq!(
+                policy_not_idempotent
+                    .decide_should_retry(make_query_info_with_cl(&error, false, cl)),
+                RetryDecision::DontRetry
+            );
+
+            let mut policy_idempotent = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy_idempotent.decide_should_retry(make_query_info_with_cl(&error, true, cl)),
+                max_likely_to_work_cl(alive, cl)
+            );
+            assert_eq!(
+                policy_idempotent.decide_should_retry(make_query_info_with_cl(&error, true, cl)),
+                RetryDecision::DontRetry
+            );
+        }
+    }
+
+    // On ReadTimeout we retry one time if there were enough responses and the data was present no matter the idempotence
+    #[test]
+    fn downgrading_consistency_read_timeout() {
+        // Enough responses and data_present == false - coordinator received only checksums
+        let enough_responses_no_data = QueryError::DbError(
+            DbError::ReadTimeout {
+                consistency: LegacyConsistency::Regular(Consistency::Two),
+                received: 2,
+                required: 2,
+                data_present: false,
+            },
+            String::new(),
+        );
+
+        for &cl in CONSISTENCY_LEVELS {
+            // Not idempotent
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &enough_responses_no_data,
+                    false,
+                    cl
+                )),
+                RetryDecision::RetrySameNode(cl)
+            );
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &enough_responses_no_data,
+                    false,
+                    cl
+                )),
+                RetryDecision::DontRetry
+            );
+
+            // Idempotent
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &enough_responses_no_data,
+                    true,
+                    cl
+                )),
+                RetryDecision::RetrySameNode(cl)
+            );
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &enough_responses_no_data,
+                    true,
+                    cl
+                )),
+                RetryDecision::DontRetry
+            );
+        }
+        // Enough responses but data_present == true - coordinator probably timed out
+        // waiting for read-repair acknowledgement.
+        let enough_responses_with_data = QueryError::DbError(
+            DbError::ReadTimeout {
+                consistency: LegacyConsistency::Regular(Consistency::Two),
+                received: 2,
+                required: 2,
+                data_present: true,
+            },
+            String::new(),
+        );
+
+        for &cl in CONSISTENCY_LEVELS {
+            // Not idempotent
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &enough_responses_with_data,
+                    false,
+                    cl
+                )),
+                RetryDecision::DontRetry
+            );
+
+            // Idempotent
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &enough_responses_with_data,
+                    true,
+                    cl
+                )),
+                RetryDecision::DontRetry
+            );
+        }
+
+        // Not enough responses, data_present == true
+        let received = 1;
+        let not_enough_responses_with_data = QueryError::DbError(
+            DbError::ReadTimeout {
+                consistency: LegacyConsistency::Regular(Consistency::Two),
+                received,
+                required: 2,
+                data_present: true,
+            },
+            String::new(),
+        );
+        for &cl in CONSISTENCY_LEVELS {
+            let expected_decision = max_likely_to_work_cl(received, cl);
+
+            // Not idempotent
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &not_enough_responses_with_data,
+                    false,
+                    cl
+                )),
+                expected_decision
+            );
+            if let RetryDecision::RetrySameNode(new_cl) = expected_decision {
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &not_enough_responses_with_data,
+                        false,
+                        new_cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+            }
+
+            // Idempotent
+            let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+            assert_eq!(
+                policy.decide_should_retry(make_query_info_with_cl(
+                    &not_enough_responses_with_data,
+                    true,
+                    cl
+                )),
+                expected_decision
+            );
+            if let RetryDecision::RetrySameNode(new_cl) = expected_decision {
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &not_enough_responses_with_data,
+                        true,
+                        new_cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+            }
+        }
+    }
+
+    // WriteTimeout will retry once when the query is idempotent and write_type == BatchLog
+    #[test]
+    fn downgrading_consistency_write_timeout() {
+        for (received, required) in (1..=5).zip(2..=6) {
+            // WriteType == BatchLog
+            let write_type_batchlog = QueryError::DbError(
+                DbError::WriteTimeout {
+                    consistency: LegacyConsistency::Regular(Consistency::Two),
+                    received,
+                    required,
+                    write_type: WriteType::BatchLog,
+                },
+                String::new(),
+            );
+
+            for &cl in CONSISTENCY_LEVELS {
+                // Not idempotent
+                let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_batchlog,
+                        false,
+                        cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+
+                // Idempotent
+                let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_batchlog,
+                        true,
+                        cl
+                    )),
+                    RetryDecision::RetrySameNode(cl)
+                );
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_batchlog,
+                        true,
+                        cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+            }
+
+            // WriteType == UnloggedBatch
+            let write_type_unlogged_batch = QueryError::DbError(
+                DbError::WriteTimeout {
+                    consistency: LegacyConsistency::Regular(Consistency::Two),
+                    received,
+                    required,
+                    write_type: WriteType::UnloggedBatch,
+                },
+                String::new(),
+            );
+
+            for &cl in CONSISTENCY_LEVELS {
+                // Not idempotent
+                let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_unlogged_batch,
+                        false,
+                        cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+
+                // Idempotent
+                let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_unlogged_batch,
+                        true,
+                        cl
+                    )),
+                    max_likely_to_work_cl(received, cl)
+                );
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_unlogged_batch,
+                        true,
+                        cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+            }
+
+            // WriteType == other
+            let write_type_other = QueryError::DbError(
+                DbError::WriteTimeout {
+                    consistency: LegacyConsistency::Regular(Consistency::Two),
+                    received,
+                    required,
+                    write_type: WriteType::Simple,
+                },
+                String::new(),
+            );
+
+            for &cl in CONSISTENCY_LEVELS {
+                // Not idempotent
+                let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_other,
+                        false,
+                        cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+
+                // Idempotent
+                let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_other,
+                        true,
+                        cl
+                    )),
+                    RetryDecision::IgnoreWriteError
+                );
+                assert_eq!(
+                    policy.decide_should_retry(make_query_info_with_cl(
+                        &write_type_other,
+                        true,
+                        cl
+                    )),
+                    RetryDecision::DontRetry
+                );
+            }
+        }
+    }
+}

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -1,0 +1,170 @@
+use scylla_cql::{
+    errors::{DbError, QueryError, WriteType},
+    frame::types::LegacyConsistency,
+    Consistency,
+};
+use tracing::debug;
+
+use crate::retry_policy::{QueryInfo, RetryDecision, RetryPolicy, RetrySession};
+
+/// Downgrading consistency retry policy - retries with lower consistency level if it knows\
+/// that the initial CL is unreachable. Also, it behaves as [DefaultRetryPolicy] when it believes that the initial CL is reachable.
+/// Behaviour based on [DataStax Java Driver]\
+///(https://docs.datastax.com/en/drivers/java/3.11/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.html)
+#[derive(Debug)]
+pub struct DowngradingConsistencyRetryPolicy;
+
+impl DowngradingConsistencyRetryPolicy {
+    pub fn new() -> DowngradingConsistencyRetryPolicy {
+        DowngradingConsistencyRetryPolicy
+    }
+}
+
+impl Default for DowngradingConsistencyRetryPolicy {
+    fn default() -> DowngradingConsistencyRetryPolicy {
+        DowngradingConsistencyRetryPolicy::new()
+    }
+}
+
+impl RetryPolicy for DowngradingConsistencyRetryPolicy {
+    fn new_session(&self) -> Box<dyn RetrySession> {
+        Box::new(DowngradingConsistencyRetrySession::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
+        Box::new(DowngradingConsistencyRetryPolicy)
+    }
+}
+
+pub struct DowngradingConsistencyRetrySession {
+    was_retry: bool,
+}
+
+impl DowngradingConsistencyRetrySession {
+    pub fn new() -> DowngradingConsistencyRetrySession {
+        DowngradingConsistencyRetrySession { was_retry: false }
+    }
+}
+
+impl Default for DowngradingConsistencyRetrySession {
+    fn default() -> DowngradingConsistencyRetrySession {
+        DowngradingConsistencyRetrySession::new()
+    }
+}
+
+impl RetrySession for DowngradingConsistencyRetrySession {
+    fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision {
+        let cl = match query_info.consistency {
+            LegacyConsistency::Serial(_) => return RetryDecision::DontRetry, // FIXME: is this proper behaviour?
+            LegacyConsistency::Regular(cl) => cl,
+        };
+
+        fn max_likely_to_work_cl(known_ok: i32, previous_cl: Consistency) -> RetryDecision {
+            let decision = if known_ok >= 3 {
+                RetryDecision::RetrySameNode(Consistency::Three)
+            } else if known_ok == 2 {
+                RetryDecision::RetrySameNode(Consistency::Two)
+            } else if known_ok == 1 || previous_cl == Consistency::EachQuorum {
+                // JAVA-1005: EACH_QUORUM does not report a global number of alive replicas
+                // so even if we get 0 alive replicas, there might be
+                // a node up in some other datacenter
+                RetryDecision::RetrySameNode(Consistency::One)
+            } else {
+                RetryDecision::DontRetry
+            };
+            if let RetryDecision::RetrySameNode(new_cl) = decision {
+                debug!(
+                    "Decided to lower required consistency from {} to {}.",
+                    previous_cl, new_cl
+                );
+            }
+            decision
+        }
+
+        match query_info.error {
+            // Basic errors - there are some problems on this node
+            // Retry on a different one if possible
+            QueryError::IoError(_)
+            | QueryError::DbError(DbError::Overloaded, _)
+            | QueryError::DbError(DbError::ServerError, _)
+            | QueryError::DbError(DbError::TruncateError, _) => {
+                if query_info.is_idempotent {
+                    RetryDecision::RetryNextNode(cl)
+                } else {
+                    RetryDecision::DontRetry
+                }
+            }
+            // Unavailable - the current node believes that not enough nodes
+            // are alive to satisfy specified consistency requirements.
+            QueryError::DbError(DbError::Unavailable { alive, .. }, _) => {
+                if !self.was_retry {
+                    self.was_retry = true;
+                    max_likely_to_work_cl(*alive, cl)
+                } else {
+                    RetryDecision::DontRetry
+                }
+            }
+            // ReadTimeout - coordinator didn't receive enough replies in time.
+            QueryError::DbError(
+                DbError::ReadTimeout {
+                    received,
+                    required,
+                    data_present,
+                    ..
+                },
+                _,
+            ) => {
+                if self.was_retry {
+                    RetryDecision::DontRetry
+                } else if received < required {
+                    self.was_retry = true;
+                    max_likely_to_work_cl(*received, cl)
+                } else if !*data_present {
+                    self.was_retry = true;
+                    RetryDecision::RetrySameNode(cl)
+                } else {
+                    RetryDecision::DontRetry
+                }
+            }
+            // Write timeout - coordinator didn't receive enough replies in time.
+            QueryError::DbError(
+                DbError::WriteTimeout {
+                    write_type,
+                    received,
+                    ..
+                },
+                _,
+            ) => {
+                if self.was_retry || !query_info.is_idempotent {
+                    RetryDecision::DontRetry
+                } else {
+                    self.was_retry = true;
+                    match write_type {
+                        WriteType::Batch | WriteType::Simple if *received > 0 => {
+                            RetryDecision::IgnoreWriteError
+                        }
+
+                        WriteType::UnloggedBatch => {
+                            // Since only part of the batch could have been persisted,
+                            // retry with whatever consistency should allow to persist all
+                            max_likely_to_work_cl(*received, cl)
+                        }
+                        WriteType::BatchLog => RetryDecision::RetrySameNode(cl),
+
+                        _ => RetryDecision::DontRetry,
+                    }
+                }
+            }
+            // The node is still bootstrapping it can't execute the query, we should try another one
+            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode(cl),
+            // Connection to the contacted node is overloaded, try another one
+            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode(cl),
+            // In all other cases propagate the error to the user
+            _ => RetryDecision::DontRetry,
+        }
+    }
+
+    fn reset(&mut self) {
+        *self = DowngradingConsistencyRetrySession::new();
+    }
+}

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -33,7 +33,7 @@ use crate::transport::load_balancing::{LoadBalancingPolicy, Statement};
 use crate::transport::metrics::Metrics;
 use crate::transport::node::Node;
 use crate::transport::retry_policy::{QueryInfo, RetryDecision, RetrySession};
-use tracing::{trace, trace_span, Instrument};
+use tracing::{trace, trace_span, warn, Instrument};
 use uuid::Uuid;
 
 // #424
@@ -375,6 +375,10 @@ where
                         continue 'nodes_in_plan;
                     }
                     RetryDecision::DontRetry => break 'nodes_in_plan,
+                    RetryDecision::IgnoreWriteError => {
+                        warn!("Ignoring error during fetching pages; stopping fetching.");
+                        return;
+                    }
                 };
             }
         }

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod caching_session;
 mod cluster;
 pub(crate) mod connection;
 mod connection_pool;
+pub mod downgrading_consistency_retry_policy;
 pub mod iterator;
 pub mod load_balancing;
 pub(crate) mod metrics;

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -22,6 +22,7 @@ pub enum RetryDecision {
     RetrySameNode(Consistency),
     RetryNextNode(Consistency),
     DontRetry,
+    IgnoreWriteError,
 }
 
 /// Specifies a policy used to decide when to retry a query

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -2,7 +2,7 @@
 //! To decide when to retry a query the `Session` can use any object which implements
 //! the `RetryPolicy` trait
 
-use crate::frame::types::LegacyConsistency;
+use crate::frame::types::{Consistency, LegacyConsistency};
 use crate::transport::errors::{DbError, QueryError, WriteType};
 
 /// Information about a failed query
@@ -19,8 +19,8 @@ pub struct QueryInfo<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RetryDecision {
-    RetrySameNode,
-    RetryNextNode,
+    RetrySameNode(Consistency),
+    RetryNextNode(Consistency),
     DontRetry,
 }
 
@@ -135,6 +135,10 @@ impl Default for DefaultRetrySession {
 
 impl RetrySession for DefaultRetrySession {
     fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision {
+        let cl = match query_info.consistency {
+            LegacyConsistency::Serial(_) => return RetryDecision::DontRetry,
+            LegacyConsistency::Regular(cl) => cl,
+        };
         match query_info.error {
             // Basic errors - there are some problems on this node
             // Retry on a different one if possible
@@ -143,7 +147,7 @@ impl RetrySession for DefaultRetrySession {
             | QueryError::DbError(DbError::ServerError, _)
             | QueryError::DbError(DbError::TruncateError, _) => {
                 if query_info.is_idempotent {
-                    RetryDecision::RetryNextNode
+                    RetryDecision::RetryNextNode(cl)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -156,7 +160,7 @@ impl RetrySession for DefaultRetrySession {
             QueryError::DbError(DbError::Unavailable { .. }, _) => {
                 if !self.was_unavailable_retry {
                     self.was_unavailable_retry = true;
-                    RetryDecision::RetryNextNode
+                    RetryDecision::RetryNextNode(cl)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -178,7 +182,7 @@ impl RetrySession for DefaultRetrySession {
             ) => {
                 if !self.was_read_timeout_retry && received >= required && !*data_present {
                     self.was_read_timeout_retry = true;
-                    RetryDecision::RetrySameNode
+                    RetryDecision::RetrySameNode(cl)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -193,15 +197,15 @@ impl RetrySession for DefaultRetrySession {
                     && *write_type == WriteType::BatchLog
                 {
                     self.was_write_timeout_retry = true;
-                    RetryDecision::RetrySameNode
+                    RetryDecision::RetrySameNode(cl)
                 } else {
                     RetryDecision::DontRetry
                 }
             }
             // The node is still bootstrapping it can't execute the query, we should try another one
-            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode,
+            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode(cl),
             // Connection to the contacted node is overloaded, try another one
-            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode,
+            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode(cl),
             // In all other cases propagate the error to the user
             _ => RetryDecision::DontRetry,
         }
@@ -302,7 +306,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&error, true)),
-            RetryDecision::RetryNextNode
+            RetryDecision::RetryNextNode(Consistency::One)
         );
     }
 
@@ -328,13 +332,13 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&error, false)),
-            RetryDecision::RetryNextNode
+            RetryDecision::RetryNextNode(Consistency::One)
         );
 
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&error, true)),
-            RetryDecision::RetryNextNode
+            RetryDecision::RetryNextNode(Consistency::One)
         );
     }
 
@@ -353,7 +357,7 @@ mod tests {
         let mut policy_not_idempotent = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy_not_idempotent.decide_should_retry(make_query_info(&error, false)),
-            RetryDecision::RetryNextNode
+            RetryDecision::RetryNextNode(Consistency::One)
         );
         assert_eq!(
             policy_not_idempotent.decide_should_retry(make_query_info(&error, false)),
@@ -363,7 +367,7 @@ mod tests {
         let mut policy_idempotent = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy_idempotent.decide_should_retry(make_query_info(&error, true)),
-            RetryDecision::RetryNextNode
+            RetryDecision::RetryNextNode(Consistency::One)
         );
         assert_eq!(
             policy_idempotent.decide_should_retry(make_query_info(&error, true)),
@@ -389,7 +393,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, false)),
-            RetryDecision::RetrySameNode
+            RetryDecision::RetrySameNode(Consistency::One)
         );
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, false)),
@@ -400,7 +404,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, true)),
-            RetryDecision::RetrySameNode
+            RetryDecision::RetrySameNode(Consistency::One)
         );
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, true)),
@@ -484,7 +488,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&good_write_type, true)),
-            RetryDecision::RetrySameNode
+            RetryDecision::RetrySameNode(Consistency::One)
         );
         assert_eq!(
             policy.decide_should_retry(make_query_info(&good_write_type, true)),


### PR DESCRIPTION
`RetryPolicy` was extended to enable specifying consistency level with which the retry attempt is to be performed.
Then, the `DowngradingConsistencyPolicy` was added, and checked with new unit tests.
Fixes #503 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
