### PR TITLE
CI: Bound all workflows with a timeout

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   # PasswordAuthenticator
   build:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     services:
       scylladb:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       scylladb:
         image: scylladb/scylla

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
     - name: Setup 3-node Cassandra cluster

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
     - name: Setup 3-node Scylla cluster

--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -13,6 +13,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python 2.7

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -13,17 +13,18 @@ env:
 jobs:
   tls:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     services:
       scylladb:
         image: scylladb/scylla-tls
         ports:
           - 9042:9042
           - 9142:9142
-        options: 
-          --health-cmd "cqlsh --debug" 
-          --health-interval 5s 
+        options:
+          --health-cmd "cqlsh --debug"
+          --health-interval 5s
           --health-retries 10
-    env: 
+    env:
       working-directory: ./scylla
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As it may happen that a pushed PR triggers a nonterminating test, it is desirable to automatically timeout such CI runs. This commit adds timeouts that have been empirically tested to suffice (by past experience with CI execution time).

Fixes: #721

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
