### PR TITLE
connection: Add configurable TCP keepalives

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -16,14 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 ssl = ["dep:tokio-openssl", "dep:openssl"]
-cloud = [
-    "ssl",
-    "scylla-cql/serde",
-    "dep:serde_yaml",
-    "dep:serde",
-    "dep:url",
-    "dep:base64",
-]
+cloud = ["ssl", "scylla-cql/serde", "dep:serde_yaml", "dep:serde", "dep:url", "dep:base64"]
 secret = ["scylla-cql/secret"]
 
 [dependencies]
@@ -34,7 +27,7 @@ bytes = "1.0.1"
 futures = "0.3.6"
 histogram = "0.6.9"
 num_enum = "0.5"
-tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
+tokio = { version = "1.27", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8.3"
@@ -58,6 +51,7 @@ serde_yaml = { version = "0.9.14", optional = true }
 url = { version = "2.3.1", optional = true }
 base64 = { version = "0.13.1", optional = true }
 rand_pcg = "0.3.1"
+socket2 = { version = "0.5.3", features = ["all"] }
 
 [dev-dependencies]
 scylla-proxy = { version = "0.0.2", path = "../scylla-proxy"}

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -162,6 +162,7 @@ pub struct SessionConfig {
     /// If it's not supported by database server Session will fall back to no compression.
     pub compression: Option<Compression>,
     pub tcp_nodelay: bool,
+    pub tcp_keepalive_interval: Option<Duration>,
 
     pub default_execution_profile_handle: ExecutionProfileHandle,
 
@@ -248,6 +249,7 @@ impl SessionConfig {
             known_nodes: Vec::new(),
             compression: None,
             tcp_nodelay: true,
+            tcp_keepalive_interval: None,
             schema_agreement_interval: Duration::from_millis(200),
             default_execution_profile_handle: ExecutionProfile::new_from_inner(Default::default())
                 .into_handle(),
@@ -462,6 +464,7 @@ impl Session {
         let connection_config = ConnectionConfig {
             compression: config.compression,
             tcp_nodelay: config.tcp_nodelay,
+            tcp_keepalive_interval: config.tcp_keepalive_interval,
             #[cfg(feature = "ssl")]
             ssl_config: config.ssl_context.map(SslConfig::new_with_global_context),
             authenticator: config.authenticator.clone(),


### PR DESCRIPTION
Similarly to other drivers, support for TCP-layer keepalives is added. This is possible, because tokio::net::TcpStream finally implements `AsFd`. This enables creating `socket2::SockRef`, which in turn allows for configuring the underlying socket.
Fixes: #132 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
