### PR TITLE
Execution profiles

### DIFF
--- a/docs/source/SUMMARY.md
+++ b/docs/source/SUMMARY.md
@@ -24,6 +24,12 @@
     - [Schema agreement](queries/schema_agreement.md)
     - [Query timeouts](queries/timeouts.md)
 
+- [Execution profiles](execution-profiles/execution-profiles.md)
+    - [Creating a profile and setting it](execution-profiles/create-and-use.md)
+    - [All options supported by a profile](execution-profiles/maximal-example.md)
+    - [Options priority](execution-profiles/priority.md)
+    - [Remapping a profile handle](execution-profiles/remap.md)
+
 - [Data Types](data-types/data-types.md)
     - [Bool, Tinyint, Smallint, Int, Bigint, Float, Double](data-types/primitive.md)
     - [Ascii, Text, Varchar](data-types/text.md)

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -7,6 +7,7 @@
    quickstart/quickstart
    connecting/connecting
    queries/queries
+   execution-profiles/execution-profiles
    data-types/data-types
    load-balancing/load-balancing
    retry-policy/retry-policy

--- a/docs/source/execution-profiles/create-and-use.md
+++ b/docs/source/execution-profiles/create-and-use.md
@@ -1,0 +1,76 @@
+# Creating a profile and setting it
+
+### Example
+To create an `ExecutionProfile` and attach it as default for `Session`:
+```rust
+# extern crate scylla;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::{Session, SessionBuilder};
+use scylla::statement::Consistency;
+use scylla::transport::ExecutionProfile;
+
+let profile = ExecutionProfile::builder()
+    .consistency(Consistency::LocalOne)
+    .request_timeout(None) // no request timeout
+    .build();
+
+let handle = profile.into_handle();
+
+let session: Session = SessionBuilder::new()
+    .known_node("127.0.0.1:9042")
+    .default_execution_profile_handle(handle)
+    .build()
+    .await?;
+# Ok(())
+# }
+```
+
+### Example
+To create an `ExecutionProfile` and attach it to a `Query`:
+```rust
+# extern crate scylla;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::query::Query;
+use scylla::statement::Consistency;
+use scylla::transport::ExecutionProfile;
+use std::time::Duration;
+
+let profile = ExecutionProfile::builder()
+    .consistency(Consistency::All)
+    .request_timeout(Some(Duration::from_secs(30)))
+    .build();
+
+let handle = profile.into_handle();
+
+let mut query1 = Query::from("SELECT * FROM ks.table");
+query1.set_execution_profile_handle(Some(handle.clone()));
+
+let mut query2 = Query::from("SELECT pk FROM ks.table WHERE pk = ?");
+query2.set_execution_profile_handle(Some(handle));
+# Ok(())
+# }
+```
+
+### Example
+To create an `ExecutionProfile` based on another profile:
+```rust
+# extern crate scylla;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::statement::Consistency;
+use scylla::transport::ExecutionProfile;
+use std::time::Duration;
+
+let base_profile = ExecutionProfile::builder()
+    .request_timeout(Some(Duration::from_secs(30)))
+    .build();
+
+let profile = base_profile.to_builder()
+    .consistency(Consistency::All)
+    .build();
+
+# Ok(())
+# }
+```

--- a/docs/source/execution-profiles/execution-profiles.md
+++ b/docs/source/execution-profiles/execution-profiles.md
@@ -1,0 +1,26 @@
+# Execution profiles
+
+Execution profiles are a way to group various query execution configuration options together. Profiles can be created to represent different workloads, which can be run conveniently on a single session.
+
+The settings that an execution profile encapsulates are [as follows](maximal-example.md):
+* consistency
+* serial consistency
+* request timeout
+* load balancing policy
+* retry policy
+* speculative execution policy
+
+There are two classes of objects related to execution profiles: `ExecutionProfile` and `ExecutionProfileHandle`. The former is simply an immutable set of the settings. The latter is a handle that at particular moment points to some `ExecutionProfile` (but during its lifetime, it can change the profile it points at). Handles are assigned to `Sessions` and `Statements`.\
+\
+At any moment, handles [can be remapped](remap.md) to point to another `ExecutionProfile`. This allows convenient switching between workloads for all `Sessions` and/or `Statements` that, for instance, share common characteristics.
+
+```eval_rst
+.. toctree::
+   :hidden:
+   :glob:
+
+   create-and-use
+   maximal-example
+   priority
+   remap
+```

--- a/docs/source/execution-profiles/maximal-example.md
+++ b/docs/source/execution-profiles/maximal-example.md
@@ -1,0 +1,48 @@
+# All options supported by a profile
+
+### Example
+`ExecutionProfile` supports all the following options:
+```rust
+# extern crate scylla;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::query::Query;
+use scylla::speculative_execution::SimpleSpeculativeExecutionPolicy;
+use scylla::statement::{Consistency, SerialConsistency};
+use scylla::transport::ExecutionProfile;
+use scylla::transport::load_balancing::{DcAwareRoundRobinPolicy, TokenAwarePolicy};
+use scylla::transport::retry_policy::FallthroughRetryPolicy;
+use std::{sync::Arc, time::Duration};
+
+let profile = ExecutionProfile::builder()
+    .consistency(Consistency::All)
+    .serial_consistency(Some(SerialConsistency::Serial))
+    .request_timeout(Some(Duration::from_secs(30)))
+    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .load_balancing_policy(
+        Arc::new(
+            TokenAwarePolicy::new(
+                Box::new(
+                    DcAwareRoundRobinPolicy::new("us_east".to_string())
+                )
+            )
+        )
+    )
+    .speculative_execution_policy(
+        Some(
+            Arc::new(
+                SimpleSpeculativeExecutionPolicy {
+                    max_retry_count: 3,
+                    retry_interval: Duration::from_millis(100),
+                }
+            )
+        )
+    )
+    .build();
+
+let mut query = Query::from("SELECT * FROM ks.table");
+query.set_execution_profile_handle(Some(profile.into_handle()));
+
+# Ok(())
+# }
+```

--- a/docs/source/execution-profiles/priority.md
+++ b/docs/source/execution-profiles/priority.md
@@ -1,0 +1,53 @@
+# Priorities of execution settings
+
+You always have a default execution profile set for the `Session`, either the default one or overriden upon `Session` creation. Moreover, you can set a profile for specific statements, in which case the statement's profile has higher priority. Some options are also available for specific statements to be set directly on them, such as request timeout and consistency. In such case, the directly set options are preferred over those specified in execution profiles.
+
+> **Recap**\
+> Priorities are as follows:\
+> `Session`'s default profile < Statement's profile < options set directly on a Statement
+
+
+### Example
+Priorities of execution profiles and directly set options:
+```rust
+# extern crate scylla;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::{Session, SessionBuilder};
+use scylla::query::Query;
+use scylla::statement::Consistency;
+use scylla::transport::ExecutionProfile;
+
+let session_profile = ExecutionProfile::builder()
+    .consistency(Consistency::One)
+    .build();
+
+let query_profile = ExecutionProfile::builder()
+    .consistency(Consistency::Two)
+    .build();
+
+let session: Session = SessionBuilder::new()
+    .known_node("127.0.0.1:9042")
+    .default_execution_profile_handle(session_profile.into_handle())
+    .build()
+    .await?;
+
+let mut query = Query::from("SELECT * FROM ks.table");
+
+// Query is not assigned any specific profile, so session's profile is applied.
+// Therefore, the query will be executed with Consistency::One.
+session.query(query.clone(), ()).await?;
+
+query.set_execution_profile_handle(Some(query_profile.into_handle()));
+// Query's profile is applied.
+// Therefore, the query will be executed with Consistency::Two.
+session.query(query.clone(), ()).await?;
+
+query.set_consistency(Consistency::Three);
+// An option is set directly on the query.
+// Therefore, the query will be executed with Consistency::Three.
+session.query(query, ()).await?;
+
+# Ok(())
+# }
+```

--- a/docs/source/execution-profiles/remap.md
+++ b/docs/source/execution-profiles/remap.md
@@ -1,0 +1,74 @@
+# Remapping execution profile handles
+
+`ExecutionProfileHandle`s can be remapped to another `ExecutionProfile`, and the change affects all sessions and statements that have been assigned that handle. This enables quick workload switches.
+
+Example mapping:
+* session1 -> handle1 -> profile1
+* statement1 -> handle1 -> profile1
+* statement2 -> handle2 -> profile2
+
+We can now remap handle2 to profile1, so that the mapping for statement2 becomes as follows:
+* statement2 -> handle2 -> profile1
+
+We can also change statement1's handle to handle2, and remap handle1 to profile2, yielding:
+* session1 -> handle1 -> profile2
+* statement1 -> handle2 -> profile1
+* statement2 -> handle2 -> profile1
+
+As you can see, profiles are a powerful and convenient way to define and modify your workloads.
+
+### Example
+Below, the remaps described above are followed in code.
+```rust
+# extern crate scylla;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::{Session, SessionBuilder};
+use scylla::query::Query;
+use scylla::statement::Consistency;
+use scylla::transport::ExecutionProfile;
+
+let profile1 = ExecutionProfile::builder()
+    .consistency(Consistency::One)
+    .build();
+
+let profile2 = ExecutionProfile::builder()
+    .consistency(Consistency::Two)
+    .build();
+
+let mut handle1 = profile1.clone().into_handle();
+let mut handle2 = profile2.clone().into_handle();
+
+let session: Session = SessionBuilder::new()
+    .known_node("127.0.0.1:9042")
+    .default_execution_profile_handle(handle1.clone())
+    .build()
+    .await?;
+
+let mut query1 = Query::from("SELECT * FROM ks.table");
+let mut query2 = Query::from("SELECT pk FROM ks.table WHERE pk = ?");
+
+query1.set_execution_profile_handle(Some(handle1.clone()));
+query2.set_execution_profile_handle(Some(handle2.clone()));
+
+// session1 -> handle1 -> profile1
+// query1 -> handle1 -> profile1
+// query2 -> handle2 -> profile2
+
+// We can now remap handle2 to profile1:
+handle2.map_to_another_profile(profile1);
+// ...so that the mapping for query2 becomes as follows:
+// query2 -> handle2 -> profile1
+
+// We can also change query1's handle to handle2:
+query1.set_execution_profile_handle(Some(handle2.clone()));
+// ...and remap handle1 to profile2:
+handle1.map_to_another_profile(profile2);
+// ...yielding:
+// session1 -> handle1 -> profile2
+// query1 -> handle2 -> profile1
+// query2 -> handle2 -> profile1
+
+# Ok(())
+# }
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,6 +1,6 @@
 # Scylla Rust Driver
 This book contains documentation for [scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver) - a driver
-for the [Scylla](https://scylladb.com) database written in Rust. 
+for the [Scylla](https://scylladb.com) database written in Rust.
 Although optimized for Scylla, the driver is also compatible with [Apache Cassandra®](https://cassandra.apache.org/).
 
 ### Other documentation
@@ -15,6 +15,7 @@ Although optimized for Scylla, the driver is also compatible with [Apache Cassan
 * [Quick start](quickstart/quickstart.md) - Setting up a Rust project using `scylla-rust-driver` and running a few queries
 * [Connecting to the cluster](connecting/connecting.md) - Configuring a connection to scylla cluster
 * [Making queries](queries/queries.md) - Making different types of queries (simple, prepared, batch, paged)
+* [Execution profiles](execution-profiles/execution-profiles.md) - Grouping query execution configuration options together and switching them all at once
 * [Data Types](data-types/data-types.md) - How to use various column data types
 * [Load balancing](load-balancing/load-balancing.md) - Load balancing configuration, local datacenters etc.
 * [Retry policy configuration](retry-policy/retry-policy.md) - What to do when a query fails, query idempotence

--- a/docs/source/load-balancing/dc-robin.md
+++ b/docs/source/load-balancing/dc-robin.md
@@ -24,6 +24,7 @@ To use this policy in `Session`:
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
 use scylla::transport::load_balancing::DcAwareRoundRobinPolicy;
+use scylla::transport::ExecutionProfile;
 use std::sync::Arc;
 
 let local_dc_name: String = "us_east".to_string();
@@ -31,9 +32,14 @@ let local_dc_name: String = "us_east".to_string();
 let mut policy = DcAwareRoundRobinPolicy::new(local_dc_name);
 policy.set_include_remote_nodes(false);
 
+let handle = ExecutionProfile::builder()
+    .load_balancing_policy(Arc::new(policy))
+    .build()
+    .into_handle();
+
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .load_balancing(Arc::new(policy))
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())

--- a/docs/source/load-balancing/robin.md
+++ b/docs/source/load-balancing/robin.md
@@ -2,7 +2,7 @@
 The simplest load balancing policy available.\
 Takes all nodes in the cluster and uses them one after another.\
 
-For example if there are nodes `A`, `B`, `C` in the cluster, 
+For example if there are nodes `A`, `B`, `C` in the cluster,
 this policy will use `A`, `B`, `C`, `A`, `B`, ...
 
 ### Example
@@ -13,12 +13,18 @@ To use this policy in `Session`:
 # use std::error::Error;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
+use scylla::transport::ExecutionProfile;
 use scylla::transport::load_balancing::RoundRobinPolicy;
 use std::sync::Arc;
 
+let handle = ExecutionProfile::builder()
+    .load_balancing_policy(Arc::new(RoundRobinPolicy::new()))
+    .build()
+    .into_handle();
+
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .load_balancing(Arc::new(RoundRobinPolicy::new()))
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())

--- a/docs/source/load-balancing/token-dc-robin.md
+++ b/docs/source/load-balancing/token-dc-robin.md
@@ -12,15 +12,21 @@ To use this policy in `Session`:
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
 use scylla::transport::load_balancing::{DcAwareRoundRobinPolicy, TokenAwarePolicy};
+use scylla::transport::ExecutionProfile;
 use std::sync::Arc;
 
 let local_dc: String = "us_east".to_string();
 let dc_robin = Box::new(DcAwareRoundRobinPolicy::new(local_dc));
 let policy = Arc::new(TokenAwarePolicy::new(dc_robin));
 
+let handle = ExecutionProfile::builder()
+    .load_balancing_policy(policy)
+    .build()
+    .into_handle();
+
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .load_balancing(policy)
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())

--- a/docs/source/load-balancing/token-robin.md
+++ b/docs/source/load-balancing/token-robin.md
@@ -12,14 +12,20 @@ To use this policy in `Session`:
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
 use scylla::transport::load_balancing::{RoundRobinPolicy, TokenAwarePolicy};
+use scylla::transport::ExecutionProfile;
 use std::sync::Arc;
 
 let robin = Box::new(RoundRobinPolicy::new());
 let policy = Arc::new(TokenAwarePolicy::new(robin));
 
+let handle = ExecutionProfile::builder()
+    .load_balancing_policy(policy)
+    .build()
+    .into_handle();
+
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .load_balancing(policy)
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())

--- a/docs/source/retry-policy/default.md
+++ b/docs/source/retry-policy/default.md
@@ -11,11 +11,17 @@ To use in `Session`:
 # use std::error::Error;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
+use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::DefaultRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())
@@ -29,11 +35,17 @@ To use in a [simple query](../queries/simple.md):
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
+use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::DefaultRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 // Create a Query manually and set the retry policy
 let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
-my_query.set_retry_policy(Box::new(DefaultRetryPolicy::new()));
+my_query.set_execution_profile_handle(Some(handle));
 
 // Run the query using this retry policy
 let to_insert: i32 = 12345;
@@ -49,14 +61,20 @@ To use in a [prepared query](../queries/prepared.md):
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::prepared_statement::PreparedStatement;
+use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::DefaultRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 // Create PreparedStatement manually and set the retry policy
 let mut prepared: PreparedStatement = session
     .prepare("INSERT INTO ks.tab (a) VALUES(?)")
     .await?;
 
-prepared.set_retry_policy(Box::new(DefaultRetryPolicy::new()));
+prepared.set_execution_profile_handle(Some(handle));
 
 // Run the query using this retry policy
 let to_insert: i32 = 12345;

--- a/docs/source/retry-policy/downgrading_consistency.md
+++ b/docs/source/retry-policy/downgrading_consistency.md
@@ -52,11 +52,17 @@ To use in `Session`:
 # use std::error::Error;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
+use scylla::transport::ExecutionProfile;
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())
@@ -70,11 +76,17 @@ To use in a [simple query](../queries/simple.md):
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
+use scylla::transport::ExecutionProfile;
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 // Create a Query manually and set the retry policy
 let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
-my_query.set_retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()));
+my_query.set_execution_profile_handle(Some(handle));
 
 // Run the query using this retry policy
 let to_insert: i32 = 12345;
@@ -90,14 +102,21 @@ To use in a [prepared query](../queries/prepared.md):
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::prepared_statement::PreparedStatement;
+use scylla::transport::ExecutionProfile;
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 // Create PreparedStatement manually and set the retry policy
 let mut prepared: PreparedStatement = session
     .prepare("INSERT INTO ks.tab (a) VALUES(?)")
     .await?;
 
-prepared.set_retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()));
+prepared.set_execution_profile_handle(Some(handle));
+
 
 // Run the query using this retry policy
 let to_insert: i32 = 12345;

--- a/docs/source/retry-policy/fallthrough.md
+++ b/docs/source/retry-policy/fallthrough.md
@@ -10,11 +10,17 @@ To use in `Session`:
 # use std::error::Error;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
+use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::FallthroughRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())
@@ -28,11 +34,17 @@ To use in a [simple query](../queries/simple.md):
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
+use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::FallthroughRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 // Create a Query manually and set the retry policy
 let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
-my_query.set_retry_policy(Box::new(FallthroughRetryPolicy::new()));
+my_query.set_execution_profile_handle(Some(handle));
 
 // Run the query using this retry policy
 let to_insert: i32 = 12345;
@@ -48,14 +60,20 @@ To use in a [prepared query](../queries/prepared.md):
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::prepared_statement::PreparedStatement;
+use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::FallthroughRetryPolicy;
+
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .build()
+    .into_handle();
 
 // Create PreparedStatement manually and set the retry policy
 let mut prepared: PreparedStatement = session
     .prepare("INSERT INTO ks.tab (a) VALUES(?)")
     .await?;
 
-prepared.set_retry_policy(Box::new(FallthroughRetryPolicy::new()));
+prepared.set_execution_profile_handle(Some(handle));
 
 // Run the query using this retry policy
 let to_insert: i32 = 12345;

--- a/docs/source/speculative-execution/percentile.md
+++ b/docs/source/speculative-execution/percentile.md
@@ -17,6 +17,7 @@ use scylla::{
     Session,
     SessionBuilder,
     speculative_execution::PercentileSpeculativeExecutionPolicy,
+    transport::execution_profile::ExecutionProfile,
 };
 
 let policy = PercentileSpeculativeExecutionPolicy  {
@@ -24,9 +25,14 @@ let policy = PercentileSpeculativeExecutionPolicy  {
     percentile: 99.0,
 };
 
+let handle = ExecutionProfile::builder()
+    .speculative_execution_policy(Some(Arc::new(policy)))
+    .build()
+    .into_handle();
+
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .speculative_execution(Arc::new(policy))
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())

--- a/docs/source/speculative-execution/simple.md
+++ b/docs/source/speculative-execution/simple.md
@@ -16,7 +16,8 @@ use std::{sync::Arc, time::Duration};
 use scylla::{
     Session,
     SessionBuilder,
-    speculative_execution::SimpleSpeculativeExecutionPolicy
+    speculative_execution::SimpleSpeculativeExecutionPolicy,
+    transport::execution_profile::ExecutionProfile,
 };
 
 let policy = SimpleSpeculativeExecutionPolicy {
@@ -24,9 +25,14 @@ let policy = SimpleSpeculativeExecutionPolicy {
     retry_interval: Duration::from_millis(100),
 };
 
+let handle = ExecutionProfile::builder()
+    .speculative_execution_policy(Some(Arc::new(policy)))
+    .build()
+    .into_handle();
+
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9042")
-    .speculative_execution(Arc::new(policy))
+    .default_execution_profile_handle(handle)
     .build()
     .await?;
 # Ok(())

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -107,3 +107,7 @@ path = "allocations.rs"
 [[example]]
 name = "query_history"
 path = "query_history.rs"
+
+[[example]]
+name = "execution_profile"
+path = "execution_profile.rs"

--- a/examples/custom_load_balancing_policy.rs
+++ b/examples/custom_load_balancing_policy.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use scylla::{
     load_balancing::{LoadBalancingPolicy, Statement},
-    transport::{ClusterData, Node},
+    transport::{ClusterData, ExecutionProfile, Node},
     Session, SessionBuilder,
 };
 use std::{env, sync::Arc};
@@ -42,9 +42,13 @@ async fn main() -> Result<()> {
         fav_datacenter_name: "PL".to_string(),
     };
 
+    let profile = ExecutionProfile::builder()
+        .load_balancing_policy(Arc::new(custom_load_balancing))
+        .build();
+
     let _session: Session = SessionBuilder::new()
         .known_node(uri)
-        .load_balancing(Arc::new(custom_load_balancing))
+        .default_execution_profile_handle(profile.into_handle())
         .build()
         .await?;
 

--- a/examples/execution_profile.rs
+++ b/examples/execution_profile.rs
@@ -1,0 +1,92 @@
+use anyhow::Result;
+use scylla::load_balancing::{RoundRobinPolicy, TokenAwarePolicy};
+use scylla::query::Query;
+use scylla::retry_policy::{DefaultRetryPolicy, FallthroughRetryPolicy};
+use scylla::speculative_execution::PercentileSpeculativeExecutionPolicy;
+use scylla::statement::{Consistency, SerialConsistency};
+use scylla::transport::session::Session;
+use scylla::transport::ExecutionProfile;
+use scylla::{SessionBuilder, SessionConfig};
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let profile1 = ExecutionProfile::builder()
+        .consistency(Consistency::EachQuorum)
+        .serial_consistency(Some(SerialConsistency::Serial))
+        .request_timeout(Some(Duration::from_secs(42)))
+        .load_balancing_policy(Arc::new(TokenAwarePolicy::new(Box::new(
+            RoundRobinPolicy::new(),
+        ))))
+        .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+        .speculative_execution_policy(Some(Arc::new(PercentileSpeculativeExecutionPolicy {
+            max_retry_count: 2,
+            percentile: 42.0,
+        })))
+        .build();
+
+    let profile2 = ExecutionProfile::builder()
+        .consistency(Consistency::One)
+        .serial_consistency(None)
+        .request_timeout(Some(Duration::from_secs(3)))
+        .load_balancing_policy(Arc::new(RoundRobinPolicy::new()))
+        .retry_policy(Box::new(DefaultRetryPolicy::new()))
+        .speculative_execution_policy(None)
+        .build();
+
+    let handle1 = profile1.clone().into_handle();
+    let mut handle2 = profile2.into_handle();
+
+    // It is even possible to use multiple sessions interleaved, having them configured with different profiles.
+    let session1: Session = SessionBuilder::new()
+        .known_node(&uri)
+        .default_execution_profile_handle(handle1.clone())
+        .build()
+        .await?;
+
+    let session2: Session = SessionBuilder::new()
+        .known_node(&uri)
+        .default_execution_profile_handle(handle2.clone())
+        .build()
+        .await?;
+
+    // As default execution profile is not provided explicitly, session 3 uses a predefined one.
+    let mut session_3_config = SessionConfig::new();
+    session_3_config.add_known_node(uri);
+    let session3: Session = Session::connect(session_3_config).await?;
+
+    session1.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session2
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    let mut query_insert: Query = "INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)".into();
+
+    // As `query_insert` is set another handle than session1, the execution profile pointed by query's handle
+    // will be preferred, so the query below will be executed with `profile2`, even though `session1` is set `profile1`.
+    query_insert.set_execution_profile_handle(Some(handle2.clone()));
+    session1.query(query_insert.clone(), (3, 4, "def")).await?;
+
+    // One can, however, change the execution profile referred by a handle:
+    handle2.map_to_another_profile(profile1);
+    // And now the following queries are executed with profile1:
+    session1.query(query_insert.clone(), (3, 4, "def")).await?;
+    session2.query("SELECT * FROM ks.t", ()).await?;
+
+    // One can unset a profile handle from a statement and, since then, execute it with session's default profile.
+    query_insert.set_execution_profile_handle(None);
+    session3.query("SELECT * FROM ks.t", ()).await?; // This executes with default session profile.
+    session2.query("SELECT * FROM ks.t", ()).await?; // This executes with profile1.
+
+    Ok(())
+}

--- a/examples/speculative-execution.rs
+++ b/examples/speculative-execution.rs
@@ -1,5 +1,6 @@
 use scylla::{
-    speculative_execution::PercentileSpeculativeExecutionPolicy, Session, SessionBuilder,
+    speculative_execution::PercentileSpeculativeExecutionPolicy,
+    transport::execution_profile::ExecutionProfile, Session, SessionBuilder,
 };
 
 use anyhow::Result;
@@ -15,9 +16,13 @@ async fn main() -> Result<()> {
         percentile: 99.0,
     };
 
+    let speculative_profile = ExecutionProfile::builder()
+        .speculative_execution_policy(Some(Arc::new(speculative)))
+        .build();
+
     let session: Session = SessionBuilder::new()
         .known_node(uri)
-        .speculative_execution(Arc::new(speculative))
+        .default_execution_profile_handle(speculative_profile.into_handle())
         .build()
         .await?;
 

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -123,6 +123,7 @@ pub use frame::response::cql_to_rust;
 pub use frame::response::cql_to_rust::FromRow;
 
 pub use transport::caching_session::CachingSession;
+pub use transport::execution_profile::ExecutionProfile;
 pub use transport::query_result::QueryResult;
 pub use transport::session::{IntoTypedRows, Session, SessionConfig};
 pub use transport::session_builder::SessionBuilder;

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::history::HistoryListener;
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
+use crate::transport::execution_profile::ExecutionProfileHandle;
 
 use super::StatementConfig;
 pub use super::{Consistency, SerialConsistency};
@@ -115,6 +116,17 @@ impl Batch {
     /// Removes the listener set by `set_history_listener`.
     pub fn remove_history_listener(&mut self) -> Option<Arc<dyn HistoryListener>> {
         self.config.history_listener.take()
+    }
+
+    /// Associates the batch with execution profile referred by the provided handle.
+    /// Handle may be later remapped to another profile, and batch will reflect those changes.
+    pub fn set_execution_profile_handle(&mut self, profile_handle: Option<ExecutionProfileHandle>) {
+        self.config.execution_profile_handle = profile_handle;
+    }
+
+    /// Borrows the execution profile handle associated with this batch.
+    pub fn get_execution_profile_handle(&self) -> Option<&ExecutionProfileHandle> {
+        self.config.execution_profile_handle.as_ref()
     }
 }
 

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -61,13 +61,13 @@ impl Batch {
     /// Sets the serial consistency to be used when executing this batch.
     /// (Ignored unless the batch is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
-        self.config.serial_consistency = sc;
+        self.config.serial_consistency = Some(sc);
     }
 
     /// Gets the serial consistency to be used when executing this batch.
     /// (Ignored unless the batch is an LWT)
     pub fn get_serial_consistency(&self) -> Option<SerialConsistency> {
-        self.config.serial_consistency
+        self.config.serial_consistency.flatten()
     }
 
     /// Sets the idempotence of this batch

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use crate::history::HistoryListener;
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
-use crate::transport::retry_policy::RetryPolicy;
 
 use super::StatementConfig;
 pub use super::{Consistency, SerialConsistency};
@@ -74,7 +73,7 @@ impl Batch {
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
     /// If set to `true` we can be sure that it is idempotent
     /// If set to `false` it is unknown whether it is idempotent
-    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
+    /// This is used in [`RetryPolicy`](crate::retry_policy::RetryPolicy) to decide if retrying a query is safe
     pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
         self.config.is_idempotent = is_idempotent;
     }
@@ -82,17 +81,6 @@ impl Batch {
     /// Gets the idempotence of this batch
     pub fn get_is_idempotent(&self) -> bool {
         self.config.is_idempotent
-    }
-
-    /// Sets a custom [`RetryPolicy`] to be used with this batch
-    /// By default Session's retry policy is used, this allows to use a custom retry policy
-    pub fn set_retry_policy(&mut self, retry_policy: Box<dyn RetryPolicy>) {
-        self.config.retry_policy = Some(retry_policy);
-    }
-
-    /// Gets custom [`RetryPolicy`] used by this batch
-    pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy>> {
-        &self.config.retry_policy
     }
 
     /// Enable or disable CQL Tracing for this batch

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,7 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use crate::transport::speculative_execution::SpeculativeExecutionPolicy;
-use crate::{history::HistoryListener, transport::retry_policy::RetryPolicy};
+use crate::history::HistoryListener;
 
 pub mod batch;
 pub mod prepared_statement;
@@ -15,9 +14,6 @@ pub struct StatementConfig {
     pub serial_consistency: Option<Option<SerialConsistency>>,
 
     pub is_idempotent: bool,
-
-    pub retry_policy: Option<Box<dyn RetryPolicy>>,
-    pub speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
 
     pub tracing: bool,
     pub timestamp: Option<i64>,
@@ -33,8 +29,6 @@ impl Default for StatementConfig {
             consistency: Default::default(),
             serial_consistency: None,
             is_idempotent: false,
-            retry_policy: None,
-            speculative_execution_policy: None,
             tracing: false,
             timestamp: None,
             request_timeout: None,
@@ -46,11 +40,6 @@ impl Default for StatementConfig {
 impl Clone for StatementConfig {
     fn clone(&self) -> Self {
         Self {
-            retry_policy: self
-                .retry_policy
-                .as_ref()
-                .map(|policy| policy.clone_boxed()),
-            speculative_execution_policy: self.speculative_execution_policy.clone(),
             history_listener: self.history_listener.clone(),
             ..*self
         }

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -58,6 +58,7 @@ impl Clone for StatementConfig {
 
 impl StatementConfig {
     /// Determines the consistency of a query
+    #[must_use]
     pub fn determine_consistency(&self, default_consistency: Consistency) -> Consistency {
         self.consistency.unwrap_or(default_consistency)
     }

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -12,7 +12,7 @@ pub use crate::frame::types::{Consistency, SerialConsistency};
 #[derive(Debug)]
 pub struct StatementConfig {
     pub consistency: Option<Consistency>,
-    pub serial_consistency: Option<SerialConsistency>,
+    pub serial_consistency: Option<Option<SerialConsistency>>,
 
     pub is_idempotent: bool,
 
@@ -26,11 +26,12 @@ pub struct StatementConfig {
     pub history_listener: Option<Arc<dyn HistoryListener>>,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for StatementConfig {
     fn default() -> Self {
         Self {
             consistency: Default::default(),
-            serial_consistency: Some(SerialConsistency::LocalSerial),
+            serial_consistency: None,
             is_idempotent: false,
             retry_policy: None,
             speculative_execution_policy: None,

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::history::HistoryListener;
+use crate::transport::execution_profile::ExecutionProfileHandle;
 
 pub mod batch;
 pub mod prepared_statement;
@@ -20,6 +21,8 @@ pub struct StatementConfig {
     pub request_timeout: Option<Duration>,
 
     pub history_listener: Option<Arc<dyn HistoryListener>>,
+
+    pub execution_profile_handle: Option<ExecutionProfileHandle>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -33,6 +36,7 @@ impl Default for StatementConfig {
             timestamp: None,
             request_timeout: None,
             history_listener: None,
+            execution_profile_handle: None,
         }
     }
 }
@@ -41,6 +45,7 @@ impl Clone for StatementConfig {
     fn clone(&self) -> Self {
         Self {
             history_listener: self.history_listener.clone(),
+            execution_profile_handle: self.execution_profile_handle.clone(),
             ..*self
         }
     }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -206,13 +206,13 @@ impl PreparedStatement {
     /// Sets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
-        self.config.serial_consistency = sc;
+        self.config.serial_consistency = Some(sc);
     }
 
     /// Gets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
     pub fn get_serial_consistency(&self) -> Option<SerialConsistency> {
-        self.config.serial_consistency
+        self.config.serial_consistency.flatten()
     }
 
     /// Sets the idempotence of this statement

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -11,6 +11,7 @@ use crate::frame::response::result::PreparedMetadata;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::frame::value::SerializedValues;
 use crate::history::HistoryListener;
+use crate::transport::execution_profile::ExecutionProfileHandle;
 use crate::transport::partitioner::PartitionerName;
 
 /// Represents a statement prepared on the server.
@@ -289,6 +290,17 @@ impl PreparedStatement {
     /// Removes the listener set by `set_history_listener`.
     pub fn remove_history_listener(&mut self) -> Option<Arc<dyn HistoryListener>> {
         self.config.history_listener.take()
+    }
+
+    /// Associates the query with execution profile referred by the provided handle.
+    /// Handle may be later remapped to another profile, and query will reflect those changes.
+    pub fn set_execution_profile_handle(&mut self, profile_handle: Option<ExecutionProfileHandle>) {
+        self.config.execution_profile_handle = profile_handle;
+    }
+
+    /// Borrows the execution profile handle associated with this query.
+    pub fn get_execution_profile_handle(&self) -> Option<&ExecutionProfileHandle> {
+        self.config.execution_profile_handle.as_ref()
     }
 }
 

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -12,7 +12,6 @@ use crate::frame::types::{Consistency, SerialConsistency};
 use crate::frame::value::SerializedValues;
 use crate::history::HistoryListener;
 use crate::transport::partitioner::PartitionerName;
-use crate::transport::retry_policy::RetryPolicy;
 
 /// Represents a statement prepared on the server.
 #[derive(Debug)]
@@ -219,7 +218,7 @@ impl PreparedStatement {
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
     /// If set to `true` we can be sure that it is idempotent
     /// If set to `false` it is unknown whether it is idempotent
-    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
+    /// This is used in [`RetryPolicy`](crate::retry_policy::RetryPolicy) to decide if retrying a query is safe
     pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
         self.config.is_idempotent = is_idempotent;
     }
@@ -227,17 +226,6 @@ impl PreparedStatement {
     /// Gets the idempotence of this statement
     pub fn get_is_idempotent(&self) -> bool {
         self.config.is_idempotent
-    }
-
-    /// Sets a custom [`RetryPolicy`] to be used with this statement
-    /// By default Session's retry policy is used, this allows to use a custom retry policy
-    pub fn set_retry_policy(&mut self, retry_policy: Box<dyn RetryPolicy>) {
-        self.config.retry_policy = Some(retry_policy);
-    }
-
-    /// Gets custom [`RetryPolicy`] used by this statement
-    pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy>> {
-        &self.config.retry_policy
     }
 
     /// Enable or disable CQL Tracing for this statement

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -62,13 +62,13 @@ impl Query {
     /// Sets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
-        self.config.serial_consistency = sc;
+        self.config.serial_consistency = Some(sc);
     }
 
     /// Gets the serial consistency to be used when executing this statement.
     /// (Ignored unless the statement is an LWT)
     pub fn get_serial_consistency(&self) -> Option<SerialConsistency> {
-        self.config.serial_consistency
+        self.config.serial_consistency.flatten()
     }
 
     /// Sets the idempotence of this statement

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -1,7 +1,6 @@
 use super::StatementConfig;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::history::HistoryListener;
-use crate::transport::retry_policy::RetryPolicy;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -75,7 +74,7 @@ impl Query {
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
     /// If set to `true` we can be sure that it is idempotent
     /// If set to `false` it is unknown whether it is idempotent
-    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
+    /// This is used in [`RetryPolicy`](crate::retry_policy::RetryPolicy) to decide if retrying a query is safe
     pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
         self.config.is_idempotent = is_idempotent;
     }
@@ -83,17 +82,6 @@ impl Query {
     /// Gets the idempotence of this statement
     pub fn get_is_idempotent(&self) -> bool {
         self.config.is_idempotent
-    }
-
-    /// Sets a custom [`RetryPolicy`] to be used with this statement
-    /// By default Session's retry policy is used, this allows to use a custom retry policy
-    pub fn set_retry_policy(&mut self, retry_policy: Box<dyn RetryPolicy>) {
-        self.config.retry_policy = Some(retry_policy);
-    }
-
-    /// Gets custom [`RetryPolicy`] used by this statement
-    pub fn get_retry_policy(&self) -> &Option<Box<dyn RetryPolicy>> {
-        &self.config.retry_policy
     }
 
     /// Enable or disable CQL Tracing for this statement

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -1,6 +1,7 @@
 use super::StatementConfig;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::history::HistoryListener;
+use crate::transport::execution_profile::ExecutionProfileHandle;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -130,6 +131,17 @@ impl Query {
     /// Removes the listener set by `set_history_listener`.
     pub fn remove_history_listener(&mut self) -> Option<Arc<dyn HistoryListener>> {
         self.config.history_listener.take()
+    }
+
+    /// Associates the query with execution profile referred by the provided handle.
+    /// Handle may be later remapped to another profile, and query will reflect those changes.
+    pub fn set_execution_profile_handle(&mut self, profile_handle: Option<ExecutionProfileHandle>) {
+        self.config.execution_profile_handle = profile_handle;
+    }
+
+    /// Borrows the execution profile handle associated with this query.
+    pub fn get_execution_profile_handle(&self) -> Option<&ExecutionProfileHandle> {
+        self.config.execution_profile_handle.as_ref()
     }
 }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -390,8 +390,13 @@ impl Connection {
             .determine_consistency(self.config.default_consistency);
         let serial_consistency = query.config.serial_consistency;
 
-        self.query_single_page_with_consistency(query, &values, consistency, serial_consistency)
-            .await
+        self.query_single_page_with_consistency(
+            query,
+            &values,
+            consistency,
+            serial_consistency.flatten(),
+        )
+        .await
     }
 
     pub async fn query_single_page_with_consistency(
@@ -420,7 +425,7 @@ impl Connection {
             query
                 .config
                 .determine_consistency(self.config.default_consistency),
-            query.config.serial_consistency,
+            query.config.serial_consistency.flatten(),
             paging_state,
         )
         .await
@@ -538,7 +543,7 @@ impl Connection {
             prepared_statement
                 .config
                 .determine_consistency(self.config.default_consistency),
-            prepared_statement.config.serial_consistency,
+            prepared_statement.config.serial_consistency.flatten(),
             paging_state,
         )
         .await
@@ -635,7 +640,7 @@ impl Connection {
             batch
                 .config
                 .determine_consistency(self.config.default_consistency),
-            batch.config.serial_consistency,
+            batch.config.serial_consistency.flatten(),
         )
         .await
     }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -477,10 +477,6 @@ impl Connection {
         let serialized_values = values.serialized()?;
         let mut paging_state: Option<Bytes> = None;
 
-        query
-            .config
-            .determine_consistency(self.config.default_consistency);
-
         loop {
             // Send next paged query
             let mut cur_result: QueryResult = self

--- a/scylla/src/transport/execution_profile.rs
+++ b/scylla/src/transport/execution_profile.rs
@@ -1,0 +1,268 @@
+use std::{fmt::Debug, sync::Arc, time::Duration};
+
+use arc_swap::ArcSwap;
+use scylla_cql::{frame::types::SerialConsistency, Consistency};
+
+use crate::{
+    load_balancing::LoadBalancingPolicy, retry_policy::RetryPolicy,
+    speculative_execution::SpeculativeExecutionPolicy,
+};
+
+use super::session;
+
+/// `ExecutionProfileBuilder` is used to create new `ExecutionProfile`s
+/// # Example
+///
+/// ```
+/// # use scylla::transport::{ExecutionProfile, retry_policy::FallthroughRetryPolicy};
+/// # use scylla::statement::Consistency;
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let profile: ExecutionProfile = ExecutionProfile::builder()
+///     .consistency(Consistency::Three) // as this is the number we shall count to
+///     .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+///     .build();
+/// # Ok(())
+/// # }
+/// ```
+pub struct ExecutionProfileBuilder {
+    request_timeout: Option<Option<Duration>>,
+    consistency: Option<Consistency>,
+    serial_consistency: Option<Option<SerialConsistency>>,
+    load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
+    retry_policy: Option<Box<dyn RetryPolicy>>,
+    speculative_execution_policy: Option<Option<Arc<dyn SpeculativeExecutionPolicy>>>,
+}
+
+impl ExecutionProfileBuilder {
+    /// Changes client-side timeout.
+    /// The default is 30 seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::transport::ExecutionProfile;
+    /// # use std::time::Duration;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let profile: ExecutionProfile = ExecutionProfile::builder()
+    ///     .request_timeout(Some(Duration::from_secs(5)))
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn request_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.request_timeout = Some(timeout);
+        self
+    }
+
+    /// Specify a default consistency to be used for queries.
+    /// It's possible to override it by explicitly setting a consistency on the chosen query.
+    pub fn consistency(mut self, consistency: Consistency) -> Self {
+        self.consistency = Some(consistency);
+        self
+    }
+
+    /// Specify a default serial consistency to be used for queries.
+    /// It's possible to override it by explicitly setting a serial consistency
+    /// on the chosen query.
+    pub fn serial_consistency(mut self, serial_consistency: Option<SerialConsistency>) -> Self {
+        self.serial_consistency = Some(serial_consistency);
+        self
+    }
+
+    /// Sets the load balancing policy.
+    /// The default is Token-aware Round-robin.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::transport::ExecutionProfile;
+    /// # use scylla::transport::load_balancing::RoundRobinPolicy;
+    /// # use std::sync::Arc;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let profile: ExecutionProfile = ExecutionProfile::builder()
+    ///     .load_balancing_policy(Arc::new(RoundRobinPolicy::new()))
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn load_balancing_policy(
+        mut self,
+        load_balancing_policy: Arc<dyn LoadBalancingPolicy>,
+    ) -> Self {
+        self.load_balancing_policy = Some(load_balancing_policy);
+        self
+    }
+
+    /// Sets the [`RetryPolicy`] to use by default on queries.
+    /// The default is [DefaultRetryPolicy](crate::transport::retry_policy::DefaultRetryPolicy).
+    /// It is possible to implement a custom retry policy by implementing the trait [`RetryPolicy`].
+    ///
+    /// # Example
+    /// ```
+    /// use scylla::transport::retry_policy::DefaultRetryPolicy;
+    /// # use scylla::transport::ExecutionProfile;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let profile: ExecutionProfile = ExecutionProfile::builder()
+    ///     .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn retry_policy(mut self, retry_policy: Box<dyn RetryPolicy>) -> Self {
+        self.retry_policy = Some(retry_policy);
+        self
+    }
+
+    /// Sets the speculative execution policy.
+    /// The default is None.
+    /// # Example
+    /// ```
+    /// # extern crate scylla;
+    /// # use std::error::Error;
+    /// # fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+    /// use std::{sync::Arc, time::Duration};
+    /// use scylla::{
+    ///     transport::ExecutionProfile,
+    ///     transport::speculative_execution::SimpleSpeculativeExecutionPolicy,
+    /// };
+    ///
+    /// let policy = SimpleSpeculativeExecutionPolicy {
+    ///     max_retry_count: 3,
+    ///     retry_interval: Duration::from_millis(100),
+    /// };
+    ///
+    /// let profile: ExecutionProfile = ExecutionProfile::builder()
+    ///     .speculative_execution_policy(Some(Arc::new(policy)))
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn speculative_execution_policy(
+        mut self,
+        speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
+    ) -> Self {
+        self.speculative_execution_policy = Some(speculative_execution_policy);
+        self
+    }
+
+    /// Builds the ExecutionProfile after setting all the options.
+    ///
+    /// # Example
+    /// ```
+    /// use scylla::transport::retry_policy::DefaultRetryPolicy;
+    /// # use scylla::transport::ExecutionProfile;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let profile: ExecutionProfile = ExecutionProfile::builder()
+    ///     .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn build(self) -> ExecutionProfile {
+        use session::defaults;
+        ExecutionProfile(Arc::new(ExecutionProfileInner {
+            request_timeout: self
+                .request_timeout
+                .unwrap_or_else(defaults::request_timeout),
+            consistency: self.consistency.unwrap_or_else(defaults::consistency),
+            serial_consistency: self
+                .serial_consistency
+                .unwrap_or_else(defaults::serial_consistency),
+            load_balancing_policy: self
+                .load_balancing_policy
+                .unwrap_or_else(defaults::load_balancing_policy),
+            retry_policy: self.retry_policy.unwrap_or_else(defaults::retry_policy),
+            speculative_execution_policy: self
+                .speculative_execution_policy
+                .unwrap_or_else(defaults::speculative_execution_policy),
+        }))
+    }
+}
+
+/// A profile that groups configurable options regarding query execution.
+///
+/// Execution profile is immutable as such, but the driver implements double indirection of form:
+/// query/Session -> ExecutionProfileHandle -> ExecutionProfile
+/// which enables on-fly changing the actual profile associated with all entities (query/Session)
+/// by the same handle.
+#[derive(Debug, Clone)]
+pub struct ExecutionProfile(pub(crate) Arc<ExecutionProfileInner>);
+
+#[derive(Debug)]
+pub(crate) struct ExecutionProfileInner {
+    pub(crate) request_timeout: Option<Duration>,
+
+    pub(crate) consistency: Consistency,
+    pub(crate) serial_consistency: Option<SerialConsistency>,
+
+    pub(crate) load_balancing_policy: Arc<dyn LoadBalancingPolicy>,
+    pub(crate) retry_policy: Box<dyn RetryPolicy>,
+    pub(crate) speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
+}
+
+impl ExecutionProfile {
+    pub(crate) fn new_from_inner(inner: ExecutionProfileInner) -> Self {
+        Self(Arc::new(inner))
+    }
+
+    /// Creates a blank builder that can be used to construct new ExecutionProfile.
+    pub fn builder() -> ExecutionProfileBuilder {
+        ExecutionProfileBuilder {
+            request_timeout: None,
+            consistency: None,
+            serial_consistency: None,
+            load_balancing_policy: None,
+            retry_policy: None,
+            speculative_execution_policy: None,
+        }
+    }
+
+    /// Creates a builder having all options set to the same as set in this ExecutionProfile.
+    pub fn to_builder(&self) -> ExecutionProfileBuilder {
+        ExecutionProfileBuilder {
+            request_timeout: Some(self.0.request_timeout),
+            consistency: Some(self.0.consistency),
+            serial_consistency: Some(self.0.serial_consistency),
+            load_balancing_policy: Some(self.0.load_balancing_policy.clone()),
+            retry_policy: Some(self.0.retry_policy.clone()),
+            speculative_execution_policy: Some(self.0.speculative_execution_policy.clone()),
+        }
+    }
+
+    /// Returns a new handle to this ExecutionProfile.
+    pub fn into_handle(self) -> ExecutionProfileHandle {
+        ExecutionProfileHandle(Arc::new((ArcSwap::new(self.0), None)))
+    }
+
+    /// Returns a new handle to this ExecutionProfile, tagging the handle with provided label.
+    /// The tag, as its name suggests, is only useful for debugging purposes, while being confused
+    /// about which statement/session is assigned which handle. Identifying handles with tags
+    /// could then help.
+    pub fn into_handle_with_label(self, label: String) -> ExecutionProfileHandle {
+        ExecutionProfileHandle(Arc::new((ArcSwap::new(self.0), Some(label))))
+    }
+}
+
+/// A handle that points to an ExecutionProfile.
+///
+/// Its goal is to enable remapping all associated entities (query/Session)
+/// to another execution profile at once.
+/// Note: Cloned handles initially point to the same Arc'ed execution profile.
+/// However, as the mapping has yet another level of indirection - through
+/// `Arc<ArcSwap>` - remapping one of them affects all the others, as under the hood
+/// it is done by replacing the Arc held by the ArcSwap, which is shared
+/// by all cloned handles.
+/// The optional String is just for debug purposes. Its purpose is described
+/// in [ExecutionProfile::into_handle_with_label].
+#[derive(Debug, Clone)]
+pub struct ExecutionProfileHandle(Arc<(ArcSwap<ExecutionProfileInner>, Option<String>)>);
+
+impl ExecutionProfileHandle {
+    pub(crate) fn access(&self) -> Arc<ExecutionProfileInner> {
+        self.0 .0.load_full()
+    }
+
+    /// Makes the handle point to a new execution profile.
+    /// All entities (queries/Session) holding this handle will reflect the change.
+    pub fn map_to_another_profile(&mut self, profile: ExecutionProfile) {
+        self.0 .0.store(profile.0)
+    }
+}

--- a/scylla/src/transport/execution_profile.rs
+++ b/scylla/src/transport/execution_profile.rs
@@ -1,3 +1,165 @@
+//! `ExecutionProfile` is a grouping of configurable options regarding query execution.
+//!
+//! Profiles can be created to represent different workloads, which thanks to them
+//! can be run conveniently on a single session.
+//!
+//! There are two classes of objects related to execution profiles: `ExecutionProfile` and `ExecutionProfileHandle`.
+//! The former is simply an immutable set of the settings. The latter is a handle that at particular moment points
+//! to some `ExecutionProfile` (but during its lifetime, it can change the profile it points at).
+//! Handles are assigned to `Sessions` and `Statements`.
+//! At any moment, handles point to another `ExecutionProfile`. This allows convenient switching between workloads
+//! for all `Sessions` and/or `Statements` that, for instance, share common characteristics.
+//!
+//! ### Example
+//! To create an `ExecutionProfile` and attach it as default for `Session`:
+//! ```
+//! # extern crate scylla;
+//! # use std::error::Error;
+//! # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+//! use scylla::{Session, SessionBuilder};
+//! use scylla::statement::Consistency;
+//! use scylla::transport::ExecutionProfile;
+//!
+//! let profile = ExecutionProfile::builder()
+//!     .consistency(Consistency::LocalOne)
+//!     .request_timeout(None) // no request timeout
+//!     .build();
+//!
+//! let handle = profile.into_handle();
+//!
+//! let session: Session = SessionBuilder::new()
+//!     .known_node("127.0.0.1:9042")
+//!     .default_execution_profile_handle(handle)
+//!     .build()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Example
+//! To create an `ExecutionProfile` and attach it to a `Query`:
+//! ```
+//! # extern crate scylla;
+//! # use std::error::Error;
+//! # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+//! use scylla::query::Query;
+//! use scylla::statement::Consistency;
+//! use scylla::transport::ExecutionProfile;
+//! use std::time::Duration;
+//!
+//! let profile = ExecutionProfile::builder()
+//!     .consistency(Consistency::All)
+//!     .request_timeout(Some(Duration::from_secs(30)))
+//!     .build();
+//!
+//! let handle = profile.into_handle();
+//!
+//! let mut query1 = Query::from("SELECT * FROM ks.table");
+//! query1.set_execution_profile_handle(Some(handle.clone()));
+//!
+//! let mut query2 = Query::from("SELECT pk FROM ks.table WHERE pk = ?");
+//! query2.set_execution_profile_handle(Some(handle));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Example
+//! To create an `ExecutionProfile` with config options defaulting
+//! to those set on another profile:
+//! ```
+//! # extern crate scylla;
+//! # use std::error::Error;
+//! # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+//! use scylla::statement::Consistency;
+//! use scylla::transport::ExecutionProfile;
+//! use std::time::Duration;
+//!
+//! let base_profile = ExecutionProfile::builder()
+//!     .request_timeout(Some(Duration::from_secs(30)))
+//!     .build();
+//!
+//! let profile = base_profile.to_builder()
+//!     .consistency(Consistency::All)
+//!     .build();
+//
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! `ExecutionProfileHandle`s can be remapped to another `ExecutionProfile`, and the change affects all sessions and statements that have been assigned that handle. This enables quick workload switches.
+//!
+//! Example mapping:
+//! * session1 -> handle1 -> profile1
+//! * statement1 -> handle1 -> profile1
+//! * statement2 -> handle2 -> profile2
+//!
+//! We can now remap handle2 to profile1, so that the mapping for statement2 becomes as follows:
+//! * statement2 -> handle2 -> profile1
+//!
+//! We can also change statement1's handle to handle2, and remap handle1 to profile2, yielding:
+//! * session1 -> handle1 -> profile2
+//! * statement1 -> handle2 -> profile1
+//! * statement2 -> handle2 -> profile1
+//!
+//! As you can see, profiles are a powerful and convenient way to define and modify your workloads.
+//!
+//! ### Example
+//! Below, the remaps described above are followed in code.
+//! ```
+//! # extern crate scylla;
+//! # use std::error::Error;
+//! # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+//! use scylla::{Session, SessionBuilder};
+//! use scylla::query::Query;
+//! use scylla::statement::Consistency;
+//! use scylla::transport::ExecutionProfile;
+//!
+//! let profile1 = ExecutionProfile::builder()
+//!     .consistency(Consistency::One)
+//!     .build();
+//!
+//! let profile2 = ExecutionProfile::builder()
+//!     .consistency(Consistency::Two)
+//!     .build();
+//!
+//! let mut handle1 = profile1.clone().into_handle();
+//! let mut handle2 = profile2.clone().into_handle();
+//!
+//! let session: Session = SessionBuilder::new()
+//!     .known_node("127.0.0.1:9042")
+//!     .default_execution_profile_handle(handle1.clone())
+//!     .build()
+//!     .await?;
+//!
+//! let mut query1 = Query::from("SELECT * FROM ks.table");
+//! let mut query2 = Query::from("SELECT pk FROM ks.table WHERE pk = ?");
+//!
+//! query1.set_execution_profile_handle(Some(handle1.clone()));
+//! query2.set_execution_profile_handle(Some(handle2.clone()));
+//!
+//! // session1 -> handle1 -> profile1
+//! //   query1 -> handle1 -> profile1
+//! //   query2 -> handle2 -> profile2
+//!
+//! // We can now remap handle2 to profile1:
+//! handle2.map_to_another_profile(profile1);
+//! // ...so that the mapping for query2 becomes as follows:
+//! // query2 -> handle2 -> profile1
+//!
+//! // We can also change query1's handle to handle2:
+//! query1.set_execution_profile_handle(Some(handle2.clone()));
+//! // ...and remap handle1 to profile2:
+//! handle1.map_to_another_profile(profile2);
+//! // ...yielding:
+//! // session1 -> handle1 -> profile2
+//! //   query1 -> handle2 -> profile1
+//! //   query2 -> handle2 -> profile1
+//!
+//! # Ok(())
+//! # }
+//! ```
+//!
+
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use arc_swap::ArcSwap;

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -156,7 +156,7 @@ impl RowIterator {
                         query_ref,
                         values_ref,
                         consistency,
-                        query.config.serial_consistency,
+                        query.config.serial_consistency.flatten(),
                         paging_state,
                     )
                     .await
@@ -240,7 +240,7 @@ impl RowIterator {
                         prepared_ref,
                         values_ref,
                         consistency,
-                        config.prepared.config.serial_consistency,
+                        config.prepared.config.serial_consistency.flatten(),
                         paging_state,
                     )
                     .await

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -152,7 +152,13 @@ impl RowIterator {
                               consistency: Consistency,
                               paging_state: Option<Bytes>| async move {
                 connection
-                    .query_with_consistency(query_ref, values_ref, consistency, paging_state)
+                    .query_with_consistency(
+                        query_ref,
+                        values_ref,
+                        consistency,
+                        query.config.serial_consistency,
+                        paging_state,
+                    )
                     .await
             };
 
@@ -230,7 +236,13 @@ impl RowIterator {
                               consistency: Consistency,
                               paging_state: Option<Bytes>| async move {
                 connection
-                    .execute_with_consistency(prepared_ref, values_ref, consistency, paging_state)
+                    .execute_with_consistency(
+                        prepared_ref,
+                        values_ref,
+                        consistency,
+                        config.prepared.config.serial_consistency,
+                        paging_state,
+                    )
                     .await
             };
 

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -3,6 +3,7 @@ mod cluster;
 pub(crate) mod connection;
 mod connection_pool;
 pub mod downgrading_consistency_retry_policy;
+pub mod execution_profile;
 pub mod host_filter;
 pub mod iterator;
 pub mod load_balancing;
@@ -15,7 +16,9 @@ pub mod session;
 pub mod session_builder;
 pub mod speculative_execution;
 pub mod topology;
+
 pub use crate::frame::{Authenticator, Compression};
+pub use execution_profile::ExecutionProfile;
 pub use scylla_cql::errors;
 
 #[cfg(test)]

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -599,6 +599,7 @@ impl Session {
                                 query_ref,
                                 values_ref,
                                 consistency,
+                                query.config.serial_consistency,
                                 paging_state_ref.clone(),
                             )
                             .await
@@ -916,6 +917,7 @@ impl Session {
                             prepared,
                             values_ref,
                             consistency,
+                            prepared.config.serial_consistency,
                             paging_state_ref.clone(),
                         )
                         .await
@@ -1097,7 +1099,12 @@ impl Session {
                 },
                 |connection: Arc<Connection>, consistency: Consistency| async move {
                     connection
-                        .batch_with_consistency(batch, values_ref, consistency)
+                        .batch_with_consistency(
+                            batch,
+                            values_ref,
+                            consistency,
+                            batch.config.serial_consistency,
+                        )
                         .await
                 },
             )

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -62,56 +62,6 @@ use crate::authentication::AuthenticatorProvider;
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
 
-/// Stores default (somehow recommended) configuration options for Session.
-pub mod defaults {
-    use scylla_cql::frame::types::SerialConsistency;
-    use scylla_cql::Consistency;
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use crate::load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, TokenAwarePolicy};
-    use crate::retry_policy::{DefaultRetryPolicy, RetryPolicy};
-    use crate::speculative_execution::SpeculativeExecutionPolicy;
-    use crate::transport::execution_profile::ExecutionProfileInner;
-
-    pub fn consistency() -> Consistency {
-        Consistency::LocalQuorum
-    }
-
-    pub fn serial_consistency() -> Option<SerialConsistency> {
-        None
-    }
-
-    pub fn request_timeout() -> Option<Duration> {
-        Some(Duration::from_secs(30))
-    }
-
-    pub fn load_balancing_policy() -> Arc<dyn LoadBalancingPolicy> {
-        Arc::new(TokenAwarePolicy::new(Box::new(RoundRobinPolicy::new())))
-    }
-
-    pub fn retry_policy() -> Box<dyn RetryPolicy> {
-        Box::new(DefaultRetryPolicy::new())
-    }
-
-    pub fn speculative_execution_policy() -> Option<Arc<dyn SpeculativeExecutionPolicy>> {
-        None
-    }
-
-    impl Default for ExecutionProfileInner {
-        fn default() -> Self {
-            Self {
-                request_timeout: request_timeout(),
-                consistency: consistency(),
-                serial_consistency: serial_consistency(),
-                load_balancing_policy: load_balancing_policy(),
-                retry_policy: retry_policy(),
-                speculative_execution_policy: speculative_execution_policy(),
-            }
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone)]
 pub enum TranslationError {
     NoRuleForAddress,

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -599,7 +599,7 @@ impl Session {
                                 query_ref,
                                 values_ref,
                                 consistency,
-                                query.config.serial_consistency,
+                                query.config.serial_consistency.flatten(),
                                 paging_state_ref.clone(),
                             )
                             .await
@@ -917,7 +917,7 @@ impl Session {
                             prepared,
                             values_ref,
                             consistency,
-                            prepared.config.serial_consistency,
+                            prepared.config.serial_consistency.flatten(),
                             paging_state_ref.clone(),
                         )
                         .await
@@ -1103,7 +1103,7 @@ impl Session {
                             batch,
                             values_ref,
                             consistency,
-                            batch.config.serial_consistency,
+                            batch.config.serial_consistency.flatten(),
                         )
                         .await
                 },
@@ -1694,7 +1694,7 @@ impl Session {
         let info = Statement::default();
         let config = StatementConfig {
             is_idempotent: true,
-            serial_consistency: Some(SerialConsistency::LocalSerial),
+            serial_consistency: Some(Some(SerialConsistency::LocalSerial)),
             ..Default::default()
         };
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -66,6 +66,42 @@ use crate::authentication::AuthenticatorProvider;
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
 
+/// Stores default (somehow recommended) configuration options for Session.
+pub mod defaults {
+    use scylla_cql::frame::types::SerialConsistency;
+    use scylla_cql::Consistency;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use crate::load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, TokenAwarePolicy};
+    use crate::retry_policy::{DefaultRetryPolicy, RetryPolicy};
+    use crate::speculative_execution::SpeculativeExecutionPolicy;
+
+    pub fn consistency() -> Consistency {
+        Consistency::LocalQuorum
+    }
+
+    pub fn serial_consistency() -> Option<SerialConsistency> {
+        None
+    }
+
+    pub fn request_timeout() -> Option<Duration> {
+        Some(Duration::from_secs(30))
+    }
+
+    pub fn load_balancing_policy() -> Arc<dyn LoadBalancingPolicy> {
+        Arc::new(TokenAwarePolicy::new(Box::new(RoundRobinPolicy::new())))
+    }
+
+    pub fn retry_policy() -> Box<dyn RetryPolicy> {
+        Box::new(DefaultRetryPolicy::new())
+    }
+
+    pub fn speculative_execution_policy() -> Option<Arc<dyn SpeculativeExecutionPolicy>> {
+        None
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub enum TranslationError {
     NoRuleForAddress,

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 use super::connection::NonErrorQueryResponse;
 use super::connection::QueryResponse;
 use super::errors::{BadQuery, NewSessionError, QueryError};
+use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle, ExecutionProfileInner};
 use super::partitioner::PartitionerName;
 use super::topology::UntranslatedPeer;
 use crate::cql_to_rust::FromRow;
@@ -43,17 +44,12 @@ use crate::transport::connection::{Connection, ConnectionConfig, VerifiedKeyspac
 use crate::transport::connection_pool::PoolConfig;
 use crate::transport::host_filter::HostFilter;
 use crate::transport::iterator::{PreparedIteratorConfig, RowIterator};
-use crate::transport::load_balancing::{
-    LoadBalancingPolicy, RoundRobinPolicy, Statement, TokenAwarePolicy,
-};
+use crate::transport::load_balancing::{LoadBalancingPolicy, Statement, TokenAwarePolicy};
 use crate::transport::metrics::Metrics;
 use crate::transport::node::Node;
 use crate::transport::query_result::QueryResult;
-use crate::transport::retry_policy::{
-    DefaultRetryPolicy, QueryInfo, RetryDecision, RetryPolicy, RetrySession,
-};
+use crate::transport::retry_policy::{QueryInfo, RetryDecision, RetrySession};
 use crate::transport::speculative_execution;
-use crate::transport::speculative_execution::SpeculativeExecutionPolicy;
 use crate::transport::Compression;
 use crate::{
     batch::{Batch, BatchStatement},
@@ -76,6 +72,7 @@ pub mod defaults {
     use crate::load_balancing::{LoadBalancingPolicy, RoundRobinPolicy, TokenAwarePolicy};
     use crate::retry_policy::{DefaultRetryPolicy, RetryPolicy};
     use crate::speculative_execution::SpeculativeExecutionPolicy;
+    use crate::transport::execution_profile::ExecutionProfileInner;
 
     pub fn consistency() -> Consistency {
         Consistency::LocalQuorum
@@ -99,6 +96,19 @@ pub mod defaults {
 
     pub fn speculative_execution_policy() -> Option<Arc<dyn SpeculativeExecutionPolicy>> {
         None
+    }
+
+    impl Default for ExecutionProfileInner {
+        fn default() -> Self {
+            Self {
+                request_timeout: request_timeout(),
+                consistency: consistency(),
+                serial_consistency: serial_consistency(),
+                load_balancing_policy: load_balancing_policy(),
+                retry_policy: retry_policy(),
+                speculative_execution_policy: speculative_execution_policy(),
+            }
+        }
     }
 }
 
@@ -152,14 +162,10 @@ impl AddressTranslator for HashMap<&'static str, &'static str> {
 /// `Session` manages connections to the cluster and allows to perform queries
 pub struct Session {
     cluster: Cluster,
-    load_balancer: Arc<dyn LoadBalancingPolicy>,
+    default_execution_profile_handle: ExecutionProfileHandle,
     schema_agreement_interval: Duration,
-    retry_policy: Box<dyn RetryPolicy>,
-    speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
     metrics: Arc<Metrics>,
-    default_consistency: Consistency,
     auto_await_schema_agreement_timeout: Option<Duration>,
-    request_timeout: Option<Duration>,
     refresh_metadata_on_auto_schema_agreement: bool,
 }
 
@@ -169,15 +175,12 @@ impl std::fmt::Debug for Session {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Session")
             .field("cluster", &ClusterNeatDebug(&self.cluster))
-            .field("load_balancer", &self.load_balancer)
-            .field("schema_agreement_interval", &self.schema_agreement_interval)
-            .field("retry_policy", &self.retry_policy)
             .field(
-                "speculative_execution_policy",
-                &self.speculative_execution_policy,
+                "default_execution_profile_handle",
+                &self.default_execution_profile_handle,
             )
+            .field("schema_agreement_interval", &self.schema_agreement_interval)
             .field("metrics", &self.metrics)
-            .field("default_consistency", &self.default_consistency)
             .field(
                 "auto_await_schema_agreement_timeout",
                 &self.auto_await_schema_agreement_timeout,
@@ -201,14 +204,10 @@ pub struct SessionConfig {
     pub compression: Option<Compression>,
     pub tcp_nodelay: bool,
 
-    /// Load balancing policy used by Session
-    pub load_balancing: Arc<dyn LoadBalancingPolicy>,
+    pub default_execution_profile_handle: ExecutionProfileHandle,
 
     pub used_keyspace: Option<String>,
     pub keyspace_case_sensitive: bool,
-
-    pub retry_policy: Box<dyn RetryPolicy>,
-    pub speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
 
     /// Provide our Session with TLS
     #[cfg(feature = "ssl")]
@@ -227,8 +226,6 @@ pub struct SessionConfig {
     /// Generally, this options is best left as default (false).
     pub disallow_shard_aware_port: bool,
 
-    pub default_consistency: Consistency,
-
     /// If empty, fetch all keyspaces
     pub keyspaces_to_fetch: Vec<String>,
 
@@ -241,10 +238,6 @@ pub struct SessionConfig {
     /// Controls the timeout for the automatic wait for schema agreement after sending a schema-altering statement.
     /// If `None`, the automatic schema agreement is disabled.
     pub auto_await_schema_agreement_timeout: Option<Duration>,
-
-    /// Controls the client-side timeout for queries.
-    /// If `None`, the queries have no timeout (the driver will block indefinitely).
-    pub request_timeout: Option<Duration>,
 
     pub address_translator: Option<Arc<dyn AddressTranslator>>,
 
@@ -282,23 +275,20 @@ impl SessionConfig {
             compression: None,
             tcp_nodelay: true,
             schema_agreement_interval: Duration::from_millis(200),
-            load_balancing: Arc::new(TokenAwarePolicy::new(Box::new(RoundRobinPolicy::new()))),
+            default_execution_profile_handle: ExecutionProfile::new_from_inner(Default::default())
+                .into_handle(),
             used_keyspace: None,
             keyspace_case_sensitive: false,
-            retry_policy: Box::new(DefaultRetryPolicy),
-            speculative_execution_policy: None,
             #[cfg(feature = "ssl")]
             ssl_context: None,
             authenticator: None,
             connect_timeout: Duration::from_secs(5),
             connection_pool_size: Default::default(),
             disallow_shard_aware_port: false,
-            default_consistency: Consistency::LocalQuorum,
             keyspaces_to_fetch: Vec::new(),
             fetch_schema_metadata: true,
             keepalive_interval: None,
             auto_await_schema_agreement_timeout: Some(std::time::Duration::from_secs(60)),
-            request_timeout: Some(Duration::from_secs(30)),
             address_translator: None,
             host_filter: None,
             refresh_metadata_on_auto_schema_agreement: true,
@@ -383,7 +373,7 @@ impl SessionConfig {
             authenticator: self.authenticator.clone(),
             connect_timeout: self.connect_timeout,
             event_sender: None,
-            default_consistency: self.default_consistency,
+            default_consistency: self.default_execution_profile_handle.access().consistency,
         }
     }
 }
@@ -490,16 +480,14 @@ impl Session {
         )
         .await?;
 
+        let default_execution_profile_handle = config.default_execution_profile_handle;
+
         let session = Session {
             cluster,
-            load_balancer: config.load_balancing,
-            retry_policy: config.retry_policy,
+            default_execution_profile_handle,
             schema_agreement_interval: config.schema_agreement_interval,
-            speculative_execution_policy: config.speculative_execution_policy,
             metrics: Arc::new(Metrics::new()),
-            default_consistency: config.default_consistency,
             auto_await_schema_agreement_timeout: config.auto_await_schema_agreement_timeout,
-            request_timeout: config.request_timeout,
             refresh_metadata_on_auto_schema_agreement: config
                 .refresh_metadata_on_auto_schema_agreement,
         };
@@ -588,7 +576,13 @@ impl Session {
                 Statement::default(),
                 &query.config,
                 |node: Arc<Node>| async move { node.random_connection().await },
-                |connection: Arc<Connection>, consistency: Consistency| {
+                |connection: Arc<Connection>,
+                 consistency: Consistency,
+                 execution_profile: &ExecutionProfileInner| {
+                    let serial_consistency = query
+                        .config
+                        .serial_consistency
+                        .unwrap_or(execution_profile.serial_consistency);
                     // Needed to avoid moving query and values into async move block
                     let query_ref = &query;
                     let values_ref = &serialized_values;
@@ -599,7 +593,7 @@ impl Session {
                                 query_ref,
                                 values_ref,
                                 consistency,
-                                query.config.serial_consistency.flatten(),
+                                serial_consistency,
                                 paging_state_ref.clone(),
                             )
                             .await
@@ -711,15 +705,16 @@ impl Session {
         let query: Query = query.into();
         let serialized_values = values.serialized()?;
 
-        let retry_session = self.retry_policy.new_session();
+        let execution_profile = query
+            .get_execution_profile_handle()
+            .unwrap_or_else(|| self.get_default_execution_profile_handle())
+            .access();
 
         let span = trace_span!("Request", query = query.contents.as_str());
         RowIterator::new_for_query(
             query,
             serialized_values.into_owned(),
-            self.default_consistency,
-            retry_session,
-            self.load_balancer.clone(),
+            execution_profile,
             self.cluster.get_data(),
             self.metrics.clone(),
         )
@@ -908,17 +903,25 @@ impl Session {
                         None => node.random_connection().await,
                     }
                 },
-                |connection: Arc<Connection>, consistency: Consistency| async move {
-                    connection
-                        .execute_with_consistency(
-                            prepared,
-                            values_ref,
-                            consistency,
-                            prepared.config.serial_consistency.flatten(),
-                            paging_state_ref.clone(),
-                        )
-                        .await
-                        .and_then(QueryResponse::into_non_error_query_response)
+                |connection: Arc<Connection>,
+                 consistency: Consistency,
+                 execution_profile: &ExecutionProfileInner| {
+                    let serial_consistency = prepared
+                        .config
+                        .serial_consistency
+                        .unwrap_or(execution_profile.serial_consistency);
+                    async move {
+                        connection
+                            .execute_with_consistency(
+                                prepared,
+                                values_ref,
+                                consistency,
+                                serial_consistency,
+                                paging_state_ref.clone(),
+                            )
+                            .await
+                            .and_then(QueryResponse::into_non_error_query_response)
+                    }
                 },
             )
             .instrument(span)
@@ -991,7 +994,10 @@ impl Session {
 
         let token = self.calculate_token(&prepared, &serialized_values)?;
 
-        let retry_session = self.retry_policy.new_session();
+        let execution_profile = prepared
+            .get_execution_profile_handle()
+            .unwrap_or_else(|| self.get_default_execution_profile_handle())
+            .access();
 
         let span = trace_span!(
             "Request",
@@ -1000,10 +1006,8 @@ impl Session {
         RowIterator::new_for_prepared_statement(PreparedIteratorConfig {
             prepared,
             values: serialized_values.into_owned(),
-            default_consistency: self.default_consistency,
             token,
-            retry_session,
-            load_balancer: self.load_balancer.clone(),
+            execution_profile,
             cluster_data: self.cluster.get_data(),
             metrics: self.metrics.clone(),
         })
@@ -1091,15 +1095,23 @@ impl Session {
                         None => node.random_connection().await,
                     }
                 },
-                |connection: Arc<Connection>, consistency: Consistency| async move {
-                    connection
-                        .batch_with_consistency(
-                            batch,
-                            values_ref,
-                            consistency,
-                            batch.config.serial_consistency.flatten(),
-                        )
-                        .await
+                |connection: Arc<Connection>,
+                 consistency: Consistency,
+                 execution_profile: &ExecutionProfileInner| {
+                    let serial_consistency = batch
+                        .config
+                        .serial_consistency
+                        .unwrap_or(execution_profile.serial_consistency);
+                    async move {
+                        connection
+                            .batch_with_consistency(
+                                batch,
+                                values_ref,
+                                consistency,
+                                serial_consistency,
+                            )
+                            .await
+                    }
                 },
             )
             .instrument(trace_span!("Batch"))
@@ -1394,7 +1406,7 @@ impl Session {
         statement_info: Statement<'a>,
         statement_config: &'a StatementConfig,
         choose_connection: impl Fn(Arc<Node>) -> ConnFut,
-        do_query: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
+        do_query: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
     ) -> Result<RunQueryResult<ResT>, QueryError>
     where
         ConnFut: Future<Output = Result<Arc<Connection>, QueryError>>,
@@ -1407,10 +1419,18 @@ impl Session {
                 .as_ref()
                 .map(|hl| (&**hl, hl.log_query_start()));
 
+        let execution_profile = statement_config
+            .execution_profile_handle
+            .as_ref()
+            .unwrap_or_else(|| self.get_default_execution_profile_handle())
+            .access();
+
+        let load_balancer = &execution_profile.load_balancing_policy;
+
         let runner = async {
             let cluster_data = self.cluster.get_data();
-            self.load_balancer.update_cluster_data(&cluster_data);
-            let query_plan = self.load_balancer.plan(&statement_info, &cluster_data);
+            load_balancer.update_cluster_data(&cluster_data);
+            let query_plan = load_balancer.plan(&statement_info, &cluster_data);
 
             // If a speculative execution policy is used to run query, query_plan has to be shared
             // between different async functions. This struct helps to wrap query_plan in mutex so it
@@ -1433,9 +1453,9 @@ impl Session {
                 }
             }
 
-            let retry_policy = &self.retry_policy;
+            let retry_policy = &execution_profile.retry_policy;
 
-            let speculative_policy = self.speculative_execution_policy.as_ref();
+            let speculative_policy = execution_profile.speculative_execution_policy.as_ref();
 
             match speculative_policy {
                 Some(speculative) if statement_config.is_idempotent => {
@@ -1464,6 +1484,7 @@ impl Session {
                             &shared_query_plan,
                             &choose_connection,
                             &do_query,
+                            &execution_profile,
                             ExecuteQueryContext {
                                 is_idempotent: statement_config.is_idempotent,
                                 consistency: statement_config.consistency,
@@ -1497,6 +1518,7 @@ impl Session {
                         query_plan,
                         &choose_connection,
                         &do_query,
+                        &execution_profile,
                         ExecuteQueryContext {
                             is_idempotent: statement_config.is_idempotent,
                             consistency: statement_config.consistency,
@@ -1512,7 +1534,9 @@ impl Session {
             }
         };
 
-        let effective_timeout = statement_config.request_timeout.or(self.request_timeout);
+        let effective_timeout = statement_config
+            .request_timeout
+            .or(execution_profile.request_timeout);
         let result = match effective_timeout {
             Some(timeout) => tokio::time::timeout(timeout, runner)
                 .await
@@ -1540,7 +1564,8 @@ impl Session {
         &'a self,
         query_plan: impl Iterator<Item = Arc<Node>>,
         choose_connection: impl Fn(Arc<Node>) -> ConnFut,
-        do_query: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
+        do_query: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
+        execution_profile: &ExecutionProfileInner,
         mut context: ExecuteQueryContext<'a>,
     ) -> Option<Result<RunQueryResult<ResT>, QueryError>>
     where
@@ -1550,7 +1575,7 @@ impl Session {
     {
         let mut last_error: Option<QueryError> = None;
         let mut current_consistency: Consistency =
-            context.consistency.unwrap_or(self.default_consistency);
+            context.consistency.unwrap_or(execution_profile.consistency);
 
         'nodes_in_plan: for node in query_plan {
             let span = trace_span!("Executing query", node = node.address.to_string().as_str());
@@ -1584,13 +1609,13 @@ impl Session {
                 let attempt_id: Option<history::AttemptId> =
                     context.log_attempt_start(connection.get_connect_address());
                 let query_result: Result<ResT, QueryError> =
-                    do_query(connection, current_consistency)
+                    do_query(connection, current_consistency, execution_profile)
                         .instrument(span.clone())
                         .await;
 
                 let elapsed = query_start.elapsed();
                 if Self::should_consider_query_for_latency_measurements(
-                    &*self.load_balancer,
+                    execution_profile.load_balancing_policy.as_ref(),
                     &query_result,
                 ) {
                     let mut average_latency_guard = node.average_latency.write().unwrap();
@@ -1621,7 +1646,7 @@ impl Session {
                     error: the_error,
                     is_idempotent: context.is_idempotent,
                     consistency: LegacyConsistency::Regular(
-                        context.consistency.unwrap_or(self.default_consistency),
+                        context.consistency.unwrap_or(execution_profile.consistency),
                     ),
                 };
 
@@ -1672,7 +1697,7 @@ impl Session {
 
     async fn schema_agreement_auxiliary<ResT, QueryFut>(
         &self,
-        do_query: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
+        do_query: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
     ) -> Result<ResT, QueryError>
     where
         QueryFut: Future<Output = Result<ResT, QueryError>>,
@@ -1715,7 +1740,7 @@ impl Session {
     pub async fn fetch_schema_version(&self) -> Result<Uuid, QueryError> {
         // We ignore custom Consistency that a retry policy could decide to put here, using the default instead.
         self.schema_agreement_auxiliary(
-            |connection: Arc<Connection>, _ignored: Consistency| async move {
+            |connection: Arc<Connection>, _: Consistency, _: &ExecutionProfileInner| async move {
                 connection.fetch_schema_version().await
             },
         )
@@ -1736,6 +1761,10 @@ impl Session {
         let partition_key = calculate_partition_key(prepared, serialized_values)?;
 
         Ok(Some(partitioner_name.hash(partition_key)))
+    }
+
+    fn get_default_execution_profile_handle(&self) -> &ExecutionProfileHandle {
+        &self.default_execution_profile_handle
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -711,10 +711,7 @@ impl Session {
         let query: Query = query.into();
         let serialized_values = values.serialized()?;
 
-        let retry_session = match &query.config.retry_policy {
-            Some(policy) => policy.new_session(),
-            None => self.retry_policy.new_session(),
-        };
+        let retry_session = self.retry_policy.new_session();
 
         let span = trace_span!("Request", query = query.contents.as_str());
         RowIterator::new_for_query(
@@ -994,10 +991,7 @@ impl Session {
 
         let token = self.calculate_token(&prepared, &serialized_values)?;
 
-        let retry_session = match &prepared.config.retry_policy {
-            Some(policy) => policy.new_session(),
-            None => self.retry_policy.new_session(),
-        };
+        let retry_session = self.retry_policy.new_session();
 
         let span = trace_span!(
             "Request",
@@ -1439,16 +1433,9 @@ impl Session {
                 }
             }
 
-            let retry_policy = statement_config
-                .retry_policy
-                .as_ref()
-                .unwrap_or(&self.retry_policy);
+            let retry_policy = &self.retry_policy;
 
-            #[allow(clippy::unnecessary_lazy_evaluations)]
-            let speculative_policy = statement_config
-                .speculative_execution_policy
-                .as_ref()
-                .or_else(|| self.speculative_execution_policy.as_ref());
+            let speculative_policy = self.speculative_execution_policy.as_ref();
 
             match speculative_policy {
                 Some(speculative) if statement_config.is_idempotent => {

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -1,18 +1,16 @@
 //! SessionBuilder provides an easy way to create new Sessions
 
 use super::errors::NewSessionError;
-use super::load_balancing::LoadBalancingPolicy;
+use super::execution_profile::ExecutionProfileHandle;
 use super::session::{AddressTranslator, Session, SessionConfig};
-use super::speculative_execution::SpeculativeExecutionPolicy;
 use super::Compression;
+use crate::transport::connection_pool::PoolSize;
 use crate::transport::host_filter::HostFilter;
-use crate::transport::{connection_pool::PoolSize, retry_policy::RetryPolicy};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::authentication::{AuthenticatorProvider, PlainTextAuthenticator};
-use crate::statement::Consistency;
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
 use tracing::warn;
@@ -67,13 +65,6 @@ impl SessionBuilder {
     /// ```
     pub fn known_node(mut self, hostname: impl AsRef<str>) -> Self {
         self.config.add_known_node(hostname);
-        self
-    }
-
-    /// Specify a default consistency to be used for queries.
-    /// It's possible to override it by explicitly setting a consistency on the chosen query.
-    pub fn default_consistency(mut self, consistency: Consistency) -> Self {
-        self.config.default_consistency = consistency;
         self
     }
 
@@ -296,81 +287,30 @@ impl SessionBuilder {
         self
     }
 
-    /// Set the load balancing policy
-    /// The default is Token-aware Round-robin.
+    /// Set the default execution profile using its handle
     ///
     /// # Example
     /// ```
-    /// # use scylla::{Session, SessionBuilder};
-    /// # use scylla::transport::load_balancing::RoundRobinPolicy;
-    /// # use std::sync::Arc;
+    /// # use scylla::{statement::Consistency, ExecutionProfile, Session, SessionBuilder};
+    /// # use std::time::Duration;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let execution_profile = ExecutionProfile::builder()
+    ///     .consistency(Consistency::All)
+    ///     .request_timeout(Some(Duration::from_secs(2)))
+    ///     .build();
     /// let session: Session = SessionBuilder::new()
     ///     .known_node("127.0.0.1:9042")
-    ///     .load_balancing(Arc::new(RoundRobinPolicy::new()))
+    ///     .default_execution_profile_handle(execution_profile.into_handle())
     ///     .build()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn load_balancing(mut self, policy: Arc<dyn LoadBalancingPolicy>) -> Self {
-        self.config.load_balancing = policy;
-        self
-    }
-
-    /// Set the speculative execution policy
-    /// The default is None
-    /// # Example
-    /// ```
-    /// # extern crate scylla;
-    /// # use scylla::Session;
-    /// # use std::error::Error;
-    /// # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
-    /// use std::{sync::Arc, time::Duration};
-    /// use scylla::{
-    ///     Session,
-    ///     SessionBuilder,
-    ///     transport::speculative_execution::SimpleSpeculativeExecutionPolicy
-    /// };
-    ///
-    /// let policy = SimpleSpeculativeExecutionPolicy {
-    ///     max_retry_count: 3,
-    ///     retry_interval: Duration::from_millis(100),
-    /// };
-    ///
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .speculative_execution(Arc::new(policy))
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn speculative_execution(mut self, policy: Arc<dyn SpeculativeExecutionPolicy>) -> Self {
-        self.config.speculative_execution_policy = Some(policy);
-        self
-    }
-
-    /// Sets the [`RetryPolicy`] to use by default on queries
-    /// The default is [DefaultRetryPolicy](crate::transport::retry_policy::DefaultRetryPolicy)
-    /// It is possible to implement a custom retry policy by implementing the trait [`RetryPolicy`]
-    ///
-    /// # Example
-    /// ```
-    /// # use scylla::{Session, SessionBuilder};
-    /// # use scylla::transport::Compression;
-    /// use scylla::transport::retry_policy::DefaultRetryPolicy;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .retry_policy(Box::new(DefaultRetryPolicy::new()))
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn retry_policy(mut self, retry_policy: Box<dyn RetryPolicy + Send + Sync>) -> Self {
-        self.config.retry_policy = retry_policy;
+    pub fn default_execution_profile_handle(
+        mut self,
+        profile_handle: ExecutionProfileHandle,
+    ) -> Self {
+        self.config.default_execution_profile_handle = profile_handle;
         self
     }
 
@@ -621,27 +561,6 @@ impl SessionBuilder {
         self
     }
 
-    /// Changes client-side timeout
-    /// The default is 30 seconds.
-    ///
-    /// # Example
-    /// ```
-    /// # use scylla::{Session, SessionBuilder};
-    /// # use std::time::Duration;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .request_timeout(Some(Duration::from_millis(500)))
-    ///     .build() // Turns SessionBuilder into Session
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn request_timeout(mut self, duration: Option<std::time::Duration>) -> Self {
-        self.config.request_timeout = duration;
-        self
-    }
-
     /// Uses a custom address translator for peer addresses retrieved from the cluster.
     /// By default, no translation is performed.
     ///
@@ -763,12 +682,17 @@ impl Default for SessionBuilder {
 
 #[cfg(test)]
 mod tests {
+    use scylla_cql::frame::types::SerialConsistency;
+    use scylla_cql::Consistency;
+
     use super::SessionBuilder;
-    use crate::transport::load_balancing::RoundRobinPolicy;
-    use crate::transport::session::KnownNode;
+    use crate::load_balancing::LatencyAwarePolicy;
+    use crate::transport::execution_profile::ExecutionProfile;
+    use crate::transport::session::{defaults, KnownNode};
     use crate::transport::Compression;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
+    use std::time::Duration;
 
     #[test]
     fn default_session_builder() {
@@ -862,21 +786,6 @@ mod tests {
     }
 
     #[test]
-    fn load_balancing() {
-        let mut builder = SessionBuilder::new();
-        assert_eq!(
-            builder.config.load_balancing.name(),
-            "TokenAwarePolicy{child_policy: RoundRobinPolicy}".to_string()
-        );
-
-        builder = builder.load_balancing(Arc::new(RoundRobinPolicy::new()));
-        assert_eq!(
-            builder.config.load_balancing.name(),
-            "RoundRobinPolicy".to_string()
-        );
-    }
-
-    #[test]
     fn use_keyspace() {
         let mut builder = SessionBuilder::new();
         assert_eq!(builder.config.used_keyspace, None);
@@ -918,18 +827,65 @@ mod tests {
         assert!(builder.config.fetch_schema_metadata);
     }
 
-    #[test]
-    fn request_timeout() {
-        let mut builder = SessionBuilder::new();
+    // LatencyAwarePolicy, which is used in the test, requires presence of Tokio runtime.
+    #[tokio::test]
+    async fn execution_profile() {
+        let default_builder = SessionBuilder::new();
+        let default_execution_profile = default_builder
+            .config
+            .default_execution_profile_handle
+            .access();
         assert_eq!(
-            builder.config.request_timeout,
-            Some(std::time::Duration::from_secs(30))
+            default_execution_profile.consistency,
+            defaults::consistency()
+        );
+        assert_eq!(
+            default_execution_profile.serial_consistency,
+            defaults::serial_consistency()
+        );
+        assert_eq!(
+            default_execution_profile.request_timeout,
+            defaults::request_timeout()
+        );
+        assert_eq!(
+            default_execution_profile.load_balancing_policy.name(),
+            defaults::load_balancing_policy().name()
         );
 
-        builder = builder.request_timeout(Some(std::time::Duration::from_secs(10)));
+        let custom_consistency = Consistency::Any;
+        let custom_serial_consistency = Some(SerialConsistency::Serial);
+        let custom_load_balancing_policy = Arc::new(LatencyAwarePolicy::default());
+        let custom_timeout = Some(Duration::from_secs(1));
+        let execution_profile_handle = ExecutionProfile::builder()
+            .consistency(custom_consistency)
+            .serial_consistency(custom_serial_consistency)
+            .request_timeout(custom_timeout)
+            .load_balancing_policy(custom_load_balancing_policy)
+            .build()
+            .into_handle();
+        let builder_with_profile =
+            default_builder.default_execution_profile_handle(execution_profile_handle.clone());
+        let execution_profile = execution_profile_handle.access();
+
+        let profile_in_builder = builder_with_profile
+            .config
+            .default_execution_profile_handle
+            .access();
         assert_eq!(
-            builder.config.request_timeout,
-            Some(std::time::Duration::from_secs(10))
+            profile_in_builder.consistency,
+            execution_profile.consistency
+        );
+        assert_eq!(
+            profile_in_builder.serial_consistency,
+            execution_profile.serial_consistency
+        );
+        assert_eq!(
+            profile_in_builder.request_timeout,
+            execution_profile.request_timeout
+        );
+        assert_eq!(
+            profile_in_builder.load_balancing_policy.name(),
+            execution_profile.load_balancing_policy.name()
         );
     }
 
@@ -947,7 +903,6 @@ mod tests {
         builder = builder.known_nodes_addr(&[addr1, addr2]);
         builder = builder.compression(Some(Compression::Snappy));
         builder = builder.tcp_nodelay(true);
-        builder = builder.load_balancing(Arc::new(RoundRobinPolicy::new()));
         builder = builder.use_keyspace("ks_name", true);
         builder = builder.fetch_schema_metadata(false);
 
@@ -965,10 +920,6 @@ mod tests {
 
         assert_eq!(builder.config.compression, Some(Compression::Snappy));
         assert!(builder.config.tcp_nodelay);
-        assert_eq!(
-            builder.config.load_balancing.name(),
-            "RoundRobinPolicy".to_string()
-        );
 
         assert_eq!(builder.config.used_keyspace, Some("ks_name".to_string()));
 

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -687,8 +687,8 @@ mod tests {
 
     use super::SessionBuilder;
     use crate::load_balancing::LatencyAwarePolicy;
-    use crate::transport::execution_profile::ExecutionProfile;
-    use crate::transport::session::{defaults, KnownNode};
+    use crate::transport::execution_profile::{defaults, ExecutionProfile};
+    use crate::transport::session::KnownNode;
     use crate::transport::Compression;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;

--- a/scylla/tests/execution_profiles.rs
+++ b/scylla/tests/execution_profiles.rs
@@ -1,0 +1,307 @@
+mod utils;
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use assert_matches::assert_matches;
+use scylla::batch::BatchStatement;
+use scylla::batch::{Batch, BatchType};
+use scylla::query::Query;
+use scylla::statement::SerialConsistency;
+use scylla::{
+    frame::types::LegacyConsistency,
+    load_balancing::{LoadBalancingPolicy, Plan, Statement},
+    retry_policy::{RetryPolicy, RetrySession},
+    speculative_execution::SpeculativeExecutionPolicy,
+    test_utils::unique_keyspace_name,
+    transport::ClusterData,
+    ExecutionProfile, SessionBuilder,
+};
+use scylla_cql::Consistency;
+use tokio::sync::mpsc;
+use utils::test_with_3_node_cluster;
+
+use scylla_proxy::{
+    Condition, ProxyError, RequestReaction, RequestRule, ShardAwareness, WorkerError,
+};
+
+#[derive(Debug)]
+enum Report {
+    LoadBalancing,
+    RetryPolicy,
+    SpeculativeExecution,
+}
+
+#[derive(Debug, Clone)]
+struct BoundToPredefinedNodePolicy<const NODE: u8> {
+    profile_reporter: mpsc::UnboundedSender<(Report, u8)>,
+    consistency_reporter: mpsc::UnboundedSender<LegacyConsistency>,
+}
+
+impl<const NODE: u8> BoundToPredefinedNodePolicy<NODE> {
+    fn report_node(&self, report: Report) {
+        self.profile_reporter.send((report, NODE)).unwrap();
+    }
+    fn report_consistency(&self, c: LegacyConsistency) {
+        self.consistency_reporter.send(c).unwrap();
+    }
+}
+
+impl<const NODE: u8> LoadBalancingPolicy for BoundToPredefinedNodePolicy<NODE> {
+    fn plan<'a>(&self, _: &Statement, cluster: &'a ClusterData) -> Plan<'a> {
+        self.report_node(Report::LoadBalancing);
+        let node = cluster.get_nodes_info().iter().next().unwrap();
+        Box::new(std::iter::once(node.clone()))
+    }
+
+    fn name(&self) -> String {
+        "BoundToPredefinedNodePolicy".to_owned()
+    }
+
+    fn requires_latency_measurements(&self) -> bool {
+        false
+    }
+
+    fn update_cluster_data(&self, _: &ClusterData) {}
+}
+
+impl<const NODE: u8> RetryPolicy for BoundToPredefinedNodePolicy<NODE> {
+    fn new_session(&self) -> Box<dyn scylla::retry_policy::RetrySession> {
+        self.report_node(Report::RetryPolicy);
+        Box::new(self.clone())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
+        Box::new(self.clone())
+    }
+}
+
+impl<const NODE: u8> RetrySession for BoundToPredefinedNodePolicy<NODE> {
+    fn decide_should_retry(
+        &mut self,
+        query_info: scylla::retry_policy::QueryInfo,
+    ) -> scylla::retry_policy::RetryDecision {
+        self.report_consistency(query_info.consistency);
+        scylla::retry_policy::RetryDecision::DontRetry
+    }
+
+    fn reset(&mut self) {}
+}
+
+impl<const NODE: u8> SpeculativeExecutionPolicy for BoundToPredefinedNodePolicy<NODE> {
+    fn max_retry_count(&self, _: &scylla::speculative_execution::Context) -> usize {
+        1
+    }
+
+    fn retry_interval(&self, _: &scylla::speculative_execution::Context) -> std::time::Duration {
+        self.report_node(Report::SpeculativeExecution);
+        std::time::Duration::from_millis(200)
+    }
+}
+
+#[tokio::test]
+#[ntest::timeout(20000)]
+async fn test_execution_profiles() {
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
+
+        let (routing_tx, mut profile_rx) = mpsc::unbounded_channel();
+        let (consistency_tx, mut consistency_rx) = mpsc::unbounded_channel();
+
+        let policy1 = Arc::new(BoundToPredefinedNodePolicy::<1> {
+            profile_reporter: routing_tx.clone(),
+            consistency_reporter: consistency_tx.clone(),
+        });
+        let policy2 = Arc::new(BoundToPredefinedNodePolicy::<2> {
+            profile_reporter: routing_tx.clone(),
+            consistency_reporter: consistency_tx.clone(),
+        });
+
+        let profile1 = ExecutionProfile::builder()
+            .load_balancing_policy(policy1.clone())
+            .retry_policy(Box::new(policy1.deref().clone()))
+            .consistency(Consistency::One)
+            .serial_consistency(None)
+            .speculative_execution_policy(None)
+            .build();
+
+        let profile2 = ExecutionProfile::builder()
+            .load_balancing_policy(policy2.clone())
+            .retry_policy(Box::new(policy2.deref().clone()))
+            .consistency(Consistency::Two)
+            .serial_consistency(Some(SerialConsistency::LocalSerial))
+            .speculative_execution_policy(Some(policy2))
+            .build();
+
+        let session = SessionBuilder::new()
+            .known_node(proxy_uris[0].as_str())
+            .address_translator(Arc::new(translation_map))
+            .default_execution_profile_handle(profile1.into_handle())
+            .build()
+            .await
+            .unwrap();
+        let ks = unique_keyspace_name();
+
+        /* Prepare schema */
+        session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 3}}", ks), &[]).await.unwrap();
+        session
+            .query(
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {}.t (a int, b int, c text, primary key (a, b))",
+                    ks
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let mut query = Query::from(format!("INSERT INTO {}.t (a, b, c) VALUES (1, 2, 'abc')", ks));
+        let mut prepared = session.prepare(format!("INSERT INTO {}.t (a, b, c) VALUES (1, 2, 'abc')", ks)).await.unwrap();
+        let mut batch = Batch::new_with_statements(BatchType::Unlogged, vec![BatchStatement::Query(query.clone())]);
+
+        while profile_rx.try_recv().is_ok() {}
+        consistency_rx.try_recv().unwrap_err();
+
+
+        /* Test load balancing and retry policy */
+
+        // Run on default per-session execution profile
+        session.query(query.clone(), &[]).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
+        profile_rx.try_recv().unwrap_err();
+
+        session.execute(&prepared, &[]).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
+        profile_rx.try_recv().unwrap_err();
+
+        session.batch(&batch, ((),)).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
+        profile_rx.try_recv().unwrap_err();
+
+        // Run on query-specific execution profile
+        query.set_execution_profile_handle(Some(profile2.clone().into_handle()));
+        session.query(query.clone(), &[]).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 2), (Report::RetryPolicy, 2)) | ((Report::RetryPolicy, 2), (Report::LoadBalancing, 2)));
+        profile_rx.try_recv().unwrap_err();
+
+        prepared.set_execution_profile_handle(Some(profile2.clone().into_handle()));
+        session.execute(&prepared, &[]).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 2), (Report::RetryPolicy, 2)) | ((Report::RetryPolicy, 2), (Report::LoadBalancing, 2)));
+        profile_rx.try_recv().unwrap_err();
+
+        batch.set_execution_profile_handle(Some(profile2.clone().into_handle()));
+        session.batch(&batch, ((),)).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 2), (Report::RetryPolicy, 2)) | ((Report::RetryPolicy, 2), (Report::LoadBalancing, 2)));
+        profile_rx.try_recv().unwrap_err();
+
+        // Run again on default per-session execution profile
+        query.set_execution_profile_handle(None);
+        session.query(query.clone(), &[]).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
+        profile_rx.try_recv().unwrap_err();
+
+        prepared.set_execution_profile_handle(None);
+        session.execute(&prepared, &[]).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
+        profile_rx.try_recv().unwrap_err();
+
+        batch.set_execution_profile_handle(None);
+        session.batch(&batch, ((),)).await.unwrap();
+        let report1 = profile_rx.recv().await.unwrap();
+        let report2 = profile_rx.recv().await.unwrap();
+        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
+        profile_rx.try_recv().unwrap_err();
+
+
+        /* Test consistencies */
+        let rule_overloaded = RequestRule(
+            Condition::True,
+            RequestReaction::forge().overloaded()
+        );
+        for i in 0..=2 {
+            running_proxy.running_nodes[i].change_request_rules(Some(vec![rule_overloaded.clone()]));
+        }
+
+        profile_rx.try_recv().unwrap_err();
+
+        // Run non-LWT on default per-session execution profile
+        session.query(query.clone(), &[]).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::One));
+        consistency_rx.try_recv().unwrap_err();
+
+        session.execute(&prepared, &[]).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::One));
+        consistency_rx.try_recv().unwrap_err();
+
+        session.batch(&batch, ((),)).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::One));
+        consistency_rx.try_recv().unwrap_err();
+
+        // Run on statement-specific execution profile
+        query.set_execution_profile_handle(Some(profile2.clone().into_handle()));
+        session.query(query.clone(), &[]).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Two));
+        consistency_rx.try_recv().unwrap_err();
+
+        prepared.set_execution_profile_handle(Some(profile2.clone().into_handle()));
+        session.execute(&prepared, &[]).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Two));
+        consistency_rx.try_recv().unwrap_err();
+
+        batch.set_execution_profile_handle(Some(profile2.clone().into_handle()));
+        session.batch(&batch, ((),)).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Two));
+        consistency_rx.try_recv().unwrap_err();
+
+        // Run with statement-set specific options
+        query.set_consistency(Consistency::Three);
+        session.query(query.clone(), &[]).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Three));
+        consistency_rx.try_recv().unwrap_err();
+
+        prepared.set_consistency(Consistency::Three);
+        session.execute(&prepared, &[]).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Three));
+        consistency_rx.try_recv().unwrap_err();
+
+        batch.set_consistency(Consistency::Three);
+        session.batch(&batch, ((),)).await.unwrap_err();
+        let report_consistency = consistency_rx.recv().await.unwrap();
+        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Three));
+        consistency_rx.try_recv().unwrap_err();
+
+        for i in 0..=2 {
+            running_proxy.running_nodes[i].change_request_rules(None);
+        }
+
+        running_proxy
+    }).await;
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/lwt_optimisation.rs
+++ b/scylla/tests/lwt_optimisation.rs
@@ -3,8 +3,8 @@ mod utils;
 use scylla::frame::types;
 use scylla::retry_policy::FallthroughRetryPolicy;
 use scylla::transport::session::Session;
-use scylla::SessionBuilder;
 use scylla::{frame::protocol_features::ProtocolFeatures, test_utils::unique_keyspace_name};
+use scylla::{ExecutionProfile, SessionBuilder};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use utils::test_with_3_node_cluster;
@@ -43,10 +43,15 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
             prepared_rx
         });
 
+        let handle = ExecutionProfile::builder()
+            .retry_policy(Box::new(FallthroughRetryPolicy))
+            .build()
+            .into_handle();
+
         // DB preparation phase
         let session: Session = SessionBuilder::new()
             .known_node(proxy_uris[0].as_str())
-            .retry_policy(Box::new(FallthroughRetryPolicy))
+            .default_execution_profile_handle(handle)
             .address_translator(Arc::new(translation_map))
             .build()
             .await


### PR DESCRIPTION
We introduce execution profiles, a concept analogous to that found in other drivers. They enable batch changes of configuration options for queries, as well as for whole sessions.
Fixes: #354

## Considerations yet to be done

- Other drivers support saving execution profiles to a file and loading them from there. Do we want such a feature?
- There is also an idea that a file could be set up to be read periodically; once it is read, the execution profile the file contains is loaded and reapplied to all statements and sessions associated with its handle. This way we would enable changing execution profiles during runtime, without changing code at all. Is this feature worth it?


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
