### PR TITLE
Allow estimating replicas for a query

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1140,6 +1140,17 @@ impl Session {
         Ok(Some(tracing_info))
     }
 
+    // Returns which replicas are likely to take part in handling the query.
+    // If a list of replicas cannot be easily narrowed down, all available replicas
+    // will be returned.
+    pub fn estimate_replicas_for_query(&self, statement: &Statement) -> Vec<Arc<Node>> {
+        let cluster_data = self.cluster.get_data();
+        match statement.token {
+            Some(token) => TokenAwarePolicy::replicas_for_token(&token, statement, &cluster_data),
+            None => cluster_data.all_nodes.clone(),
+        }
+    }
+
     // This method allows to easily run a query using load balancing, retry policy etc.
     // Requires some information about the query and two closures
     // First closure is used to choose a connection


### PR DESCRIPTION
This commit allows users to make an educated guess on which replicas are going to take part in processing the query, assuming that the query in question has a well defined token. This information can be used for analytical and observability purposes. `estimate_replicas_for_query` simply returns a vector of nodes suspected of owning the data in question.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
