### PR TITLE
cql_to_rust: expose impl_from_cql_value_from_method macro

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -93,6 +93,10 @@ name = "custom_load_balancing_policy"
 path = "custom_load_balancing_policy.rs"
 
 [[example]]
+name = "custom_deserialization"
+path = "custom_deserialization.rs"
+
+[[example]]
 name = "tower"
 path = "tower.rs"
 

--- a/examples/custom_deserialization.rs
+++ b/examples/custom_deserialization.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use scylla::cql_to_rust::{FromCqlVal, FromCqlValError};
+use scylla::frame::response::result::CqlValue;
+use scylla::macros::impl_from_cql_value_from_method;
+use scylla::{Session, SessionBuilder};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+
+    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
+    session
+        .query(
+            "CREATE TABLE IF NOT EXISTS ks.t (pk int PRIMARY KEY, v text)",
+            &[],
+        )
+        .await?;
+
+    session
+        .query("INSERT INTO ks.t (pk, v) VALUES (1, 'asdf')", ())
+        .await?;
+
+    // You can implement FromCqlVal for your own types
+    #[derive(PartialEq, Eq, Debug)]
+    struct MyType(String);
+
+    impl FromCqlVal<CqlValue> for MyType {
+        fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+            Ok(Self(
+                cql_val.into_string().ok_or(FromCqlValError::BadCqlType)?,
+            ))
+        }
+    }
+
+    let (v,) = session
+        .query("SELECT v FROM ks.t WHERE pk = 1", ())
+        .await?
+        .single_row_typed::<(MyType,)>()?;
+    assert_eq!(v, MyType("asdf".to_owned()));
+
+    // If you defined an extension trait for CqlValue then you can use
+    // the `impl_from_cql_value_from_method` macro to turn it into
+    // a FromCqlValue impl
+    #[derive(PartialEq, Eq, Debug)]
+    struct MyOtherType(String);
+
+    trait CqlValueExt {
+        fn into_my_other_type(self) -> Option<MyOtherType>;
+    }
+
+    impl CqlValueExt for CqlValue {
+        fn into_my_other_type(self) -> Option<MyOtherType> {
+            Some(MyOtherType(self.into_string()?))
+        }
+    }
+
+    impl_from_cql_value_from_method!(MyOtherType, into_my_other_type);
+
+    let (v,) = session
+        .query("SELECT v FROM ks.t WHERE pk = 1", ())
+        .await?
+        .single_row_typed::<(MyOtherType,)>()?;
+    assert_eq!(v, MyOtherType("asdf".to_owned()));
+
+    println!("Ok.");
+
+    Ok(())
+}

--- a/scylla-cql/src/macros.rs
+++ b/scylla-cql/src/macros.rs
@@ -15,3 +15,5 @@ pub use scylla_macros::ValueList;
 
 // Reexports for derive(IntoUserType)
 pub use bytes::{BufMut, Bytes, BytesMut};
+
+pub use crate::impl_from_cql_value_from_method;


### PR DESCRIPTION
This commit exposes the existing `impl_from_cql_val` macro as `impl_from_cql_value_from_method` macro. It was originally used to define implementations of the FromCqlValue macro based on CqlValue's existing methods, but it can be useful outside the crate itself too - namely, users can define more methods for CqlValue via extension traits.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
