### PR TITLE
examples: logging: removed obsolete comment

### DIFF
--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -19,7 +19,6 @@ async fn main() -> Result<()> {
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}", &[]).await?;
 
-    // This query should generate a warning message
     session.query("USE ks", &[]).await?;
 
     Ok(())


### PR DESCRIPTION
The executed request no longer produces any warnings. This was changed in 2af7800c: `session: improve use keyspace queries detection`, since when `USE KEYSPACE ` statement is no longer parsed by the driver. As since then the parsing is delegated to the database (and therefore considered stable), the warning about sending raw `USE KEYSPACE` being experimental is no longer relevant.
Fixes: #589 
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- ~~[ ] I have split my patch into logically separate commits.~~
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
