### PR TITLE
Close connections on no response to keepalives 

### DIFF
--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1177,7 +1177,7 @@ impl ProxyWorker {
     }
 }
 
-// Returns next free last IP address octet for another proxy instance.
+// Returns next free IP address for another proxy instance.
 // Useful for concurrent testing.
 #[doc(hidden)]
 pub fn get_exclusive_local_address() -> IpAddr {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -70,8 +70,8 @@ const LOCAL_VERSION: &str = "SELECT schema_version FROM system.local WHERE key='
 // FIXME: Make this constants configurable
 // The term "orphan" refers to stream ids, that were allocated for a {request, response} that no
 // one is waiting anymore (due to cancellation of `Connection::send_request`). Old orphan refers to
-// a stream id, that is orphaned for a long time. This long time is defined below
-// (`OLD_AGE_ORPHAN_THRESHOLD`). Connection, that has a big number (`OLD_ORPHAN_COUNT_THRESHOLD`)
+// a stream id that is orphaned for a long time. This long time is defined below
+// (`OLD_AGE_ORPHAN_THRESHOLD`). Connection that has a big number (`OLD_ORPHAN_COUNT_THRESHOLD`)
 // of old orphans is shut down (and created again by a connection management layer).
 const OLD_ORPHAN_COUNT_THRESHOLD: usize = 1024;
 const OLD_AGE_ORPHAN_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(1);

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -362,6 +362,9 @@ pub struct ConnectionConfig {
     pub authenticator: Option<Arc<dyn AuthenticatorProvider>>,
     pub address_translator: Option<Arc<dyn AddressTranslator>>,
     pub enable_write_coalescing: bool,
+
+    pub keepalive_interval: Option<Duration>,
+    pub keepalive_timeout: Option<Duration>,
 }
 
 impl Default for ConnectionConfig {
@@ -380,6 +383,10 @@ impl Default for ConnectionConfig {
             #[cfg(feature = "cloud")]
             cloud_config: None,
             enable_write_coalescing: true,
+
+            // Note: this is different than SessionConfig default values.
+            keepalive_interval: None,
+            keepalive_timeout: None,
         }
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -192,8 +192,13 @@ pub struct SessionConfig {
     /// If true, full schema is fetched with every metadata refresh.
     pub fetch_schema_metadata: bool,
 
-    /// Interval of sending keepalive requests
+    /// Interval of sending keepalive requests.
+    /// If `None`, keepalives are never sent, so `Self::keepalive_timeout` has no effect.
     pub keepalive_interval: Option<Duration>,
+
+    /// Controls after what time of not receiving response to keepalives a connection is closed.
+    /// If `None`, connections are never closed due to lack of response to a keepalive message.
+    pub keepalive_timeout: Option<Duration>,
 
     /// Controls the timeout for the automatic wait for schema agreement after sending a schema-altering statement.
     /// If `None`, the automatic schema agreement is disabled.
@@ -276,6 +281,7 @@ impl SessionConfig {
             keyspaces_to_fetch: Vec::new(),
             fetch_schema_metadata: true,
             keepalive_interval: Some(Duration::from_secs(30)),
+            keepalive_timeout: Some(Duration::from_secs(30)),
             auto_await_schema_agreement_timeout: Some(std::time::Duration::from_secs(60)),
             address_translator: None,
             host_filter: None,
@@ -488,6 +494,8 @@ impl Session {
             #[cfg(feature = "cloud")]
             cloud_config: config.cloud_config,
             enable_write_coalescing: config.enable_write_coalescing,
+            keepalive_interval: config.keepalive_interval,
+            keepalive_timeout: config.keepalive_timeout,
         };
 
         let pool_config = PoolConfig {

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -707,6 +707,36 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
+    /// Set the keepalive timeout.
+    /// The default is `Some(Duration::from_secs(30))`. It means that
+    /// the connection will be closed if time between sending a keepalive
+    /// and receiving a response to any keepalive (not necessarily the same -
+    /// it may be one sent later) exceeds 30 seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .keepalive_timeout(std::time::Duration::from_secs(42))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn keepalive_timeout(mut self, timeout: Duration) -> Self {
+        if timeout <= Duration::from_secs(1) {
+            warn!(
+                "Setting the keepalive timeout to low values ({:?}) is not recommended as it may aggresively close connections. Consider setting it above 5 seconds.",
+                timeout
+            );
+        }
+
+        self.config.keepalive_timeout = Some(timeout);
+        self
+    }
+
     /// Enables automatic wait for schema agreement and sets the timeout for it.
     /// By default, it is enabled and the timeout is 60 seconds.
     ///


### PR DESCRIPTION
This PR aims to add a feature that has been supported in other drivers: closing connections when not receiving responses to keepalives. To do so:
- `SessionBuilder`, `SessionConfig` and `ConnectionConfig` get new parameter: `keepalive_timeout`,
- `Keepaliver` is refactored so that it no longer resides in the connection pool layer, but...
- ...it is moved into `Connection` layer, more specifically into `router`. This enables clean closing connection when the keepalive timeout elapses without receiving a response,
- a test is added for the new feature.

Fixes: #718

## Pre-review checklist
<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
