### PR TITLE
workspace: set resolver = 2 in the root Cargo.toml manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ members = [
     "scylla-cql",
     "scylla-proxy",
 ]
+resolver = "2"


### PR DESCRIPTION
Running `cargo check` using `rust 1.73` prints the following warning message:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
```

Documentation about resolver versions can be found here: https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

Let's use the newer resolver in the whole workspace. The newer resolver is the default that Rust uses since edition 2021.

It also gets rid of the annoying warning.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
