### PR TITLE
CI: bump MSRV to 1.65

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
-  rust_min: 1.59.0 # <- Update this when bumping up MSRV
+  rust_min: 1.65.0 # <- Update this when bumping up MSRV
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # ScyllaDB Rust Driver
 
 [![Crates.io](https://img.shields.io/crates/v/scylla.svg)](https://crates.io/crates/scylla) [![docs.rs](https://docs.rs/scylla/badge.svg)](https://docs.rs/scylla)
-[![minimum rustc version](https://img.shields.io/badge/rustc-1.59-orange.svg)](https://crates.io/crates/scylla)
+[![minimum rustc version](https://img.shields.io/badge/rustc-1.65-orange.svg)](https://crates.io/crates/scylla)
 
 This is a client-side driver for [ScyllaDB] written in pure Rust with a fully async API using [Tokio].
 Although optimized for ScyllaDB, the driver is also compatible with [Apache Cassandra®].
@@ -65,7 +65,7 @@ Ongoing efforts:
 Please join the `#rust-driver` channel on [ScyllaDB Slack] to discuss any issues or questions you might have.
 
 ## Supported Rust Versions
-Our driver's minimum supported Rust version (MSRV) is 1.59.0. Any changes will be explicitly published and will only happen during major releases.
+Our driver's minimum supported Rust version (MSRV) is 1.65.0. Any changes will be explicitly published and will only happen during major releases.
 
 ## Reference Documentation
 


### PR DESCRIPTION
Bumping MSRV due to those reasons:

- The newest version of tokio (1.24.1) doesn't seem to compile with Rust 1.59 and `-D warnings`. Fortunately, 1.65 doesn't seem to be affected.
- #596 needs GATs, which were introduced in 1.65
- #614 would like to use the new `dep:` syntax for optional features.

The version 1.65 is also not the newest, released about 2.5 months ago since the time this commit message was written. Although our MSRV policy allows us to bump MSRV in major releases - and I understand going from 0.x to 0.(x+1) as such a change - choosing an older version has the benefit that, at the time of release of the next driver version, some of the users will probably already have migrated to a Rust version supported by the driver.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [ ] ~All commits compile, pass static checks and pass test.~ not really, but it should make the situation better
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
