### PR TITLE
Implement Value for Vec<&dyn Value> and Vec<Box<dyn Value>>

### DIFF
--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -473,10 +473,17 @@ impl<V: Value> Value for MaybeUnset<V> {
     }
 }
 
-// Every &impl Value should also implement Value
-impl<T: Value> Value for &T {
+// Every &impl Value and &dyn Value should also implement Value
+impl<T: Value + ?Sized> Value for &T {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         <T as Value>::serialize(*self, buf)
+    }
+}
+
+// Every Boxed Value should also implement Value
+impl<T: Value + ?Sized> Value for Box<T> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        <T as Value>::serialize(self.as_ref(), buf)
     }
 }
 


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.


The new test demonstrates the new types that are now possible to provide.
Supporting `Vec<&dyn Value>` and `Vec<Box<dyn Value>>` here is very rarely useful but I ran into a case where I needed it for abstracting across multiple cassandra drivers in order to easily test my cassandra proxy implementation across multiple drivers.