### PR TITLE
Switch Session to new serialization traits

### DIFF
--- a/docs/source/data-types/udt.md
+++ b/docs/source/data-types/udt.md
@@ -37,10 +37,10 @@ Now it can be sent and received just like any other CQL value:
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::IntoTypedRows;
-use scylla::macros::{FromUserType, IntoUserType};
+use scylla::macros::{FromUserType, IntoUserType, SerializeCql};
 use scylla::cql_to_rust::FromCqlVal;
 
-#[derive(Debug, IntoUserType, FromUserType)]
+#[derive(Debug, IntoUserType, FromUserType, SerializeCql)]
 struct MyType {
     int_val: i32,
     text_val: Option<String>,

--- a/docs/source/queries/values.md
+++ b/docs/source/queries/values.md
@@ -12,7 +12,7 @@ or a custom struct which derives from `ValueList`.
 A few examples:
 ```rust
 # extern crate scylla;
-# use scylla::{Session, ValueList, frame::response::result::CqlValue};
+# use scylla::{Session, ValueList, SerializeRow, frame::response::result::CqlValue};
 # use std::error::Error;
 # use std::collections::HashMap;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
@@ -34,7 +34,7 @@ session
 
 // Sending an integer and a string using a named struct.
 // The values will be passed in the order from the struct definition
-#[derive(ValueList)]
+#[derive(ValueList, SerializeRow)]
 struct IntString {
     first_col: i32,
     second_col: String,

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use scylla::frame::value::ValueList;
 use scylla::routing::Token;
 use scylla::transport::NodeAddr;
 use scylla::{Session, SessionBuilder};
@@ -29,8 +28,7 @@ async fn main() -> Result<()> {
             .query("INSERT INTO ks.t (pk) VALUES (?)", (pk,))
             .await?;
 
-        let serialized_pk = (pk,).serialized()?.into_owned();
-        let t = prepared.calculate_token(&serialized_pk)?.unwrap().value;
+        let t = prepared.calculate_token(&(pk,))?.unwrap().value;
 
         println!(
             "Token endpoints for query: {:?}",

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use scylla::macros::{FromUserType, IntoUserType};
+use scylla::macros::FromUserType;
 use scylla::{IntoTypedRows, SerializeCql, Session, SessionBuilder};
 use std::env;
 
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     // Define custom struct that matches User Defined Type created earlier
     // wrapping field in Option will gracefully handle null field values
-    #[derive(Debug, IntoUserType, FromUserType, SerializeCql)]
+    #[derive(Debug, FromUserType, SerializeCql)]
     struct MyType {
         int_val: i32,
         text_val: Option<String>,

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use scylla::macros::{FromUserType, IntoUserType};
-use scylla::{IntoTypedRows, Session, SessionBuilder};
+use scylla::{IntoTypedRows, SerializeCql, Session, SessionBuilder};
 use std::env;
 
 #[tokio::main]
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     // Define custom struct that matches User Defined Type created earlier
     // wrapping field in Option will gracefully handle null field values
-    #[derive(Debug, IntoUserType, FromUserType)]
+    #[derive(Debug, IntoUserType, FromUserType, SerializeCql)]
     struct MyType {
         int_val: i32,
         text_val: Option<String>,

--- a/examples/value_list.rs
+++ b/examples/value_list.rs
@@ -19,7 +19,7 @@ async fn main() {
         .await
         .unwrap();
 
-    #[derive(scylla::ValueList)]
+    #[derive(scylla::ValueList, scylla::SerializeRow)]
     struct MyType<'a> {
         k: i32,
         my: Option<&'a str>,
@@ -36,8 +36,10 @@ async fn main() {
         .unwrap();
 
     // You can also use type generics:
-    #[derive(scylla::ValueList)]
-    struct MyTypeWithGenerics<S: scylla::frame::value::Value> {
+    #[derive(scylla::ValueList, scylla::SerializeRow)]
+    struct MyTypeWithGenerics<
+        S: scylla::frame::value::Value + scylla::serialize::value::SerializeCql,
+    > {
         k: i32,
         my: Option<S>,
     }

--- a/examples/value_list.rs
+++ b/examples/value_list.rs
@@ -19,7 +19,7 @@ async fn main() {
         .await
         .unwrap();
 
-    #[derive(scylla::ValueList, scylla::SerializeRow)]
+    #[derive(scylla::SerializeRow)]
     struct MyType<'a> {
         k: i32,
         my: Option<&'a str>,
@@ -36,10 +36,8 @@ async fn main() {
         .unwrap();
 
     // You can also use type generics:
-    #[derive(scylla::ValueList, scylla::SerializeRow)]
-    struct MyTypeWithGenerics<
-        S: scylla::frame::value::Value + scylla::serialize::value::SerializeCql,
-    > {
+    #[derive(scylla::SerializeRow)]
+    struct MyTypeWithGenerics<S: scylla::serialize::value::SerializeCql> {
         k: i32,
         my: Option<S>,
     }

--- a/scylla-cql/benches/benchmark.rs
+++ b/scylla-cql/benches/benchmark.rs
@@ -3,17 +3,17 @@ use std::borrow::Cow;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use scylla_cql::frame::request::SerializableRequest;
-use scylla_cql::frame::value::LegacySerializedValues;
-use scylla_cql::frame::value::ValueList;
+use scylla_cql::frame::response::result::ColumnType;
 use scylla_cql::frame::{request::query, Compression, SerializedRequest};
+use scylla_cql::types::serialize::row::SerializedValues;
 
-fn make_query<'a>(contents: &'a str, values: &'a LegacySerializedValues) -> query::Query<'a> {
+fn make_query(contents: &str, values: SerializedValues) -> query::Query<'_> {
     query::Query {
         contents: Cow::Borrowed(contents),
         parameters: query::QueryParameters {
             consistency: scylla_cql::Consistency::LocalQuorum,
             serial_consistency: None,
-            values: Cow::Borrowed(values),
+            values: Cow::Owned(values),
             page_size: None,
             paging_state: None,
             timestamp: None,
@@ -22,13 +22,24 @@ fn make_query<'a>(contents: &'a str, values: &'a LegacySerializedValues) -> quer
 }
 
 fn serialized_request_make_bench(c: &mut Criterion) {
+    let mut values = SerializedValues::new();
     let mut group = c.benchmark_group("LZ4Compression.SerializedRequest");
     let query_args = [
-        ("INSERT foo INTO ks.table_name (?)", &(1234,).serialized().unwrap()),
-        ("INSERT foo, bar, baz INTO ks.table_name (?, ?, ?)", &(1234, "a value", "i am storing a string").serialized().unwrap()),
+        ("INSERT foo INTO ks.table_name (?)", {
+            values.add_value(&1234, &ColumnType::Int).unwrap();
+            values.clone()
+        }),
+        ("INSERT foo, bar, baz INTO ks.table_name (?, ?, ?)", {
+            values.add_value(&"a value", &ColumnType::Text).unwrap();
+            values.add_value(&"i am storing a string", &ColumnType::Text).unwrap();
+            values.clone()
+        }),
         (
             "INSERT foo, bar, baz, boop, blah INTO longer_keyspace.a_big_table_name (?, ?, ?, ?, 1000)",
-            &(1234, "a value", "i am storing a string", "dc0c8cd7-d954-47c1-8722-a857941c43fb").serialized().unwrap()
+            {
+                values.add_value(&"dc0c8cd7-d954-47c1-8722-a857941c43fb", &ColumnType::Text).unwrap();
+                values.clone()
+            }
         ),
     ];
     let queries = query_args.map(|(q, v)| make_query(q, v));

--- a/scylla-cql/benches/benchmark.rs
+++ b/scylla-cql/benches/benchmark.rs
@@ -3,11 +3,11 @@ use std::borrow::Cow;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use scylla_cql::frame::request::SerializableRequest;
-use scylla_cql::frame::value::SerializedValues;
+use scylla_cql::frame::value::LegacySerializedValues;
 use scylla_cql::frame::value::ValueList;
 use scylla_cql::frame::{request::query, Compression, SerializedRequest};
 
-fn make_query<'a>(contents: &'a str, values: &'a SerializedValues) -> query::Query<'a> {
+fn make_query<'a>(contents: &'a str, values: &'a LegacySerializedValues) -> query::Query<'a> {
     query::Query {
         contents: Cow::Borrowed(contents),
         parameters: query::QueryParameters {

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -3,6 +3,7 @@
 use crate::frame::frame_errors::{FrameError, ParseError};
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::value::SerializeValuesError;
+use crate::types::serialize::SerializationError;
 use crate::Consistency;
 use bytes::Bytes;
 use std::io::ErrorKind;
@@ -340,6 +341,9 @@ pub enum BadQuery {
     #[error("Serializing values failed: {0} ")]
     SerializeValuesError(#[from] SerializeValuesError),
 
+    #[error("Serializing values failed: {0} ")]
+    SerializationError(#[from] SerializationError),
+
     /// Serialized values are too long to compute partition key
     #[error("Serialized values are too long to compute partition key! Length: {0}, Max allowed length: {1}")]
     ValuesTooLongForKey(usize, usize),
@@ -440,6 +444,12 @@ impl From<std::io::Error> for QueryError {
 impl From<SerializeValuesError> for QueryError {
     fn from(serialized_err: SerializeValuesError) -> QueryError {
         QueryError::BadQuery(BadQuery::SerializeValuesError(serialized_err))
+    }
+}
+
+impl From<SerializationError> for QueryError {
+    fn from(serialized_err: SerializationError) -> QueryError {
+        QueryError::BadQuery(BadQuery::SerializationError(serialized_err))
     }
 }
 

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,6 +1,7 @@
 use super::response;
 use crate::cql_to_rust::CqlTypeError;
 use crate::frame::value::SerializeValuesError;
+use crate::types::serialize::SerializationError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -43,6 +44,8 @@ pub enum ParseError {
     TypeNotImplemented(u16),
     #[error(transparent)]
     SerializeValuesError(#[from] SerializeValuesError),
+    #[error(transparent)]
+    SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
 }

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -22,7 +22,7 @@ pub use startup::Startup;
 use self::batch::BatchStatement;
 
 use super::types::SerialConsistency;
-use super::value::SerializedValues;
+use super::value::LegacySerializedValues;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
 #[repr(u8)]
@@ -59,7 +59,7 @@ pub trait DeserializableRequest: SerializableRequest + Sized {
 pub enum Request<'r> {
     Query(Query<'r>),
     Execute(Execute<'r>),
-    Batch(Batch<'r, BatchStatement<'r>, Vec<SerializedValues>>),
+    Batch(Batch<'r, BatchStatement<'r>, Vec<LegacySerializedValues>>),
 }
 
 impl<'r> Request<'r> {
@@ -113,7 +113,7 @@ mod tests {
                 DeserializableRequest, SerializableRequest,
             },
             types::{self, SerialConsistency},
-            value::SerializedValues,
+            value::LegacySerializedValues,
         },
         Consistency,
     };
@@ -129,7 +129,7 @@ mod tests {
             page_size: Some(323),
             paging_state: Some(vec![2, 1, 3, 7].into()),
             values: {
-                let mut vals = SerializedValues::new();
+                let mut vals = LegacySerializedValues::new();
                 vals.add_value(&2137).unwrap();
                 Cow::Owned(vals)
             },
@@ -156,7 +156,7 @@ mod tests {
             page_size: None,
             paging_state: None,
             values: {
-                let mut vals = SerializedValues::new();
+                let mut vals = LegacySerializedValues::new();
                 vals.add_named_value("the_answer", &42).unwrap();
                 vals.add_named_value("really?", &2137).unwrap();
                 Cow::Owned(vals)
@@ -212,7 +212,7 @@ mod tests {
             timestamp: None,
             page_size: None,
             paging_state: None,
-            values: Cow::Owned(SerializedValues::new()),
+            values: Cow::Owned(LegacySerializedValues::new()),
         };
         let query = Query {
             contents: contents.clone(),

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -112,9 +112,10 @@ mod tests {
                 query::{Query, QueryParameters},
                 DeserializableRequest, SerializableRequest,
             },
+            response::result::ColumnType,
             types::{self, SerialConsistency},
-            value::LegacySerializedValues,
         },
+        types::serialize::row::SerializedValues,
         Consistency,
     };
 
@@ -129,8 +130,8 @@ mod tests {
             page_size: Some(323),
             paging_state: Some(vec![2, 1, 3, 7].into()),
             values: {
-                let mut vals = LegacySerializedValues::new();
-                vals.add_value(&2137).unwrap();
+                let mut vals = SerializedValues::new();
+                vals.add_value(&2137, &ColumnType::Int).unwrap();
                 Cow::Owned(vals)
             },
         };
@@ -156,9 +157,9 @@ mod tests {
             page_size: None,
             paging_state: None,
             values: {
-                let mut vals = LegacySerializedValues::new();
-                vals.add_named_value("the_answer", &42).unwrap();
-                vals.add_named_value("really?", &2137).unwrap();
+                let mut vals = SerializedValues::new();
+                vals.add_value(&42, &ColumnType::Int).unwrap();
+                vals.add_value(&2137, &ColumnType::Int).unwrap();
                 Cow::Owned(vals)
             },
         };
@@ -189,8 +190,8 @@ mod tests {
 
             // Not execute's values, because named values are not supported in batches.
             values: vec![
-                query.parameters.values.deref().clone(),
-                query.parameters.values.deref().clone(),
+                query.parameters.values.deref().to_old_serialized_values(),
+                query.parameters.values.deref().to_old_serialized_values(),
             ],
         };
         {
@@ -212,7 +213,7 @@ mod tests {
             timestamp: None,
             page_size: None,
             paging_state: None,
-            values: Cow::Owned(LegacySerializedValues::new()),
+            values: Cow::Borrowed(SerializedValues::EMPTY),
         };
         let query = Query {
             contents: contents.clone(),
@@ -261,7 +262,7 @@ mod tests {
             serial_consistency: None,
             timestamp: None,
 
-            values: vec![query.parameters.values.deref().clone()],
+            values: vec![query.parameters.values.deref().to_old_serialized_values()],
         };
         {
             let mut buf = Vec::new();

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -6,7 +6,7 @@ use bytes::{Buf, BufMut, Bytes};
 use crate::{
     frame::request::{RequestOpcode, SerializableRequest},
     frame::types,
-    frame::value::SerializedValues,
+    frame::value::LegacySerializedValues,
 };
 
 use super::DeserializableRequest;
@@ -61,7 +61,7 @@ pub struct QueryParameters<'a> {
     pub timestamp: Option<i64>,
     pub page_size: Option<i32>,
     pub paging_state: Option<Bytes>,
-    pub values: Cow<'a, SerializedValues>,
+    pub values: Cow<'a, LegacySerializedValues>,
 }
 
 impl Default for QueryParameters<'_> {
@@ -72,7 +72,7 @@ impl Default for QueryParameters<'_> {
             timestamp: None,
             page_size: None,
             paging_state: None,
-            values: Cow::Borrowed(SerializedValues::EMPTY),
+            values: Cow::Borrowed(LegacySerializedValues::EMPTY),
         }
     }
 }
@@ -152,9 +152,9 @@ impl<'q> QueryParameters<'q> {
         let values_have_names_flag = (flags & FLAG_WITH_NAMES_FOR_VALUES) != 0;
 
         let values = Cow::Owned(if values_flag {
-            SerializedValues::new_from_frame(buf, values_have_names_flag)?
+            LegacySerializedValues::new_from_frame(buf, values_have_names_flag)?
         } else {
-            SerializedValues::new()
+            LegacySerializedValues::new()
         });
 
         let page_size = page_size_flag.then(|| types::read_int(buf)).transpose()?;

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -5,8 +5,8 @@ use crate::types::serialize::{CellWriter, RowWriter};
 
 use super::response::result::{ColumnSpec, ColumnType, TableSpec};
 use super::value::{
-    BatchValues, CqlDate, CqlDuration, CqlTime, CqlTimestamp, MaybeUnset, SerializeValuesError,
-    SerializedValues, Unset, Value, ValueList, ValueTooBig,
+    BatchValues, CqlDate, CqlDuration, CqlTime, CqlTimestamp, LegacySerializedValues, MaybeUnset,
+    SerializeValuesError, Unset, Value, ValueList, ValueTooBig,
 };
 use bigdecimal::BigDecimal;
 use bytes::BufMut;
@@ -832,7 +832,7 @@ fn ref_value() {
 
 #[test]
 fn empty_serialized_values() {
-    const EMPTY: SerializedValues = SerializedValues::new();
+    const EMPTY: LegacySerializedValues = LegacySerializedValues::new();
     assert_eq!(EMPTY.len(), 0);
     assert!(EMPTY.is_empty());
     assert_eq!(EMPTY.iter().next(), None);
@@ -844,7 +844,7 @@ fn empty_serialized_values() {
 
 #[test]
 fn serialized_values() {
-    let mut values = SerializedValues::new();
+    let mut values = LegacySerializedValues::new();
     assert!(values.is_empty());
 
     // Add first value
@@ -920,14 +920,14 @@ fn serialized_values() {
 
 #[test]
 fn unit_value_list() {
-    let serialized_unit: SerializedValues =
+    let serialized_unit: LegacySerializedValues =
         <() as ValueList>::serialized(&()).unwrap().into_owned();
     assert!(serialized_unit.is_empty());
 }
 
 #[test]
 fn empty_array_value_list() {
-    let serialized_arr: SerializedValues = <[u8; 0] as ValueList>::serialized(&[])
+    let serialized_arr: LegacySerializedValues = <[u8; 0] as ValueList>::serialized(&[])
         .unwrap()
         .into_owned();
     assert!(serialized_arr.is_empty());
@@ -987,7 +987,7 @@ fn col_spec(name: &str, typ: ColumnType) -> ColumnSpec {
 fn serialize_values<T: ValueList + SerializeRow>(
     vl: T,
     columns: &[ColumnSpec],
-) -> SerializedValues {
+) -> LegacySerializedValues {
     let serialized = <T as ValueList>::serialized(&vl).unwrap().into_owned();
     let mut old_serialized = Vec::new();
     serialized.write_to_request(&mut old_serialized);
@@ -1158,11 +1158,11 @@ fn ref_value_list() {
 
 #[test]
 fn serialized_values_value_list() {
-    let mut ser_values = SerializedValues::new();
+    let mut ser_values = LegacySerializedValues::new();
     ser_values.add_value(&1_i32).unwrap();
     ser_values.add_value(&"qwertyuiop").unwrap();
 
-    let ser_ser_values: Cow<SerializedValues> = ser_values.serialized().unwrap();
+    let ser_ser_values: Cow<LegacySerializedValues> = ser_values.serialized().unwrap();
     assert!(matches!(ser_ser_values, Cow::Borrowed(_)));
 
     assert_eq!(&ser_values, ser_ser_values.as_ref());
@@ -1170,9 +1170,9 @@ fn serialized_values_value_list() {
 
 #[test]
 fn cow_serialized_values_value_list() {
-    let cow_ser_values: Cow<SerializedValues> = Cow::Owned(SerializedValues::new());
+    let cow_ser_values: Cow<LegacySerializedValues> = Cow::Owned(LegacySerializedValues::new());
 
-    let serialized: Cow<SerializedValues> = cow_ser_values.serialized().unwrap();
+    let serialized: Cow<LegacySerializedValues> = cow_ser_values.serialized().unwrap();
     assert!(matches!(serialized, Cow::Borrowed(_)));
 
     assert_eq!(cow_ser_values.as_ref(), serialized.as_ref());

--- a/scylla-cql/src/lib.rs
+++ b/scylla-cql/src/lib.rs
@@ -17,7 +17,7 @@ pub mod _macro_internal {
     };
     pub use crate::frame::response::result::{CqlValue, Row};
     pub use crate::frame::value::{
-        SerializedResult, SerializedValues, Value, ValueList, ValueTooBig,
+        LegacySerializedValues, SerializedResult, Value, ValueList, ValueTooBig,
     };
     pub use crate::macros::*;
 

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -680,7 +680,6 @@ impl SerializedValues {
     }
 
     /// Creates value list from the request frame
-    #[allow(dead_code)]
     pub(crate) fn new_from_frame(buf: &mut &[u8]) -> Result<Self, ParseError> {
         let values_num = types::read_short(buf)?;
         let values_beg = *buf;
@@ -697,7 +696,6 @@ impl SerializedValues {
     }
 
     // Temporary function, to be removed when we implement new batching API (right now it is needed in frame::request::mod.rs tests)
-    #[allow(dead_code)]
     pub fn to_old_serialized_values(&self) -> LegacySerializedValues {
         let mut frame = Vec::new();
         self.write_to_request(&mut frame);

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use thiserror::Error;
 
+use crate::frame::response::result::PreparedMetadata;
 use crate::frame::value::{SerializedValues, ValueList};
 use crate::frame::{response::result::ColumnSpec, types::RawValue};
 
@@ -18,6 +19,13 @@ pub struct RowSerializationContext<'a> {
 }
 
 impl<'a> RowSerializationContext<'a> {
+    #[inline]
+    pub fn from_prepared(prepared: &'a PreparedMetadata) -> Self {
+        Self {
+            columns: prepared.col_specs.as_slice(),
+        }
+    }
+
     /// Returns column/bind marker specifications for given query.
     #[inline]
     pub fn columns(&self) -> &'a [ColumnSpec] {

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
 use crate::frame::response::result::PreparedMetadata;
-use crate::frame::value::{SerializedValues, ValueList};
+use crate::frame::value::{LegacySerializedValues, ValueList};
 use crate::frame::{response::result::ColumnSpec, types::RawValue};
 
 use super::value::SerializeCql;
@@ -62,7 +62,7 @@ macro_rules! fallback_impl_contents {
         }
         #[inline]
         fn is_empty(&self) -> bool {
-            SerializedValues::is_empty(self)
+            LegacySerializedValues::is_empty(self)
         }
     };
 }
@@ -233,11 +233,11 @@ impl<T: SerializeRow + ?Sized> SerializeRow for &T {
     }
 }
 
-impl SerializeRow for SerializedValues {
+impl SerializeRow for LegacySerializedValues {
     fallback_impl_contents!();
 }
 
-impl<'b> SerializeRow for Cow<'b, SerializedValues> {
+impl<'b> SerializeRow for Cow<'b, LegacySerializedValues> {
     fallback_impl_contents!();
 }
 
@@ -337,7 +337,7 @@ impl_tuples!(
 ///
 /// ```rust
 /// # use std::borrow::Cow;
-/// # use scylla_cql::frame::value::{Value, ValueList, SerializedResult, SerializedValues};
+/// # use scylla_cql::frame::value::{Value, ValueList, SerializedResult, LegacySerializedValues};
 /// # use scylla_cql::impl_serialize_row_via_value_list;
 /// struct NoGenerics {}
 /// impl ValueList for NoGenerics {
@@ -352,7 +352,7 @@ impl_tuples!(
 /// struct WithGenerics<T, U: Clone>(T, U);
 /// impl<T: Value, U: Clone + Value> ValueList for WithGenerics<T, U> {
 ///     fn serialized(&self) -> SerializedResult<'_> {
-///         let mut values = SerializedValues::new();
+///         let mut values = LegacySerializedValues::new();
 ///         values.add_value(&self.0);
 ///         values.add_value(&self.1.clone());
 ///         Ok(Cow::Owned(values))
@@ -576,7 +576,7 @@ pub enum ValueListToSerializeRowAdapterError {
 #[cfg(test)]
 mod tests {
     use crate::frame::response::result::{ColumnSpec, ColumnType, TableSpec};
-    use crate::frame::value::{MaybeUnset, SerializedValues, ValueList};
+    use crate::frame::value::{LegacySerializedValues, MaybeUnset, ValueList};
     use crate::types::serialize::RowWriter;
 
     use super::{
@@ -638,7 +638,7 @@ mod tests {
         let mut sorted_row_data = Vec::new();
         <_ as ValueList>::write_to_request(&sorted_row, &mut sorted_row_data).unwrap();
 
-        let mut unsorted_row = SerializedValues::new();
+        let mut unsorted_row = LegacySerializedValues::new();
         unsorted_row.add_named_value("a", &1i32).unwrap();
         unsorted_row.add_named_value("b", &"Ala ma kota").unwrap();
         unsorted_row

--- a/scylla-macros/src/value_list.rs
+++ b/scylla-macros/src/value_list.rs
@@ -17,7 +17,7 @@ pub fn value_list_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::
     let generated = quote! {
         impl #impl_generics #path::ValueList for #struct_name #ty_generics #where_clause {
             fn serialized(&self) -> #path::SerializedResult {
-                let mut result = #path::SerializedValues::with_capacity(#values_len);
+                let mut result = #path::LegacySerializedValues::with_capacity(#values_len);
                 #(
                     result.add_value(&self.#field_name)?;
                 )*

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -100,6 +100,7 @@ pub mod _macro_internal {
 
 pub use scylla_cql::frame;
 pub use scylla_cql::macros::{self, *};
+pub use scylla_cql::types::serialize;
 
 pub mod authentication;
 #[cfg(feature = "cloud")]

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -338,7 +338,6 @@ impl PreparedStatement {
         self.config.execution_profile_handle.as_ref()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn serialize_values(
         &self,
         values: &impl SerializeRow,

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -1,6 +1,8 @@
 use bytes::{Bytes, BytesMut};
 use scylla_cql::errors::{BadQuery, QueryError};
 use scylla_cql::frame::types::RawValue;
+use scylla_cql::types::serialize::row::{RowSerializationContext, SerializeRow, SerializedValues};
+use scylla_cql::types::serialize::SerializationError;
 use smallvec::{smallvec, SmallVec};
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -334,6 +336,15 @@ impl PreparedStatement {
     /// Borrows the execution profile handle associated with this query.
     pub fn get_execution_profile_handle(&self) -> Option<&ExecutionProfileHandle> {
         self.config.execution_profile_handle.as_ref()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn serialize_values(
+        &self,
+        values: &impl SerializeRow,
+    ) -> Result<SerializedValues, SerializationError> {
+        let ctx = RowSerializationContext::from_prepared(self.get_prepared_metadata());
+        SerializedValues::from_serializable(&ctx, values)
     }
 }
 

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -184,19 +184,19 @@ impl PreparedStatement {
         Ok(Some((partition_key, token)))
     }
 
-    /// Calculates the token for given prepared statement and serialized values.
+    /// Calculates the token for given prepared statement and values.
     ///
     /// Returns the token that would be computed for executing the provided
     /// prepared statement with the provided values.
     // As this function creates a `PartitionKey`, it is intended rather for external usage (by users).
     // For internal purposes, `PartitionKey::calculate_token()` is preferred, as `PartitionKey`
     // is either way used internally, among others for display in traces.
-    pub fn calculate_token(
-        &self,
-        serialized_values: &LegacySerializedValues,
-    ) -> Result<Option<Token>, QueryError> {
-        self.extract_partition_key_and_calculate_token(&self.partitioner_name, serialized_values)
-            .map(|opt| opt.map(|(_pk, token)| token))
+    pub fn calculate_token(&self, values: &impl SerializeRow) -> Result<Option<Token>, QueryError> {
+        self.extract_partition_key_and_calculate_token(
+            &self.partitioner_name,
+            &self.serialize_values(values)?.to_old_serialized_values(),
+        )
+        .map(|opt| opt.map(|(_pk, token)| token))
     }
 
     /// Returns the name of the keyspace this statement is operating on.

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -1,5 +1,5 @@
 use crate::batch::{Batch, BatchStatement};
-use crate::frame::value::{BatchValues, ValueList};
+use crate::frame::value::BatchValues;
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::transport::errors::QueryError;
@@ -10,6 +10,7 @@ use bytes::Bytes;
 use dashmap::DashMap;
 use futures::future::try_join_all;
 use scylla_cql::frame::response::result::PreparedMetadata;
+use scylla_cql::types::serialize::row::SerializeRow;
 use std::collections::hash_map::RandomState;
 use std::hash::BuildHasher;
 
@@ -70,38 +71,35 @@ where
     pub async fn execute(
         &self,
         query: impl Into<Query>,
-        values: impl ValueList,
+        values: impl SerializeRow,
     ) -> Result<QueryResult, QueryError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
-        let values = values.serialized()?;
-        self.session.execute(&prepared, values.clone()).await
+        self.session.execute(&prepared, values).await
     }
 
     /// Does the same thing as [`Session::execute_iter`] but uses the prepared statement cache
     pub async fn execute_iter(
         &self,
         query: impl Into<Query>,
-        values: impl ValueList,
+        values: impl SerializeRow,
     ) -> Result<RowIterator, QueryError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
-        let values = values.serialized()?;
-        self.session.execute_iter(prepared, values.clone()).await
+        self.session.execute_iter(prepared, values).await
     }
 
     /// Does the same thing as [`Session::execute_paged`] but uses the prepared statement cache
     pub async fn execute_paged(
         &self,
         query: impl Into<Query>,
-        values: impl ValueList,
+        values: impl SerializeRow,
         paging_state: Option<Bytes>,
     ) -> Result<QueryResult, QueryError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
-        let values = values.serialized()?;
         self.session
-            .execute_paged(&prepared, values.clone(), paging_state.clone())
+            .execute_paged(&prepared, values, paging_state.clone())
             .await
     }
 

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -18,6 +18,7 @@ use futures::future::join_all;
 use futures::{future::RemoteHandle, FutureExt};
 use itertools::Itertools;
 use scylla_cql::errors::{BadQuery, NewSessionError};
+use scylla_cql::types::serialize::row::SerializedValues;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -436,11 +437,11 @@ impl ClusterData {
         &self,
         keyspace: &str,
         table: &str,
-        partition_key: impl ValueList,
+        partition_key: &SerializedValues,
     ) -> Result<Vec<Arc<Node>>, BadQuery> {
         Ok(self.get_token_endpoints(
             keyspace,
-            self.compute_token(keyspace, table, partition_key)?,
+            self.compute_token(keyspace, table, partition_key.to_old_serialized_values())?,
         ))
     }
 

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -400,12 +400,11 @@ impl ClusterData {
             .and_then(PartitionerName::from_str)
             .unwrap_or_default();
 
-        calculate_token_for_partition_key(&partition_key.to_old_serialized_values(), &partitioner)
-            .map_err(|err| match err {
-                TokenCalculationError::ValueTooLong(values_len) => {
-                    BadQuery::ValuesTooLongForKey(values_len, u16::MAX.into())
-                }
-            })
+        calculate_token_for_partition_key(partition_key, &partitioner).map_err(|err| match err {
+            TokenCalculationError::ValueTooLong(values_len) => {
+                BadQuery::ValuesTooLongForKey(values_len, u16::MAX.into())
+            }
+        })
     }
 
     /// Access to replicas owning a given token

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -4,7 +4,7 @@ use scylla_cql::errors::TranslationError;
 use scylla_cql::frame::request::options::Options;
 use scylla_cql::frame::response::Error;
 use scylla_cql::frame::types::SerialConsistency;
-use scylla_cql::frame::value::SerializedValues;
+use scylla_cql::frame::value::LegacySerializedValues;
 use socket2::{SockRef, TcpKeepalive};
 use tokio::io::{split, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{TcpSocket, TcpStream};
@@ -651,7 +651,7 @@ impl Connection {
             parameters: query::QueryParameters {
                 consistency,
                 serial_consistency,
-                values: Cow::Borrowed(SerializedValues::EMPTY),
+                values: Cow::Borrowed(LegacySerializedValues::EMPTY),
                 page_size: query.get_page_size(),
                 paging_state,
                 timestamp: query.get_timestamp(),

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -754,7 +754,7 @@ impl Connection {
 
         RowIterator::new_for_connection_execute_iter(
             prepared_statement,
-            values.to_old_serialized_values(),
+            values,
             self,
             consistency,
             serial_consistency,

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -4,6 +4,7 @@ use scylla_cql::errors::TranslationError;
 use scylla_cql::frame::request::options::Options;
 use scylla_cql::frame::response::Error;
 use scylla_cql::frame::types::SerialConsistency;
+use scylla_cql::frame::value::SerializedValues;
 use socket2::{SockRef, TcpKeepalive};
 use tokio::io::{split, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{TcpSocket, TcpStream};
@@ -596,7 +597,6 @@ impl Connection {
     pub(crate) async fn query_single_page(
         &self,
         query: impl Into<Query>,
-        values: impl ValueList,
     ) -> Result<QueryResult, QueryError> {
         let query: Query = query.into();
 
@@ -606,24 +606,18 @@ impl Connection {
             .determine_consistency(self.config.default_consistency);
         let serial_consistency = query.config.serial_consistency;
 
-        self.query_single_page_with_consistency(
-            query,
-            &values,
-            consistency,
-            serial_consistency.flatten(),
-        )
-        .await
+        self.query_single_page_with_consistency(query, consistency, serial_consistency.flatten())
+            .await
     }
 
     pub(crate) async fn query_single_page_with_consistency(
         &self,
         query: impl Into<Query>,
-        values: impl ValueList,
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,
     ) -> Result<QueryResult, QueryError> {
         let query: Query = query.into();
-        self.query_with_consistency(&query, &values, consistency, serial_consistency, None)
+        self.query_with_consistency(&query, consistency, serial_consistency, None)
             .await?
             .into_query_result()
     }
@@ -631,13 +625,11 @@ impl Connection {
     pub(crate) async fn query(
         &self,
         query: &Query,
-        values: impl ValueList,
         paging_state: Option<Bytes>,
     ) -> Result<QueryResponse, QueryError> {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.query_with_consistency(
             query,
-            values,
             query
                 .config
                 .determine_consistency(self.config.default_consistency),
@@ -650,33 +642,16 @@ impl Connection {
     pub(crate) async fn query_with_consistency(
         &self,
         query: &Query,
-        values: impl ValueList,
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,
         paging_state: Option<Bytes>,
     ) -> Result<QueryResponse, QueryError> {
-        let serialized_values = values.serialized()?;
-
-        let values_size = serialized_values.size();
-        if values_size != 0 {
-            let prepared = self.prepare(query).await?;
-            return self
-                .execute_with_consistency(
-                    &prepared,
-                    values,
-                    consistency,
-                    serial_consistency,
-                    paging_state,
-                )
-                .await;
-        }
-
         let query_frame = query::Query {
             contents: Cow::Borrowed(&query.contents),
             parameters: query::QueryParameters {
                 consistency,
                 serial_consistency,
-                values: serialized_values,
+                values: Cow::Borrowed(SerializedValues::EMPTY),
                 page_size: query.get_page_size(),
                 paging_state,
                 timestamp: query.get_timestamp(),
@@ -685,6 +660,26 @@ impl Connection {
 
         self.send_request(&query_frame, true, query.config.tracing)
             .await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn execute(
+        &self,
+        prepared: PreparedStatement,
+        values: impl ValueList,
+        paging_state: Option<Bytes>,
+    ) -> Result<QueryResponse, QueryError> {
+        // This method is used only for driver internal queries, so no need to consult execution profile here.
+        self.execute_with_consistency(
+            &prepared,
+            values,
+            prepared
+                .config
+                .determine_consistency(self.config.default_consistency),
+            prepared.config.serial_consistency.flatten(),
+            paging_state,
+        )
+        .await
     }
 
     pub(crate) async fn execute_with_consistency(
@@ -734,19 +729,33 @@ impl Connection {
     pub(crate) async fn query_iter(
         self: Arc<Self>,
         query: Query,
-        values: impl ValueList,
     ) -> Result<RowIterator, QueryError> {
-        let serialized_values = values.serialized()?.into_owned();
-
         let consistency = query
             .config
             .determine_consistency(self.config.default_consistency);
         let serial_consistency = query.config.serial_consistency.flatten();
 
-        RowIterator::new_for_connection_query_iter(
-            query,
+        RowIterator::new_for_connection_query_iter(query, self, consistency, serial_consistency)
+            .await
+    }
+
+    /// Executes a prepared statements and fetches its results over multiple pages, using
+    /// the asynchronous iterator interface.
+    pub(crate) async fn execute_iter(
+        self: Arc<Self>,
+        prepared_statement: PreparedStatement,
+        values: impl ValueList,
+    ) -> Result<RowIterator, QueryError> {
+        let consistency = prepared_statement
+            .config
+            .determine_consistency(self.config.default_consistency);
+        let serial_consistency = prepared_statement.config.serial_consistency.flatten();
+        let serialized = values.serialized()?.into_owned();
+
+        RowIterator::new_for_connection_execute_iter(
+            prepared_statement,
+            serialized,
             self,
-            serialized_values,
             consistency,
             serial_consistency,
         )
@@ -885,7 +894,7 @@ impl Connection {
             false => format!("USE {}", keyspace_name.as_str()).into(),
         };
 
-        let query_response = self.query(&query, (), None).await?;
+        let query_response = self.query(&query, None).await?;
 
         match query_response.response {
             Response::Result(result::Result::SetKeyspace(set_keyspace)) => {
@@ -929,7 +938,7 @@ impl Connection {
 
     pub(crate) async fn fetch_schema_version(&self) -> Result<Uuid, QueryError> {
         let (version_id,): (Uuid,) = self
-            .query_single_page(LOCAL_VERSION, &[])
+            .query_single_page(LOCAL_VERSION)
             .await?
             .rows
             .ok_or(QueryError::ProtocolError("Version query returned not rows"))?
@@ -1833,7 +1842,6 @@ mod tests {
     use super::ConnectionConfig;
     use crate::query::Query;
     use crate::transport::connection::open_connection;
-    use crate::transport::connection::QueryResponse;
     use crate::transport::node::ResolvedContactPoint;
     use crate::transport::topology::UntranslatedEndpoint;
     use crate::utils::test_utils::unique_keyspace_name;
@@ -1914,7 +1922,7 @@ mod tests {
         let select_query = Query::new("SELECT p FROM connection_query_iter_tab").with_page_size(7);
         let empty_res = connection
             .clone()
-            .query_iter(select_query.clone(), &[])
+            .query_iter(select_query.clone())
             .await
             .unwrap()
             .try_collect::<Vec<_>>()
@@ -1927,15 +1935,18 @@ mod tests {
         let mut insert_futures = Vec::new();
         let insert_query =
             Query::new("INSERT INTO connection_query_iter_tab (p) VALUES (?)").with_page_size(7);
+        let prepared = connection.prepare(&insert_query).await.unwrap();
         for v in &values {
-            insert_futures.push(connection.query_single_page(insert_query.clone(), (v,)));
+            let prepared_clone = prepared.clone();
+            let fut = async { connection.execute(prepared_clone, (*v,), None).await };
+            insert_futures.push(fut);
         }
 
         futures::future::try_join_all(insert_futures).await.unwrap();
 
         let mut results: Vec<i32> = connection
             .clone()
-            .query_iter(select_query.clone(), &[])
+            .query_iter(select_query.clone())
             .await
             .unwrap()
             .into_typed::<(i32,)>()
@@ -1947,7 +1958,9 @@ mod tests {
 
         // 3. INSERT query_iter should work and not return any rows.
         let insert_res1 = connection
-            .query_iter(insert_query, (0,))
+            .query_iter(Query::new(
+                "INSERT INTO connection_query_iter_tab (p) VALUES (0)",
+            ))
             .await
             .unwrap()
             .try_collect::<Vec<_>>()
@@ -2007,10 +2020,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            connection
-                .query(&"TRUNCATE t".into(), (), None)
-                .await
-                .unwrap();
+            connection.query(&"TRUNCATE t".into(), None).await.unwrap();
 
             let mut futs = Vec::new();
 
@@ -2025,8 +2035,9 @@ mod tests {
                         let q = Query::new("INSERT INTO t (p, v) VALUES (?, ?)");
                         let conn = conn.clone();
                         async move {
-                            let response: QueryResponse = conn
-                                .query(&q, (j, vec![j as u8; j as usize]), None)
+                            let prepared = conn.prepare(&q).await.unwrap();
+                            let response = conn
+                                .execute(prepared.clone(), (j, vec![j as u8; j as usize]), None)
                                 .await
                                 .unwrap();
                             // QueryResponse might contain an error - make sure that there were no errors
@@ -2045,7 +2056,7 @@ mod tests {
             // Check that everything was written properly
             let range_end = arithmetic_sequence_sum(NUM_BATCHES);
             let mut results = connection
-                .query(&"SELECT p, v FROM t".into(), (), None)
+                .query(&"SELECT p, v FROM t".into(), None)
                 .await
                 .unwrap()
                 .into_query_result()
@@ -2198,7 +2209,7 @@ mod tests {
         // As everything is normal, these queries should succeed.
         for _ in 0..3 {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            conn.query_single_page("SELECT host_id FROM system.local", ())
+            conn.query_single_page("SELECT host_id FROM system.local")
                 .await
                 .unwrap();
         }
@@ -2218,7 +2229,7 @@ mod tests {
 
         // As the router is invalidated, all further queries should immediately
         // return error.
-        conn.query_single_page("SELECT host_id FROM system.local", ())
+        conn.query_single_page("SELECT host_id FROM system.local")
             .await
             .unwrap_err();
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -4,7 +4,6 @@ use scylla_cql::errors::TranslationError;
 use scylla_cql::frame::request::options::Options;
 use scylla_cql::frame::response::Error;
 use scylla_cql::frame::types::SerialConsistency;
-use scylla_cql::frame::value::LegacySerializedValues;
 use scylla_cql::types::serialize::row::SerializedValues;
 use socket2::{SockRef, TcpKeepalive};
 use tokio::io::{split, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
@@ -652,7 +651,7 @@ impl Connection {
             parameters: query::QueryParameters {
                 consistency,
                 serial_consistency,
-                values: Cow::Borrowed(LegacySerializedValues::EMPTY),
+                values: Cow::Borrowed(SerializedValues::EMPTY),
                 page_size: query.get_page_size(),
                 paging_state,
                 timestamp: query.get_timestamp(),
@@ -696,7 +695,7 @@ impl Connection {
             parameters: query::QueryParameters {
                 consistency,
                 serial_consistency,
-                values: Cow::Owned(values.to_old_serialized_values()),
+                values: Cow::Borrowed(values),
                 page_size: prepared_statement.get_page_size(),
                 timestamp: prepared_statement.get_timestamp(),
                 paging_state,

--- a/scylla/src/transport/cql_collections_test.rs
+++ b/scylla/src/transport/cql_collections_test.rs
@@ -3,6 +3,7 @@ use crate::frame::value::Value;
 use crate::test_utils::create_new_session_builder;
 use crate::utils::test_utils::unique_keyspace_name;
 use crate::{frame::response::result::CqlValue, IntoTypedRows, Session};
+use scylla_cql::types::serialize::value::SerializeCql;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 async fn connect() -> Session {
@@ -33,7 +34,7 @@ async fn insert_and_select<InsertT, SelectT>(
     to_insert: &InsertT,
     expected: &SelectT,
 ) where
-    InsertT: Value,
+    InsertT: Value + SerializeCql,
     SelectT: FromCqlVal<Option<CqlValue>> + PartialEq + std::fmt::Debug,
 {
     session

--- a/scylla/src/transport/cql_collections_test.rs
+++ b/scylla/src/transport/cql_collections_test.rs
@@ -1,5 +1,4 @@
 use crate::cql_to_rust::FromCqlVal;
-use crate::frame::value::Value;
 use crate::test_utils::create_new_session_builder;
 use crate::utils::test_utils::unique_keyspace_name;
 use crate::{frame::response::result::CqlValue, IntoTypedRows, Session};
@@ -34,7 +33,7 @@ async fn insert_and_select<InsertT, SelectT>(
     to_insert: &InsertT,
     expected: &SelectT,
 ) where
-    InsertT: Value + SerializeCql,
+    InsertT: SerializeCql,
     SelectT: FromCqlVal<Option<CqlValue>> + PartialEq + std::fmt::Debug,
 {
     session

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -9,6 +9,8 @@ use crate::transport::session::Session;
 use crate::utils::test_utils::unique_keyspace_name;
 use bigdecimal::BigDecimal;
 use num_bigint::BigInt;
+use scylla_cql::types::serialize::value::SerializeCql;
+use scylla_macros::SerializeCql;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -64,7 +66,7 @@ async fn init_test(table_name: &str, type_name: &str) -> Session {
 // Expected values and bound values are computed using T::from_str
 async fn run_tests<T>(tests: &[&str], type_name: &str)
 where
-    T: Value + FromCqlVal<CqlValue> + FromStr + Debug + Clone + PartialEq,
+    T: Value + SerializeCql + FromCqlVal<CqlValue> + FromStr + Debug + Clone + PartialEq,
 {
     let session: Session = init_test(type_name, type_name).await;
     session.await_schema_agreement().await.unwrap();
@@ -1361,7 +1363,8 @@ async fn test_udt_after_schema_update() {
         .await
         .unwrap();
 
-    #[derive(IntoUserType, FromUserType, Debug, PartialEq)]
+    #[derive(IntoUserType, SerializeCql, FromUserType, Debug, PartialEq)]
+    #[scylla(crate = crate)]
     struct UdtV1 {
         pub first: i32,
         pub second: bool,

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -1,8 +1,8 @@
 use crate as scylla;
 use crate::cql_to_rust::FromCqlVal;
 use crate::frame::response::result::CqlValue;
-use crate::frame::value::{Counter, CqlDate, CqlTime, CqlTimestamp, Value};
-use crate::macros::{FromUserType, IntoUserType};
+use crate::frame::value::{Counter, CqlDate, CqlTime, CqlTimestamp};
+use crate::macros::FromUserType;
 use crate::test_utils::create_new_session_builder;
 use crate::transport::session::IntoTypedRows;
 use crate::transport::session::Session;
@@ -66,7 +66,7 @@ async fn init_test(table_name: &str, type_name: &str) -> Session {
 // Expected values and bound values are computed using T::from_str
 async fn run_tests<T>(tests: &[&str], type_name: &str)
 where
-    T: Value + SerializeCql + FromCqlVal<CqlValue> + FromStr + Debug + Clone + PartialEq,
+    T: SerializeCql + FromCqlVal<CqlValue> + FromStr + Debug + Clone + PartialEq,
 {
     let session: Session = init_test(type_name, type_name).await;
     session.await_schema_agreement().await.unwrap();
@@ -1363,7 +1363,7 @@ async fn test_udt_after_schema_update() {
         .await
         .unwrap();
 
-    #[derive(IntoUserType, SerializeCql, FromUserType, Debug, PartialEq)]
+    #[derive(SerializeCql, FromUserType, Debug, PartialEq)]
     #[scylla(crate = crate)]
     struct UdtV1 {
         pub first: i32,

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -27,7 +27,7 @@ use crate::frame::{
         result,
         result::{ColumnSpec, Row, Rows},
     },
-    value::SerializedValues,
+    value::LegacySerializedValues,
 };
 use crate::history::{self, HistoryListener};
 use crate::statement::Consistency;
@@ -73,7 +73,7 @@ struct ReceivedPage {
 
 pub(crate) struct PreparedIteratorConfig {
     pub(crate) prepared: PreparedStatement,
-    pub(crate) values: SerializedValues,
+    pub(crate) values: LegacySerializedValues,
     pub(crate) execution_profile: Arc<ExecutionProfileInner>,
     pub(crate) cluster_data: Arc<ClusterData>,
     pub(crate) metrics: Arc<Metrics>,
@@ -362,7 +362,7 @@ impl RowIterator {
 
     pub(crate) async fn new_for_connection_execute_iter(
         mut prepared: PreparedStatement,
-        values: SerializedValues,
+        values: LegacySerializedValues,
         connection: Arc<Connection>,
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -273,7 +273,7 @@ impl RowIterator {
                 connection
                     .execute_with_consistency(
                         prepared_ref,
-                        &values_ref.to_old_serialized_values(),
+                        values_ref,
                         consistency,
                         serial_consistency,
                         paging_state,
@@ -375,15 +375,13 @@ impl RowIterator {
         }
         let (sender, receiver) = mpsc::channel::<Result<ReceivedPage, QueryError>>(1);
 
-        let old_values = values.to_old_serialized_values();
-
         let worker_task = async move {
             let worker = SingleConnectionRowIteratorWorker {
                 sender: sender.into(),
                 fetcher: |paging_state| {
                     connection.execute_with_consistency(
                         &prepared,
-                        &old_values,
+                        &values,
                         consistency,
                         serial_consistency,
                         paging_state,

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -181,7 +181,11 @@ impl RowIterator {
 
             let query_ref = &query;
 
-            let span_creator = move || RequestSpan::new_query(&query_ref.contents, 0);
+            let span_creator = move || {
+                let span = RequestSpan::new_query(&query_ref.contents);
+                span.record_request_size(0);
+                span
+            };
 
             let worker = RowIteratorWorker {
                 sender: sender.into(),

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -238,12 +238,11 @@ impl RowIterator {
         let worker_task = async move {
             let prepared_ref = &config.prepared;
             let values_ref = &config.values;
-            let old_values = values_ref.to_old_serialized_values();
 
             let (partition_key, token) = match prepared_ref
                 .extract_partition_key_and_calculate_token(
                     prepared_ref.get_partitioner_name(),
-                    &old_values,
+                    values_ref,
                 ) {
                 Ok(res) => res.unzip(),
                 Err(err) => {

--- a/scylla/src/transport/partitioner.rs
+++ b/scylla/src/transport/partitioner.rs
@@ -3,7 +3,7 @@ use scylla_cql::frame::types::RawValue;
 use std::num::Wrapping;
 
 use crate::{
-    frame::value::SerializedValues, prepared_statement::TokenCalculationError, routing::Token,
+    frame::value::LegacySerializedValues, prepared_statement::TokenCalculationError, routing::Token,
 };
 
 #[allow(clippy::upper_case_acronyms)]
@@ -337,7 +337,7 @@ impl PartitionerHasher for CDCPartitionerHasher {
 /// NOTE: the provided values must completely constitute partition key
 /// and be in the order defined in CREATE TABLE statement.
 pub fn calculate_token_for_partition_key<P: Partitioner>(
-    serialized_partition_key_values: &SerializedValues,
+    serialized_partition_key_values: &LegacySerializedValues,
     partitioner: &P,
 ) -> Result<Token, TokenCalculationError> {
     let mut partitioner_hasher = partitioner.build_hasher();

--- a/scylla/src/transport/partitioner.rs
+++ b/scylla/src/transport/partitioner.rs
@@ -1,10 +1,8 @@
 use bytes::Buf;
-use scylla_cql::frame::types::RawValue;
+use scylla_cql::{frame::types::RawValue, types::serialize::row::SerializedValues};
 use std::num::Wrapping;
 
-use crate::{
-    frame::value::LegacySerializedValues, prepared_statement::TokenCalculationError, routing::Token,
-};
+use crate::{prepared_statement::TokenCalculationError, routing::Token};
 
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, PartialEq, Debug, Default)]
@@ -337,12 +335,12 @@ impl PartitionerHasher for CDCPartitionerHasher {
 /// NOTE: the provided values must completely constitute partition key
 /// and be in the order defined in CREATE TABLE statement.
 pub fn calculate_token_for_partition_key<P: Partitioner>(
-    serialized_partition_key_values: &LegacySerializedValues,
+    serialized_partition_key_values: &SerializedValues,
     partitioner: &P,
 ) -> Result<Token, TokenCalculationError> {
     let mut partitioner_hasher = partitioner.build_hasher();
 
-    if serialized_partition_key_values.len() == 1 {
+    if serialized_partition_key_values.element_count() == 1 {
         let val = serialized_partition_key_values.iter().next().unwrap();
         if let RawValue::Value(val) = val {
             partitioner_hasher.write(val);

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -676,7 +676,7 @@ impl Session {
                             connection
                                 .execute_with_consistency(
                                     &prepared,
-                                    &serialized.to_old_serialized_values(),
+                                    &serialized,
                                     consistency,
                                     serial_consistency,
                                     paging_state_ref.clone(),
@@ -964,11 +964,15 @@ impl Session {
     ) -> Result<QueryResult, QueryError> {
         let serialized_values = prepared.serialize_values(&values)?;
         let old_serialized_values = serialized_values.to_old_serialized_values();
-        let values_ref = &old_serialized_values;
+        let values_ref = &serialized_values;
+        let old_values_ref = &old_serialized_values;
         let paging_state_ref = &paging_state;
 
         let (partition_key, token) = prepared
-            .extract_partition_key_and_calculate_token(prepared.get_partitioner_name(), values_ref)?
+            .extract_partition_key_and_calculate_token(
+                prepared.get_partitioner_name(),
+                old_values_ref,
+            )?
             .unzip();
 
         let execution_profile = prepared

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -47,9 +47,7 @@ use super::NodeRef;
 use crate::cql_to_rust::FromRow;
 use crate::frame::response::cql_to_rust::FromRowError;
 use crate::frame::response::result;
-use crate::frame::value::{
-    BatchValues, BatchValuesFirstSerialized, BatchValuesIterator, ValueList,
-};
+use crate::frame::value::{BatchValues, BatchValuesFirstSerialized, BatchValuesIterator};
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::routing::Token;
@@ -604,10 +602,9 @@ impl Session {
     pub async fn query(
         &self,
         query: impl Into<Query>,
-        values: impl ValueList,
+        values: impl SerializeRow,
     ) -> Result<QueryResult, QueryError> {
-        self.query_paged(query, values.serialized()?.as_ref(), None)
-            .await
+        self.query_paged(query, values, None).await
     }
 
     /// Queries the database with a custom paging state.

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1107,10 +1107,10 @@ impl Session {
     pub async fn execute_iter(
         &self,
         prepared: impl Into<PreparedStatement>,
-        values: impl ValueList,
+        values: impl SerializeRow,
     ) -> Result<RowIterator, QueryError> {
         let prepared = prepared.into();
-        let serialized_values = values.serialized()?;
+        let serialized_values = prepared.serialize_values(&values)?;
 
         let execution_profile = prepared
             .get_execution_profile_handle()
@@ -1119,7 +1119,7 @@ impl Session {
 
         RowIterator::new_for_prepared_statement(PreparedIteratorConfig {
             prepared,
-            values: serialized_values.into_owned(),
+            values: serialized_values.to_old_serialized_values(),
             execution_profile,
             cluster_data: self.cluster.get_data(),
             metrics: self.metrics.clone(),

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -963,16 +963,11 @@ impl Session {
         paging_state: Option<Bytes>,
     ) -> Result<QueryResult, QueryError> {
         let serialized_values = prepared.serialize_values(&values)?;
-        let old_serialized_values = serialized_values.to_old_serialized_values();
         let values_ref = &serialized_values;
-        let old_values_ref = &old_serialized_values;
         let paging_state_ref = &paging_state;
 
         let (partition_key, token) = prepared
-            .extract_partition_key_and_calculate_token(
-                prepared.get_partitioner_name(),
-                old_values_ref,
-            )?
+            .extract_partition_key_and_calculate_token(prepared.get_partitioner_name(), values_ref)?
             .unzip();
 
         let execution_profile = prepared

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1216,7 +1216,7 @@ impl Session {
         let first_value_token = statement_info.token;
 
         // Reuse first serialized value when serializing query, and delegate to `BatchValues::write_next_to_request`
-        // directly for others (if they weren't already serialized, possibly don't even allocate the `SerializedValues`)
+        // directly for others (if they weren't already serialized, possibly don't even allocate the `LegacySerializedValues`)
         let values = BatchValuesFirstSerialized::new(&values, first_serialized_value);
         let values_ref = &values;
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -948,10 +948,9 @@ impl Session {
     pub async fn execute(
         &self,
         prepared: &PreparedStatement,
-        values: impl ValueList,
+        values: impl SerializeRow,
     ) -> Result<QueryResult, QueryError> {
-        self.execute_paged(prepared, values.serialized()?.as_ref(), None)
-            .await
+        self.execute_paged(prepared, values, None).await
     }
 
     /// Executes a previously prepared statement with previously received paging state

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -804,7 +804,7 @@ impl Session {
             let values = prepared.serialize_values(&values)?;
             RowIterator::new_for_prepared_statement(PreparedIteratorConfig {
                 prepared,
-                values: values.to_old_serialized_values(),
+                values,
                 execution_profile,
                 cluster_data: self.cluster.get_data(),
                 metrics: self.metrics.clone(),
@@ -1115,7 +1115,7 @@ impl Session {
 
         RowIterator::new_for_prepared_statement(PreparedIteratorConfig {
             prepared,
-            values: serialized_values.to_old_serialized_values(),
+            values: serialized_values,
             execution_profile,
             cluster_data: self.cluster.get_data(),
             metrics: self.metrics.clone(),

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -326,9 +326,12 @@ async fn test_prepared_statement() {
         assert!(e.is_none());
         assert_eq!((a, b, c, d), (17, 16, &String::from("I'm prepared!!!"), 7))
     }
-    // Check that ValueList macro works
+    // Check that SerializeRow macro works
     {
-        #[derive(scylla::ValueList, scylla::FromRow, PartialEq, Debug, Clone)]
+        #[derive(
+            scylla::ValueList, scylla::SerializeRow, scylla::FromRow, PartialEq, Debug, Clone,
+        )]
+        #[scylla(crate = crate)]
         struct ComplexPk {
             a: i32,
             b: i32,

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -29,8 +29,8 @@ use bytes::Bytes;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use scylla_cql::frame::response::result::ColumnType;
-use scylla_cql::frame::value::Value;
 use scylla_cql::types::serialize::row::SerializedValues;
+use scylla_cql::types::serialize::value::SerializeCql;
 use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -1999,14 +1999,17 @@ async fn test_unusual_valuelists() {
         .await
         .unwrap();
 
-    let values_dyn: Vec<&dyn Value> =
-        vec![&1 as &dyn Value, &2 as &dyn Value, &"&dyn" as &dyn Value];
+    let values_dyn: Vec<&dyn SerializeCql> = vec![
+        &1 as &dyn SerializeCql,
+        &2 as &dyn SerializeCql,
+        &"&dyn" as &dyn SerializeCql,
+    ];
     session.execute(&insert_a_b_c, values_dyn).await.unwrap();
 
-    let values_box_dyn: Vec<Box<dyn Value>> = vec![
-        Box::new(1) as Box<dyn Value>,
-        Box::new(3) as Box<dyn Value>,
-        Box::new("Box dyn") as Box<dyn Value>,
+    let values_box_dyn: Vec<Box<dyn SerializeCql>> = vec![
+        Box::new(1) as Box<dyn SerializeCql>,
+        Box::new(3) as Box<dyn SerializeCql>,
+        Box::new("Box dyn") as Box<dyn SerializeCql>,
     ];
     session
         .execute(&insert_a_b_c, values_box_dyn)

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -328,9 +328,7 @@ async fn test_prepared_statement() {
     }
     // Check that SerializeRow macro works
     {
-        #[derive(
-            scylla::ValueList, scylla::SerializeRow, scylla::FromRow, PartialEq, Debug, Clone,
-        )]
+        #[derive(scylla::SerializeRow, scylla::FromRow, PartialEq, Debug, Clone)]
         #[scylla(crate = crate)]
         struct ComplexPk {
             a: i32,

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -15,7 +15,6 @@ use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use scylla_cql::errors::NewSessionError;
 use scylla_cql::frame::response::result::Row;
-use scylla_cql::frame::value::ValueList;
 use scylla_macros::FromRow;
 use std::borrow::BorrowMut;
 use std::cell::Cell;
@@ -854,28 +853,30 @@ async fn create_peer_from_row(
     }))
 }
 
-fn query_filter_keyspace_name(
+fn query_filter_keyspace_name<'a>(
     conn: &Arc<Connection>,
-    query_str: &str,
-    keyspaces_to_fetch: &[String],
-) -> impl Stream<Item = Result<Row, QueryError>> {
-    let keyspaces = &[keyspaces_to_fetch] as &[&[String]];
-    let (query_str, query_values) = if !keyspaces_to_fetch.is_empty() {
-        (format!("{query_str} where keyspace_name in ?"), keyspaces)
-    } else {
-        (query_str.into(), &[] as &[&[String]])
-    };
-    let query_values = query_values.serialized().map(|sv| sv.into_owned());
-    let mut query = Query::new(query_str);
+    query_str: &'a str,
+    keyspaces_to_fetch: &'a [String],
+) -> impl Stream<Item = Result<Row, QueryError>> + 'a {
     let conn = conn.clone();
-    query.set_page_size(1024);
+
     let fut = async move {
-        let query_values = query_values?;
-        if query_values.is_empty() {
+        if keyspaces_to_fetch.is_empty() {
+            let mut query = Query::new(query_str);
+            query.set_page_size(1024);
+
             conn.query_iter(query).await
         } else {
+            let keyspaces = &[keyspaces_to_fetch] as &[&[String]];
+            let query_str = format!("{query_str} where keyspace_name in ?");
+
+            let mut query = Query::new(query_str);
+            query.set_page_size(1024);
+
             let prepared = conn.prepare(&query).await?;
-            conn.execute_iter(prepared, query_values).await
+            let serialized_values = prepared.serialize_values(&keyspaces)?;
+            conn.execute_iter(prepared, &serialized_values.to_old_serialized_values())
+                .await
         }
     };
     fut.into_stream().try_flatten()

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -875,8 +875,7 @@ fn query_filter_keyspace_name<'a>(
 
             let prepared = conn.prepare(&query).await?;
             let serialized_values = prepared.serialize_values(&keyspaces)?;
-            conn.execute_iter(prepared, &serialized_values.to_old_serialized_values())
-                .await
+            conn.execute_iter(prepared, serialized_values).await
         }
     };
     fut.into_stream().try_flatten()


### PR DESCRIPTION
This PR is based on https://github.com/scylladb/scylla-rust-driver/pull/855 and is the main part of serialization refactor - switching public API to new trait.
The last commit makes the actual change. Previous ones are different changes that were necessary (or helpful) to make the switch.

There are still some things to do:
- [x] Comments on new traits / structs
- [ ] Documentation
- [ ] Rename SerializeCQL / SerializeRow / NewSerializedValues to some sensible names
- [ ] (Maybe) Check who calls query_filter_keyspace_name and use prepared statements in those places to avoid unnecessary prepares.

But the code changes are pretty much ready for review.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
