### PR TITLE
Downgrade Cassandra version for CI

### DIFF
--- a/test/cluster/cassandra/docker-compose.yml
+++ b/test/cluster/cassandra/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
         - subnet: 172.42.0.0/16
 services:
   cassandra1:
-    image: cassandra
+    image: cassandra:4.0.7
     healthcheck:
         test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
         interval: 5s
@@ -21,8 +21,10 @@ services:
         ipv4_address: 172.42.0.2
     environment:
       - CASSANDRA_BROADCAST_ADDRESS=172.42.0.2
+      - HEAP_NEWSIZE=512M
+      - MAX_HEAP_SIZE=2048M
   cassandra2:
-    image: cassandra
+    image: cassandra:4.0.7
     healthcheck:
         test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
         interval: 5s
@@ -34,11 +36,13 @@ services:
     environment:
       - CASSANDRA_BROADCAST_ADDRESS=172.42.0.3
       - CASSANDRA_SEEDS=172.42.0.2
+      - HEAP_NEWSIZE=512M
+      - MAX_HEAP_SIZE=2048M
     depends_on:
       cassandra1:
         condition: service_healthy
   cassandra3:
-    image: cassandra
+    image: cassandra:4.0.7
     healthcheck:
         test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
         interval: 5s
@@ -50,6 +54,8 @@ services:
     environment:
       - CASSANDRA_BROADCAST_ADDRESS=172.42.0.4
       - CASSANDRA_SEEDS=172.42.0.2,172.42.0.3
+      - HEAP_NEWSIZE=512M
+      - MAX_HEAP_SIZE=2048M
     depends_on:
       cassandra2:
         condition: service_healthy


### PR DESCRIPTION
The cassandra tests were run on the latest version of Cassandra 4.1.0 and most probably the version contains some bugs as some tests were flaky. This PR pins version 4.0.7 for creating a 3-node Cassandra cluster, which solves the flakiness problem, however, the root cause of the problem is still unknown.
Additionally, memory flags `HEAP_NEWSIZE=512M` and `MAX_HEAP_SIZE=2048M` are added for each node creation as the GitHub Actions Linux virtual machine has a RAM limit of 7GB.

Fixes: #620 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
