### PR TITLE
transport/load_balancing: appease clippy

### DIFF
--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -84,7 +84,7 @@ fn iter_rotated_left<'a, T>(
 }
 
 // similar to slice::rotate_left, but it returns an iterator, doesn't mutate input
-fn slice_rotated_left<'a, T>(slice: &'a [T], mid: usize) -> impl Iterator<Item = &T> + Clone + 'a {
+fn slice_rotated_left<T>(slice: &[T], mid: usize) -> impl Iterator<Item = &T> + Clone {
     let begin = &slice[mid..];
     let end = &slice[..mid];
     begin.iter().chain(end.iter())


### PR DESCRIPTION
The newest version of clippy complains that a lifetime can be elided in the `slice_rotated_left` function. This commit removes the explicit lifetime and lets rustc infer it automatically.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
