### PR TITLE
Don't early-allocate trace arguments (significant perf impact somehow)

### DIFF
--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -451,7 +451,7 @@ where
         self.log_query_start();
 
         'nodes_in_plan: for node in query_plan {
-            let span = trace_span!("Executing query", node = node.address.to_string().as_str());
+            let span = trace_span!("Executing query", node = %node.address);
             // For each node in the plan choose a connection to use
             // This connection will be reused for same node retries to preserve paging cache on the shard
             let connection: Arc<Connection> = match (self.choose_connection)(node.clone())
@@ -462,7 +462,7 @@ where
                 Err(e) => {
                     trace!(
                         parent: &span,
-                        error = e.to_string().as_str(),
+                        error = %e,
                         "Choosing connection failed"
                     );
                     last_error = e;
@@ -490,7 +490,7 @@ where
                     Err(error) => {
                         trace!(
                             parent: &span,
-                            error = error.to_string().as_str(),
+                            error = %error,
                             "Query failed"
                         );
                         error
@@ -559,7 +559,7 @@ where
             let query_start = std::time::Instant::now();
 
             trace!(
-                connection = connection.get_connect_address().to_string().as_str(),
+                connection = %connection.get_connect_address(),
                 "Sending"
             );
             self.log_attempt_start(connection.get_connect_address());

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -569,7 +569,7 @@ impl Session {
         let query: Query = query.into();
         let serialized_values = values.serialized()?;
 
-        let span = trace_span!("Request", query = query.contents.as_str());
+        let span = trace_span!("Request", query = %query.contents);
         let run_query_result = self
             .run_query(
                 Statement::default(),
@@ -709,7 +709,7 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        let span = trace_span!("Request", query = query.contents.as_str());
+        let span = trace_span!("Request", query = %query.contents);
         RowIterator::new_for_query(
             query,
             serialized_values.into_owned(),
@@ -890,7 +890,7 @@ impl Session {
 
         let span = trace_span!(
             "Request",
-            prepared_id = format!("{:X}", prepared.get_id()).as_str()
+            prepared_id = %format_args!("{:X}", prepared.get_id())
         );
         let run_query_result: RunQueryResult<NonErrorQueryResponse> = self
             .run_query(
@@ -1000,7 +1000,7 @@ impl Session {
 
         let span = trace_span!(
             "Request",
-            prepared_id = format!("{:X}", prepared.get_id()).as_str()
+            prepared_id = %format_args!("{:X}", prepared.get_id())
         );
         RowIterator::new_for_prepared_statement(PreparedIteratorConfig {
             prepared,
@@ -1578,7 +1578,7 @@ impl Session {
             context.consistency.unwrap_or(execution_profile.consistency);
 
         'nodes_in_plan: for node in query_plan {
-            let span = trace_span!("Executing query", node = node.address.to_string().as_str());
+            let span = trace_span!("Executing query", node = %node.address);
             'same_node_retries: loop {
                 trace!(parent: &span, "Execution started");
                 let connection: Arc<Connection> = match choose_connection(node.clone())
@@ -1589,7 +1589,7 @@ impl Session {
                     Err(e) => {
                         trace!(
                             parent: &span,
-                            error = e.to_string().as_str(),
+                            error = %e,
                             "Choosing connection failed"
                         );
                         last_error = Some(e);
@@ -1603,7 +1603,7 @@ impl Session {
 
                 trace!(
                     parent: &span,
-                    connection = connection.get_connect_address().to_string().as_str(),
+                    connection = %connection.get_connect_address(),
                     "Sending"
                 );
                 let attempt_id: Option<history::AttemptId> =
@@ -1632,7 +1632,7 @@ impl Session {
                     Err(e) => {
                         trace!(
                             parent: &span,
-                            last_error = e.to_string().as_str(),
+                            last_error = %e,
                             "Query failed"
                         );
                         self.metrics.inc_failed_nonpaged_queries();

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -464,7 +464,7 @@ impl MetadataReader {
                     .address()
                     .to_string()
                     .as_str(),
-                error = err.to_string().as_str(),
+                error = %err,
                 "Failed to fetch metadata using current control connection"
             );
 
@@ -489,7 +489,7 @@ impl MetadataReader {
                 debug!("Fetched new metadata");
             }
             Err(error) => error!(
-                error = error.to_string().as_str(),
+                error = %error,
                 "Could not fetch metadata"
             ),
         }


### PR DESCRIPTION
Fixes #655

This would have a significant perf impact (see #655) and be unidiomatic (see https://docs.rs/tracing/0.1.37/tracing/#recording-fields)

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I added appropriate `Fixes:` annotations to PR description.
