### PR TITLE
fixes doc linting error: redundant explicit link target

### DIFF
--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! # Driver overview
 //! ### Connecting
-//! All driver activity revolves around the [Session](crate::Session)\
+//! All driver activity revolves around the [Session]\
 //! `Session` is created by specifying a few known nodes and connecting to them:
 //!
 //! ```rust,no_run
@@ -31,7 +31,7 @@
 //!    Ok(())
 //! }
 //! ```
-//! `Session` is usually created using the [SessionBuilder](crate::SessionBuilder).\
+//! `Session` is usually created using the [SessionBuilder].\
 //! All configuration options for a `Session` can be specified while building.
 //!
 //! ### Making queries

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -76,7 +76,7 @@ impl Batch {
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
     /// If set to `true` we can be sure that it is idempotent
     /// If set to `false` it is unknown whether it is idempotent
-    /// This is used in [`RetryPolicy`](crate::retry_policy::RetryPolicy) to decide if retrying a query is safe
+    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
     pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
         self.config.is_idempotent = is_idempotent;
     }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -239,7 +239,7 @@ impl PreparedStatement {
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
     /// If set to `true` we can be sure that it is idempotent
     /// If set to `false` it is unknown whether it is idempotent
-    /// This is used in [`RetryPolicy`](crate::retry_policy::RetryPolicy) to decide if retrying a query is safe
+    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
     pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
         self.config.is_idempotent = is_idempotent;
     }

--- a/scylla/src/statement/query.rs
+++ b/scylla/src/statement/query.rs
@@ -76,7 +76,7 @@ impl Query {
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application
     /// If set to `true` we can be sure that it is idempotent
     /// If set to `false` it is unknown whether it is idempotent
-    /// This is used in [`RetryPolicy`](crate::retry_policy::RetryPolicy) to decide if retrying a query is safe
+    /// This is used in [`RetryPolicy`] to decide if retrying a query is safe
     pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
         self.config.is_idempotent = is_idempotent;
     }

--- a/scylla/src/transport/host_filter.rs
+++ b/scylla/src/transport/host_filter.rs
@@ -1,7 +1,7 @@
 //! Host filters.
 //!
 //! Host filters are essentially just a predicate over
-//! [`Peer`](crate::transport::topology::Peer)s. Currently, they are used
+//! [`Peer`]s. Currently, they are used
 //! by the [`Session`](crate::transport::session::Session) to determine whether
 //! connections should be opened to a given node or not.
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -561,7 +561,7 @@ impl Session {
     ///
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/simple.html) for more information
     /// # Arguments
-    /// * `query` - query to perform, can be just a `&str` or the [Query](crate::query::Query) struct.
+    /// * `query` - query to perform, can be just a `&str` or the [Query] struct.
     /// * `values` - values bound to the query, easiest way is to use a tuple of bound values
     ///
     /// # Examples
@@ -732,12 +732,12 @@ impl Session {
     /// This method will query all pages of the result\
     ///
     /// Returns an async iterator (stream) over all received rows\
-    /// Page size can be specified in the [Query](crate::query::Query) passed to the function
+    /// Page size can be specified in the [Query] passed to the function
     ///
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/paged.html) for more information
     ///
     /// # Arguments
-    /// * `query` - query to perform, can be just a `&str` or the [Query](crate::query::Query) struct.
+    /// * `query` - query to perform, can be just a `&str` or the [Query] struct.
     /// * `values` - values bound to the query, easiest way is to use a tuple of bound values
     ///
     /// # Example
@@ -799,7 +799,7 @@ impl Session {
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html) for more information
     ///
     /// # Arguments
-    /// * `query` - query to prepare, can be just a `&str` or the [Query](crate::query::Query) struct.
+    /// * `query` - query to prepare, can be just a `&str` or the [Query] struct.
     ///
     /// # Example
     /// ```rust
@@ -876,7 +876,7 @@ impl Session {
             .as_deref()
     }
 
-    /// Execute a prepared query. Requires a [PreparedStatement](crate::prepared_statement::PreparedStatement)
+    /// Execute a prepared query. Requires a [PreparedStatement]
     /// generated using [`Session::prepare`](Session::prepare)\
     /// Returns only a single page of results, to receive multiple pages use [execute_iter](Session::execute_iter)
     ///
@@ -1036,7 +1036,7 @@ impl Session {
     /// This method will query all pages of the result\
     ///
     /// Returns an async iterator (stream) over all received rows\
-    /// Page size can be specified in the [PreparedStatement](crate::prepared_statement::PreparedStatement)
+    /// Page size can be specified in the [PreparedStatement]
     /// passed to the function
     ///
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/paged.html) for more information
@@ -1105,7 +1105,7 @@ impl Session {
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/batch.html) for more information
     ///
     /// # Arguments
-    /// * `batch` - [Batch](crate::batch::Batch) to be performed
+    /// * `batch` - [Batch] to be performed
     /// * `values` - List of values for each query, it's the easiest to use a tuple of tuples
     ///
     /// # Example


### PR DESCRIPTION
API doc build job errors on redundant explicit target.
This removes the redundant explicit target, and passes CI doc build.
```
error: redundant explicit link target
  --> scylla/src/lib.rs:16:55
   |
16 | //! All driver activity revolves around the [Session](crate::Session)\
   |                                                                          -------  ^^^^^^^^^^^^^^ explicit target is redundant
   |                                                                          |
   |                                                                          because label contains path that resolves to same destination
   |
   = note: when a link's destination is not specified,
           the label is used to resolve intra-doc links
   = note: `-D rustdoc::redundant-explicit-links` implied by `-D warnings`
help: remove explicit link target
```

fixes: https://github.com/scylladb/scylla-rust-driver/issues/847

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [-] I have provided docstrings for the public items that I want to introduce.
- [-] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
