### PR TITLE
Automated proxy addresses in tests

### DIFF
--- a/scylla-proxy/src/lib.rs
+++ b/scylla-proxy/src/lib.rs
@@ -8,3 +8,5 @@ pub use actions::{
 pub use errors::{DoorkeeperError, ProxyError, WorkerError};
 pub use frame::{RequestFrame, RequestOpcode, ResponseFrame, ResponseOpcode};
 pub use proxy::{Node, Proxy, RunningProxy, ShardAwareness};
+
+pub use proxy::get_exclusive_local_address;

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1557,7 +1557,6 @@ mod tests {
     use crate::{IntoTypedRows, SessionBuilder};
     use std::collections::HashMap;
     use std::net::SocketAddr;
-    use std::str::FromStr;
     use std::sync::Arc;
 
     // Just like resolve_hostname in session.rs
@@ -1698,7 +1697,7 @@ mod tests {
 
         let lwt_optimisation_entry = format!("{}={}", LWT_OPTIMIZATION_META_BIT_MASK_KEY, MASK);
 
-        let proxy_addr = SocketAddr::from_str("127.0.0.54:9042").unwrap();
+        let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
 
         let config = ConnectionConfig::default();
 

--- a/scylla/tests/lwt_optimisation.rs
+++ b/scylla/tests/lwt_optimisation.rs
@@ -20,7 +20,7 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
     // This is just to increase the likelyhood that only intended prepared statements (which contain this mark) are captures by the proxy.
     const MAGIC_MARK: i32 = 123;
 
-    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, 220, |proxy_uris, translation_map, mut running_proxy| async move {
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
 
         // We set up proxy, so that it informs us (via supported_rx) about cluster's Supported features (including LWT optimisation mark),
         // and also passes us information about which node was queried (via prepared_rx).

--- a/scylla/tests/retries.rs
+++ b/scylla/tests/retries.rs
@@ -20,7 +20,7 @@ use scylla_proxy::{
 async fn speculative_execution_is_fired() {
     const TIMEOUT_PER_REQUEST: Duration = Duration::from_millis(1000);
 
-    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, 217, |proxy_uris, translation_map, mut running_proxy| async move {
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
         // DB preparation phase
         let session: Session = SessionBuilder::new()
             .known_node(proxy_uris[0].as_str())
@@ -98,7 +98,7 @@ async fn speculative_execution_is_fired() {
 #[tokio::test]
 #[ntest::timeout(30000)]
 async fn retries_occur() {
-    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, 210, |proxy_uris, translation_map, mut running_proxy| async move {
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
 
         // DB preparation phase
         let session: Session = SessionBuilder::new()

--- a/scylla/tests/utils/mod.rs
+++ b/scylla/tests/utils/mod.rs
@@ -40,7 +40,6 @@ impl LoadBalancingPolicy for FixedOrderLoadBalancer {
 
 pub async fn test_with_3_node_cluster<F, Fut>(
     shard_awareness: ShardAwareness,
-    first_proxy_node_addr_last_octet: u16,
     test: F,
 ) -> Result<(), ProxyError>
 where
@@ -49,11 +48,11 @@ where
 {
     init_logger();
     let real1_uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
-    let proxy1_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet);
+    let proxy1_uri = format!("{}:9042", scylla_proxy::get_exclusive_local_address());
     let real2_uri = env::var("SCYLLA_URI2").unwrap_or_else(|_| "127.0.0.2:9042".to_string());
-    let proxy2_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet + 1);
+    let proxy2_uri = format!("{}:9042", scylla_proxy::get_exclusive_local_address());
     let real3_uri = env::var("SCYLLA_URI3").unwrap_or_else(|_| "127.0.0.3:9042".to_string());
-    let proxy3_uri = format!("127.0.0.{}:9042", first_proxy_node_addr_last_octet + 2);
+    let proxy3_uri = format!("{}:9042", scylla_proxy::get_exclusive_local_address());
 
     let real1_addr = SocketAddr::from_str(real1_uri.as_str()).unwrap();
     let proxy1_addr = SocketAddr::from_str(proxy1_uri.as_str()).unwrap();


### PR DESCRIPTION
## Pre-review checklist
As tests are run concurrently on a single process, so addresses for proxy instances used in them can be assigned automatically in a non-colliding way. To this end, one atomic suffices.

Fixes: #586

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
