### PR TITLE
codewide: Decrease excessive visibility from `pub` - breaking changes

### DIFF
--- a/scylla/src/routing.rs
+++ b/scylla/src/routing.rs
@@ -13,10 +13,10 @@ pub type Shard = u32;
 pub type ShardCount = NonZeroU16;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct ShardInfo {
-    pub shard: u16,
-    pub nr_shards: ShardCount,
-    pub msb_ignore: u8,
+pub(crate) struct ShardInfo {
+    pub(crate) shard: u16,
+    pub(crate) nr_shards: ShardCount,
+    pub(crate) msb_ignore: u8,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -33,7 +33,7 @@ impl std::str::FromStr for Token {
 }
 
 impl ShardInfo {
-    pub fn new(shard: u16, nr_shards: ShardCount, msb_ignore: u8) -> Self {
+    pub(crate) fn new(shard: u16, nr_shards: ShardCount, msb_ignore: u8) -> Self {
         ShardInfo {
             shard,
             nr_shards,
@@ -41,7 +41,7 @@ impl ShardInfo {
         }
     }
 
-    pub fn get_sharder(&self) -> Sharder {
+    pub(crate) fn get_sharder(&self) -> Sharder {
         Sharder::new(self.nr_shards, self.msb_ignore)
     }
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1284,7 +1284,7 @@ impl Connection {
         })
     }
 
-    pub fn get_shard_info(&self) -> &Option<ShardInfo> {
+    pub(crate) fn get_shard_info(&self) -> &Option<ShardInfo> {
         &self.features.shard_info
     }
 

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -38,7 +38,7 @@ impl ReplicaLocator {
     /// Creates a new `ReplicaLocator` in which the specified replication strategies
     /// (`precompute_replica_sets_for`) will have its token ranges precomputed. This function can
     /// potentially be CPU-intensive (if a ring & replication factors in given strategies are big).
-    pub fn new<'a>(
+    pub(crate) fn new<'a>(
         ring_iter: impl Iterator<Item = (Token, Arc<Node>)>,
         precompute_replica_sets_for: impl Iterator<Item = &'a Strategy>,
     ) -> Self {

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -424,7 +424,7 @@ impl<RowT: FromRow> Iterator for TypedRowIter<RowT> {
     }
 }
 
-pub enum RunQueryResult<ResT> {
+pub(crate) enum RunQueryResult<ResT> {
     IgnoredWriteError,
     Completed(ResT),
 }
@@ -2022,7 +2022,7 @@ pub(crate) async fn resolve_hostname(hostname: &str) -> Result<SocketAddr, io::E
 // When using run_query make sure that the ResT type is NOT able
 // to contain any errors.
 // See https://github.com/scylladb/scylla-rust-driver/issues/501
-pub trait AllowedRunQueryResTType {}
+pub(crate) trait AllowedRunQueryResTType {}
 
 impl AllowedRunQueryResTType for Uuid {}
 impl AllowedRunQueryResTType for QueryResult {}

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -91,7 +91,7 @@ fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
 
 const EMPTY_PLAN_ERROR: QueryError = QueryError::ProtocolError("Empty query plan - driver bug!");
 
-pub async fn execute<QueryFut, ResT>(
+pub(crate) async fn execute<QueryFut, ResT>(
     policy: &dyn SpeculativeExecutionPolicy,
     context: &Context,
     query_runner_generator: impl Fn(bool) -> QueryFut,

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -49,9 +49,9 @@ pub(crate) struct MetadataReader {
 }
 
 /// Describes all metadata retrieved from the cluster
-pub struct Metadata {
-    pub peers: Vec<Peer>,
-    pub keyspaces: HashMap<String, Keyspace>,
+pub(crate) struct Metadata {
+    pub(crate) peers: Vec<Peer>,
+    pub(crate) keyspaces: HashMap<String, Keyspace>,
 }
 
 #[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
@@ -349,7 +349,7 @@ impl Metadata {
     ///
     /// It can be used as a replacement for real metadata when initial
     /// metadata read fails.
-    pub fn new_dummy(initial_peers: &[UntranslatedEndpoint]) -> Self {
+    pub(crate) fn new_dummy(initial_peers: &[UntranslatedEndpoint]) -> Self {
         let peers = initial_peers
             .iter()
             .enumerate()


### PR DESCRIPTION
In spirit of the referenced issue, `scylla` crate is saved from the hazardous siege of `pub` qualifiers. This PR collects the changes that I believe to be API-breaking. These changes, however, seem to be relatively benign.

Refs: #660 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
