### PR TITLE
Explicit table naming in examples to prevent errors from shared tables across examples

### DIFF
--- a/examples/allocations.rs
+++ b/examples/allocations.rs
@@ -131,12 +131,12 @@ async fn main() -> Result<()> {
     let session: Session = SessionBuilder::new().known_node(args.node).build().await?;
     let session = Arc::new(session);
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
     session.await_schema_agreement().await.unwrap();
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.alloc_test (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.allocations (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
@@ -145,13 +145,13 @@ async fn main() -> Result<()> {
 
     let prepared_inserts = Arc::new(
         session
-            .prepare("INSERT INTO ks.alloc_test (a, b, c) VALUES (?, ?, 'abc')")
+            .prepare("INSERT INTO examples_ks.allocations (a, b, c) VALUES (?, ?, 'abc')")
             .await?,
     );
 
     let prepared_selects = Arc::new(
         session
-            .prepare("SELECT * FROM ks.alloc_test WHERE a = ? and b = ?")
+            .prepare("SELECT * FROM examples_ks.allocations WHERE a = ? and b = ?")
             .await?,
     );
 

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -14,9 +14,9 @@ async fn main() -> Result<()> {
         .await
         .unwrap();
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
     session
-        .query("DROP TABLE IF EXISTS ks.t;", &[])
+        .query("DROP TABLE IF EXISTS examples_ks.auth;", &[])
         .await
         .unwrap();
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,25 +12,31 @@ async fn main() -> Result<()> {
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.basic (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
 
     session
-        .query("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)", (3, 4, "def"))
+        .query(
+            "INSERT INTO examples_ks.basic (a, b, c) VALUES (?, ?, ?)",
+            (3, 4, "def"),
+        )
         .await?;
 
     session
-        .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')", &[])
+        .query(
+            "INSERT INTO examples_ks.basic (a, b, c) VALUES (1, 2, 'abc')",
+            &[],
+        )
         .await?;
 
     let prepared = session
-        .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, 7, ?)")
+        .prepare("INSERT INTO examples_ks.basic (a, b, c) VALUES (?, 7, ?)")
         .await?;
     session
         .execute(&prepared, (42_i32, "I'm prepared!"))
@@ -43,7 +49,11 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT a, b, c FROM examples_ks.basic", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(i32, i32, String)>() {
             let (a, b, c) = row?;
             println!("a, b, c: {}, {}, {}", a, b, c);
@@ -58,7 +68,11 @@ async fn main() -> Result<()> {
         _c: String,
     }
 
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT a, b, c FROM examples_ks.basic", &[])
+        .await?
+        .rows
+    {
         for row_data in rows.into_typed::<RowData>() {
             let row_data = row_data?;
             println!("row_data: {:?}", row_data);
@@ -66,7 +80,11 @@ async fn main() -> Result<()> {
     }
 
     // Or simply as untyped rows
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT a, b, c FROM examples_ks.basic", &[])
+        .await?
+        .rows
+    {
         for row in rows {
             let a = row.columns[0].as_ref().unwrap().as_int().unwrap();
             let b = row.columns[1].as_ref().unwrap().as_int().unwrap();

--- a/examples/cloud.rs
+++ b/examples/cloud.rs
@@ -16,10 +16,10 @@ async fn main() -> Result<()> {
         .await
         .unwrap();
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}",
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}",
                     &[]).await.unwrap();
     session
-        .query("DROP TABLE IF EXISTS ks.t;", &[])
+        .query("DROP TABLE IF EXISTS examples_ks.cloud;", &[])
         .await
         .unwrap();
 

--- a/examples/cql-time-types.rs
+++ b/examples/cql-time-types.rs
@@ -17,14 +17,14 @@ async fn main() -> Result<()> {
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     // Date
     // Date is a year, month and day in the range -5877641-06-23 to -5877641-06-23
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.dates (d date primary key)",
+            "CREATE TABLE IF NOT EXISTS examples_ks.dates (d date primary key)",
             &[],
         )
         .await?;
@@ -34,10 +34,17 @@ async fn main() -> Result<()> {
     let chrono_date = NaiveDate::from_ymd_opt(2020, 2, 20).unwrap();
 
     session
-        .query("INSERT INTO ks.dates (d) VALUES (?)", (chrono_date,))
+        .query(
+            "INSERT INTO examples_ks.dates (d) VALUES (?)",
+            (chrono_date,),
+        )
         .await?;
 
-    if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT d from examples_ks.dates", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(NaiveDate,)>() {
             let (read_date,): (NaiveDate,) = match row {
                 Ok(read_date) => read_date,
@@ -54,10 +61,14 @@ async fn main() -> Result<()> {
     let time_date = time::Date::from_calendar_date(2020, time::Month::March, 21).unwrap();
 
     session
-        .query("INSERT INTO ks.dates (d) VALUES (?)", (time_date,))
+        .query("INSERT INTO examples_ks.dates (d) VALUES (?)", (time_date,))
         .await?;
 
-    if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT d from examples_ks.dates", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(time::Date,)>() {
             let (read_date,) = match row {
                 Ok(read_date) => read_date,
@@ -71,10 +82,17 @@ async fn main() -> Result<()> {
     // Dates outside this range must be represented in the raw form - an u32 describing days since -5877641-06-23
     let example_big_date: CqlDate = CqlDate(u32::MAX);
     session
-        .query("INSERT INTO ks.dates (d) VALUES (?)", (example_big_date,))
+        .query(
+            "INSERT INTO examples_ks.dates (d) VALUES (?)",
+            (example_big_date,),
+        )
         .await?;
 
-    if let Some(rows) = session.query("SELECT d from ks.dates", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT d from examples_ks.dates", &[])
+        .await?
+        .rows
+    {
         for row in rows {
             let read_days: u32 = match row.columns[0] {
                 Some(CqlValue::Date(CqlDate(days))) => days,
@@ -90,7 +108,7 @@ async fn main() -> Result<()> {
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.times (t time primary key)",
+            "CREATE TABLE IF NOT EXISTS examples_ks.times (t time primary key)",
             &[],
         )
         .await?;
@@ -102,10 +120,17 @@ async fn main() -> Result<()> {
     let chrono_time = NaiveTime::from_hms_nano_opt(1, 2, 3, 456_789_012).unwrap();
 
     session
-        .query("INSERT INTO ks.times (t) VALUES (?)", (chrono_time,))
+        .query(
+            "INSERT INTO examples_ks.times (t) VALUES (?)",
+            (chrono_time,),
+        )
         .await?;
 
-    if let Some(rows) = session.query("SELECT t from ks.times", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT t from examples_ks.times", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(NaiveTime,)>() {
             let (read_time,) = row?;
 
@@ -117,10 +142,14 @@ async fn main() -> Result<()> {
     let time_time = time::Time::from_hms_nano(2, 3, 4, 567_890_123).unwrap();
 
     session
-        .query("INSERT INTO ks.times (t) VALUES (?)", (time_time,))
+        .query("INSERT INTO examples_ks.times (t) VALUES (?)", (time_time,))
         .await?;
 
-    if let Some(rows) = session.query("SELECT t from ks.times", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT t from examples_ks.times", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(time::Time,)>() {
             let (read_time,) = row?;
 
@@ -132,10 +161,14 @@ async fn main() -> Result<()> {
     let time_time = CqlTime(((3 * 60 + 4) * 60 + 5) * 1_000_000_000 + 678_901_234);
 
     session
-        .query("INSERT INTO ks.times (t) VALUES (?)", (time_time,))
+        .query("INSERT INTO examples_ks.times (t) VALUES (?)", (time_time,))
         .await?;
 
-    if let Some(rows) = session.query("SELECT t from ks.times", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT t from examples_ks.times", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(CqlTime,)>() {
             let (read_time,) = row?;
 
@@ -148,7 +181,7 @@ async fn main() -> Result<()> {
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.timestamps (t timestamp primary key)",
+            "CREATE TABLE IF NOT EXISTS examples_ks.timestamps (t timestamp primary key)",
             &[],
         )
         .await?;
@@ -161,13 +194,13 @@ async fn main() -> Result<()> {
 
     session
         .query(
-            "INSERT INTO ks.timestamps (t) VALUES (?)",
+            "INSERT INTO examples_ks.timestamps (t) VALUES (?)",
             (chrono_datetime,),
         )
         .await?;
 
     if let Some(rows) = session
-        .query("SELECT t from ks.timestamps", &[])
+        .query("SELECT t from examples_ks.timestamps", &[])
         .await?
         .rows
     {
@@ -185,11 +218,14 @@ async fn main() -> Result<()> {
     let time_datetime = time::OffsetDateTime::now_utc();
 
     session
-        .query("INSERT INTO ks.timestamps (t) VALUES (?)", (time_datetime,))
+        .query(
+            "INSERT INTO examples_ks.timestamps (t) VALUES (?)",
+            (time_datetime,),
+        )
         .await?;
 
     if let Some(rows) = session
-        .query("SELECT t from ks.timestamps", &[])
+        .query("SELECT t from examples_ks.timestamps", &[])
         .await?
         .rows
     {
@@ -207,11 +243,14 @@ async fn main() -> Result<()> {
     let cql_datetime = CqlTimestamp(1 << 31);
 
     session
-        .query("INSERT INTO ks.timestamps (t) VALUES (?)", (cql_datetime,))
+        .query(
+            "INSERT INTO examples_ks.timestamps (t) VALUES (?)",
+            (cql_datetime,),
+        )
         .await?;
 
     if let Some(rows) = session
-        .query("SELECT t from ks.timestamps", &[])
+        .query("SELECT t from examples_ks.timestamps", &[])
         .await?
         .rows
     {

--- a/examples/execution_profile.rs
+++ b/examples/execution_profile.rs
@@ -59,16 +59,17 @@ async fn main() -> Result<()> {
     session_3_config.add_known_node(uri);
     let session3: Session = Session::connect(session_3_config).await?;
 
-    session1.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session1.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session2
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.execution_profile (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
 
-    let mut query_insert: Query = "INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)".into();
+    let mut query_insert: Query =
+        "INSERT INTO examples_ks.execution_profile (a, b, c) VALUES (?, ?, ?)".into();
 
     // As `query_insert` is set another handle than session1, the execution profile pointed by query's handle
     // will be preferred, so the query below will be executed with `profile2`, even though `session1` is set `profile1`.
@@ -79,12 +80,18 @@ async fn main() -> Result<()> {
     handle2.map_to_another_profile(profile1);
     // And now the following queries are executed with profile1:
     session1.query(query_insert.clone(), (3, 4, "def")).await?;
-    session2.query("SELECT * FROM ks.t", ()).await?;
+    session2
+        .query("SELECT * FROM examples_ks.execution_profile", ())
+        .await?;
 
     // One can unset a profile handle from a statement and, since then, execute it with session's default profile.
     query_insert.set_execution_profile_handle(None);
-    session3.query("SELECT * FROM ks.t", ()).await?; // This executes with default session profile.
-    session2.query("SELECT * FROM ks.t", ()).await?; // This executes with profile1.
+    session3
+        .query("SELECT * FROM examples_ks.execution_profile", ())
+        .await?; // This executes with default session profile.
+    session2
+        .query("SELECT * FROM examples_ks.execution_profile", ())
+        .await?; // This executes with profile1.
 
     Ok(())
 }

--- a/examples/get_by_name.rs
+++ b/examples/get_by_name.rs
@@ -12,31 +12,31 @@ async fn main() -> Result<()> {
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.hello (pk int, ck int, value text, primary key (pk, ck))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.get_by_name (pk int, ck int, value text, primary key (pk, ck))",
             &[],
         )
         .await?;
 
     session
         .query(
-            "INSERT INTO ks.hello (pk, ck, value) VALUES (?, ?, ?)",
+            "INSERT INTO examples_ks.get_by_name (pk, ck, value) VALUES (?, ?, ?)",
             (3, 4, "def"),
         )
         .await?;
 
     session
         .query(
-            "INSERT INTO ks.hello (pk, ck, value) VALUES (1, 2, 'abc')",
+            "INSERT INTO examples_ks.get_by_name (pk, ck, value) VALUES (1, 2, 'abc')",
             &[],
         )
         .await?;
 
     let query_result = session
-        .query("SELECT pk, ck, value FROM ks.hello", &[])
+        .query("SELECT pk, ck, value FROM examples_ks.get_by_name", &[])
         .await?;
     let (ck_idx, _) = query_result
         .get_column_spec("ck")

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -17,9 +17,9 @@ async fn main() -> Result<()> {
     info!("Connecting to {}", uri);
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
-    session.query("USE ks", &[]).await?;
+    session.query("USE examples_ks", &[]).await?;
 
     Ok(())
 }

--- a/examples/parallel-prepared.rs
+++ b/examples/parallel-prepared.rs
@@ -14,18 +14,18 @@ async fn main() -> Result<()> {
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
     let session = Arc::new(session);
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t2 (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.parallel_prepared (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
 
     let prepared = Arc::new(
         session
-            .prepare("INSERT INTO ks.t2 (a, b, c) VALUES (?, ?, 'abc')")
+            .prepare("INSERT INTO examples_ks.parallel_prepared (a, b, c) VALUES (?, ?, 'abc')")
             .await?,
     );
     println!("Prepared statement: {:#?}", prepared);

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -14,11 +14,11 @@ async fn main() -> Result<()> {
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
     let session = Arc::new(session);
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t2 (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.parallel (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
             session
                 .query(
                     format!(
-                        "INSERT INTO ks.t2 (a, b, c) VALUES ({}, {}, 'abc')",
+                        "INSERT INTO examples_ks.parallel (a, b, c) VALUES ({}, {}, 'abc')",
                         i,
                         2 * i
                     ),

--- a/examples/query_history.rs
+++ b/examples/query_history.rs
@@ -17,11 +17,11 @@ async fn main() -> Result<()> {
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.query_history (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
@@ -47,11 +47,14 @@ async fn main() -> Result<()> {
     // The same works for other types of queries, e.g iterators
     for i in 0..32 {
         session
-            .query("INSERT INTO ks.t (a, b, c) VALUES (?, ?, 't')", (i, i))
+            .query(
+                "INSERT INTO examples_ks.query_history (a, b, c) VALUES (?, ?, 't')",
+                (i, i),
+            )
             .await?;
     }
 
-    let mut iter_query: Query = Query::new("SELECT * FROM ks.t");
+    let mut iter_query: Query = Query::new("SELECT * FROM examples_ks.query_history");
     iter_query.set_page_size(8);
     let iter_history_listener = Arc::new(HistoryCollector::new());
     iter_query.set_history_listener(iter_history_listener.clone());

--- a/examples/schema_agreement.rs
+++ b/examples/schema_agreement.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     println!("Schema version: {}", schema_version);
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     match session.await_schema_agreement().await {
         Ok(_schema_version) => println!("Schema is in agreement in time"),
@@ -31,23 +31,29 @@ async fn main() -> Result<()> {
     };
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.schema_agreement (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
 
     session.await_schema_agreement().await?;
     session
-        .query("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)", (3, 4, "def"))
+        .query(
+            "INSERT INTO examples_ks.schema_agreement (a, b, c) VALUES (?, ?, ?)",
+            (3, 4, "def"),
+        )
         .await?;
 
     session.await_schema_agreement().await?;
     session
-        .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')", &[])
+        .query(
+            "INSERT INTO examples_ks.schema_agreement (a, b, c) VALUES (1, 2, 'abc')",
+            &[],
+        )
         .await?;
 
     let prepared = session
-        .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, 7, ?)")
+        .prepare("INSERT INTO examples_ks.schema_agreement (a, b, c) VALUES (?, 7, ?)")
         .await?;
     session
         .execute(&prepared, (42_i32, "I'm prepared!"))
@@ -60,7 +66,11 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT a, b, c FROM examples_ks.schema_agreement", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(i32, i32, String)>() {
             let (a, b, c) = row?;
             println!("a, b, c: {}, {}, {}", a, b, c);

--- a/examples/speculative-execution.rs
+++ b/examples/speculative-execution.rs
@@ -26,16 +26,18 @@ async fn main() -> Result<()> {
         .build()
         .await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.speculative_execution (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
 
-    let mut select_stmt = session.prepare("SELECT a, b, c FROM ks.t").await?;
+    let mut select_stmt = session
+        .prepare("SELECT a, b, c FROM examples_ks.speculative_execution")
+        .await?;
 
     // This will allow for speculative execution
     select_stmt.set_is_idempotent(true);

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -49,25 +49,31 @@ async fn main() -> Result<()> {
         .build()
         .await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.tls (a int, b int, c text, primary key (a, b))",
             &[],
         )
         .await?;
 
     session
-        .query("INSERT INTO ks.t (a, b, c) VALUES (?, ?, ?)", (3, 4, "def"))
+        .query(
+            "INSERT INTO examples_ks.tls (a, b, c) VALUES (?, ?, ?)",
+            (3, 4, "def"),
+        )
         .await?;
 
     session
-        .query("INSERT INTO ks.t (a, b, c) VALUES (1, 2, 'abc')", &[])
+        .query(
+            "INSERT INTO examples_ks.tls (a, b, c) VALUES (1, 2, 'abc')",
+            &[],
+        )
         .await?;
 
     let prepared = session
-        .prepare("INSERT INTO ks.t (a, b, c) VALUES (?, 7, ?)")
+        .prepare("INSERT INTO examples_ks.tls (a, b, c) VALUES (?, 7, ?)")
         .await?;
     session
         .execute(&prepared, (42_i32, "I'm prepared!"))
@@ -80,7 +86,11 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT a, b, c FROM examples_ks.tls", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(i32, i32, String)>() {
             let (a, b, c) = row?;
             println!("a, b, c: {}, {}, {}", a, b, c);

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -26,18 +26,18 @@ async fn main() -> Result<()> {
         .build()
         .await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.tracing_example (val text primary key)",
+            "CREATE TABLE IF NOT EXISTS examples_ks.tracing (val text primary key)",
             &[],
         )
         .await?;
 
     // QUERY
     // Create a simple query and enable tracing for it
-    let mut query: Query = Query::new("SELECT val from ks.tracing_example");
+    let mut query: Query = Query::new("SELECT val from examples_ks.tracing");
     query.set_tracing(true);
     query.set_serial_consistency(Some(SerialConsistency::LocalSerial));
 
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
     // BATCH
     // Create a simple batch and enable tracing
     let mut batch: Batch = Batch::default();
-    batch.append_statement("INSERT INTO ks.tracing_example (val) VALUES('val')");
+    batch.append_statement("INSERT INTO examples_ks.tracing (val) VALUES('val')");
     batch.set_tracing(true);
 
     // Run the batch and print its tracing_id

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -11,18 +11,18 @@ async fn main() -> Result<()> {
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query(
-            "CREATE TYPE IF NOT EXISTS ks.my_type (int_val int, text_val text)",
+            "CREATE TYPE IF NOT EXISTS examples_ks.my_type (int_val int, text_val text)",
             &[],
         )
         .await?;
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.udt_tab (k int, my my_type, primary key (k))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.user_defined_type_table (k int, my my_type, primary key (k))",
             &[],
         )
         .await?;
@@ -42,11 +42,18 @@ async fn main() -> Result<()> {
 
     // It can be inserted like a normal value
     session
-        .query("INSERT INTO ks.udt_tab (k, my) VALUES (5, ?)", (to_insert,))
+        .query(
+            "INSERT INTO examples_ks.user_defined_type_table (k, my) VALUES (5, ?)",
+            (to_insert,),
+        )
         .await?;
 
     // And read like any normal value
-    if let Some(rows) = session.query("SELECT my FROM ks.udt_tab", &[]).await?.rows {
+    if let Some(rows) = session
+        .query("SELECT my FROM examples_ks.user_defined_type_table", &[])
+        .await?
+        .rows
+    {
         for row in rows.into_typed::<(MyType,)>() {
             let (my_type_value,): (MyType,) = row?;
             println!("{:?}", my_type_value)

--- a/examples/value_list.rs
+++ b/examples/value_list.rs
@@ -9,11 +9,11 @@ async fn main() {
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await.unwrap();
 
-    session.query("CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
 
     session
         .query(
-            "CREATE TABLE IF NOT EXISTS ks.my_type (k int, my text, primary key (k))",
+            "CREATE TABLE IF NOT EXISTS examples_ks.my_type (k int, my text, primary key (k))",
             &[],
         )
         .await
@@ -31,7 +31,10 @@ async fn main() {
     };
 
     session
-        .query("INSERT INTO ks.my_type (k, my) VALUES (?, ?)", to_insert)
+        .query(
+            "INSERT INTO examples_ks.my_type (k, my) VALUES (?, ?)",
+            to_insert,
+        )
         .await
         .unwrap();
 
@@ -48,12 +51,15 @@ async fn main() {
     };
 
     session
-        .query("INSERT INTO ks.my_type (k, my) VALUES (?, ?)", to_insert_2)
+        .query(
+            "INSERT INTO examples_ks.my_type (k, my) VALUES (?, ?)",
+            to_insert_2,
+        )
         .await
         .unwrap();
 
     let q = session
-        .query("SELECT * FROM ks.my_type", &[])
+        .query("SELECT * FROM examples_ks.my_type", &[])
         .await
         .unwrap();
 


### PR DESCRIPTION
The following examples use/reuse the following table name and schema:

`"CREATE TABLE IF NOT EXISTS ks.t (a int, b int, c text, primary key (a, b))",`

`basic`
`execution_profile`
`query_history`
`schema-agreement`
`select-paging`
`speculative-execution`
`tls`

The following examples currently use/reuse the `ks.t` table, with a different schema:
`custom_deserializion` uses `"CREATE TABLE IF NOT EXISTS ks.t (pk int primary key, v text)"`
`compare-tokens` uses `"CREATE TABLE IF NOT EXISTS ks.compare_tokens_example (pk bigint primary key)"`

Depending on what order the examples are run/rerun locally, the examples can create inconsistent table schemas for `ks.t` that cause errors in the examples. 

This PR changes the keyspace name in all examples to `examples_ks` and uses the example file name as the table name for all example tables. This should address any errors caused by tables that are shared between examples.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/844
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [-] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
