### PR TITLE
Replace Connection::query_all with Connection::query_iter

### DIFF
--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -131,23 +131,6 @@ impl QueryResult {
             .enumerate()
             .find(|(_id, spec)| spec.name == name)
     }
-
-    /// This function is used to merge results of multiple paged queries into one.\
-    /// other is the result of a new paged query.\
-    /// It is merged with current result kept in self.\
-    pub(crate) fn merge_with_next_page_res(&mut self, other: QueryResult) {
-        if let Some(other_rows) = other.rows {
-            match &mut self.rows {
-                Some(self_rows) => self_rows.extend(other_rows),
-                None => self.rows = Some(other_rows),
-            }
-        };
-
-        self.warnings.extend(other.warnings);
-        self.tracing_id = other.tracing_id;
-        self.paging_state = other.paging_state;
-        self.col_specs = other.col_specs;
-    }
 }
 
 /// [`QueryResult::rows()`](QueryResult::rows) or a similar function called on a bad QueryResult.\

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -335,7 +335,7 @@ impl MetadataReader {
     async fn fetch_metadata(&self, initial: bool) -> Result<Metadata, QueryError> {
         // TODO: Timeouts?
         self.control_connection.wait_until_initialized().await;
-        let conn = &*self.control_connection.random_connection()?;
+        let conn = &self.control_connection.random_connection()?;
 
         let res = query_metadata(
             conn,
@@ -448,7 +448,7 @@ impl MetadataReader {
 }
 
 async fn query_metadata(
-    conn: &Connection,
+    conn: &Arc<Connection>,
     connect_port: u16,
     address_translator: Option<&dyn AddressTranslator>,
     keyspace_to_fetch: &[String],
@@ -477,7 +477,7 @@ async fn query_metadata(
 }
 
 async fn query_peers(
-    conn: &Connection,
+    conn: &Arc<Connection>,
     connect_port: u16,
     address_translator: Option<&dyn AddressTranslator>,
 ) -> Result<Vec<Peer>, QueryError> {


### PR DESCRIPTION
For internal queries that can return a large number of rows (topology info, schema) we use currently use `Connection::query_all` to perform them. That method fetches results of the query in multiple pages and then returns it as a single combined `QueryResult`. This PR replaces it with a new `Connection::query_iter` method which has semantics more similar to the iterator-based query methods from the public interface (`Session::query_iter`, `Session::execute_iter`).

The motivations for this change are as follows:

- Although the new methods will use slightly more memory if the query returns only one page (because of the need to spawn a new task/channels/etc.), it should consume less memory if multiple pages are fetched because rows are processed on-line as new pages appear and only 1-2 pages need to exist at a given time.
- The logic that combines multiple pages into a single `QueryResult` will be hard to translate to use the upcoming iterator-based deserialization interface (https://github.com/scylladb/scylla-rust-driver/issues/462). Although the old interface will still be available as a deprecated fallback, I would like to adapt those methods as a form of dogfooding test for the new interface.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
