### PR TITLE
Bump verrsion of chrono dependency

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -21,7 +21,7 @@ uuid = "1.0"
 thiserror = "1.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.27", default-features = false }
 lz4_flex = { version = "0.11.1" }
 async-trait = "0.1.57"
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
In scylla-cql/src/frame/response/cql_to_rust.rs we use `DateTime::<Utc>::from_naive_utc_and_offset` but it was introduced in chrono 0.4.27. This PR bumps this dependency to correct version.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
