### PR TITLE
session_builder: Keepalive interval defaults to 30 secs

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -254,7 +254,7 @@ impl SessionConfig {
             disallow_shard_aware_port: false,
             keyspaces_to_fetch: Vec::new(),
             fetch_schema_metadata: true,
-            keepalive_interval: None,
+            keepalive_interval: Some(Duration::from_secs(30)),
             auto_await_schema_agreement_timeout: Some(std::time::Duration::from_secs(60)),
             address_translator: None,
             host_filter: None,

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -613,7 +613,8 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     }
 
     /// Set the keepalive interval.
-    /// The default is `None`, it corresponds to no keepalive messages being send.
+    /// The default is `Some(Duration::from_secs(30))`, it corresponds
+    /// to keepalive messages being sent every 30 seconds.
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
When testing the new serverless support implementation in the driver, it appeared that while being idle, the driver must deal with server closing the connection every 60 seconds. To prevent such behaviour, the default keepalive interval is set to 30 seconds.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
