### PR TITLE
Add serialize/deserialize support for [u8; N]

### DIFF
--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -137,6 +137,13 @@ impl_from_cql_value_from_method!(BigDecimal, into_decimal); // BigDecimal::from_
 impl_from_cql_value_from_method!(Duration, as_duration); // Duration::from_cql<CqlValue>
 impl_from_cql_value_from_method!(CqlDuration, as_cql_duration); // CqlDuration::from_cql<CqlValue>
 
+impl<const N: usize> FromCqlVal<CqlValue> for [u8; N] {
+    fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
+        let val = cql_val.into_blob().ok_or(FromCqlValError::BadCqlType)?;
+        val.try_into().map_err(|_| FromCqlValError::BadVal)
+    }
+}
+
 impl FromCqlVal<CqlValue> for crate::frame::value::Date {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         match cql_val {
@@ -407,6 +414,12 @@ mod tests {
             Ok("text_test".to_string()),
             String::from_cql(CqlValue::Text("text_test".to_string()))
         );
+    }
+
+    #[test]
+    fn u8_array_from_cql() {
+        let val = [1u8; 4];
+        assert_eq!(Ok(val), <[u8; 4]>::from_cql(CqlValue::Blob(val.to_vec())));
     }
 
     #[test]

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -470,6 +470,17 @@ impl Value for Vec<u8> {
     }
 }
 
+impl<const N: usize> Value for [u8; N] {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        let val_len: i32 = self.len().try_into().map_err(|_| ValueTooBig)?;
+        buf.put_i32(val_len);
+
+        buf.extend_from_slice(self);
+
+        Ok(())
+    }
+}
+
 impl Value for IpAddr {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         match self {

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -30,6 +30,12 @@ fn basic_serialization() {
 }
 
 #[test]
+fn u8_array_serialization() {
+    let val = [1u8; 4];
+    assert_eq!(serialized(val), vec![0, 0, 0, 4, 1, 1, 1, 1]);
+}
+
+#[test]
 fn naive_date_serialization() {
     // 1970-01-31 is 2^31
     let unix_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();


### PR DESCRIPTION
Right now the driver supports Vec<u8>. This PR adds serialize/deserialize support for [u8; N]

@piodul for review

