### PR TITLE
tracing: Get list of nodes from  TracingInfo

### DIFF
--- a/scylla/src/tracing.rs
+++ b/scylla/src/tracing.rs
@@ -1,4 +1,5 @@
 use crate::statement::Consistency;
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::num::NonZeroU32;
@@ -46,6 +47,17 @@ pub struct GetTracingConfig {
     /// Consistency to use in queries that read TracingInfo.
     /// Default value: One
     pub consistency: Consistency,
+}
+
+impl TracingInfo {
+    /// Returns a list of unique nodes involved in the query
+    pub fn nodes(&self) -> Vec<IpAddr> {
+        self.events
+            .iter()
+            .filter_map(|e| e.source)
+            .unique()
+            .collect()
+    }
 }
 
 impl Default for GetTracingConfig {

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -919,6 +919,7 @@ async fn test_get_tracing_info(session: &Session, ks: String) {
     // Getting tracing info from session using this uuid works
     let tracing_info: TracingInfo = session.get_tracing_info(&tracing_id).await.unwrap();
     assert!(!tracing_info.events.is_empty());
+    assert!(!tracing_info.nodes().is_empty());
 }
 
 async fn test_tracing_query_iter(session: &Session, ks: String) {


### PR DESCRIPTION
Adds a simple getter which allows to get the list of nodes involved in a traced query.

## Pre-review checklist
<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
