### PR TITLE
Add support for rate limit exceeded exception

### DIFF
--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -1,4 +1,5 @@
 pub mod frame_errors;
+pub mod protocol_features;
 pub mod request;
 pub mod response;
 pub mod server_event_type;

--- a/scylla-cql/src/frame/protocol_features.rs
+++ b/scylla-cql/src/frame/protocol_features.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+
+const RATE_LIMIT_ERROR_EXTENSION: &str = "SCYLLA_RATE_LIMIT_ERROR";
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ProtocolFeatures {
+    pub rate_limit_error: Option<i32>,
+}
+
+// TODO: Log information about options which failed to parse
+
+impl ProtocolFeatures {
+    pub fn parse_from_supported(supported: &HashMap<String, Vec<String>>) -> Self {
+        Self {
+            rate_limit_error: Self::maybe_parse_rate_limit_error(supported),
+        }
+    }
+
+    fn maybe_parse_rate_limit_error(supported: &HashMap<String, Vec<String>>) -> Option<i32> {
+        let vals = supported.get(RATE_LIMIT_ERROR_EXTENSION)?;
+        let code_str = Self::get_cql_extension_field(vals.as_slice(), "ERROR_CODE")?;
+        code_str.parse::<i32>().ok()
+    }
+
+    // Looks up a field which starts with `key=` and returns the rest
+    fn get_cql_extension_field<'a>(vals: &'a [String], key: &str) -> Option<&'a str> {
+        vals.iter()
+            .find_map(|v| v.as_str().strip_prefix(key)?.strip_prefix('='))
+    }
+
+    pub fn add_startup_options(&self, options: &mut HashMap<String, String>) {
+        if self.rate_limit_error.is_some() {
+            options.insert(RATE_LIMIT_ERROR_EXTENSION.to_string(), String::new());
+        }
+    }
+}

--- a/scylla-cql/src/frame/response/error.rs
+++ b/scylla-cql/src/frame/response/error.rs
@@ -1,5 +1,6 @@
 use crate::errors::{DbError, QueryError, WriteType};
 use crate::frame::frame_errors::ParseError;
+use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::types;
 use byteorder::ReadBytesExt;
 use bytes::Bytes;
@@ -11,7 +12,7 @@ pub struct Error {
 }
 
 impl Error {
-    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
+    pub fn deserialize(_features: &ProtocolFeatures, buf: &mut &[u8]) -> Result<Self, ParseError> {
         let code = types::read_int(buf)?;
         let reason = types::read_string(buf)?.to_owned();
 
@@ -86,6 +87,7 @@ impl From<Error> for QueryError {
 mod tests {
     use super::Error;
     use crate::errors::{DbError, WriteType};
+    use crate::frame::protocol_features::ProtocolFeatures;
     use crate::frame::types::LegacyConsistency;
     use crate::Consistency;
     use bytes::Bytes;
@@ -121,9 +123,11 @@ mod tests {
             (0x1234, DbError::Other(0x1234)),
         ];
 
+        let features = ProtocolFeatures::default();
+
         for (error_code, expected_error) in &simple_error_mappings {
             let bytes: Vec<u8> = make_error_request_bytes(*error_code, "simple message");
-            let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+            let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
             assert_eq!(error.error, *expected_error);
             assert_eq!(error.reason, "simple message");
         }
@@ -131,12 +135,14 @@ mod tests {
 
     #[test]
     fn deserialize_unavailable() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x1000, "message 2");
         bytes.extend(&1_i16.to_be_bytes());
         bytes.extend(&2_i32.to_be_bytes());
         bytes.extend(&3_i32.to_be_bytes());
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,
@@ -151,6 +157,8 @@ mod tests {
 
     #[test]
     fn deserialize_write_timeout() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x1100, "message 2");
         bytes.extend(&0x0004_i16.to_be_bytes());
         bytes.extend(&(-5_i32).to_be_bytes());
@@ -161,7 +169,7 @@ mod tests {
         bytes.extend(&write_type_str_len.to_be_bytes());
         bytes.extend(write_type_str.as_bytes());
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,
@@ -177,13 +185,15 @@ mod tests {
 
     #[test]
     fn deserialize_read_timeout() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x1200, "message 2");
         bytes.extend(&0x0002_i16.to_be_bytes());
         bytes.extend(&8_i32.to_be_bytes());
         bytes.extend(&32_i32.to_be_bytes());
         bytes.push(0_u8);
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,
@@ -199,6 +209,8 @@ mod tests {
 
     #[test]
     fn deserialize_read_failure() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x1300, "message 2");
         bytes.extend(&0x0003_i16.to_be_bytes());
         bytes.extend(&4_i32.to_be_bytes());
@@ -206,7 +218,7 @@ mod tests {
         bytes.extend(&6_i32.to_be_bytes());
         bytes.push(123_u8); // Any non-zero value means data_present is true
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,
@@ -223,6 +235,8 @@ mod tests {
 
     #[test]
     fn deserialize_function_failure() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x1400, "message 2");
 
         let keyspace_name: &str = "keyspace_name";
@@ -247,7 +261,7 @@ mod tests {
         bytes.extend(&type2_len.to_be_bytes());
         bytes.extend(type2.as_bytes());
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,
@@ -262,6 +276,8 @@ mod tests {
 
     #[test]
     fn deserialize_write_failure() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x1500, "message 2");
 
         bytes.extend(&0x0000_i16.to_be_bytes());
@@ -274,7 +290,7 @@ mod tests {
         bytes.extend(&write_type_str_len.to_be_bytes());
         bytes.extend(write_type_str.as_bytes());
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,
@@ -291,6 +307,8 @@ mod tests {
 
     #[test]
     fn deserialize_already_exists() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x2400, "message 2");
 
         let keyspace_name: &str = "keyspace_name";
@@ -304,7 +322,7 @@ mod tests {
         bytes.extend(&table_name_len.to_be_bytes());
         bytes.extend(table_name.as_bytes());
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,
@@ -318,12 +336,14 @@ mod tests {
 
     #[test]
     fn deserialize_unprepared() {
+        let features = ProtocolFeatures::default();
+
         let mut bytes = make_error_request_bytes(0x2500, "message 3");
         let statement_id = b"deadbeef";
         bytes.extend((statement_id.len() as i16).to_be_bytes());
         bytes.extend(statement_id);
 
-        let error: Error = Error::deserialize(&mut bytes.as_slice()).unwrap();
+        let error: Error = Error::deserialize(&features, &mut bytes.as_slice()).unwrap();
 
         assert_eq!(
             error.error,

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -8,6 +8,7 @@ pub mod supported;
 use crate::{errors::QueryError, frame::frame_errors::ParseError};
 use num_enum::TryFromPrimitive;
 
+use crate::frame::protocol_features::ProtocolFeatures;
 pub use error::Error;
 pub use supported::Supported;
 
@@ -37,9 +38,13 @@ pub enum Response {
 }
 
 impl Response {
-    pub fn deserialize(opcode: ResponseOpcode, buf: &mut &[u8]) -> Result<Response, ParseError> {
+    pub fn deserialize(
+        features: &ProtocolFeatures,
+        opcode: ResponseOpcode,
+        buf: &mut &[u8],
+    ) -> Result<Response, ParseError> {
         let response = match opcode {
-            ResponseOpcode::Error => Response::Error(Error::deserialize(buf)?),
+            ResponseOpcode::Error => Response::Error(Error::deserialize(features, buf)?),
             ResponseOpcode::Ready => Response::Ready,
             ResponseOpcode::Authenticate => {
                 Response::Authenticate(authenticate::Authenticate::deserialize(buf)?)

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -29,6 +29,7 @@ use std::{
 use super::errors::{BadKeyspaceName, BadQuery, DbError, QueryError};
 
 use crate::batch::{Batch, BatchStatement};
+use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::{
     self,
     request::{self, batch, execute, query, register, Request},
@@ -842,7 +843,10 @@ impl Connection {
             warn!(warning = warn_description.as_str());
         }
 
-        let response = Response::deserialize(task_response.opcode, &mut &*body_with_ext.body)?;
+        // TODO: Placeholder
+        let features = ProtocolFeatures::default();
+        let response =
+            Response::deserialize(&features, task_response.opcode, &mut &*body_with_ext.body)?;
 
         Ok(QueryResponse {
             response,


### PR DESCRIPTION
This PR adds support for a new Scylla-specific type of error returned from the database: RateLimitExceeded. It was introduced as a part of the _per-partition rate limit_ feature, upcoming in Scylla 5.1 (PR in Scylla: https://github.com/scylladb/scylladb/pull/9810). The RateLimitExceeded error is sent when Scylla detects that the per-partition rate limit is exceeded.

In order for Scylla to be able to send this error, the driver must tell the database during connection handshake that it is able to interpret it (otherwise Scylla falls back to the Config_error error). This PR adds support for Scylla-specific protocol extensions, negotiates the `SCYLLA_RATE_LIMIT_ERROR` during handshake and adds support for the RateLimitExceeded error deserialization.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
