### PR TITLE
docker-compose.yml: improve settings and the boot order

### DIFF
--- a/test/cluster/docker-compose.yml
+++ b/test/cluster/docker-compose.yml
@@ -14,16 +14,58 @@ services:
     networks:
       public:
         ipv4_address: 172.42.0.2
-    command: --rpc-address 172.42.0.2 --listen-address 172.42.0.2 --seeds 172.42.0.2 --skip-wait-for-gossip-to-settle 0
+    command: |
+      --rpc-address 172.42.0.2
+      --listen-address 172.42.0.2
+      --seeds 172.42.0.2
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
   scylla2:
     image: scylladb/scylla
     networks:
       public:
         ipv4_address: 172.42.0.3
-    command: --rpc-address 172.42.0.3 --listen-address 172.42.0.3 --seeds 172.42.0.2 --skip-wait-for-gossip-to-settle 0
+    command: |
+      --rpc-address 172.42.0.3
+      --listen-address 172.42.0.3
+      --seeds 172.42.0.2
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    depends_on:
+      scylla1:
+        condition: service_healthy
   scylla3:
     image: scylladb/scylla
     networks:
       public:
         ipv4_address: 172.42.0.4
-    command: --rpc-address 172.42.0.4 --listen-address 172.42.0.4 --seeds 172.42.0.2,172.42.0.3 --skip-wait-for-gossip-to-settle 0
+    command: |
+      --rpc-address 172.42.0.4
+      --listen-address 172.42.0.4
+      --seeds 172.42.0.2,172.42.0.3
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    depends_on:
+      scylla2:
+        condition: service_healthy


### PR DESCRIPTION
Up until now, our docker-compose file that sets up Scylla cluster was starting up all nodes in parallel. This is not something that is supported in Scylla and it can sometimes fail. We didn't see those failures until now because we didn't print the cluster logs. This commit makes sure that nodes are booted up in order.

In addition to this, now nodes start with a fixed number of shards (2 each) and memory (1GB each). I'm not sure a more powerful cluster is really needed, and - by default - the shard count is equal to the number of cores of the host machine. A large number of shards can quickly eat up the /proc/sys/fs/aio-nr resource in the system, so the cluster wasn't really usable on machines with a large number of cores.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
