### PR TITLE
data-types: add CqlDuration as the Rust equivalent of CQL Duration

### DIFF
--- a/docs/source/SUMMARY.md
+++ b/docs/source/SUMMARY.md
@@ -34,6 +34,7 @@
     - [Date](data-types/date.md)
     - [Time](data-types/time.md)
     - [Timestamp](data-types/timestamp.md)
+    - [Duration](data-types/duration.md)
     - [Decimal](data-types/decimal.md)
     - [Varint](data-types/varint.md)
     - [List, Set, Map](data-types/collections.md)

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -24,6 +24,7 @@ Database types and their Rust equivalents:
 * `Date` <----> `chrono::NaiveDate`, `u32`
 * `Time` <----> `chrono::Duration`
 * `Timestamp` <----> `chrono::Duration`
+* `Duration` <----> `value::CqlDuration`
 * `Decimal` <----> `bigdecimal::Decimal`
 * `Varint` <----> `num_bigint::BigInt`
 * `List` <----> `Vec<T>`
@@ -47,6 +48,7 @@ Database types and their Rust equivalents:
    date
    time
    timestamp
+   duration
    decimal
    varint
    collections

--- a/docs/source/data-types/duration.md
+++ b/docs/source/data-types/duration.md
@@ -1,0 +1,26 @@
+# Duration
+`Duration` is represented as [`CqlDuration`](https://docs.rs/scylla/latest/scylla/frame/value/struct.CqlDuration.html)\
+
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::IntoTypedRows;
+use scylla::frame::value::CqlDuration;
+
+// Insert some ip address into the table
+let to_insert: CqlDuration = CqlDuration { months: 1, days: 2, nanoseconds: 3 };
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
+    .await?;
+
+// Read inet from the table
+if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
+    for row in rows.into_typed::<(CqlDuration,)>() {
+        let (cql_duration,): (CqlDuration,) = row?;
+    }
+}
+# Ok(())
+# }
+```

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -1,5 +1,5 @@
 use super::result::{CqlValue, Row};
-use crate::frame::value::Counter;
+use crate::frame::value::{Counter, CqlDuration};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
 use num_bigint::BigInt;
@@ -135,6 +135,7 @@ impl_from_cql_value_from_method!(IpAddr, as_inet); // IpAddr::from_cql<CqlValue>
 impl_from_cql_value_from_method!(Uuid, as_uuid); // Uuid::from_cql<CqlValue>
 impl_from_cql_value_from_method!(BigDecimal, into_decimal); // BigDecimal::from_cql<CqlValue>
 impl_from_cql_value_from_method!(Duration, as_duration); // Duration::from_cql<CqlValue>
+impl_from_cql_value_from_method!(CqlDuration, as_cql_duration); // CqlDuration::from_cql<CqlValue>
 
 impl FromCqlVal<CqlValue> for crate::frame::value::Time {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
@@ -475,6 +476,20 @@ mod tests {
             timestamp_i64,
             i64::from_cql(CqlValue::Timestamp(Duration::milliseconds(timestamp_i64))).unwrap()
         )
+    }
+
+    #[test]
+    fn cql_duration_from_cql() {
+        use crate::frame::value::CqlDuration;
+        let cql_duration = CqlDuration {
+            months: 3,
+            days: 2,
+            nanoseconds: 1,
+        };
+        assert_eq!(
+            cql_duration,
+            CqlDuration::from_cql(CqlValue::Duration(cql_duration)).unwrap(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
CqlDuration has de facto already been the Rust type mapping for the CQL type `duration`, but was missing a `from_cql` impl. This patch adds the missing impl and adds the type mapping to the documentation.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
~~- [ ] I added appropriate `Fixes:` annotations to PR description.~~
