### PR TITLE
value: implement serialize for u8 slices

### DIFF
--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -505,6 +505,12 @@ impl Value for &str {
 
 impl Value for Vec<u8> {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        <&[u8] as Value>::serialize(&self.as_slice(), buf)
+    }
+}
+
+impl Value for &[u8] {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         let val_len: i32 = self.len().try_into().map_err(|_| ValueTooBig)?;
         buf.put_i32(val_len);
 

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -36,6 +36,12 @@ fn u8_array_serialization() {
 }
 
 #[test]
+fn u8_slice_serialization() {
+    let val = vec![1u8, 1, 1, 1];
+    assert_eq!(serialized(val.as_slice()), vec![0, 0, 0, 4, 1, 1, 1, 1]);
+}
+
+#[test]
 fn naive_date_serialization() {
     // 1970-01-31 is 2^31
     let unix_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();


### PR DESCRIPTION
Implement `Value` for `u8` slices to allow deriving `ValueList` for structs with `&[u8]` fields.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
