### PR TITLE
iterator: make token awareness work again with execute_iter

### DIFF
--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -224,16 +224,16 @@ impl RowIterator {
             .unwrap_or(config.execution_profile.serial_consistency);
         let retry_session = config.execution_profile.retry_policy.new_session();
 
-        let statement_info = RoutingInfo {
-            consistency,
-            serial_consistency: config.prepared.get_serial_consistency(),
-            token: config.token,
-            keyspace: None,
-            is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
-        };
-
         let parent_span = tracing::Span::current();
         let worker_task = async move {
+            let statement_info = RoutingInfo {
+                consistency,
+                serial_consistency: config.prepared.get_serial_consistency(),
+                token: config.token,
+                keyspace: config.prepared.get_keyspace_name(),
+                is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
+            };
+
             let prepared_ref = &config.prepared;
             let values_ref = &config.values;
             let partition_key = config.partition_key;


### PR DESCRIPTION
Due to an oversight, when the RowIterator asks the load balancing policy to calculate the plan (sequence of nodes that will be tried), it passes a RoutingInfo structure without providing the keyspace relevant to the query. The old token aware policy used to fall back to SimpleStrategy and rf=1, which could provide an illusion of token-aware routing. However, the new default load balancing policy will, in the case described above, treat this as if no routing information is available and will choose a random node.

This commit fixes the simple issue and adds a test which verifies that token awareness works both in case of `execute` and `execute_iter`.

Fixes: #699

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce~.
- [ ] ~I have adjusted the documentation in `./docs/source/`~.
- [x] I added appropriate `Fixes:` annotations to PR description.
