### PR TITLE
examples: fix clippy's complaints about redundant_locals

### DIFF
--- a/examples/parallel-prepared.rs
+++ b/examples/parallel-prepared.rs
@@ -41,7 +41,6 @@ async fn main() -> Result<()> {
         let prepared = prepared.clone();
         let permit = sem.clone().acquire_owned().await;
         tokio::task::spawn(async move {
-            let i = i;
             session
                 .execute(&prepared, (i as i32, 2 * i as i32))
                 .await

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -33,7 +33,6 @@ async fn main() -> Result<()> {
         let session = session.clone();
         let permit = sem.clone().acquire_owned().await;
         tokio::task::spawn(async move {
-            let i = i;
             session
                 .query(
                     format!(


### PR DESCRIPTION
Rust 1.73 got released very recently and introduced a new version of clippy, with new lints. The `parallel` and `parallel-prepared` examples contain code which redefines a local variable:

```
for i in 0..100_000usize {
    // ...
    tokio::task::spawn(async move {
        let i = i;
        // ...
    });
}
```

This is completely unnecesary and can be removed, as per clippy's suggestion:

```
error: redundant redefinition of a binding
  --> examples/parallel-prepared.rs:36:9
   |
36 |     for i in 0..100_000usize {
   |         ^
...
44 |             let i = i;
   |             ^^^^^^^^^^
   |
   = help: remove the redefinition of `i`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_locals
   = note: `#[deny(clippy::redundant_locals)]` on by default
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
