### PR TITLE
Slim down schema agreement API

### DIFF
--- a/docs/source/queries/schema-agreement.md
+++ b/docs/source/queries/schema-agreement.md
@@ -1,11 +1,11 @@
 # Schema agreement
 
-Sometimes after performing queries some nodes have not been updated so we need a mechanism that checks if every node have agreed schema version.
-There are four methods in `Session` that assist us. 
+Sometimes after performing queries some nodes have not been updated, so we need a mechanism that checks if every node have agreed on schema version.
+There is a number of methods in `Session` that assist us.
 Every method raise `QueryError` if something goes wrong, but they should never raise any errors, unless there is a DB or connection malfunction.
 
 ### Checking schema version
-`Session::fetch_schema_version` returns an `Uuid` of local node's schema version. 
+`Session::fetch_schema_version` returns an `Uuid` of local node's schema version.
 
 ```rust
 # extern crate scylla;
@@ -19,7 +19,9 @@ println!("Local schema version is: {}", session.fetch_schema_version().await?);
 
 ### Awaiting schema agreement
 
-`Session::await_schema_agreement` returns a `Future` that can be `await`ed on as long as schema is not in an agreement.
+`Session::await_schema_agreement` returns a `Future` that can be `await`ed as long as schema is not in an agreement.
+However, it won't wait forever; `SessionConfig` defines a timeout that limits the time of waiting. If the timeout elapses,
+the return value is `false`, otherwise it is `true`.
 
 ```rust
 # extern crate scylla;
@@ -31,28 +33,10 @@ session.await_schema_agreement().await?;
 # }
 ```
 
-### Awaiting with timeout
-We can also set timeout in milliseconds with `Session::await_timed_schema_agreement`.
-It takes one argument, an `std::time::Duration` value that tells how long our driver should await for schema agreement. If the timeout is met the return value is `false` otherwise it is `true`.
+### Interval of checking for schema agreement
 
-```rust
-# extern crate scylla;
-# use scylla::Session;
-# use std::error::Error;
-# use std::time::Duration;
-# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-if session.await_timed_schema_agreement(Duration::from_secs(5)).await? { // wait for 5 seconds
-    println!("SCHEMA AGREED");
-} else {
-    println!("SCHEMA IS NOT IN AGREEMENT - TIMED OUT");
-}
-# Ok(())
-# }
-```
-
-### Checking for schema interval
-If schema is not agreed driver sleeps for a duration before checking it again. Default value is 200 milliseconds but it can be changed with `SessionBuilder::schema_agreement_interval`.
-
+If the schema is not agreed upon, the driver sleeps for a duration before checking it again. The default value is 200 milliseconds,
+but it can be changed with `SessionBuilder::schema_agreement_interval`.
 
 ```rust
 # extern crate scylla;
@@ -70,15 +54,15 @@ SessionBuilder::new()
 ```
 
 ### Checking if schema is in agreement now
-If you want to check if schema is in agreement now without retrying after failure you can use `Session::check_schema_agreement` function.
 
+If you want to check if schema is in agreement now, without retrying after failure, you can use `Session::check_schema_agreement` function.
 
 ```rust
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-if session.check_schema_agreement().await? { 
+if session.check_schema_agreement().await? {
     println!("SCHEMA AGREED");
 } else {
     println!("SCHEMA IS NOT IN AGREEMENT");
@@ -86,5 +70,3 @@ if session.check_schema_agreement().await? {
 # Ok(())
 # }
 ```
-
-

--- a/examples/schema_agreement.rs
+++ b/examples/schema_agreement.rs
@@ -20,17 +20,12 @@ async fn main() -> Result<()> {
     let schema_version = session.fetch_schema_version().await?;
     println!("Schema version: {}", schema_version);
 
-    session.await_schema_agreement().await?; // without timeout example
     session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
-    if session
-        .await_timed_schema_agreement(Duration::from_secs(5))
-        .await?
-    {
-        // with timeout example
-        println!("Timed schema is in agreement");
+    if session.await_schema_agreement().await? {
+        println!("Schema is in agreement");
     } else {
-        println!("Timed schema is NOT in agreement");
+        println!("Schema is NOT in agreement");
     }
     session
         .query(

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -717,8 +717,8 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
-    /// Enables automatic wait for schema agreement and sets the timeout for it.
-    /// By default, it is enabled and the timeout is 60 seconds.
+    /// Sets the timeout for waiting for schema agreement.
+    /// By default, the timeout is 60 seconds.
     ///
     /// # Example
     /// ```
@@ -726,19 +726,19 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let session: Session = SessionBuilder::new()
     ///     .known_node("127.0.0.1:9042")
-    ///     .auto_schema_agreement_timeout(std::time::Duration::from_secs(120))
+    ///     .schema_agreement_timeout(std::time::Duration::from_secs(120))
     ///     .build()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn auto_schema_agreement_timeout(mut self, timeout: Duration) -> Self {
-        self.config.auto_await_schema_agreement_timeout = Some(timeout);
+    pub fn schema_agreement_timeout(mut self, timeout: Duration) -> Self {
+        self.config.schema_agreement_timeout = timeout;
         self
     }
 
-    /// Disables automatic wait for schema agreement.
-    /// By default, it is enabled and the timeout is 60 seconds.
+    /// Controls automatic waiting for schema agreement after a schema-altering
+    /// statement is sent. By default, it is enabled.
     ///
     /// # Example
     /// ```
@@ -746,14 +746,14 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let session: Session = SessionBuilder::new()
     ///     .known_node("127.0.0.1:9042")
-    ///     .no_auto_schema_agreement()
+    ///     .auto_await_schema_agreement(false)
     ///     .build()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn no_auto_schema_agreement(mut self) -> Self {
-        self.config.auto_await_schema_agreement_timeout = None;
+    pub fn auto_await_schema_agreement(mut self, enabled: bool) -> Self {
+        self.config.schema_agreement_automatic_waiting = enabled;
         self
     }
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1119,12 +1119,8 @@ async fn test_await_schema_agreement() {
 
 #[tokio::test]
 async fn test_await_timed_schema_agreement() {
-    use std::time::Duration;
     let session = create_new_session_builder().build().await.unwrap();
-    session
-        .await_timed_schema_agreement(Duration::from_millis(50))
-        .await
-        .unwrap();
+    session.await_schema_agreement().await.unwrap();
 }
 
 #[tokio::test]

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1106,15 +1106,9 @@ async fn assert_in_tracing_table(session: &Session, tracing_uuid: Uuid) {
 }
 
 #[tokio::test]
-async fn test_fetch_schema_version() {
-    let session = create_new_session_builder().build().await.unwrap();
-    session.fetch_schema_version().await.unwrap();
-}
-
-#[tokio::test]
 async fn test_await_schema_agreement() {
     let session = create_new_session_builder().build().await.unwrap();
-    session.await_schema_agreement().await.unwrap();
+    let _schema_version = session.await_schema_agreement().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Schema agreement API is another place in the driver's code that can be polished towards API stability.

## What's done

1. `fetch_schema_version() ` is removed. 
It can be a nasty source of race bugs when schema version is fetched without awaiting for schema agreement. It is especially risky when one awaits schema agreement and subsequently fetches schema version, because the schema version can change in the meantime and schema may no longer be in agreement. To cope with the problem, `await_schema_agreement()` now returns the agreed schema version, and  `fetch_schema_version()` is removed alltogether.
2. `await_schema_agreement()` gets implicit timeout.
    Similarly to
    - what Java driver 3 does in regard to awaiting schema agreement's API,
    - what was recently done in Rust driver in regard to tracing info's API,
    
    the API of awaiting schema agreement is altered so that:
    - `await_timed_schema_agreement()`, which takes explicit timeout, is
      removed,
    - `await_schema_agreement()` is now bound with a timeout that is set
      globally per-`Session` in `SessionConfig`.

    The motivation is that it could lead to application's deadlock when `await_schema_agreement()` was called with no timeout given and the cluster stoped synchronising (so schema agreement would be never reached), It is rarely desirable to block the calling application for arbitrarily long time, especially that some extreme situations are possible, such as a network partition between nodes.
    
3. `SessionBuilder`s API is accomodated to the changes. Docs are updated as well.



### Bonus
- missing docstrings were added for `AddressTranslator`.

Refs: #660 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
