### PR TITLE
statement: unpub StatementConfig

### DIFF
--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -17,9 +17,6 @@ pub use crate::frame::request::batch::BatchType;
 pub struct Batch {
     pub(crate) config: StatementConfig,
 
-    // TODO: Move this after #701 is fixed
-    retry_policy: Option<Arc<dyn RetryPolicy>>,
-
     pub statements: Vec<BatchStatement>,
     batch_type: BatchType,
 }
@@ -116,13 +113,13 @@ impl Batch {
     /// Set the retry policy for this batch, overriding the one from execution profile if not None.
     #[inline]
     pub fn set_retry_policy(&mut self, retry_policy: Option<Arc<dyn RetryPolicy>>) {
-        self.retry_policy = retry_policy;
+        self.config.retry_policy = retry_policy;
     }
 
     /// Get the retry policy set for the batch.
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
-        self.retry_policy.as_ref()
+        self.config.retry_policy.as_ref()
     }
 
     /// Sets the listener capable of listening what happens during query execution.
@@ -151,7 +148,6 @@ impl Default for Batch {
     fn default() -> Self {
         Self {
             statements: Vec::new(),
-            retry_policy: None,
             batch_type: BatchType::Logged,
             config: Default::default(),
         }

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
-use crate::history::HistoryListener;
 use crate::transport::execution_profile::ExecutionProfileHandle;
+use crate::{history::HistoryListener, retry_policy::RetryPolicy};
 
 pub mod batch;
 pub mod prepared_statement;
@@ -9,7 +9,7 @@ pub mod query;
 
 pub use crate::frame::types::{Consistency, SerialConsistency};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct StatementConfig {
     pub(crate) consistency: Option<Consistency>,
     pub(crate) serial_consistency: Option<Option<SerialConsistency>>,
@@ -23,32 +23,7 @@ pub(crate) struct StatementConfig {
     pub(crate) history_listener: Option<Arc<dyn HistoryListener>>,
 
     pub(crate) execution_profile_handle: Option<ExecutionProfileHandle>,
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for StatementConfig {
-    fn default() -> Self {
-        Self {
-            consistency: Default::default(),
-            serial_consistency: None,
-            is_idempotent: false,
-            tracing: false,
-            timestamp: None,
-            request_timeout: None,
-            history_listener: None,
-            execution_profile_handle: None,
-        }
-    }
-}
-
-impl Clone for StatementConfig {
-    fn clone(&self) -> Self {
-        Self {
-            history_listener: self.history_listener.clone(),
-            execution_profile_handle: self.execution_profile_handle.clone(),
-            ..*self
-        }
-    }
+    pub(crate) retry_policy: Option<Arc<dyn RetryPolicy>>,
 }
 
 impl StatementConfig {

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -10,19 +10,19 @@ pub mod query;
 pub use crate::frame::types::{Consistency, SerialConsistency};
 
 #[derive(Debug)]
-pub struct StatementConfig {
-    pub consistency: Option<Consistency>,
-    pub serial_consistency: Option<Option<SerialConsistency>>,
+pub(crate) struct StatementConfig {
+    pub(crate) consistency: Option<Consistency>,
+    pub(crate) serial_consistency: Option<Option<SerialConsistency>>,
 
-    pub is_idempotent: bool,
+    pub(crate) is_idempotent: bool,
 
-    pub tracing: bool,
-    pub timestamp: Option<i64>,
-    pub request_timeout: Option<Duration>,
+    pub(crate) tracing: bool,
+    pub(crate) timestamp: Option<i64>,
+    pub(crate) request_timeout: Option<Duration>,
 
-    pub history_listener: Option<Arc<dyn HistoryListener>>,
+    pub(crate) history_listener: Option<Arc<dyn HistoryListener>>,
 
-    pub execution_profile_handle: Option<ExecutionProfileHandle>,
+    pub(crate) execution_profile_handle: Option<ExecutionProfileHandle>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -54,7 +54,7 @@ impl Clone for StatementConfig {
 impl StatementConfig {
     /// Determines the consistency of a query
     #[must_use]
-    pub fn determine_consistency(&self, default_consistency: Consistency) -> Consistency {
+    pub(crate) fn determine_consistency(&self, default_consistency: Consistency) -> Consistency {
         self.consistency.unwrap_or(default_consistency)
     }
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -25,9 +25,6 @@ pub struct PreparedStatement {
     pub(crate) config: StatementConfig,
     pub prepare_tracing_ids: Vec<Uuid>,
 
-    // TODO: Move this after #701 is fixed
-    retry_policy: Option<Arc<dyn RetryPolicy>>,
-
     id: Bytes,
     shared: Arc<PreparedStatementSharedData>,
     page_size: Option<i32>,
@@ -45,7 +42,6 @@ impl Clone for PreparedStatement {
     fn clone(&self) -> Self {
         Self {
             config: self.config.clone(),
-            retry_policy: self.retry_policy.clone(),
             prepare_tracing_ids: Vec::new(),
             id: self.id.clone(),
             shared: self.shared.clone(),
@@ -62,7 +58,6 @@ impl PreparedStatement {
         is_lwt: bool,
         metadata: PreparedMetadata,
         statement: String,
-        retry_policy: Option<Arc<dyn RetryPolicy>>,
         page_size: Option<i32>,
         config: StatementConfig,
     ) -> Self {
@@ -72,7 +67,6 @@ impl PreparedStatement {
                 metadata,
                 statement,
             }),
-            retry_policy,
             prepare_tracing_ids: Vec::new(),
             page_size,
             config,
@@ -303,13 +297,13 @@ impl PreparedStatement {
     /// Set the retry policy for this statement, overriding the one from execution profile if not None.
     #[inline]
     pub fn set_retry_policy(&mut self, retry_policy: Option<Arc<dyn RetryPolicy>>) {
-        self.retry_policy = retry_policy;
+        self.config.retry_policy = retry_policy;
     }
 
     /// Get the retry policy set for the statement.
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
-        self.retry_policy.as_ref()
+        self.config.retry_policy.as_ref()
     }
 
     /// Sets the listener capable of listening what happens during query execution.

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -14,8 +14,6 @@ pub struct Query {
     pub(crate) config: StatementConfig,
 
     // TODO: Move this after #701 is fixed
-    retry_policy: Option<Arc<dyn RetryPolicy>>,
-
     pub contents: String,
     page_size: Option<i32>,
 }
@@ -25,7 +23,6 @@ impl Query {
     pub fn new(query_text: impl Into<String>) -> Self {
         Self {
             contents: query_text.into(),
-            retry_policy: None,
             page_size: None,
             config: Default::default(),
         }
@@ -131,13 +128,13 @@ impl Query {
     /// Set the retry policy for this statement, overriding the one from execution profile if not None.
     #[inline]
     pub fn set_retry_policy(&mut self, retry_policy: Option<Arc<dyn RetryPolicy>>) {
-        self.retry_policy = retry_policy;
+        self.config.retry_policy = retry_policy;
     }
 
     /// Get the retry policy set for the statement.
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
-        self.retry_policy.as_ref()
+        self.config.retry_policy.as_ref()
     }
 
     /// Sets the listener capable of listening what happens during query execution.

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -166,13 +166,11 @@ where
 
         if let Some(raw) = self.cache.get(&query.contents) {
             let page_size = query.get_page_size();
-            let retry_policy = query.get_retry_policy().cloned();
             let mut stmt = PreparedStatement::new(
                 raw.id.clone(),
                 raw.is_confirmed_lwt,
                 raw.metadata.clone(),
                 query.contents,
-                retry_policy,
                 page_size,
                 query.config,
             );

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -548,7 +548,6 @@ impl Connection {
                     .prepared_flags_contain_lwt_mark(p.prepared_metadata.flags as u32),
                 p.prepared_metadata,
                 query.contents.clone(),
-                query.get_retry_policy().cloned(),
                 query.get_page_size(),
                 query.config.clone(),
             ),


### PR DESCRIPTION
`StatementConfig` is only used internally and does not appear in any public API.

- It is made `pub(crate)` together with its fields so that we have more flexibility in changing it without introducing a breaking change.
- After that, `retry_policy` field is moved from `Query`, `PreparedStatement` and `Batch` into `StatementConfig`, as it suits there best.

Refs: #660
Fixes: #701 
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
