### PR TITLE
treewide: appease clippy and the deprecation warnings

### DIFF
--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -557,7 +557,7 @@ mod tests {
             .unwrap()
             .and_hms_opt(2, 0, 0)
             .unwrap();
-        let datetime_utc = DateTime::<Utc>::from_utc(naivedatetime_utc, Utc);
+        let datetime_utc = DateTime::<Utc>::from_naive_utc_and_offset(naivedatetime_utc, Utc);
 
         assert_eq!(
             datetime_utc,

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -142,7 +142,7 @@ fn write_int_length(v: usize, buf: &mut impl BufMut) -> Result<(), ParseError> {
 
 #[test]
 fn type_int() {
-    let vals = vec![i32::MIN, -1, 0, 1, i32::MAX];
+    let vals = [i32::MIN, -1, 0, 1, i32::MAX];
     for val in vals.iter() {
         let mut buf = Vec::new();
         write_int(*val, &mut buf);
@@ -161,7 +161,7 @@ pub fn write_long(v: i64, buf: &mut impl BufMut) {
 
 #[test]
 fn type_long() {
-    let vals = vec![i64::MIN, -1, 0, 1, i64::MAX];
+    let vals = [i64::MIN, -1, 0, 1, i64::MAX];
     for val in vals.iter() {
         let mut buf = Vec::new();
         write_long(*val, &mut buf);
@@ -192,7 +192,7 @@ fn write_short_length(v: usize, buf: &mut impl BufMut) -> Result<(), ParseError>
 
 #[test]
 fn type_short() {
-    let vals = vec![i16::MIN, -1, 0, 1, i16::MAX];
+    let vals = [i16::MIN, -1, 0, 1, i16::MAX];
     for val in vals.iter() {
         let mut buf = Vec::new();
         write_short(*val, &mut buf);

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -125,7 +125,7 @@ fn datetime_serialization() {
             ((*test_val % 1000) as i32 * 1_000_000) as u32,
         )
         .expect("invalid or out-of-range datetime");
-        let test_datetime = DateTime::<Utc>::from_utc(native_datetime, Utc);
+        let test_datetime = DateTime::<Utc>::from_naive_utc_and_offset(native_datetime, Utc);
         let bytes: Vec<u8> = serialized(test_datetime);
 
         let mut expected_bytes: Vec<u8> = vec![0, 0, 0, 8];

--- a/scylla/src/history.rs
+++ b/scylla/src/history.rs
@@ -475,7 +475,7 @@ mod tests {
     // HistoryCollector sets the timestamp to current time which changes with each test.
     // Setting it to one makes it possible to test displaying consistently.
     fn set_one_time(mut history: StructuredHistory) -> StructuredHistory {
-        let the_time: TimePoint = DateTime::<Utc>::from_utc(
+        let the_time: TimePoint = DateTime::<Utc>::from_naive_utc_and_offset(
             NaiveDateTime::new(
                 NaiveDate::from_ymd_opt(2022, 2, 22).unwrap(),
                 NaiveTime::from_hms_opt(20, 22, 22).unwrap(),

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -646,7 +646,7 @@ async fn test_use_keyspace() {
         )))
     ));
 
-    let long_name: String = vec!['a'; 49].iter().collect();
+    let long_name: String = ['a'; 49].iter().collect();
     assert!(matches!(
         session.use_keyspace(long_name, false).await,
         Err(QueryError::BadQuery(BadQuery::BadKeyspaceName(


### PR DESCRIPTION
This time, we've got a double whammy:

- `clippy` version has been bumped up in GitHub's CI runner, which introduced new lints that are failing for our codebase,
- New version of `chrono` has been released which deprecates `DateTime::from_utc`.

This PR addresses both of the issues, making the CI green again.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
