### PR TITLE
docs: don't strip Rust attributes

### DIFF
--- a/docs/_utils/prepare_sphinx_source.py
+++ b/docs/_utils/prepare_sphinx_source.py
@@ -30,7 +30,10 @@ def remove_hidden_code_lines(md_file_text):
         new_chunk_lines = []
         chunk_lines = cur_chunk.split('\n')
         for line in cur_chunk.split('\n'):
-            if not line.lstrip().startswith("#"):
+            # Rustdoc strips lines which start with '# ' (pound sign followed
+            # by a space). The space is important, otherwise the code would
+            # strip Rust attributes and procedural macro derives.
+            if not line.lstrip().startswith("# "):
                 new_chunk_lines.append(line)
         new_chunk = "\n".join(new_chunk_lines)
         result.append(new_chunk)


### PR DESCRIPTION
The `prepare_sphinx_source.py` script goes over snippets of Rust code in the docs and removes the lines that start with a pound sign (#). This is done to simulate the mdbook behavior: the snippets are supposed to be valid Rust code that compiles, however making them compile may require adding some boilerplate lines of code that shouldn't be displayed in the final documentation. Sphinx, used to generate the official documentation, doesn't understand that so we need a script to pre-process.

However, the current behavior of the script is not entirely correct. Not every line that starts with a pound sign should be removed - for example, `derive` attributes like this are currently stripped but shouldn't:

    #[derive(Debug)]
    struct Foo {
        bar: i32,
    }

In order to fix this, the code is adjusted to strip lines that start with the '# ' string (pound sign followed by a space). This is what the `rustdoc` tool actually does (and `mdbook`, too). This results in correctly pre-processed snippets of code in the documentation generated by sphinx.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
