### PR TITLE
Move enforcing timeouts to the connection router

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -673,6 +673,8 @@ impl Session {
         let query: Query = query.into();
         let serialized_values = values.serialized()?;
 
+        let timeout = query.config.request_timeout.or(self.request_timeout);
+
         let retry_session = match &query.config.retry_policy {
             Some(policy) => policy.new_session(),
             None => self.retry_policy.new_session(),
@@ -688,6 +690,7 @@ impl Session {
                 load_balancer: self.load_balancer.clone(),
                 cluster_data: self.cluster.get_data(),
                 metrics: self.metrics.clone(),
+                timeout,
             },
         )
         .instrument(span)
@@ -956,6 +959,8 @@ impl Session {
         let prepared = prepared.into();
         let serialized_values = values.serialized()?;
 
+        let timeout = prepared.config.request_timeout.or(self.request_timeout);
+
         let token = self.calculate_token(&prepared, &serialized_values)?;
 
         let retry_session = match &prepared.config.retry_policy {
@@ -977,6 +982,7 @@ impl Session {
                 load_balancer: self.load_balancer.clone(),
                 cluster_data: self.cluster.get_data(),
                 metrics: self.metrics.clone(),
+                timeout,
             },
         )
         .instrument(span)

--- a/scylla/src/utils/mod.rs
+++ b/scylla/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod parse;
+pub(crate) mod timer;
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/scylla/src/utils/timer.rs
+++ b/scylla/src/utils/timer.rs
@@ -1,0 +1,138 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+use tokio::time::{Instant, Sleep};
+
+/// A resettable timer.
+///
+/// It can be in one of two states: armed or unarmed.
+/// Waiting for an armed timer resolves when the timer's deadline is reached.
+/// Waiting for an unarmed timer resolves after the timer is reset and its new
+/// deadline is reached.
+pub struct ArmableTimer {
+    state: ArmableTimerState,
+}
+
+enum ArmableTimerState {
+    /// The timer is not set, but somebody may be waiting for it.
+    Unarmed(Option<Waker>),
+
+    /// The timer is set.
+    /// The pin box wrapper could be avoided it we used pin_project to generate
+    /// pin projections, but it's a heavy dependency and our current use cases
+    /// of the ArmableTimer don't really require pulling it in.
+    Armed(Pin<Box<Sleep>>),
+}
+
+impl Default for ArmableTimer {
+    fn default() -> Self {
+        Self {
+            state: ArmableTimerState::Unarmed(None),
+        }
+    }
+}
+
+impl ArmableTimer {
+    /// Creates a new, unarmed timer.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Arms the timer to fire at the specified moment.
+    ///
+    /// If the moment has already expired, the timer will become ready at once.
+    /// If somebody waited for the timer, they will start waiting for the new
+    /// deadline.
+    pub fn arm(&mut self, deadline: Instant) {
+        match &mut self.state {
+            ArmableTimerState::Unarmed(maybe_waker) => {
+                if let Some(waker) = maybe_waker.take() {
+                    // We can't really re-register the waker on the new Sleep
+                    // future, so wake it and let it be re-registered naturally.
+                    waker.wake();
+                }
+                self.state = ArmableTimerState::Armed(Box::pin(tokio::time::sleep_until(deadline)));
+            }
+            ArmableTimerState::Armed(sleep) => sleep.as_mut().reset(deadline),
+        }
+    }
+
+    /// Gets the current deadline of the driver, or returns `None`
+    /// if it is unarmed.
+    pub fn deadline(&self) -> Option<Instant> {
+        match &self.state {
+            ArmableTimerState::Unarmed(_) => None,
+            ArmableTimerState::Armed(sleep) => Some(sleep.deadline()),
+        }
+    }
+}
+
+impl Future for ArmableTimer {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match &mut self.state {
+            ArmableTimerState::Unarmed(maybe_waker) => {
+                *maybe_waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+            ArmableTimerState::Armed(sleep) => match sleep.as_mut().poll(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(_) => {
+                    self.state = ArmableTimerState::Unarmed(None);
+                    Poll::Ready(())
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::task::Poll;
+    use std::time::Duration;
+
+    use futures::future;
+    use tokio::time::Instant;
+
+    use super::ArmableTimer;
+
+    fn make_timer_with_awaitee() -> (Arc<Mutex<ArmableTimer>>, impl Future<Output = ()>) {
+        let timer = Arc::new(Mutex::new(ArmableTimer::new()));
+        let awaitee = future::poll_fn({
+            let timer = timer.clone();
+            move |cx| {
+                let mut lock = timer.lock().unwrap();
+                Pin::new(&mut *lock).poll(cx)
+            }
+        });
+        (timer, awaitee)
+    }
+
+    #[tokio::test]
+    async fn test_armable_timer() {
+        let (timer, mut awaitee) = make_timer_with_awaitee();
+
+        // Check that the timer is usable multiple times
+        for _ in 0..3 {
+            // Initially/after firing, the timer has no deadline
+            // and does not fire
+            assert_eq!(timer.lock().unwrap().deadline(), None);
+            assert_eq!(futures::poll(&mut awaitee).await, Poll::Pending);
+
+            // Set the deadline and make sure that the timer expires
+            let deadline = Instant::now() + Duration::from_millis(50);
+            timer.lock().unwrap().arm(deadline);
+            assert_eq!(timer.lock().unwrap().deadline(), Some(deadline));
+
+            // Wait until the timer resolves and make sure that the necessary
+            // time has elapsed
+            (&mut awaitee).await;
+            assert!(Instant::now() >= deadline);
+        }
+    }
+}


### PR DESCRIPTION
## Problem description

In my benchmarks, I observed that just by disabling driver-side timeouts I could get 3-4 times the throughput. Without timeouts, the benchmark was CPU bound, while with timeouts the CPU usage was not 100% even though the throughput was lower. Recorded flamegraphs showed that above 25% of time was spent in Mutex-related code.

Here is why I think `tokio::time::timeout` performs badly. In order to register a timer, Tokio needs to acquire a Mutex of the current thread's timer driver. When the timer is cancelled (which happens when the inner future finishes before timeout), it needs to be unregistered and the same Mutex needs to be acquired - and, because tasks can migrate between threads, it might not be the Mutex of the current thread anymore. Because nearly all of the requests finish in time and nearly all timers are cancelled, this most likely leads to lock contention.

## Solution

This PR reimplements driver-side timeouts using a different architecture. Instead of using `tokio::time::timeout` on the tasks that wait for a response from the connection router, now the connection router itself is responsible for enforcing timeouts and rejecting the requests.

In the new design, there is only one timer active for each active connection. The timers are reset much more rarely, roughly with a period of `timeout - avg latency`.

As a bonus, the PR also implements timeouts for some code paths that weren't previously covered: `batch`, `query_iter` and `execute_iter`.

## Benchmark

To test this out I ran cql-stress (a scylla-bench rewrite using Rust driver) on a machine with 16 cores (32 threads) against a single Scylla node on another, identical machine. Using the following command (release mode, debug symbols enabled):

```
cargo flamegraph -F 99 --bin cql-stress-scylla-bench -- -nodes 10.0.1.8 -max-rate 0 -mode write -workload uniform -partition-count 10000 -concurrency 4096 -duration 10s
```

... I measured the throughput and how much % of the time was spent in locking, according to the flamegraphs:

__564cf5db544d83ec3f9799a5c723e98071f21fea (before the PR)__:

- Operations/s: 549975.1976076759
- Time spent in mutex-related functions: 27.3%

__564cf5db544d83ec3f9799a5c723e98071f21fea (before the PR, but with timeouts disabled)__:

- Operations/s: 1858276.1677900965
- Time spent in mutex-related functions: 1.7%

__This PR__:

- Operations/s: 1866452.173848832
- Time spent in mutex-related functions: 1.6%

## Tests

For now, correctness tests were only done in a manual fashion (running cql-stress, adjusting timeout to be below latency and observing results). If the proxy gets merged before this, I'll add some automatic tests in this PR, if not - I'll send them separately later.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
