### PR TITLE
benchmarks/CI: make benchmarks compile and build them in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,15 +29,15 @@ jobs:
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
-      run: cargo clippy --verbose --examples --tests -- -Aclippy::uninlined_format_args
+      run: cargo clippy --verbose --all-targets -- -Aclippy::uninlined_format_args
     - name: Cargo check without features
-      run: cargo check --manifest-path "scylla/Cargo.toml" --features ""
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features ""
     - name: Cargo check with secrecy feature
-      run: cargo check --manifest-path "scylla/Cargo.toml" --features "secret"
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secret"
     - name: Build scylla-cql
       run: cargo build --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml"
     - name: Build
-      run: cargo build --verbose --examples
+      run: cargo build --verbose --all-targets
     - name: Run tests
       run: SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose
     - name: Stop the cluster
@@ -61,9 +61,9 @@ jobs:
     - name: Print Rust version
       run: rustc --version
     - name: MSRV cargo check with features
-      run: cargo check --verbose --examples --tests
+      run: cargo check --verbose --all-targets
     - name: MSRV cargo check without features
-      run: cargo check --verbose --manifest-path "scylla/Cargo.toml"
+      run: cargo check --verbose --all-targets --manifest-path "scylla/Cargo.toml"
     - name: MSRV cargo check scylla-cql
       run: cargo check --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml"
 

--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -12,7 +12,7 @@ fn types_benchmark(c: &mut Criterion) {
     c.bench_function("short", |b| {
         b.iter(|| {
             buf.clear();
-            types::write_short(-1, &mut buf);
+            types::write_short(u16::MAX, &mut buf);
             types::read_short(&mut &buf[..]).unwrap();
         })
     });


### PR DESCRIPTION
The recent fix that changed the `types::write_short` function to use u16 instead of i16 broke one of our benchmarks - it tried to call that function with a negative number. The benchmarks aren't compiled in our CI, so it didn't catch it.

In order to prevent it from happening in the future, the `rust` workflow now uses the `--all-targets` flag to build and clippy-check the benchmarks as well.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
