### PR TITLE
add topology_refresh_interval config

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -187,6 +187,7 @@ pub struct SessionConfig {
     pub authenticator: Option<Arc<dyn AuthenticatorProvider>>,
 
     pub schema_agreement_interval: Duration,
+    pub topology_refresh_interval: Option<Duration>,
     pub connect_timeout: Duration,
 
     /// Size of the per-node connection pool, i.e. how many connections the driver should keep to each node.
@@ -295,6 +296,7 @@ impl SessionConfig {
             tcp_nodelay: true,
             tcp_keepalive_interval: None,
             schema_agreement_interval: Duration::from_millis(200),
+            topology_refresh_interval: Some(Duration::from_secs(60)),
             default_execution_profile_handle: ExecutionProfile::new_from_inner(Default::default())
                 .into_handle(),
             used_keyspace: None,
@@ -555,6 +557,7 @@ impl Session {
             config.keyspaces_to_fetch,
             config.fetch_schema_metadata,
             config.host_filter,
+            config.topology_refresh_interval,
         )
         .await?;
 

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -409,6 +409,32 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
+    /// Topology refresh automatically occurs when the driver detects that a refresh is needed.
+    /// However there is also a scheduled refresh in case another client alters the schema or the cluster topology is changed.
+    ///
+    /// This configuration sets the interval at which the scheduled refresh occurs.
+    /// When set to None, the scheduled refresh never occurs but refresh still occurs when the driver detects a change.
+    ///
+    /// The default is 60 seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::{Session, SessionBuilder};
+    /// # use std::time::Duration;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .topology_refresh_interval(Some(Duration::from_secs(60)))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn topology_refresh_interval(mut self, timeout: Option<Duration>) -> Self {
+        self.config.topology_refresh_interval = timeout;
+        self
+    }
+
     /// Set the default execution profile using its handle
     ///
     /// # Example


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
    - There seems to be no existing tests for the current timeout
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.

Progress towards: https://github.com/scylladb/scylla-rust-driver/issues/786

Refer to the issue for justification.

I have observed that with this PR:
* with default config the issue still occurs in my project
* with `topology_refresh_interval(None)` the issue no longer occurs in my project.