### PR TITLE
make: do not use --verbose flag with cargo build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ dockerized-test: up wait-for-cluster
 
 .PHONY: build
 build:
-	cargo build --verbose --examples
+	cargo build --examples
 
 .PHONY: docs
 docs:


### PR DESCRIPTION
## Description

Running `make build` is too verbose to use it as a convenient `cargo build` replacement. Removing `--verbose` flag helps a lot - the terminal is not flooded with messages about which compiler flags are being used etc.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
