### PR TITLE
book: fix book workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Build the book using the script
       run: python3 docs/build_book.py
     - name: Run book tests
-      run: mdbook test -L target/debug/deps docs
+      run: mdbook test docs -L target/debug/deps


### PR DESCRIPTION
The book workflow suddenly started failing at the `mdbook test` step.

After a brief investigation it looks like `mdbook` doesn't work properly when flags are passed before the main argument.

Because of this the old command:
```bash
mdbook test -L target/debug/deps docs
```

Started failing as if the `docs` argument wasn't passed at all. It used the default book directory and couldn't find a book there because the book is in the `docs` directory.
Error: Couldn't open SUMMARY.md in "/home/runner/work/scylla-rust-driver/scylla-rust-driver/src

On the other hand this works properly:
```bash
mdbook test docs -L target/debug/deps
```

So I changed the order of arguments to fix the problem.
