### PR TITLE
topology: UDTs hold complete definition of themselves

### DIFF
--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -40,7 +40,7 @@ pub struct TableSpec {
     pub table_name: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ColumnType {
     Custom(String),
     Ascii,

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1378,7 +1378,7 @@ fn udt_type_c_def(ks: &str) -> Arc<UserDefinedType> {
                     }),
                     Box::new(CqlType::UserDefinedType {
                         frozen: true,
-                        name: "type_b".to_string(),
+                        definition: Ok(udt_type_b_def(ks)),
                     }),
                 ),
             },
@@ -1471,8 +1471,8 @@ async fn test_schema_types_in_metadata() {
     assert_eq!(
         a.type_,
         CqlType::UserDefinedType {
-            name: "type_a".to_string(),
             frozen: true,
+            definition: Ok(udt_type_a_def(&ks)),
         }
     );
 
@@ -1481,8 +1481,8 @@ async fn test_schema_types_in_metadata() {
     assert_eq!(
         b.type_,
         CqlType::UserDefinedType {
-            name: "type_b".to_string(),
             frozen: false,
+            definition: Ok(udt_type_b_def(&ks)),
         }
     );
 
@@ -1491,8 +1491,8 @@ async fn test_schema_types_in_metadata() {
     assert_eq!(
         c.type_,
         CqlType::UserDefinedType {
-            name: "type_c".to_string(),
-            frozen: true
+            frozen: true,
+            definition: Ok(udt_type_c_def(&ks))
         }
     );
 

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -709,6 +709,15 @@ async fn query_keyspaces(
     .await
 }
 
+#[derive(FromRow, Debug)]
+#[scylla_crate = "crate"]
+struct UdtRow {
+    keyspace_name: String,
+    type_name: String,
+    field_names: Vec<String>,
+    field_types: Vec<String>,
+}
+
 async fn query_user_defined_types(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
@@ -723,12 +732,12 @@ async fn query_user_defined_types(
 
     rows.map(|row_result| {
         let row = row_result?;
-        let (keyspace_name, type_name, field_names, field_types): (
-            String,
-            String,
-            Vec<String>,
-            Vec<String>,
-        ) = row.into_typed().map_err(|_| {
+        let UdtRow {
+            keyspace_name,
+            type_name,
+            field_names,
+            field_types,
+        } = row.into_typed().map_err(|_| {
             QueryError::ProtocolError("system_schema.types has invalid column type")
         })?;
 

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -25,7 +25,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use strum_macros::EnumString;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
@@ -873,7 +873,14 @@ async fn query_user_defined_types(
         .try_collect()
         .await?;
 
+    let instant_before_toposort = Instant::now();
     topo_sort_udts(&mut udt_rows)?;
+    let toposort_elapsed = instant_before_toposort.elapsed();
+    debug!(
+        "Toposort of UDT definitions took {:.2} ms (udts len: {})",
+        toposort_elapsed.as_secs_f64() * 1000.,
+        udt_rows.len(),
+    );
 
     let mut udts = HashMap::new();
     for udt_row in udt_rows {

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -674,10 +674,11 @@ async fn query_keyspaces(
     );
 
     let (mut all_tables, mut all_views, mut all_user_defined_types) = if fetch_schema {
+        let udts = query_user_defined_types(conn, keyspaces_to_fetch).await?;
         (
             query_tables(conn, keyspaces_to_fetch).await?,
             query_views(conn, keyspaces_to_fetch).await?,
-            query_user_defined_types(conn, keyspaces_to_fetch).await?,
+            udts,
         )
     } else {
         (HashMap::new(), HashMap::new(), HashMap::new())

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -108,6 +108,21 @@ pub enum CqlType {
     UserDefinedType { frozen: bool, name: String },
 }
 
+/// Definition of a user-defined type
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UserDefinedType {
+    pub name: String,
+    pub keyspace: String,
+    pub field_types: Vec<(String, CqlType)>,
+}
+
+/// Represents a user defined type whose definition is missing from the metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MissingUserDefinedType {
+    pub name: String,
+    pub keyspace: String,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, EnumString)]
 #[strum(serialize_all = "lowercase")]
 pub enum NativeType {

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -858,7 +858,7 @@ async fn query_user_defined_types(
         keyspaces_to_fetch,
     );
 
-    let udt_rows: Vec<UdtRowWithParsedFieldTypes> = rows
+    let mut udt_rows: Vec<UdtRowWithParsedFieldTypes> = rows
         .map(|row_result| {
             let row = row_result?;
             let udt_row = row
@@ -872,6 +872,8 @@ async fn query_user_defined_types(
         })
         .try_collect()
         .await?;
+
+    topo_sort_udts(&mut udt_rows)?;
 
     let mut udts = HashMap::new();
     for udt_row in udt_rows {

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -817,6 +817,36 @@ struct UdtRow {
     field_types: Vec<String>,
 }
 
+#[derive(Debug)]
+struct UdtRowWithParsedFieldTypes {
+    keyspace_name: String,
+    type_name: String,
+    field_names: Vec<String>,
+    field_types: Vec<PreCqlType>,
+}
+
+impl TryFrom<UdtRow> for UdtRowWithParsedFieldTypes {
+    type Error = InvalidCqlType;
+    fn try_from(udt_row: UdtRow) -> Result<Self, InvalidCqlType> {
+        let UdtRow {
+            keyspace_name,
+            type_name,
+            field_names,
+            field_types,
+        } = udt_row;
+        let field_types = field_types
+            .into_iter()
+            .map(|type_| map_string_to_cql_type(&type_))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            keyspace_name,
+            type_name,
+            field_names,
+            field_types,
+        })
+    }
+}
+
 async fn query_user_defined_types(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -101,6 +101,20 @@ pub struct Column {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+enum PreCqlType {
+    Native(NativeType),
+    Collection {
+        frozen: bool,
+        type_: PreCollectionType,
+    },
+    Tuple(Vec<PreCqlType>),
+    UserDefinedType {
+        frozen: bool,
+        name: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CqlType {
     Native(NativeType),
     Collection { frozen: bool, type_: CollectionType },
@@ -146,6 +160,13 @@ pub enum NativeType {
     Timeuuid,
     Uuid,
     Varint,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PreCollectionType {
+    List(Box<PreCqlType>),
+    Map(Box<PreCqlType>, Box<PreCqlType>),
+    Set(Box<PreCqlType>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
It has been requested by a customer to make `CqlType::UserDefinedType` hold a complete definition of the type. 

Before, the definition was distributed among multiple code locations: the type name was present inside the mentioned variant, the keyspace name was to be deduced from the context, and the fields definitions were only stored in a hash map in each `Keyspace`.

This PR:
- introduces `UserDefinedType` struct as a complete UDT definition,
- makes the `Keyspace` hold the hash map from UDT name to  `Arc<UserDefinedType>`,
- makes `CqlType::UserDefinedType` store a complete definition of a UDT (`Result<Arc<UserDefinedType>, MissingUserDefinedType>`, the `Err` variant is used in case when an unknown UDT is defined as a field of another UDT),
- introduces `UdtRow` struct to represent a row with UDT definition,
- adds a topological sort of `UdtRow` to avoid processing references to unknown UDTs. The topological order is always achievable, as UDTs circular dependencies are forbidden and rejected by Scylla.

This PR is based on #645, because it is very likely that it will be merged soon and otherwise it would introduce a lot of merge conflicts.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description~~.
