### PR TITLE
Bump `num_enum` to `0.6..=0.7`

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -916,32 +916,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -1402,7 +1381,7 @@ dependencies = [
  "lz4_flex",
  "ntest",
  "num-bigint",
- "num_enum 0.6.1",
+ "num_enum",
  "openssl",
  "rand",
  "rand_chacha",
@@ -1438,7 +1417,7 @@ dependencies = [
  "criterion",
  "lz4_flex",
  "num-bigint",
- "num_enum 0.6.1",
+ "num_enum",
  "scylla-macros",
  "secrecy",
  "serde",
@@ -1469,7 +1448,7 @@ dependencies = [
  "futures",
  "ntest",
  "num-bigint",
- "num_enum 0.5.11",
+ "num_enum",
  "rand",
  "scylla-cql",
  "thiserror",

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 scylla-macros = { version = "0.2.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
-num_enum = "0.7"
+num_enum = ">=0.6,<=0.7"
 tokio = { version = "1.12", features = ["io-util", "time"] }
 secrecy = { version = "0.7.0", optional = true }
 snap = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 scylla-macros = { version = "0.2.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
-num_enum = "0.6"
+num_enum = "0.7"
 tokio = { version = "1.12", features = ["io-util", "time"] }
 secrecy = { version = "0.7.0", optional = true }
 snap = "1.0"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,7 +17,7 @@ scylla-cql = { version = "0.0.8", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"
-num_enum = "0.7"
+num_enum = ">=0.6,<=0.7"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros", "rt-multi-thread"] }
 uuid = "1.0"
 thiserror = "1.0.32"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,7 +17,7 @@ scylla-cql = { version = "0.0.8", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"
-num_enum = "0.5"
+num_enum = "0.7"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros", "rt-multi-thread"] }
 uuid = "1.0"
 thiserror = "1.0.32"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 histogram = "0.6.9"
-num_enum = "0.7"
+num_enum = ">=0.6,<=0.7"
 tokio = { version = "1.27", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 histogram = "0.6.9"
-num_enum = "0.6"
+num_enum = "0.7"
 tokio = { version = "1.27", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }


### PR DESCRIPTION
This PR bumps `num_enum` from `0.5` and `0.6` to `0.6..=0.7`. The motivation for this is that `num_enum@0.7` transitively allows for `toml_edit@0.20`.

Unfortunately another dependency of `scylla`, `ntest`, still depends on `toml_edit@0.19` in its current release, but has bumped to `0.20` on master. `ntest` is however only a `dev-dependency`, so I still think this will have upside for downstream users of scylla. 

---

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
