### PR TITLE
proxy: send shard number as feedback along with the frame 

### DIFF
--- a/scylla-proxy/src/lib.rs
+++ b/scylla-proxy/src/lib.rs
@@ -2,6 +2,9 @@ mod actions;
 mod errors;
 mod frame;
 mod proxy;
+
+pub type TargetShard = u16;
+
 pub use actions::{
     Action, Condition, Reaction, RequestReaction, RequestRule, ResponseReaction, ResponseRule,
 };

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -600,6 +600,7 @@ impl Doorkeeper {
         connection_no: usize,
         driver_stream: TcpStream,
         cluster_stream: Option<TcpStream>,
+        shard: Option<TargetShard>,
     ) {
         let (driver_read, driver_write) = driver_stream.into_split();
 
@@ -611,6 +612,7 @@ impl Doorkeeper {
             driver_addr,
             real_addr: self.node.real_addr(),
             proxy_addr: self.node.proxy_addr(),
+            shard,
         };
 
         let (tx_request, rx_request) = mpsc::unbounded_channel::<RequestFrame>();
@@ -682,6 +684,7 @@ impl Doorkeeper {
             connection_no,
             driver_stream,
             cluster_stream,
+            shard,
         )
         .await;
 
@@ -836,6 +839,7 @@ struct ProxyWorker {
     driver_addr: SocketAddr,
     real_addr: Option<SocketAddr>,
     proxy_addr: SocketAddr,
+    shard: Option<TargetShard>,
 }
 
 impl ProxyWorker {

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -731,7 +731,7 @@ impl Doorkeeper {
 
             socket.connect(real_addr).await.map(|ok| {
                 info!(
-                    "Connected to the cluster from {} at {}, shard {}.",
+                    "Connected to the cluster from {} at {}, intended shard {}.",
                     ok.local_addr().unwrap(),
                     real_addr,
                     shard_preserving_addr.port() % shards

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -2048,7 +2048,7 @@ mod tests {
             .unwrap();
 
         // We must interrupt the driver's full connection opening, because our proxy does not interact further after Startup.
-        let startup_without_lwt_optimisation = select! {
+        let (startup_without_lwt_optimisation, _shard) = select! {
             _ = open_connection(UntranslatedEndpoint::ContactPoint(ContactPoint{address: proxy_addr, datacenter: None}), None, config.clone()) => unreachable!(),
             startup = startup_rx.recv() => startup.unwrap(),
         };
@@ -2056,7 +2056,7 @@ mod tests {
         proxy.running_nodes[0]
             .change_request_rules(Some(make_rules(options_with_lwt_optimisation_support)));
 
-        let startup_with_lwt_optimisation = select! {
+        let (startup_with_lwt_optimisation, _shard) = select! {
             _ = open_connection(UntranslatedEndpoint::ContactPoint(ContactPoint{address: proxy_addr, datacenter: None}), None, config.clone()) => unreachable!(),
             startup = startup_rx.recv() => startup.unwrap(),
         };

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -20,7 +20,7 @@ use scylla_cql::Consistency;
 use scylla_proxy::ShardAwareness;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
-    WorkerError,
+    TargetShard, WorkerError,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -296,9 +296,9 @@ async fn consistency_is_correctly_set_in_cql_requests() {
             async fn check_consistencies(
                 consistency: Consistency,
                 serial_consistency: Option<SerialConsistency>,
-                mut request_rx: UnboundedReceiver<RequestFrame>,
-            ) -> UnboundedReceiver<RequestFrame> {
-                let request_frame = request_rx.recv().await.unwrap();
+                mut request_rx: UnboundedReceiver<(RequestFrame, Option<TargetShard>)>,
+            ) -> UnboundedReceiver<(RequestFrame, Option<TargetShard>)> {
+                let (request_frame, _shard) = request_rx.recv().await.unwrap();
                 let deserialized_request = request_frame.deserialize().unwrap();
                 assert_eq!(deserialized_request.get_consistency().unwrap(), consistency);
                 assert_eq!(

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -4,4 +4,5 @@ mod hygiene;
 mod lwt_optimisation;
 mod new_session;
 mod retries;
+mod shards;
 pub(crate) mod utils;

--- a/scylla/tests/integration/shards.rs
+++ b/scylla/tests/integration/shards.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use crate::utils::test_with_3_node_cluster;
+use scylla::{test_utils::unique_keyspace_name, SessionBuilder};
+use tokio::sync::mpsc;
+
+use scylla_proxy::TargetShard;
+use scylla_proxy::{
+    Condition, Reaction, RequestOpcode, RequestReaction, RequestRule, ShardAwareness,
+};
+use scylla_proxy::{ProxyError, RequestFrame, WorkerError};
+
+#[tokio::test]
+#[ntest::timeout(30000)]
+#[cfg(not(scylla_cloud_tests))]
+async fn test_consistent_shard_awareness() {
+    use std::collections::HashSet;
+
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
+
+        let (feedback_txs, mut feedback_rxs): (Vec<_>, Vec<_>) = (0..3).map(|_| {
+            mpsc::unbounded_channel::<(RequestFrame, Option<TargetShard>)>()
+        }).unzip();
+        for (i, tx) in feedback_txs.iter().cloned().enumerate() {
+            running_proxy.running_nodes[i].change_request_rules(Some(vec![
+                RequestRule(Condition::RequestOpcode(RequestOpcode::Execute), RequestReaction::noop().with_feedback_when_performed(tx))
+            ]));
+        }
+
+        let session = SessionBuilder::new()
+            .known_node(proxy_uris[0].as_str())
+            .address_translator(Arc::new(translation_map))
+            .build()
+            .await
+            .unwrap();
+        let ks = unique_keyspace_name();
+
+        /* Prepare schema */
+        session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks), &[]).await.unwrap();
+        session
+            .query(
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {}.t (a int, b int, c text, primary key (a, b))",
+                    ks
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let prepared = session.prepare(format!("INSERT INTO {}.t (a, b, c) VALUES (?, ?, 'abc')", ks)).await.unwrap();
+
+        let value_lists = [
+            (4, 2),
+            (2, 1),
+            (3, 7),
+        ];
+
+        fn assert_one_shard_queried(rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<TargetShard>)>) {
+            let shards = std::iter::from_fn(|| rx.try_recv().ok().map(|(_frame, shard)| shard)).collect::<HashSet<_>>();
+            if !shards.is_empty() {
+                assert_eq!(shards.len(), 1);
+            }
+        }
+
+        for values in value_lists {
+            for _ in 0..10 {
+                session.execute(&prepared, values).await.unwrap();
+            }
+            for rx in feedback_rxs.iter_mut() {
+                assert_one_shard_queried(rx);
+            }
+        }
+
+        running_proxy
+    }).await;
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}


### PR DESCRIPTION
## Motivation
It appears (e.g. in #738) that our proxy lacks ability to inform which shard was queried. This is because it is represented in a per-node, not per-shard way.

## What's done
- proxy workers are made aware of the shard they are connected to. This, of course, requires that a shards count is known, either by `ShardAwareness::FixedNum` or by querying a node;
- proxy logs are enriched with info about target shard;
- the optional feedback (triggered by a frame matching the specified criteria) is extended: previously it sent a frame through a channel, now it sends a pair (frame, shard number).

## Outcome
- while using proxy manually, it is easier to trace what shard is queried;
- it is possible now to write automated tests asserting that a particular shard is queried. 

## Pre-review checklist
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
