### PR TITLE
batch: remove re-export of consistency enums

### DIFF
--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -6,7 +6,7 @@ use crate::statement::{prepared_statement::PreparedStatement, query::Query};
 use crate::transport::execution_profile::ExecutionProfileHandle;
 
 use super::StatementConfig;
-pub use super::{Consistency, SerialConsistency};
+use super::{Consistency, SerialConsistency};
 pub use crate::frame::request::batch::BatchType;
 
 /// CQL batch statement.


### PR DESCRIPTION
Remove re-export of consistency enums in batch.rs:
- `scylla:statement::batch::Consistency`
- `scylla:statement::batch::SerialConsistency`

A user of the driver should instead use:
- `scylla:statement::Consistency`
- `scylla:statement::SerialConsistency`

This change is a part of our effort to stabilize the API and reduce the number of pub exports.

Refs #660

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
