### PR TITLE
Expose calculate_token

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1747,7 +1747,7 @@ impl Session {
         .await
     }
 
-    fn calculate_token(
+    pub fn calculate_token(
         &self,
         prepared: &PreparedStatement,
         serialized_values: &SerializedValues,


### PR DESCRIPTION
Helps (or arguably fixes) #468

For smarter batch constitution (following up on #448), it is required to have access to the token a particular statement would be directed to. However, that is pretty difficult to do without access to calculate_token.

That was initially put in #508, but planned to put in a separate PR to keep it minimal
(https://github.com/scylladb/scylla-rust-driver/pull/508#discussion_r949399700)
It seems I had forgotten to open that separate PR, and I end up getting bitten by that now that I want to constitute my batches in a smarter way. ^^'

So here it is.

I'm only putting "helps" above because I think we may want to also expose query planning (
`session.plan(prepared_statement, serialized_values) -> impl Iterator<Item = (Arc<Node>, ShardID)>` ) as that may make it significantly easier on the user to obtain the relevant keys for batching - but I'd like to keep this PR that just *enables* the ideal behavior as simple as possible.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
