### PR TITLE
treewide: implement Clone for most error types

### DIFF
--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -20,7 +20,7 @@ pub enum FromRowError {
     WrongRowSize { expected: usize, actual: usize },
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum CqlTypeError {
     #[error("Invalid number of set elements: {0}")]
     InvalidNumberOfElements(i32),

--- a/scylla-cql/src/frame/response/error.rs
+++ b/scylla-cql/src/frame/response/error.rs
@@ -5,7 +5,7 @@ use crate::frame::types;
 use byteorder::ReadBytesExt;
 use bytes::Bytes;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Error {
     pub error: DbError,
     pub reason: String,

--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -106,7 +106,7 @@ impl Sharder {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 pub enum ShardingError {
     #[error("ShardInfo parameters missing")]
     MissingShardInfoParameter,

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -311,7 +311,7 @@ impl PreparedStatement {
     }
 }
 
-#[derive(Debug, Error, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Error, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PartitionKeyError {
     #[error("No value with given pk_index! pk_index: {0}, values.len(): {1}")]
     NoPkIndexValue(u16, i16),

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -137,7 +137,7 @@ impl QueryResult {
 /// Expected `QueryResult.rows` to be `Some`, but it was `None`.\
 /// `QueryResult.rows` is `Some` for queries that can return rows (e.g `SELECT`).\
 /// It is `None` for queries that can't return rows (e.g `INSERT`).
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[error(
     "QueryResult::rows() or similar function called on a bad QueryResult.
          Expected QueryResult.rows to be Some, but it was None.
@@ -150,7 +150,7 @@ pub struct RowsExpectedError;
 /// Expected `QueryResult.rows` to be `None`, but it was `Some`.\
 /// `QueryResult.rows` is `Some` for queries that can return rows (e.g `SELECT`).\
 /// It is `None` for queries that can't return rows (e.g `INSERT`).
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[error(
     "QueryResult::result_not_rows() called on a bad QueryResult.
          Expected QueryResult.rows to be None, but it was Some.
@@ -159,7 +159,7 @@ pub struct RowsExpectedError;
 )]
 pub struct RowsNotExpectedError;
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum FirstRowError {
     /// [`QueryResult::first_row()`](QueryResult::first_row) called on a bad QueryResult.\
     /// Expected `QueryResult.rows` to be `Some`, but it was `None`.\
@@ -173,7 +173,7 @@ pub enum FirstRowError {
     RowsEmpty,
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum FirstRowTypedError {
     /// [`QueryResult::first_row_typed()`](QueryResult::first_row_typed) called on a bad QueryResult.\
     /// Expected `QueryResult.rows` to be `Some`, but it was `None`.\
@@ -191,7 +191,7 @@ pub enum FirstRowTypedError {
     FromRowError(#[from] FromRowError),
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum MaybeFirstRowTypedError {
     /// [`QueryResult::maybe_first_row_typed()`](QueryResult::maybe_first_row_typed) called on a bad QueryResult.\
     /// Expected `QueryResult.rows` to be `Some`, but it was `None`.
@@ -205,7 +205,7 @@ pub enum MaybeFirstRowTypedError {
     FromRowError(#[from] FromRowError),
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum SingleRowError {
     /// [`QueryResult::single_row()`](QueryResult::single_row) called on a bad QueryResult.\
     /// Expected `QueryResult.rows` to be `Some`, but it was `None`.\
@@ -219,7 +219,7 @@ pub enum SingleRowError {
     BadNumberOfRows(usize),
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum SingleRowTypedError {
     /// [`QueryResult::single_row_typed()`](QueryResult::single_row_typed) called on a bad QueryResult.\
     /// Expected `QueryResult.rows` to be `Some`, but it was `None`.\


### PR DESCRIPTION
For convenience, adds a `#[derive(Clone)]` for those error types for which it was currently possible. Some error types currently have fields that cannot be cloned (mostly std::io::Error), notably:

- ParseError, FrameError - extensively used in deserialization, but don't seem to appear in the main API.
- CloudConfigError - only used when creating a session that connects to Scylla Cloud.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
