### PR TITLE
doc: replace python3 with python in Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -31,7 +31,7 @@ setup:
 	$(POETRY) install
 	$(POETRY) update
 	cp -TLr source $(SOURCEDIR)
-	python3 _utils/prepare_sphinx_source.py _source
+	python _utils/prepare_sphinx_source.py _source
 
 # Clean commands
 .PHONY: pristine


### PR DESCRIPTION
In some setups, documentation won't build if python3 is used in the "python3 _utils/prepare_sphinx_source.py _source" command.
This commit replaces python3 with python to make it work.
