### PR TITLE
query: remove obsolete leftover TODO

### DIFF
--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 pub struct Query {
     pub(crate) config: StatementConfig,
 
-    // TODO: Move this after #701 is fixed
     pub contents: String,
     page_size: Option<i32>,
 }


### PR DESCRIPTION
Even though #701 was fixed with #772, a TODO was left. Now it misleadingly points to `contents`. It is thus removed.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
