### PR TITLE
Fix RoutingInfo consistency

### DIFF
--- a/scylla-cql/benches/benchmark.rs
+++ b/scylla-cql/benches/benchmark.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use scylla_cql::frame::request::Request;
@@ -7,11 +9,11 @@ use scylla_cql::frame::{request::query, Compression, SerializedRequest};
 
 fn make_query<'a>(contents: &'a str, values: &'a SerializedValues) -> query::Query<'a> {
     query::Query {
-        contents,
+        contents: Cow::Borrowed(contents),
         parameters: query::QueryParameters {
             consistency: scylla_cql::Consistency::LocalQuorum,
             serial_consistency: None,
-            values,
+            values: Cow::Borrowed(values),
             page_size: None,
             paging_state: None,
             timestamp: None,
@@ -25,7 +27,7 @@ fn serialized_request_make_bench(c: &mut Criterion) {
         ("INSERT foo INTO ks.table_name (?)", &(1234,).serialized().unwrap()),
         ("INSERT foo, bar, baz INTO ks.table_name (?, ?, ?)", &(1234, "a value", "i am storing a string").serialized().unwrap()),
         (
-            "INSERT foo, bar, baz, boop, blah INTO longer_keyspace.a_big_table_name (?, ?, ?, ?, 1000)", 
+            "INSERT foo, bar, baz, boop, blah INTO longer_keyspace.a_big_table_name (?, ?, ?, ?, 1000)",
             &(1234, "a value", "i am storing a string", "dc0c8cd7-d954-47c1-8722-a857941c43fb").serialized().unwrap()
         ),
     ];

--- a/scylla-cql/benches/benchmark.rs
+++ b/scylla-cql/benches/benchmark.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use scylla_cql::frame::request::Request;
+use scylla_cql::frame::request::SerializableRequest;
 use scylla_cql::frame::value::SerializedValues;
 use scylla_cql::frame::value::ValueList;
 use scylla_cql::frame::{request::query, Compression, SerializedRequest};

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use std::convert::TryFrom;
 
-use request::Request;
+use request::SerializableRequest;
 use response::ResponseOpcode;
 
 const HEADER_SIZE: usize = 9;
@@ -60,7 +60,7 @@ pub struct SerializedRequest {
 }
 
 impl SerializedRequest {
-    pub fn make<R: Request>(
+    pub fn make<R: SerializableRequest>(
         req: &R,
         compression: Option<Compression>,
         tracing: bool,

--- a/scylla-cql/src/frame/request/auth_response.rs
+++ b/scylla-cql/src/frame/request/auth_response.rs
@@ -1,7 +1,7 @@
 use crate::frame::frame_errors::ParseError;
 use bytes::BufMut;
 
-use crate::frame::request::{Request, RequestOpcode};
+use crate::frame::request::{RequestOpcode, SerializableRequest};
 use crate::frame::types::write_bytes_opt;
 
 // Implements Authenticate Response
@@ -9,7 +9,7 @@ pub struct AuthResponse {
     pub response: Option<Vec<u8>>,
 }
 
-impl Request for AuthResponse {
+impl SerializableRequest for AuthResponse {
     const OPCODE: RequestOpcode = RequestOpcode::AuthResponse;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -13,7 +13,7 @@ use crate::frame::{
 const FLAG_WITH_SERIAL_CONSISTENCY: u8 = 0x10;
 const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
 
-#[cfg_attr(test, derive(Debug))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Batch<'b, Statement, Values>
 where
     BatchStatement<'b>: From<&'b Statement>,
@@ -30,7 +30,7 @@ where
 
 /// The type of a batch.
 #[derive(Clone, Copy)]
-#[cfg_attr(test, derive(Debug))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum BatchType {
     Logged = 0,
     Unlogged = 1,

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -1,11 +1,11 @@
-use crate::frame::{frame_errors::ParseError, value::BatchValuesIterator};
 use bytes::{Buf, BufMut};
 use std::{borrow::Cow, convert::TryInto};
 
 use crate::frame::{
+    frame_errors::ParseError,
     request::{Request, RequestOpcode},
     types,
-    value::{BatchValues, SerializedValues},
+    value::{BatchValues, BatchValuesIterator, SerializedValues},
 };
 
 use super::DeserializableRequest;

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -13,6 +13,7 @@ use crate::frame::{
 const FLAG_WITH_SERIAL_CONSISTENCY: u8 = 0x10;
 const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
 
+#[cfg_attr(test, derive(Debug))]
 pub struct Batch<'b, Statement, Values>
 where
     BatchStatement<'b>: From<&'b Statement>,
@@ -29,6 +30,7 @@ where
 
 /// The type of a batch.
 #[derive(Clone, Copy)]
+#[cfg_attr(test, derive(Debug))]
 pub enum BatchType {
     Logged = 0,
     Unlogged = 1,

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, convert::TryInto};
 
 use crate::frame::{
     frame_errors::ParseError,
-    request::{Request, RequestOpcode},
+    request::{RequestOpcode, SerializableRequest},
     types,
     value::{BatchValues, BatchValuesIterator, SerializedValues},
 };
@@ -68,7 +68,7 @@ pub enum BatchStatement<'a> {
     Prepared { id: Cow<'a, [u8]> },
 }
 
-impl<Statement, Values> Request for Batch<'_, Statement, Values>
+impl<Statement, Values> SerializableRequest for Batch<'_, Statement, Values>
 where
     for<'s> BatchStatement<'s>: From<&'s Statement>,
     Statement: Clone,

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -92,9 +92,10 @@ where
                 .ok_or_else(|| counts_mismatch_err(idx, self.statements.clone().count()))??;
             n_serialized_statements += 1;
         }
+        // At this point, we have all statements serialized. If any values are still left, we have a mismatch.
         if value_lists.skip_next().is_some() {
             return Err(counts_mismatch_err(
-                std::iter::from_fn(|| value_lists.skip_next()).count() + 1,
+                n_serialized_statements + 1 /*skipped above*/ + value_lists.count(),
                 n_serialized_statements,
             ));
         }

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -34,6 +34,29 @@ pub enum BatchType {
     Counter = 2,
 }
 
+pub struct BatchTypeParseError {
+    value: u8,
+}
+
+impl From<BatchTypeParseError> for ParseError {
+    fn from(err: BatchTypeParseError) -> Self {
+        Self::BadIncomingData(format!("Bad BatchType value: {}", err.value))
+    }
+}
+
+impl TryFrom<u8> for BatchType {
+    type Error = BatchTypeParseError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Logged),
+            1 => Ok(Self::Unlogged),
+            2 => Ok(Self::Counter),
+            _ => Err(BatchTypeParseError { value }),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub enum BatchStatement<'a> {
     Query { text: &'a str },

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -6,6 +6,7 @@ use crate::{
     frame::types,
 };
 
+#[cfg_attr(test, derive(Debug))]
 pub struct Execute<'a> {
     pub id: Bytes,
     pub parameters: query::QueryParameters<'a>,

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -2,7 +2,7 @@ use crate::frame::frame_errors::ParseError;
 use bytes::{BufMut, Bytes};
 
 use crate::{
-    frame::request::{query, Request, RequestOpcode},
+    frame::request::{query, RequestOpcode, SerializableRequest},
     frame::types,
 };
 
@@ -14,7 +14,7 @@ pub struct Execute<'a> {
     pub parameters: query::QueryParameters<'a>,
 }
 
-impl Request for Execute<'_> {
+impl SerializableRequest for Execute<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Execute;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -6,6 +6,8 @@ use crate::{
     frame::types,
 };
 
+use super::{query::QueryParameters, DeserializableRequest};
+
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Execute<'a> {
     pub id: Bytes,
@@ -22,5 +24,14 @@ impl Request for Execute<'_> {
         // Serializing params
         self.parameters.serialize(buf)?;
         Ok(())
+    }
+}
+
+impl<'e> DeserializableRequest for Execute<'e> {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
+        let id = types::read_short_bytes(buf)?.to_vec().into();
+        let parameters = QueryParameters::deserialize(buf)?;
+
+        Ok(Self { id, parameters })
     }
 }

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -6,7 +6,7 @@ use crate::{
     frame::types,
 };
 
-#[cfg_attr(test, derive(Debug))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Execute<'a> {
     pub id: Bytes,
     pub parameters: query::QueryParameters<'a>,

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -31,7 +31,7 @@ pub enum RequestOpcode {
     AuthResponse = 0x0F,
 }
 
-pub trait Request {
+pub trait SerializableRequest {
     const OPCODE: RequestOpcode;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError>;
@@ -45,7 +45,7 @@ pub trait Request {
 
 /// Not intended for driver's direct usage (as driver has no interest in deserialising CQL requests),
 /// but very useful for testing (e.g. asserting that the sent requests have proper parameters set).
-pub trait DeserializableRequest: Request + Sized {
+pub trait DeserializableRequest: SerializableRequest + Sized {
     fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError>;
 }
 
@@ -61,7 +61,7 @@ mod tests {
                 batch::{Batch, BatchStatement, BatchType},
                 execute::Execute,
                 query::{Query, QueryParameters},
-                DeserializableRequest, Request,
+                DeserializableRequest, SerializableRequest,
             },
             types::{self, LegacyConsistency, SerialConsistency},
             value::SerializedValues,

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -48,3 +48,193 @@ pub trait Request {
 pub trait DeserializableRequest: Request + Sized {
     fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError>;
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, ops::Deref};
+
+    use bytes::Bytes;
+
+    use crate::{
+        frame::{
+            request::{
+                batch::{Batch, BatchStatement, BatchType},
+                execute::Execute,
+                query::{Query, QueryParameters},
+                DeserializableRequest, Request,
+            },
+            types::{self, LegacyConsistency, SerialConsistency},
+            value::SerializedValues,
+        },
+        Consistency,
+    };
+
+    #[test]
+    fn request_ser_de_identity() {
+        // Query
+        let contents = Cow::Borrowed("SELECT host_id from system.peers");
+        let parameters = QueryParameters {
+            consistency: Consistency::All,
+            serial_consistency: Some(SerialConsistency::Serial),
+            timestamp: None,
+            page_size: Some(323),
+            paging_state: Some(vec![2, 1, 3, 7].into()),
+            values: {
+                let mut vals = SerializedValues::new();
+                vals.add_value(&2137).unwrap();
+                Cow::Owned(vals)
+            },
+        };
+        let query = Query {
+            contents,
+            parameters,
+        };
+
+        {
+            let mut buf = Vec::new();
+            query.serialize(&mut buf).unwrap();
+
+            let query_deserialized = Query::deserialize(&mut &buf[..]).unwrap();
+            assert_eq!(&query_deserialized, &query);
+        }
+
+        // Execute
+        let id: Bytes = vec![2, 4, 5, 2, 6, 7, 3, 1].into();
+        let parameters = QueryParameters {
+            consistency: Consistency::Any,
+            serial_consistency: None,
+            timestamp: Some(3423434),
+            page_size: None,
+            paging_state: None,
+            values: {
+                let mut vals = SerializedValues::new();
+                vals.add_named_value("the_answer", &42).unwrap();
+                vals.add_named_value("really?", &2137).unwrap();
+                Cow::Owned(vals)
+            },
+        };
+        let execute = Execute { id, parameters };
+        {
+            let mut buf = Vec::new();
+            execute.serialize(&mut buf).unwrap();
+
+            let execute_deserialized = Execute::deserialize(&mut &buf[..]).unwrap();
+            assert_eq!(&execute_deserialized, &execute);
+        }
+
+        // Batch
+        let statements = vec![
+            BatchStatement::Query {
+                text: query.contents,
+            },
+            BatchStatement::Prepared {
+                id: Cow::Borrowed(&execute.id),
+            },
+        ];
+        let batch = Batch {
+            statements: Cow::Owned(statements),
+            batch_type: BatchType::Logged,
+            consistency: Consistency::EachQuorum,
+            serial_consistency: Some(SerialConsistency::LocalSerial),
+            timestamp: Some(32432),
+
+            // Not execute's values, because named values are not supported in batches.
+            values: vec![
+                query.parameters.values.deref().clone(),
+                query.parameters.values.deref().clone(),
+            ],
+        };
+        {
+            let mut buf = Vec::new();
+            batch.serialize(&mut buf).unwrap();
+
+            let batch_deserialized = Batch::deserialize(&mut &buf[..]).unwrap();
+            assert_eq!(&batch_deserialized, &batch);
+        }
+    }
+
+    #[test]
+    fn deser_rejects_unknown_flags() {
+        // Query
+        let contents = Cow::Borrowed("SELECT host_id from system.peers");
+        let parameters = QueryParameters {
+            consistency: Default::default(),
+            serial_consistency: Some(SerialConsistency::LocalSerial),
+            timestamp: None,
+            page_size: None,
+            paging_state: None,
+            values: Cow::Owned(SerializedValues::new()),
+        };
+        let query = Query {
+            contents: contents.clone(),
+            parameters,
+        };
+
+        {
+            let mut buf = Vec::new();
+            query.serialize(&mut buf).unwrap();
+
+            // Sanity check: query deserializes to the equivalent.
+            let query_deserialized = Query::deserialize(&mut &buf[..]).unwrap();
+            assert_eq!(&query_deserialized.contents, &query.contents);
+            assert_eq!(&query_deserialized.parameters, &query.parameters);
+
+            // Now modify flags by adding an unknown one.
+            // Find flags in buffer:
+            let mut buf_ptr = buf.as_slice();
+            let serialised_contents = types::read_long_string(&mut buf_ptr).unwrap();
+            assert_eq!(serialised_contents, contents);
+
+            // Now buf_ptr points at consistency.
+            let consistency = types::read_consistency(&mut buf_ptr).unwrap();
+            assert_eq!(
+                consistency,
+                LegacyConsistency::Regular(Consistency::default())
+            );
+
+            // Now buf_ptr points at flags, but it is immutable. Get mutable reference into the buffer.
+            let flags_idx = buf.len() - buf_ptr.len();
+            let flags_mut = &mut buf[flags_idx];
+
+            // This assumes that the following flag is unknown, which is true at the time of writing this test.
+            *flags_mut |= 0x80;
+
+            // Unknown flag should lead to frame rejection, as unknown flags can be new protocol extensions
+            // leading to different semantics.
+            let _parse_error = Query::deserialize(&mut &buf[..]).unwrap_err();
+        }
+
+        // Batch
+        let statements = vec![BatchStatement::Query {
+            text: query.contents,
+        }];
+        let batch = Batch {
+            statements: Cow::Owned(statements),
+            batch_type: BatchType::Logged,
+            consistency: Consistency::EachQuorum,
+            serial_consistency: None,
+            timestamp: None,
+
+            values: vec![query.parameters.values.deref().clone()],
+        };
+        {
+            let mut buf = Vec::new();
+            batch.serialize(&mut buf).unwrap();
+
+            // Sanity check: batch deserializes to the equivalent.
+            let batch_deserialized = Batch::deserialize(&mut &buf[..]).unwrap();
+            assert_eq!(batch, batch_deserialized);
+
+            // Now modify flags by adding an unknown one.
+            // There are no timestamp nor serial consistency, so flags are the last byte in the buf.
+            let buf_len = buf.len();
+            let flags_mut = &mut buf[buf_len - 1];
+            // This assumes that the following flag is unknown, which is true at the time of writing this test.
+            *flags_mut |= 0x80;
+
+            // Unknown flag should lead to frame rejection, as unknown flags can be new protocol extensions
+            // leading to different semantics.
+            let _parse_error = Batch::deserialize(&mut &buf[..]).unwrap_err();
+        }
+    }
+}

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -42,3 +42,9 @@ pub trait Request {
         Ok(v.into())
     }
 }
+
+/// Not intended for driver's direct usage (as driver has no interest in deserialising CQL requests),
+/// but very useful for testing (e.g. asserting that the sent requests have proper parameters set).
+pub trait DeserializableRequest: Request + Sized {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError>;
+}

--- a/scylla-cql/src/frame/request/options.rs
+++ b/scylla-cql/src/frame/request/options.rs
@@ -1,11 +1,11 @@
 use crate::frame::frame_errors::ParseError;
 use bytes::BufMut;
 
-use crate::frame::request::{Request, RequestOpcode};
+use crate::frame::request::{RequestOpcode, SerializableRequest};
 
 pub struct Options;
 
-impl Request for Options {
+impl SerializableRequest for Options {
     const OPCODE: RequestOpcode = RequestOpcode::Options;
 
     fn serialize(&self, _buf: &mut impl BufMut) -> Result<(), ParseError> {

--- a/scylla-cql/src/frame/request/prepare.rs
+++ b/scylla-cql/src/frame/request/prepare.rs
@@ -2,7 +2,7 @@ use crate::frame::frame_errors::ParseError;
 use bytes::BufMut;
 
 use crate::{
-    frame::request::{Request, RequestOpcode},
+    frame::request::{RequestOpcode, SerializableRequest},
     frame::types,
 };
 
@@ -10,7 +10,7 @@ pub struct Prepare<'a> {
     pub query: &'a str,
 }
 
-impl<'a> Request for Prepare<'a> {
+impl<'a> SerializableRequest for Prepare<'a> {
     const OPCODE: RequestOpcode = RequestOpcode::Prepare;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -19,6 +19,7 @@ const FLAG_WITH_SERIAL_CONSISTENCY: u8 = 0x10;
 const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
 const FLAG_WITH_NAMES_FOR_VALUES: u8 = 0x40;
 
+#[cfg_attr(test, derive(Debug))]
 pub struct Query<'q> {
     pub contents: Cow<'q, str>,
     pub parameters: QueryParameters<'q>,
@@ -33,7 +34,7 @@ impl Request for Query<'_> {
         Ok(())
     }
 }
-
+#[cfg_attr(test, derive(Debug))]
 pub struct QueryParameters<'a> {
     pub consistency: types::Consistency,
     pub serial_consistency: Option<types::SerialConsistency>,

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::frame::frame_errors::ParseError;
 use bytes::{BufMut, Bytes};
 
@@ -17,16 +19,16 @@ const FLAG_WITH_SERIAL_CONSISTENCY: u8 = 0x10;
 const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
 const FLAG_WITH_NAMES_FOR_VALUES: u8 = 0x40;
 
-pub struct Query<'a> {
-    pub contents: &'a str,
-    pub parameters: QueryParameters<'a>,
+pub struct Query<'q> {
+    pub contents: Cow<'q, str>,
+    pub parameters: QueryParameters<'q>,
 }
 
 impl Request for Query<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Query;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
-        types::write_long_string(self.contents, buf)?;
+        types::write_long_string(&self.contents, buf)?;
         self.parameters.serialize(buf)?;
         Ok(())
     }
@@ -38,7 +40,7 @@ pub struct QueryParameters<'a> {
     pub timestamp: Option<i64>,
     pub page_size: Option<i32>,
     pub paging_state: Option<Bytes>,
-    pub values: &'a SerializedValues,
+    pub values: Cow<'a, SerializedValues>,
 }
 
 impl Default for QueryParameters<'_> {
@@ -49,7 +51,7 @@ impl Default for QueryParameters<'_> {
             timestamp: None,
             page_size: None,
             paging_state: None,
-            values: SerializedValues::EMPTY,
+            values: Cow::Borrowed(SerializedValues::EMPTY),
         }
     }
 }

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -19,7 +19,7 @@ const FLAG_WITH_SERIAL_CONSISTENCY: u8 = 0x10;
 const FLAG_WITH_DEFAULT_TIMESTAMP: u8 = 0x20;
 const FLAG_WITH_NAMES_FOR_VALUES: u8 = 0x40;
 
-#[cfg_attr(test, derive(Debug))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Query<'q> {
     pub contents: Cow<'q, str>,
     pub parameters: QueryParameters<'q>,
@@ -34,7 +34,7 @@ impl Request for Query<'_> {
         Ok(())
     }
 }
-#[cfg_attr(test, derive(Debug))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct QueryParameters<'a> {
     pub consistency: types::Consistency,
     pub serial_consistency: Option<types::SerialConsistency>,

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -4,7 +4,7 @@ use crate::frame::frame_errors::ParseError;
 use bytes::{Buf, BufMut, Bytes};
 
 use crate::{
-    frame::request::{Request, RequestOpcode},
+    frame::request::{RequestOpcode, SerializableRequest},
     frame::types,
     frame::value::SerializedValues,
 };
@@ -33,7 +33,7 @@ pub struct Query<'q> {
     pub parameters: QueryParameters<'q>,
 }
 
-impl Request for Query<'_> {
+impl SerializableRequest for Query<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Query;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {

--- a/scylla-cql/src/frame/request/register.rs
+++ b/scylla-cql/src/frame/request/register.rs
@@ -2,7 +2,7 @@ use bytes::BufMut;
 
 use crate::frame::{
     frame_errors::ParseError,
-    request::{Request, RequestOpcode},
+    request::{RequestOpcode, SerializableRequest},
     server_event_type::EventType,
     types,
 };
@@ -11,7 +11,7 @@ pub struct Register {
     pub event_types_to_register_for: Vec<EventType>,
 }
 
-impl Request for Register {
+impl SerializableRequest for Register {
     const OPCODE: RequestOpcode = RequestOpcode::Register;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {

--- a/scylla-cql/src/frame/request/startup.rs
+++ b/scylla-cql/src/frame/request/startup.rs
@@ -4,7 +4,7 @@ use bytes::BufMut;
 use std::collections::HashMap;
 
 use crate::{
-    frame::request::{Request, RequestOpcode},
+    frame::request::{RequestOpcode, SerializableRequest},
     frame::types,
 };
 
@@ -12,7 +12,7 @@ pub struct Startup {
     pub options: HashMap<String, String>,
 }
 
-impl Request for Startup {
+impl SerializableRequest for Startup {
     const OPCODE: RequestOpcode = RequestOpcode::Startup;
 
     fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -249,6 +249,16 @@ pub trait BatchValuesIterator<'a> {
         buf: &mut impl BufMut,
     ) -> Option<Result<(), SerializeValuesError>>;
     fn skip_next(&mut self) -> Option<()>;
+    fn count(mut self) -> usize
+    where
+        Self: Sized,
+    {
+        let mut count = 0;
+        while self.skip_next().is_some() {
+            count += 1;
+        }
+        count
+    }
 }
 
 /// Implements `BatchValuesIterator` from an `Iterator` over references to things that implement `ValueList`

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -1,3 +1,4 @@
+use crate::frame::frame_errors::ParseError;
 use crate::frame::types;
 use bigdecimal::BigDecimal;
 use bytes::BufMut;
@@ -196,6 +197,39 @@ impl SerializedValues {
 
     pub fn size(&self) -> usize {
         self.serialized_values.len()
+    }
+
+    /// Creates value list from the request frame
+    pub fn new_from_frame(buf: &mut &[u8], contains_names: bool) -> Result<Self, ParseError> {
+        let values_num = types::read_short(buf)?;
+        let values_beg = *buf;
+        for _ in 0..values_num {
+            if contains_names {
+                let _name = types::read_string(buf)?;
+            }
+            let _serialized = types::read_bytes_opt(buf)?;
+        }
+
+        let values_len_in_buf = values_beg.len() - buf.len();
+        let values_in_frame = &values_beg[0..values_len_in_buf];
+        Ok(SerializedValues {
+            serialized_values: values_in_frame.to_vec(),
+            values_num,
+            contains_names,
+        })
+    }
+
+    pub fn iter_name_value_pairs(&self) -> impl Iterator<Item = (Option<&str>, &[u8])> {
+        let mut buf = &self.serialized_values[..];
+        (0..self.values_num).map(move |_| {
+            // `unwrap()`s here are safe, as we assume type-safety: if `SerializedValues` exits,
+            // we have a guarantee that the layout of the serialized values is valid.
+            let name = self
+                .contains_names
+                .then(|| types::read_string(&mut buf).unwrap());
+            let serialized = types::read_bytes(&mut buf).unwrap();
+            (name, serialized)
+        })
     }
 }
 

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use scylla_cql::frame::frame_errors::{FrameError, ParseError};
 use scylla_cql::frame::protocol_features::ProtocolFeatures;
+use scylla_cql::frame::request::Request;
 pub use scylla_cql::frame::request::RequestOpcode;
 pub use scylla_cql::frame::response::ResponseOpcode;
 use scylla_cql::frame::types::LegacyConsistency;
@@ -68,6 +69,10 @@ impl RequestFrame {
             writer,
         )
         .await
+    }
+
+    pub fn deserialize(&self) -> Result<Request, ParseError> {
+        Request::deserialize(&mut &self.body[..], self.opcode)
     }
 }
 #[derive(Clone, Debug)]

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -181,3 +181,22 @@ impl From<PreparedStatement> for BatchStatement {
         BatchStatement::PreparedStatement(p)
     }
 }
+
+impl<'a: 'b, 'b> From<&'a BatchStatement>
+    for scylla_cql::frame::request::batch::BatchStatement<'b>
+{
+    fn from(val: &'a BatchStatement) -> Self {
+        match val {
+            BatchStatement::Query(query) => {
+                scylla_cql::frame::request::batch::BatchStatement::Query {
+                    text: &query.contents,
+                }
+            }
+            BatchStatement::PreparedStatement(prepared) => {
+                scylla_cql::frame::request::batch::BatchStatement::Prepared {
+                    id: prepared.get_id(),
+                }
+            }
+        }
+    }
+}

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::history::HistoryListener;
@@ -189,12 +190,12 @@ impl<'a: 'b, 'b> From<&'a BatchStatement>
         match val {
             BatchStatement::Query(query) => {
                 scylla_cql::frame::request::batch::BatchStatement::Query {
-                    text: &query.contents,
+                    text: Cow::Borrowed(&query.contents),
                 }
             }
             BatchStatement::PreparedStatement(prepared) => {
                 scylla_cql::frame::request::batch::BatchStatement::Prepared {
-                    id: prepared.get_id(),
+                    id: Cow::Borrowed(prepared.get_id()),
                 }
             }
         }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -13,6 +13,7 @@ use tracing::instrument::WithSubscriber;
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
+use std::borrow::Cow;
 #[cfg(feature = "ssl")]
 use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
@@ -760,16 +761,8 @@ impl Connection {
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,
     ) -> Result<QueryResult, QueryError> {
-        let statements_iter = batch.statements.iter().map(|s| match s {
-            BatchStatement::Query(q) => batch::BatchStatement::Query { text: &q.contents },
-            BatchStatement::PreparedStatement(s) => {
-                batch::BatchStatement::Prepared { id: s.get_id() }
-            }
-        });
-
         let batch_frame = batch::Batch {
-            statements_count: statements_iter.len(),
-            statements: statements_iter,
+            statements: Cow::Borrowed(&batch.statements),
             values,
             batch_type: batch.get_type(),
             consistency,

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -49,7 +49,7 @@ use crate::batch::{Batch, BatchStatement};
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::{
     self,
-    request::{self, batch, execute, query, register, Request},
+    request::{self, batch, execute, query, register, SerializableRequest},
     response::{event::Event, result, NonErrorResponse, Response, ResponseOpcode},
     server_event_type::EventType,
     value::{BatchValues, ValueList},
@@ -106,7 +106,7 @@ impl RouterHandle {
 
     async fn send_request(
         &self,
-        request: &impl Request,
+        request: &impl SerializableRequest,
         compression: Option<Compression>,
         tracing: bool,
     ) -> Result<TaskResponse, QueryError> {
@@ -872,7 +872,7 @@ impl Connection {
 
     async fn send_request(
         &self,
-        request: &impl Request,
+        request: &impl SerializableRequest,
         compress: bool,
         tracing: bool,
     ) -> Result<QueryResponse, QueryError> {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -656,11 +656,11 @@ impl Connection {
         let serialized_values = values.serialized()?;
 
         let query_frame = query::Query {
-            contents: &query.contents,
+            contents: Cow::Borrowed(&query.contents),
             parameters: query::QueryParameters {
                 consistency,
                 serial_consistency,
-                values: &serialized_values,
+                values: serialized_values,
                 page_size: query.get_page_size(),
                 paging_state,
                 timestamp: query.get_timestamp(),
@@ -686,7 +686,7 @@ impl Connection {
             parameters: query::QueryParameters {
                 consistency,
                 serial_consistency,
-                values: &serialized_values,
+                values: serialized_values,
                 page_size: prepared_statement.get_page_size(),
                 timestamp: prepared_statement.get_timestamp(),
                 paging_state,

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -151,6 +151,12 @@ impl RowIterator {
             .serial_consistency
             .unwrap_or(execution_profile.serial_consistency);
 
+        let routing_info = RoutingInfo {
+            consistency,
+            serial_consistency,
+            ..Default::default()
+        };
+
         let retry_session = query
             .get_retry_policy()
             .map(|rp| &**rp)
@@ -188,7 +194,7 @@ impl RowIterator {
                 sender: sender.into(),
                 choose_connection,
                 page_query,
-                statement_info: RoutingInfo::default(),
+                statement_info: routing_info,
                 query_is_idempotent: query.config.is_idempotent,
                 query_consistency: consistency,
                 retry_session,
@@ -237,7 +243,7 @@ impl RowIterator {
         let worker_task = async move {
             let statement_info = RoutingInfo {
                 consistency,
-                serial_consistency: config.prepared.get_serial_consistency(),
+                serial_consistency,
                 token: config.token,
                 keyspace: config.prepared.get_keyspace_name(),
                 is_confirmed_lwt: config.prepared.is_confirmed_lwt(),

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -1,0 +1,455 @@
+use crate::utils::test_with_3_node_cluster;
+
+use scylla::execution_profile::{ExecutionProfileBuilder, ExecutionProfileHandle};
+use scylla::load_balancing::{DefaultPolicy, LoadBalancingPolicy, RoutingInfo};
+use scylla::prepared_statement::PreparedStatement;
+use scylla::retry_policy::FallthroughRetryPolicy;
+use scylla::routing::Token;
+use scylla::test_utils::unique_keyspace_name;
+use scylla::transport::session::Session;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use scylla::statement::batch::BatchStatement;
+use scylla::statement::query::Query;
+use scylla::{
+    batch::{Batch, BatchType},
+    statement::SerialConsistency,
+};
+use scylla::{ExecutionProfile, SessionBuilder};
+use scylla_cql::Consistency;
+use scylla_proxy::ShardAwareness;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    WorkerError,
+};
+use std::sync::Arc;
+use std::time::Duration;
+
+fn consistencies() -> impl Iterator<Item = Consistency> {
+    [
+        Consistency::All,
+        Consistency::Any,
+        Consistency::EachQuorum,
+        Consistency::LocalOne,
+        Consistency::LocalQuorum,
+        Consistency::One,
+        Consistency::Quorum,
+        Consistency::Three,
+        Consistency::Two,
+    ]
+    .into_iter()
+}
+
+fn serial_consistencies() -> impl Iterator<Item = SerialConsistency> {
+    [SerialConsistency::Serial, SerialConsistency::LocalSerial].into_iter()
+}
+
+// Every consistency and every serial consistency is yielded at least once.
+// These are NOT all combinations of those.
+fn pairs_of_all_consistencies() -> impl Iterator<Item = (Consistency, Option<SerialConsistency>)> {
+    let consistencies = consistencies();
+    let serial_consistencies = serial_consistencies()
+        .map(Some)
+        .chain(std::iter::repeat(None));
+    consistencies.zip(serial_consistencies)
+}
+
+const CREATE_TABLE_STR: &str = "CREATE TABLE consistency_tests (a int, b int, PRIMARY KEY (a, b))";
+const QUERY_STR: &str = "INSERT INTO consistency_tests (a, b) VALUES (?, 1)";
+
+async fn create_schema(session: &Session, ks: &str) {
+    session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks), &[]).await.unwrap();
+    session.use_keyspace(ks, false).await.unwrap();
+
+    session.query(CREATE_TABLE_STR, &[]).await.unwrap();
+}
+
+// The following functions perform a request with consistencies set directly on a statement.
+async fn query_consistency_set_directly(
+    session: &Session,
+    query: &Query,
+    c: Consistency,
+    sc: Option<SerialConsistency>,
+) {
+    let mut query = query.clone();
+    query.set_consistency(c);
+    query.set_serial_consistency(sc);
+    session.query(query.clone(), (1,)).await.unwrap();
+    session.query_iter(query, (1,)).await.unwrap();
+}
+
+async fn execute_consistency_set_directly(
+    session: &Session,
+    prepared: &PreparedStatement,
+    c: Consistency,
+    sc: Option<SerialConsistency>,
+) {
+    let mut prepared = prepared.clone();
+    prepared.set_consistency(c);
+    prepared.set_serial_consistency(sc);
+    session.execute(&prepared, (1,)).await.unwrap();
+    session.execute_iter(prepared, (1,)).await.unwrap();
+}
+
+async fn batch_consistency_set_directly(
+    session: &Session,
+    batch: &Batch,
+    c: Consistency,
+    sc: Option<SerialConsistency>,
+) {
+    let mut batch = batch.clone();
+    batch.set_consistency(c);
+    batch.set_serial_consistency(sc);
+    session.batch(&batch, ((1,),)).await.unwrap();
+}
+
+// The following functions perform a request with consistencies set on a per-statement execution profile.
+async fn query_consistency_set_on_exec_profile(
+    session: &Session,
+    query: &Query,
+    profile: ExecutionProfileHandle,
+) {
+    let mut query = query.clone();
+    query.set_execution_profile_handle(Some(profile));
+    session.query(query.clone(), (1,)).await.unwrap();
+    session.query_iter(query, (1,)).await.unwrap();
+}
+
+async fn execute_consistency_set_on_exec_profile(
+    session: &Session,
+    prepared: &PreparedStatement,
+    profile: ExecutionProfileHandle,
+) {
+    let mut prepared = prepared.clone();
+    prepared.set_execution_profile_handle(Some(profile));
+    session.execute(&prepared, (1,)).await.unwrap();
+    session.execute_iter(prepared, (1,)).await.unwrap();
+}
+
+async fn batch_consistency_set_on_exec_profile(
+    session: &Session,
+    batch: &Batch,
+    profile: ExecutionProfileHandle,
+) {
+    let mut batch = batch.clone();
+    batch.set_execution_profile_handle(Some(profile));
+    session.batch(&batch, ((1,),)).await.unwrap();
+}
+
+// For all consistencies (as defined by `pairs_of_all_consistencies()`) and every method of setting consistencies
+// (directly on statement, on per-statement exec profile, on default per-session exec profile)
+// performs a request and calls `check_consistencies()` asserting function with `rx`, which is a generic way
+// of input for assertions.
+// `check_consistencies()` does not simply use &mut Rx, because then we enter the atrocious world of higher-order lifetimes
+// whose validity the compiler can not yet prove.
+async fn check_for_all_consistencies_and_setting_options<
+    Fut1: std::future::Future<Output = Rx>,
+    Fut2: std::future::Future<Output = Rx>,
+    Rx,
+>(
+    session_builder: SessionBuilder,
+    base_for_every_profile: ExecutionProfileBuilder,
+    ks: &str,
+    mut rx: Rx,
+    after_session_init: impl Fn(Rx) -> Fut1,
+    check_consistencies: impl Fn(Consistency, Option<SerialConsistency>, Rx) -> Fut2,
+) {
+    let session = session_builder
+        .clone()
+        .default_execution_profile_handle(base_for_every_profile.clone().build().into_handle())
+        .build()
+        .await
+        .unwrap();
+    create_schema(&session, ks).await;
+    rx = after_session_init(rx).await;
+
+    // We will be using these requests:
+    let query = Query::from(QUERY_STR);
+    let prepared = session.prepare(QUERY_STR).await.unwrap();
+    let batch = Batch::new_with_statements(
+        BatchType::Logged,
+        vec![BatchStatement::Query(Query::from(QUERY_STR))],
+    );
+
+    for (consistency, serial_consistency) in pairs_of_all_consistencies() {
+        // Some checks are double, because both non-paged and paged executions are done.
+        // (queries and prepared statements are double, batches are single)
+
+        // Set directly
+        query_consistency_set_directly(&session, &query, consistency, serial_consistency).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        execute_consistency_set_directly(&session, &prepared, consistency, serial_consistency)
+            .await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        batch_consistency_set_directly(&session, &batch, consistency, serial_consistency).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        // Set on an exec profile
+        let handle = base_for_every_profile
+            .clone()
+            .consistency(consistency)
+            .serial_consistency(serial_consistency)
+            .build()
+            .into_handle();
+        query_consistency_set_on_exec_profile(&session, &query, handle.clone()).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        execute_consistency_set_on_exec_profile(&session, &prepared, handle.clone()).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        batch_consistency_set_on_exec_profile(&session, &batch, handle.clone()).await;
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        // Set on session's default exec profile
+        let session_with_consistencies = session_builder
+            .clone()
+            .default_execution_profile_handle(handle)
+            .build()
+            .await
+            .unwrap();
+        session_with_consistencies
+            .use_keyspace(ks, true)
+            .await
+            .unwrap();
+        rx = after_session_init(rx).await;
+
+        session_with_consistencies
+            .query(QUERY_STR, (1,))
+            .await
+            .unwrap();
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+        session_with_consistencies
+            .query_iter(QUERY_STR, (1,))
+            .await
+            .unwrap();
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        session_with_consistencies
+            .execute(&prepared, (1,))
+            .await
+            .unwrap();
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+        session_with_consistencies
+            .execute_iter(prepared.clone(), (1,))
+            .await
+            .unwrap();
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+
+        session_with_consistencies
+            .batch(&batch, ((1,),))
+            .await
+            .unwrap();
+        rx = check_consistencies(consistency, serial_consistency, rx).await;
+    }
+}
+
+// Checks that the expected consistency and serial_consistency are set
+//  in the CQL request frame.
+#[tokio::test]
+#[ntest::timeout(60000)]
+#[cfg(not(scylla_cloud_tests))]
+async fn consistency_is_correctly_set_in_cql_requests() {
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let request_rule = |tx| {
+                RequestRule(
+                    Condition::or(
+                        Condition::RequestOpcode(RequestOpcode::Execute),
+                        Condition::or(
+                            Condition::RequestOpcode(RequestOpcode::Batch),
+                            Condition::and(
+                                Condition::RequestOpcode(RequestOpcode::Query),
+                                Condition::BodyContainsCaseSensitive(Box::new(
+                                    *b"INTO consistency_tests",
+                                )),
+                            ),
+                        ),
+                    ),
+                    RequestReaction::noop().with_feedback_when_performed(tx),
+                )
+            };
+
+            let (request_tx, request_rx) = mpsc::unbounded_channel();
+            for running_node in running_proxy.running_nodes.iter_mut() {
+                running_node.change_request_rules(Some(vec![request_rule(request_tx.clone())]));
+            }
+
+            let fallthrough_exec_profile_builder =
+                ExecutionProfile::builder().retry_policy(Box::new(FallthroughRetryPolicy));
+
+            let translation_map = Arc::new(translation_map);
+
+            // DB preparation phase
+            let ks = unique_keyspace_name();
+            let session_builder = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .keepalive_interval(Duration::from_secs(10000))
+                .address_translator(translation_map.clone());
+
+            async fn check_consistencies(
+                consistency: Consistency,
+                serial_consistency: Option<SerialConsistency>,
+                mut request_rx: UnboundedReceiver<RequestFrame>,
+            ) -> UnboundedReceiver<RequestFrame> {
+                let request_frame = request_rx.recv().await.unwrap();
+                let deserialized_request = request_frame.deserialize().unwrap();
+                assert_eq!(deserialized_request.get_consistency().unwrap(), consistency);
+                assert_eq!(
+                    deserialized_request.get_serial_consistency().unwrap(),
+                    serial_consistency
+                );
+                request_rx
+            }
+
+            check_for_all_consistencies_and_setting_options(
+                session_builder,
+                fallthrough_exec_profile_builder,
+                &ks,
+                request_rx,
+                |rx| async move { rx },
+                check_consistencies,
+            )
+            .await;
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OwnedRoutingInfo {
+    pub consistency: Consistency,
+    pub serial_consistency: Option<SerialConsistency>,
+
+    #[allow(unused)]
+    pub keyspace: Option<String>,
+    #[allow(unused)]
+    pub token: Option<Token>,
+    #[allow(unused)]
+    pub is_confirmed_lwt: bool,
+}
+
+impl OwnedRoutingInfo {
+    fn from(info: RoutingInfo) -> Self {
+        let RoutingInfo {
+            consistency,
+            serial_consistency,
+            token,
+            keyspace,
+            is_confirmed_lwt,
+        } = info;
+        Self {
+            consistency,
+            serial_consistency,
+            token,
+            keyspace: keyspace.map(ToOwned::to_owned),
+            is_confirmed_lwt,
+        }
+    }
+}
+
+// Wraps over DefaultPolicy to provide access to RoutingInfo fed into the load balancer.
+#[derive(Debug)]
+struct RoutingInfoReportingWrapper {
+    wrapped: Arc<dyn LoadBalancingPolicy>,
+    routing_info_tx: UnboundedSender<OwnedRoutingInfo>,
+}
+
+impl LoadBalancingPolicy for RoutingInfoReportingWrapper {
+    fn pick<'a>(
+        &'a self,
+        query: &'a RoutingInfo,
+        cluster: &'a scylla::transport::ClusterData,
+    ) -> Option<scylla::transport::NodeRef<'a>> {
+        self.routing_info_tx
+            .send(OwnedRoutingInfo::from(query.clone()))
+            .unwrap();
+        self.wrapped.pick(query, cluster)
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        query: &'a RoutingInfo,
+        cluster: &'a scylla::transport::ClusterData,
+    ) -> scylla::load_balancing::FallbackPlan<'a> {
+        self.routing_info_tx
+            .send(OwnedRoutingInfo::from(query.clone()))
+            .unwrap();
+        self.wrapped.fallback(query, cluster)
+    }
+
+    fn name(&self) -> String {
+        "RoutingInfoReportingWrapper".to_owned()
+    }
+}
+
+// Checks that the expected consistency and serial_consistency are set
+// in the RoutingInfo that is exposed to the load balancer.
+#[tokio::test]
+#[ignore = "Not yet passes, a bug is yet to be fixed."]
+#[ntest::timeout(60000)]
+#[cfg(not(scylla_cloud_tests))]
+async fn consistency_is_correctly_set_in_routing_info() {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    let ks = unique_keyspace_name();
+
+    let (routing_info_tx, routing_info_rx) = mpsc::unbounded_channel();
+
+    let reporting_load_balancer = RoutingInfoReportingWrapper {
+        wrapped: DefaultPolicy::builder().build(),
+        routing_info_tx,
+    };
+
+    let exec_profile_builder = ExecutionProfile::builder()
+        .retry_policy(Box::new(FallthroughRetryPolicy))
+        .load_balancing_policy(Arc::new(reporting_load_balancer));
+
+    // DB preparation phase
+    let session_builder = SessionBuilder::new()
+        .known_node(uri.as_str())
+        .keepalive_interval(Duration::from_secs(10000))
+        .default_execution_profile_handle(exec_profile_builder.clone().build().into_handle());
+
+    async fn on_session_init(
+        mut routing_info_rx: UnboundedReceiver<OwnedRoutingInfo>,
+    ) -> UnboundedReceiver<OwnedRoutingInfo> {
+        // Clear RoutingInfo got from DB preparation (keyspace & table creation)
+        while routing_info_rx.try_recv().is_ok() {}
+        routing_info_rx
+    }
+
+    async fn check_consistencies(
+        consistency: Consistency,
+        serial_consistency: Option<SerialConsistency>,
+        mut routing_info_rx: UnboundedReceiver<OwnedRoutingInfo>,
+    ) -> UnboundedReceiver<OwnedRoutingInfo> {
+        let info = routing_info_rx.recv().await.unwrap();
+        assert_eq!(info.consistency, consistency);
+        assert_eq!(info.serial_consistency, serial_consistency);
+        routing_info_rx
+    }
+
+    check_for_all_consistencies_and_setting_options(
+        session_builder,
+        exec_profile_builder,
+        &ks,
+        routing_info_rx,
+        on_session_init,
+        check_consistencies,
+    )
+    .await;
+}

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -400,7 +400,6 @@ impl LoadBalancingPolicy for RoutingInfoReportingWrapper {
 // Checks that the expected consistency and serial_consistency are set
 // in the RoutingInfo that is exposed to the load balancer.
 #[tokio::test]
-#[ignore = "Not yet passes, a bug is yet to be fixed."]
 #[ntest::timeout(60000)]
 #[cfg(not(scylla_cloud_tests))]
 async fn consistency_is_correctly_set_in_routing_info() {

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod consistency;
 mod execution_profiles;
 mod hygiene;
 mod lwt_optimisation;


### PR DESCRIPTION
A bug has been found that put wrong `Consistency` and `SerialConsistency` into `RoutingInfo`. In order to:
- be sure that it's fully fixed,
- prevent regressions,
- check consistencies in other contexts,

the following is done:
- proxy acquires deserialization capabilities for request frames; it understands `Query`, `Execute` and `Batch` frames,
- a test is added to check that request frames contains consistencies that match the specified ones,
- a test is added to check that `RoutingInfo` for `LoadBalancingPolicy` contains the specified consistencies,
- as the latter test confirms the bug in `Session`, the affected methods are fixed,
- minor refactor is done in `Session` to make fiddling with consistency clearer,
- bonus: utilities for single-node dry-mode cluster are added, based on the bindings' test implementation. These will most probably prove useful for writing future tests.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
