### PR TITLE
Add separate struct for view metadata to store more info

### DIFF
--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -2087,10 +2087,19 @@ async fn test_views_in_schema_info() {
         .views
         .keys()
         .collect::<std::collections::HashSet<&String>>();
+    let views_base_table = keyspace_meta
+        .views
+        .values()
+        .map(|view_meta| &view_meta.base_table_name)
+        .collect::<std::collections::HashSet<&String>>();
 
     assert_eq!(tables, std::collections::HashSet::from([&"t".to_string()]));
     assert_eq!(
         views,
         std::collections::HashSet::from([&"mv1".to_string(), &"mv2".to_string()])
     );
+    assert_eq!(
+        views_base_table,
+        std::collections::HashSet::from([&"t".to_string()])
+    )
 }


### PR DESCRIPTION
Added MaterlizedView struct to store base table name for a view.
This will allow to find all materialized views for a given table name, or find the base table metadata for a certain view.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
