### PR TITLE
statement/transport: re-add per-statement setters for retry policy

### DIFF
--- a/docs/source/retry-policy/default.md
+++ b/docs/source/retry-policy/default.md
@@ -33,18 +33,21 @@ To use in a [simple query](../queries/simple.md):
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
 use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::DefaultRetryPolicy;
 
+// Create a Query manually and set the retry policy
+let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
+my_query.set_retry_policy(Some(Arc::new(DefaultRetryPolicy::new())));
+
+// You can also set retry policy in an execution profile
 let handle = ExecutionProfile::builder()
     .retry_policy(Box::new(DefaultRetryPolicy::new()))
     .build()
     .into_handle();
-
-// Create a Query manually and set the retry policy
-let mut my_query: Query = Query::new("INSERT INTO ks.tab (a) VALUES(?)");
 my_query.set_execution_profile_handle(Some(handle));
 
 // Run the query using this retry policy
@@ -59,21 +62,23 @@ To use in a [prepared query](../queries/prepared.md):
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::prepared_statement::PreparedStatement;
 use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::DefaultRetryPolicy;
 
-let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(DefaultRetryPolicy::new()))
-    .build()
-    .into_handle();
-
 // Create PreparedStatement manually and set the retry policy
 let mut prepared: PreparedStatement = session
     .prepare("INSERT INTO ks.tab (a) VALUES(?)")
     .await?;
+prepared.set_retry_policy(Some(Arc::new(DefaultRetryPolicy::new())));
 
+// You can also set retry policy in an execution profile
+let handle = ExecutionProfile::builder()
+    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .build()
+    .into_handle();
 prepared.set_execution_profile_handle(Some(handle));
 
 // Run the query using this retry policy

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::history::HistoryListener;
+use crate::retry_policy::RetryPolicy;
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
 use crate::transport::execution_profile::ExecutionProfileHandle;
 
@@ -14,6 +15,9 @@ pub use crate::frame::request::batch::BatchType;
 #[derive(Clone)]
 pub struct Batch {
     pub(crate) config: StatementConfig,
+
+    // TODO: Move this after #701 is fixed
+    retry_policy: Option<Arc<dyn RetryPolicy>>,
 
     pub statements: Vec<BatchStatement>,
     batch_type: BatchType,
@@ -108,6 +112,18 @@ impl Batch {
         self.config.timestamp
     }
 
+    /// Set the retry policy for this batch, overriding the one from execution profile if not None.
+    #[inline]
+    pub fn set_retry_policy(&mut self, retry_policy: Option<Arc<dyn RetryPolicy>>) {
+        self.retry_policy = retry_policy;
+    }
+
+    /// Get the retry policy set for the batch.
+    #[inline]
+    pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
+        self.retry_policy.as_ref()
+    }
+
     /// Sets the listener capable of listening what happens during query execution.
     pub fn set_history_listener(&mut self, history_listener: Arc<dyn HistoryListener>) {
         self.config.history_listener = Some(history_listener);
@@ -134,6 +150,7 @@ impl Default for Batch {
     fn default() -> Self {
         Self {
             statements: Vec::new(),
+            retry_policy: None,
             batch_type: BatchType::Logged,
             config: Default::default(),
         }

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -166,11 +166,13 @@ where
 
         if let Some(raw) = self.cache.get(&query.contents) {
             let page_size = query.get_page_size();
+            let retry_policy = query.get_retry_policy().cloned();
             let mut stmt = PreparedStatement::new(
                 raw.id.clone(),
                 raw.is_confirmed_lwt,
                 raw.metadata.clone(),
                 query.contents,
+                retry_policy,
                 page_size,
                 query.config,
             );

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -423,6 +423,7 @@ impl Connection {
                     .prepared_flags_contain_lwt_mark(p.prepared_metadata.flags as u32),
                 p.prepared_metadata,
                 query.contents.clone(),
+                query.get_retry_policy().cloned(),
                 query.get_page_size(),
                 query.config.clone(),
             ),

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -151,7 +151,11 @@ impl RowIterator {
             .serial_consistency
             .unwrap_or(execution_profile.serial_consistency);
 
-        let retry_session = execution_profile.retry_policy.new_session();
+        let retry_session = query
+            .get_retry_policy()
+            .map(|rp| &**rp)
+            .unwrap_or(&*execution_profile.retry_policy)
+            .new_session();
 
         let parent_span = tracing::Span::current();
         let worker_task = async move {
@@ -222,7 +226,12 @@ impl RowIterator {
             .config
             .serial_consistency
             .unwrap_or(config.execution_profile.serial_consistency);
-        let retry_session = config.execution_profile.retry_policy.new_session();
+        let retry_session = config
+            .prepared
+            .get_retry_policy()
+            .map(|rp| &**rp)
+            .unwrap_or(&*config.execution_profile.retry_policy)
+            .new_session();
 
         let parent_span = tracing::Span::current();
         let worker_task = async move {


### PR DESCRIPTION
The `set_retry_policy` and `get_retry_policy` methods of `Query`, `PreparedStatement` and `Batch` were removed #592, but are re-added here due to user request and because they will be useful for cpp-rust-driver.

One important difference with the old `{set,get}_retry_policy` is that the new methods take and `Arc<dyn RetryPolicy>` instead of `Box<dyn RetryPolicy>`. This was done in order not to introduce additional allocations when a query/statement/batch is cloned.

The retry_policy field was added directly to
`Batch`/`Query`/`PreparedStatement` instead of `StatementConfig`. Unfortunately, `StatementConfig` is public along with all of its fields, so adding more fields to it will be a breaking change. This should be fixed during/after #701.

Fixes: #692

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
