### PR TITLE
LWT routing optimisation

### DIFF
--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -34,6 +34,7 @@ async fn main() -> Result<()> {
         let statement_info = scylla::transport::load_balancing::Statement {
             token: Some(scylla::routing::Token { value: t }),
             keyspace: Some("ks"),
+            is_confirmed_lwt: false,
         };
         println!(
             "Estimated replicas for query: {:?}",

--- a/scylla-cql/src/frame/protocol_features.rs
+++ b/scylla-cql/src/frame/protocol_features.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
 const RATE_LIMIT_ERROR_EXTENSION: &str = "SCYLLA_RATE_LIMIT_ERROR";
-
+pub const SCYLLA_LWT_ADD_METADATA_MARK_EXTENSION: &str = "SCYLLA_LWT_ADD_METADATA_MARK";
+pub const LWT_OPTIMIZATION_META_BIT_MASK_KEY: &str = "LWT_OPTIMIZATION_META_BIT_MASK";
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ProtocolFeatures {
     pub rate_limit_error: Option<i32>,
+    pub lwt_optimization_meta_bit_mask: Option<u32>,
 }
 
 // TODO: Log information about options which failed to parse
@@ -14,6 +16,9 @@ impl ProtocolFeatures {
     pub fn parse_from_supported(supported: &HashMap<String, Vec<String>>) -> Self {
         Self {
             rate_limit_error: Self::maybe_parse_rate_limit_error(supported),
+            lwt_optimization_meta_bit_mask: Self::maybe_parse_lwt_optimization_meta_bit_mask(
+                supported,
+            ),
         }
     }
 
@@ -21,6 +26,15 @@ impl ProtocolFeatures {
         let vals = supported.get(RATE_LIMIT_ERROR_EXTENSION)?;
         let code_str = Self::get_cql_extension_field(vals.as_slice(), "ERROR_CODE")?;
         code_str.parse::<i32>().ok()
+    }
+
+    fn maybe_parse_lwt_optimization_meta_bit_mask(
+        supported: &HashMap<String, Vec<String>>,
+    ) -> Option<u32> {
+        let vals = supported.get(SCYLLA_LWT_ADD_METADATA_MARK_EXTENSION)?;
+        let mask_str =
+            Self::get_cql_extension_field(vals.as_slice(), LWT_OPTIMIZATION_META_BIT_MASK_KEY)?;
+        mask_str.parse::<u32>().ok()
     }
 
     // Looks up a field which starts with `key=` and returns the rest
@@ -33,5 +47,17 @@ impl ProtocolFeatures {
         if self.rate_limit_error.is_some() {
             options.insert(RATE_LIMIT_ERROR_EXTENSION.to_string(), String::new());
         }
+        if let Some(mask) = self.lwt_optimization_meta_bit_mask {
+            options.insert(
+                SCYLLA_LWT_ADD_METADATA_MARK_EXTENSION.to_string(),
+                format!("{}={}", LWT_OPTIMIZATION_META_BIT_MASK_KEY, mask),
+            );
+        }
+    }
+
+    pub fn prepared_flags_contain_lwt_mark(&self, flags: u32) -> bool {
+        self.lwt_optimization_meta_bit_mask
+            .map(|mask| (flags & mask) == mask)
+            .unwrap_or(false)
     }
 }

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -353,6 +353,7 @@ pub struct PartitionKeyIndex {
 
 #[derive(Debug, Clone)]
 pub struct PreparedMetadata {
+    pub flags: i32,
     pub col_count: usize,
     /// pk_indexes are sorted by `index` and can be reordered in partition key order
     /// using `sequence` field
@@ -552,6 +553,7 @@ fn deser_prepared_metadata(buf: &mut &[u8]) -> StdResult<PreparedMetadata, Parse
     let col_specs = deser_col_specs(buf, &global_table_spec, col_count)?;
 
     Ok(PreparedMetadata {
+        flags,
         col_count,
         pk_indexes,
         col_specs,

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -104,6 +104,11 @@ pub mod transport;
 
 pub(crate) mod utils;
 
+/// This module is NOT part of the public API (it is `pub` only for internal use of integration tests).
+/// Future minor releases are free to introduce breaking API changes inside it.
+#[doc(hidden)]
+pub use utils::test_utils;
+
 pub use statement::batch;
 pub use statement::prepared_statement;
 pub use statement::query;

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -20,6 +20,7 @@ use std::hash::BuildHasher;
 #[derive(Debug)]
 struct RawPreparedStatementData {
     pub id: Bytes,
+    pub is_confirmed_lwt: bool,
     pub metadata: PreparedMetadata,
     pub partitioner_name: PartitionerName,
 }
@@ -167,6 +168,7 @@ where
             let page_size = query.get_page_size();
             let mut stmt = PreparedStatement::new(
                 raw.id.clone(),
+                raw.is_confirmed_lwt,
                 raw.metadata.clone(),
                 query.contents,
                 page_size,
@@ -193,6 +195,7 @@ where
 
             let raw = RawPreparedStatementData {
                 id: prepared.get_id().clone(),
+                is_confirmed_lwt: prepared.is_confirmed_lwt(),
                 metadata: prepared.get_prepared_metadata().clone(),
                 partitioner_name: prepared.get_partitioner_name().clone(),
             };

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -334,6 +334,9 @@ impl Connection {
             Response::Error(err) => return Err(err.into()),
             Response::Result(result::Result::Prepared(p)) => PreparedStatement::new(
                 p.id,
+                self.features
+                    .protocol_features
+                    .prepared_flags_contain_lwt_mark(p.prepared_metadata.flags as u32),
                 p.prepared_metadata,
                 query.contents.clone(),
                 query.get_page_size(),

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -206,6 +206,7 @@ impl RowIterator {
         let statement_info = Statement {
             token: config.token,
             keyspace: None,
+            is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
         };
 
         let worker_task = async move {

--- a/scylla/src/transport/load_balancing/latency_aware.rs
+++ b/scylla/src/transport/load_balancing/latency_aware.rs
@@ -728,6 +728,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 160 }),
                     keyspace: Some("keyspace_with_simple_strategy_replication_factor_2"),
+                    is_confirmed_lwt: false,
                 },
                 latency_stats: &[
                     (
@@ -759,6 +760,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 160 }),
                     keyspace: Some("keyspace_with_simple_strategy_replication_factor_2"),
+                    is_confirmed_lwt: false,
                 },
                 latency_stats: &[
                     (
@@ -790,6 +792,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 60 }),
                     keyspace: Some("keyspace_with_simple_strategy_replication_factor_1"),
+                    is_confirmed_lwt: false,
                 },
                 latency_stats: &[
                     (
@@ -826,6 +829,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 60 }),
                     keyspace: Some("keyspace_with_simple_strategy_replication_factor_2"),
+                    is_confirmed_lwt: false,
                 },
                 latency_stats: &[
                     (
@@ -861,6 +865,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 60 }),
                     keyspace: Some("invalid"),
+                    is_confirmed_lwt: false,
                 },
                 latency_stats: &[],
                 preset_min_avg: None,
@@ -871,6 +876,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 60 }),
                     keyspace: None,
+                    is_confirmed_lwt: false,
                 },
                 latency_stats: &[
                     (

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -25,6 +25,14 @@ pub use latency_aware::LatencyAwarePolicy;
 pub struct Statement<'a> {
     pub token: Option<Token>,
     pub keyspace: Option<&'a str>,
+
+    /// If, while preparing, we received from the cluster information that the statement is an LWT,
+    /// then we can use this information for routing optimisation. Namely, an optimisation
+    /// can be performed: the query should be routed to the replicas in a predefined order
+    /// (i. e. always try first to contact replica A, then B if it fails, then C, etc.).
+    /// If false, the query should be routed normally.
+    /// Note: this a Scylla-specific optimisation. Therefore, the flag will be always false for Cassandra.
+    pub is_confirmed_lwt: bool,
 }
 
 impl<'a> Statement<'a> {
@@ -32,6 +40,7 @@ impl<'a> Statement<'a> {
         Self {
             token: None,
             keyspace: None,
+            is_confirmed_lwt: false,
         }
     }
 }
@@ -196,6 +205,7 @@ mod tests {
     pub const EMPTY_STATEMENT: Statement = Statement {
         token: None,
         keyspace: None,
+        is_confirmed_lwt: false,
     };
 
     pub fn get_plan_and_collect_node_identifiers<L: LoadBalancingPolicy>(

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -211,6 +211,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 160 }),
                     keyspace: Some("keyspace_with_simple_strategy_replication_factor_2"),
+                    is_confirmed_lwt: false,
                 },
                 expected_plan: vec![3, 1],
             },
@@ -218,6 +219,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 60 }),
                     keyspace: Some("keyspace_with_simple_strategy_replication_factor_3"),
+                    is_confirmed_lwt: false,
                 },
                 expected_plan: vec![1, 2, 3],
             },
@@ -225,6 +227,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 500 }),
                     keyspace: Some("keyspace_with_simple_strategy_replication_factor_3"),
+                    is_confirmed_lwt: false,
                 },
                 expected_plan: vec![1, 2, 3],
             },
@@ -232,6 +235,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 60 }),
                     keyspace: Some("invalid"),
+                    is_confirmed_lwt: false,
                 },
                 expected_plan: vec![1],
             },
@@ -239,6 +243,7 @@ mod tests {
                 statement: Statement {
                     token: Some(Token { value: 60 }),
                     keyspace: None,
+                    is_confirmed_lwt: false,
                 },
                 expected_plan: vec![1],
             },
@@ -262,6 +267,7 @@ mod tests {
         let statement = Statement {
             token: Some(Token { value: 0 }),
             keyspace: Some("keyspace_with_nts"),
+            is_confirmed_lwt: false,
         };
 
         let plan = tests::get_plan_and_collect_node_identifiers(&policy, &statement, &cluster);

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -195,6 +195,7 @@ mod tests {
     use super::*;
 
     use crate::load_balancing::tests::DumbPolicy;
+    use crate::load_balancing::RoundRobinPolicy;
     use crate::transport::load_balancing::tests;
     use crate::transport::topology::Keyspace;
     use crate::transport::topology::Metadata;
@@ -294,6 +295,125 @@ mod tests {
             &cluster,
         );
         assert_eq!(plan.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn token_aware_policy_optimises_lwt_routing() {
+        let keyspace = Some("keyspace_with_simple_strategy_replication_factor_3");
+        let token = Some(Token { value: 60 });
+        let tests = [
+            Statement {
+                token,
+                keyspace,
+                is_confirmed_lwt: false,
+            },
+            Statement {
+                token,
+                keyspace,
+                is_confirmed_lwt: true,
+            },
+        ];
+
+        let policy = TokenAwarePolicy::new(Box::new(RoundRobinPolicy::default()));
+        let cluster = mock_cluster_data_for_token_aware_tests();
+
+        let plans = (0..15)
+            .map(|i| {
+                let plan =
+                    tests::get_plan_and_collect_node_identifiers(&policy, &tests[i % 2], &cluster);
+                if i % 2 == 0 {
+                    // non-LWT
+                    (Some(plan), None)
+                } else {
+                    // LWT
+                    (None, Some(plan)) // child policy not applied in case of LWT
+                }
+            })
+            .collect::<HashSet<_>>();
+
+        let expected_plans = [
+            (None, Some(vec![1, 2, 3])), // LWT case
+            (Some(vec![1, 2, 3]), None), // non-LWT cases
+            (Some(vec![2, 3, 1]), None),
+            (Some(vec![3, 1, 2]), None),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(plans, expected_plans);
+    }
+
+    // creates ClusterData with info about 3 nodes living in the same datacenter
+    // ring field is populated as follows:
+    // ring tokens:            50 100 150 200 250 300 400 500
+    // corresponding node ids: 2  1   2   3   1   2   3   1
+    fn mock_cluster_data_for_token_aware_tests() -> ClusterData {
+        let peers = [
+            Peer {
+                datacenter: Some("eu".into()),
+                rack: None,
+                address: tests::id_to_invalid_addr(1),
+                tokens: vec![
+                    Token { value: 100 },
+                    Token { value: 250 },
+                    Token { value: 500 },
+                ],
+                untranslated_address: Some(tests::id_to_invalid_addr(1)),
+            },
+            Peer {
+                datacenter: Some("eu".into()),
+                rack: None,
+                address: tests::id_to_invalid_addr(2),
+                tokens: vec![
+                    Token { value: 50 },
+                    Token { value: 150 },
+                    Token { value: 300 },
+                ],
+                untranslated_address: Some(tests::id_to_invalid_addr(2)),
+            },
+            Peer {
+                datacenter: Some("us".into()),
+                rack: None,
+                address: tests::id_to_invalid_addr(3),
+                tokens: vec![Token { value: 200 }, Token { value: 400 }],
+                untranslated_address: Some(tests::id_to_invalid_addr(3)),
+            },
+        ];
+
+        let keyspaces = [
+            (
+                "keyspace_with_simple_strategy_replication_factor_2".into(),
+                Keyspace {
+                    strategy: Strategy::SimpleStrategy {
+                        replication_factor: 2,
+                    },
+                    tables: HashMap::new(),
+                    views: HashMap::new(),
+                    user_defined_types: HashMap::new(),
+                },
+            ),
+            (
+                "keyspace_with_simple_strategy_replication_factor_3".into(),
+                Keyspace {
+                    strategy: Strategy::SimpleStrategy {
+                        replication_factor: 3,
+                    },
+                    tables: HashMap::new(),
+                    views: HashMap::new(),
+                    user_defined_types: HashMap::new(),
+                },
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let info = Metadata {
+            peers: Vec::from(peers),
+            keyspaces,
+        };
+
+        ClusterData::new(info, &Default::default(), &HashMap::new(), &None, None)
     }
 
     // creates ClusterData with info about 8 nodes living in two different datacenters

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -860,6 +860,7 @@ impl Session {
         let statement_info = Statement {
             token,
             keyspace: prepared.get_keyspace_name(),
+            is_confirmed_lwt: prepared.is_confirmed_lwt(),
         };
 
         let span = trace_span!(
@@ -1037,6 +1038,7 @@ impl Session {
                 Statement {
                     token: self.calculate_token(ps, first_serialized_value)?,
                     keyspace: ps.get_keyspace_name(),
+                    is_confirmed_lwt: false,
                 }
             }
             _ => Statement::default(),

--- a/scylla/src/utils/mod.rs
+++ b/scylla/src/utils/mod.rs
@@ -1,4 +1,3 @@
 pub(crate) mod parse;
 
-#[cfg(test)]
-pub(crate) mod test_utils;
+pub mod test_utils;

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -3,11 +3,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(test)]
 use crate::Session;
 
 static UNIQUE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-pub(crate) fn unique_keyspace_name() -> String {
+pub fn unique_keyspace_name() -> String {
     let cnt = UNIQUE_COUNTER.fetch_add(1, Ordering::SeqCst);
     let name = format!(
         "test_rust_{}_{}",
@@ -21,6 +22,7 @@ pub(crate) fn unique_keyspace_name() -> String {
     name
 }
 
+#[cfg(test)]
 pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
     // Cassandra doesn't have a concept of features, so first detect
     // if there is the `supported_features` column in system.local

--- a/scylla/tests/lwt_optimisation.rs
+++ b/scylla/tests/lwt_optimisation.rs
@@ -1,0 +1,150 @@
+mod utils;
+
+use scylla::frame::types;
+use scylla::retry_policy::FallthroughRetryPolicy;
+use scylla::transport::session::Session;
+use scylla::SessionBuilder;
+use scylla::{frame::protocol_features::ProtocolFeatures, test_utils::unique_keyspace_name};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use utils::test_with_3_node_cluster;
+
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    ResponseOpcode, ResponseReaction, ResponseRule, ShardAwareness, WorkerError,
+};
+
+#[tokio::test]
+#[ntest::timeout(20000)]
+async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optimally() {
+    // This is just to increase the likelyhood that only intended prepared statements (which contain this mark) are captures by the proxy.
+    const MAGIC_MARK: i32 = 123;
+
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, 220, |proxy_uris, translation_map, mut running_proxy| async move {
+
+        // We set up proxy, so that it informs us (via supported_rx) about cluster's Supported features (including LWT optimisation mark),
+        // and also passes us information about which node was queried (via prepared_rx).
+
+        let (supported_tx, mut supported_rx) = mpsc::unbounded_channel();
+
+        running_proxy.running_nodes[0].change_response_rules(Some(vec![ResponseRule(
+            Condition::ResponseOpcode(ResponseOpcode::Supported),
+            ResponseReaction::noop().with_feedback_when_performed(supported_tx)
+        )]));
+
+        let prepared_rule = |tx| RequestRule(
+            Condition::and(Condition::RequestOpcode(RequestOpcode::Execute), Condition::BodyContainsCaseSensitive(Box::new(MAGIC_MARK.to_be_bytes()))),
+            RequestReaction::noop().with_feedback_when_performed(tx)
+        );
+
+        let mut prepared_rxs = [0, 1, 2].map(|i| {
+            let (prepared_tx, prepared_rx) = mpsc::unbounded_channel();
+            running_proxy.running_nodes[i].change_request_rules(Some(vec![prepared_rule(prepared_tx)]));
+            prepared_rx
+        });
+
+        // DB preparation phase
+        let session: Session = SessionBuilder::new()
+            .known_node(proxy_uris[0].as_str())
+            .retry_policy(Box::new(FallthroughRetryPolicy))
+            .address_translator(Arc::new(translation_map))
+            .build()
+            .await
+            .unwrap();
+
+        let supported_frame = supported_rx.recv().await.unwrap();
+        let supported_options = types::read_string_multimap(&mut &*supported_frame.body).unwrap();
+        let supported_features = ProtocolFeatures::parse_from_supported(&supported_options);
+
+        // This will branch our test for cases both when cluster supports the optimisations and when it does not.
+        let supports_optimisation_mark = supported_features.lwt_optimization_meta_bit_mask.is_some();
+
+        // Create schema
+        let ks = unique_keyspace_name();
+        session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 3}}", ks), &[]).await.unwrap();
+        session.use_keyspace(ks, false).await.unwrap();
+
+        session
+            .query("CREATE TABLE t (a int primary key, b int)", &[])
+            .await
+            .unwrap();
+
+
+        fn clear_rxs(rxs: &mut [mpsc::UnboundedReceiver<RequestFrame>; 3]) {
+            for rx in rxs.iter_mut() {
+                while rx.try_recv().is_ok() {}
+            }
+        }
+
+        async fn assert_all_replicas_queried(rxs: &mut [mpsc::UnboundedReceiver<RequestFrame>; 3]) {
+            for rx in rxs.iter_mut() {
+                rx.recv().await.unwrap();
+            }
+            clear_rxs(rxs);
+        }
+
+        fn assert_one_replica_queried(rxs: &mut [mpsc::UnboundedReceiver<RequestFrame>; 3]) {
+            let mut found_queried = false;
+            for rx in rxs.iter_mut() {
+                if rx.try_recv().is_ok() {
+                    assert!(!found_queried);
+                    found_queried = true;
+                };
+            }
+            assert!(found_queried);
+            clear_rxs(rxs);
+        }
+
+        #[allow(unused)]
+        fn who_was_queried(rxs: &mut [mpsc::UnboundedReceiver<RequestFrame>; 3]) {
+            for (i, rx) in rxs.iter_mut().enumerate() {
+                if rx.try_recv().is_ok() {
+                    println!("{} was queried.", i);
+                    return;
+                }
+            }
+            println!("NOBODY was queried!");
+        }
+
+        // We will check which nodes where queries, for both LWT and non-LWT prepared statements.
+        let prepared_non_lwt = session.prepare("INSERT INTO t (a, b) VALUES (?, 1)").await.unwrap();
+        let prepared_lwt = session.prepare("UPDATE t SET b=3 WHERE a=? IF b=2").await.unwrap();
+
+        if supports_optimisation_mark {
+            // We make sure that the driver properly marked prepared statements wrt being LWT.
+            assert!(!prepared_non_lwt.is_confirmed_lwt());
+            assert!(prepared_lwt.is_confirmed_lwt());
+        }
+
+        assert!(prepared_non_lwt.is_token_aware());
+        assert!(prepared_lwt.is_token_aware());
+
+        // We execute non-LWT statements and ensure that all nodes were queried (due to RoundRobin).
+        for _ in 0..15 {
+            session.execute(&prepared_non_lwt, (MAGIC_MARK,)).await.unwrap();
+        }
+
+        assert_all_replicas_queried(&mut prepared_rxs).await;
+
+        // We execute LWT statements, and...
+        for _ in 0..15 {
+            session.execute(&prepared_lwt, (MAGIC_MARK,)).await.unwrap();
+        }
+
+        if supports_optimisation_mark {
+            // ...if cluster supports LWT, we assert that one replica was always queried first (and effectively only that one was queried).
+            assert_one_replica_queried(&mut prepared_rxs);
+        } else {
+            // ...else we assert that replicas were shuffled as in case of non-LWT.
+            assert_all_replicas_queried(&mut prepared_rxs).await;
+        }
+
+        running_proxy
+    }).await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/retries.rs
+++ b/scylla/tests/retries.rs
@@ -16,12 +16,11 @@ use scylla_proxy::{
 };
 
 #[tokio::test]
-#[ntest::timeout(5000)]
+#[ntest::timeout(30000)]
 async fn speculative_execution_is_fired() {
     const TIMEOUT_PER_REQUEST: Duration = Duration::from_millis(1000);
 
-    // We choose Unaware to support testing Cassandra
-    let res = test_with_3_node_cluster(ShardAwareness::Unaware, 217, |proxy_uris, translation_map, mut running_proxy| async move {
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, 217, |proxy_uris, translation_map, mut running_proxy| async move {
         // DB preparation phase
         let session: Session = SessionBuilder::new()
             .known_node(proxy_uris[0].as_str())
@@ -97,10 +96,9 @@ async fn speculative_execution_is_fired() {
 }
 
 #[tokio::test]
-#[ntest::timeout(10000)]
+#[ntest::timeout(30000)]
 async fn retries_occur() {
-    // We choose Unaware to support testing Cassandra
-    let res = test_with_3_node_cluster(ShardAwareness::Unaware, 210, |proxy_uris, translation_map, mut running_proxy| async move {
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, 210, |proxy_uris, translation_map, mut running_proxy| async move {
 
         // DB preparation phase
         let session: Session = SessionBuilder::new()

--- a/scylla/tests/retries.rs
+++ b/scylla/tests/retries.rs
@@ -1,103 +1,18 @@
-use futures::Future;
-use itertools::Itertools;
-use scylla::load_balancing::LoadBalancingPolicy;
+mod utils;
+
 use scylla::query::Query;
 use scylla::retry_policy::FallthroughRetryPolicy;
 use scylla::speculative_execution::SimpleSpeculativeExecutionPolicy;
 use scylla::transport::session::Session;
 use scylla::SessionBuilder;
-use std::collections::HashMap;
-use std::env;
-use std::net::SocketAddr;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{info, instrument::WithSubscriber};
+use tracing::info;
+use utils::test_with_3_node_cluster;
 
 use scylla_proxy::{
-    Condition, Node, Proxy, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule,
-    RunningProxy, ShardAwareness, WorkerError,
+    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, WorkerError,
 };
-
-fn init_logger() {
-    let _ = tracing_subscriber::fmt::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .without_time()
-        .try_init();
-}
-
-#[derive(Debug)]
-struct FixedOrderLoadBalancer;
-impl LoadBalancingPolicy for FixedOrderLoadBalancer {
-    fn plan<'a>(
-        &self,
-        _statement: &scylla::load_balancing::Statement,
-        cluster: &'a scylla::transport::ClusterData,
-    ) -> scylla::load_balancing::Plan<'a> {
-        Box::new(
-            cluster
-                .get_nodes_info()
-                .clone()
-                .into_iter()
-                .sorted_by(|node1, node2| Ord::cmp(&node1.address, &node2.address)),
-        )
-    }
-
-    fn name(&self) -> String {
-        "FixedOrderLoadBalancer".to_string()
-    }
-}
-
-async fn test_with_3_node_cluster<F, Fut>(
-    first_proxy_node_addr_last_octet: u16,
-    test: F,
-) -> Result<(), ProxyError>
-where
-    F: FnOnce([String; 3], HashMap<SocketAddr, SocketAddr>, RunningProxy) -> Fut,
-    Fut: Future<Output = RunningProxy>,
-{
-    init_logger();
-    let real1_uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
-    let proxy1_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet);
-    let real2_uri = env::var("SCYLLA_URI2").unwrap_or_else(|_| "127.0.0.2:9042".to_string());
-    let proxy2_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet + 1);
-    let real3_uri = env::var("SCYLLA_URI3").unwrap_or_else(|_| "127.0.0.3:9042".to_string());
-    let proxy3_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet + 2);
-
-    let real1_addr = SocketAddr::from_str(real1_uri.as_str()).unwrap();
-    let proxy1_addr = SocketAddr::from_str(proxy1_uri.as_str()).unwrap();
-    let real2_addr = SocketAddr::from_str(real2_uri.as_str()).unwrap();
-    let proxy2_addr = SocketAddr::from_str(proxy2_uri.as_str()).unwrap();
-    let real3_addr = SocketAddr::from_str(real3_uri.as_str()).unwrap();
-    let proxy3_addr = SocketAddr::from_str(proxy3_uri.as_str()).unwrap();
-
-    let proxy = Proxy::new(
-        [
-            (proxy1_addr, real1_addr),
-            (proxy2_addr, real2_addr),
-            (proxy3_addr, real3_addr),
-        ]
-        .map(|(proxy_addr, real_addr)| {
-            Node::builder()
-                .real_address(real_addr)
-                .proxy_address(proxy_addr)
-                .shard_awareness(ShardAwareness::QueryNode)
-                .build()
-        }),
-    );
-
-    let translation_map = proxy.translation_map();
-    let running_proxy = proxy.run().with_current_subscriber().await.unwrap();
-
-    let running_proxy = test(
-        [proxy1_uri, proxy2_uri, proxy3_uri],
-        translation_map,
-        running_proxy,
-    )
-    .await;
-
-    running_proxy.finish().await
-}
 
 #[tokio::test]
 #[ntest::timeout(5000)]

--- a/scylla/tests/retries.rs
+++ b/scylla/tests/retries.rs
@@ -11,14 +11,17 @@ use tracing::info;
 use utils::test_with_3_node_cluster;
 
 use scylla_proxy::{
-    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, WorkerError,
+    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, ShardAwareness,
+    WorkerError,
 };
 
 #[tokio::test]
 #[ntest::timeout(5000)]
 async fn speculative_execution_is_fired() {
     const TIMEOUT_PER_REQUEST: Duration = Duration::from_millis(1000);
-    let res = test_with_3_node_cluster(217, |proxy_uris, translation_map, mut running_proxy| async move {
+
+    // We choose Unaware to support testing Cassandra
+    let res = test_with_3_node_cluster(ShardAwareness::Unaware, 217, |proxy_uris, translation_map, mut running_proxy| async move {
         // DB preparation phase
         let session: Session = SessionBuilder::new()
             .known_node(proxy_uris[0].as_str())
@@ -96,7 +99,8 @@ async fn speculative_execution_is_fired() {
 #[tokio::test]
 #[ntest::timeout(10000)]
 async fn retries_occur() {
-    let res = test_with_3_node_cluster(210, |proxy_uris, translation_map, mut running_proxy| async move {
+    // We choose Unaware to support testing Cassandra
+    let res = test_with_3_node_cluster(ShardAwareness::Unaware, 210, |proxy_uris, translation_map, mut running_proxy| async move {
 
         // DB preparation phase
         let session: Session = SessionBuilder::new()

--- a/scylla/tests/utils/mod.rs
+++ b/scylla/tests/utils/mod.rs
@@ -39,6 +39,7 @@ impl LoadBalancingPolicy for FixedOrderLoadBalancer {
 }
 
 pub async fn test_with_3_node_cluster<F, Fut>(
+    shard_awareness: ShardAwareness,
     first_proxy_node_addr_last_octet: u16,
     test: F,
 ) -> Result<(), ProxyError>
@@ -71,7 +72,7 @@ where
             Node::builder()
                 .real_address(real_addr)
                 .proxy_address(proxy_addr)
-                .shard_awareness(ShardAwareness::QueryNode)
+                .shard_awareness(shard_awareness)
                 .build()
         }),
     );

--- a/scylla/tests/utils/mod.rs
+++ b/scylla/tests/utils/mod.rs
@@ -1,0 +1,90 @@
+use futures::Future;
+use itertools::Itertools;
+use scylla::load_balancing::LoadBalancingPolicy;
+use std::collections::HashMap;
+use std::env;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use tracing::instrument::WithSubscriber;
+
+use scylla_proxy::{Node, Proxy, ProxyError, RunningProxy, ShardAwareness};
+
+pub fn init_logger() {
+    let _ = tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .without_time()
+        .try_init();
+}
+
+#[derive(Debug)]
+pub struct FixedOrderLoadBalancer;
+impl LoadBalancingPolicy for FixedOrderLoadBalancer {
+    fn plan<'a>(
+        &self,
+        _statement: &scylla::load_balancing::Statement,
+        cluster: &'a scylla::transport::ClusterData,
+    ) -> scylla::load_balancing::Plan<'a> {
+        Box::new(
+            cluster
+                .get_nodes_info()
+                .clone()
+                .into_iter()
+                .sorted_by(|node1, node2| Ord::cmp(&node1.address, &node2.address)),
+        )
+    }
+
+    fn name(&self) -> String {
+        "FixedOrderLoadBalancer".to_string()
+    }
+}
+
+pub async fn test_with_3_node_cluster<F, Fut>(
+    first_proxy_node_addr_last_octet: u16,
+    test: F,
+) -> Result<(), ProxyError>
+where
+    F: FnOnce([String; 3], HashMap<SocketAddr, SocketAddr>, RunningProxy) -> Fut,
+    Fut: Future<Output = RunningProxy>,
+{
+    init_logger();
+    let real1_uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let proxy1_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet);
+    let real2_uri = env::var("SCYLLA_URI2").unwrap_or_else(|_| "127.0.0.2:9042".to_string());
+    let proxy2_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet + 1);
+    let real3_uri = env::var("SCYLLA_URI3").unwrap_or_else(|_| "127.0.0.3:9042".to_string());
+    let proxy3_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet + 2);
+
+    let real1_addr = SocketAddr::from_str(real1_uri.as_str()).unwrap();
+    let proxy1_addr = SocketAddr::from_str(proxy1_uri.as_str()).unwrap();
+    let real2_addr = SocketAddr::from_str(real2_uri.as_str()).unwrap();
+    let proxy2_addr = SocketAddr::from_str(proxy2_uri.as_str()).unwrap();
+    let real3_addr = SocketAddr::from_str(real3_uri.as_str()).unwrap();
+    let proxy3_addr = SocketAddr::from_str(proxy3_uri.as_str()).unwrap();
+
+    let proxy = Proxy::new(
+        [
+            (proxy1_addr, real1_addr),
+            (proxy2_addr, real2_addr),
+            (proxy3_addr, real3_addr),
+        ]
+        .map(|(proxy_addr, real_addr)| {
+            Node::builder()
+                .real_address(real_addr)
+                .proxy_address(proxy_addr)
+                .shard_awareness(ShardAwareness::QueryNode)
+                .build()
+        }),
+    );
+
+    let translation_map = proxy.translation_map();
+    let running_proxy = proxy.run().with_current_subscriber().await.unwrap();
+
+    let running_proxy = test(
+        [proxy1_uri, proxy2_uri, proxy3_uri],
+        translation_map,
+        running_proxy,
+    )
+    .await;
+
+    running_proxy.finish().await
+}


### PR DESCRIPTION
This enables optimisation of LWT queries routing. If the cluster supports the LWT mark protocol extension, then it will be negotiated and henceforth prepared statements which contain an LWT will be routed to the replicas only.
Fixes: #100 
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
