### PR TITLE
Extended request spans

### DIFF
--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
             .await?;
 
         let serialized_pk = (pk,).serialized()?.into_owned();
-        let t = Murmur3Partitioner::hash(prepared.compute_partition_key(&serialized_pk)?).value;
+        let t = Murmur3Partitioner::hash(&prepared.compute_partition_key(&serialized_pk)?).value;
 
         let statement_info = load_balancing::RoutingInfo {
             token: Some(scylla::routing::Token { value: t }),

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -378,6 +378,8 @@ pub struct Rows {
     pub metadata: ResultMetadata,
     pub rows_count: usize,
     pub rows: Vec<Row>,
+    /// Original size of the serialized rows.
+    pub serialized_size: usize,
 }
 
 #[derive(Debug)]
@@ -836,6 +838,8 @@ pub fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue,
 fn deser_rows(buf: &mut &[u8]) -> StdResult<Rows, ParseError> {
     let metadata = deser_result_metadata(buf)?;
 
+    let original_size = buf.len();
+
     // TODO: the protocol allows an optimization (which must be explicitly requested on query by
     // the driver) where the column metadata is not sent with the result.
     // Implement this optimization. We'll then need to take the column types by a parameter.
@@ -861,6 +865,7 @@ fn deser_rows(buf: &mut &[u8]) -> StdResult<Rows, ParseError> {
         metadata,
         rows_count,
         rows,
+        serialized_size: original_size - buf.len(),
     })
 }
 

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -193,6 +193,10 @@ impl SerializedValues {
     pub fn len(&self) -> i16 {
         self.values_num
     }
+
+    pub fn size(&self) -> usize {
+        self.serialized_values.len()
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -432,7 +432,7 @@ impl ClusterData {
                 Some(buf.into())
             }
         };
-        Ok(partitioner.hash(serialized_pk.unwrap_or_default()))
+        Ok(partitioner.hash(&serialized_pk.unwrap_or_default()))
     }
 
     /// Access to replicas owning a given token

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -437,6 +437,16 @@ impl ClusterData {
 
     /// Access to replicas owning a given token
     pub fn get_token_endpoints(&self, keyspace: &str, token: Token) -> Vec<Arc<Node>> {
+        self.get_token_endpoints_iter(keyspace, token)
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn get_token_endpoints_iter(
+        &self,
+        keyspace: &str,
+        token: Token,
+    ) -> impl Iterator<Item = &Arc<Node>> {
         let keyspace = self.keyspaces.get(keyspace);
         let strategy = keyspace
             .map(|k| &k.strategy)
@@ -445,7 +455,7 @@ impl ClusterData {
             .replica_locator()
             .replicas_for_token(token, strategy, None);
 
-        replica_set.into_iter().cloned().collect()
+        replica_set.into_iter()
     }
 
     /// Access to replicas owning a given partition key (similar to `nodetool getendpoints`)

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use tracing::instrument::WithSubscriber;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -186,7 +187,7 @@ impl Cluster {
         };
 
         let (fut, worker_handle) = worker.work().remote_handle();
-        tokio::spawn(fut);
+        tokio::spawn(fut.with_current_subscriber());
 
         let result = Cluster {
             data: cluster_data,
@@ -533,7 +534,7 @@ impl ClusterWorker {
 
                             let cluster_data = self.cluster_data.load_full();
                             let use_keyspace_future = Self::handle_use_keyspace_request(cluster_data, request);
-                            tokio::spawn(use_keyspace_future);
+                            tokio::spawn(use_keyspace_future.with_current_subscriber());
                         },
                         None => return, // If use_keyspace_channel was closed then cluster was dropped, we can stop working
                     }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -6,6 +6,7 @@ use tokio::io::{split, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWrite
 use tokio::net::{TcpSocket, TcpStream};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
+use tracing::instrument::WithSubscriber;
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
@@ -860,7 +861,7 @@ impl Connection {
                 orphan_notification_receiver,
             )
             .remote_handle();
-            tokio::task::spawn(task);
+            tokio::task::spawn(task.with_current_subscriber());
             return Ok(handle);
         }
 
@@ -872,7 +873,7 @@ impl Connection {
             orphan_notification_receiver,
         )
         .remote_handle();
-        tokio::task::spawn(task);
+        tokio::task::spawn(task.with_current_subscriber());
         Ok(handle)
     }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -192,13 +192,14 @@ impl NonErrorQueryResponse {
     }
 
     pub fn into_query_result(self) -> Result<QueryResult, QueryError> {
-        let (rows, paging_state, col_specs) = match self.response {
+        let (rows, paging_state, col_specs, serialized_size) = match self.response {
             NonErrorResponse::Result(result::Result::Rows(rs)) => (
                 Some(rs.rows),
                 rs.metadata.paging_state,
                 rs.metadata.col_specs,
+                rs.serialized_size,
             ),
-            NonErrorResponse::Result(_) => (None, None, vec![]),
+            NonErrorResponse::Result(_) => (None, None, vec![], 0),
             _ => {
                 return Err(QueryError::ProtocolError(
                     "Unexpected server response, expected Result or Error",
@@ -212,6 +213,7 @@ impl NonErrorQueryResponse {
             tracing_id: self.tracing_id,
             paging_state,
             col_specs,
+            serialized_size,
         })
     }
 }

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -388,6 +388,7 @@ mod checked_channel_sender {
                     metadata: Default::default(),
                     rows_count: 0,
                     rows: Vec::new(),
+                    serialized_size: 0,
                 },
                 tracing_id,
             };

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -1257,7 +1257,7 @@ mod latency_awareness {
     use futures::{future::RemoteHandle, FutureExt};
     use itertools::Either;
     use scylla_cql::errors::{DbError, QueryError};
-    use tracing::trace;
+    use tracing::{instrument::WithSubscriber, trace};
     use uuid::Uuid;
 
     use crate::{load_balancing::NodeRef, transport::node::Node};
@@ -1392,7 +1392,7 @@ mod latency_awareness {
                 }
             }
             .remote_handle();
-            tokio::task::spawn(updater_fut);
+            tokio::task::spawn(updater_fut.with_current_subscriber());
 
             Self {
                 exclusion_threshold,

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 /// Result of a single query\
 /// Contains all rows returned by the database and some more information
+#[non_exhaustive]
 #[derive(Default, Debug)]
 pub struct QueryResult {
     /// Rows returned by the database.\
@@ -22,6 +23,8 @@ pub struct QueryResult {
     pub paging_state: Option<Bytes>,
     /// Column specification returned from the server
     pub col_specs: Vec<ColumnSpec>,
+    /// The original size of the serialized rows in request
+    pub serialized_size: usize,
 }
 
 impl QueryResult {
@@ -304,6 +307,7 @@ mod tests {
             tracing_id: None,
             paging_state: None,
             col_specs: vec![column_spec],
+            serialized_size: 0,
         }
     }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -719,7 +719,6 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        let span = trace_span!("Request", query = %query.contents);
         RowIterator::new_for_query(
             query,
             serialized_values.into_owned(),
@@ -727,7 +726,6 @@ impl Session {
             self.cluster.get_data(),
             self.metrics.clone(),
         )
-        .instrument(span)
         .await
     }
 
@@ -1029,10 +1027,6 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        let span = trace_span!(
-            "Request",
-            prepared_id = %format_args!("{:X}", prepared.get_id())
-        );
         RowIterator::new_for_prepared_statement(PreparedIteratorConfig {
             prepared,
             values: serialized_values.into_owned(),
@@ -1042,7 +1036,6 @@ impl Session {
             cluster_data: self.cluster.get_data(),
             metrics: self.metrics.clone(),
         })
-        .instrument(span)
         .await
     }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1766,7 +1766,7 @@ impl Session {
 
         let partition_key = calculate_partition_key(prepared, serialized_values)?;
 
-        Ok(Some(partitioner_name.hash(partition_key)))
+        Ok(Some(partitioner_name.hash(&partition_key)))
     }
 
     fn get_default_execution_profile_handle(&self) -> &ExecutionProfileHandle {

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -231,7 +231,7 @@ async fn test_prepared_statement() {
                 .unwrap(),
         };
         let prepared_token = Murmur3Partitioner::hash(
-            prepared_statement
+            &prepared_statement
                 .compute_partition_key(&serialized_values)
                 .unwrap(),
         );
@@ -257,7 +257,7 @@ async fn test_prepared_statement() {
                 .unwrap(),
         };
         let prepared_token = Murmur3Partitioner::hash(
-            prepared_complex_pk_statement
+            &prepared_complex_pk_statement
                 .compute_partition_key(&serialized_values)
                 .unwrap(),
         );
@@ -531,7 +531,7 @@ async fn test_token_calculation() {
                 .unwrap(),
         };
         let prepared_token = Murmur3Partitioner::hash(
-            prepared_statement
+            &prepared_statement
                 .compute_partition_key(&serialized_values)
                 .unwrap(),
         );

--- a/scylla/src/utils/mod.rs
+++ b/scylla/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod parse;
 
+pub(crate) mod pretty;
 pub mod test_utils;

--- a/scylla/src/utils/pretty.rs
+++ b/scylla/src/utils/pretty.rs
@@ -1,0 +1,21 @@
+use std::fmt::{LowerHex, UpperHex};
+
+pub(crate) struct HexBytes<'a>(pub(crate) &'a [u8]);
+
+impl<'a> LowerHex for HexBytes<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> UpperHex for HexBytes<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02X}", b)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Provides more information in trace spans emitted for unprepared query, prepared query and batch requests.

The following information is provided:

- `kind`: type of operation (`unprepared`, `prepared`, `batch`),
- `contents` - the query string (applicable only to unprepared queries),
- `routing_key`: routing key of the request (if known, i.e. applies only to prepared queries),
- `token`: partition token relevant to the request (if known, i.e. applies only to prepared queries),
- `request_size`: serialized size of query parameters (not implemented for batches),
- `result_size`: serialized size of rows returned in response,
- `result_rows`: number of rows returned in response,
- `shard`: ID of the shard the request was served on,
- `speculative_executions` - the number of times this request was speculatively executed,

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
