### PR TITLE
Fix derives so that they work with generics

### DIFF
--- a/examples/value_list.rs
+++ b/examples/value_list.rs
@@ -35,6 +35,23 @@ async fn main() {
         .await
         .unwrap();
 
+    // You can also use type generics:
+    #[derive(scylla::ValueList)]
+    struct MyTypeWithGenerics<S: scylla::frame::value::Value> {
+        k: i32,
+        my: Option<S>,
+    }
+
+    let to_insert_2 = MyTypeWithGenerics {
+        k: 18,
+        my: Some("Some string".to_owned()),
+    };
+
+    session
+        .query("INSERT INTO ks.my_type (k, my) VALUES (?, ?)", to_insert_2)
+        .await
+        .unwrap();
+
     let q = session
         .query("SELECT * FROM ks.my_type", &[])
         .await

--- a/examples/value_list.rs
+++ b/examples/value_list.rs
@@ -20,14 +20,14 @@ async fn main() {
         .unwrap();
 
     #[derive(scylla::ValueList)]
-    struct MyType {
+    struct MyType<'a> {
         k: i32,
-        my: Option<String>,
+        my: Option<&'a str>,
     }
 
     let to_insert = MyType {
         k: 17,
-        my: Some("Some string".to_string()),
+        my: Some("Some str"),
     };
 
     session

--- a/scylla-macros/src/parser.rs
+++ b/scylla-macros/src/parser.rs
@@ -1,16 +1,13 @@
-use proc_macro::TokenStream;
-use syn::{parse, Data, DeriveInput, Fields, FieldsNamed, Ident};
+use syn::{Data, DeriveInput, Fields, FieldsNamed};
 
 /// Parses the tokens_input to a DeriveInput and returns the struct name from which it derives and
 /// the named fields
-pub(crate) fn parse_struct_with_named_fields(
-    tokens_input: TokenStream,
+pub(crate) fn parse_named_fields<'a>(
+    input: &'a DeriveInput,
     current_derive: &str,
-) -> (Ident, FieldsNamed) {
-    let input = parse::<DeriveInput>(tokens_input).expect("No DeriveInput");
-    let struct_name = input.ident;
-    let struct_fields = match input.data {
-        Data::Struct(data) => match data.fields {
+) -> &'a FieldsNamed {
+    match &input.data {
+        Data::Struct(data) => match &data.fields {
             Fields::Named(named_fields) => named_fields,
             _ => panic!(
                 "derive({}) works only for structs with named fields. Tuples don't need derive.",
@@ -18,7 +15,5 @@ pub(crate) fn parse_struct_with_named_fields(
             ),
         },
         _ => panic!("derive({}) works only on structs!", current_derive),
-    };
-
-    (struct_name, struct_fields)
+    }
 }

--- a/scylla-macros/src/value_list.rs
+++ b/scylla-macros/src/value_list.rs
@@ -1,17 +1,20 @@
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::DeriveInput;
 
 /// #[derive(ValueList)] allows to parse a struct as a list of values,
 /// which can be fed to the query directly.
-/// Works only on simple structs without generics etc
 pub fn value_list_derive(tokens_input: TokenStream) -> TokenStream {
-    let (struct_name, struct_fields) =
-        crate::parser::parse_struct_with_named_fields(tokens_input, "ValueList");
+    let item = syn::parse::<DeriveInput>(tokens_input).expect("No DeriveInput");
+    let struct_fields = crate::parser::parse_named_fields(&item, "ValueList");
+
+    let struct_name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
     let values_len = struct_fields.named.len();
     let field_name = struct_fields.named.iter().map(|field| &field.ident);
     let generated = quote! {
-        impl scylla::frame::value::ValueList for #struct_name {
+        impl #impl_generics scylla::frame::value::ValueList for #struct_name #ty_generics #where_clause {
             fn serialized(&self) -> scylla::frame::value::SerializedResult {
                 let mut result = scylla::frame::value::SerializedValues::with_capacity(#values_len);
                 #(


### PR DESCRIPTION
Derives were written without using the dedicated [`item.generics.split_for_impl()`](https://docs.rs/syn/latest/syn/struct.Generics.html#method.split_for_impl) which resulted in them not working as soon as the struct contained generics. Notably, it was impossible to derive `ValueList` on a struct that contained an `&str`, forcing the user to reallocate.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
