### PR TITLE
CI: print logs from the cluster as a build step

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -24,5 +24,11 @@ jobs:
     - name: Run tests on cassandra
       run: |
         CDC='disabled' SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose -- --skip test_views_in_schema_info
-    - name: Stop cluster
+    - name: Stop the cluster
+      if: ${{ always() }}
+      run: docker-compose -f test/cluster/cassandra/docker-compose.yml stop
+    - name: Print the cluster logs
+      if: ${{ always() }}
+      run: docker-compose -f test/cluster/cassandra/docker-compose.yml logs
+    - name: Remove cluster
       run: docker-compose -f test/cluster/cassandra/docker-compose.yml down

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,13 @@ jobs:
       run: cargo build --verbose --examples
     - name: Run tests
       run: SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose
-    - name: Stop cluster
+    - name: Stop the cluster
+      if: ${{ always() }}
+      run: docker-compose -f test/cluster/docker-compose.yml stop
+    - name: Print the cluster logs
+      if: ${{ always() }}
+      run: docker-compose -f test/cluster/docker-compose.yml logs
+    - name: Remove cluster
       run: docker-compose -f test/cluster/docker-compose.yml down
 
   # Tests that our current minimum supported rust version compiles everything sucessfully


### PR DESCRIPTION
Some test failures may be caused due to issues in Cassandra or Scylla and it is hard to identify them if they are silent during the whole CI run.

This PR modifies our CI jobs that use docker-compose so that the logs from the cluster are always printed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I added appropriate `Fixes:` annotations to PR description.
