### PR TITLE
Quietly prepare unprepared query

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -657,6 +657,20 @@ impl Connection {
     ) -> Result<QueryResponse, QueryError> {
         let serialized_values = values.serialized()?;
 
+        let values_size = serialized_values.size();
+        if values_size != 0 {
+            let prepared = self.prepare(query).await?;
+            return self
+                .execute_with_consistency(
+                    &prepared,
+                    values,
+                    consistency,
+                    serial_consistency,
+                    paging_state,
+                )
+                .await;
+        }
+
         let query_frame = query::Query {
             contents: Cow::Borrowed(&query.contents),
             parameters: query::QueryParameters {

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -5,4 +5,5 @@ mod lwt_optimisation;
 mod new_session;
 mod retries;
 mod shards;
+mod silent_prepare_query;
 pub(crate) mod utils;

--- a/scylla/tests/integration/retries.rs
+++ b/scylla/tests/integration/retries.rs
@@ -46,7 +46,7 @@ async fn speculative_execution_is_fired() {
         q.set_is_idempotent(true); // this is to allow speculative execution to fire
 
         let drop_frame_rule = RequestRule(
-            Condition::RequestOpcode(RequestOpcode::Query)
+            Condition::RequestOpcode(RequestOpcode::Prepare)
                 .and(Condition::BodyContainsCaseSensitive(Box::new(*b"t"))),
             RequestReaction::drop_frame(),
         );
@@ -121,7 +121,7 @@ async fn retries_occur() {
         q.set_is_idempotent(true); // this is to allow retry to fire
 
         let forge_error_rule = RequestRule(
-            Condition::RequestOpcode(RequestOpcode::Query)
+            Condition::RequestOpcode(RequestOpcode::Prepare)
                 .and(Condition::BodyContainsCaseSensitive(Box::new(*b"INTO t"))),
             RequestReaction::forge().server_error(),
         );

--- a/scylla/tests/integration/silent_prepare_query.rs
+++ b/scylla/tests/integration/silent_prepare_query.rs
@@ -1,0 +1,110 @@
+use crate::utils::test_with_3_node_cluster;
+use scylla::transport::session::Session;
+use scylla::SessionBuilder;
+use scylla::{query::Query, test_utils::unique_keyspace_name};
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, ShardAwareness,
+    WorkerError,
+};
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test]
+#[ntest::timeout(30000)]
+#[cfg(not(scylla_cloud_tests))]
+async fn test_prepare_query_with_values() {
+    // unprepared query with non empty values should be prepared
+    const TIMEOUT_PER_REQUEST: Duration = Duration::from_millis(1000);
+
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
+        // DB preparation phase
+        let session: Session = SessionBuilder::new()
+            .known_node(proxy_uris[0].as_str())
+            .address_translator(Arc::new(translation_map))
+            .build()
+            .await
+            .unwrap();
+
+        let ks = unique_keyspace_name();
+        session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks), &[]).await.unwrap();
+        session.use_keyspace(ks, false).await.unwrap();
+        session
+            .query("CREATE TABLE t (a int primary key)", &[])
+            .await
+            .unwrap();
+
+        let q = Query::from("INSERT INTO t (a) VALUES (?)");
+
+        let drop_unprepared_frame_rule = RequestRule(
+            Condition::RequestOpcode(RequestOpcode::Query)
+                .and(Condition::BodyContainsCaseSensitive(Box::new(*b"t"))),
+            RequestReaction::drop_frame(),
+        );
+
+        running_proxy.running_nodes[2]
+        .change_request_rules(Some(vec![drop_unprepared_frame_rule]));
+
+        tokio::select! {
+            _res = session.query(q, (0,)) => (),
+            _ = tokio::time::sleep(TIMEOUT_PER_REQUEST) => panic!("Rules did not work: no received response"),
+        };
+
+        running_proxy
+    }).await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+#[tokio::test]
+#[ntest::timeout(30000)]
+#[cfg(not(scylla_cloud_tests))]
+async fn test_query_with_no_values() {
+    // unprepared query with empty values should not be prepared
+    const TIMEOUT_PER_REQUEST: Duration = Duration::from_millis(1000);
+
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
+        // DB preparation phase
+        let session: Session = SessionBuilder::new()
+            .known_node(proxy_uris[0].as_str())
+            .address_translator(Arc::new(translation_map))
+            .build()
+            .await
+            .unwrap();
+
+        let ks = unique_keyspace_name();
+        session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks), &[]).await.unwrap();
+        session.use_keyspace(ks, false).await.unwrap();
+        session
+            .query("CREATE TABLE t (a int primary key)", &[])
+            .await
+            .unwrap();
+
+        let q = Query::from("INSERT INTO t (a) VALUES (1)");
+
+        let drop_prepared_frame_rule = RequestRule(
+            Condition::RequestOpcode(RequestOpcode::Prepare)
+                .and(Condition::BodyContainsCaseSensitive(Box::new(*b"t"))),
+            RequestReaction::drop_frame(),
+        );
+
+        running_proxy.running_nodes[2]
+        .change_request_rules(Some(vec![drop_prepared_frame_rule]));
+
+        tokio::select! {
+            _res = session.query(q, ()) => (),
+            _ = tokio::time::sleep(TIMEOUT_PER_REQUEST) => panic!("Rules did not work: no received response"),
+        };
+
+        running_proxy
+    }).await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}


### PR DESCRIPTION
## Motivation
See the referenced issue (#800)

## What's done
Information about the types of the bind markers is necessary to make the serialization API safe (i.e. so that the user data won't be misinterpreted when sending it to the database). The problem with unprepared statements is that the driver doesn't have a good way to determine column names and types of the bind markers.

Now before sending an unprepared statement, it is quietly prepared on one connection to obtain the information about the bind markers. If the list of values to be bound is empty, we just send it as an unprepared query.

## Evaluation
Integration tests are added.

Refs: #800 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
