### PR TITLE
Update syn to 2.0

### DIFF
--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -12,6 +12,6 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
+syn = "2.0"
 quote = "1.0" 
 proc-macro2 = "1.0"


### PR DESCRIPTION
The way attributes are handled was changed a lot in syn `2.0`.
For our usage here the changes arent too complex though:
* Attribute now has `path` as a method instead of a field
* Attribute now has `meta` as a field instead of a method
* NameValue now has the value as an expression from which we must extract the literal instead of just holding a literal directly.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
