### PR TITLE
SerializeRow: Add is_empty method

### DIFF
--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1000,11 +1000,14 @@ fn serialize_values<T: ValueList + SerializeRow>(
     let mut writer = BufBackedRowWriter::new(&mut new_serialized);
     <T as SerializeRow>::serialize(&vl, &ctx, &mut writer).unwrap();
     let value_count: u16 = writer.value_count().try_into().unwrap();
+    let is_empty = writer.value_count() == 0;
 
     // Prepend with value count, like `ValueList` does
     new_serialized[0..2].copy_from_slice(&value_count.to_be_bytes());
 
     assert_eq!(old_serialized, new_serialized);
+    assert_eq!(<T as SerializeRow>::is_empty(&vl), is_empty);
+    assert_eq!(serialized.is_empty(), is_empty);
 
     serialized
 }
@@ -1016,9 +1019,12 @@ fn serialize_values_only_new<T: SerializeRow>(vl: T, columns: &[ColumnSpec]) -> 
     let mut writer = BufBackedRowWriter::new(&mut serialized);
     <T as SerializeRow>::serialize(&vl, &ctx, &mut writer).unwrap();
     let value_count: u16 = writer.value_count().try_into().unwrap();
+    let is_empty = writer.value_count() == 0;
 
     // Prepend with value count, like `ValueList` does
     serialized[0..2].copy_from_slice(&value_count.to_be_bytes());
+
+    assert_eq!(<T as SerializeRow>::is_empty(&vl), is_empty);
 
     serialized
 }


### PR DESCRIPTION
Currently ongoing serialization refactor requires to only perform queries with values using prepared statements. Session interface still allows to pass values in query* methods, so we need a way to know if we can perform unprepared query or not.

One way is to always perform prepared queries, but that is not optimal. Before ongoing refactor we could serialize values and check if they are empty. This will no longer be possible soon, because serializing will require knowing column types, which in this case means having a prepared statement.

This commit implements third way - additional method on SerializeRow trait that allows us to check if values are empty (in which case we can skip the prepare).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
