### PR TITLE
CI: use ubuntu-20.04 in serverless workflow

### DIFF
--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -12,14 +12,12 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # ccm requires Python 2 when creating a serverless cluster.
+    # Python 2 is pre-installed on Ubuntu 20.04.
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 2.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: '2.7'
       - name: Install scylla-ccm
         run: pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
 


### PR DESCRIPTION
ccm requries Python 2 when creating a serverless cluster. Installing Python 2 with actions/setup-python@v2 is now deprecated, so we solve it by explicitly using ubuntu-20.04 runners, which have it installed.

Closes #751

## Pre-review checklist
- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [X] I added appropriate `Fixes:` annotations to PR description.
