### PR TITLE
caching_session: use custom hasher instead of ahash in tests

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -51,7 +51,6 @@ ntest = "0.8.1"
 criterion = "0.3"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 assert_matches = "1.5.0"
-ahash = { version = "0.8.0", default-features = false, features=["compile-time-rng"] }
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
Currently, we are importing the `ahash` crate for only one reason: to test that CachingSession works with custom hasher implementations. The custom hasher quality doesn't matter at all in this test, so it's very easy to write own implementation for testing purposes, rendering the dependency on `ahash` obsolete.

The change was prompted by a report from one of our users which use a fork of the driver and managed to trigger a bug in cargo - most likely this one: https://github.com/rust-lang/cargo/issues/7463 . The most likely cause was that the project specified a different, non-compatible version of ahash in the dependencies than the one in scylla's dev-dependencies. While it doesn't fix the cargo bug and it can still happen with other dev-dependencies, the bug should no longer happen with conflicting `ahash`. Moreover, removing an unneeded depdencency from a project is a good motivation in itself.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
