### PR TITLE
routing: remove Node struct

### DIFF
--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -1,16 +1,8 @@
 use rand::Rng;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::net::SocketAddr;
 use std::num::NonZeroU16;
 use thiserror::Error;
-
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-pub struct Node {
-    // TODO: potentially a node may have multiple addresses, remember them?
-    // but we need an Ord instance on Node
-    pub addr: SocketAddr,
-}
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub struct Token {


### PR DESCRIPTION
Remove struct `scylla::routing::Node` from `routing.rs`. This structure was introduced in 2020 in 1c8df890d6419e4612fbdbb4aef1fb68c35ffb88 and it is unused in our current code (and it looks like the original commit didn't even use it at all). 

Moreover, this struct clashes with `scylla::transport::Node` making it error-prone to find the wrong `Node` struct for a user of the driver. The deleted `Node` structure also relied solely on `SocketAddr`, while we  want to identify the nodes by `host_id` (as in `scylla::transport::Node`).

Refs #660

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
