### PR TITLE
Allow ssl-context only for non-cloud session builder

### DIFF
--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -328,6 +328,38 @@ impl SessionBuilder {
         self.config.enable_write_coalescing = enable;
         self
     }
+
+    /// ssl feature
+    /// Provide SessionBuilder with SslContext from openssl crate that will be
+    /// used to create an ssl connection to the database.
+    /// If set to None SSL connection won't be used.
+    /// Default is None.
+    ///
+    /// # Example
+    /// ```
+    /// # use std::fs;
+    /// # use std::path::PathBuf;
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use openssl::ssl::{SslContextBuilder, SslVerifyMode, SslMethod, SslFiletype};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let certdir = fs::canonicalize(PathBuf::from("./examples/certs/scylla.crt"))?;
+    /// let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
+    /// context_builder.set_certificate_file(certdir.as_path(), SslFiletype::PEM)?;
+    /// context_builder.set_verify(SslVerifyMode::NONE);
+    ///
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .ssl_context(Some(context_builder.build()))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "ssl")]
+    pub fn ssl_context(mut self, ssl_context: Option<SslContext>) -> Self {
+        self.config.ssl_context = ssl_context;
+        self
+    }
 }
 #[cfg(feature = "cloud")]
 impl CloudSessionBuilder {
@@ -494,38 +526,6 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     pub fn use_keyspace(mut self, keyspace_name: impl Into<String>, case_sensitive: bool) -> Self {
         self.config.used_keyspace = Some(keyspace_name.into());
         self.config.keyspace_case_sensitive = case_sensitive;
-        self
-    }
-
-    /// ssl feature
-    /// Provide SessionBuilder with SslContext from openssl crate that will be
-    /// used to create an ssl connection to the database.
-    /// If set to None SSL connection won't be used.
-    /// Default is None.
-    ///
-    /// # Example
-    /// ```
-    /// # use std::fs;
-    /// # use std::path::PathBuf;
-    /// # use scylla::{Session, SessionBuilder};
-    /// # use openssl::ssl::{SslContextBuilder, SslVerifyMode, SslMethod, SslFiletype};
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let certdir = fs::canonicalize(PathBuf::from("./examples/certs/scylla.crt"))?;
-    /// let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
-    /// context_builder.set_certificate_file(certdir.as_path(), SslFiletype::PEM)?;
-    /// context_builder.set_verify(SslVerifyMode::NONE);
-    ///
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .ssl_context(Some(context_builder.build()))
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "ssl")]
-    pub fn ssl_context(mut self, ssl_context: Option<SslContext>) -> Self {
-        self.config.ssl_context = ssl_context;
         self
     }
 


### PR DESCRIPTION
For serverless clusters, the secure connection bundle should specify the contact points and the SSL context, so setting SSL context for `CloudSessionBuilder` should not be allowed.

Fixes #695

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
