### PR TITLE
serialization: implement new serialization traits for the currently supported types

### DIFF
--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -44,7 +44,7 @@ pub struct Counter(pub i64);
 
 /// Enum providing a way to represent a value that might be unset
 #[derive(Clone, Copy)]
-pub enum MaybeUnset<V: Value> {
+pub enum MaybeUnset<V> {
     Unset,
     Set(V),
 }

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -8,7 +8,7 @@ pub mod writers;
 
 pub use writers::{
     BufBackedCellValueBuilder, BufBackedCellWriter, BufBackedRowWriter, CellValueBuilder,
-    CellWriter, CountingWriter, RowWriter,
+    CellWriter, CountingCellWriter, RowWriter,
 };
 #[derive(Debug, Clone, Error)]
 pub struct SerializationError(Arc<dyn Error + Send + Sync>);

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -13,6 +13,14 @@ pub use writers::{
 #[derive(Debug, Clone, Error)]
 pub struct SerializationError(Arc<dyn Error + Send + Sync>);
 
+impl SerializationError {
+    /// Constructs a new `SerializationError`.
+    #[inline]
+    pub fn new(err: impl Error + Send + Sync + 'static) -> SerializationError {
+        SerializationError(Arc::new(err))
+    }
+}
+
 impl Display for SerializationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "SerializationError: {}", self.0)

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -246,8 +246,18 @@ impl<T: SerializeCql, S: BuildHasher> SerializeRow for HashMap<&str, T, S> {
     impl_serialize_row_for_map!();
 }
 
-impl<T: ValueList> SerializeRow for &T {
-    fallback_impl_contents!();
+impl<T: SerializeRow> SerializeRow for &T {
+    fn preliminary_type_check(ctx: &RowSerializationContext<'_>) -> Result<(), SerializationError> {
+        <T as SerializeRow>::preliminary_type_check(ctx)
+    }
+
+    fn serialize<W: RowWriter>(
+        &self,
+        ctx: &RowSerializationContext<'_>,
+        writer: &mut W,
+    ) -> Result<(), SerializationError> {
+        <T as SerializeRow>::serialize(self, ctx, writer)
+    }
 }
 
 impl SerializeRow for SerializedValues {

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -9,7 +9,7 @@ use super::{CellWriter, RowWriter, SerializationError};
 
 /// Contains information needed to serialize a row.
 pub struct RowSerializationContext<'a> {
-    columns: &'a [ColumnSpec],
+    pub(crate) columns: &'a [ColumnSpec],
 }
 
 impl<'a> RowSerializationContext<'a> {

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -79,7 +79,9 @@ pub fn serialize_legacy_row<T: ValueList>(
         let _proof = match value {
             RawValue::Null => cell_writer.set_null(),
             RawValue::Unset => cell_writer.set_unset(),
-            RawValue::Value(v) => cell_writer.set_value(v),
+            // The unwrap below will succeed because the value was successfully
+            // deserialized from the CQL format, so it must have
+            RawValue::Value(v) => cell_writer.set_value(v).unwrap(),
         };
     };
 

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -174,7 +174,8 @@ impl SerializeCql for f64 {
     impl_serialize_via_writer!(|me, writer| writer.set_value(me.to_be_bytes().as_slice()).unwrap());
 }
 impl SerializeCql for Uuid {
-    fallback_impl_contents!();
+    impl_exact_preliminary_type_check!(Uuid, Timeuuid);
+    impl_serialize_via_writer!(|me, writer| writer.set_value(me.as_bytes().as_ref()).unwrap());
 }
 impl SerializeCql for BigInt {
     fallback_impl_contents!();

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -188,13 +188,28 @@ impl SerializeCql for &str {
     });
 }
 impl SerializeCql for Vec<u8> {
-    fallback_impl_contents!();
+    impl_exact_preliminary_type_check!(Blob);
+    impl_serialize_via_writer!(|me, typ, writer| {
+        writer
+            .set_value(me.as_ref())
+            .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
+    });
 }
 impl SerializeCql for &[u8] {
-    fallback_impl_contents!();
+    impl_exact_preliminary_type_check!(Blob);
+    impl_serialize_via_writer!(|me, typ, writer| {
+        writer
+            .set_value(me)
+            .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
+    });
 }
 impl<const N: usize> SerializeCql for [u8; N] {
-    fallback_impl_contents!();
+    impl_exact_preliminary_type_check!(Blob);
+    impl_serialize_via_writer!(|me, typ, writer| {
+        writer
+            .set_value(me.as_ref())
+            .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
+    });
 }
 impl SerializeCql for IpAddr {
     fallback_impl_contents!();

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -73,7 +73,7 @@ pub fn serialize_legacy_value<T: Value, W: CellWriter>(
                     },
                 )))
             } else {
-                Ok(writer.set_value(contents))
+                Ok(writer.set_value(contents).unwrap()) // len <= i32::MAX, so unwrap will succeed
             }
         }
         _ => Err(SerializationError(Arc::new(

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -213,7 +213,13 @@ impl<const N: usize> SerializeCql for [u8; N] {
     });
 }
 impl SerializeCql for IpAddr {
-    fallback_impl_contents!();
+    impl_exact_preliminary_type_check!(Inet);
+    impl_serialize_via_writer!(|me, writer| {
+        match me {
+            IpAddr::V4(ip) => writer.set_value(&ip.octets()).unwrap(),
+            IpAddr::V6(ip) => writer.set_value(&ip.octets()).unwrap(),
+        }
+    });
 }
 impl SerializeCql for String {
     impl_exact_preliminary_type_check!(Ascii, Text);


### PR DESCRIPTION
The new `SerializeCql` and `SerializeRow` traits are supposed to eventually replace `Value` and `ValueList`. Currently, the new traits are implemented with a blanket implementation based on the old traits - this was just done in order to parallelize work on adapting the whole codebase to the new traits; the blanket implementations are inefficient and not type safe. This PR gets rid of them and, for each type for which we implement `Value` or `ValueList`, introduces proper implementations of `SerializeCql` and `SerializeRow`.

All types now check whether the CQL type serialized to matches, and most of them serialize exactly the same as they used to with the old traits. However, some slight differences were made in order to utilize the information available to the new traits and make it more robust:

- `CqlValue::UserDefinedType` now doesn't assume that the order of the fields is the same as in the CQL type - it sorts the fields according to the CQL type.
- `impl SerializeRow for BTreeMap/HashMap` doesn't serialize in the "named values" format anymore as it is no longer supported by the new traits. Instead, it uses provided information about the column names to properly order the values before sending them to the database.

Existing tests in `value_tests.rs` are adapted so that they perform serialization using both old and new traits and compare the results (with a small number of exceptions where serialization behavior was changed).

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/821

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
