### PR TITLE
Proceed on unresolvable hostname

### DIFF
--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -357,8 +357,8 @@ pub enum BadQuery {
 #[derive(Error, Debug, Clone)]
 pub enum NewSessionError {
     /// Failed to resolve hostname passed in Session creation
-    #[error("Couldn't resolve address: {0}")]
-    FailedToResolveAddress(String),
+    #[error("Couldn't resolve any hostname: {0:?}")]
+    FailedToResolveAnyHostname(Vec<String>),
 
     /// List of known nodes passed to Session constructor is empty
     /// There needs to be at least one node to connect to

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -1,5 +1,6 @@
 mod execution_profiles;
 mod hygiene;
 mod lwt_optimisation;
+mod new_session;
 mod retries;
 pub(crate) mod utils;

--- a/scylla/tests/integration/new_session.rs
+++ b/scylla/tests/integration/new_session.rs
@@ -1,0 +1,34 @@
+use assert_matches::assert_matches;
+use scylla::SessionBuilder;
+use scylla_cql::errors::NewSessionError;
+
+#[cfg(not(scylla_cloud_tests))]
+#[tokio::test]
+async fn proceed_if_only_some_hostnames_are_invalid() {
+    // on purpose left without port
+    let uri1 = "scylladbisthefastestdb.invalid".to_owned();
+    // correctly provided port, but unknown domain
+    let uri2 = "cassandrasuckssomuch.invalid:9042".to_owned();
+    let uri3 = std::env::var("SCYLLA_URI3").unwrap_or_else(|_| "127.0.0.3:9042".to_string());
+
+    let session = SessionBuilder::new()
+        .known_nodes([uri1, uri2, uri3])
+        .build()
+        .await
+        .unwrap();
+    session
+        .query("SELECT host_id FROM system.local", &[])
+        .await
+        .unwrap();
+}
+
+#[cfg(not(scylla_cloud_tests))]
+#[tokio::test]
+async fn all_hostnames_invalid() {
+    let uri = "cassandrasuckssomuch.invalid:9042".to_owned();
+
+    assert_matches!(
+        SessionBuilder::new().known_node(uri).build().await,
+        Err(NewSessionError::FailedToResolveAnyHostname(_))
+    );
+}


### PR DESCRIPTION
A user encountered a following problem:
> Rust Driver wasn't able to start if one of the configured nodes was not available

This was found to be caused by the hostname resolution logic, which considered failure in resolving any hostname to be a critical error.
As it makes more sense to fail only when we end up with no contact points with known resolved addresses, in that case, a new variant is returned: `NewSessionError::FailedToResolveAnyHostname`, else initialisation continues successfully.
The new behaviour is automatically tested.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
