### PR TITLE
Stateful partitioners

### DIFF
--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -31,7 +31,9 @@ async fn main() -> Result<()> {
             .await?;
 
         let serialized_pk = (pk,).serialized()?.into_owned();
-        let t = Murmur3Partitioner::hash(&prepared.compute_partition_key(&serialized_pk)?).value;
+        let t = Murmur3Partitioner
+            .hash_one(&prepared.compute_partition_key(&serialized_pk)?)
+            .value;
 
         println!(
             "Token endpoints for query: {:?}",

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -30,10 +30,7 @@ async fn main() -> Result<()> {
             .await?;
 
         let serialized_pk = (pk,).serialized()?.into_owned();
-        let t = session
-            .calculate_token(&prepared, &serialized_pk)?
-            .unwrap()
-            .value;
+        let t = prepared.calculate_token(&serialized_pk)?.unwrap().value;
 
         println!(
             "Token endpoints for query: {:?}",

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use scylla::frame::value::ValueList;
 use scylla::routing::Token;
-use scylla::transport::partitioner::{Murmur3Partitioner, Partitioner};
 use scylla::transport::NodeAddr;
 use scylla::{Session, SessionBuilder};
 use std::env;
@@ -31,8 +30,9 @@ async fn main() -> Result<()> {
             .await?;
 
         let serialized_pk = (pk,).serialized()?.into_owned();
-        let t = Murmur3Partitioner
-            .hash_one(&prepared.compute_partition_key(&serialized_pk)?)
+        let t = session
+            .calculate_token(&prepared, &serialized_pk)?
+            .unwrap()
             .value;
 
         println!(

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -34,7 +34,7 @@ pub struct SchemaChange {
     pub event: SchemaChangeEvent,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableSpec {
     pub ks_name: String,
     pub table_name: String,
@@ -329,7 +329,7 @@ impl CqlValue {
     // TODO
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnSpec {
     pub table_spec: TableSpec,
     pub name: String,

--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -1,7 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use bytes::BytesMut;
-use scylla::frame::types;
+use scylla::{
+    frame::types,
+    frame::value::ValueList,
+    transport::partitioner::{calculate_token_for_partition_key, Murmur3Partitioner},
+};
 
 fn types_benchmark(c: &mut Criterion) {
     let mut buf = BytesMut::with_capacity(64);
@@ -35,5 +39,57 @@ fn types_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, types_benchmark);
+fn calculate_token_bench(c: &mut Criterion) {
+    let simple_pk = ("I'm prepared!!!",);
+    let serialized_simple_pk = simple_pk.serialized().unwrap().into_owned();
+    let simple_pk_long_column = (
+        17_i32,
+        16_i32,
+        String::from_iter(std::iter::repeat('.').take(2000)),
+    );
+    let serialized_simple_pk_long_column = simple_pk_long_column.serialized().unwrap().into_owned();
+
+    let complex_pk = (17_i32, 16_i32, "I'm prepared!!!");
+    let serialized_complex_pk = complex_pk.serialized().unwrap().into_owned();
+    let complex_pk_long_column = (
+        17_i32,
+        16_i32,
+        String::from_iter(std::iter::repeat('.').take(2000)),
+    );
+    let serialized_values_long_column = complex_pk_long_column.serialized().unwrap().into_owned();
+
+    c.bench_function("calculate_token_from_partition_key simple pk", |b| {
+        b.iter(|| calculate_token_for_partition_key(&serialized_simple_pk, &Murmur3Partitioner))
+    });
+
+    c.bench_function(
+        "calculate_token_from_partition_key simple pk long column",
+        |b| {
+            b.iter(|| {
+                calculate_token_for_partition_key(
+                    &serialized_simple_pk_long_column,
+                    &Murmur3Partitioner,
+                )
+            })
+        },
+    );
+
+    c.bench_function("calculate_token_from_partition_key complex pk", |b| {
+        b.iter(|| calculate_token_for_partition_key(&serialized_complex_pk, &Murmur3Partitioner))
+    });
+
+    c.bench_function(
+        "calculate_token_from_partition_key complex pk long column",
+        |b| {
+            b.iter(|| {
+                calculate_token_for_partition_key(
+                    &serialized_values_long_column,
+                    &Murmur3Partitioner,
+                )
+            })
+        },
+    );
+}
+
+criterion_group!(benches, types_benchmark, calculate_token_bench);
 criterion_main!(benches);

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -124,7 +124,7 @@ impl PreparedStatement {
 
     /// Computes the partition key of the target table from given values —
     /// it assumes that all partition key columns are passed in values.
-    /// Partition keys have a specific serialization rules.
+    /// Partition keys have specific serialization rules.
     /// Ref: <https://github.com/scylladb/scylla/blob/40adf38915b6d8f5314c621a94d694d172360833/compound_compat.hh#L33-L47>
     pub fn compute_partition_key(
         &self,
@@ -142,48 +142,47 @@ impl PreparedStatement {
             {
                 buf.extend_from_slice(v);
             }
-            return Ok(buf.into());
-        }
+        } else {
+            // Composite partition key case
 
-        // Composite partition key case
-
-        // Iterate on values using sorted pk_indexes (see deser_prepared_metadata),
-        // and use PartitionKeyIndex.sequence to insert the value in pk_values with the correct order.
-        // At the same time, compute the size of the buffer to reserve it before writing in it.
-        let mut pk_values: SmallVec<[_; 8]> =
-            smallvec![None; self.get_prepared_metadata().pk_indexes.len()];
-        let mut values_iter = bound_values.iter();
-        let mut buf_size = 0;
-        // pk_indexes contains the indexes of the partition key value, so the current offset of the
-        // iterator must be kept, in order to compute the next position of the pk in the iterator.
-        // At each iteration values_iter.nth(0) will roughly correspond to values[values_iter_offset],
-        // so values[pk_index.index] will be retrieved with values_iter.nth(pk_index.index - values_iter_offset)
-        let mut values_iter_offset = 0;
-        for pk_index in self.get_prepared_metadata().pk_indexes.iter().copied() {
-            // Find value matching current pk_index
-            let next_val = values_iter
-                .nth((pk_index.index - values_iter_offset) as usize)
-                .ok_or_else(|| {
-                    PartitionKeyError::NoPkIndexValue(pk_index.index, bound_values.len())
-                })?;
-            // Add it in sequence order to pk_values
-            if let Some(v) = next_val {
-                pk_values[pk_index.sequence as usize] = Some(v);
-                buf_size += std::mem::size_of::<u16>() + v.len() + std::mem::size_of::<u8>();
+            // Iterate on values using sorted pk_indexes (see deser_prepared_metadata),
+            // and use PartitionKeyIndex.sequence to insert the value in pk_values with the correct order.
+            // At the same time, compute the size of the buffer to reserve it before writing in it.
+            let mut pk_values: SmallVec<[_; 8]> =
+                smallvec![None; self.get_prepared_metadata().pk_indexes.len()];
+            let mut values_iter = bound_values.iter();
+            let mut buf_size = 0;
+            // pk_indexes contains the indexes of the partition key value, so the current offset of the
+            // iterator must be kept, in order to compute the next position of the pk in the iterator.
+            // At each iteration values_iter.nth(0) will roughly correspond to values[values_iter_offset],
+            // so values[pk_index.index] will be retrieved with values_iter.nth(pk_index.index - values_iter_offset)
+            let mut values_iter_offset = 0;
+            for pk_index in self.get_prepared_metadata().pk_indexes.iter().copied() {
+                // Find value matching current pk_index
+                let next_val = values_iter
+                    .nth((pk_index.index - values_iter_offset) as usize)
+                    .ok_or_else(|| {
+                        PartitionKeyError::NoPkIndexValue(pk_index.index, bound_values.len())
+                    })?;
+                // Add it in sequence order to pk_values
+                if let Some(v) = next_val {
+                    pk_values[pk_index.sequence as usize] = Some(v);
+                    buf_size += std::mem::size_of::<u16>() + v.len() + std::mem::size_of::<u8>();
+                }
+                values_iter_offset = pk_index.index + 1;
             }
-            values_iter_offset = pk_index.index + 1;
-        }
-        // Add values' bytes
-        buf.reserve(buf_size);
-        for v in pk_values.iter().flatten() {
-            let v_len_u16: u16 = v
-                .len()
-                .try_into()
-                .map_err(|_| PartitionKeyError::ValueTooLong(v.len()))?;
+            // Add values' bytes
+            buf.reserve(buf_size);
+            for v in pk_values.iter().flatten() {
+                let v_len_u16: u16 = v
+                    .len()
+                    .try_into()
+                    .map_err(|_| PartitionKeyError::ValueTooLong(v.len()))?;
 
-            buf.put_u16(v_len_u16);
-            buf.extend_from_slice(v);
-            buf.put_u8(0);
+                buf.put_u16(v_len_u16);
+                buf.extend_from_slice(v);
+                buf.put_u8(0);
+            }
         }
         Ok(buf.into())
     }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -126,6 +126,11 @@ impl PreparedStatement {
     /// it assumes that all partition key columns are passed in values.
     /// Partition keys have specific serialization rules.
     /// Ref: <https://github.com/scylladb/scylla/blob/40adf38915b6d8f5314c621a94d694d172360833/compound_compat.hh#L33-L47>
+    ///
+    /// Note: this is no longer required to compute a token. This is because partitioners
+    /// are now stateful and stream-based, so they do not require materialised partition key.
+    /// Therefore, for computing a token, there are more efficient methods, such as
+    /// [Self::calculate_token()].
     pub fn compute_partition_key(
         &self,
         bound_values: &SerializedValues,

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -1,6 +1,7 @@
 /// Cluster manages up to date information and connections to database nodes
 use crate::frame::response::event::{Event, StatusChangeEvent};
 use crate::frame::value::ValueList;
+use crate::prepared_statement::TokenCalculationError;
 use crate::routing::Token;
 use crate::transport::host_filter::HostFilter;
 use crate::transport::{
@@ -11,9 +12,9 @@ use crate::transport::{
     partitioner::PartitionerName,
     topology::{Keyspace, Metadata, MetadataReader},
 };
+use crate::Session;
 
 use arc_swap::ArcSwap;
-use bytes::{BufMut, Bytes, BytesMut};
 use futures::future::join_all;
 use futures::{future::RemoteHandle, FutureExt};
 use itertools::Itertools;
@@ -409,31 +410,16 @@ impl ClusterData {
             .and_then(|t| t.partitioner.as_deref())
             .and_then(PartitionerName::from_str)
             .unwrap_or_default();
-        let serialized_values = partition_key.serialized()?;
-        // Null values are skipped in computation; null values in partition key are unsound,
-        // but it is consistent with computation of prepared statements token.
-        let serialized_pk = match serialized_values.len() {
-            0 => None,
-            1 => serialized_values
-                .iter()
-                .next()
-                .unwrap()
-                .map(Bytes::copy_from_slice),
-            _ => {
-                let mut buf = BytesMut::new();
-                for value in serialized_values.iter().flatten() {
-                    let value_size = value
-                        .len()
-                        .try_into()
-                        .map_err(|_| BadQuery::ValuesTooLongForKey(value.len(), u16::MAX.into()))?;
-                    buf.put_u16(value_size);
-                    buf.extend_from_slice(value);
-                    buf.put_u8(0);
-                }
-                Some(buf.into())
+
+        Session::calculate_token_for_partition_key(
+            &partition_key.serialized().unwrap(),
+            &partitioner,
+        )
+        .map_err(|err| match err {
+            TokenCalculationError::ValueTooLong(values_len) => {
+                BadQuery::ValuesTooLongForKey(values_len, u16::MAX.into())
             }
-        };
-        Ok(partitioner.hash(&serialized_pk.unwrap_or_default()))
+        })
     }
 
     /// Access to replicas owning a given token

--- a/scylla/src/transport/partitioner.rs
+++ b/scylla/src/transport/partitioner.rs
@@ -21,13 +21,6 @@ impl PartitionerName {
             None
         }
     }
-
-    pub(crate) fn hash(&self, pk: &[u8]) -> Token {
-        match self {
-            PartitionerName::Murmur3 => Murmur3Partitioner.hash_one(pk),
-            PartitionerName::CDC => CDCPartitioner.hash_one(pk),
-        }
-    }
 }
 
 impl Partitioner for PartitionerName {

--- a/scylla/src/transport/partitioner.rs
+++ b/scylla/src/transport/partitioner.rs
@@ -24,95 +24,91 @@ impl PartitionerName {
 
     pub(crate) fn hash(&self, pk: &[u8]) -> Token {
         match self {
-            PartitionerName::Murmur3 => Murmur3Partitioner::hash(pk),
-            PartitionerName::CDC => CDCPartitioner::hash(pk),
+            PartitionerName::Murmur3 => Murmur3Partitioner.hash_one(pk),
+            PartitionerName::CDC => CDCPartitioner.hash_one(pk),
         }
     }
 }
 
+/// A trait for creating instances of `PartitionHasher`, which ultimately compute the token.
+///
+/// The Partitioners' design is based on std::hash design: `Partitioner`
+/// corresponds to `HasherBuilder`, and `PartitionerHasher` to `Hasher`.
+/// See their documentation for more details.
 pub trait Partitioner {
-    fn hash(pk: &[u8]) -> Token;
+    type Hasher: PartitionerHasher;
+
+    fn build_hasher(&self) -> Self::Hasher;
+
+    fn hash_one(&self, data: &[u8]) -> Token {
+        let mut hasher = self.build_hasher();
+        hasher.write(data);
+        hasher.finish()
+    }
+}
+
+/// A trait for hashing a stream of serialized CQL values.
+///
+/// Instances of this trait are created by a `Partitioner` and are stateful.
+/// At any point, one can call `finish()` and a `Token` will be computed
+/// based on values that has been fed so far.
+pub trait PartitionerHasher {
+    fn write(&mut self, pk_part: &[u8]);
+    fn finish(&self) -> Token;
 }
 
 pub struct Murmur3Partitioner;
-pub struct CDCPartitioner;
 
-impl Murmur3Partitioner {
-    // An implementation of MurmurHash3 ported from Scylla. Please note that this
-    // is not a "correct" implementation of MurmurHash3 - it replicates the same
-    // bugs made in the original Cassandra implementation in order to be compatible.
-    fn hash3_x64_128(mut data: &[u8]) -> i128 {
-        let length = data.len();
+impl Partitioner for Murmur3Partitioner {
+    type Hasher = Murmur3PartitionerHasher;
 
-        let c1: Wrapping<i64> = Wrapping(0x87c3_7b91_1142_53d5_u64 as i64);
-        let c2: Wrapping<i64> = Wrapping(0x4cf5_ad43_2745_937f_u64 as i64);
-
-        let mut h1 = Wrapping(0_i64);
-        let mut h2 = Wrapping(0_i64);
-
-        while data.len() >= 16 {
-            let mut k1 = Wrapping(data.get_i64_le());
-            let mut k2 = Wrapping(data.get_i64_le());
-
-            k1 *= c1;
-            k1 = Self::rotl64(k1, 31);
-            k1 *= c2;
-            h1 ^= k1;
-
-            h1 = Self::rotl64(h1, 27);
-            h1 += h2;
-            h1 = h1 * Wrapping(5) + Wrapping(0x52dce729);
-
-            k2 *= c2;
-            k2 = Self::rotl64(k2, 33);
-            k2 *= c1;
-            h2 ^= k2;
-
-            h2 = Self::rotl64(h2, 31);
-            h2 += h1;
-            h2 = h2 * Wrapping(5) + Wrapping(0x38495ab5);
+    fn build_hasher(&self) -> Self::Hasher {
+        Self::Hasher {
+            total_len: 0,
+            buf: Default::default(),
+            h1: Wrapping(0),
+            h2: Wrapping(0),
         }
+    }
+}
 
-        let mut k1 = Wrapping(0_i64);
-        let mut k2 = Wrapping(0_i64);
+pub struct Murmur3PartitionerHasher {
+    total_len: usize,
+    buf: [u8; Self::BUF_CAPACITY],
+    h1: Wrapping<i64>,
+    h2: Wrapping<i64>,
+}
 
-        debug_assert!(data.len() < 16);
+impl Murmur3PartitionerHasher {
+    const BUF_CAPACITY: usize = 16;
 
-        if data.len() > 8 {
-            for i in (8..data.len()).rev() {
-                k2 ^= Wrapping(data[i] as i8 as i64) << ((i - 8) * 8);
-            }
+    const C1: Wrapping<i64> = Wrapping(0x87c3_7b91_1142_53d5_u64 as i64);
+    const C2: Wrapping<i64> = Wrapping(0x4cf5_ad43_2745_937f_u64 as i64);
 
-            k2 *= c2;
-            k2 = Self::rotl64(k2, 33);
-            k2 *= c1;
-            h2 ^= k2;
-        }
+    fn hash_16_bytes(&mut self, mut k1: Wrapping<i64>, mut k2: Wrapping<i64>) {
+        k1 *= Self::C1;
+        k1 = Self::rotl64(k1, 31);
+        k1 *= Self::C2;
+        self.h1 ^= k1;
 
-        if !data.is_empty() {
-            for i in (0..std::cmp::min(8, data.len())).rev() {
-                k1 ^= Wrapping(data[i] as i8 as i64) << (i * 8);
-            }
+        self.h1 = Self::rotl64(self.h1, 27);
+        self.h1 += self.h2;
+        self.h1 = self.h1 * Wrapping(5) + Wrapping(0x52dce729);
 
-            k1 *= c1;
-            k1 = Self::rotl64(k1, 31);
-            k1 *= c2;
-            h1 ^= k1;
-        }
+        k2 *= Self::C2;
+        k2 = Self::rotl64(k2, 33);
+        k2 *= Self::C1;
+        self.h2 ^= k2;
 
-        h1 ^= Wrapping(length as i64);
-        h2 ^= Wrapping(length as i64);
+        self.h2 = Self::rotl64(self.h2, 31);
+        self.h2 += self.h1;
+        self.h2 = self.h2 * Wrapping(5) + Wrapping(0x38495ab5);
+    }
 
-        h1 += h2;
-        h2 += h1;
-
-        h1 = Self::fmix(h1);
-        h2 = Self::fmix(h2);
-
-        h1 += h2;
-        h2 += h1;
-
-        ((h2.0 as i128) << 64) | h1.0 as i128
+    fn fetch_16_bytes_from_buf(buf: &mut &[u8]) -> (Wrapping<i64>, Wrapping<i64>) {
+        let k1 = Wrapping(buf.get_i64_le());
+        let k2 = Wrapping(buf.get_i64_le());
+        (k1, k2)
     }
 
     #[inline]
@@ -132,27 +128,181 @@ impl Murmur3Partitioner {
     }
 }
 
-impl Partitioner for Murmur3Partitioner {
-    fn hash(pk: &[u8]) -> Token {
+// The implemented Murmur3 algorithm is roughly as follows:
+// 1. while there are at least 16 bytes given:
+//      consume 16 bytes by parsing them into i64s, then
+//      include them in h1, h2, k1, k2;
+// 2. do some magic with remaining n < 16 bytes,
+//      include them in h1, h2, k1, k2;
+// 3. compute the token based on h1, h2, k1, k2.
+//
+// Therefore, the buffer of capacity 16 is used. As soon as it gets full,
+// point 1. is executed. Points 2. and 3. are exclusively done in `finish()`,
+// so they don't mutate the state.
+impl PartitionerHasher for Murmur3PartitionerHasher {
+    fn write(&mut self, mut pk_part: &[u8]) {
+        let mut buf_len = self.total_len % Self::BUF_CAPACITY;
+        self.total_len += pk_part.len();
+
+        // If the buffer is nonempty and can be filled completely, so that we can fetch two i64s from it,
+        // fill it and hash its contents, then make it empty.
+        if buf_len > 0 && Self::BUF_CAPACITY - buf_len <= pk_part.len() {
+            // First phase: populate buffer until full, then consume two i64s.
+            let to_write = Ord::min(Self::BUF_CAPACITY - buf_len, pk_part.len());
+            self.buf[buf_len..buf_len + to_write].copy_from_slice(&pk_part[..to_write]);
+            pk_part.advance(to_write);
+            buf_len += to_write;
+
+            debug_assert_eq!(buf_len, Self::BUF_CAPACITY);
+            // consume 16 bytes from internal buf
+            let mut buf_ptr = &self.buf[..];
+            let (k1, k2) = Self::fetch_16_bytes_from_buf(&mut buf_ptr);
+            debug_assert!(buf_ptr.is_empty());
+            self.hash_16_bytes(k1, k2);
+            buf_len = 0;
+        }
+
+        // If there were enough data, now we have an empty buffer. Further data, if enough, can be hence
+        // hashed directly from the external buffer.
+        if buf_len == 0 {
+            // Second phase: fast path for big values.
+            while pk_part.len() >= Self::BUF_CAPACITY {
+                let (k1, k2) = Self::fetch_16_bytes_from_buf(&mut pk_part);
+                self.hash_16_bytes(k1, k2);
+            }
+        }
+
+        // Third phase: move remaining bytes to the buffer.
+        debug_assert!(pk_part.len() < Self::BUF_CAPACITY - buf_len);
+        let to_write = pk_part.len();
+        self.buf[buf_len..buf_len + to_write].copy_from_slice(&pk_part[..to_write]);
+        pk_part.advance(to_write);
+        buf_len += to_write;
+        debug_assert!(pk_part.is_empty());
+
+        debug_assert!(buf_len < Self::BUF_CAPACITY);
+    }
+
+    fn finish(&self) -> Token {
+        let mut h1 = self.h1;
+        let mut h2 = self.h2;
+
+        let mut k1 = Wrapping(0_i64);
+        let mut k2 = Wrapping(0_i64);
+
+        let buf_len = self.total_len % Self::BUF_CAPACITY;
+
+        if buf_len > 8 {
+            for i in (8..buf_len).rev() {
+                k2 ^= Wrapping(self.buf[i] as i8 as i64) << ((i - 8) * 8);
+            }
+
+            k2 *= Self::C2;
+            k2 = Self::rotl64(k2, 33);
+            k2 *= Self::C1;
+            h2 ^= k2;
+        }
+
+        if buf_len > 0 {
+            for i in (0..std::cmp::min(8, buf_len)).rev() {
+                k1 ^= Wrapping(self.buf[i] as i8 as i64) << (i * 8);
+            }
+
+            k1 *= Self::C1;
+            k1 = Self::rotl64(k1, 31);
+            k1 *= Self::C2;
+            h1 ^= k1;
+        }
+
+        h1 ^= Wrapping(self.total_len as i64);
+        h2 ^= Wrapping(self.total_len as i64);
+
+        h1 += h2;
+        h2 += h1;
+
+        h1 = Self::fmix(h1);
+        h2 = Self::fmix(h2);
+
+        h1 += h2;
+        h2 += h1;
+
         Token {
-            value: Self::hash3_x64_128(pk) as i64,
+            value: (((h2.0 as i128) << 64) | h1.0 as i128) as i64,
         }
     }
 }
 
+enum CDCPartitionerHasherState {
+    Feeding {
+        len: usize,
+        buf: [u8; CDCPartitionerHasher::BUF_CAPACITY],
+    },
+    Computed(Token),
+}
+
+pub struct CDCPartitioner;
+
+pub struct CDCPartitionerHasher {
+    state: CDCPartitionerHasherState,
+}
+
 impl Partitioner for CDCPartitioner {
-    fn hash(mut pk: &[u8]) -> Token {
-        let value = if pk.len() < 8 { i64::MIN } else { pk.get_i64() };
-        Token { value }
+    type Hasher = CDCPartitionerHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        Self::Hasher {
+            state: CDCPartitionerHasherState::Feeding {
+                len: 0,
+                buf: Default::default(),
+            },
+        }
+    }
+}
+
+impl CDCPartitionerHasher {
+    const BUF_CAPACITY: usize = 8;
+}
+
+impl PartitionerHasher for CDCPartitionerHasher {
+    fn write(&mut self, pk_part: &[u8]) {
+        match &mut self.state {
+            CDCPartitionerHasherState::Feeding { len, buf } => {
+                // We feed the buffer until it's full.
+                let copied_len = Ord::min(pk_part.len(), Self::BUF_CAPACITY - *len);
+                buf[*len..*len + copied_len].copy_from_slice(&pk_part[..copied_len]);
+                *len += copied_len;
+
+                // If the buffer is full, we can compute and fix the token.
+                if *len == Self::BUF_CAPACITY {
+                    let token = Token {
+                        value: (&mut &buf[..]).get_i64(),
+                    };
+                    self.state = CDCPartitionerHasherState::Computed(token);
+                }
+            }
+            CDCPartitionerHasherState::Computed(_) => (),
+        }
+    }
+
+    fn finish(&self) -> Token {
+        match self.state {
+            CDCPartitionerHasherState::Feeding { .. } => Token { value: i64::MIN },
+            CDCPartitionerHasherState::Computed(token) => token,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use rand::Rng;
+    use rand_pcg::Pcg32;
+
+    use crate::transport::partitioner::PartitionerHasher;
+
     use super::{CDCPartitioner, Murmur3Partitioner, Partitioner};
 
     fn assert_correct_murmur3_hash(pk: &'static str, expected_hash: i64) {
-        let hash = Murmur3Partitioner::hash(pk.as_bytes()).value;
+        let hash = Murmur3Partitioner.hash_one(pk.as_bytes()).value;
         assert_eq!(hash, expected_hash);
     }
 
@@ -169,8 +319,66 @@ mod tests {
     }
 
     fn assert_correct_cdc_hash(pk: &'static str, expected_hash: i64) {
-        let hash = CDCPartitioner::hash(pk.as_bytes()).value;
+        let hash = CDCPartitioner.hash_one(pk.as_bytes()).value;
         assert_eq!(hash, expected_hash);
+    }
+
+    #[test]
+    fn partitioners_output_same_result_no_matter_how_input_is_partitioned() {
+        let inputs: &[&[u8]] = &[
+            b"",
+            b"0",
+            "Ala ma kota, a kota ma Ala.".as_bytes(),
+            "Zażółć gęślą jaźń. Wsiadł rycerz Szaławiła na bułanego konia. Litwo, ojczyzno moja, ...".as_bytes(),
+        ];
+
+        let seed = 0x2137;
+        let mut randgen = Pcg32::new(seed, 0);
+
+        // Splits the given data 2^n times and feeds partitioner with the chunks got.
+        fn split_and_feed(
+            randgen: &mut impl Rng,
+            partitioner: &mut impl PartitionerHasher,
+            data: &[u8],
+            n: usize,
+        ) {
+            if n == 0 {
+                partitioner.write(data);
+            } else {
+                let pivot = if !data.is_empty() {
+                    randgen.gen_range(0..data.len())
+                } else {
+                    0
+                };
+                let (data1, data2) = data.split_at(pivot);
+                for data in [data1, data2] {
+                    split_and_feed(randgen, partitioner, data, n - 1);
+                }
+            }
+        }
+
+        fn check_for_partitioner<P: Partitioner>(
+            partitioner: P,
+            randgen: &mut impl Rng,
+            input: &[u8],
+        ) {
+            let result_single_batch = partitioner.hash_one(input);
+
+            let results_chunks = (0..1000).map(|_| {
+                let mut partitioner_hasher = partitioner.build_hasher();
+                split_and_feed(randgen, &mut partitioner_hasher, input, 2);
+                partitioner_hasher.finish()
+            });
+
+            for result_chunk in results_chunks {
+                assert_eq!(result_single_batch, result_chunk)
+            }
+        }
+
+        for input in inputs {
+            check_for_partitioner(Murmur3Partitioner, &mut randgen, input);
+            check_for_partitioner(CDCPartitioner, &mut randgen, input);
+        }
     }
 
     #[test]

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -229,7 +229,7 @@ async fn test_prepared_statement() {
                 .as_bigint()
                 .unwrap(),
         };
-        let prepared_token = Murmur3Partitioner::hash(
+        let prepared_token = Murmur3Partitioner.hash_one(
             &prepared_statement
                 .compute_partition_key(&serialized_values)
                 .unwrap(),
@@ -255,7 +255,7 @@ async fn test_prepared_statement() {
                 .as_bigint()
                 .unwrap(),
         };
-        let prepared_token = Murmur3Partitioner::hash(
+        let prepared_token = Murmur3Partitioner.hash_one(
             &prepared_complex_pk_statement
                 .compute_partition_key(&serialized_values)
                 .unwrap(),
@@ -527,7 +527,7 @@ async fn test_token_calculation() {
                 .as_bigint()
                 .unwrap(),
         };
-        let prepared_token = Murmur3Partitioner::hash(
+        let prepared_token = Murmur3Partitioner.hash_one(
             &prepared_statement
                 .compute_partition_key(&serialized_values)
                 .unwrap(),

--- a/scylla/src/utils/mod.rs
+++ b/scylla/src/utils/mod.rs
@@ -2,3 +2,11 @@ pub(crate) mod parse;
 
 pub(crate) mod pretty;
 pub mod test_utils;
+
+// FIXME: replace this with `Option::unzip()` once MSRV is bumped to at least 1.66
+pub(crate) fn unzip_option<T, U>(opt: Option<(T, U)>) -> (Option<T>, Option<U>) {
+    match opt {
+        Some((a, b)) => (Some(a), Some(b)),
+        None => (None, None),
+    }
+}


### PR DESCRIPTION

## Motivation
Currently, partitioners require the whole input to be passed in a single contiguous slice, which often forces an allocation that could else be avoided.

## What's done
1. **Partitioners' API is refactored** so it resembles `std::hash` API:
    - `Partitioner` corresponds to `BuildHasher` as it becomes kind of a factory,
    - `PartitionerHasher` is introduced and corresponds to `Hasher`. It contains the hashing state, which enables feeding it with multiple chunks of data separately.
A **test** is added that **ensures consistent hashing result** no matter how the partition key is partitioned into chunks.
2. After the partitioners gain ability to partition by chunks, the codebase is modified so that **all needless allocations of partition key are avoided**, i.e., allocations that only served the purpose of calculating token.
To this end, `PartitionKey` struct is introduced, whose motivation is as follows: the algorithm for computing partition key for a given prepared statement and bound values can be divided into steps. The first of them involves extracting values that consistute the partition key and putting them in proper partition key order. `PartitionKey` performs this step on construction, and serves as an entry point for further steps, with token calculation among others. For those further steps to be done, an iterator over partition key values is accessible, which yields pairs _(value, spec)_ for each column that constitutes partition key, in partition key order.
3. As **there was one more place** where materialised partition key was used - by decoding it into the produced trace - an adaptor is introduced that operates on `PartitionKey`'s iterator provides values to be deserialised by the mechanism added recently in #766. **Allocation is then saved there**, too.
4. **An API cleanup is done** regarding partition key and token computation. `calculate_token_from_partition_key()` is moved to `partitioner.rs`, `calculate_token()` to `prepared_statement.rs`, and a number of helper functions are deleted as no longer needed.

## Pre-review checklist
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
