### PR TITLE
Latency awareness: add `scale` parameter

### DIFF
--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -1488,11 +1488,11 @@ mod latency_awareness {
                 Some(prev_avg) => Some({
                     let delay = (now - prev_avg.timestamp).as_secs_f64();
                     let prev_weight = (delay + 1.).ln() / delay;
-                    let last_latency_nanos = last_latency.as_nanos() as f64;
-                    let prev_avg_nanos = prev_avg.average.as_nanos() as f64;
-                    let average = Duration::from_nanos(
-                        ((1. - prev_weight) * last_latency_nanos + prev_weight * prev_avg_nanos)
-                            .round() as u64,
+
+                    let last_latency_secs = last_latency.as_secs_f64();
+                    let prev_avg_secs = prev_avg.average.as_secs_f64();
+                    let average = Duration::from_secs_f64(
+                        (1. - prev_weight) * last_latency_secs + prev_weight * prev_avg_secs,
                     );
                     Self {
                         num_measures: prev_avg.num_measures + 1,


### PR DESCRIPTION
The parameter was omited accidentally while porting.

To the best of my understanding of the previous version of the code, the scale that was implicitly used before was equal to **1 second**. The new default value is, in line with other drivers, **100 milliseconds**. This implies that this is an API-breaking change.

Fixes: #650

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
