### PR TITLE
Make `CloudConfig` public

### DIFF
--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -26,8 +26,11 @@ pub enum CloudConfigError {
     Ssl(#[from] openssl::error::ErrorStack),
 }
 
+/// Configuration for creating a session to a serverless cluster.
+/// This can be automatically created if you provide the bundle path
+/// to the [`CloudSessionBuilder`] constructor.
 #[derive(Debug)]
-pub(crate) struct CloudConfig {
+pub struct CloudConfig {
     datacenters: HashMap<String, Datacenter>,
     auth_infos: HashMap<String, AuthInfo>,
 
@@ -67,6 +70,8 @@ impl CloudConfig {
     }
 }
 
+/// Contains all authentication info for creating TLS connections using SNI proxy
+/// to connect to cloud nodes.
 #[derive(Debug)]
 pub(crate) struct AuthInfo {
     key: PKey<Private>,
@@ -97,6 +102,7 @@ impl AuthInfo {
     }
 }
 
+/// Contains cloud datacenter configuration for creating TLS connections to its nodes.  
 #[derive(Debug)]
 pub(crate) struct Datacenter {
     certificate_authority: X509,
@@ -137,6 +143,7 @@ impl Datacenter {
     }
 }
 
+/// Contains the names of the primary datacenter and authentication info.
 #[derive(Debug)]
 pub(crate) struct Context {
     datacenter_name: String,

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -215,9 +215,9 @@ pub struct SessionConfig {
     /// It is true by default but can be disabled if successive schema-altering statements should be performed.
     pub refresh_metadata_on_auto_schema_agreement: bool,
 
-    // If the driver is to connect to ScyllaCloud, there is a config for it.
+    /// If the driver is to connect to ScyllaCloud, there is a config for it.
     #[cfg(feature = "cloud")]
-    pub(crate) cloud_config: Option<Arc<CloudConfig>>,
+    pub cloud_config: Option<Arc<CloudConfig>>,
 
     /// If true, the driver will inject a small delay before flushing data
     /// to the socket - by rescheduling the task that writes data to the socket.


### PR DESCRIPTION
Allows to construct `CloudConfig` and manually set it in `SessionConfig`. It will also help to add serverless support in C++ bindings.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
