### PR TITLE
Fix GitHub Actions warnings in CI

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -22,6 +22,6 @@ jobs:
           - 9042:9042
         options: --health-cmd "cqlsh --username cassandra --password cassandra --debug" --health-interval 5s --health-retries 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       run: cargo test --verbose authenticate_superuser -- custom_authentication --ignored

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -22,7 +22,7 @@ jobs:
           - 9042:9042
         options: --health-cmd "cqlsh --debug" --health-interval 5s --health-retries 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install mdbook
       run: cargo install mdbook --no-default-features
     - name: Build the project

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup 3-node Cassandra cluster
       run: |
         docker-compose -f test/cluster/cassandra/docker-compose.yml up -d

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup 3-node Scylla cluster
       run: |
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
@@ -49,7 +49,7 @@ jobs:
   min_rust:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Rust ${{ env.rust_min }}
       run: |
         rustup install ${{ env.rust_min }}
@@ -67,6 +67,6 @@ jobs:
   cargo_docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Compile docs
       run: RUSTDOCFLAGS=-Dwarnings cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,10 +51,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install Rust ${{ env.rust_min }}
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.rust_min }}
-        override: true
+      run: |
+        rustup install ${{ env.rust_min }}
+        rustup override set ${{ env.rust_min }}
     - name: Print Rust version
       run: rustc --version
     - name: MSRV cargo check with features

--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install scylla-ccm
         run: pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
 

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       working-directory: ./scylla
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check
       run: cargo check --verbose --features "ssl"
       working-directory: ${{env.working-directory}}


### PR DESCRIPTION
Before this PR, GitHub Actions would warn that `actions/checkout@v2` and `actions-rs/toolchain@v1` use deprecated functionality:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Those warnings are fixed in this PR by:
- Updating the version of `actions/checkout` action (from `@v2` to `@v3`)
- Removing use of `actions-rs/toolchain@v1` action: This action is no longer maintaned and there isn't a new version that fixes the problems. It can be easily replaced by executing two `rustup` commands.

## Pre-review checklist

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
