### PR TITLE
configurable topology refresh duration

### DIFF
--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .known_node("127.0.0.72:4321")
         .known_node("localhost:8000")
         .connection_timeout(Duration::from_secs(3))
-        .cluster_topology_refresh_interval(Duration::from_secs(10))
+        .cluster_metadata_refresh_interval(Duration::from_secs(10))
         .known_node_addr(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             9000,
@@ -36,7 +36,7 @@ After successfully connecting to some specified node the driver will fetch topol
 other nodes in this cluster and connect to them as well.
 
 The driver refreshes the cluster metadata periodically, which contains information about cluster topology as well as the cluster schema. By default, the driver refreshes the cluster metadata every 60 seconds. 
-However, you can set the `cluster_topology_refresh_interval` to a non-negative value to periodically refresh the cluster topology. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
+However, you can set the `cluster_metadata_refresh_interval` to a non-negative value to periodically refresh the cluster topology. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
 
 Scylla Serverless is an elastic and dynamic deployment model. When creating a `Session` you need to
 specify the secure connection bundle as follows:

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -36,7 +36,7 @@ After successfully connecting to some specified node the driver will fetch topol
 other nodes in this cluster and connect to them as well.
 
 The driver refreshes the cluster metadata periodically, which contains information about cluster topology as well as the cluster schema. By default, the driver refreshes the cluster metadata every 60 seconds. 
-However, you can set the `cluster_metadata_refresh_interval` to a non-negative value to periodically refresh the cluster topology. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
+However, you can set the `cluster_metadata_refresh_interval` to a non-negative value to periodically refresh the cluster metadata. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
 
 Scylla Serverless is an elastic and dynamic deployment model. When creating a `Session` you need to
 specify the secure connection bundle as follows:

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -35,10 +35,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 After successfully connecting to some specified node the driver will fetch topology information about
 other nodes in this cluster and connect to them as well.
 
-You can also set the `cluster_topology_refresh_interval` to a non-negative value to periodically refresh the
-cluster topology. This is useful when you do not have unexpected amount of traffic or when you
-have an extra traffic causing topology to change frequently. The default value is 60,
-which means that the driver will refresh the topology every 60 seconds.
+The driver refreshes the cluster metadata periodically, which contains information about cluster topology as well as the cluster schema. By default, the driver refreshes the cluster metadata every 60 seconds. 
+However, you can set the `cluster_topology_refresh_interval` to a non-negative value to periodically refresh the cluster topology. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
 
 Scylla Serverless is an elastic and dynamic deployment model. When creating a `Session` you need to
 specify the secure connection bundle as follows:

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 After successfully connecting to some specified node the driver will fetch topology information about
 other nodes in this cluster and connect to them as well.
 
-You can also set the `cluster_topology_refresh_interval` to a non-zero value to periodically refresh the
+You can also set the `cluster_topology_refresh_interval` to a non-negative value to periodically refresh the
 cluster topology. This is useful when you do not have unexpected amount of traffic or when you
 have an extra traffic causing topology to change frequently. The default value is 60,
 which means that the driver will refresh the topology every 60 seconds.

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -20,6 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .known_node("127.0.0.72:4321")
         .known_node("localhost:8000")
         .connection_timeout(Duration::from_secs(3))
+        .cluster_topology_refresh_interval(Duration::from_secs(10))
         .known_node_addr(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             9000,
@@ -33,6 +34,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 After successfully connecting to some specified node the driver will fetch topology information about
 other nodes in this cluster and connect to them as well.
+
+You can also set the `cluster_topology_refresh_interval` to a non-zero value to periodically refresh the
+cluster topology. This is useful when you do not have unexpected amount of traffic or when you
+have an extra traffic causing topology to change frequently. The default value is 60,
+which means that the driver will refresh the topology every 60 seconds.
 
 Scylla Serverless is an elastic and dynamic deployment model. When creating a `Session` you need to
 specify the secure connection bundle as follows:

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -125,7 +125,7 @@ struct ClusterWorker {
     host_filter: Option<Arc<dyn HostFilter>>,
 
     // This value determines how frequently the cluster
-    // worker will refresh the cluster topology
+    // worker will refresh the cluster metadata
     cluster_metadata_refresh_interval: Duration,
 }
 

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -126,7 +126,7 @@ struct ClusterWorker {
 
     // This value determines how frequently the cluster
     // worker will refresh the cluster topology
-    topology_refresh_interval: Duration,
+    cluster_metadata_refresh_interval: Duration,
 }
 
 #[derive(Debug)]
@@ -147,7 +147,7 @@ impl Cluster {
         keyspaces_to_fetch: Vec<String>,
         fetch_schema_metadata: bool,
         host_filter: Option<Arc<dyn HostFilter>>,
-        topology_refresh_interval: Duration,
+        cluster_metadata_refresh_interval: Duration,
     ) -> Result<Cluster, QueryError> {
         let (refresh_sender, refresh_receiver) = tokio::sync::mpsc::channel(32);
         let (use_keyspace_sender, use_keyspace_receiver) = tokio::sync::mpsc::channel(32);
@@ -189,7 +189,7 @@ impl Cluster {
             used_keyspace: None,
 
             host_filter,
-            topology_refresh_interval,
+            cluster_metadata_refresh_interval,
         };
 
         let (fut, worker_handle) = worker.work().remote_handle();
@@ -495,7 +495,7 @@ impl ClusterWorker {
 
             // Wait until it's time for the next refresh
             let sleep_until: Instant = last_refresh_time
-                .checked_add(self.topology_refresh_interval)
+                .checked_add(self.cluster_metadata_refresh_interval)
                 .unwrap_or_else(Instant::now);
 
             let sleep_future = tokio::time::sleep_until(sleep_until);

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -263,7 +263,7 @@ pub struct SessionConfig {
     /// can be configured according to the traffic pattern
     /// for e.g: if they do not want unexpected traffic
     /// or they expect the topology to change frequently.
-    pub cluster_topology_refresh_interval: Duration,
+    pub cluster_metadata_refresh_interval: Duration,
 }
 
 /// Describes database server known on Session startup.
@@ -326,7 +326,7 @@ impl SessionConfig {
             tracing_info_fetch_attempts: NonZeroU32::new(5).unwrap(),
             tracing_info_fetch_interval: Duration::from_millis(3),
             tracing_info_fetch_consistency: Consistency::One,
-            cluster_topology_refresh_interval: Duration::from_secs(60),
+            cluster_metadata_refresh_interval: Duration::from_secs(60),
         }
     }
 
@@ -563,7 +563,7 @@ impl Session {
             config.keyspaces_to_fetch,
             config.fetch_schema_metadata,
             config.host_filter,
-            config.cluster_topology_refresh_interval,
+            config.cluster_metadata_refresh_interval,
         )
         .await?;
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -258,7 +258,7 @@ pub struct SessionConfig {
     /// in [`Session::get_tracing_info`].
     pub tracing_info_fetch_consistency: Consistency,
 
-    /// Interval between refreshing cluster topology. This
+    /// Interval between refreshing cluster metadata. This
     /// can be configured according to the traffic pattern
     /// for e.g: if they do not want unexpected traffic
     /// or they expect the topology to change frequently.

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -258,6 +258,12 @@ pub struct SessionConfig {
     /// Consistency level of fetching [`TracingInfo`]
     /// in [`Session::get_tracing_info`].
     pub tracing_info_fetch_consistency: Consistency,
+
+    /// Interval between refreshing cluster topology. This
+    /// can be configured according to the traffic pattern
+    /// for e.g: if they do not want unexpected traffic
+    /// or they expect the topology to change frequently.
+    pub cluster_topology_refresh_interval: Duration,
 }
 
 /// Describes database server known on Session startup.
@@ -320,6 +326,7 @@ impl SessionConfig {
             tracing_info_fetch_attempts: NonZeroU32::new(5).unwrap(),
             tracing_info_fetch_interval: Duration::from_millis(3),
             tracing_info_fetch_consistency: Consistency::One,
+            cluster_topology_refresh_interval: Duration::from_secs(60),
         }
     }
 
@@ -556,6 +563,7 @@ impl Session {
             config.keyspaces_to_fetch,
             config.fetch_schema_metadata,
             config.host_filter,
+            config.cluster_topology_refresh_interval,
         )
         .await?;
 

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -901,6 +901,25 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self.config.tracing_info_fetch_consistency = consistency;
         self
     }
+
+    /// Set the interval at which the driver will refresh the cluster topology.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let session: Session = SessionBuilder::new()
+    ///         .known_node("127.0.0.1:9042")
+    ///         .cluster_topology_refresh_interval(std::time::Duration::from_secs(60))
+    ///         .build()
+    ///         .await?;
+    /// #   Ok(())
+    /// # }
+    /// ```
+    pub fn cluster_topology_refresh_interval(mut self, interval: Duration) -> Self {
+        self.config.cluster_topology_refresh_interval = interval;
+        self
+    }
 }
 
 /// Creates a [`SessionBuilder`] with default configuration, same as [`SessionBuilder::new`]
@@ -1116,6 +1135,15 @@ mod tests {
     }
 
     #[test]
+    fn cluster_topology_refresh_interval() {
+        let builder = SessionBuilder::new();
+        assert_eq!(
+            builder.config.cluster_topology_refresh_interval,
+            std::time::Duration::from_secs(60)
+        );
+    }
+
+    #[test]
     fn all_features() {
         let mut builder = SessionBuilder::new();
 
@@ -1131,6 +1159,7 @@ mod tests {
         builder = builder.tcp_nodelay(true);
         builder = builder.use_keyspace("ks_name", true);
         builder = builder.fetch_schema_metadata(false);
+        builder = builder.cluster_topology_refresh_interval(Duration::from_secs(1));
 
         assert_eq!(
             builder.config.known_nodes,
@@ -1146,6 +1175,10 @@ mod tests {
 
         assert_eq!(builder.config.compression, Some(Compression::Snappy));
         assert!(builder.config.tcp_nodelay);
+        assert_eq!(
+            builder.config.cluster_topology_refresh_interval,
+            Duration::from_secs(1)
+        );
 
         assert_eq!(builder.config.used_keyspace, Some("ks_name".to_string()));
 

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -902,22 +902,27 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
-    /// Set the interval at which the driver will refresh the cluster topology.
+    /// Set the interval at which the driver refreshes the cluster metadata which contains information
+    /// about the cluster topology as well as the cluster schema.
     ///
+    /// The default is 60 seconds.
+    ///
+    /// In the given example, we have set the duration value to 20 seconds, which
+    /// means that the metadata is refreshed every 20 seconds.
     /// # Example
     /// ```
     /// # use scylla::{Session, SessionBuilder};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///     let session: Session = SessionBuilder::new()
     ///         .known_node("127.0.0.1:9042")
-    ///         .cluster_topology_refresh_interval(std::time::Duration::from_secs(60))
+    ///         .cluster_metadata_refresh_interval(std::time::Duration::from_secs(20))
     ///         .build()
     ///         .await?;
     /// #   Ok(())
     /// # }
     /// ```
-    pub fn cluster_topology_refresh_interval(mut self, interval: Duration) -> Self {
-        self.config.cluster_topology_refresh_interval = interval;
+    pub fn cluster_metadata_refresh_interval(mut self, interval: Duration) -> Self {
+        self.config.cluster_metadata_refresh_interval = interval;
         self
     }
 }
@@ -1135,10 +1140,10 @@ mod tests {
     }
 
     #[test]
-    fn cluster_topology_refresh_interval() {
+    fn cluster_metadata_refresh_interval() {
         let builder = SessionBuilder::new();
         assert_eq!(
-            builder.config.cluster_topology_refresh_interval,
+            builder.config.cluster_metadata_refresh_interval,
             std::time::Duration::from_secs(60)
         );
     }
@@ -1159,7 +1164,7 @@ mod tests {
         builder = builder.tcp_nodelay(true);
         builder = builder.use_keyspace("ks_name", true);
         builder = builder.fetch_schema_metadata(false);
-        builder = builder.cluster_topology_refresh_interval(Duration::from_secs(1));
+        builder = builder.cluster_metadata_refresh_interval(Duration::from_secs(1));
 
         assert_eq!(
             builder.config.known_nodes,
@@ -1176,7 +1181,7 @@ mod tests {
         assert_eq!(builder.config.compression, Some(Compression::Snappy));
         assert!(builder.config.tcp_nodelay);
         assert_eq!(
-            builder.config.cluster_topology_refresh_interval,
+            builder.config.cluster_metadata_refresh_interval,
             Duration::from_secs(1)
         );
 


### PR DESCRIPTION
This pull requests a configurable way to topology refresh duration. Two files session.rs and cluster.rs have been modified to set the session configuration and consume the duration configuration respectively.

Note: I am not sure if we need any test cases in this case as the duration is still provided from where its called. 

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.


Fixes: #232 
