### PR TITLE
Cassandra 3 nodes CI & proxy features enhancements

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -13,18 +13,16 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      cassandra:
-        image: cassandra
-        ports:
-          - 9042:9042
-    env:
-      CDC: 'disabled'
     steps:
     - uses: actions/checkout@v2
+    - name: Setup 3-node Cassandra cluster
+      run: |
+        docker-compose -f test/cluster/cassandra/docker-compose.yml up -d
       # A separate step for building to separate measuring time of compilation and testing
     - name: Build the project
       run: cargo build --verbose --tests
     - name: Run tests on cassandra
-      # test threads must be one because else database tests will run in parallel and will result in flaky tests
-      run: cargo test --verbose -- --test-threads=1 --skip test_views_in_schema_info --skip retries_occur --skip speculative_execution_is_fired
+      run: |
+        CDC='disabled' SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose -- --skip test_views_in_schema_info
+    - name: Stop cluster
+      run: docker-compose -f test/cluster/cassandra/docker-compose.yml down

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use scylla_cql::frame::frame_errors::{FrameError, ParseError};
 use scylla_cql::frame::protocol_features::ProtocolFeatures;
@@ -98,6 +100,21 @@ impl ResponseFrame {
         Ok(ResponseFrame {
             params: request_params.for_response(),
             opcode: ResponseOpcode::Error,
+            body: buf.freeze(),
+        })
+    }
+
+    /// Creates a Supported response frame with given supported options.
+    pub fn forged_supported(
+        request_params: FrameParams,
+        options: &HashMap<String, Vec<String>>,
+    ) -> Result<Self, ParseError> {
+        let mut buf = BytesMut::new();
+        types::write_string_multimap(options, &mut buf)?;
+
+        Ok(ResponseFrame {
+            params: request_params.for_response(),
+            opcode: ResponseOpcode::Supported,
             body: buf.freeze(),
         })
     }

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -74,6 +74,7 @@ where
     T: Value + FromCqlVal<CqlValue> + FromStr + Debug + Clone + PartialEq,
 {
     let session: Session = init_test(type_name, type_name).await;
+    session.await_schema_agreement().await.unwrap();
 
     for test in tests.iter() {
         let insert_string_encoded_value =

--- a/scylla/tests/retries.rs
+++ b/scylla/tests/retries.rs
@@ -144,29 +144,24 @@ async fn speculative_execution_is_fired() {
 
         info!("--------------------- second query - 0 and 2 nodes not responding  ----------------");
         running_proxy.running_nodes[0]
-            .change_request_rules(Some(vec![drop_frame_rule.clone()]))
-            .await;
+            .change_request_rules(Some(vec![drop_frame_rule.clone()]));
         running_proxy.running_nodes[2]
-            .change_request_rules(Some(vec![drop_frame_rule.clone()]))
-            .await;
+            .change_request_rules(Some(vec![drop_frame_rule.clone()]));
 
         session.query(q.clone(), (2,)).await.unwrap();
 
         info!("--------------------- third query - 0 and 1 nodes not responding  ----------------");
         running_proxy.running_nodes[2]
-            .change_request_rules(None)
-            .await;
+            .change_request_rules(None);
         running_proxy.running_nodes[1]
-            .change_request_rules(Some(vec![drop_frame_rule.clone()]))
-            .await;
+            .change_request_rules(Some(vec![drop_frame_rule.clone()]));
 
         session.query(q.clone(), (1,)).await.unwrap();
 
 
         info!("--------------------- fourth query - all nodes not responding  ----------------");
         running_proxy.running_nodes[2]
-        .change_request_rules(Some(vec![drop_frame_rule]))
-        .await;
+        .change_request_rules(Some(vec![drop_frame_rule]));
 
         tokio::select! {
             res = session.query(q, (0,)) => panic!("Rules did not work: received response {:?}", res),
@@ -224,25 +219,21 @@ async fn retries_occur() {
 
         info!("--------------------- second query - 0 and 2 nodes not responding  ----------------");
         running_proxy.running_nodes[0]
-            .change_request_rules(Some(vec![forge_error_rule.clone()]))
-            .await;
+            .change_request_rules(Some(vec![forge_error_rule.clone()]));
         running_proxy.running_nodes[2]
-            .change_request_rules(Some(vec![forge_error_rule.clone()]))
-            .await;
+            .change_request_rules(Some(vec![forge_error_rule.clone()]));
 
         session.query(q.clone(), (2,)).await.unwrap();
 
         info!("--------------------- third query - all nodes not responding  ----------------");
         running_proxy.running_nodes[1]
-            .change_request_rules(Some(vec![forge_error_rule]))
-            .await;
+            .change_request_rules(Some(vec![forge_error_rule]));
 
         session.query(q.clone(), (1,)).await.unwrap_err();
 
         info!("--------------------- fourth query - 0 and 1 nodes not responding  ----------------");
         running_proxy.running_nodes[2]
-        .change_request_rules(None)
-        .await;
+        .change_request_rules(None);
 
         session.query(q, (1,)).await.unwrap();
 

--- a/test/cluster/cassandra/docker-compose.yml
+++ b/test/cluster/cassandra/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '2.4' # 2.4 is the last version that supports depends_on conditions for service health
+
+networks:
+  public:
+    name: scylla_rust_driver_public
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.42.0.0/16
+services:
+  cassandra1:
+    image: cassandra
+    healthcheck:
+        test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
+        interval: 5s
+        timeout: 5s
+        retries: 60
+    networks:
+      public:
+        ipv4_address: 172.42.0.2
+    environment:
+      - CASSANDRA_BROADCAST_ADDRESS=172.42.0.2
+  cassandra2:
+    image: cassandra
+    healthcheck:
+        test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
+        interval: 5s
+        timeout: 5s
+        retries: 60
+    networks:
+      public:
+        ipv4_address: 172.42.0.3
+    environment:
+      - CASSANDRA_BROADCAST_ADDRESS=172.42.0.3
+      - CASSANDRA_SEEDS=172.42.0.2
+    depends_on:
+      cassandra1:
+        condition: service_healthy
+  cassandra3:
+    image: cassandra
+    healthcheck:
+        test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
+        interval: 5s
+        timeout: 5s
+        retries: 60
+    networks:
+      public:
+        ipv4_address: 172.42.0.4
+    environment:
+      - CASSANDRA_BROADCAST_ADDRESS=172.42.0.4
+      - CASSANDRA_SEEDS=172.42.0.2,172.42.0.3
+    depends_on:
+      cassandra2:
+        condition: service_healthy


### PR DESCRIPTION
I've made our CI Cassandra cluster consist of 3 nodes (instead of only 1). This will let us test freely on both C* and Scylla in case that the test assumes 3 nodes present; we will no longer have to opt those tests out for C*.

Moveover, I've made several improvements to proxy:
- rule changing is no longer async
- Reaction prettier printing
- Support frames can be conveniently forged
- ShardAwareness::QueryNode falls back to Unaware in case of shard info not present at node

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
