### PR TITLE
retry_policy: Added support for SerialConsistency

### DIFF
--- a/scylla/src/history.rs
+++ b/scylla/src/history.rs
@@ -672,7 +672,7 @@ mod tests {
         history_collector.log_attempt_error(
             attempt_id,
             &QueryError::TimeoutError,
-            &RetryDecision::RetrySameNode(Consistency::Quorum),
+            &RetryDecision::RetrySameNode(Some(Consistency::Quorum)),
         );
 
         let second_attempt_id: AttemptId =
@@ -696,7 +696,7 @@ mod tests {
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Error at 2022-02-22 20:22:22 UTC
 |   Error: Timeout Error
-|   Retry decision: RetrySameNode(Quorum)
+|   Retry decision: RetrySameNode(Some(Quorum))
 |
 | - Attempt #1 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
@@ -768,7 +768,7 @@ mod tests {
         history_collector.log_attempt_error(
             attempt1,
             &timeout_error(),
-            &RetryDecision::RetryNextNode(Consistency::Quorum),
+            &RetryDecision::RetryNextNode(Some(Consistency::Quorum)),
         );
         let _attempt2: AttemptId =
             history_collector.log_attempt_start(query_id, None, node3_addr());
@@ -780,7 +780,7 @@ mod tests {
         history_collector.log_attempt_error(
             spec2_attempt1,
             &no_stream_id_error(),
-            &RetryDecision::RetrySameNode(Consistency::Quorum),
+            &RetryDecision::RetrySameNode(Some(Consistency::Quorum)),
         );
 
         let spec2_attempt2: AttemptId =
@@ -792,7 +792,7 @@ mod tests {
         history_collector.log_attempt_error(
             spec1_attempt1,
             &unavailable_error(),
-            &RetryDecision::RetryNextNode(Consistency::Quorum),
+            &RetryDecision::RetryNextNode(Some(Consistency::Quorum)),
         );
 
         let _spec4_attempt1: AttemptId =
@@ -811,7 +811,7 @@ mod tests {
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Error at 2022-02-22 20:22:22 UTC
 |   Error: Timeout Error
-|   Retry decision: RetryNextNode(Quorum)
+|   Retry decision: RetryNextNode(Some(Quorum))
 |
 | - Attempt #1 sent to 127.0.0.3:19042
 |   request send time: 2022-02-22 20:22:22 UTC
@@ -824,7 +824,7 @@ mod tests {
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Error at 2022-02-22 20:22:22 UTC
 |   Error: Database returned an error: Not enough nodes are alive to satisfy required consistency level (consistency: Quorum, required: 2, alive: 1), Error message: Not enough nodes to satisfy consistency
-|   Retry decision: RetryNextNode(Quorum)
+|   Retry decision: RetryNextNode(Some(Quorum))
 |
 |
 | > Speculative fiber #1
@@ -833,7 +833,7 @@ mod tests {
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Error at 2022-02-22 20:22:22 UTC
 |   Error: Unable to allocate stream id
-|   Retry decision: RetrySameNode(Quorum)
+|   Retry decision: RetrySameNode(Some(Quorum))
 |
 | - Attempt #1 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
@@ -866,7 +866,7 @@ mod tests {
         history_collector.log_attempt_error(
             query1_attempt1,
             &timeout_error(),
-            &RetryDecision::RetryNextNode(Consistency::Quorum),
+            &RetryDecision::RetryNextNode(Some(Consistency::Quorum)),
         );
         let query1_attempt2: AttemptId =
             history_collector.log_attempt_start(query1_id, None, node2_addr());
@@ -889,7 +889,7 @@ mod tests {
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Error at 2022-02-22 20:22:22 UTC
 |   Error: Timeout Error
-|   Retry decision: RetryNextNode(Quorum)
+|   Retry decision: RetryNextNode(Some(Quorum))
 |
 | - Attempt #1 sent to 127.0.0.2:19042
 |   request send time: 2022-02-22 20:22:22 UTC

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -56,26 +56,36 @@ impl Default for DowngradingConsistencyRetrySession {
 impl RetrySession for DowngradingConsistencyRetrySession {
     fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision {
         let cl = match query_info.consistency {
-            LegacyConsistency::Serial(_) => return RetryDecision::DontRetry, // FIXME: is this proper behaviour?
+            LegacyConsistency::Serial(_) => {
+                return match query_info.error {
+                    QueryError::DbError(DbError::Unavailable { .. }, _) => {
+                        // JAVA-764: if the requested consistency level is serial, it means that the operation failed at
+                        // the paxos phase of a LWT.
+                        // Retry on the next host, on the assumption that the initial coordinator could be network-isolated.
+                        RetryDecision::RetryNextNode(None)
+                    }
+                    _ => RetryDecision::DontRetry,
+                };
+            }
             LegacyConsistency::Regular(cl) => cl,
         };
 
         fn max_likely_to_work_cl(known_ok: i32, previous_cl: Consistency) -> RetryDecision {
             let decision = if known_ok >= 3 {
-                RetryDecision::RetrySameNode(Consistency::Three)
+                RetryDecision::RetrySameNode(Some(Consistency::Three))
             } else if known_ok == 2 {
-                RetryDecision::RetrySameNode(Consistency::Two)
+                RetryDecision::RetrySameNode(Some(Consistency::Two))
             } else if known_ok == 1 || previous_cl == Consistency::EachQuorum {
                 // JAVA-1005: EACH_QUORUM does not report a global number of alive replicas
                 // so even if we get 0 alive replicas, there might be
                 // a node up in some other datacenter
-                RetryDecision::RetrySameNode(Consistency::One)
+                RetryDecision::RetrySameNode(Some(Consistency::One))
             } else {
                 RetryDecision::DontRetry
             };
             if let RetryDecision::RetrySameNode(new_cl) = decision {
                 debug!(
-                    "Decided to lower required consistency from {} to {}.",
+                    "Decided to lower required consistency from {} to {:?}.",
                     previous_cl, new_cl
                 );
             }
@@ -90,7 +100,7 @@ impl RetrySession for DowngradingConsistencyRetrySession {
             | QueryError::DbError(DbError::ServerError, _)
             | QueryError::DbError(DbError::TruncateError, _) => {
                 if query_info.is_idempotent {
-                    RetryDecision::RetryNextNode(cl)
+                    RetryDecision::RetryNextNode(None)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -122,7 +132,7 @@ impl RetrySession for DowngradingConsistencyRetrySession {
                     max_likely_to_work_cl(*received, cl)
                 } else if !*data_present {
                     self.was_retry = true;
-                    RetryDecision::RetrySameNode(cl)
+                    RetryDecision::RetrySameNode(None)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -150,16 +160,16 @@ impl RetrySession for DowngradingConsistencyRetrySession {
                             // retry with whatever consistency should allow to persist all
                             max_likely_to_work_cl(*received, cl)
                         }
-                        WriteType::BatchLog => RetryDecision::RetrySameNode(cl),
+                        WriteType::BatchLog => RetryDecision::RetrySameNode(None),
 
                         _ => RetryDecision::DontRetry,
                     }
                 }
             }
             // The node is still bootstrapping it can't execute the query, we should try another one
-            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode(cl),
+            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode(None),
             // Connection to the contacted node is overloaded, try another one
-            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode(cl),
+            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode(None),
             // In all other cases propagate the error to the user
             _ => RetryDecision::DontRetry,
         }
@@ -286,20 +296,20 @@ mod tests {
         let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info_with_cl(&error, true, cl)),
-            RetryDecision::RetryNextNode(cl)
+            RetryDecision::RetryNextNode(None)
         );
     }
 
     fn max_likely_to_work_cl(known_ok: i32, current_cl: Consistency) -> RetryDecision {
         if known_ok >= 3 {
-            RetryDecision::RetrySameNode(Consistency::Three)
+            RetryDecision::RetrySameNode(Some(Consistency::Three))
         } else if known_ok == 2 {
-            RetryDecision::RetrySameNode(Consistency::Two)
+            RetryDecision::RetrySameNode(Some(Consistency::Two))
         } else if known_ok == 1 || current_cl == Consistency::EachQuorum {
             // JAVA-1005: EACH_QUORUM does not report a global number of alive replicas
             // so even if we get 0 alive replicas, there might be
             // a node up in some other datacenter
-            RetryDecision::RetrySameNode(Consistency::One)
+            RetryDecision::RetrySameNode(Some(Consistency::One))
         } else {
             RetryDecision::DontRetry
         }
@@ -330,13 +340,13 @@ mod tests {
             let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
             assert_eq!(
                 policy.decide_should_retry(make_query_info_with_cl(&error, false, cl)),
-                RetryDecision::RetryNextNode(cl)
+                RetryDecision::RetryNextNode(None)
             );
 
             let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
             assert_eq!(
                 policy.decide_should_retry(make_query_info_with_cl(&error, true, cl)),
-                RetryDecision::RetryNextNode(cl)
+                RetryDecision::RetryNextNode(None)
             );
         }
     }
@@ -402,7 +412,7 @@ mod tests {
                     false,
                     cl
                 )),
-                RetryDecision::RetrySameNode(cl)
+                RetryDecision::RetrySameNode(None)
             );
             assert_eq!(
                 policy.decide_should_retry(make_query_info_with_cl(
@@ -421,7 +431,7 @@ mod tests {
                     true,
                     cl
                 )),
-                RetryDecision::RetrySameNode(cl)
+                RetryDecision::RetrySameNode(None)
             );
             assert_eq!(
                 policy.decide_should_retry(make_query_info_with_cl(
@@ -497,7 +507,7 @@ mod tests {
                     policy.decide_should_retry(make_query_info_with_cl(
                         &not_enough_responses_with_data,
                         false,
-                        new_cl
+                        new_cl.unwrap_or(cl)
                     )),
                     RetryDecision::DontRetry
                 );
@@ -518,7 +528,7 @@ mod tests {
                     policy.decide_should_retry(make_query_info_with_cl(
                         &not_enough_responses_with_data,
                         true,
-                        new_cl
+                        new_cl.unwrap_or(cl)
                     )),
                     RetryDecision::DontRetry
                 );
@@ -561,7 +571,7 @@ mod tests {
                         true,
                         cl
                     )),
-                    RetryDecision::RetrySameNode(cl)
+                    RetryDecision::RetrySameNode(None)
                 );
                 assert_eq!(
                     policy.decide_should_retry(make_query_info_with_cl(

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -383,12 +383,12 @@ where
                 match retry_decision {
                     RetryDecision::RetrySameNode(cl) => {
                         self.metrics.inc_retries_num();
-                        current_consistency = cl;
+                        current_consistency = cl.unwrap_or(current_consistency);
                         continue 'same_node_retries;
                     }
                     RetryDecision::RetryNextNode(cl) => {
                         self.metrics.inc_retries_num();
-                        current_consistency = cl;
+                        current_consistency = cl.unwrap_or(current_consistency);
                         continue 'nodes_in_plan;
                     }
                     RetryDecision::DontRetry => break 'nodes_in_plan,

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -19,8 +19,8 @@ pub struct QueryInfo<'a> {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RetryDecision {
-    RetrySameNode(Consistency),
-    RetryNextNode(Consistency),
+    RetrySameNode(Option<Consistency>), // None means that the same consistency should be used as before
+    RetryNextNode(Option<Consistency>), // ditto
     DontRetry,
     IgnoreWriteError,
 }
@@ -136,9 +136,8 @@ impl Default for DefaultRetrySession {
 
 impl RetrySession for DefaultRetrySession {
     fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision {
-        let cl = match query_info.consistency {
-            LegacyConsistency::Serial(_) => return RetryDecision::DontRetry,
-            LegacyConsistency::Regular(cl) => cl,
+        if let LegacyConsistency::Serial(_) = query_info.consistency {
+            return RetryDecision::DontRetry;
         };
         match query_info.error {
             // Basic errors - there are some problems on this node
@@ -148,7 +147,7 @@ impl RetrySession for DefaultRetrySession {
             | QueryError::DbError(DbError::ServerError, _)
             | QueryError::DbError(DbError::TruncateError, _) => {
                 if query_info.is_idempotent {
-                    RetryDecision::RetryNextNode(cl)
+                    RetryDecision::RetryNextNode(None)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -161,7 +160,7 @@ impl RetrySession for DefaultRetrySession {
             QueryError::DbError(DbError::Unavailable { .. }, _) => {
                 if !self.was_unavailable_retry {
                     self.was_unavailable_retry = true;
-                    RetryDecision::RetryNextNode(cl)
+                    RetryDecision::RetryNextNode(None)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -183,7 +182,7 @@ impl RetrySession for DefaultRetrySession {
             ) => {
                 if !self.was_read_timeout_retry && received >= required && !*data_present {
                     self.was_read_timeout_retry = true;
-                    RetryDecision::RetrySameNode(cl)
+                    RetryDecision::RetrySameNode(None)
                 } else {
                     RetryDecision::DontRetry
                 }
@@ -198,15 +197,15 @@ impl RetrySession for DefaultRetrySession {
                     && *write_type == WriteType::BatchLog
                 {
                     self.was_write_timeout_retry = true;
-                    RetryDecision::RetrySameNode(cl)
+                    RetryDecision::RetrySameNode(None)
                 } else {
                     RetryDecision::DontRetry
                 }
             }
             // The node is still bootstrapping it can't execute the query, we should try another one
-            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode(cl),
+            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode(None),
             // Connection to the contacted node is overloaded, try another one
-            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode(cl),
+            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode(None),
             // In all other cases propagate the error to the user
             _ => RetryDecision::DontRetry,
         }
@@ -307,7 +306,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&error, true)),
-            RetryDecision::RetryNextNode(Consistency::One)
+            RetryDecision::RetryNextNode(None)
         );
     }
 
@@ -333,13 +332,13 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&error, false)),
-            RetryDecision::RetryNextNode(Consistency::One)
+            RetryDecision::RetryNextNode(None)
         );
 
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&error, true)),
-            RetryDecision::RetryNextNode(Consistency::One)
+            RetryDecision::RetryNextNode(None)
         );
     }
 
@@ -358,7 +357,7 @@ mod tests {
         let mut policy_not_idempotent = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy_not_idempotent.decide_should_retry(make_query_info(&error, false)),
-            RetryDecision::RetryNextNode(Consistency::One)
+            RetryDecision::RetryNextNode(None)
         );
         assert_eq!(
             policy_not_idempotent.decide_should_retry(make_query_info(&error, false)),
@@ -368,7 +367,7 @@ mod tests {
         let mut policy_idempotent = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy_idempotent.decide_should_retry(make_query_info(&error, true)),
-            RetryDecision::RetryNextNode(Consistency::One)
+            RetryDecision::RetryNextNode(None)
         );
         assert_eq!(
             policy_idempotent.decide_should_retry(make_query_info(&error, true)),
@@ -394,7 +393,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, false)),
-            RetryDecision::RetrySameNode(Consistency::One)
+            RetryDecision::RetrySameNode(None)
         );
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, false)),
@@ -405,7 +404,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, true)),
-            RetryDecision::RetrySameNode(Consistency::One)
+            RetryDecision::RetrySameNode(None)
         );
         assert_eq!(
             policy.decide_should_retry(make_query_info(&enough_responses_no_data, true)),
@@ -489,7 +488,7 @@ mod tests {
         let mut policy = DefaultRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info(&good_write_type, true)),
-            RetryDecision::RetrySameNode(Consistency::One)
+            RetryDecision::RetrySameNode(None)
         );
         assert_eq!(
             policy.decide_should_retry(make_query_info(&good_write_type, true)),


### PR DESCRIPTION
RetryDecision contains Option<Consistency> now instead of Consistency. None conveys meaning of "retry with the same CL as before", which is especially suitable when the previous consistency was Serial (even though such a case seems to be impossible in the code ATM). Moreover, covered one special case of LWT Unavailable error in DowngradingConsistencyPolicy, mirroring Java driver's behaviour.
Fixes: #527 
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
