### PR TITLE
Add rack-awareness to default LBP

### DIFF
--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -11,6 +11,7 @@ for queries with non-local consistency mode is also supported.
 `DefaultPolicyBuilder` with the following default values:
 
 - `preferred_datacenter`: `None`
+- `preferred_rack`: `None`
 - `is_token_aware`: `true`
 - `permit_dc_failover`: `false`
 - `latency_awareness`: `None`
@@ -25,6 +26,7 @@ use scylla::load_balancing::DefaultPolicy;
 
 let default_policy = DefaultPolicy::builder()
         .prefer_datacenter("dc1".to_string())
+        .prefer_rack("rack1".to_string())
         .token_aware(true)
         .permit_dc_failover(true)
         .build();
@@ -47,6 +49,14 @@ When datacenter failover is disabled (`permit_dc_failover` is set to
 false), the default policy will only include local nodes in load balancing
 plans. Remote nodes will be excluded, even if they are alive and available to
 serve requests.
+
+#### Preferred Rack
+
+The `preferred_rack` field in `DefaultPolicy` allows the load balancing policy to
+prioritize nodes based on their availability zones in the preferred datacenter.
+When a preferred rack is set, the policy will first return replicas in the local rack
+in the preferred datacenter, and then the other replicas in the datacenter.
+When a preferred datacenter is not set, setting preferred rack will not have any effect.
 
 #### Datacenter Failover
 


### PR DESCRIPTION
Added rack-awareness option to prefer replicas in local rack while picking a coordinator. It will allow to create a top-level tier with local datacenter and local rack replicas in the fallback plan.

Fixes: #604 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I added appropriate `Fixes:` annotations to PR description.
