### PR TITLE
Minimal implementation of custom hasher for CachingSession

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -49,6 +49,7 @@ async-trait = "0.1.56"
 criterion = "0.3"
 tracing-subscriber = "0.3.14"
 assert_matches = "1.5.0"
+ahash = { version = "0.8.0", default-features = false, features=["compile-time-rng"] }
 
 [[bench]]
 name = "benchmark"

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -42,7 +42,7 @@ impl<S> CachingSession<S>
 where
     S: BuildHasher + Clone,
 {
-    /// Builds a [`CachingCaching::session`] from a [`Session`] and a cache size,
+    /// Builds a [`CachingSession`] from a [`Session`], a cache size, and a [`BuildHasher`].,
     /// using a customer hasher.
     pub fn with_hasher(session: Session, cache_size: usize, hasher: S) -> Self {
         Self {

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -1,5 +1,3 @@
-use std::collections::hash_map::RandomState;
-use std::hash::BuildHasher;
 use crate::batch::{Batch, BatchStatement};
 use crate::frame::value::{BatchValues, ValueList};
 use crate::prepared_statement::PreparedStatement;
@@ -10,11 +8,14 @@ use crate::{QueryResult, Session};
 use bytes::Bytes;
 use dashmap::DashMap;
 use futures::future::try_join_all;
+use std::collections::hash_map::RandomState;
+use std::hash::BuildHasher;
 
 /// Provides auto caching while executing queries
 #[derive(Debug)]
 pub struct CachingSession<S = RandomState>
-    where S: Clone + BuildHasher
+where
+    S: Clone + BuildHasher,
 {
     pub session: Session,
     /// The prepared statement cache size
@@ -25,7 +26,8 @@ pub struct CachingSession<S = RandomState>
 }
 
 impl<S> CachingSession<S>
-    where S: Default + BuildHasher + Clone
+where
+    S: Default + BuildHasher + Clone,
 {
     pub fn from(session: Session, cache_size: usize) -> Self {
         Self {
@@ -37,7 +39,8 @@ impl<S> CachingSession<S>
 }
 
 impl<S> CachingSession<S>
-    where S: BuildHasher + Clone
+where
+    S: BuildHasher + Clone,
 {
     /// Builds a [`CachingCaching::session`] from a [`Session`] and a cache size,
     /// using a customer hasher.
@@ -341,9 +344,12 @@ mod tests {
     /// This test checks that we can construct a CachingSession with custom HashBuilder implementations
     #[tokio::test]
     async fn test_custom_hasher() {
-        let _session: CachingSession::<std::collections::hash_map::RandomState> = CachingSession::from(new_for_test().await, 2);
-        let _session: CachingSession::<ahash::RandomState> = CachingSession::from(new_for_test().await, 2);
-        let _session: CachingSession::<ahash::RandomState> = CachingSession::with_hasher(new_for_test().await, 2, Default::default());
+        let _session: CachingSession<std::collections::hash_map::RandomState> =
+            CachingSession::from(new_for_test().await, 2);
+        let _session: CachingSession<ahash::RandomState> =
+            CachingSession::from(new_for_test().await, 2);
+        let _session: CachingSession<ahash::RandomState> =
+            CachingSession::with_hasher(new_for_test().await, 2, Default::default());
     }
 
     #[tokio::test]

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -37,7 +37,7 @@ impl<S> CachingSession<S>
 }
 
 impl<S> CachingSession<S>
-    where S: Default + BuildHasher + Clone
+    where S: BuildHasher + Clone
 {
     /// Builds a [`CachingCaching::session`] from a [`Session`] and a cache size,
     /// using a customer hasher.

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -127,7 +127,7 @@ impl<S> CachingSession<S>
                     Ok::<(), QueryError>(())
                 }),
         )
-            .await?;
+        .await?;
 
         Ok(prepared_batch)
     }
@@ -390,7 +390,7 @@ mod tests {
             unprepared_batch.append_statement(unprepared_insert_8_b);
 
             session
-                .batch(&unprepared_batch, ((10, 20), (10, ), (20, )))
+                .batch(&unprepared_batch, ((10, 20), (10,), (20,)))
                 .await
                 .unwrap();
             assert_test_batch_table_rows_contain(&session, &[(10, 20), (10, 7), (8, 20)]).await;
@@ -399,7 +399,7 @@ mod tests {
             assert_batch_prepared(&prepared_batch);
 
             session
-                .batch(&prepared_batch, ((15, 25), (15, ), (25, )))
+                .batch(&prepared_batch, ((15, 25), (15,), (25,)))
                 .await
                 .unwrap();
             assert_test_batch_table_rows_contain(&session, &[(15, 25), (15, 7), (8, 25)]).await;
@@ -412,7 +412,7 @@ mod tests {
             partially_prepared_batch.append_statement(unprepared_insert_8_b);
 
             session
-                .batch(&partially_prepared_batch, ((30, 40), (30, ), (40, )))
+                .batch(&partially_prepared_batch, ((30, 40), (30,), (40,)))
                 .await
                 .unwrap();
             assert_test_batch_table_rows_contain(&session, &[(30, 40), (30, 7), (8, 40)]).await;
@@ -424,7 +424,7 @@ mod tests {
             assert_batch_prepared(&prepared_batch);
 
             session
-                .batch(&prepared_batch, ((35, 45), (35, ), (45, )))
+                .batch(&prepared_batch, ((35, 45), (35,), (45,)))
                 .await
                 .unwrap();
             assert_test_batch_table_rows_contain(&session, &[(35, 45), (35, 7), (8, 45)]).await;
@@ -437,7 +437,7 @@ mod tests {
             fully_prepared_batch.append_statement(prepared_insert_8_b);
 
             session
-                .batch(&fully_prepared_batch, ((50, 60), (50, ), (60, )))
+                .batch(&fully_prepared_batch, ((50, 60), (50,), (60,)))
                 .await
                 .unwrap();
             assert_test_batch_table_rows_contain(&session, &[(50, 60), (50, 7), (8, 60)]).await;
@@ -446,7 +446,7 @@ mod tests {
             assert_batch_prepared(&prepared_batch);
 
             session
-                .batch(&prepared_batch, ((55, 65), (55, ), (65, )))
+                .batch(&prepared_batch, ((55, 65), (55,), (65,)))
                 .await
                 .unwrap();
 
@@ -459,7 +459,7 @@ mod tests {
             bad_batch.append_statement("This isnt even CQL");
             bad_batch.append_statement(unprepared_insert_8_b);
 
-            assert!(session.batch(&bad_batch, ((1, 2), (), (2, ))).await.is_err());
+            assert!(session.batch(&bad_batch, ((1, 2), (), (2,))).await.is_err());
             assert!(session.prepare_batch(&bad_batch).await.is_err());
         }
     }


### PR DESCRIPTION
This is a minimal version of a PR I had tried to push through a while back. It's very small and straightforward, and avoids some of the additional APIs I had provided in the last PR. In short, the `CachingSession` now has a 3rd type parameter, `S`, which will be used to customize the hash algorithm used by DashMap.

There are lots of benchmarks for other hash algorithms, such as these:
https://github.com/rust-lang/hashbrown#performance
https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md#why-use-ahash-over-x

As you can see from those benchmarks there are significantly faster algorithms than what rust provides by default.

## Pre-review checklist
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.

I don't think there are any "Fixes" annotations to apply here.