### PR TITLE
scylla-proxy: Add option to filter out control connection messages

### DIFF
--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -31,3 +31,5 @@ rand = "0.8.5"
 assert_matches = "1.5.0"
 ntest = "0.9.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+tokio = { version = "1.12", features = ["signal"] }
+

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -260,15 +260,18 @@ async fn consistency_is_correctly_set_in_cql_requests() {
         |proxy_uris, translation_map, mut running_proxy| async move {
             let request_rule = |tx| {
                 RequestRule(
-                    Condition::or(
-                        Condition::RequestOpcode(RequestOpcode::Execute),
+                    Condition::and(
+                        Condition::not(Condition::ConnectionRegisteredAnyEvent),
                         Condition::or(
-                            Condition::RequestOpcode(RequestOpcode::Batch),
-                            Condition::and(
-                                Condition::RequestOpcode(RequestOpcode::Query),
-                                Condition::BodyContainsCaseSensitive(Box::new(
-                                    *b"INTO consistency_tests",
-                                )),
+                            Condition::RequestOpcode(RequestOpcode::Execute),
+                            Condition::or(
+                                Condition::RequestOpcode(RequestOpcode::Batch),
+                                Condition::and(
+                                    Condition::RequestOpcode(RequestOpcode::Query),
+                                    Condition::BodyContainsCaseSensitive(Box::new(
+                                        *b"INTO consistency_tests",
+                                    )),
+                                ),
                             ),
                         ),
                     ),

--- a/scylla/tests/integration/shards.rs
+++ b/scylla/tests/integration/shards.rs
@@ -23,7 +23,7 @@ async fn test_consistent_shard_awareness() {
         }).unzip();
         for (i, tx) in feedback_txs.iter().cloned().enumerate() {
             running_proxy.running_nodes[i].change_request_rules(Some(vec![
-                RequestRule(Condition::RequestOpcode(RequestOpcode::Execute), RequestReaction::noop().with_feedback_when_performed(tx))
+                RequestRule(Condition::RequestOpcode(RequestOpcode::Execute).and(Condition::not(Condition::ConnectionRegisteredAnyEvent)), RequestReaction::noop().with_feedback_when_performed(tx))
             ]));
         }
 


### PR DESCRIPTION
Proxy does not allow filtering of control connection messages. Right now this is not a problem, as all queries performed by driver are not prepared, so tests can filter them out by checking query content.

The ongoing serialization refactor changes that and prepares some queries performed automatically by driver, which breaks some tests, as they are not able to differentiate test's queries from internal driver queries.

This PR adds a mechanism to filter out control connection messages by ignoring messages on connections that had any event registered. Control connection is the only one in rust driver that does it, so this should by a reliable heuristic.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
