### PR TITLE
Add size hint to serialization path

### DIFF
--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -66,7 +66,8 @@ impl SerializedRequest {
         tracing: bool,
     ) -> Result<SerializedRequest, FrameError> {
         let mut flags = 0;
-        let mut data = vec![0; HEADER_SIZE];
+        let mut data = Vec::with_capacity(32);
+        data.resize(HEADER_SIZE, 0);
 
         if let Some(compression) = compression {
             flags |= FLAG_COMPRESSION;


### PR DESCRIPTION
This is a mostly straightforward change to `Value` serialization. Previously, buffers used in serialiazation were preallocating capacity based on the size of a value, not the number of bytes it will use when serialized. This is described in two issues:

1. #579 
2. #385 

I've fixed this by adding a new method to `Value`, size_hint. It's documented in the code, which I'll inline here:

```rust
pub trait Value {
    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig>;
    /// A *hint* to callers indicating how much memory the serialized
    /// form of this `Value` will take. This hint is not defined as a
    /// lower bound, upper bound, nor is an exact size. Every implementation
    /// is free to return the "best guess" available.
    /// The default impl returns `std::mem::size_of::<i32>()` as every Value
    /// at minimum has an i32 sized tag.
    fn size_hint() -> usize {
        std::mem::size_of::<i32>()
    }
}
```

I've then implemented this method on a bunch of Value impls. The ranges tend to be either exact or optimistic. For example, `i8` can be exact:
```
impl Value for i8 {
    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> { /*...*/ }

    fn size_hint() -> usize {
        size_of::<i32>() + size_of::<Self>()
    }
}
```
In other cases we know a lower bound but may optimize for slightly above that lower bound:
```rust
impl Value for &str {
    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> { /*...*/ }
    fn size_hint() -> usize {
        // 1i32 for the tag, 3i32 for additional characters. This optimizes
        // for the likely case that strings will rarely be empty, and likely
        // be at least a few characters
        4 * size_of::<i32>()
    }
}
```

In the case of `&str` the true lower bound is `size_of::<i32>()`, but typically strings *aren't empty*, and once you allocate 4 bytes it's reasonable to just allocate 16 and handle what is probably the majority case.

The results are alright.

```
main
serialize_lz4_for_iai
  Instructions:               10459
  L1 Accesses:                13456
  L2 Accesses:                   32
  RAM Accesses:                 156
  Estimated Cycles:           19076

fix
serialize_lz4_for_iai
  Instructions:                9838 (-5.937470%)
  L1 Accesses:                12605 (-6.324316%)
  L2 Accesses:                   32 (No change)
  RAM Accesses:                 157 (+0.641026%)
  Estimated Cycles:           18260 (-4.277626%)
```

Ultimately I think that all of these individual allocations can be removed and, instead, a single buffer could be used. But this is a relatively small, non-breaking change, and it improves memory usage.

## Pre-review checklist

(idk what Fixes annotations are, but)

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/579

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [?] I added appropriate `Fixes:` annotations to PR description.
