### PR TITLE
Dereference `datacenter` of type `&&str` when comparing with `&str`

### DIFF
--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -275,7 +275,7 @@ impl<'a> ReplicaSet<'a> {
                 datacenter,
             } => replicas
                 .iter()
-                .filter(|node| node.datacenter.as_deref() == Some(datacenter))
+                .filter(|node| node.datacenter.as_deref() == Some(*datacenter))
                 .count(),
             ReplicaSetInner::ChainedNTS {
                 datacenter_repfactors,
@@ -317,7 +317,7 @@ impl<'a> ReplicaSet<'a> {
                     datacenter,
                 } => replicas
                     .iter()
-                    .filter(|node| node.datacenter.as_deref() == Some(datacenter))
+                    .filter(|node| node.datacenter.as_deref() == Some(*datacenter))
                     .nth(index),
                 ReplicaSetInner::ChainedNTS {
                     datacenter_repfactors,
@@ -466,7 +466,7 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
             } => {
                 while let Some(replica) = replicas.get(*idx) {
                     *idx += 1;
-                    if replica.datacenter.as_deref() == Some(datacenter) {
+                    if replica.datacenter.as_deref() == Some(*datacenter) {
                         return Some(replica);
                     }
                 }


### PR DESCRIPTION
I encountered a compile error when updating from `0.7.0` to `0.10.1`:


```rs
error[E0277]: can't compare `Option<&str>` with `Option<&&str>`
   --> /Users/oeb25/.cargo/registry/src/index.crates.io-6f17d22bba15001f/scylla-0.10.1/src/transport/locator/mod.rs:278:59
    |
278 |                 .filter(|node| node.datacenter.as_deref() == Some(datacenter))
    |                                                           ^^ no implementation for `Option<&str> == Option<&&str>`
    |
    = help: the trait `PartialEq<Option<&&str>>` is not implemented for `Option<&str>`
    = help: the following other types implement trait `PartialEq<Rhs>`:
              <Option<Box<U>> as PartialEq<rkyv::niche::option_box::ArchivedOptionBox<T>>>
              <Option<T> as PartialEq>
              <Option<U> as PartialEq<rkyv::option::ArchivedOption<T>>>
```

<details>
<summary><i>Two more similar errors</i></summary>

```rs
error[E0277]: can't compare `Option<&str>` with `Option<&&str>`
   --> /Users/oeb25/.cargo/registry/src/index.crates.io-6f17d22bba15001f/scylla-0.10.1/src/transport/locator/mod.rs:320:63
    |
320 |                     .filter(|node| node.datacenter.as_deref() == Some(datacenter))
    |                                                               ^^ no implementation for `Option<&str> == Option<&&str>`
    |
    = help: the trait `PartialEq<Option<&&str>>` is not implemented for `Option<&str>`
    = help: the following other types implement trait `PartialEq<Rhs>`:
              <Option<Box<U>> as PartialEq<rkyv::niche::option_box::ArchivedOptionBox<T>>>
              <Option<T> as PartialEq>
              <Option<U> as PartialEq<rkyv::option::ArchivedOption<T>>>

error[E0277]: can't compare `Option<&str>` with `Option<&mut &str>`
   --> /Users/oeb25/.cargo/registry/src/index.crates.io-6f17d22bba15001f/scylla-0.10.1/src/transport/locator/mod.rs:469:54
    |
469 |                     if replica.datacenter.as_deref() == Some(datacenter) {
    |                                                      ^^ no implementation for `Option<&str> == Option<&mut &str>`
    |
    = help: the trait `PartialEq<Option<&mut &str>>` is not implemented for `Option<&str>`
    = help: the following other types implement trait `PartialEq<Rhs>`:
              <Option<Box<U>> as PartialEq<rkyv::niche::option_box::ArchivedOptionBox<T>>>
              <Option<T> as PartialEq>
              <Option<U> as PartialEq<rkyv::option::ArchivedOption<T>>>
```

</details>

When building this repo by itself the error does not occur, which I do not understand, and I'd love to know why if anybody can figure it out. Here's [the commit to reproduce](https://github.com/oeb25/stract/commit/70acab5dad6bbc1f182a1094d58f4d566c13db14).

Introducing these dereferences should not change anything for already working code, but should hopefully fix the issue encountered above.

---

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
