### PR TITLE
codewide: Allow setting Serial,LocalSerial for Consistency

### DIFF
--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -2,8 +2,8 @@
 
 use crate::frame::frame_errors::{FrameError, ParseError};
 use crate::frame::protocol_features::ProtocolFeatures;
-use crate::frame::types::LegacyConsistency;
 use crate::frame::value::SerializeValuesError;
+use crate::Consistency;
 use bytes::Bytes;
 use std::io::ErrorKind;
 use std::sync::Arc;
@@ -108,7 +108,7 @@ pub enum DbError {
     )]
     Unavailable {
         /// Consistency level of the query
-        consistency: LegacyConsistency,
+        consistency: Consistency,
         /// Number of nodes required to be alive to satisfy required consistency level
         required: i32,
         /// Found number of active nodes
@@ -132,7 +132,7 @@ pub enum DbError {
             (consistency: {consistency}, received: {received}, required: {required}, data_present: {data_present})")]
     ReadTimeout {
         /// Consistency level of the query
-        consistency: LegacyConsistency,
+        consistency: Consistency,
         /// Number of nodes that responded to the read request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -146,7 +146,7 @@ pub enum DbError {
             (consistency: {consistency}, received: {received}, required: {required}, write_type: {write_type})")]
     WriteTimeout {
         /// Consistency level of the query
-        consistency: LegacyConsistency,
+        consistency: Consistency,
         /// Number of nodes that responded to the write request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -163,7 +163,7 @@ pub enum DbError {
     )]
     ReadFailure {
         /// Consistency level of the query
-        consistency: LegacyConsistency,
+        consistency: Consistency,
         /// Number of nodes that responded to the read request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -182,7 +182,7 @@ pub enum DbError {
     )]
     WriteFailure {
         /// Consistency level of the query
-        consistency: LegacyConsistency,
+        consistency: Consistency,
         /// Number of nodes that responded to the read request
         received: i32,
         /// Number of nodes required to respond to satisfy required consistency level
@@ -550,7 +550,7 @@ impl WriteType {
 #[cfg(test)]
 mod tests {
     use super::{DbError, QueryError, WriteType};
-    use crate::frame::types::{Consistency, LegacyConsistency};
+    use crate::frame::types::Consistency;
 
     #[test]
     fn write_type_from_str() {
@@ -581,7 +581,7 @@ mod tests {
     fn dberror_full_info() {
         // Test that DbError::Unavailable is displayed correctly
         let db_error = DbError::Unavailable {
-            consistency: LegacyConsistency::Regular(Consistency::Three),
+            consistency: Consistency::Three,
             required: 3,
             alive: 2,
         };

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -112,7 +112,7 @@ mod tests {
                 query::{Query, QueryParameters},
                 DeserializableRequest, SerializableRequest,
             },
-            types::{self, LegacyConsistency, SerialConsistency},
+            types::{self, SerialConsistency},
             value::SerializedValues,
         },
         Consistency,
@@ -236,10 +236,7 @@ mod tests {
 
             // Now buf_ptr points at consistency.
             let consistency = types::read_consistency(&mut buf_ptr).unwrap();
-            assert_eq!(
-                consistency,
-                LegacyConsistency::Regular(Consistency::default())
-            );
+            assert_eq!(consistency, Consistency::default());
 
             // Now buf_ptr points at flags, but it is immutable. Get mutable reference into the buffer.
             let flags_idx = buf.len() - buf_ptr.len();

--- a/scylla-cql/src/frame/response/error.rs
+++ b/scylla-cql/src/frame/response/error.rs
@@ -92,7 +92,6 @@ mod tests {
     use super::Error;
     use crate::errors::{DbError, OperationType, WriteType};
     use crate::frame::protocol_features::ProtocolFeatures;
-    use crate::frame::types::LegacyConsistency;
     use crate::Consistency;
     use bytes::Bytes;
     use std::convert::TryInto;
@@ -151,7 +150,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::Unavailable {
-                consistency: LegacyConsistency::Regular(Consistency::One),
+                consistency: Consistency::One,
                 required: 2,
                 alive: 3,
             }
@@ -178,7 +177,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::WriteTimeout {
-                consistency: LegacyConsistency::Regular(Consistency::Quorum),
+                consistency: Consistency::Quorum,
                 received: -5, // Allow negative values when they don't make sense, it's better than crashing with ProtocolError
                 required: 100,
                 write_type: WriteType::Simple,
@@ -202,7 +201,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::ReadTimeout {
-                consistency: LegacyConsistency::Regular(Consistency::Two),
+                consistency: Consistency::Two,
                 received: 8,
                 required: 32,
                 data_present: false,
@@ -227,7 +226,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::ReadFailure {
-                consistency: LegacyConsistency::Regular(Consistency::Three),
+                consistency: Consistency::Three,
                 received: 4,
                 required: 5,
                 numfailures: 6,
@@ -299,7 +298,7 @@ mod tests {
         assert_eq!(
             error.error,
             DbError::WriteFailure {
-                consistency: LegacyConsistency::Regular(Consistency::Any),
+                consistency: Consistency::Any,
                 received: 2,
                 required: 4,
                 numfailures: 8,

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -10,6 +10,7 @@ use std::convert::TryInto;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::str;
+use thiserror::Error;
 use uuid::Uuid;
 
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
@@ -27,6 +28,11 @@ pub enum Consistency {
     LocalQuorum = 0x0006,
     EachQuorum = 0x0007,
     LocalOne = 0x000A,
+
+    // Apparently, Consistency can be set to Serial or LocalSerial in SELECT statements
+    // to make them use Paxos.
+    Serial = 0x0008,
+    LocalSerial = 0x0009,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
@@ -38,13 +44,34 @@ pub enum SerialConsistency {
     LocalSerial = 0x0009,
 }
 
-// LegacyConsistency exists, because Scylla may return a SerialConsistency value
-// as Consistency when returning certain error types - the distinction between
-// Consistency and SerialConsistency is not really a thing in CQL.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum LegacyConsistency {
-    Regular(Consistency),
-    Serial(SerialConsistency),
+impl Consistency {
+    pub fn is_serial(&self) -> bool {
+        matches!(self, Consistency::Serial | Consistency::LocalSerial)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Expected Consistency Serial or LocalSerial, got: {0}")]
+pub struct NonSerialConsistencyError(Consistency);
+
+impl TryFrom<Consistency> for SerialConsistency {
+    type Error = NonSerialConsistencyError;
+
+    fn try_from(c: Consistency) -> Result<Self, Self::Error> {
+        match c {
+            Consistency::Any
+            | Consistency::One
+            | Consistency::Two
+            | Consistency::Three
+            | Consistency::Quorum
+            | Consistency::All
+            | Consistency::LocalQuorum
+            | Consistency::EachQuorum
+            | Consistency::LocalOne => Err(NonSerialConsistencyError(c)),
+            Consistency::Serial => Ok(SerialConsistency::Serial),
+            Consistency::LocalSerial => Ok(SerialConsistency::LocalSerial),
+        }
+    }
 }
 
 impl std::fmt::Display for Consistency {
@@ -56,15 +83,6 @@ impl std::fmt::Display for Consistency {
 impl std::fmt::Display for SerialConsistency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl std::fmt::Display for LegacyConsistency {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::Regular(c) => c.fmt(f),
-            Self::Serial(c) => c.fmt(f),
-        }
     }
 }
 
@@ -439,18 +457,10 @@ fn type_uuid() {
     assert_eq!(u, u2);
 }
 
-pub fn read_consistency(buf: &mut &[u8]) -> Result<LegacyConsistency, ParseError> {
+pub fn read_consistency(buf: &mut &[u8]) -> Result<Consistency, ParseError> {
     let raw = read_short(buf)?;
-    let parsed = match Consistency::try_from(raw) {
-        Ok(c) => LegacyConsistency::Regular(c),
-        Err(_) => {
-            let parsed_serial = SerialConsistency::try_from(raw).map_err(|_| {
-                ParseError::BadIncomingData(format!("unknown consistency: {}", raw))
-            })?;
-            LegacyConsistency::Serial(parsed_serial)
-        }
-    };
-    Ok(parsed)
+    Consistency::try_from(raw)
+        .map_err(|_| ParseError::BadIncomingData(format!("unknown consistency: {}", raw)))
 }
 
 pub fn write_consistency(c: Consistency, buf: &mut impl BufMut) {
@@ -467,7 +477,7 @@ fn type_consistency() {
     let mut buf = Vec::new();
     write_consistency(c, &mut buf);
     let c2 = read_consistency(&mut &*buf).unwrap();
-    assert_eq!(LegacyConsistency::Regular(c), c2);
+    assert_eq!(c, c2);
 
     let c: i16 = 0x1234;
     buf.clear();

--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -9,7 +9,6 @@ use crate::frame::{
 };
 use scylla_cql::{
     errors::{DbError, WriteType},
-    frame::types::LegacyConsistency,
     Consistency,
 };
 
@@ -427,7 +426,7 @@ impl ExampleDbErrors {
     }
     pub fn unavailable() -> DbError {
         DbError::Unavailable {
-            consistency: LegacyConsistency::Regular(Consistency::One),
+            consistency: Consistency::One,
             required: 2,
             alive: 1,
         }
@@ -443,7 +442,7 @@ impl ExampleDbErrors {
     }
     pub fn read_timeout() -> DbError {
         DbError::ReadTimeout {
-            consistency: LegacyConsistency::Regular(Consistency::One),
+            consistency: Consistency::One,
             received: 2,
             required: 3,
             data_present: true,
@@ -451,7 +450,7 @@ impl ExampleDbErrors {
     }
     pub fn write_timeout() -> DbError {
         DbError::WriteTimeout {
-            consistency: LegacyConsistency::Regular(Consistency::One),
+            consistency: Consistency::One,
             received: 2,
             required: 3,
             write_type: WriteType::UnloggedBatch,
@@ -459,7 +458,7 @@ impl ExampleDbErrors {
     }
     pub fn read_failure() -> DbError {
         DbError::ReadFailure {
-            consistency: LegacyConsistency::Regular(Consistency::One),
+            consistency: Consistency::One,
             received: 2,
             required: 3,
             data_present: true,
@@ -468,7 +467,7 @@ impl ExampleDbErrors {
     }
     pub fn write_failure() -> DbError {
         DbError::WriteFailure {
-            consistency: LegacyConsistency::Regular(Consistency::One),
+            consistency: Consistency::One,
             received: 2,
             required: 3,
             write_type: WriteType::UnloggedBatch,

--- a/scylla/src/history.rs
+++ b/scylla/src/history.rs
@@ -468,7 +468,6 @@ mod tests {
     use futures::StreamExt;
     use scylla_cql::{
         errors::{DbError, QueryError},
-        frame::types::LegacyConsistency,
         Consistency,
     };
 
@@ -576,7 +575,7 @@ mod tests {
     fn unavailable_error() -> QueryError {
         QueryError::DbError(
             DbError::Unavailable {
-                consistency: LegacyConsistency::Regular(Consistency::Quorum),
+                consistency: Consistency::Quorum,
                 required: 2,
                 alive: 1,
             },

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -22,7 +22,6 @@ use super::execution_profile::ExecutionProfileInner;
 use super::session::RequestSpan;
 use crate::cql_to_rust::{FromRow, FromRowError};
 
-use crate::frame::types::LegacyConsistency;
 use crate::frame::{
     response::{
         result,
@@ -572,7 +571,7 @@ where
                 let query_info = QueryInfo {
                     error: &last_error,
                     is_idempotent: self.query_is_idempotent,
-                    consistency: LegacyConsistency::Regular(self.query_consistency),
+                    consistency: self.query_consistency,
                 };
 
                 let retry_decision = self.retry_session.decide_should_retry(query_info);

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -4,7 +4,6 @@
 #[cfg(feature = "cloud")]
 use crate::cloud::CloudConfig;
 
-use crate::frame::types::LegacyConsistency;
 use crate::history;
 use crate::history::HistoryListener;
 use crate::utils::pretty::{CommaSeparatedDisplayer, CqlValueDisplayer};
@@ -1767,11 +1766,9 @@ impl Session {
                 let query_info = QueryInfo {
                     error: the_error,
                     is_idempotent: context.is_idempotent,
-                    consistency: LegacyConsistency::Regular(
-                        context
-                            .consistency_set_on_statement
-                            .unwrap_or(execution_profile.consistency),
-                    ),
+                    consistency: context
+                        .consistency_set_on_statement
+                        .unwrap_or(execution_profile.consistency),
                 };
 
                 let retry_decision = context.retry_session.decide_should_retry(query_info);

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -9,7 +9,6 @@ use scylla::query::Query;
 use scylla::statement::SerialConsistency;
 use scylla::transport::NodeRef;
 use scylla::{
-    frame::types::LegacyConsistency,
     load_balancing::{LoadBalancingPolicy, RoutingInfo},
     retry_policy::{RetryPolicy, RetrySession},
     speculative_execution::SpeculativeExecutionPolicy,
@@ -34,14 +33,14 @@ enum Report {
 #[derive(Debug, Clone)]
 struct BoundToPredefinedNodePolicy<const NODE: u8> {
     profile_reporter: mpsc::UnboundedSender<(Report, u8)>,
-    consistency_reporter: mpsc::UnboundedSender<LegacyConsistency>,
+    consistency_reporter: mpsc::UnboundedSender<Consistency>,
 }
 
 impl<const NODE: u8> BoundToPredefinedNodePolicy<NODE> {
     fn report_node(&self, report: Report) {
         self.profile_reporter.send((report, NODE)).unwrap();
     }
-    fn report_consistency(&self, c: LegacyConsistency) {
+    fn report_consistency(&self, c: Consistency) {
         self.consistency_reporter.send(c).unwrap();
     }
 }
@@ -260,55 +259,55 @@ async fn test_execution_profiles() {
         // Run non-LWT on default per-session execution profile
         session.query(query.clone(), &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::One));
+        assert_matches!(report_consistency, Consistency::One);
         consistency_rx.try_recv().unwrap_err();
 
         session.execute(&prepared, &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::One));
+        assert_matches!(report_consistency, Consistency::One);
         consistency_rx.try_recv().unwrap_err();
 
         session.batch(&batch, ((),)).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::One));
+        assert_matches!(report_consistency, Consistency::One);
         consistency_rx.try_recv().unwrap_err();
 
         // Run on statement-specific execution profile
         query.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.query(query.clone(), &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Two));
+        assert_matches!(report_consistency, Consistency::Two);
         consistency_rx.try_recv().unwrap_err();
 
         prepared.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.execute(&prepared, &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Two));
+        assert_matches!(report_consistency, Consistency::Two);
         consistency_rx.try_recv().unwrap_err();
 
         batch.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.batch(&batch, ((),)).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Two));
+        assert_matches!(report_consistency, Consistency::Two);
         consistency_rx.try_recv().unwrap_err();
 
         // Run with statement-set specific options
         query.set_consistency(Consistency::Three);
         session.query(query.clone(), &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Three));
+        assert_matches!(report_consistency, Consistency::Three);
         consistency_rx.try_recv().unwrap_err();
 
         prepared.set_consistency(Consistency::Three);
         session.execute(&prepared, &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Three));
+        assert_matches!(report_consistency, Consistency::Three);
         consistency_rx.try_recv().unwrap_err();
 
         batch.set_consistency(Consistency::Three);
         session.batch(&batch, ((),)).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
-        assert_matches!(report_consistency, LegacyConsistency::Regular(Consistency::Three));
+        assert_matches!(report_consistency, Consistency::Three);
         consistency_rx.try_recv().unwrap_err();
 
         for i in 0..=2 {


### PR DESCRIPTION
# Motivation
See #736.

# What's done
- `Consistency` is extended with `Serial` and `LocalSerial` to support reading using Paxos (SELECT statements),
- `LegacyConsistency` is removed altogether,
- a test is added that performs such a Paxos read.

Fixes: #736

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
