### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .vscode
-/scylla/target
-/target
+target/
 Cargo.lock
 /book/book
 /docs/_build


### PR DESCRIPTION
Fix target directory exclude so that it applies to all rust target dirs. This will ensure that `scylla-cql/target/` gets excluded, or any other rust project target directories in the future.

I also removed `/scylla/target` as it should now be covered by `target/`.

A `/` at the beginning of an exclusion means "relative to the .gitignore", so `/target` would only apply to the workspace target dir. 

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I added appropriate `Fixes:` annotations to PR description.
