### PR TITLE
cassandra/docker-compose: go back to using the latest cassandra version

### DIFF
--- a/test/cluster/cassandra/docker-compose.yml
+++ b/test/cluster/cassandra/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
         - subnet: 172.42.0.0/16
 services:
   cassandra1:
-    image: cassandra:4.0.7
+    image: cassandra
     healthcheck:
         test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
         interval: 5s
@@ -24,7 +24,7 @@ services:
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
   cassandra2:
-    image: cassandra:4.0.7
+    image: cassandra
     healthcheck:
         test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
         interval: 5s
@@ -42,7 +42,7 @@ services:
       cassandra1:
         condition: service_healthy
   cassandra3:
-    image: cassandra:4.0.7
+    image: cassandra
     healthcheck:
         test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
         interval: 5s


### PR DESCRIPTION
In January the tests started failing on Cassandra `4.1`, so we pinned the cassandra version to `4.0.7`, which didn't have these problems. `4.0.7` is the version that we've been using in the CI since then.

In the meantime there were new releases of Cassandra, at the moment the latest is `4.1.3`. Let's try to go back to the latest version, maybe the problems fixed themselves during the last nine months.

Refs: https://github.com/scylladb/scylla-rust-driver/issues/620
Refs: https://github.com/scylladb/scylla-rust-driver/pull/629

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/633

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
