### PR TITLE
cql_to_rust: impl FromCqlValue for Date

### DIFF
--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -137,6 +137,15 @@ impl_from_cql_value_from_method!(BigDecimal, into_decimal); // BigDecimal::from_
 impl_from_cql_value_from_method!(Duration, as_duration); // Duration::from_cql<CqlValue>
 impl_from_cql_value_from_method!(CqlDuration, as_cql_duration); // CqlDuration::from_cql<CqlValue>
 
+impl FromCqlVal<CqlValue> for crate::frame::value::Date {
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+        match cql_val {
+            CqlValue::Date(d) => Ok(crate::frame::value::Date(d)),
+            _ => Err(FromCqlValError::BadCqlType),
+        }
+    }
+}
+
 impl FromCqlVal<CqlValue> for crate::frame::value::Time {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         match cql_val {
@@ -455,6 +464,20 @@ mod tests {
 
         let max_date: CqlValue = CqlValue::Date(u32::MAX);
         assert!(NaiveDate::from_cql(max_date).is_err());
+    }
+
+    #[test]
+    fn date_from_cql() {
+        use crate::frame::value::Date;
+
+        let unix_epoch: CqlValue = CqlValue::Date(2_u32.pow(31));
+        assert_eq!(Ok(Date(2_u32.pow(31))), Date::from_cql(unix_epoch));
+
+        let min_date: CqlValue = CqlValue::Date(0);
+        assert_eq!(Ok(Date(0)), Date::from_cql(min_date));
+
+        let max_date: CqlValue = CqlValue::Date(u32::MAX);
+        assert_eq!(Ok(Date(u32::MAX)), Date::from_cql(max_date));
     }
 
     #[test]


### PR DESCRIPTION
The driver supports serializing and deserializing between the `date` CQL type and the `chrono::NaiveDate` type. However, the `NaiveDate` type is not always sufficient as it can't represent the whole range of values the `date` CQL type can. For that purpose, we provide a `Date` type that is able to represent all CQL values of `date` type.

Until now, it was only possible to serialize `Date`. This commit adds a missing FromCqlValue impl necessary for deserialization.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
