### PR TITLE
dev-deps: downgrade criterion to 0.4

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = "0.1.57"
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.4" # Note: v0.5 needs at least rust 1.70.0
 
 [[bench]]
 name = "benchmark"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -56,7 +56,7 @@ socket2 = { version = "0.5.3", features = ["all"] }
 [dev-dependencies]
 scylla-proxy = { version = "0.0.3", path = "../scylla-proxy" }
 ntest = "0.9.0"
-criterion = "0.5"
+criterion = "0.4" # Note: v0.5 needs at least rust 1.70.0
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 assert_matches = "1.5.0"
 rand_chacha = "0.3.1"


### PR DESCRIPTION
The `criterion` library, since version 0.5, depends on `clap` v4 or higher. Recently, `clap` 4.4.0 has been released which has bumped its required MSRV to 1.70.0. Our MSRV is still 1.65.0. Apparently, the cargo resolver isn't smart enough to choose an older version of `clap` which still supports 1.65.0, so this breaks our MSRV build in CI (see rust-lang/cargo#9930).

In order to unblock the CI without checking in Cargo.toml - which would be annoying - the `criterion` dependency is downgraded to 0.4. This library is only used for benchmarks and is a dev-dependency, so it's not a big deal. No changes in the code are necessary.

In the future, if we decide to bump MSRV to 1.70.0 or further, we can update the dependency.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
