### PR TITLE
scylla_cql: autoderive Default for Consistency

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 scylla-macros = { version = "0.2.0", path = "../scylla-macros"}
 byteorder = "1.3.4"
 bytes = "1.0.1"
-num_enum = "0.5"
+num_enum = "0.6"
 tokio = { version = "1.12", features = ["io-util", "time"] }
 secrecy = { version = "0.7.0", optional = true }
 snap = "1.0"

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -12,7 +12,7 @@ use std::net::SocketAddr;
 use std::str;
 use uuid::Uuid;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "SCREAMING_SNAKE_CASE"))]
 #[repr(i16)]
@@ -23,6 +23,7 @@ pub enum Consistency {
     Three = 0x0003,
     Quorum = 0x0004,
     All = 0x0005,
+    #[default]
     LocalQuorum = 0x0006,
     EachQuorum = 0x0007,
     LocalOne = 0x000A,
@@ -44,22 +45,6 @@ pub enum SerialConsistency {
 pub enum LegacyConsistency {
     Regular(Consistency),
     Serial(SerialConsistency),
-}
-
-// Although we could `impl Default for Consistency` with an automatic derive,
-// this would require adding a #[default] annotation on the default variant,
-// but - unfortunately - that annotation is also recognized by `TryFromPrimitive`
-// derive macro. If there is a #[default] variant then `TryFromPrimitive`
-// falls back to it - if not, then it returns an error. This breaks one of the
-// tests.
-//
-// It will be possible to fix this properly after the following issue is closed:
-// https://github.com/illicitonion/num_enum/issues/75
-#[allow(clippy::derivable_impls)]
-impl Default for Consistency {
-    fn default() -> Self {
-        Consistency::LocalQuorum
-    }
 }
 
 impl std::fmt::Display for Consistency {

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 histogram = "0.6.9"
-num_enum = "0.5"
+num_enum = "0.6"
 tokio = { version = "1.27", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }


### PR DESCRIPTION
As the [awaited issue](https://github.com/illicitonion/num_enum/issues/75) in `num_enum` crate has been resolved in its 0.6 release, it is now possible to derive Default for Consistency automatically.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
