### PR TITLE
treewide: appease clippy

### DIFF
--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -46,6 +46,16 @@ pub enum LegacyConsistency {
     Serial(SerialConsistency),
 }
 
+// Although we could `impl Default for Consistency` with an automatic derive,
+// this would require adding a #[default] annotation on the default variant,
+// but - unfortunately - that annotation is also recognized by `TryFromPrimitive`
+// derive macro. If there is a #[default] variant then `TryFromPrimitive`
+// falls back to it - if not, then it returns an error. This breaks one of the
+// tests.
+//
+// It will be possible to fix this properly after the following issue is closed:
+// https://github.com/illicitonion/num_enum/issues/75
+#[allow(clippy::derivable_impls)]
 impl Default for Consistency {
     fn default() -> Self {
         Consistency::LocalQuorum

--- a/scylla/src/transport/partitioner.rs
+++ b/scylla/src/transport/partitioner.rs
@@ -4,8 +4,9 @@ use std::num::Wrapping;
 use crate::routing::Token;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub(crate) enum PartitionerName {
+    #[default]
     Murmur3,
     CDC,
 }
@@ -26,12 +27,6 @@ impl PartitionerName {
             PartitionerName::Murmur3 => Murmur3Partitioner::hash(pk),
             PartitionerName::CDC => CDCPartitioner::hash(pk),
         }
-    }
-}
-
-impl Default for PartitionerName {
-    fn default() -> Self {
-        PartitionerName::Murmur3
     }
 }
 


### PR DESCRIPTION
The usual: clippy have been updated in GitHub's CI runner image that we use and it has new lints that our codebase doesn't currently pass.

This time, clippy complains about some `impl Default`s being unnecessarily hand-written where they could be easily implemented with an automatic derive. This commit removes the problematic impl for PartitionerName and replaces it with a derive, but the impl for Consistency is left as is and marked with an "allow" annotation. Unfortunately, implementing Default with a derive requires adding a #[default] annotation in the enum body which incorrectly interacts with num_enum::TryFromPrimitive macro.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
