### PR TITLE
Implemented client-side per-session and per-statement configurable timeouts

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -24,4 +24,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run tests
-      run: cargo test --verbose --  --ignored
+      run: cargo test --verbose authenticate_superuser --  --ignored

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -14,7 +14,7 @@ scylla-macros = { version = "0.1.1", path = "../scylla-macros"}
 byteorder = "1.3.4"
 bytes = "1.0.1"
 num_enum = "0.5"
-tokio = { version = "1.12", features = ["io-util"] }
+tokio = { version = "1.12", features = ["io-util", "time"] }
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -47,6 +47,7 @@ smallvec = "1.8.0"
 [dev-dependencies]
 criterion = "0.3"
 tracing-subscriber = "0.3.14"
+assert_matches = "1.5.0"
 
 [[bench]]
 name = "benchmark"

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::transport::retry_policy::RetryPolicy;
 use crate::transport::speculative_execution::SpeculativeExecutionPolicy;
@@ -21,6 +21,7 @@ pub struct StatementConfig {
 
     pub tracing: bool,
     pub timestamp: Option<i64>,
+    pub request_timeout: Option<Duration>,
 }
 
 impl Default for StatementConfig {
@@ -33,6 +34,7 @@ impl Default for StatementConfig {
             speculative_execution_policy: None,
             tracing: false,
             timestamp: None,
+            request_timeout: None,
         }
     }
 }
@@ -40,16 +42,12 @@ impl Default for StatementConfig {
 impl Clone for StatementConfig {
     fn clone(&self) -> Self {
         Self {
-            consistency: self.consistency,
-            serial_consistency: self.serial_consistency,
-            is_idempotent: self.is_idempotent,
             retry_policy: self
                 .retry_policy
                 .as_ref()
                 .map(|policy| policy.clone_boxed()),
             speculative_execution_policy: self.speculative_execution_policy.clone(),
-            tracing: self.tracing,
-            timestamp: self.timestamp,
+            ..*self
         }
     }
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -1,6 +1,7 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use smallvec::{smallvec, SmallVec};
 use std::convert::TryInto;
+use std::time::Duration;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -245,6 +246,19 @@ impl PreparedStatement {
     /// Gets the default timestamp for this statement in microseconds.
     pub fn get_timestamp(&self) -> Option<i64> {
         self.config.timestamp
+    }
+
+    /// Sets the client-side timeout for this statement.
+    /// If not None, the driver will stop waiting for the request
+    /// to finish after `timeout` passed.
+    /// Otherwise, default session client timeout will be applied.
+    pub fn set_request_timeout(&mut self, timeout: Option<Duration>) {
+        self.config.request_timeout = timeout
+    }
+
+    /// Gets client timeout associated with this query
+    pub fn get_request_timeout(&self) -> Option<Duration> {
+        self.config.request_timeout
     }
 
     /// Sets the name of the partitioner used for this statement.

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -1,6 +1,7 @@
 use super::StatementConfig;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::transport::retry_policy::RetryPolicy;
+use std::time::Duration;
 
 /// CQL query statement.
 ///
@@ -116,6 +117,19 @@ impl Query {
     /// Gets the default timestamp for this statement in microseconds.
     pub fn get_timestamp(&self) -> Option<i64> {
         self.config.timestamp
+    }
+
+    /// Sets the client-side timeout for this statement.
+    /// If not None, the driver will stop waiting for the request
+    /// to finish after `timeout` passed.
+    /// Otherwise, default session client timeout will be applied.
+    pub fn set_request_timeout(&mut self, timeout: Option<Duration>) {
+        self.config.request_timeout = timeout
+    }
+
+    /// Gets client timeout associated with this query
+    pub fn get_request_timeout(&self) -> Option<Duration> {
+        self.config.request_timeout
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -63,6 +63,8 @@ pub struct Session {
     metrics: Arc<Metrics>,
     default_consistency: Consistency,
     auto_await_schema_agreement_timeout: Option<Duration>,
+    #[allow(dead_code)]
+    request_timeout: Option<Duration>,
 }
 
 /// This implementation deliberately omits some details from Cluster in order
@@ -120,7 +122,7 @@ pub struct SessionConfig {
     pub auth_password: Option<String>,
 
     pub schema_agreement_interval: Duration,
-    pub connect_timeout: std::time::Duration,
+    pub connect_timeout: Duration,
 
     /// Size of the per-node connection pool, i.e. how many connections the driver should keep to each node.
     /// The default is `PerShard(1)`, which is the recommended setting for Scylla clusters.
@@ -141,6 +143,10 @@ pub struct SessionConfig {
     /// Controls the timeout for the automatic wait for schema agreement after sending a schema-altering statement.
     /// If `None`, the automatic schema agreement is disabled.
     pub auto_await_schema_agreement_timeout: Option<Duration>,
+
+    /// Controls the client-side timeout for queries.
+    /// If `None`, the queries have no timeout (the driver will block indefinitely).
+    pub request_timeout: Option<Duration>,
 }
 
 /// Describes database server known on Session startup.
@@ -176,13 +182,14 @@ impl SessionConfig {
             ssl_context: None,
             auth_username: None,
             auth_password: None,
-            connect_timeout: std::time::Duration::from_secs(5),
+            connect_timeout: Duration::from_secs(5),
             connection_pool_size: Default::default(),
             disallow_shard_aware_port: false,
             default_consistency: Consistency::LocalQuorum,
             fetch_schema_metadata: true,
             keepalive_interval: None,
             auto_await_schema_agreement_timeout: Some(std::time::Duration::from_secs(60)),
+            request_timeout: Some(Duration::from_secs(30)),
         }
     }
 
@@ -374,6 +381,7 @@ impl Session {
             metrics: Arc::new(Metrics::new()),
             default_consistency: config.default_consistency,
             auto_await_schema_agreement_timeout: config.auto_await_schema_agreement_timeout,
+            request_timeout: config.request_timeout,
         };
 
         if let Some(keyspace_name) = config.used_keyspace {

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -541,6 +541,27 @@ impl SessionBuilder {
         self.config.auto_await_schema_agreement_timeout = None;
         self
     }
+
+    /// Changes client-side timeout
+    /// The default is 30 seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use std::time::Duration;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .request_timeout(Some(Duration::from_millis(500)))
+    ///     .build() // Turns SessionBuilder into Session
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn request_timeout(mut self, duration: Option<std::time::Duration>) -> Self {
+        self.config.request_timeout = duration;
+        self
+    }
 }
 
 /// Creates a [`SessionBuilder`] with default configuration, same as [`SessionBuilder::new`]
@@ -705,6 +726,21 @@ mod tests {
 
         builder = builder.fetch_schema_metadata(true);
         assert!(builder.config.fetch_schema_metadata);
+    }
+
+    #[test]
+    fn request_timeout() {
+        let mut builder = SessionBuilder::new();
+        assert_eq!(
+            builder.config.request_timeout,
+            Some(std::time::Duration::from_secs(30))
+        );
+
+        builder = builder.request_timeout(Some(std::time::Duration::from_secs(10)));
+        assert_eq!(
+            builder.config.request_timeout,
+            Some(std::time::Duration::from_secs(10))
+        );
     }
 
     #[test]

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -14,6 +14,7 @@ use crate::transport::topology::{CollectionType, ColumnKind, CqlType, NativeType
 use crate::CachingSession;
 use crate::QueryResult;
 use crate::{IntoTypedRows, Session, SessionBuilder};
+use assert_matches::assert_matches;
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
@@ -1179,6 +1180,74 @@ async fn test_timestamp() {
     .collect::<Vec<_>>();
 
     assert_eq!(results, expected_results);
+}
+
+#[ignore = "works on remote Scylla instances only (local ones are too fast)"]
+#[tokio::test]
+async fn test_request_timeout() {
+    use std::time::Duration;
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    {
+        let session = SessionBuilder::new()
+            .known_node(uri.as_str())
+            .build()
+            .await
+            .unwrap();
+
+        let mut query: Query = Query::new("SELECT * FROM system_schema.tables");
+        query.set_request_timeout(Some(Duration::from_millis(1)));
+        match session.query(query, &[]).await {
+            Ok(_) => panic!("the query should have failed due to a client-side timeout"),
+            Err(e) => assert_matches!(e, QueryError::RequestTimeout(_)),
+        }
+
+        let mut prepared = session
+            .prepare("SELECT * FROM system_schema.tables")
+            .await
+            .unwrap();
+
+        prepared.set_request_timeout(Some(Duration::from_millis(1)));
+        match session.execute(&prepared, &[]).await {
+            Ok(_) => panic!("the prepared query should have failed due to a client-side timeout"),
+            Err(e) => assert_matches!(e, QueryError::RequestTimeout(_)),
+        };
+    }
+    {
+        let timeouting_session = SessionBuilder::new()
+            .known_node(uri)
+            .request_timeout(Some(Duration::from_millis(1)))
+            .build()
+            .await
+            .unwrap();
+
+        let mut query = Query::new("SELECT * FROM system_schema.tables");
+
+        match timeouting_session.query(query.clone(), &[]).await {
+            Ok(_) => panic!("the query should have failed due to a client-side timeout"),
+            Err(e) => assert_matches!(e, QueryError::RequestTimeout(_)),
+        };
+
+        query.set_request_timeout(Some(Duration::from_secs(10000)));
+
+        timeouting_session.query(query, &[]).await.expect(
+            "the query should have not failed, because no client-side timeout was specified",
+        );
+
+        let mut prepared = timeouting_session
+            .prepare("SELECT * FROM system_schema.tables")
+            .await
+            .unwrap();
+
+        match timeouting_session.execute(&prepared, &[]).await {
+            Ok(_) => panic!("the prepared query should have failed due to a client-side timeout"),
+            Err(e) => assert_matches!(e, QueryError::RequestTimeout(_)),
+        };
+
+        prepared.set_request_timeout(Some(Duration::from_secs(10000)));
+
+        timeouting_session.execute(&prepared, &[]).await.expect("the prepared query should have not failed, because no client-side timeout was specified");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Two levels of client-side timeouts were added: per Session and per Statement (PreparedStatement and Query). If no timeout is specified for a statement, a global per-session one is used. Once a timeout elapses, an `RequestTimeout` error is returned.

Fixes: #304

## Pre-review checklist
<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
