### PR TITLE
examples/execution_profile: fix usage of illegal consistency

### DIFF
--- a/examples/execution_profile.rs
+++ b/examples/execution_profile.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     println!("Connecting to {} ...", uri);
 
     let profile1 = ExecutionProfile::builder()
-        .consistency(Consistency::EachQuorum)
+        .consistency(Consistency::LocalQuorum)
         .serial_consistency(Some(SerialConsistency::Serial))
         .request_timeout(Some(Duration::from_secs(42)))
         .load_balancing_policy(Arc::new(load_balancing::DefaultPolicy::default()))


### PR DESCRIPTION
The example in `execution_profile.rs` tried to send a read request using consistency `EACH_QUORUM`.
This doesn't work, the query failed with the following message:
```
Error: Database returned an error: The query is syntactically correct but invalid, Error message: EACH_QUORUM ConsistencyLevel is only supported for writes
```
Examples shouldn't fail. Let's fix it by changing `EachQuorum` to `LocalQuorum` which can be used in SELECTs.
After this change the example doesn't fail.

It still demonstrates how to create an execution profile with a custom consistency level, it doesn't matter what consistency level is used.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/835

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
