### PR TITLE
add workflow to run examples in ci

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,87 @@
+# This workflow runs all driver examples to ensure that they run without errors
+name: Examples
+
+on:
+  push:
+    branches:
+    - main
+    - 'branch-*'
+  pull_request:
+    branches:
+    - main
+    - 'branch-*'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      scylladb:
+        image: scylladb/scylla
+        ports:
+          - 9042:9042
+        options:
+          --health-cmd "cqlsh --debug"
+          --health-interval 5s
+          --health-retries 10
+    env:
+      working-directory: ./scylla
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check
+      run: cargo check --verbose --features "ssl"
+      working-directory: ${{env.working-directory}}
+    - name: Run allocations example
+      run: cargo run --example allocations
+    - name: Run auth example
+      run: cargo run --example auth
+    - name: Run basic example
+      run: cargo run --example basic
+    # - name: Run cloud example
+    #   run: cargo run --example cloud
+    - name: Run compare-tokens example
+      run: cargo run --example compare-tokens
+    - name: Run cql-time-types example
+      run: cargo run --example cql-time-types
+    - name: Run cqlsh-rs example
+      run: cargo run --example cqlsh-rs
+    - name: Run custom_deserialization example
+      run: cargo run --example custom_deserialization
+    - name: Run custom_load_balancing_policy example
+      run: cargo run --example custom_load_balancing_policy
+    - name: Run execution_profile example
+      run: cargo run --example execution_profile
+    - name: Run get_by_name example
+      run: cargo run --example get_by_name
+    - name: Run logging example
+      run: cargo run --example logging
+    - name: Run parallel-prepared example
+      run: cargo run --example parallel-prepared
+    - name: Run parallel example
+      run: cargo run --example parallel
+    - name: Run query_history example
+      run: cargo run --example query_history
+    - name: Run custom_load_balancing_policy example
+      run: cargo run --example custom_load_balancing_policy
+    - name: Run schema_agreement example
+      run: cargo run --example schema_agreement
+    - name: Run select-paging example
+      run: cargo run --example select-paging
+    - name: Run select-paging example
+      run: cargo run --example select-paging
+    - name: Run speculative-execution example
+      run: cargo run --example speculative-execution
+    # - name: Run tls example
+    #   run: cargo run --example tls
+    - name: Run tower example
+      run: cargo run --example tower
+    - name: Run custom_load_balancing_policy example
+      run: cargo run --example custom_load_balancing_policy
+    - name: Run user-defined-type example
+      run: cargo run --example user-defined-type
+    - name: Run value_list example
+      run: cargo run --example value_list


### PR DESCRIPTION
https://github.com/scylladb/scylla-rust-driver/issues/839 suggested putting examples into into CI. I took a look into doing so on my own fork. As @piodul pointed out, these examples are not all fundamentally similar. This PR excludes the `cloud` and `tls` examples since it seems like the `cloud` credentials may need to be reviewed and the `tls` example already runs in CI against a specific `tls` image.

Furthermore, when running all examples in series, tables persist between example runs causing errors when tables share names. See https://github.com/scylladb/scylla-rust-driver/issues/844

Possible fix for https://github.com/scylladb/scylla-rust-driver/issues/839

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
