### PR TITLE
Improve common time and date crates support

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -26,10 +26,10 @@ jobs:
         docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait
       # A separate step for building to separate measuring time of compilation and testing
     - name: Build the project
-      run: cargo build --verbose --tests
+      run: cargo build --verbose --tests --features "full-serialization"
     - name: Run tests on cassandra
       run: |
-        CDC='disabled' SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose -- --skip test_views_in_schema_info --skip test_large_batch_statements
+        CDC='disabled' SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose --features "full-serialization" -- --skip test_views_in_schema_info --skip test_large_batch_statements
     - name: Stop the cluster
       if: ${{ always() }}
       run: docker compose -f test/cluster/cassandra/docker-compose.yml stop

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,14 +32,14 @@ jobs:
       run: cargo clippy --verbose --all-targets -- -Aclippy::uninlined_format_args
     - name: Cargo check without features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features ""
-    - name: Cargo check with secrecy feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secret"
+    - name: Cargo check with all serialization features
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "full-serialization"
     - name: Build scylla-cql
-      run: cargo build --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml"
+      run: cargo build --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml" --features "full-serialization"
     - name: Build
-      run: cargo build --verbose --all-targets
+      run: cargo build --verbose --all-targets --features "full-serialization"
     - name: Run tests
-      run: SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose
+      run: SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose --features "full-serialization"
     - name: Stop the cluster
       if: ${{ always() }}
       run: docker compose -f test/cluster/docker-compose.yml stop
@@ -63,7 +63,7 @@ jobs:
     - name: Use MSRV Cargo.lock
       run: mv Cargo.lock.msrv Cargo.lock
     - name: MSRV cargo check with features
-      run: cargo check --verbose --all-targets --locked
+      run: cargo check --verbose --all-targets --all-features --locked
     - name: MSRV cargo check without features
       run: cargo check --verbose --all-targets --locked --manifest-path "scylla/Cargo.toml"
     - name: MSRV cargo check scylla-cql

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -425,6 +425,7 @@ dependencies = [
  "rustyline-derive",
  "scylla",
  "stats_alloc",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -1418,6 +1419,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "time",
  "tokio",
  "tokio-openssl",
  "tracing",
@@ -1444,6 +1446,7 @@ dependencies = [
  "serde",
  "snap",
  "thiserror",
+ "time",
  "tokio",
  "uuid",
 ]
@@ -1689,6 +1692,32 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+dependencies = [
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -21,9 +21,9 @@ Database types and their Rust equivalents:
 * `Blob` <----> `Vec<u8>`
 * `Inet` <----> `std::net::IpAddr`
 * `Uuid`, `Timeuuid` <----> `uuid::Uuid`
-* `Date` <----> `u32`, `chrono::NaiveDate`, `time::Date`
-* `Time` <----> `i64`, `chrono::NaiveTime`, `time::Time`
-* `Timestamp` <----> `i64`, `chrono::DateTime<Utc>`, `time::OffsetDateTime`
+* `Date` <----> `value::CqlDate`, `chrono::NaiveDate`, `time::Date`
+* `Time` <----> `value::CqlTime`, `chrono::NaiveTime`, `time::Time`
+* `Timestamp` <----> `value::CqlTimestamp`, `chrono::DateTime<Utc>`, `time::OffsetDateTime`
 * `Duration` <----> `value::CqlDuration`
 * `Decimal` <----> `bigdecimal::Decimal`
 * `Varint` <----> `num_bigint::BigInt`

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -21,9 +21,9 @@ Database types and their Rust equivalents:
 * `Blob` <----> `Vec<u8>`
 * `Inet` <----> `std::net::IpAddr`
 * `Uuid`, `Timeuuid` <----> `uuid::Uuid`
-* `Date` <----> `chrono::NaiveDate`, `u32`
-* `Time` <----> `chrono::Duration`
-* `Timestamp` <----> `chrono::Duration`
+* `Date` <----> `u32`, `chrono::NaiveDate`, `time::Date`
+* `Time` <----> `i64`, `chrono::NaiveTime`, `time::Time`
+* `Timestamp` <----> `i64`, `chrono::DateTime<Utc>`, `time::OffsetDateTime`
 * `Duration` <----> `value::CqlDuration`
 * `Decimal` <----> `bigdecimal::Decimal`
 * `Varint` <----> `num_bigint::BigInt`

--- a/docs/source/data-types/time.md
+++ b/docs/source/data-types/time.md
@@ -1,31 +1,115 @@
 # Time
-`Time` is represented as [`chrono::Duration`](https://docs.rs/chrono/0.4.19/chrono/struct.Duration.html)
 
-Internally `Time` is represented as number of nanoseconds since midnight. 
-It can't be negative or exceed `86399999999999` (24 hours).
+Depending on feature flags used, three different types can be used to interact with time.
 
-When sending in a query it needs to be wrapped in `value::Time` to differentiate from [`Timestamp`](timestamp.md)
+Internally [time](https://docs.scylladb.com/stable/cql/types.html#times) is represented as number of nanoseconds since
+midnight. It can't be negative or exceed `86399999999999` (23:59:59.999999999).
+
+## CqlTime
+
+Without any extra features enabled, only `frame::value::CqlTime` is available. It's an
+[`i64`](https://doc.rust-lang.org/std/primitive.i64.html) wrapper and it matches the internal time representation.
+
+However, for most use cases other types are more practical. See following sections for `chrono` and `time`.
 
 ```rust
 # extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::frame::value::CqlTime;
+use scylla::IntoTypedRows;
+
+// 64 seconds since midnight
+let to_insert = CqlTime(64 * 1_000_000_000);
+
+// Insert time into the table
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
+    .await?;
+
+// Read time from the table
+if let Some(rows) = session
+    .query("SELECT a FROM keyspace.table", &[])
+    .await?
+    .rows
+{
+    for row in rows.into_typed::<(CqlTime,)>() {
+        let (time_value,): (CqlTime,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+## chrono::NaiveTime
+
+If `chrono` feature is enabled, [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html)
+can be used to interact with the database. Although chrono can represent leap seconds, they are not supported.
+Attempts to convert [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html) with leap
+second to `CqlTime` or write it to the database will return an error.
+
+```rust
 # extern crate chrono;
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use chrono::NaiveTime;
+use scylla::IntoTypedRows;
+
+// 01:02:03.456,789,012
+let to_insert = NaiveTime::from_hms_nano_opt(1, 2, 3, 456_789_012);
+
+// Insert time into the table
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
+    .await?;
+
+// Read time from the table
+if let Some(rows) = session
+    .query("SELECT a FROM keyspace.table", &[])
+    .await?
+    .rows
+{
+    for row in rows.into_typed::<(NaiveTime,)>() {
+        let (time_value,): (NaiveTime,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+## time::Time
+
+If `time` feature is enabled, [`time::Time`](https://docs.rs/time/0.3/time/struct.Time.html) can be used to interact
+with the database.
+
+```rust
+# extern crate scylla;
+# extern crate time;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::IntoTypedRows;
-use scylla::frame::value::Time;
-use chrono::Duration;
+use time::Time;
 
-// Insert some time into the table
-let to_insert: Duration = Duration::seconds(64);
+// 01:02:03.456,789,012
+let to_insert = Time::from_hms_nano(1, 2, 3, 456_789_012).unwrap();
+
+// Insert time into the table
 session
-    .query("INSERT INTO keyspace.table (a) VALUES(?)", (Time(to_insert),))
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
     .await?;
 
-// Read time from the table, no need for a wrapper here
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(Duration,)>() {
-        let (time_value,): (Duration,) = row?;
+// Read time from the table
+if let Some(rows) = session
+    .query("SELECT a FROM keyspace.table", &[])
+    .await?
+    .rows
+{
+    for row in rows.into_typed::<(Time,)>() {
+        let (time_value,): (Time,) = row?;
     }
 }
 # Ok(())

--- a/docs/source/data-types/timestamp.md
+++ b/docs/source/data-types/timestamp.md
@@ -1,31 +1,127 @@
 # Timestamp
-`Timestamp` is represented as [`chrono::Duration`](https://docs.rs/chrono/0.4.19/chrono/struct.Duration.html)
 
-Internally `Timestamp` is represented as `i64` describing number of milliseconds since unix epoch.
-Driver converts this to `chrono::Duration`
+Depending on feature flags, three different types can be used to interact with timestamps.
 
-When sending in a query it needs to be wrapped in `value::Timestamp` to differentiate from [`Time`](time.md)
+Internally [timestamp](https://docs.scylladb.com/stable/cql/types.html#timestamps) is represented as
+[`i64`](https://doc.rust-lang.org/std/primitive.i64.html) describing number of milliseconds since unix epoch.
+
+## CqlTimestamp
+
+Without any extra features enabled, only `frame::value::CqlTimestamp` is available. It's an
+[`i64`](https://doc.rust-lang.org/std/primitive.i64.html) wrapper and it matches the internal time representation. It's
+the only type that supports full range of values that database accepts.
+
+However, for most use cases other types are more practical. See following sections for `chrono` and `time`.
 
 ```rust
 # extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::frame::value::CqlTimestamp;
+use scylla::IntoTypedRows;
+
+// 64 seconds since unix epoch, 1970-01-01 00:01:04
+let to_insert = CqlTimestamp(64 * 1000);
+
+// Write timestamp to the table
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
+    .await?;
+
+// Read timestamp from the table
+if let Some(rows) = session
+    .query("SELECT a FROM keyspace.table", &[])
+    .await?
+    .rows
+{
+    for row in rows.into_typed::<(CqlTimestamp,)>() {
+        let (timestamp_value,): (CqlTimestamp,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+## chrono::DateTime
+
+If full value range is not required, `chrono` feature can be used to enable support of
+[`chrono::DateTime`](https://docs.rs/chrono/0.4/chrono/struct.DateTime.html). All values are expected to be converted
+to UTC timezone explicitly, as [timestamp](https://docs.scylladb.com/stable/cql/types.html#timestamps) doesn't store
+timezone information. Any precision finer than 1ms will be lost.
+
+```rust
 # extern crate chrono;
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use scylla::IntoTypedRows;
+
+// 64.123 seconds since unix epoch, 1970-01-01 00:01:04.123
+let to_insert = NaiveDateTime::new(
+    NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+    NaiveTime::from_hms_milli_opt(0, 1, 4, 123).unwrap(),
+)
+.and_utc();
+
+// Write timestamp to the table
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
+    .await?;
+
+// Read timestamp from the table
+if let Some(rows) = session
+    .query("SELECT a FROM keyspace.table", &[])
+    .await?
+    .rows
+{
+    for row in rows.into_typed::<(DateTime<Utc>,)>() {
+        let (timestamp_value,): (DateTime<Utc>,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+## time::OffsetDateTime
+
+Alternatively, `time` feature can be used to enable support of
+[`time::OffsetDateTime`](https://docs.rs/time/0.3/time/struct.OffsetDateTime.html). As
+[timestamp](https://docs.scylladb.com/stable/cql/types.html#timestamps) doesn't support timezone information, time will
+be corrected to UTC and timezone info will be erased on write. On read, UTC timestamp is returned. Any precision finer
+than 1ms will also be lost.
+
+```rust
+# extern crate scylla;
+# extern crate time;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::IntoTypedRows;
-use scylla::frame::value::Timestamp;
-use chrono::Duration;
+use time::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
 
-// Insert some timestamp into the table
-let to_insert: Duration = Duration::seconds(64);
+// 64.123 seconds since unix epoch, 1970-01-01 00:01:04.123
+let to_insert = PrimitiveDateTime::new(
+    Date::from_calendar_date(1970, Month::January, 1).unwrap(),
+    Time::from_hms_milli(0, 1, 4, 123).unwrap(),
+)
+.assume_utc();
+
+// Write timestamp to the table
 session
-    .query("INSERT INTO keyspace.table (a) VALUES(?)", (Timestamp(to_insert),))
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
     .await?;
 
-// Read timestamp from the table, no need for a wrapper here
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(Duration,)>() {
-        let (timestamp_value,): (Duration,) = row?;
+// Read timestamp from the table
+if let Some(rows) = session
+    .query("SELECT a FROM keyspace.table", &[])
+    .await?
+    .rows
+{
+    for row in rows.into_typed::<(OffsetDateTime,)>() {
+        let (timestamp_value,): (OffsetDateTime,) = row?;
     }
 }
 # Ok(())

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,11 +10,12 @@ futures = "0.3.6"
 openssl = "0.10.32"
 rustyline = "9"
 rustyline-derive = "0.6"
-scylla = {path = "../scylla", features = ["ssl", "cloud"]}
+scylla = {path = "../scylla", features = ["ssl", "cloud", "chrono", "time"]}
 tokio = {version = "1.1.0", features = ["full"]}
 tracing = "0.1.25"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 chrono = { version = "0.4", default-features = false }
+time = { version = "0.3.22" }
 uuid = "1.0"
 tower = "0.4"
 stats_alloc = "0.1"

--- a/examples/cql-time-types.rs
+++ b/examples/cql-time-types.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
     if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await?.rows {
         for row in rows {
             let read_days: u32 = match row.columns[0] {
-                Some(CqlValue::Date(days)) => days,
+                Some(CqlValue::Date(CqlDate(days))) => days,
                 _ => panic!("oh no"),
             };
 

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -21,13 +21,16 @@ uuid = "1.0"
 thiserror = "1.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
-chrono = { version = "0.4.27", default-features = false }
+chrono = { version = "0.4.27", default-features = false, optional = true }
 lz4_flex = { version = "0.11.1" }
 async-trait = "0.1.57"
 serde = { version = "1.0", features = ["derive"], optional = true }
+time = { version = "0.3", optional = true }
 
 [dev-dependencies]
 criterion = "0.4" # Note: v0.5 needs at least rust 1.70.0
+# Use large-dates feature to test potential edge cases
+time = { version = "0.3.21", features = ["large-dates"] }
 
 [[bench]]
 name = "benchmark"
@@ -35,3 +38,5 @@ harness = false
 
 [features]
 secret = ["secrecy"]
+time = ["dep:time"]
+chrono = ["dep:chrono"]

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -40,3 +40,4 @@ harness = false
 secret = ["secrecy"]
 time = ["dep:time"]
 chrono = ["dep:chrono"]
+full-serialization = ["chrono", "time", "secret"]

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -24,7 +24,7 @@ num-bigint = "0.3"
 chrono = { version = "0.4.27", default-features = false }
 lz4_flex = { version = "0.11.1" }
 async-trait = "0.1.57"
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.4" # Note: v0.5 needs at least rust 1.70.0

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1,13 +1,11 @@
 use crate::cql_to_rust::{FromRow, FromRowError};
 use crate::frame::response::event::SchemaChangeEvent;
 use crate::frame::types::vint_decode;
-use crate::frame::value::{Counter, CqlDuration};
+use crate::frame::value::{Counter, CqlDate, CqlDuration, CqlTime, CqlTimestamp};
 use crate::frame::{frame_errors::ParseError, types};
 use bigdecimal::BigDecimal;
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{Buf, Bytes};
-use chrono;
-use chrono::prelude::*;
 use num_bigint::BigInt;
 use std::{
     convert::{TryFrom, TryInto},
@@ -16,6 +14,9 @@ use std::{
     str,
 };
 use uuid::Uuid;
+
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, NaiveDate, Utc};
 
 #[derive(Debug)]
 pub struct SetKeyspace {
@@ -92,7 +93,7 @@ pub enum CqlValue {
     BigInt(i64),
     Text(String),
     /// Milliseconds since unix epoch
-    Timestamp(chrono::Duration),
+    Timestamp(i64),
     Inet(IpAddr),
     List(Vec<CqlValue>),
     Map(Vec<(CqlValue, CqlValue)>),
@@ -108,7 +109,7 @@ pub enum CqlValue {
     SmallInt(i16),
     TinyInt(i8),
     /// Nanoseconds since midnight
-    Time(chrono::Duration),
+    Time(i64),
     Timeuuid(Uuid),
     Tuple(Vec<Option<CqlValue>>),
     Uuid(Uuid),
@@ -123,29 +124,55 @@ impl CqlValue {
         }
     }
 
-    pub fn as_date(&self) -> Option<NaiveDate> {
-        // Days since -5877641-06-23 i.e. 2^31 days before unix epoch
-        let date_days: u32 = match self {
-            CqlValue::Date(days) => *days,
-            _ => return None,
-        };
-
-        // date_days is u32 then converted to i64
-        // then we substract 2^31 - this can't panic
-        let days_since_epoch =
-            chrono::Duration::days(date_days.into()) - chrono::Duration::days(1 << 31);
-
-        NaiveDate::from_ymd_opt(1970, 1, 1)
-            .unwrap()
-            .checked_add_signed(days_since_epoch)
-    }
-
-    pub fn as_duration(&self) -> Option<chrono::Duration> {
+    pub fn as_cql_date(&self) -> Option<CqlDate> {
         match self {
-            Self::Timestamp(i) => Some(*i),
-            Self::Time(i) => Some(*i),
+            Self::Date(d) => Some(CqlDate(*d)),
             _ => None,
         }
+    }
+
+    #[cfg(feature = "chrono")]
+    pub fn as_naive_date(&self) -> Option<NaiveDate> {
+        self.as_cql_date().and_then(|date| date.try_into().ok())
+    }
+
+    #[cfg(feature = "time")]
+    pub fn as_date(&self) -> Option<time::Date> {
+        self.as_cql_date().and_then(|date| date.try_into().ok())
+    }
+
+    pub fn as_cql_timestamp(&self) -> Option<CqlTimestamp> {
+        match self {
+            Self::Timestamp(i) => Some(CqlTimestamp(*i)),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "chrono")]
+    pub fn as_datetime(&self) -> Option<DateTime<Utc>> {
+        self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
+    }
+
+    #[cfg(feature = "time")]
+    pub fn as_offset_date_time(&self) -> Option<time::OffsetDateTime> {
+        self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
+    }
+
+    pub fn as_cql_time(&self) -> Option<CqlTime> {
+        match self {
+            Self::Time(i) => Some(CqlTime(*i)),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "chrono")]
+    pub fn as_naive_time(&self) -> Option<chrono::NaiveTime> {
+        self.as_cql_time().and_then(|ts| ts.try_into().ok())
+    }
+
+    #[cfg(feature = "time")]
+    pub fn as_time(&self) -> Option<time::Time> {
+        self.as_cql_time().and_then(|ts| ts.try_into().ok())
     }
 
     pub fn as_cql_duration(&self) -> Option<CqlDuration> {
@@ -201,7 +228,7 @@ impl CqlValue {
     pub fn as_bigint(&self) -> Option<i64> {
         match self {
             Self::BigInt(i) => Some(*i),
-            Self::Timestamp(d) => Some(d.num_milliseconds()),
+            Self::Timestamp(d) => Some(*d),
             _ => None,
         }
     }
@@ -691,7 +718,7 @@ pub fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue,
             }
             let millis = buf.read_i64::<BigEndian>()?;
 
-            CqlValue::Timestamp(chrono::Duration::milliseconds(millis))
+            CqlValue::Timestamp(millis)
         }
         Time => {
             if buf.len() != 8 {
@@ -709,7 +736,7 @@ pub fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue,
                 }));
             }
 
-            CqlValue::Time(chrono::Duration::nanoseconds(nanoseconds))
+            CqlValue::Time(nanoseconds)
         }
         Timeuuid => {
             if buf.len() != 16 {
@@ -915,10 +942,8 @@ pub fn deserialize(buf: &mut &[u8]) -> StdResult<Result, ParseError> {
 #[cfg(test)]
 mod tests {
     use crate as scylla;
-    use crate::frame::value::{Counter, CqlDuration};
+    use crate::frame::value::{Counter, CqlDate, CqlDuration};
     use bigdecimal::BigDecimal;
-    use chrono::Duration;
-    use chrono::NaiveDate;
     use num_bigint::BigInt;
     use num_bigint::ToBigInt;
     use scylla::frame::response::result::{ColumnType, CqlValue};
@@ -1212,7 +1237,7 @@ mod tests {
     }
 
     #[test]
-    fn date_deserialize() {
+    fn test_deserialize_date() {
         // Date is correctly parsed from a 4 byte array
         let four_bytes: [u8; 4] = [12, 23, 34, 45];
         let date: CqlValue =
@@ -1230,55 +1255,147 @@ mod tests {
         super::deser_cql_value(&ColumnType::Date, &mut [1, 2, 3].as_ref()).unwrap_err();
         super::deser_cql_value(&ColumnType::Date, &mut [1, 2, 3, 4, 5].as_ref()).unwrap_err();
 
-        // 2^31 when converted to NaiveDate is 1970-01-01
-        let unix_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-        let date: CqlValue =
-            super::deser_cql_value(&ColumnType::Date, &mut 2_u32.pow(31).to_be_bytes().as_ref())
-                .unwrap();
+        // Deserialize unix epoch
+        let unix_epoch_bytes = 2_u32.pow(31).to_be_bytes();
 
-        assert_eq!(date.as_date().unwrap(), unix_epoch);
+        let date =
+            super::deser_cql_value(&ColumnType::Date, &mut unix_epoch_bytes.as_ref()).unwrap();
+        assert_eq!(date.as_cql_date(), Some(CqlDate(1 << 31)));
 
         // 2^31 - 30 when converted to NaiveDate is 1969-12-02
-        let before_epoch: NaiveDate = NaiveDate::from_ymd_opt(1969, 12, 2).unwrap();
+        let before_epoch = CqlDate((1 << 31) - 30);
         let date: CqlValue = super::deser_cql_value(
             &ColumnType::Date,
-            &mut (2_u32.pow(31) - 30).to_be_bytes().as_ref(),
+            &mut ((1_u32 << 31) - 30).to_be_bytes().as_ref(),
         )
         .unwrap();
 
-        assert_eq!(date.as_date().unwrap(), before_epoch);
+        assert_eq!(date.as_cql_date(), Some(before_epoch));
 
         // 2^31 + 30 when converted to NaiveDate is 1970-01-31
-        let after_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 31).unwrap();
-        let date: CqlValue = super::deser_cql_value(
+        let after_epoch = CqlDate((1 << 31) + 30);
+        let date = super::deser_cql_value(
             &ColumnType::Date,
-            &mut (2_u32.pow(31) + 30).to_be_bytes().as_ref(),
+            &mut ((1_u32 << 31) + 30).to_be_bytes().as_ref(),
         )
         .unwrap();
 
-        assert_eq!(date.as_date().unwrap(), after_epoch);
+        assert_eq!(date.as_cql_date(), Some(after_epoch));
 
-        // 0 and u32::MAX is out of NaiveDate range, fails with an error, not panics
-        assert!(
+        // Min date
+        let min_date = CqlDate(u32::MIN);
+        let date = super::deser_cql_value(&ColumnType::Date, &mut u32::MIN.to_be_bytes().as_ref())
+            .unwrap();
+        assert_eq!(date.as_cql_date(), Some(min_date));
+
+        // Max date
+        let max_date = CqlDate(u32::MAX);
+        let date = super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
+            .unwrap();
+        assert_eq!(date.as_cql_date(), Some(max_date));
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_naive_date_from_cql() {
+        use chrono::NaiveDate;
+
+        // 2^31 when converted to NaiveDate is 1970-01-01
+        let unix_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+        let date =
+            super::deser_cql_value(&ColumnType::Date, &mut (1u32 << 31).to_be_bytes().as_ref())
+                .unwrap();
+
+        assert_eq!(date.as_naive_date(), Some(unix_epoch));
+
+        // 2^31 - 30 when converted to NaiveDate is 1969-12-02
+        let before_epoch = NaiveDate::from_ymd_opt(1969, 12, 2).unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Date,
+            &mut ((1u32 << 31) - 30).to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_naive_date(), Some(before_epoch));
+
+        // 2^31 + 30 when converted to NaiveDate is 1970-01-31
+        let after_epoch = NaiveDate::from_ymd_opt(1970, 1, 31).unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Date,
+            &mut ((1u32 << 31) + 30).to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_naive_date(), Some(after_epoch));
+
+        // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
+        assert_eq!(
             super::deser_cql_value(&ColumnType::Date, &mut 0_u32.to_be_bytes().as_ref())
                 .unwrap()
-                .as_date()
-                .is_none()
+                .as_naive_date(),
+            None
         );
 
-        assert!(
+        assert_eq!(
             super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
                 .unwrap()
-                .as_date()
-                .is_none()
+                .as_naive_date(),
+            None
+        );
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn test_date_from_cql() {
+        use time::Date;
+        use time::Month::*;
+
+        // 2^31 when converted to time::Date is 1970-01-01
+        let unix_epoch = Date::from_calendar_date(1970, January, 1).unwrap();
+        let date =
+            super::deser_cql_value(&ColumnType::Date, &mut (1u32 << 31).to_be_bytes().as_ref())
+                .unwrap();
+
+        assert_eq!(date.as_date(), Some(unix_epoch));
+
+        // 2^31 - 30 when converted to time::Date is 1969-12-02
+        let before_epoch = Date::from_calendar_date(1969, December, 2).unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Date,
+            &mut ((1u32 << 31) - 30).to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_date(), Some(before_epoch));
+
+        // 2^31 + 30 when converted to time::Date is 1970-01-31
+        let after_epoch = Date::from_calendar_date(1970, January, 31).unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Date,
+            &mut ((1u32 << 31) + 30).to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_date(), Some(after_epoch));
+
+        // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
+        assert_eq!(
+            super::deser_cql_value(&ColumnType::Date, &mut 0_u32.to_be_bytes().as_ref())
+                .unwrap()
+                .as_date(),
+            None
         );
 
-        // It's hard to test NaiveDate more because it involves calculating days between calendar dates
-        // There are more tests using database queries that should cover it
+        assert_eq!(
+            super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
+                .unwrap()
+                .as_date(),
+            None
+        );
     }
 
     #[test]
-    fn test_time_deserialize() {
+    fn test_deserialize_time() {
         // Time is an i64 - nanoseconds since midnight
         // in range 0..=86399999999999
 
@@ -1290,7 +1407,7 @@ mod tests {
             let bytes: [u8; 8] = test_val.to_be_bytes();
             let cql_value: CqlValue =
                 super::deser_cql_value(&ColumnType::Time, &mut &bytes[..]).unwrap();
-            assert_eq!(cql_value, CqlValue::Time(Duration::nanoseconds(*test_val)));
+            assert_eq!(cql_value, CqlValue::Time(*test_val));
         }
 
         // Negative values cause an error
@@ -1299,19 +1416,85 @@ mod tests {
             let bytes: [u8; 8] = test_val.to_be_bytes();
             super::deser_cql_value(&ColumnType::Time, &mut &bytes[..]).unwrap_err();
         }
+    }
 
-        // chrono::Duration has enough precision to represent nanoseconds accurately
-        assert_eq!(Duration::nanoseconds(1).num_nanoseconds().unwrap(), 1);
-        assert_eq!(
-            Duration::nanoseconds(7364737473).num_nanoseconds().unwrap(),
-            7364737473
-        );
-        assert_eq!(
-            Duration::nanoseconds(86399999999999)
-                .num_nanoseconds()
-                .unwrap(),
-            86399999999999
-        );
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_naive_time_from_cql() {
+        use chrono::NaiveTime;
+
+        // 0 when converted to NaiveTime is 0:0:0.0
+        let midnight = NaiveTime::from_hms_nano_opt(0, 0, 0, 0).unwrap();
+        let time =
+            super::deser_cql_value(&ColumnType::Time, &mut (0i64).to_be_bytes().as_ref()).unwrap();
+
+        assert_eq!(time.as_naive_time(), Some(midnight));
+
+        // 10:10:30.500,000,001
+        let (h, m, s, n) = (10, 10, 30, 500_000_001);
+        let midnight = NaiveTime::from_hms_nano_opt(h, m, s, n).unwrap();
+        let time = super::deser_cql_value(
+            &ColumnType::Time,
+            &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
+                .to_be_bytes()
+                .as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(time.as_naive_time(), Some(midnight));
+
+        // 23:59:59.999,999,999
+        let (h, m, s, n) = (23, 59, 59, 999_999_999);
+        let midnight = NaiveTime::from_hms_nano_opt(h, m, s, n).unwrap();
+        let time = super::deser_cql_value(
+            &ColumnType::Time,
+            &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
+                .to_be_bytes()
+                .as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(time.as_naive_time(), Some(midnight));
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn test_primitive_time_from_cql() {
+        use time::Time;
+
+        // 0 when converted to NaiveTime is 0:0:0.0
+        let midnight = Time::from_hms_nano(0, 0, 0, 0).unwrap();
+        let time =
+            super::deser_cql_value(&ColumnType::Time, &mut (0i64).to_be_bytes().as_ref()).unwrap();
+
+        dbg!(&time);
+        assert_eq!(time.as_time(), Some(midnight));
+
+        // 10:10:30.500,000,001
+        let (h, m, s, n) = (10, 10, 30, 500_000_001);
+        let midnight = Time::from_hms_nano(h, m, s, n).unwrap();
+        let time = super::deser_cql_value(
+            &ColumnType::Time,
+            &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
+                .to_be_bytes()
+                .as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(time.as_time(), Some(midnight));
+
+        // 23:59:59.999,999,999
+        let (h, m, s, n) = (23, 59, 59, 999_999_999);
+        let midnight = Time::from_hms_nano(h, m, s, n).unwrap();
+        let time = super::deser_cql_value(
+            &ColumnType::Time,
+            &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
+                .to_be_bytes()
+                .as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(time.as_time(), Some(midnight));
     }
 
     #[test]
@@ -1323,17 +1506,124 @@ mod tests {
             let bytes: [u8; 8] = test_val.to_be_bytes();
             let cql_value: CqlValue =
                 super::deser_cql_value(&ColumnType::Timestamp, &mut &bytes[..]).unwrap();
-            assert_eq!(
-                cql_value,
-                CqlValue::Timestamp(Duration::milliseconds(*test_val))
-            );
-
-            // Check that Duration converted back to i64 is correct
-            assert_eq!(
-                Duration::milliseconds(*test_val).num_milliseconds(),
-                *test_val
-            );
+            assert_eq!(cql_value, CqlValue::Timestamp(*test_val));
         }
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_datetime_from_cql() {
+        use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+
+        // 0 when converted to DateTime is 1970-01-01 0:00:00.00
+        let unix_epoch = NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc();
+        let date = super::deser_cql_value(&ColumnType::Timestamp, &mut 0i64.to_be_bytes().as_ref())
+            .unwrap();
+
+        assert_eq!(date.as_datetime(), Some(unix_epoch));
+
+        // When converted to NaiveDateTime, this is 1969-12-01 11:29:29.5
+        let timestamp: i64 = -((((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500);
+        let before_epoch = NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(1969, 12, 1).unwrap(),
+            NaiveTime::from_hms_milli_opt(11, 29, 29, 500).unwrap(),
+        )
+        .and_utc();
+        let date = super::deser_cql_value(
+            &ColumnType::Timestamp,
+            &mut timestamp.to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_datetime(), Some(before_epoch));
+
+        // when converted to NaiveDateTime, this is is 1970-01-31 12:30:30.5
+        let timestamp: i64 = (((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500;
+        let after_epoch = NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(1970, 1, 31).unwrap(),
+            NaiveTime::from_hms_milli_opt(12, 30, 30, 500).unwrap(),
+        )
+        .and_utc();
+        let date = super::deser_cql_value(
+            &ColumnType::Timestamp,
+            &mut timestamp.to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_datetime(), Some(after_epoch));
+
+        // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
+        assert_eq!(
+            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MIN.to_be_bytes().as_ref())
+                .unwrap()
+                .as_datetime(),
+            None
+        );
+
+        assert_eq!(
+            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MAX.to_be_bytes().as_ref())
+                .unwrap()
+                .as_datetime(),
+            None
+        );
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn test_offset_datetime_from_cql() {
+        use time::{Date, Month::*, OffsetDateTime, PrimitiveDateTime, Time};
+
+        // 0 when converted to OffsetDateTime is 1970-01-01 0:00:00.00
+        let unix_epoch = OffsetDateTime::from_unix_timestamp(0).unwrap();
+        let date = super::deser_cql_value(&ColumnType::Timestamp, &mut 0i64.to_be_bytes().as_ref())
+            .unwrap();
+
+        assert_eq!(date.as_offset_date_time(), Some(unix_epoch));
+
+        // When converted to NaiveDateTime, this is 1969-12-01 11:29:29.5
+        let timestamp: i64 = -((((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500);
+        let before_epoch = PrimitiveDateTime::new(
+            Date::from_calendar_date(1969, December, 1).unwrap(),
+            Time::from_hms_milli(11, 29, 29, 500).unwrap(),
+        )
+        .assume_utc();
+        let date = super::deser_cql_value(
+            &ColumnType::Timestamp,
+            &mut timestamp.to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_offset_date_time(), Some(before_epoch));
+
+        // when converted to NaiveDateTime, this is is 1970-01-31 12:30:30.5
+        let timestamp: i64 = (((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500;
+        let after_epoch = PrimitiveDateTime::new(
+            Date::from_calendar_date(1970, January, 31).unwrap(),
+            Time::from_hms_milli(12, 30, 30, 500).unwrap(),
+        )
+        .assume_utc();
+        let date = super::deser_cql_value(
+            &ColumnType::Timestamp,
+            &mut timestamp.to_be_bytes().as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(date.as_offset_date_time(), Some(after_epoch));
+
+        // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
+        assert_eq!(
+            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MIN.to_be_bytes().as_ref())
+                .unwrap()
+                .as_offset_date_time(),
+            None
+        );
+
+        assert_eq!(
+            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MAX.to_be_bytes().as_ref())
+                .unwrap()
+                .as_offset_date_time(),
+            None
+        );
     }
 
     #[test]

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -941,10 +941,10 @@ impl Value for CqlValue {
                 serialize_tuple(fields.iter().map(|(_, value)| value), buf)
             }
 
-            CqlValue::Date(d) => CqlDate(*d).serialize(buf),
+            CqlValue::Date(d) => d.serialize(buf),
             CqlValue::Duration(d) => d.serialize(buf),
-            CqlValue::Timestamp(t) => CqlTimestamp(*t).serialize(buf),
-            CqlValue::Time(t) => CqlTime(*t).serialize(buf),
+            CqlValue::Timestamp(t) => t.serialize(buf),
+            CqlValue::Time(t) => t.serialize(buf),
 
             CqlValue::Ascii(s) | CqlValue::Text(s) => s.serialize(buf),
             CqlValue::List(v) | CqlValue::Set(v) => v.serialize(buf),

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -2,8 +2,6 @@ use crate::frame::frame_errors::ParseError;
 use crate::frame::types;
 use bigdecimal::BigDecimal;
 use bytes::BufMut;
-use chrono::prelude::*;
-use chrono::Duration;
 use num_bigint::BigInt;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -12,6 +10,9 @@ use std::hash::BuildHasher;
 use std::net::IpAddr;
 use thiserror::Error;
 use uuid::Uuid;
+
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
 
 use super::response::result::CqlValue;
 use super::types::vint_encode;
@@ -43,20 +44,209 @@ pub enum MaybeUnset<V: Value> {
     Set(V),
 }
 
-/// Wrapper that allows to send dates outside of NaiveDate range (-262145-1-1 to 262143-12-31)
-/// Days since -5877641-06-23 i.e. 2^31 days before unix epoch
+/// Native CQL date representation that allows for a bigger range of dates (-262145-1-1 to 262143-12-31).
+///
+/// Represented as number of days since -5877641-06-23 i.e. 2^31 days before unix epoch.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct Date(pub u32);
+pub struct CqlDate(pub u32);
 
-/// Wrapper used to differentiate between Time and Timestamp as sending values
-/// Milliseconds since unix epoch
+/// Native CQL timestamp representation that allows full supported timestamp range.
+///
+/// Represented as signed milliseconds since unix epoch.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct Timestamp(pub Duration);
+pub struct CqlTimestamp(pub i64);
 
-/// Wrapper used to differentiate between Time and Timestamp as sending values
-/// Nanoseconds since midnight
+/// Native CQL time representation.
+///
+/// Represented as nanoseconds since midnight.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct Time(pub Duration);
+pub struct CqlTime(pub i64);
+
+#[cfg(feature = "chrono")]
+impl From<NaiveDate> for CqlDate {
+    fn from(value: NaiveDate) -> Self {
+        let unix_epoch = NaiveDate::from_yo_opt(1970, 1).unwrap();
+
+        // `NaiveDate` range is -262145-01-01 to 262143-12-31
+        // Both values are well within supported range
+        let days = ((1 << 31) + value.signed_duration_since(unix_epoch).num_days()) as u32;
+
+        Self(days)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryInto<NaiveDate> for CqlDate {
+    type Error = ValueTooBig;
+
+    fn try_into(self) -> Result<NaiveDate, Self::Error> {
+        let days_since_unix_epoch = self.0 as i64 - (1 << 31);
+
+        // date_days is u32 then converted to i64 then we subtract 2^31;
+        // Max value is 2^31, min value is -2^31. Both values can safely fit in chrono::Duration, this call won't panic
+        let duration_since_unix_epoch = chrono::Duration::days(days_since_unix_epoch);
+
+        NaiveDate::from_yo_opt(1970, 1)
+            .unwrap()
+            .checked_add_signed(duration_since_unix_epoch)
+            .ok_or(ValueTooBig)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<DateTime<Utc>> for CqlTimestamp {
+    fn from(value: DateTime<Utc>) -> Self {
+        Self(value.timestamp_millis())
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryInto<DateTime<Utc>> for CqlTimestamp {
+    type Error = ValueTooBig;
+
+    fn try_into(self) -> Result<DateTime<Utc>, Self::Error> {
+        match Utc.timestamp_millis_opt(self.0) {
+            chrono::LocalResult::Single(datetime) => Ok(datetime),
+            _ => Err(ValueTooBig),
+        }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryFrom<NaiveTime> for CqlTime {
+    type Error = ValueTooBig;
+
+    fn try_from(value: NaiveTime) -> Result<Self, Self::Error> {
+        let nanos = value
+            .signed_duration_since(chrono::NaiveTime::MIN)
+            .num_nanoseconds()
+            .unwrap();
+
+        // Value can exceed max CQL time in case of leap second
+        if nanos <= 86399999999999 {
+            Ok(Self(nanos))
+        } else {
+            Err(ValueTooBig)
+        }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryInto<NaiveTime> for CqlTime {
+    type Error = ValueTooBig;
+
+    fn try_into(self) -> Result<NaiveTime, Self::Error> {
+        let secs = (self.0 / 1_000_000_000)
+            .try_into()
+            .map_err(|_| ValueTooBig)?;
+        let nanos = (self.0 % 1_000_000_000)
+            .try_into()
+            .map_err(|_| ValueTooBig)?;
+        NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).ok_or(ValueTooBig)
+    }
+}
+
+#[cfg(feature = "time")]
+impl From<time::Date> for CqlDate {
+    fn from(value: time::Date) -> Self {
+        const JULIAN_DAY_OFFSET: i64 =
+            (1 << 31) - time::OffsetDateTime::UNIX_EPOCH.date().to_julian_day() as i64;
+
+        // Statically assert that no possible value will ever overflow
+        const _: () =
+            assert!(time::Date::MAX.to_julian_day() as i64 + JULIAN_DAY_OFFSET < u32::MAX as i64);
+        const _: () =
+            assert!(time::Date::MIN.to_julian_day() as i64 + JULIAN_DAY_OFFSET > u32::MIN as i64);
+
+        let days = value.to_julian_day() as i64 + JULIAN_DAY_OFFSET;
+
+        Self(days as u32)
+    }
+}
+
+#[cfg(feature = "time")]
+impl TryInto<time::Date> for CqlDate {
+    type Error = ValueTooBig;
+
+    fn try_into(self) -> Result<time::Date, Self::Error> {
+        const JULIAN_DAY_OFFSET: i64 =
+            (1 << 31) - time::OffsetDateTime::UNIX_EPOCH.date().to_julian_day() as i64;
+
+        let julian_days = (self.0 as i64 - JULIAN_DAY_OFFSET)
+            .try_into()
+            .map_err(|_| ValueTooBig)?;
+
+        time::Date::from_julian_day(julian_days).map_err(|_| ValueTooBig)
+    }
+}
+
+#[cfg(feature = "time")]
+impl From<time::OffsetDateTime> for CqlTimestamp {
+    fn from(value: time::OffsetDateTime) -> Self {
+        // Statically assert that no possible value will ever overflow. OffsetDateTime doesn't allow offset to overflow
+        // the UTC PrimitiveDateTime value value
+        const _: () = assert!(
+            time::PrimitiveDateTime::MAX
+                .assume_utc()
+                .unix_timestamp_nanos()
+                // Nanos to millis
+                / 1_000_000
+                < i64::MAX as i128
+        );
+        const _: () = assert!(
+            time::PrimitiveDateTime::MIN
+                .assume_utc()
+                .unix_timestamp_nanos()
+                / 1_000_000
+                > i64::MIN as i128
+        );
+
+        // Edge cases were statically asserted above, checked math is not required
+        Self(value.unix_timestamp() * 1000 + value.millisecond() as i64)
+    }
+}
+
+#[cfg(feature = "time")]
+impl TryInto<time::OffsetDateTime> for CqlTimestamp {
+    type Error = ValueTooBig;
+
+    fn try_into(self) -> Result<time::OffsetDateTime, Self::Error> {
+        time::OffsetDateTime::from_unix_timestamp_nanos(self.0 as i128 * 1_000_000)
+            .map_err(|_| ValueTooBig)
+    }
+}
+
+#[cfg(feature = "time")]
+impl From<time::Time> for CqlTime {
+    fn from(value: time::Time) -> Self {
+        let (h, m, s, n) = value.as_hms_nano();
+
+        // no need for checked arithmetic as all these types are guaranteed to fit in i64 without overflow
+        let nanos = (h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64;
+
+        Self(nanos)
+    }
+}
+
+#[cfg(feature = "time")]
+impl TryInto<time::Time> for CqlTime {
+    type Error = ValueTooBig;
+
+    fn try_into(self) -> Result<time::Time, Self::Error> {
+        let h = self.0 / 3_600_000_000_000;
+        let m = self.0 / 60_000_000_000 % 60;
+        let s = self.0 / 1_000_000_000 % 60;
+        let n = self.0 % 1_000_000_000;
+
+        time::Time::from_hms_nano(
+            h.try_into().map_err(|_| ValueTooBig)?,
+            m as u8,
+            s as u8,
+            n as u32,
+        )
+        .map_err(|_| ValueTooBig)
+    }
+}
 
 /// Keeps a buffer with serialized Values
 /// Allows adding new Values and iterating over serialized ones
@@ -385,24 +575,14 @@ impl Value for BigDecimal {
     }
 }
 
+#[cfg(feature = "chrono")]
 impl Value for NaiveDate {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
-        buf.put_i32(4);
-        let unix_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-
-        let days: u32 = self
-            .signed_duration_since(unix_epoch)
-            .num_days()
-            .checked_add(1 << 31)
-            .and_then(|days| days.try_into().ok()) // convert to u32
-            .ok_or(ValueTooBig)?;
-
-        buf.put_u32(days);
-        Ok(())
+        CqlDate::from(*self).serialize(buf)
     }
 }
 
-impl Value for Date {
+impl Value for CqlDate {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         buf.put_i32(4);
         buf.put_u32(self.0);
@@ -410,27 +590,54 @@ impl Value for Date {
     }
 }
 
-impl Value for Timestamp {
+#[cfg(feature = "time")]
+impl Value for time::Date {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        CqlDate::from(*self).serialize(buf)
+    }
+}
+
+impl Value for CqlTimestamp {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         buf.put_i32(8);
-        buf.put_i64(self.0.num_milliseconds());
+        buf.put_i64(self.0);
         Ok(())
     }
 }
 
-impl Value for Time {
+impl Value for CqlTime {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         buf.put_i32(8);
-        buf.put_i64(self.0.num_nanoseconds().ok_or(ValueTooBig)?);
+        buf.put_i64(self.0);
         Ok(())
     }
 }
 
+#[cfg(feature = "chrono")]
 impl Value for DateTime<Utc> {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
-        buf.put_i32(8);
-        buf.put_i64(self.timestamp_millis());
-        Ok(())
+        CqlTimestamp::from(*self).serialize(buf)
+    }
+}
+
+#[cfg(feature = "time")]
+impl Value for time::OffsetDateTime {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        CqlTimestamp::from(*self).serialize(buf)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl Value for NaiveTime {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        CqlTime::try_from(*self)?.serialize(buf)
+    }
+}
+
+#[cfg(feature = "time")]
+impl Value for time::Time {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        CqlTime::from(*self).serialize(buf)
     }
 }
 
@@ -734,10 +941,10 @@ impl Value for CqlValue {
                 serialize_tuple(fields.iter().map(|(_, value)| value), buf)
             }
 
-            CqlValue::Date(d) => Date(*d).serialize(buf),
+            CqlValue::Date(d) => CqlDate(*d).serialize(buf),
             CqlValue::Duration(d) => d.serialize(buf),
-            CqlValue::Timestamp(t) => Timestamp(*t).serialize(buf),
-            CqlValue::Time(t) => Time(*t).serialize(buf),
+            CqlValue::Timestamp(t) => CqlTimestamp(*t).serialize(buf),
+            CqlValue::Time(t) => CqlTime(*t).serialize(buf),
 
             CqlValue::Ascii(s) | CqlValue::Text(s) => s.serialize(buf),
             CqlValue::List(v) | CqlValue::Set(v) => v.serialize(buf),

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -18,6 +18,8 @@ default = []
 ssl = ["dep:tokio-openssl", "dep:openssl"]
 cloud = ["ssl", "scylla-cql/serde", "dep:serde_yaml", "dep:serde", "dep:url", "dep:base64"]
 secret = ["scylla-cql/secret"]
+chrono = ["scylla-cql/chrono"]
+time = ["scylla-cql/time"]
 
 [dependencies]
 scylla-macros = { version = "0.2.0", path = "../scylla-macros" }
@@ -61,6 +63,7 @@ tokio = { version = "1.27", features = ["test-util"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 assert_matches = "1.5.0"
 rand_chacha = "0.3.1"
+time = "0.3"
 
 [[bench]]
 name = "benchmark"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -20,6 +20,7 @@ cloud = ["ssl", "scylla-cql/serde", "dep:serde_yaml", "dep:serde", "dep:url", "d
 secret = ["scylla-cql/secret"]
 chrono = ["scylla-cql/chrono"]
 time = ["scylla-cql/time"]
+full-serialization = ["chrono", "time", "secret"]
 
 [dependencies]
 scylla-macros = { version = "0.2.0", path = "../scylla-macros" }

--- a/scylla/src/tracing.rs
+++ b/scylla/src/tracing.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use crate::cql_to_rust::{FromRow, FromRowError};
 use crate::frame::response::result::Row;
+use crate::frame::value::CqlTimestamp;
 
 /// Tracing info retrieved from `system_traces.sessions`
 /// with all events from `system_traces.events`
@@ -17,7 +18,7 @@ pub struct TracingInfo {
     pub parameters: Option<HashMap<String, String>>,
     pub request: Option<String>,
     /// started_at is a timestamp - time since unix epoch
-    pub started_at: Option<chrono::Duration>,
+    pub started_at: Option<CqlTimestamp>,
 
     pub events: Vec<TracingEvent>,
 }
@@ -64,7 +65,7 @@ impl FromRow for TracingInfo {
                 Option<i32>,
                 Option<HashMap<String, String>>,
                 Option<String>,
-                Option<chrono::Duration>,
+                Option<CqlTimestamp>,
             )>::from_row(row)?;
 
         Ok(TracingInfo {

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -1,16 +1,13 @@
 use crate as scylla;
 use crate::cql_to_rust::FromCqlVal;
 use crate::frame::response::result::CqlValue;
-use crate::frame::value::Counter;
-use crate::frame::value::Value;
-use crate::frame::value::{Date, Time, Timestamp};
+use crate::frame::value::{Counter, CqlDate, CqlTime, CqlTimestamp, Value};
 use crate::macros::{FromUserType, IntoUserType};
 use crate::test_utils::create_new_session_builder;
 use crate::transport::session::IntoTypedRows;
 use crate::transport::session::Session;
 use crate::utils::test_utils::unique_keyspace_name;
 use bigdecimal::BigDecimal;
-use chrono::{Duration, NaiveDate};
 use num_bigint::BigInt;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
@@ -194,9 +191,10 @@ async fn test_counter() {
     }
 }
 
+#[cfg(features = "chrono")]
 #[tokio::test]
 async fn test_naive_date() {
-    let session: Session = init_test("naive_date", "date").await;
+    let session: Session = init_test("chrono_naive_date_tests", "date").await;
 
     let min_naive_date: NaiveDate = NaiveDate::MIN;
     assert_eq!(
@@ -214,7 +212,7 @@ async fn test_naive_date() {
         // Basic test values
         (
             "0000-01-01",
-            Some(NaiveDate::from_ymd_opt(0000, 1, 1).unwrap()),
+            Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()),
         ),
         (
             "1970-01-01",
@@ -250,7 +248,7 @@ async fn test_naive_date() {
         session
             .query(
                 format!(
-                    "INSERT INTO naive_date (id, val) VALUES (0, '{}')",
+                    "INSERT INTO chrono_naive_date_tests (id, val) VALUES (0, '{}')",
                     date_text
                 ),
                 &[],
@@ -259,7 +257,7 @@ async fn test_naive_date() {
             .unwrap();
 
         let read_date: Option<NaiveDate> = session
-            .query("SELECT val from naive_date", &[])
+            .query("SELECT val from chrono_naive_date_tests", &[])
             .await
             .unwrap()
             .rows
@@ -276,14 +274,14 @@ async fn test_naive_date() {
         if let Some(naive_date) = date {
             session
                 .query(
-                    "INSERT INTO naive_date (id, val) VALUES (0, ?)",
+                    "INSERT INTO chrono_naive_date_tests (id, val) VALUES (0, ?)",
                     (naive_date,),
                 )
                 .await
                 .unwrap();
 
             let (read_date,): (NaiveDate,) = session
-                .query("SELECT val from naive_date", &[])
+                .query("SELECT val from chrono_naive_date_tests", &[])
                 .await
                 .unwrap()
                 .rows
@@ -295,36 +293,19 @@ async fn test_naive_date() {
             assert_eq!(read_date, *naive_date);
         }
     }
-
-    // 1 less/more than min/max values allowed by the database should cause error
-    session
-        .query(
-            "INSERT INTO naive_date (id, val) VALUES (0, '-5877641-06-22')",
-            &[],
-        )
-        .await
-        .unwrap_err();
-
-    session
-        .query(
-            "INSERT INTO naive_date (id, val) VALUES (0, '5881580-07-12')",
-            &[],
-        )
-        .await
-        .unwrap_err();
 }
 
 #[tokio::test]
-async fn test_date() {
+async fn test_cql_date() {
     // Tests value::Date which allows to insert dates outside NaiveDate range
 
-    let session: Session = init_test("date_tests", "date").await;
+    let session: Session = init_test("cql_date_tests", "date").await;
 
     let tests = [
-        ("1970-01-01", Date(2_u32.pow(31))),
-        ("1969-12-02", Date(2_u32.pow(31) - 30)),
-        ("1970-01-31", Date(2_u32.pow(31) + 30)),
-        ("-5877641-06-23", Date(0)),
+        ("1970-01-01", CqlDate(2_u32.pow(31))),
+        ("1969-12-02", CqlDate(2_u32.pow(31) - 30)),
+        ("1970-01-31", CqlDate(2_u32.pow(31) + 30)),
+        ("-5877641-06-23", CqlDate(0)),
         // NOTICE: dropped for Cassandra 4 compatibility
         //("5881580-07-11", Date(u32::MAX)),
     ];
@@ -333,7 +314,7 @@ async fn test_date() {
         session
             .query(
                 format!(
-                    "INSERT INTO date_tests (id, val) VALUES (0, '{}')",
+                    "INSERT INTO cql_date_tests (id, val) VALUES (0, '{}')",
                     date_text
                 ),
                 &[],
@@ -341,40 +322,138 @@ async fn test_date() {
             .await
             .unwrap();
 
-        let read_date: Date = session
-            .query("SELECT val from date_tests", &[])
+        let read_date: CqlDate = session
+            .query("SELECT val from cql_date_tests", &[])
             .await
             .unwrap()
             .rows
             .unwrap()[0]
             .columns[0]
             .as_ref()
-            .map(|cql_val| match cql_val {
-                CqlValue::Date(days) => Date(*days),
-                _ => panic!(),
-            })
+            .map(|cql_val| cql_val.as_cql_date().unwrap())
             .unwrap();
 
         assert_eq!(read_date, *date);
     }
+
+    // 1 less/more than min/max values allowed by the database should cause error
+    session
+        .query(
+            "INSERT INTO cql_date_tests (id, val) VALUES (0, '-5877641-06-22')",
+            &[],
+        )
+        .await
+        .unwrap_err();
+
+    session
+        .query(
+            "INSERT INTO cql_date_tests (id, val) VALUES (0, '5881580-07-12')",
+            &[],
+        )
+        .await
+        .unwrap_err();
+}
+
+#[cfg(features = "time")]
+#[tokio::test]
+async fn test_date() {
+    use time::{Date, Month::*};
+
+    let session: Session = init_test("time_date_tests", "date").await;
+
+    let tests = [
+        // Basic test values
+        (
+            "0000-01-01",
+            Some(Date::from_calendar_date(0, January, 1).unwrap()),
+        ),
+        (
+            "1970-01-01",
+            Some(Date::from_calendar_date(1970, January, 1).unwrap()),
+        ),
+        (
+            "2020-03-07",
+            Some(Date::from_calendar_date(2020, March, 7).unwrap()),
+        ),
+        (
+            "1337-04-05",
+            Some(Date::from_calendar_date(1337, April, 5).unwrap()),
+        ),
+        (
+            "-0001-12-31",
+            Some(Date::from_calendar_date(-1, December, 31).unwrap()),
+        ),
+        // min/max values allowed by time::Date depend on feature flags, but following values must always be allowed
+        (
+            "9999-12-31",
+            Some(Date::from_calendar_date(9999, December, 31).unwrap()),
+        ),
+        (
+            "-9999-01-01",
+            Some(Date::from_calendar_date(-9999, January, 1).unwrap()),
+        ),
+        // min value allowed by the database
+        ("-5877641-06-23", None),
+    ];
+
+    for (date_text, date) in tests.iter() {
+        session
+            .query(
+                format!(
+                    "INSERT INTO time_date_tests (id, val) VALUES (0, '{}')",
+                    date_text
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let (read_date,) = session
+            .query("SELECT val from time_date_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(Date,)>()
+            .unwrap();
+
+        assert_eq!(read_date, *date);
+
+        // If date is representable by time::Date try inserting it and reading again
+        if let Some(date) = date {
+            session
+                .query(
+                    "INSERT INTO time_date_tests (id, val) VALUES (0, ?)",
+                    (date,),
+                )
+                .await
+                .unwrap();
+
+            let (read_date,) = session
+                .query("SELECT val from time_date_tests", &[])
+                .await
+                .unwrap()
+                .first_row_typed::<(Date,)>()
+                .unwrap();
+            assert_eq!(read_date, *date);
+        }
+    }
 }
 
 #[tokio::test]
-async fn test_time() {
-    // Time is an i64 - nanoseconds since midnight
+async fn test_cql_time() {
+    // CqlTime is an i64 - nanoseconds since midnight
     // in range 0..=86399999999999
 
-    let session: Session = init_test("time_tests", "time").await;
+    let session: Session = init_test("cql_time_tests", "time").await;
 
     let max_time: i64 = 24 * 60 * 60 * 1_000_000_000 - 1;
     assert_eq!(max_time, 86399999999999);
 
     let tests = [
-        ("00:00:00", Duration::nanoseconds(0)),
-        ("01:01:01", Duration::seconds(60 * 60 + 60 + 1)),
-        ("00:00:00.000000000", Duration::nanoseconds(0)),
-        ("00:00:00.000000001", Duration::nanoseconds(1)),
-        ("23:59:59.999999999", Duration::nanoseconds(max_time)),
+        ("00:00:00", CqlTime(0)),
+        ("01:01:01", CqlTime((60 * 60 + 60 + 1) * 1_000_000_000)),
+        ("00:00:00.000000000", CqlTime(0)),
+        ("00:00:00.000000001", CqlTime(1)),
+        ("23:59:59.999999999", CqlTime(max_time)),
     ];
 
     for (time_str, time_duration) in &tests {
@@ -382,7 +461,7 @@ async fn test_time() {
         session
             .query(
                 format!(
-                    "INSERT INTO time_tests (id, val) VALUES (0, '{}')",
+                    "INSERT INTO cql_time_tests (id, val) VALUES (0, '{}')",
                     time_str
                 ),
                 &[],
@@ -390,35 +469,35 @@ async fn test_time() {
             .await
             .unwrap();
 
-        let (read_time,): (Duration,) = session
-            .query("SELECT val from time_tests", &[])
+        let (read_time,) = session
+            .query("SELECT val from cql_time_tests", &[])
             .await
             .unwrap()
             .rows
             .unwrap()
-            .into_typed::<(Duration,)>()
+            .into_typed::<(CqlTime,)>()
             .next()
             .unwrap()
             .unwrap();
 
         assert_eq!(read_time, *time_duration);
 
-        // Insert time as a bound Time value and verify that it matches
+        // Insert time as a bound CqlTime value and verify that it matches
         session
             .query(
-                "INSERT INTO time_tests (id, val) VALUES (0, ?)",
-                (Time(*time_duration),),
+                "INSERT INTO cql_time_tests (id, val) VALUES (0, ?)",
+                (*time_duration,),
             )
             .await
             .unwrap();
 
-        let (read_time,): (Duration,) = session
-            .query("SELECT val from time_tests", &[])
+        let (read_time,) = session
+            .query("SELECT val from cql_time_tests", &[])
             .await
             .unwrap()
             .rows
             .unwrap()
-            .into_typed::<(Duration,)>()
+            .into_typed::<(CqlTime,)>()
             .next()
             .unwrap()
             .unwrap();
@@ -442,7 +521,7 @@ async fn test_time() {
         session
             .query(
                 format!(
-                    "INSERT INTO time_tests (id, val) VALUES (0, '{}')",
+                    "INSERT INTO cql_time_tests (id, val) VALUES (0, '{}')",
                     time_str
                 ),
                 &[],
@@ -452,9 +531,157 @@ async fn test_time() {
     }
 }
 
+#[cfg(feature = "chrono")]
 #[tokio::test]
-async fn test_timestamp() {
-    let session: Session = init_test("timestamp_tests", "timestamp").await;
+async fn test_naive_time() {
+    use chrono::NaiveTime;
+
+    let session = init_test("chrono_time_tests", "time").await;
+
+    let tests = [
+        ("00:00:00", NaiveTime::MIN),
+        ("01:01:01", NaiveTime::from_hms_opt(1, 1, 1).unwrap()),
+        (
+            "00:00:00.000000000",
+            NaiveTime::from_hms_nano_opt(0, 0, 0, 0).unwrap(),
+        ),
+        (
+            "00:00:00.000000001",
+            NaiveTime::from_hms_nano_opt(0, 0, 0, 1).unwrap(),
+        ),
+        (
+            "12:34:56.789012345",
+            NaiveTime::from_hms_nano_opt(12, 34, 56, 789_012_345).unwrap(),
+        ),
+        (
+            "23:59:59.999999999",
+            NaiveTime::from_hms_nano_opt(23, 59, 59, 999_999_999).unwrap(),
+        ),
+    ];
+
+    for (time_text, time) in tests.iter() {
+        // Insert as string and read it again
+        session
+            .query(
+                format!(
+                    "INSERT INTO chrono_time_tests (id, val) VALUES (0, '{}')",
+                    time_text
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let (read_time,) = session
+            .query("SELECT val from chrono_time_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(NaiveTime,)>()
+            .unwrap();
+
+        assert_eq!(read_time, *time);
+
+        // Insert as type and read it again
+        session
+            .query(
+                "INSERT INTO chrono_time_tests (id, val) VALUES (0, ?)",
+                (time,),
+            )
+            .await
+            .unwrap();
+
+        let (read_time,) = session
+            .query("SELECT val from chrono_time_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(NaiveTime,)>()
+            .unwrap();
+        assert_eq!(read_time, *time);
+    }
+
+    // chrono can represent leap seconds, this should not panic
+    let leap_second = NaiveTime::from_hms_nano_opt(23, 59, 59, 1_500_000_000);
+    session
+        .query(
+            "INSERT INTO cql_time_tests (id, val) VALUES (0, ?)",
+            (leap_second,),
+        )
+        .await
+        .unwrap_err();
+}
+
+#[cfg(feature = "time")]
+#[tokio::test]
+async fn test_time() {
+    use time::Time;
+
+    let session = init_test("time_time_tests", "time").await;
+
+    let tests = [
+        ("00:00:00", Time::MIDNIGHT),
+        ("01:01:01", Time::from_hms(1, 1, 1).unwrap()),
+        (
+            "00:00:00.000000000",
+            Time::from_hms_nano(0, 0, 0, 0).unwrap(),
+        ),
+        (
+            "00:00:00.000000001",
+            Time::from_hms_nano(0, 0, 0, 1).unwrap(),
+        ),
+        (
+            "12:34:56.789012345",
+            Time::from_hms_nano(12, 34, 56, 789_012_345).unwrap(),
+        ),
+        (
+            "23:59:59.999999999",
+            Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap(),
+        ),
+    ];
+
+    for (time_text, time) in tests.iter() {
+        // Insert as string and read it again
+        session
+            .query(
+                format!(
+                    "INSERT INTO time_time_tests (id, val) VALUES (0, '{}')",
+                    time_text
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let (read_time,) = session
+            .query("SELECT val from time_time_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(Time,)>()
+            .unwrap();
+
+        assert_eq!(read_time, *time);
+
+        // Insert as type and read it again
+        session
+            .query(
+                "INSERT INTO time_time_tests (id, val) VALUES (0, ?)",
+                (time,),
+            )
+            .await
+            .unwrap();
+
+        let (read_time,) = session
+            .query("SELECT val from time_time_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(Time,)>()
+            .unwrap();
+        assert_eq!(read_time, *time);
+    }
+}
+
+#[tokio::test]
+async fn test_cql_timestamp() {
+    let session: Session = init_test("cql_timestamp_tests", "timestamp").await;
 
     //let epoch_date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
 
@@ -465,9 +692,9 @@ async fn test_timestamp() {
     //let after_epoch_offset = after_epoch.signed_duration_since(epoch_date);
 
     let tests = [
-        ("0", Duration::milliseconds(0)),
-        ("9223372036854775807", Duration::milliseconds(i64::MAX)),
-        ("-9223372036854775808", Duration::milliseconds(i64::MIN)),
+        ("0", CqlTimestamp(0)),
+        ("9223372036854775807", CqlTimestamp(i64::MAX)),
+        ("-9223372036854775808", CqlTimestamp(i64::MIN)),
         // NOTICE: dropped for Cassandra 4 compatibility
         //("1970-01-01", Duration::milliseconds(0)),
         //("2020-03-08", after_epoch_offset),
@@ -486,7 +713,7 @@ async fn test_timestamp() {
         session
             .query(
                 format!(
-                    "INSERT INTO timestamp_tests (id, val) VALUES (0, '{}')",
+                    "INSERT INTO cql_timestamp_tests (id, val) VALUES (0, '{}')",
                     timestamp_str
                 ),
                 &[],
@@ -494,41 +721,350 @@ async fn test_timestamp() {
             .await
             .unwrap();
 
-        let (read_timestamp,): (Duration,) = session
-            .query("SELECT val from timestamp_tests", &[])
+        let (read_timestamp,) = session
+            .query("SELECT val from cql_timestamp_tests", &[])
             .await
             .unwrap()
             .rows
             .unwrap()
-            .into_typed::<(Duration,)>()
+            .into_typed::<(CqlTimestamp,)>()
             .next()
             .unwrap()
             .unwrap();
 
         assert_eq!(read_timestamp, *timestamp_duration);
 
-        // Insert timestamp as a bound Timestamp value and verify that it matches
+        // Insert timestamp as a bound CqlTimestamp value and verify that it matches
         session
             .query(
-                "INSERT INTO timestamp_tests (id, val) VALUES (0, ?)",
-                (Timestamp(*timestamp_duration),),
+                "INSERT INTO cql_timestamp_tests (id, val) VALUES (0, ?)",
+                (*timestamp_duration,),
             )
             .await
             .unwrap();
 
-        let (read_timestamp,): (Duration,) = session
-            .query("SELECT val from timestamp_tests", &[])
+        let (read_timestamp,) = session
+            .query("SELECT val from cql_timestamp_tests", &[])
             .await
             .unwrap()
             .rows
             .unwrap()
-            .into_typed::<(Duration,)>()
+            .into_typed::<(CqlTimestamp,)>()
             .next()
             .unwrap()
             .unwrap();
 
         assert_eq!(read_timestamp, *timestamp_duration);
     }
+}
+
+#[cfg(feature = "chrono")]
+#[tokio::test]
+async fn test_date_time() {
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+    let session = init_test("chrono_datetime_tests", "timestamp").await;
+
+    let tests = [
+        (
+            "0",
+            NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc(),
+        ),
+        (
+            "2001-02-03T04:05:06.789+0000",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(2001, 2, 3).unwrap(),
+                NaiveTime::from_hms_milli_opt(4, 5, 6, 789).unwrap(),
+            )
+            .and_utc(),
+        ),
+        (
+            "2011-02-03T04:05:00.000+0000",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(2011, 2, 3).unwrap(),
+                NaiveTime::from_hms_milli_opt(4, 5, 0, 0).unwrap(),
+            )
+            .and_utc(),
+        ),
+        // New Zealand timezone, converted to GMT
+        (
+            "2011-02-03T04:05:06.987+1245",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(2011, 2, 2).unwrap(),
+                NaiveTime::from_hms_milli_opt(15, 20, 6, 987).unwrap(),
+            )
+            .and_utc(),
+        ),
+        (
+            "9999-12-31T23:59:59.999+0000",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(9999, 12, 31).unwrap(),
+                NaiveTime::from_hms_milli_opt(23, 59, 59, 999).unwrap(),
+            )
+            .and_utc(),
+        ),
+        (
+            "-377705116800000",
+            NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(-9999, 1, 1).unwrap(),
+                NaiveTime::from_hms_milli_opt(0, 0, 0, 0).unwrap(),
+            )
+            .and_utc(),
+        ),
+    ];
+
+    for (datetime_text, datetime) in tests.iter() {
+        // Insert as string and read it again
+        session
+            .query(
+                format!(
+                    "INSERT INTO chrono_datetime_tests (id, val) VALUES (0, '{}')",
+                    datetime_text
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let (read_datetime,) = session
+            .query("SELECT val from chrono_datetime_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(DateTime<Utc>,)>()
+            .unwrap();
+
+        assert_eq!(read_datetime, *datetime);
+
+        // Insert as type and read it again
+        session
+            .query(
+                "INSERT INTO chrono_datetime_tests (id, val) VALUES (0, ?)",
+                (datetime,),
+            )
+            .await
+            .unwrap();
+
+        let (read_datetime,) = session
+            .query("SELECT val from chrono_datetime_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(DateTime<Utc>,)>()
+            .unwrap();
+        assert_eq!(read_datetime, *datetime);
+    }
+
+    // chrono datetime has higher precision, round excessive submillisecond time down
+    let nanosecond_precision_1st_half = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(2015, 6, 30).unwrap(),
+        NaiveTime::from_hms_nano_opt(23, 59, 59, 123_123_456).unwrap(),
+    )
+    .and_utc();
+    let nanosecond_precision_1st_half_rounded = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(2015, 6, 30).unwrap(),
+        NaiveTime::from_hms_milli_opt(23, 59, 59, 123).unwrap(),
+    )
+    .and_utc();
+    session
+        .query(
+            "INSERT INTO chrono_datetime_tests (id, val) VALUES (0, ?)",
+            (nanosecond_precision_1st_half,),
+        )
+        .await
+        .unwrap();
+
+    let (read_datetime,) = session
+        .query("SELECT val from chrono_datetime_tests", &[])
+        .await
+        .unwrap()
+        .first_row_typed::<(DateTime<Utc>,)>()
+        .unwrap();
+    assert_eq!(read_datetime, nanosecond_precision_1st_half_rounded);
+
+    let nanosecond_precision_2nd_half = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(2015, 6, 30).unwrap(),
+        NaiveTime::from_hms_nano_opt(23, 59, 59, 123_987_654).unwrap(),
+    )
+    .and_utc();
+    let nanosecond_precision_2nd_half_rounded = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(2015, 6, 30).unwrap(),
+        NaiveTime::from_hms_milli_opt(23, 59, 59, 123).unwrap(),
+    )
+    .and_utc();
+    session
+        .query(
+            "INSERT INTO chrono_datetime_tests (id, val) VALUES (0, ?)",
+            (nanosecond_precision_2nd_half,),
+        )
+        .await
+        .unwrap();
+
+    let (read_datetime,) = session
+        .query("SELECT val from chrono_datetime_tests", &[])
+        .await
+        .unwrap()
+        .first_row_typed::<(DateTime<Utc>,)>()
+        .unwrap();
+    assert_eq!(read_datetime, nanosecond_precision_2nd_half_rounded);
+
+    // chrono can represent leap seconds, this should not panic
+    let leap_second = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(2015, 6, 30).unwrap(),
+        NaiveTime::from_hms_milli_opt(23, 59, 59, 1500).unwrap(),
+    )
+    .and_utc();
+    session
+        .query(
+            "INSERT INTO cql_datetime_tests (id, val) VALUES (0, ?)",
+            (leap_second,),
+        )
+        .await
+        .unwrap_err();
+}
+
+#[cfg(feature = "time")]
+#[tokio::test]
+async fn test_offset_date_time() {
+    use time::{Date, Month::*, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+    let session = init_test("time_datetime_tests", "timestamp").await;
+
+    let tests = [
+        ("0", OffsetDateTime::UNIX_EPOCH),
+        (
+            "2001-02-03T04:05:06.789+0000",
+            PrimitiveDateTime::new(
+                Date::from_calendar_date(2001, February, 3).unwrap(),
+                Time::from_hms_milli(4, 5, 6, 789).unwrap(),
+            )
+            .assume_utc(),
+        ),
+        (
+            "2011-02-03T04:05:00.000+0000",
+            PrimitiveDateTime::new(
+                Date::from_calendar_date(2011, February, 3).unwrap(),
+                Time::from_hms_milli(4, 5, 0, 0).unwrap(),
+            )
+            .assume_utc(),
+        ),
+        // New Zealand timezone, converted to GMT
+        (
+            "2011-02-03T04:05:06.987+1245",
+            PrimitiveDateTime::new(
+                Date::from_calendar_date(2011, February, 3).unwrap(),
+                Time::from_hms_milli(4, 5, 6, 987).unwrap(),
+            )
+            .assume_offset(UtcOffset::from_hms(12, 45, 0).unwrap()),
+        ),
+        (
+            "9999-12-31T23:59:59.999+0000",
+            PrimitiveDateTime::new(
+                Date::from_calendar_date(9999, December, 31).unwrap(),
+                Time::from_hms_milli(23, 59, 59, 999).unwrap(),
+            )
+            .assume_utc(),
+        ),
+        (
+            "-377705116800000",
+            PrimitiveDateTime::new(
+                Date::from_calendar_date(-9999, January, 1).unwrap(),
+                Time::from_hms_milli(0, 0, 0, 0).unwrap(),
+            )
+            .assume_utc(),
+        ),
+    ];
+
+    for (datetime_text, datetime) in tests.iter() {
+        // Insert as string and read it again
+        session
+            .query(
+                format!(
+                    "INSERT INTO time_datetime_tests (id, val) VALUES (0, '{}')",
+                    datetime_text
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let (read_datetime,) = session
+            .query("SELECT val from time_datetime_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(OffsetDateTime,)>()
+            .unwrap();
+
+        assert_eq!(read_datetime, *datetime);
+
+        // Insert as type and read it again
+        session
+            .query(
+                "INSERT INTO time_datetime_tests (id, val) VALUES (0, ?)",
+                (datetime,),
+            )
+            .await
+            .unwrap();
+
+        let (read_datetime,) = session
+            .query("SELECT val from time_datetime_tests", &[])
+            .await
+            .unwrap()
+            .first_row_typed::<(OffsetDateTime,)>()
+            .unwrap();
+        assert_eq!(read_datetime, *datetime);
+    }
+
+    // time datetime has higher precision, round excessive submillisecond time down
+    let nanosecond_precision_1st_half = PrimitiveDateTime::new(
+        Date::from_calendar_date(2015, June, 30).unwrap(),
+        Time::from_hms_nano(23, 59, 59, 123_123_456).unwrap(),
+    )
+    .assume_utc();
+    let nanosecond_precision_1st_half_rounded = PrimitiveDateTime::new(
+        Date::from_calendar_date(2015, June, 30).unwrap(),
+        Time::from_hms_milli(23, 59, 59, 123).unwrap(),
+    )
+    .assume_utc();
+    session
+        .query(
+            "INSERT INTO time_datetime_tests (id, val) VALUES (0, ?)",
+            (nanosecond_precision_1st_half,),
+        )
+        .await
+        .unwrap();
+
+    let (read_datetime,) = session
+        .query("SELECT val from time_datetime_tests", &[])
+        .await
+        .unwrap()
+        .first_row_typed::<(OffsetDateTime,)>()
+        .unwrap();
+    assert_eq!(read_datetime, nanosecond_precision_1st_half_rounded);
+
+    let nanosecond_precision_2nd_half = PrimitiveDateTime::new(
+        Date::from_calendar_date(2015, June, 30).unwrap(),
+        Time::from_hms_nano(23, 59, 59, 123_987_654).unwrap(),
+    )
+    .assume_utc();
+    let nanosecond_precision_2nd_half_rounded = PrimitiveDateTime::new(
+        Date::from_calendar_date(2015, June, 30).unwrap(),
+        Time::from_hms_milli(23, 59, 59, 123).unwrap(),
+    )
+    .assume_utc();
+    session
+        .query(
+            "INSERT INTO time_datetime_tests (id, val) VALUES (0, ?)",
+            (nanosecond_precision_2nd_half,),
+        )
+        .await
+        .unwrap();
+
+    let (read_datetime,) = session
+        .query("SELECT val from time_datetime_tests", &[])
+        .await
+        .unwrap()
+        .first_row_typed::<(OffsetDateTime,)>()
+        .unwrap();
+    assert_eq!(read_datetime, nanosecond_precision_2nd_half_rounded);
 }
 
 #[tokio::test]

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -191,9 +191,11 @@ async fn test_counter() {
     }
 }
 
-#[cfg(features = "chrono")]
+#[cfg(feature = "chrono")]
 #[tokio::test]
 async fn test_naive_date() {
+    use chrono::NaiveDate;
+
     let session: Session = init_test("chrono_naive_date_tests", "date").await;
 
     let min_naive_date: NaiveDate = NaiveDate::MIN;
@@ -354,7 +356,7 @@ async fn test_cql_date() {
         .unwrap_err();
 }
 
-#[cfg(features = "time")]
+#[cfg(feature = "time")]
 #[tokio::test]
 async fn test_date() {
     use time::{Date, Month::*};
@@ -408,12 +410,13 @@ async fn test_date() {
             .await
             .unwrap();
 
-        let (read_date,) = session
+        let read_date = session
             .query("SELECT val from time_date_tests", &[])
             .await
             .unwrap()
             .first_row_typed::<(Date,)>()
-            .unwrap();
+            .ok()
+            .map(|val| val.0);
 
         assert_eq!(read_date, *date);
 


### PR DESCRIPTION
Fixes: #741

## Goals

Goal of this MR is to improve the support of common time crates.

## Changes

Breaking changes were introduced and a major version bump would be required.

* Reworked `scylla::frame::value` date and time types:
  * Align structs with internal CQL representation;
  * Rename to add `Cql`- prefix to explicitly show direct relation to CQL types;
* Moved `chrono` dependency of `scylla-cql` behind `scylla-cql/chrono` feature;
* Added optional `time` dependency with full serialization support;
* Implemented traits to convert between chrono/time types and CQL types;
* Removed implementation of `FromCqlValue<CqlValue>` for `chrono::Duration` as it may be misleading. `CqlTime` and `CqlTimestamp` structs are no longer a `chrono::Duration` wrappers;
* `CqlValue::as_date` function signature changed to return `time::Date` instead of `chrono::NaiveDate` for better naming consistency;
* `CqlValue::as_cql_time` and `CqlValue::as_cql_timestamp` functions now ensure that row is of Time or Timestamp type correspondingly. Upstream behavior is to parse all bignum types as time or timestamp;

## Points for discussion

1) If we can guarantee that CQL time type never exceeds 23:59:59.999,999,999 extra guarantees can be given about `CqlTime` struct and implementations of `TryFrom<CqlTime>` for `chrono::NaiveTime` and `time::Time` can be replaced with `From<CqlTime>`. However, this would require restricting access to internal value of `CqlTime` (like implementing constructor and getter). I wasn't sure if we can give this guarantee, so it's not present in current implementation;
2) Support for `std::time::SystemTime` was intentionally not implemented as it represents local time and not UTC time. This may and probably will lead to incorrect values in the database tables, as CQL timestamp is UTC;
3) `scylla::history` module requires `chrono` dependency for `scylla` crate. I wasn't sure about how to best handle it nor its intended use case, so I didn't touch it. Potentially it could be nice to change `history::TimePoint` type based on what features were used.

## Other concerns

I wasn't able to run `test/dockerized/run.sh` script without changes. On my machine no containers were found with `grep cluster_scylla` command on line 5. It worked after replacing it with `grep cluster-scylla` locally. I would need more info on behavior on machines other than mine to push this fix.

This MR will produce a lot of conflicts with #665, I'll tag here it so it won't go unnoticed.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.

## Pre-merge checklist

- [x] Set up CI for feature flags combinations.

I would appreciate some help with setting up CI for feature flag combinations as added functionality is NOT tested with github CI.