### PR TITLE
Add additional tracing fields specific to Scylla

### DIFF
--- a/docs/source/tracing/tracing.md
+++ b/docs/source/tracing/tracing.md
@@ -17,7 +17,8 @@ Queries that support tracing:
 * [`Session::prepare()`](prepare.md)
 
 After obtaining the tracing id you can use `Session::get_tracing_info()` to query tracing information.\
-`TracingInfo` contains values that are the same in Scylla and Cassandra®, skipping any database-specific ones.\
+`Session::get_tracing_info()` returns a `TracingInfo` which only contains values that are the same
+in both Scylla and Cassandra®, skipping any database-specific ones.\
 If `TracingInfo` does not contain some needed value it's possible to query it manually from the tables
 `system_traces.sessions` and `system_traces.events`
 

--- a/scylla/src/tracing.rs
+++ b/scylla/src/tracing.rs
@@ -18,6 +18,12 @@ pub struct TracingInfo {
     pub request: Option<String>,
     /// started_at is a timestamp - time since unix epoch
     pub started_at: Option<chrono::Duration>,
+    /// only present in Scylla
+    pub request_size: Option<i32>,
+    /// only present in Scylla
+    pub response_size: Option<i32>,
+    /// only present in Scylla
+    pub username: Option<String>,
 
     pub events: Vec<TracingEvent>,
 }
@@ -30,6 +36,10 @@ pub struct TracingEvent {
     pub source: Option<IpAddr>,
     pub source_elapsed: Option<i32>,
     pub thread: Option<String>,
+    /// only present in Scylla
+    pub scylla_parent_id: Option<i64>,
+    /// only present in Scylla
+    pub scylla_span_id: Option<i64>,
 }
 
 impl TracingInfo {
@@ -75,6 +85,9 @@ impl FromRow for TracingInfo {
             parameters,
             request,
             started_at,
+            request_size: None,
+            response_size: None,
+            username: None,
             events: Vec::new(),
         })
     }
@@ -97,6 +110,8 @@ impl FromRow for TracingEvent {
             source,
             source_elapsed,
             thread,
+            scylla_parent_id: None,
+            scylla_span_id: None,
         })
     }
 }


### PR DESCRIPTION
Introduction of some new struct fields that express the additional fields that are present in the
Scylla schemas for `system_traces.sessions` and `system_traces.events`.

Since I was unable to write a `FromRow` implementation that I was happy with in any form, the
provided implementation will perform conversion for only the fields present in both databases.
This therefore also stands for `Session::get_tracing_info`, where the documentation has been
updated.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
    If there's any feedback about what kind of tests should be added for this type of change let me know and I'll do them.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
