### PR TITLE
session_builder: move `write_coalescing()` to generic builder

### DIFF
--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -300,37 +300,6 @@ impl SessionBuilder {
         self
     }
 
-    /// If true, the driver will inject a small delay before flushing data
-    /// to the socket - by rescheduling the task that writes data to the socket.
-    /// This gives the task an opportunity to collect more write requests
-    /// and write them in a single syscall, increasing the efficiency.
-    ///
-    /// However, this optimization may worsen latency if the rate of requests
-    /// issued by the application is low, but otherwise the application is
-    /// heavily loaded with other tasks on the same tokio executor.
-    /// Please do performance measurements before committing to disabling
-    /// this option.
-    ///
-    /// This option is true by default.
-    ///
-    /// # Example
-    /// ```
-    /// # use scylla::{Session, SessionBuilder};
-    /// # use scylla::transport::Compression;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .write_coalescing(false) // Enabled by default
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn write_coalescing(mut self, enable: bool) -> Self {
-        self.config.enable_write_coalescing = enable;
-        self
-    }
-
     /// ssl feature
     /// Provide SessionBuilder with SslContext from openssl crate that will be
     /// used to create an ssl connection to the database.
@@ -899,6 +868,37 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// ```
     pub fn tracing_info_fetch_consistency(mut self, consistency: Consistency) -> Self {
         self.config.tracing_info_fetch_consistency = consistency;
+        self
+    }
+
+    /// If true, the driver will inject a small delay before flushing data
+    /// to the socket - by rescheduling the task that writes data to the socket.
+    /// This gives the task an opportunity to collect more write requests
+    /// and write them in a single syscall, increasing the efficiency.
+    ///
+    /// However, this optimization may worsen latency if the rate of requests
+    /// issued by the application is low, but otherwise the application is
+    /// heavily loaded with other tasks on the same tokio executor.
+    /// Please do performance measurements before committing to disabling
+    /// this option.
+    ///
+    /// This option is true by default.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use scylla::transport::Compression;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .write_coalescing(false) // Enabled by default
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_coalescing(mut self, enable: bool) -> Self {
+        self.config.enable_write_coalescing = enable;
         self
     }
 }


### PR DESCRIPTION
When added, `write_coalescing()` method was mistakenly put on `SessionBuilder` instead of `GenericSessionBuilder`. It is moved there, as there is nothing against using it in Cloud.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
