### PR TITLE
Identify nodes by host id instead of IPs

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -27,7 +27,7 @@ histogram = "0.6.9"
 num_enum = "0.5"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
-uuid = "1.0"
+uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8.3"
 thiserror = "1.0"
 itertools = "0.10.0"

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -310,6 +310,7 @@ impl ClusterData {
                 _ => {
                     let is_enabled = host_filter.map_or(true, |f| f.accept(&peer));
                     Arc::new(Node::new(
+                        peer.host_id,
                         peer.address,
                         pool_config.clone(),
                         peer.datacenter,

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -304,7 +304,11 @@ impl ClusterData {
             // Changing rack/datacenter but not ip address seems improbable
             // so we can just create new node and connections then
             let node: Arc<Node> = match known_peers.get(&peer.address) {
-                Some(node) if node.datacenter == peer.datacenter && node.rack == peer.rack => {
+                Some(node)
+                    if node.datacenter == peer.datacenter
+                        && node.rack == peer.rack
+                        && node.host_id == peer.host_id =>
+                {
                     node.clone()
                 }
                 _ => {

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -112,6 +112,8 @@ fn slice_rotated_left<T>(slice: &[T], mid: usize) -> impl Iterator<Item = &T> + 
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
 
     use crate::transport::node::TimestampedAverage;
@@ -191,6 +193,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(*id),
                 tokens: Vec::new(),
                 untranslated_address: Some(tests::id_to_invalid_addr(*id)),
+                host_id: Uuid::new_v4(),
             })
             .collect::<Vec<_>>();
 
@@ -248,6 +251,7 @@ mod tests {
                     Token { value: 500 },
                 ],
                 untranslated_address: None,
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("eu".into()),
@@ -259,6 +263,7 @@ mod tests {
                     Token { value: 300 },
                 ],
                 untranslated_address: None,
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("us".into()),
@@ -266,6 +271,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(3),
                 tokens: vec![Token { value: 200 }, Token { value: 400 }],
                 untranslated_address: None,
+                host_id: Uuid::new_v4(),
             },
         ];
 

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -192,6 +192,8 @@ impl LoadBalancingPolicy for TokenAwarePolicy {
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
 
     use crate::load_balancing::tests::DumbPolicy;
@@ -359,6 +361,7 @@ mod tests {
                     Token { value: 500 },
                 ],
                 untranslated_address: Some(tests::id_to_invalid_addr(1)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("eu".into()),
@@ -370,6 +373,7 @@ mod tests {
                     Token { value: 300 },
                 ],
                 untranslated_address: Some(tests::id_to_invalid_addr(2)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("us".into()),
@@ -377,6 +381,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(3),
                 tokens: vec![Token { value: 200 }, Token { value: 400 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(3)),
+                host_id: Uuid::new_v4(),
             },
         ];
 
@@ -437,6 +442,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(1),
                 tokens: vec![Token { value: 50 }, Token { value: 200 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(1)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("waw".into()),
@@ -444,6 +450,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(2),
                 tokens: vec![Token { value: 150 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(2)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("waw".into()),
@@ -451,6 +458,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(3),
                 tokens: vec![Token { value: 510 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(3)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("waw".into()),
@@ -458,6 +466,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(4),
                 tokens: vec![Token { value: 300 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(4)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -465,6 +474,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(5),
                 tokens: vec![Token { value: 100 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(5)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -472,6 +482,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(6),
                 tokens: vec![Token { value: 250 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(6)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -479,6 +490,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(7),
                 tokens: vec![Token { value: 500 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(7)),
+                host_id: Uuid::new_v4(),
             },
             Peer {
                 datacenter: Some("her".into()),
@@ -486,6 +498,7 @@ mod tests {
                 address: tests::id_to_invalid_addr(8),
                 tokens: vec![Token { value: 400 }],
                 untranslated_address: Some(tests::id_to_invalid_addr(8)),
+                host_id: Uuid::new_v4(),
             },
         ];
 

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 /// Node represents a cluster node along with it's data and connections
 use crate::routing::{Sharder, Token};
 use crate::transport::connection::Connection;
@@ -54,6 +56,7 @@ impl TimestampedAverage {
 /// Node represents a cluster node along with it's data and connections
 #[derive(Debug)]
 pub struct Node {
+    pub host_id: Uuid,
     pub address: SocketAddr,
     pub datacenter: Option<String>,
     pub rack: Option<String>,
@@ -75,6 +78,7 @@ impl Node {
     /// `datacenter` - optional datacenter name
     /// `rack` - optional rack name
     pub(crate) fn new(
+        host_id: Uuid,
         address: SocketAddr,
         pool_config: PoolConfig,
         datacenter: Option<String>,
@@ -87,6 +91,7 @@ impl Node {
         });
 
         Node {
+            host_id,
             address,
             datacenter,
             rack,

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -54,6 +54,10 @@ impl TimestampedAverage {
 }
 
 /// Node represents a cluster node along with it's data and connections
+///
+/// Note: if a Node changes its address (the optionally translated address),
+/// then it is not longer represented by the same instance of Node struct,
+/// but instead a new instance is created (for implementation reasons).
 #[derive(Debug)]
 pub struct Node {
     pub host_id: Uuid,

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -167,7 +167,7 @@ impl Node {
 
 impl PartialEq for Node {
     fn eq(&self, other: &Self) -> bool {
-        self.address == other.address
+        self.host_id == other.host_id
     }
 }
 
@@ -175,6 +175,6 @@ impl Eq for Node {}
 
 impl Hash for Node {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.address.hash(state);
+        self.host_id.hash(state);
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -399,11 +399,10 @@ pub enum RunQueryResult<ResT> {
 /// Represents a CQL session, which can be used to communicate
 /// with the database
 impl Session {
-    // because it's more convenient
     /// Estabilishes a CQL session with the database
     ///
     /// Usually it's easier to use [SessionBuilder](crate::transport::session_builder::SessionBuilder)
-    /// instead of calling `Session::connect` directly
+    /// instead of calling `Session::connect` directly, because it's more convenient.
     /// # Arguments
     /// * `config` - Connection configuration - known nodes, Compression, etc.
     /// Must contain at least one known node.

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -49,6 +49,7 @@ pub struct Metadata {
     pub keyspaces: HashMap<String, Keyspace>,
 }
 
+#[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
 pub struct Peer {
     pub host_id: Uuid,
     pub address: SocketAddr,

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -61,6 +61,7 @@ pub struct Peer {
 
 #[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
 pub struct UntranslatedPeer {
+    pub host_id: Uuid,
     pub untranslated_address: SocketAddr,
 }
 
@@ -544,7 +545,7 @@ async fn query_peers(
             (false, Some(translator)) => {
                 // We use the provided translator and skip the peer if there is no rule for translating it.
                 (Some(untranslated_address),
-                    match translator.translate_address(&UntranslatedPeer {untranslated_address}).await {
+                    match translator.translate_address(&UntranslatedPeer {host_id, untranslated_address}).await {
                         Ok(address) => address,
                         Err(err) => {
                             warn!("Could not translate address {}; TranslationError: {:?}; node therefore skipped.",


### PR DESCRIPTION
As a corresponding change has been merged into Scylla itself, we should adjust as well.
Moreover, for Serverless Cloud host IDs are the only valid way of identifying nodes.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
