### PR TITLE
test_coalescing: improve error handling

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1833,6 +1833,7 @@ mod tests {
     use super::ConnectionConfig;
     use crate::query::Query;
     use crate::transport::connection::open_connection;
+    use crate::transport::connection::QueryResponse;
     use crate::transport::node::ResolvedContactPoint;
     use crate::transport::topology::UntranslatedEndpoint;
     use crate::utils::test_utils::unique_keyspace_name;
@@ -2024,9 +2025,13 @@ mod tests {
                         let q = Query::new("INSERT INTO t (p, v) VALUES (?, ?)");
                         let conn = conn.clone();
                         async move {
-                            conn.query(&q, (j, vec![j as u8; j as usize]), None)
+                            let response: QueryResponse = conn
+                                .query(&q, (j, vec![j as u8; j as usize]), None)
                                 .await
                                 .unwrap();
+                            // QueryResponse might contain an error - make sure that there were no errors
+                            let _nonerror_response =
+                                response.into_non_error_query_response().unwrap();
                         }
                     });
                     let _joined: Vec<()> = futures::future::join_all(futs).await;

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -2026,16 +2026,16 @@ mod tests {
                         async move {
                             conn.query(&q, (j, vec![j as u8; j as usize]), None)
                                 .await
-                                .unwrap()
+                                .unwrap();
                         }
                     });
-                    futures::future::join_all(futs).await;
+                    let _joined: Vec<()> = futures::future::join_all(futs).await;
                 }));
 
                 tokio::task::yield_now().await;
             }
 
-            futures::future::join_all(futs).await;
+            let _joined: Vec<()> = futures::future::try_join_all(futs).await.unwrap();
 
             // Check that everything was written properly
             let range_end = arithmetic_sequence_sum(NUM_BATCHES);


### PR DESCRIPTION
`test_coalescing` spawns a lot of tokio tasks, each of which runs a query on the database.
If a query fails, the task will panic because of the `unwrap()`.

The problem is that all of the tasks are joined using `join_all`, which doesn't check for errors in the joined tasks.
For example, this piece of code prints "Ok!" and the program finishes successfuly:
```rust
let mut tasks = Vec::new();
for _i in 0..4 {
    tasks.push(tokio::spawn(async { panic!("Panic!") }));
}

futures::future::join_all(tasks).await;

println!("Ok!");
```
There are some error messages in the output, but the important thig is that they don't stop the control flow.

To fix it, let's use `try_join_all` instead of `join_all`. `try_join_all` will check whether the task panicked or not, and return an error if there was a panic.

I manually tested that it works by inserting a panic!() after `conn.query()`.

Let's also make sure that the result of join_all doesn't contain any `Result<>`, as it could hide the errors. The result of `join_all` should be just a `Vec<>` of unit values.
    
The PR also adds a check that `Connection::query` didn't return `QueryResponse::Error`. It is required to check it in order to ensure that the query didn't fail.

Refs: https://github.com/scylladb/scylla-rust-driver/issues/828

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
