### PR TITLE
scylla/Cargo.toml: bump the tracing dependency to 0.1.36

### DIFF
--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -14,7 +14,7 @@ futures = "0.3.6"
 uuid = "1.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
-tracing = "0.1.25"
+tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 ```
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0"
 itertools = "0.10.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
-tracing = "0.1.25"
+tracing = "0.1.36"
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }


### PR DESCRIPTION
The #668 PR introduced changes that require new features from the `tracing` crate. Bump the depdendency to `0.1.36` which supports all required features.

Additionally, the dependency is also updated in the quickstart guide.

Fixes: #754

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
