### PR TITLE
connection: remove re-export of QueryResult

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -60,10 +60,7 @@ use crate::statement::prepared_statement::PreparedStatement;
 use crate::statement::Consistency;
 use crate::transport::session::IntoTypedRows;
 use crate::transport::Compression;
-
-// Existing code imports scylla::transport::connection::QueryResult because it used to be located in this file.
-// Reexport QueryResult to avoid breaking the existing code.
-pub use crate::QueryResult;
+use crate::QueryResult;
 
 // Queries for schema agreement
 const LOCAL_VERSION: &str = "SELECT schema_version FROM system.local WHERE key='local'";


### PR DESCRIPTION
Remove re-export of `QueryResult` (from `scylla::transport::query_result::QueryResult` to `scylla::transport::connection::QueryResult`). The motivation for this change is to reduce the number of re-exports in the codebase (some of them don't make sense and are there for legacy reasons), as a part of our effort of stabilizing the API.

It probably makes sense to follow this up with moving `QueryResult` from `transport/` module to a more appropriate module (`query/` module?).

Refs #660

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
