### PR TITLE
default policy: Rack awareness without token awareness

### DIFF
--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -44,7 +44,7 @@ policy to prioritize nodes based on their location. It has three modes:
 
 When a datacenter `"my_dc"` is preferred, the policy will treat nodes in `"my_dc"`
 as "local" nodes, and nodes in other datacenters as "remote" nodes. This affects
-the order in which nodes are returned by the policy when selecting replicas for
+the order in which nodes are returned by the policy when selecting nodes for
 read or write operations. If no datacenter is preferred, the policy will treat
 all nodes as local nodes.
 
@@ -52,7 +52,8 @@ all nodes as local nodes.
 availability zones (racks) in the preferred datacenter, too. When a datacenter
 and a rack are preferred, the policy will first return replicas in the local rack
 in the preferred datacenter, and then the other replicas in the datacenter
-(followed by remote replicas).
+(followed by remote replicas). After replicas, the other node will be ordered
+similarly, too (local rack nodes, local datacenter nodes, remote nodes).
 
 When datacenter failover is disabled (`permit_dc_failover` is set to
 false), the default policy will only include local nodes in load balancing

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -396,13 +396,13 @@ impl DefaultPolicy {
     fn make_rack_predicate<'a>(
         predicate: impl Fn(&NodeRef<'a>) -> bool + 'a,
         replica_location: ReplicaLocationCriteria<'a>,
-    ) -> impl Fn(NodeRef<'a>) -> bool {
+    ) -> impl Fn(&NodeRef<'a>) -> bool {
         move |node| match replica_location {
             ReplicaLocationCriteria::Any | ReplicaLocationCriteria::Datacenter(_) => {
-                predicate(&node)
+                predicate(node)
             }
             ReplicaLocationCriteria::DatacenterAndRack(_, rack) => {
-                predicate(&node) && node.rack.as_deref() == Some(rack)
+                predicate(node) && node.rack.as_deref() == Some(rack)
             }
         }
     }

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -244,19 +244,17 @@ impl<'a> ReplicaSet<'a> {
     pub fn choose_filtered<R>(
         self,
         rng: &mut R,
-        predicate: impl Fn(NodeRef<'a>) -> bool,
+        predicate: impl Fn(&NodeRef<'a>) -> bool,
     ) -> Option<NodeRef<'a>>
     where
         R: Rng + ?Sized,
     {
         let happy = self.choose(rng)?;
-        if predicate(happy) {
+        if predicate(&happy) {
             return Some(happy);
         }
 
-        self.into_iter()
-            .filter(|node_ref| predicate(node_ref))
-            .choose(rng)
+        self.into_iter().filter(predicate).choose(rng)
     }
 
     /// Gets the size of the set.


### PR DESCRIPTION
Until now, the default policy respected rack preference only when it came to replicas.
Considering non-token-aware queries (e.g. unprepared statements), they would never prioritize the preferred rack.

Now, local rack nodes are always preferred before other nodes, both in `pick()` and in `fallback()`.
Existing tests adjusted for new behaviour.

The PR contains breaking changes, as it slightly changes signature of `ReplicaSet::choose_filtered()` (note the reference added).

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
