### PR TITLE
value_tests: fix clippy's new complaint about needless_borrows_for_generic_args

### DIFF
--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -904,9 +904,9 @@ fn check_ref_tuple() {
     }
     let s = String::from("hello");
     let tuple: ((&str,),) = ((&s,),);
-    assert_has_batch_values(&tuple);
+    assert_has_batch_values::<&_>(&tuple);
     let tuple2: ((&str, &str), (&str, &str)) = ((&s, &s), (&s, &s));
-    assert_has_batch_values(&tuple2);
+    assert_has_batch_values::<&_>(&tuple2);
 }
 
 #[test]


### PR DESCRIPTION
A new clippy lint started complaining about the `check_ref_tuple` test: its inner `assert_has_batch_values`, supposedly, needlessly borrows its argument.

As it looks like one of the points of the test is to verify that batch values taken by reference still implement batch values, the clippy lint seems incorrect. Silence the lint by explicitly specifying that the type of the generic argument for `assert_has_batch_values` is a reference.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
