### PR TITLE
Remove uses of deprecated NaiveData::from_ymd/hms

### DIFF
--- a/docs/source/data-types/date.md
+++ b/docs/source/data-types/date.md
@@ -17,7 +17,7 @@ use scylla::IntoTypedRows;
 use chrono::naive::NaiveDate;
 
 // Insert some date into the table
-let to_insert: NaiveDate = NaiveDate::from_ymd(2021, 3, 24);
+let to_insert: NaiveDate = NaiveDate::from_ymd_opt(2021, 3, 24).unwrap();
 session
     .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
     .await?;

--- a/examples/cql-time-types.rs
+++ b/examples/cql-time-types.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
         .await?;
 
     // Dates in the range -262145-1-1 to 262143-12-31 can be represented using chrono::NaiveDate
-    let example_date: NaiveDate = NaiveDate::from_ymd(2020, 2, 20);
+    let example_date: NaiveDate = NaiveDate::from_ymd_opt(2020, 2, 20).unwrap();
 
     session
         .query("INSERT INTO ks.dates (d) VALUES (?)", (example_date,))

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -377,19 +377,19 @@ mod tests {
     fn naive_date_from_cql() {
         let unix_epoch: CqlValue = CqlValue::Date(2_u32.pow(31));
         assert_eq!(
-            Ok(NaiveDate::from_ymd(1970, 1, 1)),
+            Ok(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()),
             NaiveDate::from_cql(unix_epoch)
         );
 
         let before_epoch: CqlValue = CqlValue::Date(2_u32.pow(31) - 30);
         assert_eq!(
-            Ok(NaiveDate::from_ymd(1969, 12, 2)),
+            Ok(NaiveDate::from_ymd_opt(1969, 12, 2).unwrap()),
             NaiveDate::from_cql(before_epoch)
         );
 
         let after_epoch: CqlValue = CqlValue::Date(2_u32.pow(31) + 30);
         assert_eq!(
-            Ok(NaiveDate::from_ymd(1970, 1, 31)),
+            Ok(NaiveDate::from_ymd_opt(1970, 1, 31).unwrap()),
             NaiveDate::from_cql(after_epoch)
         );
 

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -135,7 +135,9 @@ impl CqlValue {
         let days_since_epoch =
             chrono::Duration::days(date_days.into()) - chrono::Duration::days(1 << 31);
 
-        NaiveDate::from_ymd(1970, 1, 1).checked_add_signed(days_since_epoch)
+        NaiveDate::from_ymd_opt(1970, 1, 1)
+            .unwrap()
+            .checked_add_signed(days_since_epoch)
     }
 
     pub fn as_duration(&self) -> Option<chrono::Duration> {
@@ -1222,7 +1224,7 @@ mod tests {
         super::deser_cql_value(&ColumnType::Date, &mut [1, 2, 3, 4, 5].as_ref()).unwrap_err();
 
         // 2^31 when converted to NaiveDate is 1970-01-01
-        let unix_epoch: NaiveDate = NaiveDate::from_ymd(1970, 1, 1);
+        let unix_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
         let date: CqlValue =
             super::deser_cql_value(&ColumnType::Date, &mut 2_u32.pow(31).to_be_bytes().as_ref())
                 .unwrap();
@@ -1230,7 +1232,7 @@ mod tests {
         assert_eq!(date.as_date().unwrap(), unix_epoch);
 
         // 2^31 - 30 when converted to NaiveDate is 1969-12-02
-        let before_epoch: NaiveDate = NaiveDate::from_ymd(1969, 12, 2);
+        let before_epoch: NaiveDate = NaiveDate::from_ymd_opt(1969, 12, 2).unwrap();
         let date: CqlValue = super::deser_cql_value(
             &ColumnType::Date,
             &mut (2_u32.pow(31) - 30).to_be_bytes().as_ref(),
@@ -1240,7 +1242,7 @@ mod tests {
         assert_eq!(date.as_date().unwrap(), before_epoch);
 
         // 2^31 + 30 when converted to NaiveDate is 1970-01-31
-        let after_epoch: NaiveDate = NaiveDate::from_ymd(1970, 1, 31);
+        let after_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 31).unwrap();
         let date: CqlValue = super::deser_cql_value(
             &ColumnType::Date,
             &mut (2_u32.pow(31) + 30).to_be_bytes().as_ref(),

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -285,7 +285,7 @@ impl Value for BigDecimal {
 impl Value for NaiveDate {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         buf.put_i32(4);
-        let unix_epoch = NaiveDate::from_ymd(1970, 1, 1);
+        let unix_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
 
         let days: u32 = self
             .signed_duration_since(unix_epoch)

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -30,12 +30,12 @@ fn basic_serialization() {
 #[test]
 fn naive_date_serialization() {
     // 1970-01-31 is 2^31
-    let unix_epoch: NaiveDate = NaiveDate::from_ymd(1970, 1, 1);
+    let unix_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
     assert_eq!(serialized(unix_epoch), vec![0, 0, 0, 4, 128, 0, 0, 0]);
     assert_eq!(2_u32.pow(31).to_be_bytes(), [128, 0, 0, 0]);
 
     // 1969-12-02 is 2^31 - 30
-    let before_epoch: NaiveDate = NaiveDate::from_ymd(1969, 12, 2);
+    let before_epoch: NaiveDate = NaiveDate::from_ymd_opt(1969, 12, 2).unwrap();
     assert_eq!(
         serialized(before_epoch),
         vec![0, 0, 0, 4, 127, 255, 255, 226]
@@ -43,7 +43,7 @@ fn naive_date_serialization() {
     assert_eq!((2_u32.pow(31) - 30).to_be_bytes(), [127, 255, 255, 226]);
 
     // 1970-01-31 is 2^31 + 30
-    let after_epoch: NaiveDate = NaiveDate::from_ymd(1970, 1, 31);
+    let after_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 31).unwrap();
     assert_eq!(serialized(after_epoch), vec![0, 0, 0, 4, 128, 0, 0, 30]);
     assert_eq!((2_u32.pow(31) + 30).to_be_bytes(), [128, 0, 0, 30]);
 }

--- a/scylla/src/history.rs
+++ b/scylla/src/history.rs
@@ -481,8 +481,8 @@ mod tests {
     fn set_one_time(mut history: StructuredHistory) -> StructuredHistory {
         let the_time: TimePoint = DateTime::<Utc>::from_utc(
             NaiveDateTime::new(
-                NaiveDate::from_ymd(2022, 2, 22),
-                NaiveTime::from_hms(20, 22, 22),
+                NaiveDate::from_ymd_opt(2022, 2, 22).unwrap(),
+                NaiveTime::from_hms_opt(20, 22, 22).unwrap(),
             ),
             Utc,
         );

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -202,18 +202,39 @@ async fn test_naive_date() {
     let session: Session = init_test("naive_date", "date").await;
 
     let min_naive_date: NaiveDate = NaiveDate::MIN;
-    assert_eq!(min_naive_date, NaiveDate::from_ymd(-262144, 1, 1));
+    assert_eq!(
+        min_naive_date,
+        NaiveDate::from_ymd_opt(-262144, 1, 1).unwrap()
+    );
 
     let max_naive_date: NaiveDate = NaiveDate::MAX;
-    assert_eq!(max_naive_date, NaiveDate::from_ymd(262143, 12, 31));
+    assert_eq!(
+        max_naive_date,
+        NaiveDate::from_ymd_opt(262143, 12, 31).unwrap()
+    );
 
     let tests = [
         // Basic test values
-        ("0000-01-01", Some(NaiveDate::from_ymd(0000, 1, 1))),
-        ("1970-01-01", Some(NaiveDate::from_ymd(1970, 1, 1))),
-        ("2020-03-07", Some(NaiveDate::from_ymd(2020, 3, 7))),
-        ("1337-04-05", Some(NaiveDate::from_ymd(1337, 4, 5))),
-        ("-0001-12-31", Some(NaiveDate::from_ymd(-1, 12, 31))),
+        (
+            "0000-01-01",
+            Some(NaiveDate::from_ymd_opt(0000, 1, 1).unwrap()),
+        ),
+        (
+            "1970-01-01",
+            Some(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()),
+        ),
+        (
+            "2020-03-07",
+            Some(NaiveDate::from_ymd_opt(2020, 3, 7).unwrap()),
+        ),
+        (
+            "1337-04-05",
+            Some(NaiveDate::from_ymd_opt(1337, 4, 5).unwrap()),
+        ),
+        (
+            "-0001-12-31",
+            Some(NaiveDate::from_ymd_opt(-1, 12, 31).unwrap()),
+        ),
         // min/max values allowed by NaiveDate
         ("-262144-01-01", Some(min_naive_date)),
         // NOTICE: dropped for Cassandra 4 compatibility
@@ -438,12 +459,12 @@ async fn test_time() {
 async fn test_timestamp() {
     let session: Session = init_test("timestamp_tests", "timestamp").await;
 
-    //let epoch_date = NaiveDate::from_ymd(1970, 1, 1);
+    //let epoch_date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
 
-    //let before_epoch = NaiveDate::from_ymd(1333, 4, 30);
+    //let before_epoch = NaiveDate::from_ymd_opt(1333, 4, 30).unwrap();
     //let before_epoch_offset = before_epoch.signed_duration_since(epoch_date);
 
-    //let after_epoch = NaiveDate::from_ymd(2020, 3, 8);
+    //let after_epoch = NaiveDate::from_ymd_opt(2020, 3, 8).unwrap();
     //let after_epoch_offset = after_epoch.signed_duration_since(epoch_date);
 
     let tests = [


### PR DESCRIPTION
The functions `NaiveData::from_ymd` and `from_hms` have been deprecated. This causes the CI to fail
during clippy check.
(see https://github.com/scylladb/scylla-rust-driver/actions/runs/3462054587/jobs/5780445658)

Change all occurences of `from_ymd` and `from_hms` to `from_ymd_opt` and `from_hms_opt`.

The `_opt` variant requires adding an `unwrap()`, but this doesn't decrease safety.
In all cases where there is an `unwrap()` the old code would've panicked.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
