### PR TITLE
Pick connections based on batch first statement's shard - v2

### DIFF
--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -263,10 +263,6 @@ pub enum BadQuery {
     #[error("Serializing values failed: {0} ")]
     SerializeValuesError(#[from] SerializeValuesError),
 
-    /// Number of values provided doesn't match number of statements in a batch
-    #[error("Length of provided values ({0}) must be equal to number of batch statements ({1})")]
-    ValueLenMismatch(usize, usize),
-
     /// Serialized values are too long to compute partition key
     #[error("Serialized values are too long to compute partition key! Length: {0}, Max allowed length: {1}")]
     ValuesTooLongForKey(usize, usize),

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -66,7 +66,7 @@ where
             statement.serialize(buf)?;
             value_lists
                 .write_next_to_request(buf)
-                .ok_or_else(|| counts_mismatch_err(idx, self.statements_count))??;
+                .ok_or_else(|| counts_mismatch_err(idx, self.statements.clone().count()))??;
             n_serialized_statements += 1;
         }
         if value_lists.skip_next().is_some() {

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -99,21 +99,6 @@ pub trait ValueList {
     }
 }
 
-/// Represents List of ValueList for Batch statement
-pub trait BatchValues {
-    fn len(&self) -> usize;
-
-    fn write_nth_to_request(
-        &self,
-        n: usize,
-        buf: &mut impl BufMut,
-    ) -> Result<(), SerializeValuesError>;
-
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
 impl SerializedValues {
     /// Creates empty value list
     pub const fn new() -> Self {
@@ -227,6 +212,85 @@ impl<'a> Iterator for SerializedValuesIterator<'a> {
         }
 
         Some(types::read_bytes_opt(&mut self.serialized_values).expect("badly encoded value"))
+    }
+}
+
+/// Represents List of ValueList for Batch statement
+///
+/// This trait is not implemented directly, but rather implemented through `BatchValuesGatWorkaround`
+/// (until GATs are made available in Rust)
+pub trait BatchValues: for<'r> BatchValuesGatWorkaround<'r> {}
+impl<T: for<'r> BatchValuesGatWorkaround<'r> + ?Sized> BatchValues for T {}
+
+pub trait BatchValuesGatWorkaround<'r> {
+    type BatchValuesIter: BatchValuesIterator;
+    fn batch_values_iter(&'r self) -> Self::BatchValuesIter;
+    fn len(&'r self) -> usize;
+    fn is_empty(&'r self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// An iterator-like for `ValueList`
+///
+/// An instance of this can be easily obtained from `IT: Iterator<Item: ValueList>`: that would be
+/// `BatchValuesIteratorFromIterator<IT>`
+///
+/// It's just essentially making methods from `ValueList` accessible instead of being an actual iterator because of
+/// several compiler limitations that would otherwise be very complex to overcome.\
+/// (specifically, types being different would require yielding enums for tuple impls, and the trait
+/// bound of `for<'r> <BatchValuesGatWorkaround<'r>::BatchValuesIter as Iterator>::Item: ValueList` is very
+/// hard to express considering several compiler limitations)
+pub trait BatchValuesIterator {
+    fn next_serialized(&mut self) -> Option<SerializedResult<'_>>;
+    fn write_next_to_request(
+        &mut self,
+        buf: &mut impl BufMut,
+    ) -> Option<Result<(), SerializeValuesError>>;
+    fn skip_next(&mut self) -> Option<()>;
+}
+
+/// Implements `BatchValuesIterator` from an `Iterator` over things that implement `ValueList`
+///
+/// Essentially used internally by this lib to provide implementors of `BatchValuesIterator` for cases
+/// that always serialize the same concrete `ValueList` type
+pub struct BatchValuesIteratorFromIterator<IT: Iterator> {
+    it: IT,
+    item_container_for_serialized: Option<IT::Item>,
+}
+
+impl<IT> BatchValuesIterator for BatchValuesIteratorFromIterator<IT>
+where
+    IT: Iterator,
+    IT::Item: ValueList,
+{
+    fn next_serialized(&mut self) -> Option<SerializedResult<'_>> {
+        self.item_container_for_serialized = self.it.next();
+        self.item_container_for_serialized
+            .as_ref()
+            .map(|vl| vl.serialized())
+    }
+    fn write_next_to_request(
+        &mut self,
+        buf: &mut impl BufMut,
+    ) -> Option<Result<(), SerializeValuesError>> {
+        self.it.next().map(|vl| vl.write_to_request(buf))
+    }
+    fn skip_next(&mut self) -> Option<()> {
+        self.it.next().map(|_| ())
+    }
+}
+
+impl<IT> From<IT> for BatchValuesIteratorFromIterator<IT>
+where
+    IT: Iterator,
+    IT::Item: ValueList,
+{
+    fn from(it: IT) -> Self {
+        BatchValuesIteratorFromIterator {
+            it,
+            item_container_for_serialized: None,
+        }
     }
 }
 
@@ -805,78 +869,149 @@ impl<'b> ValueList for Cow<'b, SerializedValues> {
 // BatchValues impls
 //
 
-// Implement BatchValues for slices of ValueList types
-impl<T: ValueList> BatchValues for &[T] {
-    fn len(&self) -> usize {
-        <[T]>::len(*self)
-    }
+/// Implements `BatchValues` from an `Iterator` over things that implement `ValueList`
+///
+/// This is to avoid requiring allocating a new `Vec` containing all the `ValueList`s directly:
+/// with this, one can write:
+/// `session.batch(&batch, BatchValuesFromIterator::from(lines_to_insert.iter().map(|l| &l.value_list)))`
+/// where `lines_to_insert` may also contain e.g. data to pick the statement...
+///
+/// The underlying iterator will always be cloned at least once, once to compute the length if it can't be known
+/// in advance, and be re-cloned at every retry.
+/// It is consequently expected that the provided iterator is cheap to clone (e.g. `slice.iter().map(...)`).
+pub struct BatchValuesFromIter<IT> {
+    it: IT,
+}
 
-    fn write_nth_to_request(
-        &self,
-        n: usize,
-        buf: &mut impl BufMut,
-    ) -> Result<(), SerializeValuesError> {
-        self[n].write_to_request(buf)?;
-        Ok(())
+impl<IT> BatchValuesFromIter<IT>
+where
+    IT: Iterator + Clone,
+    IT::Item: ValueList,
+{
+    pub fn new(into_iter: impl IntoIterator<IntoIter = IT>) -> Self {
+        Self {
+            it: into_iter.into_iter(),
+        }
+    }
+}
+
+impl<IT> From<IT> for BatchValuesFromIter<IT>
+where
+    IT: Iterator + Clone,
+    IT::Item: ValueList,
+{
+    fn from(it: IT) -> Self {
+        Self { it }
+    }
+}
+
+impl<'r, IT> BatchValuesGatWorkaround<'r> for BatchValuesFromIter<IT>
+where
+    IT: Iterator + Clone,
+    IT::Item: ValueList,
+{
+    type BatchValuesIter = BatchValuesIteratorFromIterator<IT>;
+    fn batch_values_iter(&'r self) -> <Self as BatchValuesGatWorkaround>::BatchValuesIter {
+        self.it.clone().into()
+    }
+    fn len(&'r self) -> usize {
+        match self.it.size_hint() {
+            (l, Some(h)) if l == h => l,
+            _ => self.it.clone().count(),
+        }
+    }
+}
+
+// Implement BatchValues for slices of ValueList types
+impl<'r, T: ValueList + 'r> BatchValuesGatWorkaround<'r> for [T] {
+    type BatchValuesIter = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>>;
+    fn batch_values_iter(&'r self) -> Self::BatchValuesIter {
+        self.iter().into()
+    }
+    fn len(&'r self) -> usize {
+        <[_]>::len(self)
     }
 }
 
 // Implement BatchValues for Vec<ValueList>
-impl<T: ValueList> BatchValues for Vec<T> {
-    fn len(&self) -> usize {
-        Vec::<T>::len(self)
+impl<'r, T: ValueList + 'r> BatchValuesGatWorkaround<'r> for Vec<T> {
+    type BatchValuesIter = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>>;
+    fn batch_values_iter(&'r self) -> Self::BatchValuesIter {
+        BatchValuesGatWorkaround::<'r>::batch_values_iter(self.as_slice())
     }
-
-    fn write_nth_to_request(
-        &self,
-        n: usize,
-        buf: &mut impl BufMut,
-    ) -> Result<(), SerializeValuesError> {
-        self[n].write_to_request(buf)?;
-        Ok(())
+    fn len(&'r self) -> usize {
+        Vec::len(self)
     }
 }
 
 // Here is an example implementation for (T0, )
 // Further variants are done using a macro
-impl<T0: ValueList> BatchValues for (T0,) {
-    fn len(&self) -> usize {
-        1
+impl<'r, T0: ValueList + 'r> BatchValuesGatWorkaround<'r> for (T0,) {
+    type BatchValuesIter = BatchValuesIteratorFromIterator<std::iter::Once<&'r T0>>;
+    fn batch_values_iter(&'r self) -> Self::BatchValuesIter {
+        std::iter::once(&self.0).into()
     }
-
-    fn write_nth_to_request(
-        &self,
-        n: usize,
-        buf: &mut impl BufMut,
-    ) -> Result<(), SerializeValuesError> {
-        match n {
-            0 => self.0.write_to_request(buf)?,
-            _ => panic!("Tried to serialize ValueList with an out of range index! index: {}, ValueList len: {}", n, 1),
-        };
-
-        Ok(())
+    fn len(&'r self) -> usize {
+        1
     }
 }
 
+pub struct TupleValuesIter<'a, T> {
+    tuple: &'a T,
+    idx: usize,
+}
+
 macro_rules! impl_batch_values_for_tuple {
-    ( $($Ti:ident),* ; $($FieldI:tt),* ; $TupleSize:tt ) => {
-        impl<$($Ti),+> BatchValues for ($($Ti,)+)
+    ( $($Ti:ident),* ; $($FieldI:tt),* ; $TupleSize:tt) => {
+        impl<'r, $($Ti),+> BatchValuesGatWorkaround<'r> for ($($Ti,)+)
         where
-        $($Ti: ValueList),+
+            $($Ti: ValueList + 'r),+
         {
+            type BatchValuesIter = TupleValuesIter<'r, ($($Ti,)+)>;
+            fn batch_values_iter(&'r self) -> Self::BatchValuesIter {
+                TupleValuesIter {
+                    tuple: self,
+                    idx: 0,
+                }
+            }
             fn len(&self) -> usize{
                 $TupleSize
             }
-
-            fn write_nth_to_request(&self, n: usize, buf: &mut impl BufMut) -> Result<(), SerializeValuesError> {
-                match n {
+        }
+        impl<'r, $($Ti),+> BatchValuesIterator for TupleValuesIter<'r, ($($Ti,)+)>
+        where
+            $($Ti: ValueList + 'r),+
+        {
+            fn next_serialized(&mut self) -> Option<SerializedResult<'_>> {
+                let serialized_value_res = match self.idx {
                     $(
-                        $FieldI => self.$FieldI.write_to_request(buf) ?,
+                        $FieldI => self.tuple.$FieldI.serialized(),
                     )*
-                    _ => panic!("Tried to serialize ValueList with an out of range index! index: {}, ValueList len: {}", n, $TupleSize),
+                    _ => return None,
+                };
+                self.idx += 1;
+                Some(serialized_value_res)
+            }
+            fn write_next_to_request(
+                &mut self,
+                buf: &mut impl BufMut,
+            ) -> Option<Result<(), SerializeValuesError>> {
+                let ret = match self.idx {
+                    $(
+                        $FieldI => self.tuple.$FieldI.write_to_request(buf),
+                    )*
+                    _ => return None,
+                };
+                self.idx += 1;
+                Some(ret)
+            }
+            fn skip_next(&mut self) -> Option<()> {
+                if self.idx < $TupleSize {
+                    self.idx += 1;
+                    Some(())
+                } else {
+                    None
                 }
-
-                Ok(())
             }
         }
     }
@@ -906,17 +1041,75 @@ impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T
                              0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15; 16);
 
 // Every &impl BatchValues should also implement BatchValues
-impl<T: BatchValues> BatchValues for &T {
-    fn len(&self) -> usize {
-        <T as BatchValues>::len(*self)
+impl<'a, 'r, T: BatchValues + ?Sized> BatchValuesGatWorkaround<'r> for &'a T {
+    type BatchValuesIter = <T as BatchValuesGatWorkaround<'a>>::BatchValuesIter;
+    fn batch_values_iter(&'r self) -> Self::BatchValuesIter {
+        <T as BatchValuesGatWorkaround<'a>>::batch_values_iter(*self)
     }
+    fn len(&'r self) -> usize {
+        <T as BatchValuesGatWorkaround<'a>>::len(*self)
+    }
+}
 
-    fn write_nth_to_request(
-        &self,
-        n: usize,
+/// Allows reusing already-serialized first value
+///
+/// We'll need to build a `SerializedValues` for the first ~`ValueList` of a batch to figure out the shard (#448).
+/// Once that is done, we can use that instead of re-serializing.
+///
+/// This struct implements both `BatchValues` and `BatchValuesIterator` for that purpose
+pub struct BatchValuesFirstSerialized<'f, T> {
+    first: Option<&'f SerializedValues>,
+    rest: T,
+}
+
+impl<'f, T: BatchValues> BatchValuesFirstSerialized<'f, T> {
+    pub fn new(batch_values: T, already_serialized_first: Option<&'f SerializedValues>) -> Self {
+        Self {
+            first: already_serialized_first,
+            rest: batch_values,
+        }
+    }
+}
+
+impl<'r, 'f, BV: BatchValues> BatchValuesGatWorkaround<'r> for BatchValuesFirstSerialized<'f, BV> {
+    type BatchValuesIter =
+        BatchValuesFirstSerialized<'f, <BV as BatchValuesGatWorkaround<'r>>::BatchValuesIter>;
+    fn batch_values_iter(&'r self) -> Self::BatchValuesIter {
+        BatchValuesFirstSerialized {
+            first: self.first,
+            rest: self.rest.batch_values_iter(),
+        }
+    }
+    fn len(&'r self) -> usize {
+        self.rest.len()
+    }
+}
+
+impl<'f, IT: BatchValuesIterator> BatchValuesIterator for BatchValuesFirstSerialized<'f, IT> {
+    fn next_serialized(&mut self) -> Option<SerializedResult<'_>> {
+        match self.first.take() {
+            Some(first) => {
+                self.rest.skip_next();
+                Some(Ok(Cow::Borrowed(first)))
+            }
+            None => self.rest.next_serialized(),
+        }
+    }
+    fn write_next_to_request(
+        &mut self,
         buf: &mut impl BufMut,
-    ) -> Result<(), SerializeValuesError> {
-        <T as BatchValues>::write_nth_to_request(*self, n, buf)?;
-        Ok(())
+    ) -> Option<Result<(), SerializeValuesError>> {
+        match self.first.take() {
+            Some(first) => {
+                self.rest.skip_next();
+                first.write_to_request(buf);
+                Some(Ok(()))
+            }
+            None => self.rest.write_next_to_request(buf),
+        }
+    }
+    fn skip_next(&mut self) -> Option<()> {
+        self.rest.skip_next();
+        self.first.take().map(|_| ())
     }
 }

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -647,6 +647,7 @@ fn tuple_batch_values() {
 }
 
 #[test]
+#[allow(clippy::needless_borrow)]
 fn ref_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
 
@@ -661,6 +662,7 @@ fn ref_batch_values() {
 }
 
 #[test]
+#[allow(clippy::needless_borrow)]
 fn check_ref_tuple() {
     fn assert_has_batch_values<BV: BatchValues>(bv: BV) {
         let mut it = bv.batch_values_iter();

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1,3 +1,5 @@
+use crate::frame::value::{BatchValuesGatWorkaround, BatchValuesIterator};
+
 use super::value::{
     BatchValues, Date, MaybeUnset, SerializeValuesError, SerializedValues, Time, Timestamp, Unset,
     Value, ValueList, ValueTooBig,
@@ -391,17 +393,21 @@ fn cow_serialized_values_value_list() {
 fn slice_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
 
-    assert_eq!(<&[&[i8]] as BatchValues>::len(&batch_values), 3);
+    assert_eq!(
+        <&[&[i8]] as BatchValuesGatWorkaround<'_>>::len(&batch_values),
+        3
+    );
 
+    let mut it = batch_values.batch_values_iter();
     {
         let mut request: Vec<u8> = Vec::new();
-        batch_values.write_nth_to_request(0, &mut request).unwrap();
+        it.write_next_to_request(&mut request).unwrap().unwrap();
         assert_eq!(request, vec![0, 2, 0, 0, 0, 1, 1, 0, 0, 0, 1, 2]);
     }
 
     {
         let mut request: Vec<u8> = Vec::new();
-        batch_values.write_nth_to_request(1, &mut request).unwrap();
+        it.write_next_to_request(&mut request).unwrap().unwrap();
         assert_eq!(
             request,
             vec![0, 4, 0, 0, 0, 1, 2, 0, 0, 0, 1, 3, 0, 0, 0, 1, 4, 0, 0, 0, 1, 5]
@@ -410,26 +416,32 @@ fn slice_batch_values() {
 
     {
         let mut request: Vec<u8> = Vec::new();
-        batch_values.write_nth_to_request(2, &mut request).unwrap();
+        it.write_next_to_request(&mut request).unwrap().unwrap();
         assert_eq!(request, vec![0, 1, 0, 0, 0, 1, 6]);
     }
+
+    assert_eq!(it.write_next_to_request(&mut Vec::new()), None);
 }
 
 #[test]
 fn vec_batch_values() {
     let batch_values: Vec<Vec<i8>> = vec![vec![1, 2], vec![2, 3, 4, 5], vec![6]];
 
-    assert_eq!(<Vec<Vec<i8>> as BatchValues>::len(&batch_values), 3);
+    assert_eq!(
+        <Vec<Vec<i8>> as BatchValuesGatWorkaround<'_>>::len(&batch_values),
+        3
+    );
 
+    let mut it = batch_values.batch_values_iter();
     {
         let mut request: Vec<u8> = Vec::new();
-        batch_values.write_nth_to_request(0, &mut request).unwrap();
+        it.write_next_to_request(&mut request).unwrap().unwrap();
         assert_eq!(request, vec![0, 2, 0, 0, 0, 1, 1, 0, 0, 0, 1, 2]);
     }
 
     {
         let mut request: Vec<u8> = Vec::new();
-        batch_values.write_nth_to_request(1, &mut request).unwrap();
+        it.write_next_to_request(&mut request).unwrap().unwrap();
         assert_eq!(
             request,
             vec![0, 4, 0, 0, 0, 1, 2, 0, 0, 0, 1, 3, 0, 0, 0, 1, 4, 0, 0, 0, 1, 5]
@@ -438,7 +450,7 @@ fn vec_batch_values() {
 
     {
         let mut request: Vec<u8> = Vec::new();
-        batch_values.write_nth_to_request(2, &mut request).unwrap();
+        it.write_next_to_request(&mut request).unwrap().unwrap();
         assert_eq!(request, vec![0, 1, 0, 0, 0, 1, 6]);
     }
 }
@@ -448,9 +460,10 @@ fn tuple_batch_values() {
     fn check_twoi32_tuple(tuple: impl BatchValues, size: usize) {
         assert_eq!(tuple.len(), size);
 
+        let mut it = tuple.batch_values_iter();
         for i in 0..size {
             let mut request: Vec<u8> = Vec::new();
-            tuple.write_nth_to_request(i, &mut request).unwrap();
+            it.write_next_to_request(&mut request).unwrap().unwrap();
 
             let mut expected: Vec<u8> = Vec::new();
             let i: i32 = i.try_into().unwrap();
@@ -637,12 +650,13 @@ fn tuple_batch_values() {
 fn ref_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
 
-    assert_eq!(<&&&&[&[i8]] as BatchValues>::len(&&&&batch_values), 3);
+    assert_eq!(
+        <&&&&[&[i8]] as BatchValuesGatWorkaround<'_>>::len(&&&&batch_values),
+        3
+    );
+    let mut it = <&&&&[&[i8]] as BatchValuesGatWorkaround<'_>>::batch_values_iter(&&&&batch_values);
 
-    {
-        let mut request: Vec<u8> = Vec::new();
-        <&&&&[&[i8]] as BatchValues>::write_nth_to_request(&&&&batch_values, 0, &mut request)
-            .unwrap();
-        assert_eq!(request, vec![0, 2, 0, 0, 0, 1, 1, 0, 0, 0, 1, 2]);
-    }
+    let mut request: Vec<u8> = Vec::new();
+    it.write_next_to_request(&mut request).unwrap().unwrap();
+    assert_eq!(request, vec![0, 2, 0, 0, 0, 1, 1, 0, 0, 0, 1, 2]);
 }

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -392,12 +392,6 @@ fn cow_serialized_values_value_list() {
 #[test]
 fn slice_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
-
-    assert_eq!(
-        <&[&[i8]] as BatchValuesGatWorkaround<'_>>::len(&batch_values),
-        3
-    );
-
     let mut it = batch_values.batch_values_iter();
     {
         let mut request: Vec<u8> = Vec::new();
@@ -427,11 +421,6 @@ fn slice_batch_values() {
 fn vec_batch_values() {
     let batch_values: Vec<Vec<i8>> = vec![vec![1, 2], vec![2, 3, 4, 5], vec![6]];
 
-    assert_eq!(
-        <Vec<Vec<i8>> as BatchValuesGatWorkaround<'_>>::len(&batch_values),
-        3
-    );
-
     let mut it = batch_values.batch_values_iter();
     {
         let mut request: Vec<u8> = Vec::new();
@@ -458,8 +447,6 @@ fn vec_batch_values() {
 #[test]
 fn tuple_batch_values() {
     fn check_twoi32_tuple(tuple: impl BatchValues, size: usize) {
-        assert_eq!(tuple.len(), size);
-
         let mut it = tuple.batch_values_iter();
         for i in 0..size {
             let mut request: Vec<u8> = Vec::new();
@@ -652,7 +639,6 @@ fn ref_batch_values() {
 
     return check_ref_bv::<&&&&&[&[i8]]>(&&&&batch_values);
     fn check_ref_bv<B: BatchValues>(batch_values: B) {
-        assert_eq!(<B as BatchValuesGatWorkaround<'_>>::len(&batch_values), 3);
         let mut it = <B as BatchValuesGatWorkaround<'_>>::batch_values_iter(&batch_values);
 
         let mut request: Vec<u8> = Vec::new();

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -641,14 +641,6 @@ impl Connection {
         values: impl BatchValues,
         consistency: Consistency,
     ) -> Result<QueryResult, QueryError> {
-        let statements_count = batch.statements.len();
-        if statements_count != values.len() {
-            return Err(QueryError::BadQuery(BadQuery::ValueLenMismatch(
-                values.len(),
-                statements_count,
-            )));
-        }
-
         let statements_iter = batch.statements.iter().map(|s| match s {
             BatchStatement::Query(q) => batch::BatchStatement::Query { text: &q.contents },
             BatchStatement::PreparedStatement(s) => {
@@ -657,8 +649,8 @@ impl Connection {
         });
 
         let batch_frame = batch::Batch {
+            statements_count: statements_iter.len(),
             statements: statements_iter,
-            statements_count,
             values,
             batch_type: batch.get_type(),
             consistency,

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -265,7 +265,11 @@ mod tests {
             }
 
             downgrading_consistency_policy_assert_never_retries(
-                QueryError::BadQuery(BadQuery::ValueLenMismatch(1, 2)),
+                QueryError::BadQuery(BadQuery::Other(
+                    "Length of provided values must be equal to number of batch statements \
+                        (got 1 values, 2 statements)"
+                        .to_owned(),
+                )),
                 cl,
             );
             downgrading_consistency_policy_assert_never_retries(

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -292,7 +292,11 @@ mod tests {
             default_policy_assert_never_retries(QueryError::DbError(dberror, String::new()));
         }
 
-        default_policy_assert_never_retries(QueryError::BadQuery(BadQuery::ValueLenMismatch(1, 2)));
+        default_policy_assert_never_retries(QueryError::BadQuery(BadQuery::Other(
+            "Length of provided values must be equal to number of batch statements \
+                        (got 1 values, 2 statements)"
+                .to_owned(),
+        )));
         default_policy_assert_never_retries(QueryError::ProtocolError("test"));
     }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -27,7 +27,9 @@ use super::topology::UntranslatedPeer;
 use crate::cql_to_rust::FromRow;
 use crate::frame::response::cql_to_rust::FromRowError;
 use crate::frame::response::result;
-use crate::frame::value::{BatchValues, SerializedValues, ValueList};
+use crate::frame::value::{
+    BatchValues, BatchValuesFirstSerialized, BatchValuesIterator, SerializedValues, ValueList,
+};
 use crate::prepared_statement::{PartitionKeyError, PreparedStatement};
 use crate::query::Query;
 use crate::routing::Token;
@@ -1014,13 +1016,43 @@ impl Session {
         batch: &Batch,
         values: impl BatchValues,
     ) -> Result<QueryResult, QueryError> {
+        // Shard-awareness behavior for batch will be to pick shard based on first batch statement's shard
+        // If users batch statements by shard, they will be rewarded with full shard awareness
+
+        // Extract first serialized_value
+        let mut batch_values_iter_for_first_serialized_value = values.batch_values_iter();
+        let first_serialized_value = batch_values_iter_for_first_serialized_value
+            .next_serialized()
+            .transpose()?;
+        let first_serialized_value = first_serialized_value.as_deref();
+        let statement_info = match (first_serialized_value, batch.statements.first()) {
+            (Some(first_serialized_value), Some(BatchStatement::PreparedStatement(ps))) => {
+                Statement {
+                    token: self.calculate_token(ps, first_serialized_value)?,
+                    keyspace: ps.get_keyspace_name(),
+                }
+            }
+            _ => Statement::default(),
+        };
+        let first_value_token = statement_info.token;
+
+        // Reuse first serialized value when serializing query, and delegate to `BatchValues::write_next_to_request`
+        // directly for others (if they weren't already serialized, possibly don't even allocate the `SerializedValues`)
+        let values = BatchValuesFirstSerialized::new(&values, first_serialized_value);
         let values_ref = &values;
 
         let run_query_result = self
             .run_query(
-                Statement::default(),
+                statement_info,
                 &batch.config,
-                |node: Arc<Node>| async move { node.random_connection().await },
+                |node: Arc<Node>| async move {
+                    match first_value_token {
+                        Some(first_value_token) => {
+                            node.connection_for_token(first_value_token).await
+                        }
+                        None => node.random_connection().await,
+                    }
+                },
                 |connection: Arc<Connection>, consistency: Consistency| async move {
                     connection
                         .batch_with_consistency(batch, values_ref, consistency)


### PR DESCRIPTION
Fixes #448 

Follow-up on #508 being reverted in #569 because of #568 - first commit reintroduces #508, while second commit fixes #568.

-> This re-fixes #448, without reintroducing #568.

#568 is effectively fixed by using default generic argument on the `BatchValuesGatWorkaround` trait which will generate an implicit  `where Self: 'r` bound in `for<'r> BatchValuesGatWorkaround<'r>` (becoming in effect `for<'r where Self: 'r> BatchValuesGatWorkaround<'r>`). This trick is explained in more detail at https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats.

We also get rid of lending iteration in `BatchValuesIterator`, giving more flexibility for future shard-pick heuristic improvements (this is also unlocked by that same implicit bound).

--

Update: c7f7640 now also moves to the recently-stabilized GATs.  This removes the need for the previously described GAT workaround. The implicit bound is replaced by an explicit `where Self: 'r` bound.
Since we don't need `for<'r> X::AssociatedType<'r>: Something` bounds anywhere, we don't hit the limitations described [here](https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats), and the simplification is probably worth losing those.

## Pre-review checklist

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I added appropriate `Fixes:` annotations to PR description.
