### PR TITLE
connection: send DRIVER_VERSION in STARTUP message

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1146,6 +1146,7 @@ pub async fn open_connection(
         source_port,
         config,
         Some("scylla-rust-driver".to_string()),
+        option_env!("CARGO_PKG_VERSION").map(|v| v.to_string()),
     )
     .await
 }
@@ -1155,6 +1156,7 @@ pub async fn open_named_connection(
     source_port: Option<u16>,
     config: ConnectionConfig,
     driver_name: Option<String>,
+    driver_version: Option<String>,
 ) -> Result<(Connection, ErrorReceiver), QueryError> {
     // TODO: shouldn't all this logic be in Connection::new?
     let (mut connection, error_receiver) =
@@ -1201,6 +1203,9 @@ pub async fn open_named_connection(
     options.insert("CQL_VERSION".to_string(), "4.0.0".to_string()); // FIXME: hardcoded values
     if let Some(name) = driver_name {
         options.insert("DRIVER_NAME".to_string(), name);
+    }
+    if let Some(version) = driver_version {
+        options.insert("DRIVER_VERSION".to_string(), version);
     }
     if let Some(compression) = &config.compression {
         let compression_str = compression.to_string();


### PR DESCRIPTION
When sending a `STARTUP` message while establishing the connection, this change properly populates the `DRIVER_VERSION` field.

Before this change, `SELECT * FROM system.clients` would allow a user to see that Scylla Rust Driver has connected to the cluster, but the version number was `null`.

The version number is fetched compile-time by invoking option_env! and reading a standard `CARGO_PKG_VERSION` environment variable.

Example contents of system.clients after change:
```
>> `select driver_name, driver_version from system.clients;`
| Text("scylla-rust-driver")| Text("0.6.1")   |
| Text("scylla-rust-driver")| Text("0.6.1")   |
```

Fixes #610

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
