### PR TITLE
Latency aware policy

### DIFF
--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -15,13 +15,14 @@ use tokio::sync::mpsc;
 
 use super::errors::QueryError;
 use crate::cql_to_rust::{FromRow, FromRowError};
+use crate::Session;
 
 use crate::frame::types::LegacyConsistency;
 use crate::frame::{
     response::{
         result,
         result::{ColumnSpec, Row, Rows},
-        Response,
+        NonErrorResponse,
     },
     value::SerializedValues,
 };
@@ -30,10 +31,10 @@ use crate::routing::Token;
 use crate::statement::Consistency;
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
 use crate::transport::cluster::ClusterData;
-use crate::transport::connection::{Connection, QueryResponse};
+use crate::transport::connection::{Connection, NonErrorQueryResponse, QueryResponse};
 use crate::transport::load_balancing::{LoadBalancingPolicy, Statement};
 use crate::transport::metrics::Metrics;
-use crate::transport::node::Node;
+use crate::transport::node::{Node, TimestampedAverage};
 use crate::transport::retry_policy::{QueryInfo, RetryDecision, RetrySession};
 use tracing::{trace, trace_span, warn, Instrument};
 use uuid::Uuid;
@@ -313,6 +314,7 @@ where
     QueryFut: Future<Output = Result<QueryResponse, QueryError>>,
 {
     async fn work(mut self, cluster_data: Arc<ClusterData>) {
+        self.load_balancer.update_cluster_data(&cluster_data);
         let query_plan = self.load_balancer.plan(&self.statement_info, &cluster_data);
 
         let mut last_error: QueryError =
@@ -325,7 +327,7 @@ where
             let span = trace_span!("Executing query", node = node.address.to_string().as_str());
             // For each node in the plan choose a connection to use
             // This connection will be reused for same node retries to preserve paging cache on the shard
-            let connection: Arc<Connection> = match (self.choose_connection)(node)
+            let connection: Arc<Connection> = match (self.choose_connection)(node.clone())
                 .instrument(span.clone())
                 .await
             {
@@ -346,7 +348,7 @@ where
                 trace!(parent: &span, "Execution started");
                 // Query pages until an error occurs
                 let queries_result: Result<(), QueryError> = self
-                    .query_pages(&connection, current_consistency)
+                    .query_pages(&connection, current_consistency, &node)
                     .instrument(span.clone())
                     .await;
 
@@ -408,6 +410,7 @@ where
         &mut self,
         connection: &Arc<Connection>,
         consistency: Consistency,
+        node: &Node,
     ) -> Result<(), QueryError> {
         loop {
             self.metrics.inc_total_paged_queries();
@@ -418,24 +421,33 @@ where
                 "Sending"
             );
             self.log_attempt_start(connection.get_connect_address());
-            let query_response: QueryResponse =
+            let query_response =
                 (self.page_query)(connection.clone(), consistency, self.paging_state.clone())
-                    .await?;
+                    .await?
+                    .into_non_error_query_response();
 
-            match query_response.response {
-                Response::Result(result::Result::Rows(mut rows)) => {
-                    let _ = self
-                        .metrics
-                        .log_query_latency(query_start.elapsed().as_millis() as u64);
+            let elapsed = query_start.elapsed();
+            if Session::should_consider_query_for_latency_measurements(
+                &*self.load_balancer,
+                &query_response,
+            ) {
+                let mut average_latency_guard = node.average_latency.write().unwrap();
+                *average_latency_guard =
+                    TimestampedAverage::compute_next(*average_latency_guard, elapsed);
+            }
+            match query_response {
+                Ok(NonErrorQueryResponse {
+                    response: NonErrorResponse::Result(result::Result::Rows(mut rows)),
+                    tracing_id,
+                    ..
+                }) => {
+                    let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                     self.log_attempt_success();
                     self.log_query_success();
 
                     self.paging_state = rows.metadata.paging_state.take();
 
-                    let received_page = ReceivedPage {
-                        rows,
-                        tracing_id: query_response.tracing_id,
-                    };
+                    let received_page = ReceivedPage { rows, tracing_id };
 
                     // Send next page to RowIterator
                     if self.sender.send(Ok(received_page)).await.is_err() {
@@ -452,11 +464,11 @@ where
                     self.retry_session.reset();
                     self.log_query_start();
                 }
-                Response::Error(err) => {
+                Err(err) => {
                     self.metrics.inc_failed_paged_queries();
-                    return Err(err.into());
+                    return Err(err);
                 }
-                _ => {
+                Ok(_) => {
                     self.metrics.inc_failed_paged_queries();
 
                     return Err(QueryError::ProtocolError(

--- a/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
+++ b/scylla/src/transport/load_balancing/dc_aware_round_robin.rs
@@ -148,7 +148,7 @@ mod tests {
         policy: DcAwareRoundRobinPolicy,
         expected_plans: HashSet<Vec<u16>>,
     ) {
-        let cluster = tests::mock_cluster_data_for_round_robin_tests();
+        let cluster = tests::mock_cluster_data_for_round_robin_and_latency_aware_tests();
 
         let plans = (0..32)
             .map(|_| {

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -106,6 +106,32 @@ mod tests {
     use std::collections::HashMap;
     use std::net::SocketAddr;
 
+    // Used as child policy for load balancing policy tests
+    // Forwards plan passed to it in apply_child_policy() method
+    #[derive(Debug)]
+    pub struct DumbPolicy {}
+
+    impl LoadBalancingPolicy for DumbPolicy {
+        fn plan<'a>(&self, _: &Statement, _: &'a ClusterData) -> Plan<'a> {
+            let empty_node_list: Vec<Arc<Node>> = Vec::new();
+
+            Box::new(empty_node_list.into_iter())
+        }
+
+        fn name(&self) -> String {
+            "".into()
+        }
+    }
+
+    impl ChildLoadBalancingPolicy for DumbPolicy {
+        fn apply_child_policy(
+            &self,
+            plan: Vec<Arc<Node>>,
+        ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync> {
+            Box::new(plan.into_iter())
+        }
+    }
+
     #[test]
     fn test_slice_rotation() {
         let a = [1, 2, 3, 4, 5];

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -16,6 +16,10 @@ pub use dc_aware_round_robin::DcAwareRoundRobinPolicy;
 pub use round_robin::RoundRobinPolicy;
 pub use token_aware::TokenAwarePolicy;
 
+mod latency_aware;
+
+pub use latency_aware::LatencyAwarePolicy;
+
 /// Represents info about statement that can be used by load balancing policies.
 #[derive(Default)]
 pub struct Statement<'a> {

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -105,8 +105,11 @@ fn slice_rotated_left<T>(slice: &[T], mid: usize) -> impl Iterator<Item = &T> + 
 mod tests {
     use super::*;
 
+    use crate::transport::node::TimestampedAverage;
+    use crate::transport::topology::Keyspace;
     use crate::transport::topology::Metadata;
     use crate::transport::topology::Peer;
+    use crate::transport::topology::Strategy;
     use std::collections::HashMap;
     use std::net::SocketAddr;
 
@@ -170,7 +173,7 @@ mod tests {
 
     // creates ClusterData with info about 5 nodes living in 2 different datacenters
     // ring field is empty
-    pub fn mock_cluster_data_for_round_robin_tests() -> ClusterData {
+    pub fn mock_cluster_data_for_round_robin_and_latency_aware_tests() -> ClusterData {
         let peers = [("eu", 1), ("eu", 2), ("eu", 3), ("us", 4), ("us", 5)]
             .iter()
             .map(|(dc, id)| Peer {
@@ -202,5 +205,93 @@ mod tests {
     ) -> Vec<u16> {
         let plan = policy.plan(statement, cluster);
         plan.map(|node| node.address.port()).collect::<Vec<_>>()
+    }
+
+    pub fn set_nodes_latency_stats(
+        cluster: &mut ClusterData,
+        averages: &[(u16, Option<TimestampedAverage>)],
+    ) {
+        for (id, average) in averages {
+            *cluster
+                .known_peers
+                .get_mut(&tests::id_to_invalid_addr(*id))
+                .unwrap()
+                .average_latency
+                .write()
+                .unwrap() = *average;
+        }
+    }
+
+    // creates ClusterData with info about 3 nodes living in the same datacenter
+    // ring field is populated as follows:
+    // ring tokens:            50 100 150 200 250 300 400 500
+    // corresponding node ids: 2  1   2   3   1   2   3   1
+    pub fn mock_cluster_data_for_token_aware_tests() -> ClusterData {
+        let peers = [
+            Peer {
+                datacenter: Some("eu".into()),
+                rack: None,
+                address: tests::id_to_invalid_addr(1),
+                tokens: vec![
+                    Token { value: 100 },
+                    Token { value: 250 },
+                    Token { value: 500 },
+                ],
+                untranslated_address: None,
+            },
+            Peer {
+                datacenter: Some("eu".into()),
+                rack: None,
+                address: tests::id_to_invalid_addr(2),
+                tokens: vec![
+                    Token { value: 50 },
+                    Token { value: 150 },
+                    Token { value: 300 },
+                ],
+                untranslated_address: None,
+            },
+            Peer {
+                datacenter: Some("us".into()),
+                rack: None,
+                address: tests::id_to_invalid_addr(3),
+                tokens: vec![Token { value: 200 }, Token { value: 400 }],
+                untranslated_address: None,
+            },
+        ];
+
+        let keyspaces = [
+            (
+                "keyspace_with_simple_strategy_replication_factor_2".into(),
+                Keyspace {
+                    strategy: Strategy::SimpleStrategy {
+                        replication_factor: 2,
+                    },
+                    tables: HashMap::new(),
+                    views: HashMap::new(),
+                    user_defined_types: HashMap::new(),
+                },
+            ),
+            (
+                "keyspace_with_simple_strategy_replication_factor_3".into(),
+                Keyspace {
+                    strategy: Strategy::SimpleStrategy {
+                        replication_factor: 3,
+                    },
+                    tables: HashMap::new(),
+                    views: HashMap::new(),
+                    user_defined_types: HashMap::new(),
+                },
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let info = Metadata {
+            peers: Vec::from(peers),
+            keyspaces,
+        };
+
+        ClusterData::new(info, &Default::default(), &HashMap::new(), &None, None)
     }
 }

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -41,6 +41,13 @@ pub trait LoadBalancingPolicy: Send + Sync + std::fmt::Debug {
 
     /// Returns name of load balancing policy
     fn name(&self) -> String;
+
+    /// Informs whether latency measurements should be done when the policy is active.
+    fn requires_latency_measurements(&self) -> bool {
+        false
+    }
+
+    fn update_cluster_data(&self, _cluster_data: &ClusterData) {}
 }
 
 /// This trait is used to apply policy to plan made by parent policy.

--- a/scylla/src/transport/load_balancing/round_robin.rs
+++ b/scylla/src/transport/load_balancing/round_robin.rs
@@ -77,7 +77,7 @@ mod tests {
     // ConnectionKeeper (which lives in Node) requires context of Tokio runtime
     #[tokio::test]
     async fn test_round_robin_policy() {
-        let cluster = tests::mock_cluster_data_for_round_robin_tests();
+        let cluster = tests::mock_cluster_data_for_round_robin_and_latency_aware_tests();
 
         let policy = RoundRobinPolicy::new();
 

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -188,6 +188,7 @@ impl LoadBalancingPolicy for TokenAwarePolicy {
 mod tests {
     use super::*;
 
+    use crate::load_balancing::tests::DumbPolicy;
     use crate::transport::load_balancing::tests;
     use crate::transport::topology::Keyspace;
     use crate::transport::topology::Metadata;
@@ -453,31 +454,5 @@ mod tests {
         };
 
         ClusterData::new(info, &Default::default(), &HashMap::new(), &None, None)
-    }
-
-    // Used as child policy for TokenAwarePolicy tests
-    // Forwards plan passed to it in apply_child_policy() method
-    #[derive(Debug)]
-    struct DumbPolicy {}
-
-    impl LoadBalancingPolicy for DumbPolicy {
-        fn plan<'a>(&self, _: &Statement, _: &'a ClusterData) -> Plan<'a> {
-            let empty_node_list: Vec<Arc<Node>> = Vec::new();
-
-            Box::new(empty_node_list.into_iter())
-        }
-
-        fn name(&self) -> String {
-            "".into()
-        }
-    }
-
-    impl ChildLoadBalancingPolicy for DumbPolicy {
-        fn apply_child_policy(
-            &self,
-            plan: Vec<Arc<Node>>,
-        ) -> Box<dyn Iterator<Item = Arc<Node>> + Send + Sync> {
-            Box::new(plan.into_iter())
-        }
     }
 }

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -174,6 +174,14 @@ impl LoadBalancingPolicy for TokenAwarePolicy {
             self.child_policy.name()
         )
     }
+
+    fn requires_latency_measurements(&self) -> bool {
+        self.child_policy.requires_latency_measurements()
+    }
+
+    fn update_cluster_data(&self, cluster_data: &ClusterData) {
+        self.child_policy.update_cluster_data(cluster_data);
+    }
 }
 
 #[cfg(test)]

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -199,7 +199,7 @@ mod tests {
     // ConnectionKeeper (which lives in Node) requires context of Tokio runtime
     #[tokio::test]
     async fn test_token_aware_policy() {
-        let cluster = mock_cluster_data_for_token_aware_tests();
+        let cluster = tests::mock_cluster_data_for_token_aware_tests();
 
         struct Test<'a> {
             statement: Statement<'a>,
@@ -271,7 +271,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_token_aware_fallback_policy() {
-        let cluster = mock_cluster_data_for_token_aware_tests();
+        let cluster = tests::mock_cluster_data_for_token_aware_tests();
 
         let policy = TokenAwarePolicy::new(Box::new(DumbPolicy {}));
 
@@ -282,79 +282,6 @@ mod tests {
             &cluster,
         );
         assert_eq!(plan.len(), 0);
-    }
-
-    // creates ClusterData with info about 3 nodes living in the same datacenter
-    // ring field is populated as follows:
-    // ring tokens:            50 100 150 200 250 300 400 500
-    // corresponding node ids: 2  1   2   3   1   2   3   1
-    fn mock_cluster_data_for_token_aware_tests() -> ClusterData {
-        let peers = [
-            Peer {
-                datacenter: Some("eu".into()),
-                rack: None,
-                address: tests::id_to_invalid_addr(1),
-                tokens: vec![
-                    Token { value: 100 },
-                    Token { value: 250 },
-                    Token { value: 500 },
-                ],
-                untranslated_address: Some(tests::id_to_invalid_addr(1)),
-            },
-            Peer {
-                datacenter: Some("eu".into()),
-                rack: None,
-                address: tests::id_to_invalid_addr(2),
-                tokens: vec![
-                    Token { value: 50 },
-                    Token { value: 150 },
-                    Token { value: 300 },
-                ],
-                untranslated_address: Some(tests::id_to_invalid_addr(2)),
-            },
-            Peer {
-                datacenter: Some("us".into()),
-                rack: None,
-                address: tests::id_to_invalid_addr(3),
-                tokens: vec![Token { value: 200 }, Token { value: 400 }],
-                untranslated_address: Some(tests::id_to_invalid_addr(3)),
-            },
-        ];
-
-        let keyspaces = [
-            (
-                "keyspace_with_simple_strategy_replication_factor_2".into(),
-                Keyspace {
-                    strategy: Strategy::SimpleStrategy {
-                        replication_factor: 2,
-                    },
-                    tables: HashMap::new(),
-                    views: HashMap::new(),
-                    user_defined_types: HashMap::new(),
-                },
-            ),
-            (
-                "keyspace_with_simple_strategy_replication_factor_3".into(),
-                Keyspace {
-                    strategy: Strategy::SimpleStrategy {
-                        replication_factor: 3,
-                    },
-                    tables: HashMap::new(),
-                    views: HashMap::new(),
-                    user_defined_types: HashMap::new(),
-                },
-            ),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-
-        let info = Metadata {
-            peers: Vec::from(peers),
-            keyspaces,
-        };
-
-        ClusterData::new(info, &Default::default(), &HashMap::new(), &None, None)
     }
 
     // creates ClusterData with info about 8 nodes living in two different datacenters

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -4,10 +4,12 @@
 use crate::frame::types::LegacyConsistency;
 use crate::history;
 use crate::history::HistoryListener;
+use crate::transport::node::TimestampedAverage;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::join_all;
 use futures::future::try_join_all;
+use scylla_cql::errors::DbError;
 use scylla_cql::frame::response::NonErrorResponse;
 use std::collections::HashMap;
 use std::future::Future;
@@ -1274,6 +1276,34 @@ impl Session {
         }
     }
 
+    pub fn should_consider_query_for_latency_measurements(
+        load_balancer: &dyn LoadBalancingPolicy,
+        result: &Result<impl AllowedRunQueryResTType, QueryError>,
+    ) -> bool {
+        load_balancer.requires_latency_measurements()
+            && match result {
+                Ok(_) => true,
+                Err(err) => match err {
+                    // "fast" errors, i.e. ones that are returned quickly after the query begins
+                    QueryError::BadQuery(_)
+                    | QueryError::TooManyOrphanedStreamIds(_)
+                    | QueryError::UnableToAllocStreamId
+                    | QueryError::DbError(DbError::IsBootstrapping, _)
+                    | QueryError::DbError(DbError::Unavailable { .. }, _)
+                    | QueryError::DbError(DbError::Unprepared { .. }, _)
+                    | QueryError::DbError(DbError::Overloaded { .. }, _) => false,
+
+                    // "slow" errors, i.e. ones that are returned after considerable time of query being run
+                    QueryError::DbError(_, _)
+                    | QueryError::InvalidMessage(_)
+                    | QueryError::IoError(_)
+                    | QueryError::ProtocolError(_)
+                    | QueryError::TimeoutError
+                    | QueryError::RequestTimeout(_) => true,
+                },
+            }
+    }
+
     // This method allows to easily run a query using load balancing, retry policy etc.
     // Requires some information about the query and two closures
     // First closure is used to choose a connection
@@ -1306,6 +1336,7 @@ impl Session {
 
         let runner = async {
             let cluster_data = self.cluster.get_data();
+            self.load_balancer.update_cluster_data(&cluster_data);
             let query_plan = self.load_balancer.plan(&statement_info, &cluster_data);
 
             // If a speculative execution policy is used to run query, query_plan has to be shared
@@ -1491,12 +1522,19 @@ impl Session {
                         .instrument(span.clone())
                         .await;
 
+                let elapsed = query_start.elapsed();
+                if Self::should_consider_query_for_latency_measurements(
+                    &*self.load_balancer,
+                    &query_result,
+                ) {
+                    let mut average_latency_guard = node.average_latency.write().unwrap();
+                    *average_latency_guard =
+                        TimestampedAverage::compute_next(*average_latency_guard, elapsed);
+                }
                 last_error = match query_result {
                     Ok(response) => {
                         trace!(parent: &span, "Query succeeded");
-                        let _ = self
-                            .metrics
-                            .log_query_latency(query_start.elapsed().as_millis() as u64);
+                        let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
                         return Some(Ok(RunQueryResult::Completed(response)));
                     }


### PR DESCRIPTION
A LatencyAware load balancing policy, similar to what other drivers deliver, was added. Its goal is to avoid slow nodes as coordinators.
If a policy requests that latency statistics be collected, then an exponential moving average of latencies will be updated for a node upon query completion with that node serving as coordinator.

Fixes: #515 #505 #260

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
