### PR TITLE
transport: fix clippy warnings

### DIFF
--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -561,7 +561,7 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
 
-        rows.sort();
+        rows.sort_unstable();
         assert_eq!(rows, vec![(1, 1000), (2, 2000)]);
     }
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1934,7 +1934,7 @@ async fn test_unprepared_reprepare_in_execute() {
         .unwrap()
         .map(|r| r.unwrap())
         .collect();
-    all_rows.sort();
+    all_rows.sort_unstable();
     assert_eq!(all_rows, vec![(1, 2, 3), (1, 3, 2)]);
 }
 
@@ -2056,7 +2056,7 @@ async fn test_unprepared_reprepare_in_batch() {
         .unwrap()
         .map(|r| r.unwrap())
         .collect();
-    all_rows.sort();
+    all_rows.sort_unstable();
     assert_eq!(all_rows, vec![(1, 2, 3), (1, 3, 2), (4, 5, 6), (4, 6, 5)]);
 }
 
@@ -2124,7 +2124,7 @@ async fn test_unprepared_reprepare_in_caching_session_execute() {
         .unwrap()
         .map(|r| r.unwrap())
         .collect();
-    all_rows.sort();
+    all_rows.sort_unstable();
     assert_eq!(all_rows, vec![(1, 2, 3), (1, 3, 2)]);
 }
 


### PR DESCRIPTION
Running clippy 0.1.60 on our code results in a set of warnings about our `sort` usage:

```
error: used `sort` on primitive type `tuple`
   --> scylla/src/transport/caching_session.rs:564:9
    |
564 |         rows.sort();
    |         ^^^^^^^^^^^ help: try: `rows.sort_unstable()`
    |
    = note: `-D clippy::stable-sort-primitive` implied by `-D warnings`
    = note: an unstable sort would perform faster without any observable difference for this data type
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive

...
```
This pull request applies the above suggestions .

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
