### PR TITLE
codewide: Decrease excessive visibility from `pub` - nonbreaking changes

### DIFF
--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -19,10 +19,10 @@ use std::hash::BuildHasher;
 /// to the `CachingSession::execute` family of methods.
 #[derive(Debug)]
 struct RawPreparedStatementData {
-    pub id: Bytes,
-    pub is_confirmed_lwt: bool,
-    pub metadata: PreparedMetadata,
-    pub partitioner_name: PartitionerName,
+    id: Bytes,
+    is_confirmed_lwt: bool,
+    metadata: PreparedMetadata,
+    partitioner_name: PartitionerName,
 }
 
 /// Provides auto caching while executing queries

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -69,18 +69,18 @@ pub struct RowIterator {
 }
 
 struct ReceivedPage {
-    pub rows: Rows,
-    pub tracing_id: Option<Uuid>,
+    rows: Rows,
+    tracing_id: Option<Uuid>,
 }
 
 pub(crate) struct PreparedIteratorConfig {
-    pub prepared: PreparedStatement,
-    pub values: SerializedValues,
-    pub partition_key: Option<Bytes>,
-    pub token: Option<Token>,
-    pub execution_profile: Arc<ExecutionProfileInner>,
-    pub cluster_data: Arc<ClusterData>,
-    pub metrics: Arc<Metrics>,
+    pub(crate) prepared: PreparedStatement,
+    pub(crate) values: SerializedValues,
+    pub(crate) partition_key: Option<Bytes>,
+    pub(crate) token: Option<Token>,
+    pub(crate) execution_profile: Arc<ExecutionProfileInner>,
+    pub(crate) cluster_data: Arc<ClusterData>,
+    pub(crate) metrics: Arc<Metrics>,
 }
 
 /// Fetching pages is asynchronous so `RowIterator` does not implement the `Iterator` trait.\

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -20,13 +20,13 @@ use std::{
 
 use super::topology::{PeerEndpoint, UntranslatedEndpoint};
 
-/// This enum is introduced to support address translation only in PoolRefiller,
-/// as well as to cope with the bug in older Cassandra and Scylla releases.
+/// This enum is introduced to support address translation only upon opening a connection,
+/// as well as to cope with a bug present in older Cassandra and Scylla releases.
 /// The bug involves misconfiguration of rpc_address and/or broadcast_rpc_address
 /// in system.local to 0.0.0.0. Mitigation involves replacing the faulty address
-/// with connection's address, but then that address must not be subject to AddressTranslator,
+/// with connection's address, but then that address must not be subject to `AddressTranslator`,
 /// so we carry that information using this enum. Address translation is never performed
-/// on Untranslatable variant.
+/// on `Untranslatable` variant.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum NodeAddr {

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -380,7 +380,7 @@ impl Metadata {
 impl MetadataReader {
     /// Creates new MetadataReader, which connects to initially_known_peers in the background
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         initially_known_peers: Vec<ContactPoint>,
         mut connection_config: ConnectionConfig,
         keepalive_interval: Option<Duration>,
@@ -423,7 +423,7 @@ impl MetadataReader {
     }
 
     /// Fetches current metadata from the cluster
-    pub async fn read_metadata(&mut self, initial: bool) -> Result<Metadata, QueryError> {
+    pub(crate) async fn read_metadata(&mut self, initial: bool) -> Result<Metadata, QueryError> {
         let mut result = self.fetch_metadata(initial).await;
         if let Ok(metadata) = result {
             self.update_known_peers(&metadata);

--- a/scylla/src/utils/parse.rs
+++ b/scylla/src/utils/parse.rs
@@ -1,20 +1,20 @@
 /// An error that can occur during parsing.
 #[derive(Copy, Clone)]
 pub(crate) struct ParseError {
-    pub remaining: usize,
-    pub cause: ParseErrorCause,
+    pub(crate) remaining: usize,
+    pub(crate) cause: ParseErrorCause,
 }
 
 impl ParseError {
     /// Given the original string, returns the 1-based position
     /// of the error in characters.
     /// If an incorrect string was given, the function may return 0.
-    pub fn calculate_position(&self, original: &str) -> Option<usize> {
+    pub(crate) fn calculate_position(&self, original: &str) -> Option<usize> {
         calculate_position(original, self.remaining)
     }
 
     /// Returns the error cause.
-    pub fn get_cause(&self) -> ParseErrorCause {
+    pub(crate) fn get_cause(&self) -> ParseErrorCause {
         self.cause
     }
 }
@@ -49,13 +49,13 @@ pub(crate) struct ParserState<'s> {
 
 impl<'s> ParserState<'s> {
     /// Creates a new parser from given input string.
-    pub fn new(s: &'s str) -> Self {
+    pub(crate) fn new(s: &'s str) -> Self {
         Self { s }
     }
 
     /// Applies given parsing function until it returns false
     /// and returns the final parser state.
-    pub fn parse_while(
+    pub(crate) fn parse_while(
         self,
         mut parser: impl FnMut(Self) -> ParseResult<(bool, Self)>,
     ) -> ParseResult<Self> {
@@ -72,7 +72,7 @@ impl<'s> ParserState<'s> {
     /// If the input string contains given string at the beginning,
     /// returns a new parser state with given string skipped.
     /// Otherwise, returns an error.
-    pub fn accept(self, part: &'static str) -> ParseResult<Self> {
+    pub(crate) fn accept(self, part: &'static str) -> ParseResult<Self> {
         match self.s.strip_prefix(part) {
             Some(s) => Ok(Self { s }),
             None => Err(self.error(ParseErrorCause::Expected(part))),
@@ -80,31 +80,31 @@ impl<'s> ParserState<'s> {
     }
 
     /// Returns new parser state with whitespace skipped from the beginning.
-    pub fn skip_white(self) -> Self {
+    pub(crate) fn skip_white(self) -> Self {
         let (_, me) = self.take_while(char::is_whitespace);
         me
     }
 
     /// Skips characters from the beginning while they satisfy given predicate
     /// and returns new parser state which
-    pub fn take_while(self, mut pred: impl FnMut(char) -> bool) -> (&'s str, Self) {
+    pub(crate) fn take_while(self, mut pred: impl FnMut(char) -> bool) -> (&'s str, Self) {
         let idx = self.s.find(move |c| !pred(c)).unwrap_or(self.s.len());
         let new = Self { s: &self.s[idx..] };
         (&self.s[..idx], new)
     }
 
     /// Returns the number of remaining bytes to parse.
-    pub fn get_remaining(self) -> usize {
+    pub(crate) fn get_remaining(self) -> usize {
         self.s.len()
     }
 
     /// Returns true if the input string was parsed completely.
-    pub fn is_at_eof(self) -> bool {
+    pub(crate) fn is_at_eof(self) -> bool {
         self.s.is_empty()
     }
 
     /// Returns an error with given cause, associated with given position.
-    pub fn error(self, cause: ParseErrorCause) -> ParseError {
+    pub(crate) fn error(self, cause: ParseErrorCause) -> ParseError {
         ParseError {
             remaining: self.get_remaining(),
             cause,
@@ -114,7 +114,7 @@ impl<'s> ParserState<'s> {
     /// Given the original string, returns the 1-based position
     /// of the error in characters.
     /// If an incorrect string was given, the function may return None.
-    pub fn calculate_position(self, original: &str) -> Option<usize> {
+    pub(crate) fn calculate_position(self, original: &str) -> Option<usize> {
         calculate_position(original, self.get_remaining())
     }
 }

--- a/scylla/src/utils/pretty.rs
+++ b/scylla/src/utils/pretty.rs
@@ -26,7 +26,7 @@ impl<'a> UpperHex for HexBytes<'a> {
 
 // Displays a CqlValue. The syntax should resemble the CQL literal syntax
 // (but no guarantee is given that it's always the same).
-pub(crate) struct CqlValueDisplayer<C>(pub C);
+pub(crate) struct CqlValueDisplayer<C>(pub(crate) C);
 
 impl<C> Display for CqlValueDisplayer<C>
 where
@@ -154,7 +154,7 @@ impl<'a> Display for CqlStringLiteralDisplayer<'a> {
     }
 }
 
-pub(crate) struct CommaSeparatedDisplayer<I>(pub I);
+pub(crate) struct CommaSeparatedDisplayer<I>(pub(crate) I);
 
 impl<I, T> Display for CommaSeparatedDisplayer<I>
 where


### PR DESCRIPTION
In spirit of the referenced issue, `scylla` crate is saved from the hazardous siege of `pub` qualifiers. This PR collects the changes that I believe to be non-breaking, so that they can be merged immediately.

Refs: #660 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
