### PR TITLE
treewide: appease cargo doc

### DIFF
--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -26,7 +26,7 @@ pub enum CqlTypeError {
     InvalidNumberOfElements(i32),
 }
 
-/// This trait defines a way to convert CqlValue or Option<CqlValue> into some rust type
+/// This trait defines a way to convert CqlValue or `Option<CqlValue>` into some rust type
 // We can't use From trait because impl From<Option<CqlValue>> for String {...}
 // is forbidden since neither From nor String are defined in this crate
 pub trait FromCqlVal<T>: Sized {

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -91,7 +91,7 @@ pub type SerializedResult<'a> = Result<Cow<'a, SerializedValues>, SerializeValue
 /// gets serialized and but into request
 pub trait ValueList {
     /// Provides a view of ValueList as SerializedValues
-    /// returns Cow<SerializedValues> to make impl ValueList for SerializedValues efficient
+    /// returns `Cow<SerializedValues>` to make impl ValueList for SerializedValues efficient
     fn serialized(&self) -> SerializedResult<'_>;
 
     fn write_to_request(&self, buf: &mut impl BufMut) -> Result<(), SerializeValuesError> {
@@ -495,7 +495,7 @@ impl Value for String {
     }
 }
 
-/// Every Option<T> can be serialized as None -> NULL, Some(val) -> val.serialize()
+/// Every `Option<T>` can be serialized as None -> NULL, Some(val) -> val.serialize()
 impl<T: Value> Value for Option<T> {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         match self {

--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -671,7 +671,7 @@ impl Reaction for ResponseReaction {
     }
 }
 
-/// Describes what to with the given <something> (frame),
+/// Describes what to with the given \<something\> (frame),
 /// how to transform it and after what delay.
 #[derive(Clone)]
 pub struct Action<TFrom, TTo> {

--- a/scylla/src/transport/load_balancing/token_aware.rs
+++ b/scylla/src/transport/load_balancing/token_aware.rs
@@ -314,7 +314,7 @@ mod tests {
             },
         ];
 
-        let policy = TokenAwarePolicy::new(Box::new(RoundRobinPolicy::default()));
+        let policy = TokenAwarePolicy::new(Box::<RoundRobinPolicy>::default());
         let cluster = mock_cluster_data_for_token_aware_tests();
 
         let plans = (0..15)


### PR DESCRIPTION
The new version of cargo doc started complaining about unescaped `<` and `>` signs because they looked like html tags. This commit gets rid of this complaint either by putting them into `backticks` if they are a part of some rust code mentioned in a docstring, or escaping them with a backslash in other cases.

Also contains a bonus commit that fixes one missed clippy lint.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [ ] ~All commits compile, pass static checks and pass test.~ (not really possible with our current, sad state of CI)
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
