### PR TITLE
transport: reset the node up/down marker on topology update

### DIFF
--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -472,8 +472,8 @@ impl ClusterWorker {
                                 // later as planned.
 
                                 match status {
-                                    StatusChangeEvent::Down(addr) => self.change_node_down_marker(addr, true),
-                                    StatusChangeEvent::Up(addr) => self.change_node_down_marker(addr, false),
+                                    StatusChangeEvent::Down(addr) => self.change_node_up_marker(addr, false),
+                                    StatusChangeEvent::Up(addr) => self.change_node_up_marker(addr, true),
                                 }
                                 continue;
                             },
@@ -514,7 +514,7 @@ impl ClusterWorker {
         }
     }
 
-    fn change_node_down_marker(&mut self, addr: SocketAddr, is_down: bool) {
+    fn change_node_up_marker(&mut self, addr: SocketAddr, is_up: bool) {
         let cluster_data = self.cluster_data.load_full();
 
         let node = match cluster_data.known_peers.get(&addr) {
@@ -525,7 +525,7 @@ impl ClusterWorker {
             }
         };
 
-        node.change_down_marker(is_down);
+        node.change_up_marker(is_up);
     }
 
     async fn handle_use_keyspace_request(

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -320,6 +320,9 @@ impl ClusterData {
                 }
             };
 
+            // Reset the up marker to what the source of truth says.
+            node.change_up_marker(peer.up);
+
             new_known_peers.insert(peer.address, node.clone());
 
             if let Some(dc) = &node.datacenter {

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -182,6 +182,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(*id),
                 tokens: Vec::new(),
                 untranslated_address: Some(tests::id_to_invalid_addr(*id)),
+                up: true,
             })
             .collect::<Vec<_>>();
 
@@ -238,6 +239,7 @@ mod tests {
                     Token { value: 500 },
                 ],
                 untranslated_address: None,
+                up: true,
             },
             Peer {
                 datacenter: Some("eu".into()),
@@ -249,6 +251,7 @@ mod tests {
                     Token { value: 300 },
                 ],
                 untranslated_address: None,
+                up: true,
             },
             Peer {
                 datacenter: Some("us".into()),
@@ -256,6 +259,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(3),
                 tokens: vec![Token { value: 200 }, Token { value: 400 }],
                 untranslated_address: None,
+                up: true,
             },
         ];
 

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -305,6 +305,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(1),
                 tokens: vec![Token { value: 50 }, Token { value: 200 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(1)),
+                up: true,
             },
             Peer {
                 datacenter: Some("waw".into()),
@@ -312,6 +313,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(2),
                 tokens: vec![Token { value: 150 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(2)),
+                up: true,
             },
             Peer {
                 datacenter: Some("waw".into()),
@@ -319,6 +321,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(3),
                 tokens: vec![Token { value: 510 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(3)),
+                up: true,
             },
             Peer {
                 datacenter: Some("waw".into()),
@@ -326,6 +329,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(4),
                 tokens: vec![Token { value: 300 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(4)),
+                up: true,
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -333,6 +337,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(5),
                 tokens: vec![Token { value: 100 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(5)),
+                up: true,
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -340,6 +345,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(6),
                 tokens: vec![Token { value: 250 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(6)),
+                up: true,
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -347,6 +353,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(7),
                 tokens: vec![Token { value: 500 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(7)),
+                up: true,
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -354,6 +361,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(8),
                 tokens: vec![Token { value: 400 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(8)),
+                up: true,
             },
         ];
 

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -63,7 +63,7 @@ pub struct Node {
     // If the node is filtered out by the host filter, this will be None
     pool: Option<NodeConnectionPool>,
 
-    down_marker: AtomicBool,
+    up_marker: AtomicBool,
 }
 
 impl Node {
@@ -91,8 +91,8 @@ impl Node {
             datacenter,
             rack,
             pool,
-            down_marker: false.into(),
             average_latency: RwLock::new(None),
+            up_marker: true.into(),
         }
     }
 
@@ -114,8 +114,8 @@ impl Node {
         self.get_pool()?.random_connection()
     }
 
-    pub fn is_down(&self) -> bool {
-        self.down_marker.load(Ordering::Relaxed)
+    pub fn is_up(&self) -> bool {
+        self.up_marker.load(Ordering::Relaxed)
     }
 
     /// Returns a boolean which indicates whether this node was is enabled.
@@ -125,8 +125,8 @@ impl Node {
         self.pool.is_some()
     }
 
-    pub(crate) fn change_down_marker(&self, is_down: bool) {
-        self.down_marker.store(is_down, Ordering::Relaxed);
+    pub(crate) fn change_up_marker(&self, is_up: bool) {
+        self.up_marker.store(is_up, Ordering::Relaxed);
     }
 
     pub(crate) async fn use_keyspace(


### PR DESCRIPTION
For node up/down markers to work reliably, a source of truth other than CQL events is needed. That's because the CQL events delivery is prone to connection failures. By quering `system.cluster_status` table from time to time, we are able to get the true information about the status of nodes in the cluster.

This pull request implements this quering and resets each node up/down marker value to the information received from the periodic quering.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
