### PR TITLE
connection: make it possible to switch off write coalescing

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -300,6 +300,7 @@ pub struct ConnectionConfig {
     pub(crate) cloud_config: Option<Arc<CloudConfig>>,
     pub authenticator: Option<Arc<dyn AuthenticatorProvider>>,
     pub address_translator: Option<Arc<dyn AddressTranslator>>,
+    pub enable_write_coalescing: bool,
 }
 
 impl Default for ConnectionConfig {
@@ -316,6 +317,7 @@ impl Default for ConnectionConfig {
             address_translator: None,
             #[cfg(feature = "cloud")]
             cloud_config: None,
+            enable_write_coalescing: true,
         }
     }
 }
@@ -901,6 +903,8 @@ impl Connection {
         // across .await points. Therefore, it should not be too expensive.
         let handler_map = StdMutex::new(ResponseHandlerMap::new());
 
+        let enable_write_coalescing = config.enable_write_coalescing;
+
         let r = Self::reader(
             BufReader::with_capacity(8192, read_half),
             &handler_map,
@@ -910,6 +914,7 @@ impl Connection {
             BufWriter::with_capacity(8192, write_half),
             &handler_map,
             receiver,
+            enable_write_coalescing,
         );
         let o = Self::orphaner(&handler_map, orphan_notification_receiver);
 
@@ -1019,6 +1024,7 @@ impl Connection {
         mut write_half: (impl AsyncWrite + Unpin),
         handler_map: &StdMutex<ResponseHandlerMap>,
         mut task_receiver: mpsc::Receiver<Task>,
+        enable_write_coalescing: bool,
     ) -> Result<(), QueryError> {
         // When the Connection object is dropped, the sender half
         // of the channel will be dropped, this task will return an error
@@ -1035,7 +1041,7 @@ impl Connection {
                 write_half.write_all(req_data).await?;
                 task = match task_receiver.try_recv() {
                     Ok(t) => t,
-                    Err(_) => {
+                    Err(_) if enable_write_coalescing => {
                         // Yielding was empirically tested to inject a 1-300µs delay,
                         // much better than tokio::time::sleep's 1ms granularity.
                         // Also, yielding in a busy system let's the queue catch up with new items.
@@ -1045,6 +1051,7 @@ impl Connection {
                             Err(_) => break,
                         }
                     }
+                    Err(_) => break,
                 }
             }
             trace!("Sending {} requests; {} bytes", num_requests, total_sent);
@@ -1603,7 +1610,7 @@ mod tests {
     use crate::transport::connection::open_connection;
     use crate::transport::topology::UntranslatedEndpoint;
     use crate::utils::test_utils::unique_keyspace_name;
-    use crate::SessionBuilder;
+    use crate::{IntoTypedRows, SessionBuilder};
     use futures::{StreamExt, TryStreamExt};
     use std::collections::HashMap;
     use std::net::SocketAddr;
@@ -1719,6 +1726,119 @@ mod tests {
             .await
             .unwrap();
         assert!(insert_res1.is_empty());
+    }
+
+    #[tokio::test]
+    #[cfg(not(scylla_cloud_tests))]
+    async fn test_coalescing() {
+        // It's difficult to write a reliable test that checks whether coalescing
+        // works like intended or not. Instead, this is a smoke test which is supposed
+        // to trigger the coalescing logic and check that everything works fine
+        // no matter whether coalescing is enabled or not.
+
+        let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+        let addr: SocketAddr = resolve_hostname(&uri).await;
+        let ks = unique_keyspace_name();
+
+        {
+            // Preparation phase
+            let session = SessionBuilder::new()
+                .known_node_addr(addr)
+                .build()
+                .await
+                .unwrap();
+            session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'SimpleStrategy', 'replication_factor' : 1}}", ks.clone()), &[]).await.unwrap();
+            session.use_keyspace(ks.clone(), false).await.unwrap();
+            session
+                .query(
+                    "CREATE TABLE IF NOT EXISTS t (p int primary key, v blob)",
+                    &[],
+                )
+                .await
+                .unwrap();
+        }
+
+        let subtest = |enable_coalescing: bool, ks: String| async move {
+            let (connection, _) = super::open_connection(
+                UntranslatedEndpoint::ContactPoint(ContactPoint {
+                    address: addr,
+                    datacenter: None,
+                }),
+                None,
+                ConnectionConfig {
+                    enable_write_coalescing: enable_coalescing,
+                    ..ConnectionConfig::default()
+                },
+            )
+            .await
+            .unwrap();
+            let connection = Arc::new(connection);
+
+            connection
+                .use_keyspace(&super::VerifiedKeyspaceName::new(ks, false).unwrap())
+                .await
+                .unwrap();
+
+            connection
+                .query(&"TRUNCATE t".into(), (), None)
+                .await
+                .unwrap();
+
+            let mut futs = Vec::new();
+
+            const NUM_BATCHES: i32 = 10;
+
+            for batch_size in 0..NUM_BATCHES {
+                // Each future should issue more and more queries in the first poll
+                let base = arithmetic_sequence_sum(batch_size);
+                let conn = connection.clone();
+                futs.push(tokio::task::spawn(async move {
+                    let futs = (base..base + batch_size).map(|j| {
+                        let q = Query::new("INSERT INTO t (p, v) VALUES (?, ?)");
+                        let conn = conn.clone();
+                        async move {
+                            conn.query(&q, (j, vec![j as u8; j as usize]), None)
+                                .await
+                                .unwrap()
+                        }
+                    });
+                    futures::future::join_all(futs).await;
+                }));
+
+                tokio::task::yield_now().await;
+            }
+
+            futures::future::join_all(futs).await;
+
+            // Check that everything was written properly
+            let range_end = arithmetic_sequence_sum(NUM_BATCHES);
+            let mut results = connection
+                .query(&"SELECT p, v FROM t".into(), (), None)
+                .await
+                .unwrap()
+                .into_query_result()
+                .unwrap()
+                .rows()
+                .unwrap()
+                .into_typed::<(i32, Vec<u8>)>()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            results.sort();
+
+            let expected = (0..range_end)
+                .map(|i| (i, vec![i as u8; i as usize]))
+                .collect::<Vec<_>>();
+
+            assert_eq!(results, expected);
+        };
+
+        subtest(true, ks.clone()).await;
+        subtest(false, ks.clone()).await;
+    }
+
+    // Returns the sum of integral numbers in the range [0..n)
+    fn arithmetic_sequence_sum(n: i32) -> i32 {
+        n * (n - 1) / 2
     }
 
     #[tokio::test]

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -293,6 +293,37 @@ impl SessionBuilder {
         self.config.address_translator = Some(translator);
         self
     }
+
+    /// If true, the driver will inject a small delay before flushing data
+    /// to the socket - by rescheduling the task that writes data to the socket.
+    /// This gives the task an opportunity to collect more write requests
+    /// and write them in a single syscall, increasing the efficiency.
+    ///
+    /// However, this optimization may worsen latency if the rate of requests
+    /// issued by the application is low, but otherwise the application is
+    /// heavily loaded with other tasks on the same tokio executor.
+    /// Please do performance measurements before committing to disabling
+    /// this option.
+    ///
+    /// This option is true by default.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use scylla::transport::Compression;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .write_coalescing(false) // Enabled by default
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_coalescing(mut self, enable: bool) -> Self {
+        self.config.enable_write_coalescing = enable;
+        self
+    }
 }
 #[cfg(feature = "cloud")]
 impl CloudSessionBuilder {


### PR DESCRIPTION
Each connection is managed by a tokio task that reads from and writes to a single socket. The task (called internally as "router") polls, amongst others, a future that collects write requests from a channel and pushes them to the socket. It currently has a heuristic that is meant to be a throughput optimization: if there are no more write requests on the channel, the future yields, hoping to give an opportunity for more write requests to arrive on the channel. This improves efficiency as it allows more requests to be batched together into a single write and reduces the number of syscalls issued.

The described optimization was implemented in:
e1c0b6f3b48eac2f60c043c05fc0b806189788c4

However, this optimization obviously can cause worse latency in some scenarios. For example, if there aren't many requests being issued but the application otherwise runs lots of unrelated tokio tasks, then a yielded task can be rescheduled again only after a significant delay. If the request rate is low enough then batching won't ever bring any benefit but will only make the latency worse.

In order to help in those scenarios, this commit adds a flag that allows turning off the write coalescing optimization. Write coalescing is kept turned on by default, but it can be easily disabled when constructing a new session.

Results of a test with modified cql-stress that runs 100 tasks which spin for 0.25ms and then yield, in a loop (https://github.com/piodul/cql-stress/commit/f20050e3a3514af20f431e0c4c187cd254500fbd):

```
cargo run --release --bin cql-stress-scylla-bench -- -max-rate 10000 -mode write -workload uniform -partition-count 128 -concurrency 16 -nodes 127.0.0.1 -duration 10s -noise-task-count 100 -noise-task-hog-duration 250us
```

With the coalescing optimization _enabled_:

```
  99h:          11.5ms
  95h:          7.21ms
  90h:          6.25ms
  median:       3.74ms
  mean:         4.11ms
```

With the coalescing optimization _disabled_:

```
  99h:          6.24ms
  95h:          4.89ms
  90h:          4.25ms
  median:       2.32ms
  mean:         2.44ms
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
