### PR TITLE
Shard selecting load balancing

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ uuid = "1.0"
 tower = "0.4"
 stats_alloc = "0.1"
 clap = { version = "3.2.4", features = ["derive"] }
+rand = "0.8.5"
 
 [[example]]
 name = "auth"

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
                 .get_cluster_data()
                 .get_token_endpoints("ks", Token { value: t })
                 .iter()
-                .map(|n| n.address)
+                .map(|(node, _shard)| node.address)
                 .collect::<Vec<NodeAddr>>()
         );
 

--- a/examples/custom_load_balancing_policy.rs
+++ b/examples/custom_load_balancing_policy.rs
@@ -1,15 +1,27 @@
 use anyhow::Result;
+use rand::{thread_rng, Rng};
 use scylla::{
     load_balancing::{LoadBalancingPolicy, RoutingInfo},
-    transport::{ClusterData, ExecutionProfile},
+    routing::Shard,
+    transport::{ClusterData, ExecutionProfile, NodeRef},
     Session, SessionBuilder,
 };
 use std::{env, sync::Arc};
 
 /// Example load balancing policy that prefers nodes from favorite datacenter
+/// This is, of course, very naive, as it is completely non token-aware.
+/// For more realistic implementation, see [`DefaultPolicy`](scylla::load_balancing::DefaultPolicy).
 #[derive(Debug)]
 struct CustomLoadBalancingPolicy {
     fav_datacenter_name: String,
+}
+
+fn with_random_shard(node: NodeRef) -> (NodeRef, Shard) {
+    let nr_shards = node
+        .sharder()
+        .map(|sharder| sharder.nr_shards.get())
+        .unwrap_or(1);
+    (node, thread_rng().gen_range(0..nr_shards) as Shard)
 }
 
 impl LoadBalancingPolicy for CustomLoadBalancingPolicy {
@@ -17,7 +29,7 @@ impl LoadBalancingPolicy for CustomLoadBalancingPolicy {
         &'a self,
         _info: &'a RoutingInfo,
         cluster: &'a ClusterData,
-    ) -> Option<scylla::transport::NodeRef<'a>> {
+    ) -> Option<(NodeRef<'a>, Shard)> {
         self.fallback(_info, cluster).next()
     }
 
@@ -31,9 +43,9 @@ impl LoadBalancingPolicy for CustomLoadBalancingPolicy {
             .unique_nodes_in_datacenter_ring(&self.fav_datacenter_name);
 
         match fav_dc_nodes {
-            Some(nodes) => Box::new(nodes.iter()),
+            Some(nodes) => Box::new(nodes.iter().map(with_random_shard)),
             // If there is no dc with provided name, fallback to other datacenters
-            None => Box::new(cluster.get_nodes_info().iter()),
+            None => Box::new(cluster.get_nodes_info().iter().map(with_random_shard)),
         }
     }
 

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -513,7 +513,7 @@ where
 
         self.log_query_start();
 
-        'nodes_in_plan: for node in query_plan {
+        'nodes_in_plan: for (node, shard) in query_plan {
             let span =
                 trace_span!(parent: &self.parent_span, "Executing query", node = %node.address);
             // For each node in the plan choose a connection to use

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -285,7 +285,7 @@ impl RowIterator {
                         config
                             .cluster_data
                             .get_token_endpoints_iter(keyspace, token)
-                            .cloned()
+                            .map(|(node, shard)| (node.clone(), shard))
                             .collect(),
                     )
                 } else {

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -718,7 +718,7 @@ impl DefaultPolicyBuilder {
         let pick_predicate = if let Some(ref latency_awareness) = latency_awareness {
             let latency_predicate = latency_awareness.generate_predicate();
             Box::new(
-                move |node_and_shard @ (node, shard): &(NodeRef<'_>, Shard)| {
+                move |node_and_shard @ (node, _shard): &(NodeRef<'_>, Shard)| {
                     DefaultPolicy::is_alive(node_and_shard) && latency_predicate(node)
                 },
             ) as Box<dyn Fn(&(NodeRef<'_>, Shard)) -> bool + Send + Sync + 'static>

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -76,7 +76,7 @@ pub struct DefaultPolicy {
     permit_dc_failover: bool,
     pick_predicate: Box<dyn Fn(&(NodeRef<'_>, Shard)) -> bool + Send + Sync>,
     latency_awareness: Option<LatencyAwareness>,
-    fixed_shuffle_seed: Option<u64>,
+    fixed_seed: Option<u64>,
 }
 
 impl fmt::Debug for DefaultPolicy {
@@ -86,7 +86,7 @@ impl fmt::Debug for DefaultPolicy {
             .field("is_token_aware", &self.is_token_aware)
             .field("permit_dc_failover", &self.permit_dc_failover)
             .field("latency_awareness", &self.latency_awareness)
-            .field("fixed_shuffle_seed", &self.fixed_shuffle_seed)
+            .field("fixed_shuffle_seed", &self.fixed_seed)
             .finish_non_exhaustive()
     }
 }
@@ -181,7 +181,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                 &self.pick_predicate,
                 NodeLocationCriteria::DatacenterAndRack(dc, rack),
             );
-            let local_rack_picked = Self::pick_node(nodes, rack_predicate);
+            let local_rack_picked = self.pick_node(nodes, rack_predicate);
 
             if let Some(alive_local_rack) = local_rack_picked {
                 return Some(alive_local_rack);
@@ -189,14 +189,14 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         }
 
         // Try to pick some alive local random node.
-        if let Some(alive_local) = Self::pick_node(nodes, &self.pick_predicate) {
+        if let Some(alive_local) = self.pick_node(nodes, &self.pick_predicate) {
             return Some(alive_local);
         }
 
         let all_nodes = cluster.replica_locator().unique_nodes_in_global_ring();
         // If a datacenter failover is possible, loosen restriction about locality.
         if self.is_datacenter_failover_possible(&routing_info) {
-            let picked = Self::pick_node(all_nodes, &self.pick_predicate);
+            let picked = self.pick_node(all_nodes, &self.pick_predicate);
             if let Some(alive_maybe_remote) = picked {
                 return Some(alive_maybe_remote);
             }
@@ -204,21 +204,21 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
 
         // Previous checks imply that every node we could have selected is down.
         // Let's try to return a down node that wasn't disabled.
-        let picked = Self::pick_node(nodes, |(node, _shard)| node.is_enabled());
+        let picked = self.pick_node(nodes, |(node, _shard)| node.is_enabled());
         if let Some(down_but_enabled_local_node) = picked {
             return Some(down_but_enabled_local_node);
         }
 
         // If a datacenter failover is possible, loosen restriction about locality.
         if self.is_datacenter_failover_possible(&routing_info) {
-            let picked = Self::pick_node(all_nodes, |(node, _shard)| node.is_enabled());
+            let picked = self.pick_node(all_nodes, |(node, _shard)| node.is_enabled());
             if let Some(down_but_enabled_maybe_remote_node) = picked {
                 return Some(down_but_enabled_maybe_remote_node);
             }
         }
 
         // Every node is disabled. This could be due to a bad host filter - configuration error.
-        nodes.first()
+        nodes.first().map(|node| self.with_random_shard(node))
     }
 
     fn fallback<'a>(
@@ -289,7 +289,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                     .chain(maybe_remote_replicas),
             )
         } else {
-            Either::Right(std::iter::empty::<NodeRef<'a>>())
+            Either::Right(std::iter::empty::<(NodeRef<'a>, Shard)>())
         };
 
         // Get a list of all local alive nodes, and apply a round robin to it
@@ -301,29 +301,35 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                     &self.pick_predicate,
                     NodeLocationCriteria::DatacenterAndRack(dc, rack),
                 );
-                Either::Left(Self::round_robin_nodes(local_nodes, rack_predicate))
+                Either::Left(self.round_robin_nodes_with_shards(local_nodes, rack_predicate))
             } else {
-                Either::Right(std::iter::empty::<NodeRef<'a>>())
+                Either::Right(std::iter::empty::<(NodeRef<'a>, Shard)>())
             };
-        let robined_local_nodes = Self::round_robin_nodes(local_nodes, Self::is_alive);
+        let robined_local_nodes = self.round_robin_nodes_with_shards(local_nodes, Self::is_alive);
 
         let all_nodes = cluster.replica_locator().unique_nodes_in_global_ring();
 
         // If a datacenter failover is possible, loosen restriction about locality.
         let maybe_remote_nodes = if self.is_datacenter_failover_possible(&routing_info) {
-            let robined_all_nodes = Self::round_robin_nodes(all_nodes, Self::is_alive);
+            let robined_all_nodes = self.round_robin_nodes_with_shards(all_nodes, Self::is_alive);
 
             Either::Left(robined_all_nodes)
         } else {
-            Either::Right(std::iter::empty::<NodeRef<'a>>())
+            Either::Right(std::iter::empty::<(NodeRef<'a>, Shard)>())
         };
 
         // Even if we consider some enabled nodes to be down, we should try contacting them in the last resort.
-        let maybe_down_local_nodes = local_nodes.iter().filter(|node| node.is_enabled());
+        let maybe_down_local_nodes = local_nodes
+            .iter()
+            .filter_map(|node| node.is_enabled().then(|| self.with_random_shard(node)));
 
         // If a datacenter failover is possible, loosen restriction about locality.
         let maybe_down_nodes = if self.is_datacenter_failover_possible(&routing_info) {
-            Either::Left(all_nodes.iter().filter(|node| node.is_enabled()))
+            Either::Left(
+                all_nodes
+                    .iter()
+                    .filter_map(|node| node.is_enabled().then(|| self.with_random_shard(node))),
+            )
         } else {
             Either::Right(std::iter::empty())
         };
@@ -545,7 +551,7 @@ impl DefaultPolicy {
 
         let replica_set = self.nonfiltered_replica_set(ts, replica_location, cluster);
 
-        if let Some(fixed) = self.fixed_shuffle_seed {
+        if let Some(fixed) = self.fixed_seed {
             let mut gen = Pcg32::new(fixed, 0);
             replica_set.choose_filtered(&mut gen, predicate)
         } else {
@@ -576,7 +582,7 @@ impl DefaultPolicy {
         }
     }
 
-    fn randomly_rotated_nodes(nodes: &[Arc<Node>]) -> impl Iterator<Item = (NodeRef<'_>, Shard)> {
+    fn randomly_rotated_nodes(nodes: &[Arc<Node>]) -> impl Iterator<Item = NodeRef<'_>> {
         // Create a randomly rotated slice view
         let nodes_len = nodes.len();
         if nodes_len > 0 {
@@ -593,18 +599,24 @@ impl DefaultPolicy {
     }
 
     fn pick_node<'a>(
+        &'a self,
         nodes: &'a [Arc<Node>],
-        predicate: impl Fn(&(NodeRef<'_>, Shard)) -> bool,
+        predicate: impl Fn(&(NodeRef<'a>, Shard)) -> bool,
     ) -> Option<(NodeRef<'_>, Shard)> {
         // Select the first node that matches the predicate
-        Self::randomly_rotated_nodes(nodes).find(predicate)
+        Self::randomly_rotated_nodes(nodes)
+            .map(|node| self.with_random_shard(node))
+            .find(predicate)
     }
 
-    fn round_robin_nodes<'a>(
+    fn round_robin_nodes_with_shards<'a>(
+        &'a self,
         nodes: &'a [Arc<Node>],
-        predicate: impl Fn(&(NodeRef<'_>, Shard)) -> bool,
+        predicate: impl Fn(&(NodeRef<'a>, Shard)) -> bool,
     ) -> impl Iterator<Item = (NodeRef<'_>, Shard)> {
-        Self::randomly_rotated_nodes(nodes).filter(predicate)
+        Self::randomly_rotated_nodes(nodes)
+            .map(|node| self.with_random_shard(node))
+            .filter(predicate)
     }
 
     fn shuffle<'a>(
@@ -613,7 +625,7 @@ impl DefaultPolicy {
     ) -> impl Iterator<Item = (NodeRef<'a>, Shard)> {
         let mut vec: Vec<(NodeRef<'_>, Shard)> = iter.collect();
 
-        if let Some(fixed) = self.fixed_shuffle_seed {
+        if let Some(fixed) = self.fixed_seed {
             let mut gen = Pcg32::new(fixed, 0);
             vec.shuffle(&mut gen);
         } else {
@@ -621,6 +633,22 @@ impl DefaultPolicy {
         }
 
         vec.into_iter()
+    }
+
+    fn with_random_shard<'a>(&self, node: NodeRef<'a>) -> (NodeRef<'a>, Shard) {
+        let nr_shards = node
+            .sharder()
+            .map(|sharder| sharder.nr_shards.get())
+            .unwrap_or(1);
+        (
+            node,
+            (if let Some(fixed) = self.fixed_seed {
+                let mut gen = Pcg32::new(fixed, 0);
+                gen.gen_range(0..nr_shards)
+            } else {
+                thread_rng().gen_range(0..nr_shards)
+            }) as Shard,
+        )
     }
 
     fn is_alive(&(node, _shard): &(NodeRef<'_>, Shard)) -> bool {
@@ -644,7 +672,7 @@ impl Default for DefaultPolicy {
             permit_dc_failover: false,
             pick_predicate: Box::new(Self::is_alive),
             latency_awareness: None,
-            fixed_shuffle_seed: None,
+            fixed_seed: None,
         }
     }
 }
@@ -704,7 +732,7 @@ impl DefaultPolicyBuilder {
             permit_dc_failover: self.permit_dc_failover,
             pick_predicate,
             latency_awareness,
-            fixed_shuffle_seed: (!self.enable_replica_shuffle).then(rand::random),
+            fixed_seed: (!self.enable_replica_shuffle).then(rand::random),
         })
     }
 
@@ -1249,7 +1277,7 @@ mod tests {
                     preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
                     is_token_aware: true,
                     permit_dc_failover: true,
-                    fixed_shuffle_seed: Some(123),
+                    fixed_seed: Some(123),
                     ..Default::default()
                 },
                 routing_info: RoutingInfo {
@@ -1342,7 +1370,7 @@ mod tests {
                     preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
                     is_token_aware: true,
                     permit_dc_failover: true,
-                    fixed_shuffle_seed: Some(123),
+                    fixed_seed: Some(123),
                     ..Default::default()
                 },
                 routing_info: RoutingInfo {
@@ -1588,7 +1616,7 @@ mod tests {
                     ),
                     is_token_aware: true,
                     permit_dc_failover: false,
-                    fixed_shuffle_seed: Some(123),
+                    fixed_seed: Some(123),
                     ..Default::default()
                 },
                 routing_info: RoutingInfo {
@@ -1720,7 +1748,7 @@ mod tests {
                     preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
                     is_token_aware: true,
                     permit_dc_failover: true,
-                    fixed_shuffle_seed: Some(123),
+                    fixed_seed: Some(123),
                     ..Default::default()
                 },
                 routing_info: RoutingInfo {
@@ -1817,7 +1845,7 @@ mod tests {
                     preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
                     is_token_aware: true,
                     permit_dc_failover: true,
-                    fixed_shuffle_seed: Some(123),
+                    fixed_seed: Some(123),
                     ..Default::default()
                 },
                 routing_info: RoutingInfo {
@@ -2074,7 +2102,7 @@ mod tests {
                     ),
                     is_token_aware: true,
                     permit_dc_failover: false,
-                    fixed_shuffle_seed: Some(123),
+                    fixed_seed: Some(123),
                     ..Default::default()
                 },
                 routing_info: RoutingInfo {
@@ -2145,7 +2173,7 @@ mod latency_awareness {
     use tracing::{instrument::WithSubscriber, trace};
     use uuid::Uuid;
 
-    use crate::{load_balancing::NodeRef, transport::node::Node};
+    use crate::{load_balancing::NodeRef, routing::Shard, transport::node::Node};
     use std::{
         collections::HashMap,
         ops::Deref,
@@ -2331,8 +2359,8 @@ mod latency_awareness {
 
         pub(super) fn wrap<'a>(
             &self,
-            fallback: impl Iterator<Item = NodeRef<'a>>,
-        ) -> impl Iterator<Item = NodeRef<'a>> {
+            fallback: impl Iterator<Item = (NodeRef<'a>, Shard)>,
+        ) -> impl Iterator<Item = (NodeRef<'a>, Shard)> {
             let min_avg_latency = match self.last_min_latency.load() {
                 Some(min_avg) => min_avg,
                 None => return Either::Left(fallback), // noop, as no latency data has been collected yet
@@ -2653,8 +2681,8 @@ mod latency_awareness {
 
     struct IteratorWithSkippedNodes<'a, Fast, Penalised>
     where
-        Fast: Iterator<Item = NodeRef<'a>>,
-        Penalised: Iterator<Item = NodeRef<'a>>,
+        Fast: Iterator<Item = (NodeRef<'a>, Shard)>,
+        Penalised: Iterator<Item = (NodeRef<'a>, Shard)>,
     {
         fast_nodes: Fast,
         penalised_nodes: Penalised,
@@ -2663,13 +2691,13 @@ mod latency_awareness {
     impl<'a>
         IteratorWithSkippedNodes<
             'a,
-            std::vec::IntoIter<NodeRef<'a>>,
-            std::vec::IntoIter<NodeRef<'a>>,
+            std::vec::IntoIter<(NodeRef<'a>, Shard)>,
+            std::vec::IntoIter<(NodeRef<'a>, Shard)>,
         >
     {
         fn new(
             average_latencies: &HashMap<Uuid, RwLock<Option<TimestampedAverage>>>,
-            nodes: impl Iterator<Item = NodeRef<'a>>,
+            nodes: impl Iterator<Item = (NodeRef<'a>, Shard)>,
             exclusion_threshold: f64,
             retry_period: Duration,
             minimum_measurements: usize,
@@ -2678,7 +2706,7 @@ mod latency_awareness {
             let mut fast_nodes = vec![];
             let mut penalised_nodes = vec![];
 
-            for node in nodes {
+            for node_and_shard @ (node, _shard) in nodes {
                 match fast_enough(
                     average_latencies,
                     node.host_id,
@@ -2687,11 +2715,11 @@ mod latency_awareness {
                     minimum_measurements,
                     min_avg,
                 ) {
-                    FastEnough::Yes => fast_nodes.push(node),
+                    FastEnough::Yes => fast_nodes.push(node_and_shard),
                     FastEnough::No { average } => {
                         trace!("Latency awareness: Penalising node {{address={}, datacenter={:?}, rack={:?}}} for being on average at least {} times slower (latency: {}ms) than the fastest ({}ms).",
                                 node.address, node.datacenter, node.rack, exclusion_threshold, average.as_millis(), min_avg.as_millis());
-                        penalised_nodes.push(node);
+                        penalised_nodes.push(node_and_shard);
                     }
                 }
             }
@@ -2705,10 +2733,10 @@ mod latency_awareness {
 
     impl<'a, Fast, Penalised> Iterator for IteratorWithSkippedNodes<'a, Fast, Penalised>
     where
-        Fast: Iterator<Item = NodeRef<'a>>,
-        Penalised: Iterator<Item = NodeRef<'a>>,
+        Fast: Iterator<Item = (NodeRef<'a>, Shard)>,
+        Penalised: Iterator<Item = (NodeRef<'a>, Shard)>,
     {
-        type Item = &'a Arc<Node>;
+        type Item = (NodeRef<'a>, Shard);
 
         fn next(&mut self) -> Option<Self::Item> {
             self.fast_nodes
@@ -2803,7 +2831,7 @@ mod latency_awareness {
                 is_token_aware: true,
                 pick_predicate,
                 latency_awareness: Some(latency_awareness),
-                fixed_shuffle_seed: None,
+                fixed_seed: None,
             }
         }
 

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -3,7 +3,7 @@ pub use self::latency_awareness::LatencyAwarenessBuilder;
 
 use super::{FallbackPlan, LoadBalancingPolicy, NodeRef, RoutingInfo};
 use crate::{
-    routing::Token,
+    routing::{Token, Shard},
     transport::{cluster::ClusterData, locator::ReplicaSet, node::Node, topology::Strategy},
 };
 use itertools::{Either, Itertools};
@@ -92,7 +92,7 @@ impl fmt::Debug for DefaultPolicy {
 }
 
 impl LoadBalancingPolicy for DefaultPolicy {
-    fn pick<'a>(&'a self, query: &'a RoutingInfo, cluster: &'a ClusterData) -> Option<NodeRef<'a>> {
+    fn pick<'a>(&'a self, query: &'a RoutingInfo, cluster: &'a ClusterData) -> Option<(NodeRef<'a>, Shard)> {
         let routing_info = self.routing_info(query, cluster);
         if let Some(ref token_with_strategy) = routing_info.token_with_strategy {
             if self.preferences.datacenter().is_some()

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -3,7 +3,7 @@
 //! See [the book](https://rust-driver.docs.scylladb.com/stable/load-balancing/load-balancing.html) for more information
 
 use super::{cluster::ClusterData, NodeRef};
-use crate::routing::{Token, Shard};
+use crate::routing::{Shard, Token};
 use scylla_cql::{errors::QueryError, frame::types};
 
 use std::time::Duration;
@@ -62,7 +62,11 @@ pub type FallbackPlan<'a> = Box<dyn Iterator<Item = (NodeRef<'a>, Shard)> + Send
 /// This trait is used to produce an iterator of nodes to contact for a given query.
 pub trait LoadBalancingPolicy: Send + Sync + std::fmt::Debug {
     /// Returns the first node to contact for a given query.
-    fn pick<'a>(&'a self, query: &'a RoutingInfo, cluster: &'a ClusterData) -> Option<(NodeRef<'a>, Shard)>;
+    fn pick<'a>(
+        &'a self,
+        query: &'a RoutingInfo,
+        cluster: &'a ClusterData,
+    ) -> Option<(NodeRef<'a>, Shard)>;
 
     /// Returns all contact-appropriate nodes for a given query.
     fn fallback<'a>(&'a self, query: &'a RoutingInfo, cluster: &'a ClusterData)

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -3,7 +3,7 @@
 //! See [the book](https://rust-driver.docs.scylladb.com/stable/load-balancing/load-balancing.html) for more information
 
 use super::{cluster::ClusterData, NodeRef};
-use crate::routing::Token;
+use crate::routing::{Token, Shard};
 use scylla_cql::{errors::QueryError, frame::types};
 
 use std::time::Duration;
@@ -39,7 +39,7 @@ pub struct RoutingInfo<'a> {
 ///
 /// It is computed on-demand, only if querying the most preferred node fails
 /// (or when speculative execution is triggered).
-pub type FallbackPlan<'a> = Box<dyn Iterator<Item = NodeRef<'a>> + Send + Sync + 'a>;
+pub type FallbackPlan<'a> = Box<dyn Iterator<Item = (NodeRef<'a>, Shard)> + Send + Sync + 'a>;
 
 /// Policy that decides which nodes to contact for each query.
 ///
@@ -62,7 +62,7 @@ pub type FallbackPlan<'a> = Box<dyn Iterator<Item = NodeRef<'a>> + Send + Sync +
 /// This trait is used to produce an iterator of nodes to contact for a given query.
 pub trait LoadBalancingPolicy: Send + Sync + std::fmt::Debug {
     /// Returns the first node to contact for a given query.
-    fn pick<'a>(&'a self, query: &'a RoutingInfo, cluster: &'a ClusterData) -> Option<NodeRef<'a>>;
+    fn pick<'a>(&'a self, query: &'a RoutingInfo, cluster: &'a ClusterData) -> Option<(NodeRef<'a>, Shard)>;
 
     /// Returns all contact-appropriate nodes for a given query.
     fn fallback<'a>(&'a self, query: &'a RoutingInfo, cluster: &'a ClusterData)

--- a/scylla/src/transport/load_balancing/plan.rs
+++ b/scylla/src/transport/load_balancing/plan.rs
@@ -1,7 +1,7 @@
 use tracing::error;
 
 use super::{FallbackPlan, LoadBalancingPolicy, NodeRef, RoutingInfo};
-use crate::{transport::ClusterData, routing::Shard};
+use crate::{routing::Shard, transport::ClusterData};
 
 enum PlanState<'a> {
     Created,
@@ -113,11 +113,14 @@ mod tests {
     use super::*;
 
     fn expected_nodes() -> Vec<(Arc<Node>, Shard)> {
-        vec![(Arc::new(Node::new_for_test(
-            NodeAddr::Translatable(SocketAddr::from_str("127.0.0.1:9042").unwrap()),
-            None,
-            None,
-        )), todo!())]
+        vec![(
+            Arc::new(Node::new_for_test(
+                NodeAddr::Translatable(SocketAddr::from_str("127.0.0.1:9042").unwrap()),
+                None,
+                None,
+            )),
+            todo!(),
+        )]
     }
 
     #[derive(Debug)]
@@ -138,7 +141,11 @@ mod tests {
             _query: &'a RoutingInfo,
             _cluster: &'a ClusterData,
         ) -> FallbackPlan<'a> {
-            Box::new(self.expected_nodes.iter().map(|(node_ref, shard)| (node_ref, *shard)))
+            Box::new(
+                self.expected_nodes
+                    .iter()
+                    .map(|(node_ref, shard)| (node_ref, *shard)),
+            )
         }
 
         fn name(&self) -> String {
@@ -159,6 +166,9 @@ mod tests {
         };
         let routing_info = RoutingInfo::default();
         let plan = Plan::new(&policy, &routing_info, &cluster_data);
-        assert_eq!(Vec::from_iter(plan.map(|(node, shard)| (node.clone(), shard))), policy.expected_nodes);
+        assert_eq!(
+            Vec::from_iter(plan.map(|(node, shard)| (node.clone(), shard))),
+            policy.expected_nodes
+        );
     }
 }

--- a/scylla/src/transport/load_balancing/plan.rs
+++ b/scylla/src/transport/load_balancing/plan.rs
@@ -119,7 +119,7 @@ mod tests {
                 None,
                 None,
             )),
-            todo!(),
+            42,
         )]
     }
 

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -49,8 +49,9 @@ impl ReplicaLocator {
         let datacenters = replication_data
             .get_global_ring()
             .iter()
-            .filter_map(|(_, node)| node.datacenter.clone())
+            .filter_map(|(_, node)| node.datacenter.as_deref())
             .unique()
+            .map(ToOwned::to_owned)
             .collect();
 
         Self {

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -85,16 +85,20 @@ impl ReplicaLocator {
                 if let Some(datacenter) = datacenter {
                     let replicas = self.get_simple_strategy_replicas(token, *replication_factor);
 
-                    return ReplicaSetInner::FilteredSimple {
-                        replicas,
-                        datacenter,
-                    }
-                    .into();
+                    return ReplicaSet {
+                        inner: ReplicaSetInner::FilteredSimple {
+                            replicas,
+                            datacenter,
+                        },
+                        token,
+                    };
                 } else {
-                    return ReplicaSetInner::Plain(
-                        self.get_simple_strategy_replicas(token, *replication_factor),
-                    )
-                    .into();
+                    return ReplicaSet {
+                        inner: ReplicaSetInner::Plain(
+                            self.get_simple_strategy_replicas(token, *replication_factor),
+                        ),
+                        token,
+                    };
                 }
             }
             Strategy::NetworkTopologyStrategy {
@@ -102,21 +106,28 @@ impl ReplicaLocator {
             } => {
                 if let Some(dc) = datacenter {
                     if let Some(repfactor) = datacenter_repfactors.get(dc) {
-                        return ReplicaSetInner::Plain(
-                            self.get_network_strategy_replicas(token, dc, *repfactor),
-                        )
-                        .into();
+                        return ReplicaSet {
+                            inner: ReplicaSetInner::Plain(
+                                self.get_network_strategy_replicas(token, dc, *repfactor),
+                            ),
+                            token,
+                        };
                     } else {
                         debug!("Datacenter ({}) does not exist!", dc);
-                        return EMPTY_REPLICAS.into();
+                        return ReplicaSet {
+                            inner: ReplicaSetInner::Plain(EMPTY_REPLICAS),
+                            token,
+                        };
                     }
                 } else {
-                    return ReplicaSetInner::ChainedNTS {
-                        datacenter_repfactors,
-                        locator: self,
+                    return ReplicaSet {
+                        inner: ReplicaSetInner::ChainedNTS {
+                            datacenter_repfactors,
+                            locator: self,
+                            token,
+                        },
                         token,
-                    }
-                    .into();
+                    };
                 }
             }
             Strategy::Other { name, .. } => {
@@ -211,6 +222,14 @@ impl ReplicaLocator {
     }
 }
 
+fn with_computed_shard(node: NodeRef, token: Token) -> (NodeRef, Shard) {
+    let shard = node
+        .sharder()
+        .map(|sharder| sharder.shard_of(token))
+        .unwrap_or(0);
+    (node, shard)
+}
+
 #[derive(Debug)]
 enum ReplicaSetInner<'a> {
     Plain(ReplicasArray<'a>),
@@ -238,6 +257,7 @@ enum ReplicaSetInner<'a> {
 #[derive(Debug)]
 pub struct ReplicaSet<'a> {
     inner: ReplicaSetInner<'a>,
+    token: Token,
 }
 
 impl<'a> ReplicaSet<'a> {
@@ -312,14 +332,17 @@ impl<'a> ReplicaSet<'a> {
             let index = rng.gen_range(0..len);
 
             match &self.inner {
-                ReplicaSetInner::Plain(replicas) => replicas.get(index),
+                ReplicaSetInner::Plain(replicas) => replicas
+                    .get(index)
+                    .map(|node| with_computed_shard(node, self.token)),
                 ReplicaSetInner::FilteredSimple {
                     replicas,
                     datacenter,
                 } => replicas
                     .iter()
                     .filter(|node| node.datacenter.as_deref() == Some(datacenter))
-                    .nth(index),
+                    .nth(index)
+                    .map(|node| with_computed_shard(node, self.token)),
                 ReplicaSetInner::ChainedNTS {
                     datacenter_repfactors,
                     locator,
@@ -339,7 +362,8 @@ impl<'a> ReplicaSet<'a> {
                         if nodes_to_skip < repfactor {
                             return locator
                                 .get_network_strategy_replicas(*token, datacenter, repfactor)
-                                .get(nodes_to_skip);
+                                .get(nodes_to_skip)
+                                .map(|node| with_computed_shard(node, self.token));
                         }
 
                         nodes_to_skip -= repfactor;
@@ -400,23 +424,9 @@ impl<'a> IntoIterator for ReplicaSet<'a> {
             }
         };
 
-        ReplicaSetIterator { inner }
-    }
-}
-
-impl<'a> From<ReplicaSetInner<'a>> for ReplicaSet<'a> {
-    fn from(item: ReplicaSetInner<'a>) -> Self {
-        Self { inner: item }
-    }
-}
-
-impl<'a, T> From<T> for ReplicaSet<'a>
-where
-    T: Into<ReplicasArray<'a>>,
-{
-    fn from(item: T) -> Self {
-        Self {
-            inner: ReplicaSetInner::Plain(item.into()),
+        ReplicaSetIterator {
+            inner,
+            token: self.token,
         }
     }
 }
@@ -445,6 +455,7 @@ enum ReplicaSetIteratorInner<'a> {
 /// Iterator that returns replicas from some replica set.
 pub struct ReplicaSetIterator<'a> {
     inner: ReplicaSetIteratorInner<'a>,
+    token: Token,
 }
 
 impl<'a> Iterator for ReplicaSetIterator<'a> {
@@ -455,7 +466,7 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
             ReplicaSetIteratorInner::Plain { replicas, idx } => {
                 if let Some(replica) = replicas.get(*idx) {
                     *idx += 1;
-                    return Some(replica);
+                    return Some(with_computed_shard(replica, self.token));
                 }
 
                 None
@@ -468,7 +479,7 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
                 while let Some(replica) = replicas.get(*idx) {
                     *idx += 1;
                     if replica.datacenter.as_deref() == Some(datacenter) {
-                        return Some(replica);
+                        return Some(with_computed_shard(replica, self.token));
                     }
                 }
 
@@ -484,7 +495,7 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
             } => {
                 if let Some(replica) = replicas.get(*replicas_idx) {
                     *replicas_idx += 1;
-                    Some(replica)
+                    Some(with_computed_shard(replica, self.token))
                 } else if *datacenter_idx + 1 < locator.datacenters.len() {
                     *datacenter_idx += 1;
                     *replicas_idx = 0;
@@ -590,7 +601,12 @@ enum ReplicasOrderedIteratorInner<'a> {
     },
 }
 
-enum ReplicasOrderedNTSIterator<'a> {
+struct ReplicasOrderedNTSIterator<'a> {
+    token: Token,
+    inner: ReplicasOrderedNTSIteratorInner<'a>,
+}
+
+enum ReplicasOrderedNTSIteratorInner<'a> {
     FreshForPick {
         datacenter_repfactors: &'a HashMap<String, usize>,
         locator: &'a ReplicaLocator,
@@ -612,8 +628,8 @@ impl<'a> Iterator for ReplicasOrderedNTSIterator<'a> {
     type Item = (NodeRef<'a>, Shard);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match *self {
-            Self::FreshForPick {
+        match self.inner {
+            ReplicasOrderedNTSIteratorInner::FreshForPick {
                 datacenter_repfactors,
                 locator,
                 token,
@@ -625,19 +641,19 @@ impl<'a> Iterator for ReplicasOrderedNTSIterator<'a> {
                     if let Some(dc) = &node.datacenter {
                         if datacenter_repfactors.get(dc).is_some() {
                             // ...then this node must be the primary replica.
-                            *self = Self::Picked {
+                            self.inner = ReplicasOrderedNTSIteratorInner::Picked {
                                 datacenter_repfactors,
                                 locator,
                                 token,
                                 picked: node,
                             };
-                            return Some(node);
+                            return Some(with_computed_shard(node, self.token));
                         }
                     }
                 }
                 None
             }
-            Self::Picked {
+            ReplicasOrderedNTSIteratorInner::Picked {
                 datacenter_repfactors,
                 locator,
                 token,
@@ -674,19 +690,19 @@ impl<'a> Iterator for ReplicasOrderedNTSIterator<'a> {
                     "all_replicas somehow contained a node that wasn't present in the global ring!"
                 );
 
-                *self = Self::ComputedFallback {
+                self.inner = ReplicasOrderedNTSIteratorInner::ComputedFallback {
                     replicas: ReplicasArray::Owned(replicas_ordered),
                     idx: 0,
                 };
                 self.next()
             }
-            Self::ComputedFallback {
+            ReplicasOrderedNTSIteratorInner::ComputedFallback {
                 ref replicas,
                 ref mut idx,
             } => {
                 if let Some(replica) = replicas.get(*idx) {
                     *idx += 1;
-                    Some(replica)
+                    Some(with_computed_shard(replica, self.token))
                 } else {
                     None
                 }
@@ -728,10 +744,13 @@ impl<'a> IntoIterator for ReplicasOrdered<'a> {
                     locator,
                     token,
                 } => ReplicasOrderedIteratorInner::PolyDatacenterNTS {
-                    replicas_ordered_iter: ReplicasOrderedNTSIterator::FreshForPick {
-                        datacenter_repfactors,
-                        locator,
-                        token,
+                    replicas_ordered_iter: ReplicasOrderedNTSIterator {
+                        token: replica_set.token,
+                        inner: ReplicasOrderedNTSIteratorInner::FreshForPick {
+                            datacenter_repfactors,
+                            locator,
+                            token,
+                        },
                     },
                 },
             },

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 
 /// Node represents a cluster node along with it's data and connections
-use crate::routing::{Sharder, Token};
+use crate::routing::{Shard, Sharder, Token};
 use crate::transport::connection::Connection;
 use crate::transport::connection::VerifiedKeyspaceName;
 use crate::transport::connection_pool::{NodeConnectionPool, PoolConfig};
@@ -139,6 +139,10 @@ impl Node {
 
     pub fn sharder(&self) -> Option<Sharder> {
         self.pool.as_ref()?.sharder()
+    }
+
+    pub(crate) fn shard_for_token(&self, token: Token) -> Option<Shard> {
+        self.sharder().map(|sharder| sharder.shard_of(token))
     }
 
     /// Get connection which should be used to connect using given token

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -146,12 +146,21 @@ impl Node {
     }
 
     /// Get connection which should be used to connect using given token
-    /// If this connection is broken get any random connection to this Node
+    /// If this connection is broken, get any random connection to this `Node`
     pub(crate) async fn connection_for_token(
         &self,
         token: Token,
     ) -> Result<Arc<Connection>, QueryError> {
         self.get_pool()?.connection_for_token(token)
+    }
+
+    /// Get a connection targetting the given shard
+    /// If such connection is broken, get any random connection to this `Node`
+    pub(crate) async fn connection_for_shard(
+        &self,
+        shard: Shard,
+    ) -> Result<Arc<Connection>, QueryError> {
+        self.get_pool()?.connection_for_shard(shard)
     }
 
     /// Get random connection

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -57,7 +57,7 @@ use crate::frame::value::{
 };
 use crate::prepared_statement::{PartitionKeyError, PreparedStatement};
 use crate::query::Query;
-use crate::routing::Token;
+use crate::routing::{Token, Shard};
 use crate::statement::{Consistency, SerialConsistency};
 use crate::tracing::{TracingEvent, TracingInfo};
 use crate::transport::cluster::{Cluster, ClusterData, ClusterNeatDebug};
@@ -1558,16 +1558,16 @@ impl Session {
             // can be shared safely.
             struct SharedPlan<'a, I>
             where
-                I: Iterator<Item = NodeRef<'a>>,
+                I: Iterator<Item = (NodeRef<'a>, Shard)>,
             {
                 iter: std::sync::Mutex<I>,
             }
 
             impl<'a, I> Iterator for &SharedPlan<'a, I>
             where
-                I: Iterator<Item = NodeRef<'a>>,
+                I: Iterator<Item = (NodeRef<'a>, Shard)>,
             {
-                type Item = NodeRef<'a>;
+                type Item = (NodeRef<'a>, Shard);
 
                 fn next(&mut self) -> Option<Self::Item> {
                     self.iter.lock().unwrap().next()
@@ -1694,7 +1694,7 @@ impl Session {
 
     async fn execute_query<'a, ConnFut, QueryFut, ResT>(
         &'a self,
-        query_plan: impl Iterator<Item = NodeRef<'a>>,
+        query_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
         choose_connection: impl Fn(Arc<Node>) -> ConnFut,
         do_query: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
         execution_profile: &ExecutionProfileInner,
@@ -1710,7 +1710,7 @@ impl Session {
             .consistency_set_on_statement
             .unwrap_or(execution_profile.consistency);
 
-        'nodes_in_plan: for node in query_plan {
+        'nodes_in_plan: for (node, shard) in query_plan {
             let span = trace_span!("Executing query", node = %node.address);
             'same_node_retries: loop {
                 trace!(parent: &span, "Execution started");

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -4,9 +4,10 @@ use scylla::execution_profile::{ExecutionProfileBuilder, ExecutionProfileHandle}
 use scylla::load_balancing::{DefaultPolicy, LoadBalancingPolicy, RoutingInfo};
 use scylla::prepared_statement::PreparedStatement;
 use scylla::retry_policy::FallthroughRetryPolicy;
-use scylla::routing::Token;
+use scylla::routing::{Shard, Token};
 use scylla::test_utils::unique_keyspace_name;
 use scylla::transport::session::Session;
+use scylla::transport::NodeRef;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use scylla::statement::batch::BatchStatement;
@@ -374,7 +375,7 @@ impl LoadBalancingPolicy for RoutingInfoReportingWrapper {
         &'a self,
         query: &'a RoutingInfo,
         cluster: &'a scylla::transport::ClusterData,
-    ) -> Option<scylla::transport::NodeRef<'a>> {
+    ) -> Option<(NodeRef<'a>, Shard)> {
         self.routing_info_tx
             .send(OwnedRoutingInfo::from(query.clone()))
             .unwrap();

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -6,6 +6,7 @@ use assert_matches::assert_matches;
 use scylla::batch::BatchStatement;
 use scylla::batch::{Batch, BatchType};
 use scylla::query::Query;
+use scylla::routing::Shard;
 use scylla::statement::SerialConsistency;
 use scylla::transport::NodeRef;
 use scylla::{
@@ -47,9 +48,13 @@ impl<const NODE: u8> BoundToPredefinedNodePolicy<NODE> {
 }
 
 impl<const NODE: u8> LoadBalancingPolicy for BoundToPredefinedNodePolicy<NODE> {
-    fn pick<'a>(&'a self, _info: &'a RoutingInfo, cluster: &'a ClusterData) -> Option<NodeRef<'a>> {
+    fn pick<'a>(
+        &'a self,
+        _info: &'a RoutingInfo,
+        cluster: &'a ClusterData,
+    ) -> Option<(NodeRef<'a>, Shard)> {
         self.report_node(Report::LoadBalancing);
-        cluster.get_nodes_info().iter().next()
+        cluster.get_nodes_info().iter().next().map(|node| (node, 0)) // FIXME: hardcoded shard 0
     }
 
     fn fallback<'a>(


### PR DESCRIPTION
# Motivation
Most of our drivers, being inherited from Cassandra, load balance only over nodes, not specific shards. Multiple ideas have arised that could benefit from having a shard-selecting load balancing. Among them:
- **shard-aware batching** (#738);
- **tablets support**:
with tablets enabled (ATM experimental in ScyllaDB), target shard is derived from token (computed from partition key), but rather read from `system.tablets`. Therefore, a load balancer should be able to decide a target shard on its own, by abstracting over either token ring or tablets being used for cluster topology.
- **overloaded shard optimisation**:
some tests have shown that sometimes, when a shard is particularly overloaded, it may be beneficial (performance-wise) to send the request to the proper node, **but** a wrong shard. That shard would then do part of the work that the overloaded shard would else have to do itself.

# Design
- LB policy now is to return a `(NodeRef, Shard)` pair, enabling finer-grained control over targeted shards.
- regarding tablets support: `ReplicaLocator` is the place where the abstraction over either token ring or tablets is to be implemented. Ideally, the LB policy does not have to be aware of the actual mechanism (token ring or tablets) being used for a particular query.

# What's done
- internal and public load-balancing-related interfaces are changed from `NodeRef` to `(NodeRef, Shard)` pair,
- shard selection logic is removed from `NodeConnectionPool`; a method is added there that returns a connection to a specific shard,
- `Session`'s logic propagates the load balancing policy's target shard down to the connection pool,
- a stub implementation of shard selection is added to `ReplicaLocator`. At the moment, it simply computes the shard based on the token, the same way as it was done in the connection pool layer before.


## Pre-review checklist
- [x] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
