### PR TITLE
Add serialize and deserialize support for DateTime<Utc> and secret

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -32,3 +32,5 @@ criterion = "0.3"
 name = "benchmark"
 harness = false
 
+[features]
+secret = []

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 num_enum = "0.5"
 tokio = { version = "1.12", features = ["io-util", "time"] }
+secrecy = "0.7.0"
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -500,6 +500,24 @@ mod tests {
     }
 
     #[test]
+    fn datetime_from_cql() {
+        use chrono::{DateTime, Duration, Utc};
+        let naivedatetime_utc = NaiveDate::from_ymd_opt(2022, 12, 31)
+            .unwrap()
+            .and_hms_opt(2, 0, 0)
+            .unwrap();
+        let datetime_utc = DateTime::<Utc>::from_utc(naivedatetime_utc, Utc);
+
+        assert_eq!(
+            datetime_utc,
+            DateTime::<Utc>::from_cql(CqlValue::Timestamp(Duration::milliseconds(
+                datetime_utc.timestamp_millis()
+            )))
+            .unwrap()
+        );
+    }
+
+    #[test]
     fn uuid_from_cql() {
         let test_uuid: Uuid = Uuid::parse_str("8e14e760-7fa8-11eb-bc66-000000000001").unwrap();
 

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -159,6 +159,7 @@ impl FromCqlVal<CqlValue> for DateTime<Utc> {
     }
 }
 
+#[cfg(feature = "secret")]
 impl<V: FromCqlVal<CqlValue> + Zeroize> FromCqlVal<CqlValue> for Secret<V> {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         Ok(Secret::new(FromCqlVal::from_cql(cql_val)?))

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -4,6 +4,7 @@ use bytes::BufMut;
 use chrono::prelude::*;
 use chrono::Duration;
 use num_bigint::BigInt;
+use secrecy::{ExposeSecret, Secret, Zeroize};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;
@@ -377,6 +378,20 @@ impl Value for Time {
         buf.put_i32(8);
         buf.put_i64(self.0.num_nanoseconds().ok_or(ValueTooBig)?);
         Ok(())
+    }
+}
+
+impl Value for DateTime<Utc> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        buf.put_i32(8);
+        buf.put_i64(self.timestamp_millis());
+        Ok(())
+    }
+}
+
+impl<V: Value + Zeroize> Value for Secret<V> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        self.expose_secret().serialize(buf)
     }
 }
 

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -4,7 +4,6 @@ use bytes::BufMut;
 use chrono::prelude::*;
 use chrono::Duration;
 use num_bigint::BigInt;
-use secrecy::{ExposeSecret, Secret, Zeroize};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;
@@ -14,6 +13,9 @@ use uuid::Uuid;
 
 use super::response::result::CqlValue;
 use super::types::vint_encode;
+
+#[cfg(feature = "secret")]
+use secrecy::{ExposeSecret, Secret, Zeroize};
 
 /// Every value being sent in a query must implement this trait
 /// serialize() should write the Value as [bytes] to the provided buffer

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -389,6 +389,7 @@ impl Value for DateTime<Utc> {
     }
 }
 
+#[cfg(feature = "secret")]
 impl<V: Value + Zeroize> Value for Secret<V> {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         self.expose_secret().serialize(buf)

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -108,10 +108,11 @@ fn datetime_serialization() {
     let max_time: i64 = 24 * 60 * 60 * 1_000_000_000 - 1;
 
     for test_val in &[0, 1, 15, 18463, max_time, max_time + 16] {
-        let native_datetime = NaiveDateTime::from_timestamp(
+        let native_datetime = NaiveDateTime::from_timestamp_opt(
             *test_val / 1000,
             ((*test_val % 1000) as i32 * 1_000_000) as u32,
-        );
+        )
+        .expect("invalid or out-of-range datetime");
         let test_datetime = DateTime::<Utc>::from_utc(native_datetime, Utc);
         let bytes: Vec<u8> = serialized(test_datetime);
 

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -102,6 +102,28 @@ fn timestamp_serialization() {
 }
 
 #[test]
+fn datetime_serialization() {
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    // Datetime is milliseconds since unix epoch represented as i64
+    let max_time: i64 = 24 * 60 * 60 * 1_000_000_000 - 1;
+
+    for test_val in &[0, 1, 15, 18463, max_time, max_time + 16] {
+        let native_datetime = NaiveDateTime::from_timestamp(
+            *test_val / 1000,
+            ((*test_val % 1000) as i32 * 1_000_000) as u32,
+        );
+        let test_datetime = DateTime::<Utc>::from_utc(native_datetime, Utc);
+        let bytes: Vec<u8> = serialized(test_datetime);
+
+        let mut expected_bytes: Vec<u8> = vec![0, 0, 0, 8];
+        expected_bytes.extend_from_slice(&test_val.to_be_bytes());
+
+        assert_eq!(bytes, expected_bytes);
+        assert_eq!(expected_bytes.len(), 12);
+    }
+}
+
+#[test]
 fn timeuuid_serialization() {
     // A few random timeuuids generated manually
     let tests = [


### PR DESCRIPTION
Implement FromCqlVal and Value for DateTime<Utc> and secrecy::Secret.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
