### PR TITLE
examples: update UDT parsing example to be in line with docs

### DIFF
--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -48,8 +48,8 @@ async fn main() -> Result<()> {
     // And read like any normal value
     if let Some(rows) = session.query("SELECT my FROM ks.udt_tab", &[]).await?.rows {
         for row in rows.into_typed::<(MyType,)>() {
-            let (my_val,) = row?;
-            println!("{:?}", my_val)
+            let (my_type_value,): (MyType,) = row?;
+            println!("{:?}", my_type_value)
         }
     }
 


### PR DESCRIPTION
## What's done

Previously there was some discrepancy between the examples, specifically how to parse a row into a custom type and and the [docs](https://rust-driver.docs.scylladb.com/stable/data-types/udt.html) about UDT.

Now it is updated.

Fixes: #829 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
