### PR TITLE
secrecy: Features and dependencies cleanup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
       run: cargo clippy --verbose --examples --tests
     - name: Cargo check without features
       run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
+    - name: Cargo check with secrecy feature
+      run: cargo check --manifest-path "scylla/Cargo.toml" --features "secret"
     - name: Build scylla-cql
       run: cargo build --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml"
     - name: Build

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 num_enum = "0.5"
 tokio = { version = "1.12", features = ["io-util", "time"] }
-secrecy = "0.7.0"
+secrecy = { version = "0.7.0", optional = true }
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"
@@ -33,4 +33,4 @@ name = "benchmark"
 harness = false
 
 [features]
-secret = []
+secret = ["secrecy"]

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -16,6 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 defaults = []
 ssl = ["tokio-openssl", "openssl"]
+secret = ["scylla-cql/secret"]
 
 [dependencies]
 scylla-macros = { version = "0.1.2", path = "../scylla-macros"}


### PR DESCRIPTION
First, secrecy is now built as `scylla-cql` dependency only if the corresponding feature is requested. Secondly, the corresponding feature that turns on the secrecy-related serialization has been added to scylla crate.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
