### PR TITLE
LWT routing optimisation: plan contains replicas in ring order

### DIFF
--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -166,5 +166,11 @@ And only if latency awareness is enabled:
 
 If no preferred datacenter is specified, all nodes are treated as local ones.
 
-Replicas in the same priority groups are shuffled. Non-replicas are randomly
+Replicas in the same priority groups are shuffled[^*]. Non-replicas are randomly
 rotated (similarly to a round robin with a random index).
+
+[^*]: There is an optimisation implemented for LWT requests[^**] that routes them
+to the replicas in the ring order (as it prevents contention due to Paxos conflicts),
+so replicas in that case are not shuffled in groups at all.
+
+[^**]: In order for the optimisation to be applied, LWT statements must be prepared before.

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -279,7 +279,7 @@ impl DefaultPolicy {
                     "Datacenter specified as the preferred one ({}) does not exist!",
                     preferred_datacenter
                 );
-                // We won't guess any DC, as it could lead to possible violation dc failover ban.
+                // We won't guess any DC, as it could lead to possible violation of dc failover ban.
                 return &[];
             }
         }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -285,18 +285,18 @@ impl DefaultPolicy {
                 .replica_locator()
                 .unique_nodes_in_datacenter_ring(preferred_datacenter.as_str())
             {
-                return nodes;
+                nodes
             } else {
                 tracing::warn!(
                     "Datacenter specified as the preferred one ({}) does not exist!",
                     preferred_datacenter
                 );
                 // We won't guess any DC, as it could lead to possible violation of dc failover ban.
-                return &[];
+                &[]
             }
+        } else {
+            cluster.replica_locator().unique_nodes_in_global_ring()
         }
-
-        cluster.replica_locator().unique_nodes_in_global_ring()
     }
 
     fn nonfiltered_replica_set<'a>(

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -1202,7 +1202,7 @@ mod tests {
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1227,7 +1227,7 @@ mod tests {
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1251,7 +1251,7 @@ mod tests {
                     consistency: Consistency::LocalOne, // local Consistency forbids datacenter failover
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1273,7 +1273,7 @@ mod tests {
                     consistency: Consistency::One,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1295,7 +1295,7 @@ mod tests {
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1320,7 +1320,7 @@ mod tests {
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1344,7 +1344,7 @@ mod tests {
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1366,7 +1366,7 @@ mod tests {
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1390,7 +1390,7 @@ mod tests {
                     consistency: Consistency::LocalOne, // local Consistency forbids datacenter failover
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1450,7 +1450,7 @@ mod tests {
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1472,7 +1472,7 @@ mod tests {
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new().build(), // empty plan, because all nodes are remote and failover is forbidden
@@ -1491,7 +1491,7 @@ mod tests {
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1513,7 +1513,7 @@ mod tests {
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1538,7 +1538,7 @@ mod tests {
                     consistency: Consistency::One,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1566,7 +1566,7 @@ mod tests {
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
-                // going though the ring, we get order: B , C , E , G , A , F , D
+                // going through the ring, we get order: B , C , E , G , A , F , D
                 //                                      eu  eu  us  eu  eu  us  us
                 //                                      r1  r1  r1  r2  r1  r2  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -1592,7 +1592,7 @@ mod tests {
                     consistency: Consistency::One,
                     ..Default::default()
                 },
-                // going though the ring, we get order: F , A , C , D , G , B , E
+                // going through the ring, we get order: F , A , C , D , G , B , E
                 //                                      us  eu  eu  us  eu  eu  us
                 //                                      r2  r1  r1  r1  r2  r1  r1
                 expected_groups: ExpectedGroupsBuilder::new()
@@ -2765,7 +2765,7 @@ mod latency_awareness {
                         consistency: Consistency::Quorum,
                         ..Default::default()
                     },
-                    // going though the ring, we get order: F , A , C , D , G , B , E
+                    // going through the ring, we get order: F , A , C , D , G , B , E
                     //                                      us  eu  eu  us  eu  eu  us
                     //                                      r2  r1  r1  r1  r2  r1  r1
                     expected_groups: ExpectedGroupsBuilder::new()
@@ -2791,7 +2791,7 @@ mod latency_awareness {
                         (C, slow_penalised()),
                         (D, slow_penalised()),
                     ],
-                    // going though the ring, we get order: F , A , C , D , G , B , E
+                    // going through the ring, we get order: F , A , C , D , G , B , E
                     //                                      us  eu  eu  us  eu  eu  us
                     //                                      r2  r1  r1  r1  r2  r1  r1
                     expected_groups: ExpectedGroupsBuilder::new()
@@ -2814,7 +2814,7 @@ mod latency_awareness {
                         consistency: Consistency::Quorum,
                         ..Default::default()
                     },
-                    // going though the ring, we get order: F , A , C , D , G , B , E
+                    // going through the ring, we get order: F , A , C , D , G , B , E
                     //                                      us  eu  eu  us  eu  eu  us
                     //                                      r2  r1  r1  r1  r2  r1  r1
                     expected_groups: ExpectedGroupsBuilder::new()

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -53,9 +53,8 @@ pub type FallbackPlan<'a> = Box<dyn Iterator<Item = NodeRef<'a>> + Send + Sync +
 /// `pick` and `fallback`. `pick` returns a first node to contact for a given query, `fallback`
 /// returns the rest of the load balancing plan.
 ///
-/// `fallback` is called only after a failed send to `pick`ed node (or when executing
-/// speculatively).
-/// If a `pick` returns `None`, `fallback` will not be called.
+/// `fallback` is called not only if a send to `pick`ed node failed (or when executing
+/// speculatively), but also if `pick` returns `None`.
 ///
 /// Usually the driver needs only the first node from load balancing plan (most queries are send
 /// successfully, and there is no need to retry).

--- a/scylla/src/transport/locator/precomputed_replicas.rs
+++ b/scylla/src/transport/locator/precomputed_replicas.rs
@@ -84,6 +84,7 @@ impl PrecomputedReplicas {
         // Each ring will precompute for at least this RF
         let min_precomputed_rep_factor: usize = 1;
 
+        // The maximum replication factor over those used with Simple strategy.
         let mut max_global_repfactor: usize = min_precomputed_rep_factor;
         let mut dc_repfactors: HashMap<&'a str, BTreeSet<usize>> = HashMap::new();
 

--- a/scylla/src/transport/locator/replication_info.rs
+++ b/scylla/src/transport/locator/replication_info.rs
@@ -213,7 +213,7 @@ mod tests {
     use super::ReplicationInfo;
 
     #[tokio::test]
-    async fn test_simple_stategy() {
+    async fn test_simple_strategy() {
         let ring = create_ring(&mock_metadata_for_token_aware_tests());
         let replication_info = ReplicationInfo::new(ring);
 

--- a/scylla/src/transport/locator/token_ring.rs
+++ b/scylla/src/transport/locator/token_ring.rs
@@ -1,6 +1,7 @@
 use crate::routing::Token;
 
-/// A token ring is a continous hash ring. It defines association by hasing a key onto the ring and the walking the ring in one direction.
+/// A token ring is a continuous hash ring. It defines association by hashing a key
+/// onto the ring and then walking the ring in one direction.
 /// Cassandra and Scylla use it for determining data ownership which allows for efficient load balancing.
 /// The token ring is used by the driver to find the replicas for a given token.
 /// Each ring member has a token (i64 number) which defines the member's position on the ring.
@@ -30,7 +31,7 @@ impl<ElemT> TokenRing<ElemT> {
     /// Provides an iterator over the ring members starting at the given token.
     /// The iterator traverses the whole ring in the direction of increasing tokens.
     /// After reaching the maximum token it wraps around and continues from the lowest one.
-    /// The iterator visits each member once, it doesn't have an infinte length.
+    /// The iterator visits each member once, it doesn't have infinite length.
     pub fn ring_range_full(&self, token: Token) -> impl Iterator<Item = &(Token, ElemT)> {
         let binary_search_index: usize = match self.ring.binary_search_by(|e| e.0.cmp(&token)) {
             Ok(exact_match_index) => exact_match_index,
@@ -47,7 +48,7 @@ impl<ElemT> TokenRing<ElemT> {
     /// The iterator traverses the whole ring in the direction of increasing tokens.
     /// After reaching the maximum token it wraps around and continues from the lowest one.
     /// The iterator visits each member once, it doesn't have an infinte length.
-    /// To access the token along with the element you can use `ring_range_full`
+    /// To access the token along with the element you can use `ring_range_full`.
     pub fn ring_range(&self, token: Token) -> impl Iterator<Item = &ElemT> {
         self.ring_range_full(token).map(|(_t, e)| e)
     }

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -214,3 +214,25 @@ impl Hash for Node {
         self.host_id.hash(state);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Node {
+        pub(crate) fn new_for_test(
+            address: NodeAddr,
+            datacenter: Option<String>,
+            rack: Option<String>,
+        ) -> Self {
+            Self {
+                host_id: Uuid::new_v4(),
+                address,
+                datacenter,
+                rack,
+                pool: None,
+                down_marker: false.into(),
+            }
+        }
+    }
+}

--- a/scylla/tests/integration/lwt_optimisation.rs
+++ b/scylla/tests/integration/lwt_optimisation.rs
@@ -12,13 +12,11 @@ use scylla_proxy::{
     ResponseOpcode, ResponseReaction, ResponseRule, ShardAwareness, WorkerError,
 };
 
-// FIXME: This will only work again after refactor of load balancing is finished.
-#[ignore]
 #[tokio::test]
 #[ntest::timeout(20000)]
 #[cfg(not(scylla_cloud_tests))]
 async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optimally() {
-    // This is just to increase the likelyhood that only intended prepared statements (which contain this mark) are captures by the proxy.
+    // This is just to increase the likelihood that only intended prepared statements (which contain this mark) are captured by the proxy.
     const MAGIC_MARK: i32 = 123;
 
     let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {


### PR DESCRIPTION
While routing statements that are confirmed LWTs, replicas are never shuffled but instead attempted in the ring order. This is done according to https://github.com/scylladb/gocql/issues/40.

### `ReplicaSet` currently
In case of Network Topology Strategy, the replica iterator we obtain from the `ReplicaLocator` (`ReplicaSetIterator`) does not yield replicas in the ring order.

### Meet `ReplicasOrdered`
To support that, `ReplicasOrdered` struct is added and constructible from `ReplicaSet`. It is also convertible into `ReplicasOrderedIterator`, which does yield replicas in the ring order.

### Costs incurred
The first call to `next()` on `ReplicasOrderedIterator` is cheap, because the primary replica can be computed cheaply, and this suits the `pick()` method.
The second call to `next()` is expensive, because all the replicas are materialised in a vector (there is no cheap way to compute the second replica and so on). All subsequent calls are cheap (because replicas are already computed). This suits the `fallback()` method expected high cost. Because of this characteristic, a semantic change was done to `Plan` (and `LoadBalancingPolicy`, as result).

### Plan semantics change
Before, `pick()` could return `None` and this signified that the plan is empty, so `fallback()` was not even called in such case.
Now, `pick()` can return `None` and this signifies that _the first node cannot be computed **cheaply**_. `fallback()` is called even then, for it is still possible to compute the first node (and the others) more expensively.

### Taken approach
If the first replica computed by `pick()` is believed to be down, then `pick()` doesn't attempt to compute any more replicas, but returns `None`. Then, `fallback()` is called and computes all remaining replicas at once.
Thanks to that, `pick()` remains cheap.

Fixes: #672 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
