### PR TITLE
frame: reduce visibility of several funcs/consts

### DIFF
--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -22,10 +22,10 @@ use response::ResponseOpcode;
 const HEADER_SIZE: usize = 9;
 
 // Frame flags
-pub const FLAG_COMPRESSION: u8 = 0x01;
-pub const FLAG_TRACING: u8 = 0x02;
-pub const FLAG_CUSTOM_PAYLOAD: u8 = 0x04;
-pub const FLAG_WARNING: u8 = 0x08;
+const FLAG_COMPRESSION: u8 = 0x01;
+const FLAG_TRACING: u8 = 0x02;
+const FLAG_CUSTOM_PAYLOAD: u8 = 0x04;
+const FLAG_WARNING: u8 = 0x08;
 
 // All of the Authenticators supported by Scylla
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -220,7 +220,7 @@ pub fn parse_response_body_extensions(
     })
 }
 
-pub fn compress_append(
+fn compress_append(
     uncomp_body: &[u8],
     compression: Compression,
     out: &mut Vec<u8>,
@@ -246,7 +246,7 @@ pub fn compress_append(
     }
 }
 
-pub fn decompress(mut comp_body: &[u8], compression: Compression) -> Result<Vec<u8>, FrameError> {
+fn decompress(mut comp_body: &[u8], compression: Compression) -> Result<Vec<u8>, FrameError> {
     match compression {
         Compression::Lz4 => {
             let uncomp_len = comp_body.get_u32() as usize;


### PR DESCRIPTION
Reduce visibility of several functions and constants which are only used internally within `frame` and don't have to be exposed publicly. In this patch only the most obvious ones are tackled (ones that require a change solely in `scylla-cql`). This change is a part of our effort to stabilize the API.

Refs #660

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
