### PR TITLE
Add support for custom authentication

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -22,4 +22,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run tests
-      run: cargo test --verbose authenticate_superuser --  --ignored
+      run: cargo test --verbose authenticate_superuser -- custom_authentication --ignored

--- a/docs/source/connecting/authentication.md
+++ b/docs/source/connecting/authentication.md
@@ -1,8 +1,9 @@
 # Authentication
 
-Driver supports authentication by username and password.
+Driver supports both authentication by username and password and custom authentication defined by a user.
+###### Important: The default authentication credentials are sent in plain text to the server. For this reason, it is highly recommended that this be used in conjunction with client-to-node encryption (SSL), or in a trusted network environment.
 
-To specify credentials use the `user` method in `SessionBuilder`:
+To use the default authentication, specify credentials using the `user` method in `SessionBuilder`:
 
 ```rust
 # extern crate scylla;
@@ -19,4 +20,73 @@ let session: Session = SessionBuilder::new()
 
 # Ok(())
 # }
+```
+ ### Custom Authentication
+
+A custom authentication is defined by implementing the `AuthenticatorSession`.
+An `AuthenticatorSession` instance is created per session, so it is also necessary to define a `AuthenticatorProvider` for it.
+Finally, to make use of the custom authentication, use the `authenticator_provider` method in `SessionBuilder`:
+
+```rust
+# extern crate scylla;
+# extern crate scylla_cql;
+# extern crate tokio;
+# extern crate bytes;
+# extern crate async_trait;
+# use std::error::Error;
+# use std::sync::Arc;
+use bytes::{BufMut, BytesMut};
+use async_trait::async_trait;
+use scylla::authentication::{AuthError, AuthenticatorProvider, AuthenticatorSession};
+
+struct CustomAuthenticator;
+
+#[async_trait]
+impl AuthenticatorSession for CustomAuthenticator {
+    // to handle an authentication challenge initiated by the server.
+    // The information contained in the token parameter is authentication protocol specific.
+    // It may be NULL or empty. 
+    async fn evaluate_challenge(
+        &mut self,
+        _token: Option<&[u8]>,
+    ) -> Result<Option<Vec<u8>>, AuthError> {
+        Err("Challenges are not expected".to_string())
+    }
+
+    // to handle the success phase of exchange. The token parameters contain information that may be used to finalize the request.
+    async fn success(&mut self, _token: Option<&[u8]>) -> Result<(), AuthError> {
+        Ok(())
+    }
+}
+
+struct CustomAuthenticatorProvider;
+
+#[async_trait]
+impl AuthenticatorProvider for CustomAuthenticatorProvider {
+    async fn start_authentication_session(
+        &self,
+        _name: &str,
+    ) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError> {
+        let mut response = BytesMut::new();
+        let cred = "\0cassandra\0cassandra";
+        let cred_length = 20;
+
+        response.put_i32(cred_length);
+        response.put_slice(cred.as_bytes());
+
+        Ok((Some(response.to_vec()), Box::new(CustomAuthenticator)))
+    }
+}
+
+async fn authentication_example() -> Result<(), Box<dyn Error>> {
+    use scylla::{Session, SessionBuilder};
+
+    let _session: Session = SessionBuilder::new()
+        .known_node("127.0.0.1:9042")
+        .authenticator_provider(Arc::new(CustomAuthenticatorProvider))
+        .build()
+        .await?;
+
+    Ok(())
+}
 ```

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -22,6 +22,7 @@ bigdecimal = "0.2.0"
 num-bigint = "0.3"
 chrono = "0.4"
 lz4_flex = { version = "0.9.2" }
+async-trait = "0.1.57"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -28,7 +28,7 @@ pub const FLAG_CUSTOM_PAYLOAD: u8 = 0x04;
 pub const FLAG_WARNING: u8 = 0x08;
 
 // All of the Authenticators supported by Scylla
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Authenticator {
     AllowAllAuthenticator,
     PasswordAuthenticator,

--- a/scylla-cql/src/frame/request/auth_response.rs
+++ b/scylla-cql/src/frame/request/auth_response.rs
@@ -1,37 +1,18 @@
 use crate::frame::frame_errors::ParseError;
 use bytes::BufMut;
-use std::convert::TryInto;
 
 use crate::frame::request::{Request, RequestOpcode};
-use crate::frame::Authenticator;
+use crate::frame::types::write_bytes_opt;
 
 // Implements Authenticate Response
 pub struct AuthResponse {
-    pub username: Option<String>,
-    pub password: Option<String>,
-    pub authenticator: Authenticator,
+    pub response: Option<Vec<u8>>,
 }
 
 impl Request for AuthResponse {
     const OPCODE: RequestOpcode = RequestOpcode::AuthResponse;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
-        if self.username.is_none() || self.password.is_none() {
-            return Err(ParseError::BadDataToSerialize(
-                "Bad credentials: username or password missing. You can use SessionBuilder::user(\"user\", \"pass\") to provide credentials.".to_string(),
-            ));
-        }
-        let username_as_bytes = self.username.as_ref().unwrap().as_bytes();
-        let password_as_bytes = self.password.as_ref().unwrap().as_bytes();
-
-        // The body of AuthResponse is a single [bytes] value (i32 length and then contents)
-        let buf_size = 2 + username_as_bytes.len() + password_as_bytes.len();
-        buf.put_i32(buf_size.try_into()?);
-
-        buf.put_u8(0);
-        buf.put_slice(username_as_bytes);
-        buf.put_u8(0);
-        buf.put_slice(password_as_bytes);
-        Ok(())
+        write_bytes_opt(self.response.as_ref(), buf)
     }
 }

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -213,6 +213,18 @@ pub fn write_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), ParseError> {
     Ok(())
 }
 
+pub fn write_bytes_opt(v: Option<&Vec<u8>>, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    match v {
+        Some(bytes) => {
+            write_int_length(bytes.len(), buf)?;
+            buf.put_slice(bytes);
+        }
+        None => write_int(-1, buf),
+    }
+
+    Ok(())
+}
+
 pub fn write_short_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), ParseError> {
     write_short_length(v.len(), buf)?;
     buf.put_slice(v);

--- a/scylla/src/authentication/mod.rs
+++ b/scylla/src/authentication/mod.rs
@@ -1,0 +1,89 @@
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+
+/// Type to represent an authentication error message.
+pub type AuthError = String;
+
+/// Trait used to represent a user-defined custom authentication.
+#[async_trait]
+pub trait AuthenticatorSession: Send + Sync {
+    /// To handle an authentication challenge initiated by the server.
+    /// The information contained in the token parameter is authentication protocol specific.
+    /// It may be NULL or empty.
+    async fn evaluate_challenge(
+        &mut self,
+        token: Option<&[u8]>,
+    ) -> Result<Option<Vec<u8>>, AuthError>;
+
+    /// To handle the success phase of exchange.
+    /// The token parameters contain information that may be used to finalize the request.
+    async fn success(&mut self, token: Option<&[u8]>) -> Result<(), AuthError>;
+}
+
+/// Trait used to represent a factory of [`AuthenticatorSession`] instances.
+/// A new [`AuthenticatorSession`] instance will be created for each session.
+///
+/// The custom authenticator can be set using SessionBuilder::authenticator_provider method.  
+///
+/// Default: [`PlainTextAuthenticator`] is the default authenticator which requires username and
+/// password. It can be set by using SessionBuilder::user(\"user\", \"pass\") method.
+#[async_trait]
+pub trait AuthenticatorProvider: Sync + Send {
+    /// A pair of initial response and boxed [`AuthenticatorSession`]
+    /// should be returned if authentication is required by the server.
+    async fn start_authentication_session(
+        &self,
+        authenticator_name: &str,
+    ) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError>;
+}
+
+struct PlainTextAuthenticatorSession;
+
+#[async_trait]
+impl AuthenticatorSession for PlainTextAuthenticatorSession {
+    async fn evaluate_challenge(
+        &mut self,
+        _token: Option<&[u8]>,
+    ) -> Result<Option<Vec<u8>>, AuthError> {
+        Err("Challenges are not expected during PlainTextAuthentication".to_string())
+    }
+
+    async fn success(&mut self, _token: Option<&[u8]>) -> Result<(), AuthError> {
+        Ok(())
+    }
+}
+
+/// Default authenticator provider that requires username and password if authentication is required.
+pub struct PlainTextAuthenticator {
+    username: String,
+    password: String,
+}
+
+impl PlainTextAuthenticator {
+    /// Creates new [`PlainTextAuthenticator`] instance with provided username and password.
+    pub fn new(username: String, password: String) -> Self {
+        PlainTextAuthenticator { username, password }
+    }
+}
+
+#[async_trait]
+impl AuthenticatorProvider for PlainTextAuthenticator {
+    async fn start_authentication_session(
+        &self,
+        _authenticator_name: &str,
+    ) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError> {
+        let mut response = BytesMut::new();
+        let username_as_bytes = self.username.as_bytes();
+        let password_as_bytes = self.password.as_bytes();
+
+        response.put_u8(0);
+        response.put_slice(username_as_bytes);
+        response.put_u8(0);
+        response.put_slice(password_as_bytes);
+
+        Ok((
+            Some(response.to_vec()),
+            Box::new(PlainTextAuthenticatorSession),
+        ))
+    }
+}

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -96,6 +96,7 @@
 pub use scylla_cql::frame;
 pub use scylla_cql::macros::{self, *};
 
+pub mod authentication;
 pub mod history;
 pub mod routing;
 pub mod statement;

--- a/scylla/src/transport/authenticate_test.rs
+++ b/scylla/src/transport/authenticate_test.rs
@@ -1,4 +1,8 @@
+use crate::authentication::{AuthError, AuthenticatorProvider, AuthenticatorSession};
 use crate::utils::test_utils::unique_keyspace_name;
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+use std::sync::Arc;
 
 #[tokio::test]
 #[ignore]
@@ -10,6 +14,61 @@ async fn authenticate_superuser() {
     let session = crate::SessionBuilder::new()
         .known_node(uri)
         .user("cassandra", "cassandra")
+        .build()
+        .await
+        .unwrap();
+    let ks = unique_keyspace_name();
+
+    session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 1}}", ks), &[]).await.unwrap();
+    session.use_keyspace(ks, false).await.unwrap();
+    session.query("DROP TABLE IF EXISTS t;", &[]).await.unwrap();
+
+    println!("Ok.");
+}
+
+struct CustomAuthenticator;
+
+#[async_trait]
+impl AuthenticatorSession for CustomAuthenticator {
+    async fn evaluate_challenge(
+        &mut self,
+        _token: Option<&[u8]>,
+    ) -> Result<Option<Vec<u8>>, AuthError> {
+        Err("Challenges are not expected".to_string())
+    }
+
+    async fn success(&mut self, _token: Option<&[u8]>) -> Result<(), AuthError> {
+        Ok(())
+    }
+}
+
+struct CustomAuthenticatorProvider;
+
+#[async_trait]
+impl AuthenticatorProvider for CustomAuthenticatorProvider {
+    async fn start_authentication_session(
+        &self,
+        _authenticator_name: &str,
+    ) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError> {
+        let mut response = BytesMut::new();
+        let cred = "\0cassandra\0cassandra";
+
+        response.put_slice(cred.as_bytes());
+
+        Ok((Some(response.to_vec()), Box::new(CustomAuthenticator)))
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn custom_authentication() {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} with cassandra superuser ...", uri);
+
+    let session = crate::SessionBuilder::new()
+        .known_node(uri)
+        .authenticator_provider(Arc::new(CustomAuthenticatorProvider))
         .build()
         .await
         .unwrap();

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -62,6 +62,7 @@ use crate::{
 
 pub use crate::transport::connection_pool::PoolSize;
 
+use crate::authentication::AuthenticatorProvider;
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
 
@@ -177,8 +178,7 @@ pub struct SessionConfig {
     #[cfg(feature = "ssl")]
     pub ssl_context: Option<SslContext>,
 
-    pub auth_username: Option<String>,
-    pub auth_password: Option<String>,
+    pub authenticator: Option<Arc<dyn AuthenticatorProvider>>,
 
     pub schema_agreement_interval: Duration,
     pub connect_timeout: Duration,
@@ -253,8 +253,7 @@ impl SessionConfig {
             speculative_execution_policy: None,
             #[cfg(feature = "ssl")]
             ssl_context: None,
-            auth_username: None,
-            auth_password: None,
+            authenticator: None,
             connect_timeout: Duration::from_secs(5),
             connection_pool_size: Default::default(),
             disallow_shard_aware_port: false,
@@ -345,8 +344,7 @@ impl SessionConfig {
             tcp_nodelay: self.tcp_nodelay,
             #[cfg(feature = "ssl")]
             ssl_context: self.ssl_context.clone(),
-            auth_username: self.auth_username.to_owned(),
-            auth_password: self.auth_password.to_owned(),
+            authenticator: self.authenticator.clone(),
             connect_timeout: self.connect_timeout,
             event_sender: None,
             default_consistency: self.default_consistency,


### PR DESCRIPTION
Added AuthenticatorProvider and AuthenticatorSession traits. AuthenticatorProvider serves as a factory to create a new AuthenticatorSession instance for each session.

AuthenticatorSession trait has 3 methods to be implemented by a user:
 * initial_response: to initiate a request to begin an authentication exchange. Resources required for this specific exchange can be stored in the struct implementing AuthenticatorSession trait.
 * evaluate_challenge: to handle an authentication challenge initiated by the server. The information contained in the token parameter is authentication protocol specific. It may be NULL or empty.
 * success: to handle the success phase of exchange. The token parameters contain information that may be used to finalize the request.

Fixes #562 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
