### PR TITLE
Make SerializationError a newtype

### DIFF
--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, sync::Arc};
+use std::{error::Error, sync::Arc};
 
 pub mod row;
 pub mod value;
@@ -9,4 +9,4 @@ pub use writers::{
     CellWriter, CountingWriter, RowWriter,
 };
 
-type SerializationError = Arc<dyn Any + Send + Sync>;
+type SerializationError = Arc<dyn Error + Send + Sync>;

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -1,4 +1,6 @@
-use std::{error::Error, sync::Arc};
+use std::{error::Error, fmt::Display, sync::Arc};
+
+use thiserror::Error;
 
 pub mod row;
 pub mod value;
@@ -8,5 +10,11 @@ pub use writers::{
     BufBackedCellValueBuilder, BufBackedCellWriter, BufBackedRowWriter, CellValueBuilder,
     CellWriter, CountingWriter, RowWriter,
 };
+#[derive(Debug, Clone, Error)]
+pub struct SerializationError(Arc<dyn Error + Send + Sync>);
 
-type SerializationError = Arc<dyn Error + Send + Sync>;
+impl Display for SerializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SerializationError: {}", self.0)
+    }
+}

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -72,7 +72,7 @@ pub fn serialize_legacy_row<T: ValueList>(
     writer: &mut impl RowWriter,
 ) -> Result<(), SerializationError> {
     let serialized =
-        <T as ValueList>::serialized(r).map_err(|err| Arc::new(err) as SerializationError)?;
+        <T as ValueList>::serialized(r).map_err(|err| SerializationError(Arc::new(err)))?;
 
     let mut append_value = |value: RawValue| {
         let cell_writer = writer.make_cell_writer();
@@ -93,9 +93,11 @@ pub fn serialize_legacy_row<T: ValueList>(
 
         for col in ctx.columns() {
             let val = values_by_name.get(col.name.as_str()).ok_or_else(|| {
-                Arc::new(ValueListToSerializeRowAdapterError::NoBindMarkerWithName {
-                    name: col.name.clone(),
-                }) as SerializationError
+                SerializationError(Arc::new(
+                    ValueListToSerializeRowAdapterError::NoBindMarkerWithName {
+                        name: col.name.clone(),
+                    },
+                ))
             })?;
             append_value(*val);
         }


### PR DESCRIPTION
## Pre-review checklist

This PR consists of first 2 commits of https://github.com/scylladb/scylla-rust-driver/pull/858
It was split out in order to merge it before #858, so that #862 and #851 can be rebased on top of it.

There are 2 changes made here:
- changing `dyn Any` to `dyn Error` in SerializationError - it also supports downcasting, but is more useful interface
- Making SerializationError a newtype instead of type alias. This prevents making conversion implementations too generic, like `impl From<SerializationError> for QueryError`, which after desugaring is `impl From<Arc<dyn Error + Send + Sync>> for QueryError` - and writing such implementations doesn't seem like a good idea.

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
