### PR TITLE
exec_profile: Default to SerialConsistency::LocalSerial

### DIFF
--- a/scylla/src/transport/execution_profile.rs
+++ b/scylla/src/transport/execution_profile.rs
@@ -183,7 +183,7 @@ pub(crate) mod defaults {
         Consistency::LocalQuorum
     }
     pub fn serial_consistency() -> Option<SerialConsistency> {
-        None
+        Some(SerialConsistency::LocalSerial)
     }
     pub fn request_timeout() -> Option<Duration> {
         Some(Duration::from_secs(30))


### PR DESCRIPTION
Contrary to what is stated in documentation, the default SerialConsistency was None, which resulted in SerialConsistency not being set in the CQL frames. This led to ProtocolError in case of LWT statements. As it is better to always include SerialConsistency (even for statements for which it is not relevant), the previous default is reverted.

Ref: https://github.com/scylladb/scylla-enterprise/issues/2970

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
