### PR TITLE
connection: clearly mark db-side warnings as such

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -839,7 +839,10 @@ impl Connection {
         )?;
 
         for warn_description in &body_with_ext.warnings {
-            warn!(warning = warn_description.as_str());
+            warn!(
+                warning = warn_description.as_str(),
+                "Response from the database contains a warning",
+            );
         }
 
         let response =


### PR DESCRIPTION
The CQL protocol allows the database to return some warnings along with the response and the driver prints them using the tracing::warn! macro. Those warnings, when reported by tracing, may be confused with a driver-side error, so this commit attempts to make it more clear that the warning was generated on the db-side.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
