### PR TITLE
Fix #599

### DIFF
--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -250,7 +250,7 @@ pub trait BatchValuesIterator<'a> {
     fn skip_next(&mut self) -> Option<()>;
 }
 
-/// Implements `BatchValuesIterator` from an `Iterator` over things that implement `ValueList`
+/// Implements `BatchValuesIterator` from an `Iterator` over references to things that implement `ValueList`
 ///
 /// Essentially used internally by this lib to provide implementors of `BatchValuesIterator` for cases
 /// that always serialize the same concrete `ValueList` type

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -223,6 +223,10 @@ pub trait BatchValues: for<'r> BatchValuesGatWorkaround<'r> {}
 impl<T: for<'r> BatchValuesGatWorkaround<'r> + ?Sized> BatchValues for T {}
 
 pub trait BatchValuesGatWorkaround<'r, ImplicitBounds = &'r Self> {
+    /// For some unknown reason, this type, when not resolved to a concrete type for a given async function,
+    /// cannot live across await boundaries while maintaining the corresponding future `Send`, unless `'r: 'static`
+    ///
+    /// See <https://github.com/scylladb/scylla-rust-driver/issues/599> for more details
     type BatchValuesIter: BatchValuesIterator<'r>;
     fn batch_values_iter(&'r self) -> Self::BatchValuesIter;
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1030,10 +1030,7 @@ impl Session {
         // If users batch statements by shard, they will be rewarded with full shard awareness
 
         // Extract first serialized_value
-        let mut batch_values_iter_for_first_serialized_value = values.batch_values_iter();
-        let first_serialized_value = batch_values_iter_for_first_serialized_value
-            .next_serialized()
-            .transpose()?;
+        let first_serialized_value = values.batch_values_iter().next_serialized().transpose()?;
         let first_serialized_value = first_serialized_value.as_deref();
         let statement_info = match (first_serialized_value, batch.statements.first()) {
             (Some(first_serialized_value), Some(BatchStatement::PreparedStatement(ps))) => {


### PR DESCRIPTION
Fixes #599

For some unknown reason, the `BatchValuesIter` associated type, when not resolved to a concrete type for a given async function, cannot live across await boundaries while maintaining the corresponding future `Send`, unless `'r: 'static`

It is consequently required to drop that variable before any `await` in `Session::batch`.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
