### PR TITLE
session: remove estimate_replicas_for_query, get_tracing_info_custom

### DIFF
--- a/scylla/src/tracing.rs
+++ b/scylla/src/tracing.rs
@@ -1,9 +1,6 @@
-use crate::statement::Consistency;
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::net::IpAddr;
-use std::num::NonZeroU32;
-use std::time::Duration;
 use uuid::Uuid;
 
 use crate::cql_to_rust::{FromRow, FromRowError};
@@ -35,20 +32,6 @@ pub struct TracingEvent {
     pub thread: Option<String>,
 }
 
-/// Used to configure a custom retry strategy when querying tracing info
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct GetTracingConfig {
-    /// Number of attempts to be made before giving up.
-    /// Default value: 5
-    pub attempts: NonZeroU32,
-    /// Interval to wait between each attempt.
-    /// Default value: 3 milliseconds
-    pub interval: Duration,
-    /// Consistency to use in queries that read TracingInfo.
-    /// Default value: One
-    pub consistency: Consistency,
-}
-
 impl TracingInfo {
     /// Returns a list of unique nodes involved in the query
     pub fn nodes(&self) -> Vec<IpAddr> {
@@ -57,16 +40,6 @@ impl TracingInfo {
             .filter_map(|e| e.source)
             .unique()
             .collect()
-    }
-}
-
-impl Default for GetTracingConfig {
-    fn default() -> GetTracingConfig {
-        GetTracingConfig {
-            attempts: NonZeroU32::new(5).unwrap(),
-            interval: Duration::from_millis(3),
-            consistency: Consistency::One,
-        }
     }
 }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1451,20 +1451,6 @@ impl Session {
         Ok(Some(tracing_info))
     }
 
-    // Returns which replicas are likely to take part in handling the query.
-    // If a list of replicas cannot be easily narrowed down, all available replicas
-    // will be returned.
-    pub fn estimate_replicas_for_query(&self, statement: &RoutingInfo) -> Vec<Arc<Node>> {
-        let cluster_data = self.cluster.get_data();
-        match statement.token {
-            Some(token) => {
-                let cluster_data = self.cluster.get_data();
-                cluster_data.get_token_endpoints(statement.keyspace.unwrap_or(""), token)
-            }
-            None => cluster_data.get_nodes_info().to_owned(),
-        }
-    }
-
     // This method allows to easily run a query using load balancing, retry policy etc.
     // Requires some information about the query and two closures
     // First closure is used to choose a connection

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -24,6 +24,7 @@ use std::fmt::Display;
 use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
+use std::num::NonZeroU32;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -56,7 +57,7 @@ use crate::prepared_statement::{PartitionKeyError, PreparedStatement};
 use crate::query::Query;
 use crate::routing::Token;
 use crate::statement::{Consistency, SerialConsistency};
-use crate::tracing::{GetTracingConfig, TracingEvent, TracingInfo};
+use crate::tracing::{TracingEvent, TracingInfo};
 use crate::transport::cluster::{Cluster, ClusterData, ClusterNeatDebug};
 use crate::transport::connection::{Connection, ConnectionConfig, VerifiedKeyspaceName};
 use crate::transport::connection_pool::PoolConfig;
@@ -130,6 +131,9 @@ pub struct Session {
     auto_await_schema_agreement_timeout: Option<Duration>,
     refresh_metadata_on_auto_schema_agreement: bool,
     keyspace_name: ArcSwapOption<String>,
+    tracing_info_fetch_attempts: NonZeroU32,
+    tracing_info_fetch_interval: Duration,
+    tracing_info_fetch_consistency: Consistency,
 }
 
 /// This implementation deliberately omits some details from Cluster in order
@@ -235,6 +239,22 @@ pub struct SessionConfig {
     /// Please do performance measurements before committing to disabling
     /// this option.
     pub enable_write_coalescing: bool,
+
+    /// Number of attempts to fetch [`TracingInfo`]
+    /// in [`Session::get_tracing_info`]. Tracing info
+    /// might not be available immediately on queried node - that's why
+    /// the driver performs a few attempts with sleeps in between.
+    pub tracing_info_fetch_attempts: NonZeroU32,
+
+    /// Delay between attempts to fetch [`TracingInfo`]
+    /// in [`Session::get_tracing_info`]. Tracing info
+    /// might not be available immediately on queried node - that's why
+    /// the driver performs a few attempts with sleeps in between.
+    pub tracing_info_fetch_interval: Duration,
+
+    /// Consistency level of fetching [`TracingInfo`]
+    /// in [`Session::get_tracing_info`].
+    pub tracing_info_fetch_consistency: Consistency,
 }
 
 /// Describes database server known on Session startup.
@@ -294,6 +314,9 @@ impl SessionConfig {
             #[cfg(feature = "cloud")]
             cloud_config: None,
             enable_write_coalescing: true,
+            tracing_info_fetch_attempts: NonZeroU32::new(5).unwrap(),
+            tracing_info_fetch_interval: Duration::from_millis(3),
+            tracing_info_fetch_consistency: Consistency::One,
         }
     }
 
@@ -544,6 +567,9 @@ impl Session {
             refresh_metadata_on_auto_schema_agreement: config
                 .refresh_metadata_on_auto_schema_agreement,
             keyspace_name: ArcSwapOption::default(), // will be set by use_keyspace
+            tracing_info_fetch_attempts: config.tracing_info_fetch_attempts,
+            tracing_info_fetch_interval: config.tracing_info_fetch_interval,
+            tracing_info_fetch_consistency: config.tracing_info_fetch_consistency,
         };
 
         if let Some(keyspace_name) = config.used_keyspace {
@@ -1337,8 +1363,24 @@ impl Session {
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/tracing/tracing.html)
     /// for more information about query tracing
     pub async fn get_tracing_info(&self, tracing_id: &Uuid) -> Result<TracingInfo, QueryError> {
-        self.get_tracing_info_custom(tracing_id, &GetTracingConfig::default())
-            .await
+        // tracing_info_fetch_attempts is NonZeroU32 so at least one attempt will be made
+        for _ in 0..self.tracing_info_fetch_attempts.get() {
+            let current_try: Option<TracingInfo> = self
+                .try_getting_tracing_info(tracing_id, Some(self.tracing_info_fetch_consistency))
+                .await?;
+
+            match current_try {
+                Some(tracing_info) => return Ok(tracing_info),
+                None => tokio::time::sleep(self.tracing_info_fetch_interval).await,
+            };
+        }
+
+        Err(QueryError::ProtocolError(
+            "All tracing queries returned an empty result, \
+            maybe the trace information didn't propagate yet. \
+            Consider configuring Session with \
+            a longer fetch interval (tracing_info_fetch_interval)",
+        ))
     }
 
     /// Gets the name of the keyspace that is currently set, or `None` if no
@@ -1354,35 +1396,6 @@ impl Session {
     #[inline]
     pub fn get_keyspace(&self) -> Option<Arc<String>> {
         self.keyspace_name.load_full()
-    }
-
-    /// Queries tracing info with custom retry settings.\
-    /// Tracing info might not be available immediately on queried node -
-    /// that's why the driver performs a few attempts with sleeps in between.
-    /// [`GetTracingConfig`] allows to specify a custom querying strategy.
-    pub async fn get_tracing_info_custom(
-        &self,
-        tracing_id: &Uuid,
-        config: &GetTracingConfig,
-    ) -> Result<TracingInfo, QueryError> {
-        // config.attempts is NonZeroU32 so at least one attempt will be made
-        for _ in 0..config.attempts.get() {
-            let current_try: Option<TracingInfo> = self
-                .try_getting_tracing_info(tracing_id, Some(config.consistency))
-                .await?;
-
-            match current_try {
-                Some(tracing_info) => return Ok(tracing_info),
-                None => tokio::time::sleep(config.interval).await,
-            };
-        }
-
-        Err(QueryError::ProtocolError(
-            "All tracing queries returned an empty result, \
-            maybe information didn't reach this node yet. \
-            Consider using get_tracing_info_custom with \
-            bigger interval in GetTracingConfig",
-        ))
     }
 
     // Tries getting the tracing info


### PR DESCRIPTION
This PR removes two public functions from `Session`: `estimate_replicas_for_query` and `get_tracing_info_custom`.

Those changes are a part of our effort to stabilize the API and reduce the number of pub functions.

Refs https://github.com/scylladb/scylla-rust-driver/issues/660

#### `estimate_replicas_for_query`
Remove `estimate_replicas_for_query` from Session. A user of this function can switch to using `get_token_endpoints()` from `ClusterData` directly.

It did not make sense for `estimate_replicas_for_query()` to be in `Session`, as this is too much low-level function for `Session` and doesn't fit the abstraction of `Session`.

#### `get_tracing_info_custom`
Remove `Session::get_tracing_info_custom` - a variant of `Session::get_tracing_info` that allows for additional customization of the fetch process (number of attempts, interval between attempts, consistency level of fetching tracing info). This customization is now moved to `SessionConfig` (as new parameters) and new helper functions were introduced to `SessionBuilder`.

Since now this customization is on `SessionConfig`, `create_new_session_builder()` in `test_utils.rs` returns a `SessionBuilder` with pre-configured large number of `TracingInfo` fetch attempts, longer delays (to account for a slow CI). Previously each tracing test had to configure it on its own by using `get_tracing_info_custom`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
