### PR TITLE
CI/Makefile: disable `uninlined_format_args` clippy lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
-      run: cargo clippy --verbose --examples --tests
+      run: cargo clippy --verbose --examples --tests -- -Aclippy::uninlined_format_args
     - name: Cargo check without features
       run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
     - name: Cargo check with secrecy feature

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ check-without-features:
 
 .PHONY: clippy
 clippy:
-	RUSTFLAGS=-Dwarnings cargo clippy --examples --tests
+	RUSTFLAGS=-Dwarnings cargo clippy --examples --tests -- -Aclippy::uninlined_format_args
 
 .PHONY: test
 test: up wait-for-cluster


### PR DESCRIPTION
New version of clippy introduced the `uninlined_format_args` lint which recommends putting variable names directly into format strings, like this:

    let what = "world";
    println!("Hello, {what}!");

    // Instead of:
    println!("Hello, {}!", what);

The problem with this feature is that rust-analyzer does not support renaming variables inside format strings yet. The lint has been downgraded to pedantic level and will most likely appear as such in the next release.

This commit disables the new lint in the CI and local Makefile. We can turn it on again after this feature gets better support from rust-analyzer.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
