### PR TITLE
doc: enable publishing docs for tag v0.9.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,12 +14,12 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- General configuration ------------------------------------------------
 
 # Build documentation for the following tags and branches
-TAGS = []
+TAGS = ['v0.9.0']
 BRANCHES = ['main']
 # Set the latest version.
-LATEST_VERSION = 'main'
+LATEST_VERSION = 'v0.9.0'
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = []
+UNSTABLE_VERSIONS = ['main']
 # Set which versions are deprecated
 DEPRECATED_VERSIONS = []
 


### PR DESCRIPTION
Currently, the Rust Driver documentation shows the docs for the branch "main".
This commit enables publishing the docs for the latest Rust Driver version and sets it as the latest STABLE version.

