### PR TITLE
serialize: make new serialization traits object-safe

### DIFF
--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1,7 +1,7 @@
 use crate::frame::{response::result::CqlValue, types::RawValue, value::BatchValuesIterator};
 use crate::types::serialize::row::{RowSerializationContext, SerializeRow};
 use crate::types::serialize::value::SerializeCql;
-use crate::types::serialize::{BufBackedCellWriter, BufBackedRowWriter};
+use crate::types::serialize::{CellWriter, RowWriter};
 
 use super::response::result::{ColumnSpec, ColumnType, TableSpec};
 use super::value::{
@@ -27,7 +27,7 @@ where
     T::preliminary_type_check(&typ).unwrap();
 
     let mut new_result: Vec<u8> = Vec::new();
-    let writer = BufBackedCellWriter::new(&mut new_result);
+    let writer = CellWriter::new(&mut new_result);
     SerializeCql::serialize(&val, &typ, writer).unwrap();
 
     assert_eq!(result, new_result);
@@ -37,7 +37,7 @@ where
 
 fn serialized_only_new<T: SerializeCql>(val: T, typ: ColumnType) -> Vec<u8> {
     let mut result: Vec<u8> = Vec::new();
-    let writer = BufBackedCellWriter::new(&mut result);
+    let writer = CellWriter::new(&mut result);
     SerializeCql::serialize(&val, &typ, writer).unwrap();
     result
 }
@@ -997,7 +997,7 @@ fn serialize_values<T: ValueList + SerializeRow>(
     let ctx = RowSerializationContext { columns };
     <T as SerializeRow>::preliminary_type_check(&ctx).unwrap();
     let mut new_serialized = vec![0, 0];
-    let mut writer = BufBackedRowWriter::new(&mut new_serialized);
+    let mut writer = RowWriter::new(&mut new_serialized);
     <T as SerializeRow>::serialize(&vl, &ctx, &mut writer).unwrap();
     let value_count: u16 = writer.value_count().try_into().unwrap();
     let is_empty = writer.value_count() == 0;
@@ -1016,7 +1016,7 @@ fn serialize_values_only_new<T: SerializeRow>(vl: T, columns: &[ColumnSpec]) -> 
     let ctx = RowSerializationContext { columns };
     <T as SerializeRow>::preliminary_type_check(&ctx).unwrap();
     let mut serialized = vec![0, 0];
-    let mut writer = BufBackedRowWriter::new(&mut serialized);
+    let mut writer = RowWriter::new(&mut serialized);
     <T as SerializeRow>::serialize(&vl, &ctx, &mut writer).unwrap();
     let value_count: u16 = writer.value_count().try_into().unwrap();
     let is_empty = writer.value_count() == 0;

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -24,8 +24,6 @@ where
     let mut result: Vec<u8> = Vec::new();
     Value::serialize(&val, &mut result).unwrap();
 
-    T::preliminary_type_check(&typ).unwrap();
-
     let mut new_result: Vec<u8> = Vec::new();
     let writer = CellWriter::new(&mut new_result);
     SerializeCql::serialize(&val, &typ, writer).unwrap();
@@ -995,7 +993,6 @@ fn serialize_values<T: ValueList + SerializeRow>(
     serialized.write_to_request(&mut old_serialized);
 
     let ctx = RowSerializationContext { columns };
-    <T as SerializeRow>::preliminary_type_check(&ctx).unwrap();
     let mut new_serialized = vec![0, 0];
     let mut writer = RowWriter::new(&mut new_serialized);
     <T as SerializeRow>::serialize(&vl, &ctx, &mut writer).unwrap();
@@ -1014,7 +1011,6 @@ fn serialize_values<T: ValueList + SerializeRow>(
 
 fn serialize_values_only_new<T: SerializeRow>(vl: T, columns: &[ColumnSpec]) -> Vec<u8> {
     let ctx = RowSerializationContext { columns };
-    <T as SerializeRow>::preliminary_type_check(&ctx).unwrap();
     let mut serialized = vec![0, 0];
     let mut writer = RowWriter::new(&mut serialized);
     <T as SerializeRow>::serialize(&vl, &ctx, &mut writer).unwrap();

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -8,7 +8,7 @@ pub mod writers;
 
 pub use writers::{
     BufBackedCellValueBuilder, BufBackedCellWriter, BufBackedRowWriter, CellValueBuilder,
-    CellWriter, CountingCellWriter, RowWriter,
+    CellWriter, RowWriter,
 };
 #[derive(Debug, Clone, Error)]
 pub struct SerializationError(Arc<dyn Error + Send + Sync>);

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -6,10 +6,7 @@ pub mod row;
 pub mod value;
 pub mod writers;
 
-pub use writers::{
-    BufBackedCellValueBuilder, BufBackedCellWriter, BufBackedRowWriter, CellValueBuilder,
-    CellWriter, RowWriter,
-};
+pub use writers::{CellValueBuilder, CellWriter, RowWriter};
 #[derive(Debug, Clone, Error)]
 pub struct SerializationError(Arc<dyn Error + Send + Sync>);
 

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -223,8 +223,8 @@ macro_rules! impl_serialize_row_for_map {
                     Some(v) => {
                         <T as SerializeCql>::serialize(v, &col.typ, writer.make_cell_writer())
                             .map_err(|err| {
-                                mk_typck_err::<Self>(
-                                    BuiltinTypeCheckErrorKind::ColumnTypeCheckFailed {
+                                mk_ser_err::<Self>(
+                                    BuiltinSerializationErrorKind::ColumnSerializationFailed {
                                         name: col.name.clone(),
                                         err,
                                     },

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -33,25 +33,7 @@ impl<'a> RowSerializationContext<'a> {
 }
 
 pub trait SerializeRow {
-    /// Checks if it _might_ be possible to serialize the row according to the
-    /// information in the context.
-    ///
-    /// This function is intended to serve as an optimization in the future,
-    /// if we were ever to introduce prepared statements parametrized by types.
-    ///
-    /// Sometimes, a row cannot be fully type checked right away without knowing
-    /// the exact values of the columns (e.g. when deserializing to `CqlValue`),
-    /// but it's fine to do full type checking later in `serialize`.
-    fn preliminary_type_check(
-        _ctx: &RowSerializationContext<'_>,
-    ) -> Result<(), SerializationError> {
-        Ok(())
-    }
-
     /// Serializes the row according to the information in the given context.
-    ///
-    /// The function may assume that `preliminary_type_check` was called,
-    /// though it must not do anything unsafe if this assumption does not hold.
     fn serialize(
         &self,
         ctx: &RowSerializationContext<'_>,

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -42,7 +42,11 @@ pub trait SerializeRow {
     /// Sometimes, a row cannot be fully type checked right away without knowing
     /// the exact values of the columns (e.g. when deserializing to `CqlValue`),
     /// but it's fine to do full type checking later in `serialize`.
-    fn preliminary_type_check(ctx: &RowSerializationContext<'_>) -> Result<(), SerializationError>;
+    fn preliminary_type_check(
+        _ctx: &RowSerializationContext<'_>,
+    ) -> Result<(), SerializationError> {
+        Ok(())
+    }
 
     /// Serializes the row according to the information in the given context.
     ///

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -10,7 +10,7 @@ use crate::frame::value::{SerializedValues, ValueList};
 use crate::frame::{response::result::ColumnSpec, types::RawValue};
 
 use super::value::SerializeCql;
-use super::{BufBackedRowWriter as RowWriter, CellWriter, RowWriter as _, SerializationError};
+use super::{RowWriter, SerializationError};
 
 /// Contains information needed to serialize a row.
 pub struct RowSerializationContext<'a> {
@@ -455,7 +455,7 @@ macro_rules! impl_serialize_row_via_value_list {
             fn serialize(
                 &self,
                 ctx: &$crate::types::serialize::row::RowSerializationContext<'_>,
-                writer: &mut $crate::types::serialize::writers::BufBackedRowWriter,
+                writer: &mut $crate::types::serialize::writers::RowWriter,
             ) -> ::std::result::Result<(), $crate::types::serialize::SerializationError> {
                 $crate::types::serialize::row::serialize_legacy_row(self, ctx, writer)
             }
@@ -660,7 +660,7 @@ pub enum ValueListToSerializeRowAdapterError {
 mod tests {
     use crate::frame::response::result::{ColumnSpec, ColumnType, TableSpec};
     use crate::frame::value::{MaybeUnset, SerializedValues, ValueList};
-    use crate::types::serialize::BufBackedRowWriter;
+    use crate::types::serialize::RowWriter;
 
     use super::{RowSerializationContext, SerializeRow};
 
@@ -688,7 +688,7 @@ mod tests {
         <_ as ValueList>::write_to_request(&row, &mut legacy_data).unwrap();
 
         let mut new_data = Vec::new();
-        let mut new_data_writer = BufBackedRowWriter::new(&mut new_data);
+        let mut new_data_writer = RowWriter::new(&mut new_data);
         let ctx = RowSerializationContext {
             columns: &[
                 col_spec("a", ColumnType::Int),
@@ -725,7 +725,7 @@ mod tests {
         unsorted_row.add_named_value("c", &None::<i64>).unwrap();
 
         let mut unsorted_row_data = Vec::new();
-        let mut unsorted_row_data_writer = BufBackedRowWriter::new(&mut unsorted_row_data);
+        let mut unsorted_row_data_writer = RowWriter::new(&mut unsorted_row_data);
         let ctx = RowSerializationContext {
             columns: &[
                 col_spec("a", ColumnType::Int),

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -210,7 +210,7 @@ impl<T: SerializeCql, S: BuildHasher> SerializeRow for HashMap<&str, T, S> {
     impl_serialize_row_for_map!();
 }
 
-impl<T: SerializeRow> SerializeRow for &T {
+impl<T: SerializeRow + ?Sized> SerializeRow for &T {
     fn serialize(
         &self,
         ctx: &RowSerializationContext<'_>,

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -28,22 +28,7 @@ use super::writers::WrittenCellProof;
 use super::{CellWriter, SerializationError};
 
 pub trait SerializeCql {
-    /// Given a CQL type, checks if it _might_ be possible to serialize to that type.
-    ///
-    /// This function is intended to serve as an optimization in the future,
-    /// if we were ever to introduce prepared statements parametrized by types.
-    ///
-    /// Some types cannot be type checked without knowing the exact value,
-    /// this is the case e.g. for `CqlValue`. It's also fine to do it later in
-    /// `serialize`.
-    fn preliminary_type_check(_typ: &ColumnType) -> Result<(), SerializationError> {
-        Ok(())
-    }
-
     /// Serializes the value to given CQL type.
-    ///
-    /// The function may assume that `preliminary_type_check` was called,
-    /// though it must not do anything unsafe if this assumption does not hold.
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -572,7 +557,6 @@ fn check_and_serialize<'b, V: SerializeCql>(
     typ: &ColumnType,
     writer: CellWriter<'b>,
 ) -> Result<WrittenCellProof<'b>, SerializationError> {
-    V::preliminary_type_check(typ)?;
     v.serialize(typ, writer)
 }
 

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -36,7 +36,9 @@ pub trait SerializeCql {
     /// Some types cannot be type checked without knowing the exact value,
     /// this is the case e.g. for `CqlValue`. It's also fine to do it later in
     /// `serialize`.
-    fn preliminary_type_check(typ: &ColumnType) -> Result<(), SerializationError>;
+    fn preliminary_type_check(_typ: &ColumnType) -> Result<(), SerializationError> {
+        Ok(())
+    }
 
     /// Serializes the value to given CQL type.
     ///

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -25,9 +25,7 @@ use crate::frame::value::{
 use crate::frame::value::ValueOverflow;
 
 use super::writers::WrittenCellProof;
-use super::{
-    BufBackedCellWriter as CellWriter, CellValueBuilder, CellWriter as _, SerializationError,
-};
+use super::{CellWriter, SerializationError};
 
 pub trait SerializeCql {
     /// Given a CQL type, checks if it _might_ be possible to serialize to that type.
@@ -1048,7 +1046,7 @@ macro_rules! impl_serialize_cql_via_value {
             fn serialize<'b>(
                 &self,
                 _typ: &$crate::frame::response::result::ColumnType,
-                writer: $crate::types::serialize::writers::BufBackedCellWriter<'b>,
+                writer: $crate::types::serialize::writers::CellWriter<'b>,
             ) -> ::std::result::Result<
                 $crate::types::serialize::writers::WrittenCellProof<'b>,
                 $crate::types::serialize::SerializationError,
@@ -1576,7 +1574,7 @@ pub enum ValueToSerializeCqlAdapterError {
 mod tests {
     use crate::frame::response::result::ColumnType;
     use crate::frame::value::{MaybeUnset, Value};
-    use crate::types::serialize::BufBackedCellWriter;
+    use crate::types::serialize::CellWriter;
 
     use super::SerializeCql;
 
@@ -1585,7 +1583,7 @@ mod tests {
         <V as Value>::serialize(&v, &mut legacy_data).unwrap();
 
         let mut new_data = Vec::new();
-        let new_data_writer = BufBackedCellWriter::new(&mut new_data);
+        let new_data_writer = CellWriter::new(&mut new_data);
         <V as SerializeCql>::serialize(&v, &ColumnType::Int, new_data_writer).unwrap();
 
         assert_eq!(legacy_data, new_data);

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1392,4 +1392,19 @@ mod tests {
         check_compat(None::<i32>);
         check_compat(MaybeUnset::Unset::<i32>);
     }
+
+    #[test]
+    fn test_dyn_serialize_cql() {
+        let v: i32 = 123;
+        let mut typed_data = Vec::new();
+        let typed_data_writer = CellWriter::new(&mut typed_data);
+        <_ as SerializeCql>::serialize(&v, &ColumnType::Int, typed_data_writer).unwrap();
+
+        let v = &v as &dyn SerializeCql;
+        let mut erased_data = Vec::new();
+        let erased_data_writer = CellWriter::new(&mut erased_data);
+        <_ as SerializeCql>::serialize(&v, &ColumnType::Int, erased_data_writer).unwrap();
+
+        assert_eq!(typed_data, erased_data);
+    }
 }

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -188,9 +188,6 @@ impl SerializeCql for time::Time {
 }
 #[cfg(feature = "secret")]
 impl<V: SerializeCql + Zeroize> SerializeCql for Secret<V> {
-    fn preliminary_type_check(typ: &ColumnType) -> Result<(), SerializationError> {
-        V::preliminary_type_check(typ)
-    }
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -284,9 +281,6 @@ impl SerializeCql for String {
     });
 }
 impl<T: SerializeCql> SerializeCql for Option<T> {
-    fn preliminary_type_check(typ: &ColumnType) -> Result<(), SerializationError> {
-        T::preliminary_type_check(typ)
-    }
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -299,9 +293,6 @@ impl<T: SerializeCql> SerializeCql for Option<T> {
     }
 }
 impl SerializeCql for Unset {
-    fn preliminary_type_check(_typ: &ColumnType) -> Result<(), SerializationError> {
-        Ok(()) // Fits everything
-    }
     impl_serialize_via_writer!(|_me, writer| writer.set_unset());
 }
 impl SerializeCql for Counter {
@@ -322,9 +313,6 @@ impl SerializeCql for CqlDuration {
     });
 }
 impl<V: SerializeCql> SerializeCql for MaybeUnset<V> {
-    fn preliminary_type_check(typ: &ColumnType) -> Result<(), SerializationError> {
-        V::preliminary_type_check(typ)
-    }
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -337,9 +325,6 @@ impl<V: SerializeCql> SerializeCql for MaybeUnset<V> {
     }
 }
 impl<T: SerializeCql + ?Sized> SerializeCql for &T {
-    fn preliminary_type_check(typ: &ColumnType) -> Result<(), SerializationError> {
-        T::preliminary_type_check(typ)
-    }
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -349,9 +334,6 @@ impl<T: SerializeCql + ?Sized> SerializeCql for &T {
     }
 }
 impl<T: SerializeCql + ?Sized> SerializeCql for Box<T> {
-    fn preliminary_type_check(typ: &ColumnType) -> Result<(), SerializationError> {
-        T::preliminary_type_check(typ)
-    }
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -451,10 +433,6 @@ impl<'a, T: SerializeCql + 'a> SerializeCql for &'a [T] {
     }
 }
 impl SerializeCql for CqlValue {
-    fn preliminary_type_check(_typ: &ColumnType) -> Result<(), SerializationError> {
-        Ok(())
-    }
-
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -922,13 +900,6 @@ macro_rules! impl_serialize_cql_via_value {
         where
             Self: $crate::frame::value::Value,
         {
-            fn preliminary_type_check(
-                _typ: &$crate::frame::response::result::ColumnType,
-            ) -> ::std::result::Result<(), $crate::types::serialize::SerializationError> {
-                // No-op - the old interface didn't offer type safety
-                ::std::result::Result::Ok(())
-            }
-
             fn serialize<'b>(
                 &self,
                 _typ: &$crate::frame::response::result::ColumnType,

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -545,14 +545,8 @@ impl<'a, T: SerializeCql + 'a> SerializeCql for &'a [T] {
     }
 }
 impl SerializeCql for CqlValue {
-    fn preliminary_type_check(typ: &ColumnType) -> Result<(), SerializationError> {
-        match typ {
-            ColumnType::Custom(_) => Err(mk_typck_err::<Self>(
-                typ,
-                BuiltinTypeCheckErrorKind::CustomTypeUnsupported,
-            )),
-            _ => Ok(()),
-        }
+    fn preliminary_type_check(_typ: &ColumnType) -> Result<(), SerializationError> {
+        Ok(())
     }
 
     fn serialize<'b>(
@@ -569,6 +563,12 @@ fn serialize_cql_value<'b>(
     typ: &ColumnType,
     writer: CellWriter<'b>,
 ) -> Result<WrittenCellProof<'b>, SerializationError> {
+    if let ColumnType::Custom(_) = typ {
+        return Err(mk_typck_err::<CqlValue>(
+            typ,
+            BuiltinTypeCheckErrorKind::CustomTypeUnsupported,
+        ));
+    }
     match value {
         CqlValue::Ascii(a) => check_and_serialize(a, typ, writer),
         CqlValue::Boolean(b) => check_and_serialize(b, typ, writer),

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -439,14 +439,14 @@ fn serialize_cql_value<'b>(
         ));
     }
     match value {
-        CqlValue::Ascii(a) => check_and_serialize(a, typ, writer),
-        CqlValue::Boolean(b) => check_and_serialize(b, typ, writer),
-        CqlValue::Blob(b) => check_and_serialize(b, typ, writer),
-        CqlValue::Counter(c) => check_and_serialize(c, typ, writer),
-        CqlValue::Decimal(d) => check_and_serialize(d, typ, writer),
-        CqlValue::Date(d) => check_and_serialize(d, typ, writer),
-        CqlValue::Double(d) => check_and_serialize(d, typ, writer),
-        CqlValue::Duration(d) => check_and_serialize(d, typ, writer),
+        CqlValue::Ascii(a) => <_ as SerializeCql>::serialize(&a, typ, writer),
+        CqlValue::Boolean(b) => <_ as SerializeCql>::serialize(&b, typ, writer),
+        CqlValue::Blob(b) => <_ as SerializeCql>::serialize(&b, typ, writer),
+        CqlValue::Counter(c) => <_ as SerializeCql>::serialize(&c, typ, writer),
+        CqlValue::Decimal(d) => <_ as SerializeCql>::serialize(&d, typ, writer),
+        CqlValue::Date(d) => <_ as SerializeCql>::serialize(&d, typ, writer),
+        CqlValue::Double(d) => <_ as SerializeCql>::serialize(&d, typ, writer),
+        CqlValue::Duration(d) => <_ as SerializeCql>::serialize(&d, typ, writer),
         CqlValue::Empty => {
             if !typ.supports_special_empty_value() {
                 return Err(mk_typck_err::<CqlValue>(
@@ -456,13 +456,13 @@ fn serialize_cql_value<'b>(
             }
             Ok(writer.set_value(&[]).unwrap())
         }
-        CqlValue::Float(f) => check_and_serialize(f, typ, writer),
-        CqlValue::Int(i) => check_and_serialize(i, typ, writer),
-        CqlValue::BigInt(b) => check_and_serialize(b, typ, writer),
-        CqlValue::Text(t) => check_and_serialize(t, typ, writer),
-        CqlValue::Timestamp(t) => check_and_serialize(t, typ, writer),
-        CqlValue::Inet(i) => check_and_serialize(i, typ, writer),
-        CqlValue::List(l) => check_and_serialize(l, typ, writer),
+        CqlValue::Float(f) => <_ as SerializeCql>::serialize(&f, typ, writer),
+        CqlValue::Int(i) => <_ as SerializeCql>::serialize(&i, typ, writer),
+        CqlValue::BigInt(b) => <_ as SerializeCql>::serialize(&b, typ, writer),
+        CqlValue::Text(t) => <_ as SerializeCql>::serialize(&t, typ, writer),
+        CqlValue::Timestamp(t) => <_ as SerializeCql>::serialize(&t, typ, writer),
+        CqlValue::Inet(i) => <_ as SerializeCql>::serialize(&i, typ, writer),
+        CqlValue::List(l) => <_ as SerializeCql>::serialize(&l, typ, writer),
         CqlValue::Map(m) => serialize_mapping(
             std::any::type_name::<CqlValue>(),
             m.len(),
@@ -470,16 +470,16 @@ fn serialize_cql_value<'b>(
             typ,
             writer,
         ),
-        CqlValue::Set(s) => check_and_serialize(s, typ, writer),
+        CqlValue::Set(s) => <_ as SerializeCql>::serialize(&s, typ, writer),
         CqlValue::UserDefinedType {
             keyspace,
             type_name,
             fields,
         } => serialize_udt(typ, keyspace, type_name, fields, writer),
-        CqlValue::SmallInt(s) => check_and_serialize(s, typ, writer),
-        CqlValue::TinyInt(t) => check_and_serialize(t, typ, writer),
-        CqlValue::Time(t) => check_and_serialize(t, typ, writer),
-        CqlValue::Timeuuid(t) => check_and_serialize(t, typ, writer),
+        CqlValue::SmallInt(s) => <_ as SerializeCql>::serialize(&s, typ, writer),
+        CqlValue::TinyInt(t) => <_ as SerializeCql>::serialize(&t, typ, writer),
+        CqlValue::Time(t) => <_ as SerializeCql>::serialize(&t, typ, writer),
+        CqlValue::Timeuuid(t) => <_ as SerializeCql>::serialize(&t, typ, writer),
         CqlValue::Tuple(t) => {
             // We allow serializing tuples that have less fields
             // than the database tuple, but not the other way around.
@@ -505,8 +505,8 @@ fn serialize_cql_value<'b>(
             };
             serialize_tuple_like(typ, fields.iter(), t.iter(), writer)
         }
-        CqlValue::Uuid(u) => check_and_serialize(u, typ, writer),
-        CqlValue::Varint(v) => check_and_serialize(v, typ, writer),
+        CqlValue::Uuid(u) => <_ as SerializeCql>::serialize(&u, typ, writer),
+        CqlValue::Varint(v) => <_ as SerializeCql>::serialize(&v, typ, writer),
     }
 }
 
@@ -550,14 +550,6 @@ fn fix_cql_value_name_in_err(mut err: SerializationError) -> SerializationError 
     };
 
     err
-}
-
-fn check_and_serialize<'b, V: SerializeCql>(
-    v: &V,
-    typ: &ColumnType,
-    writer: CellWriter<'b>,
-) -> Result<WrittenCellProof<'b>, SerializationError> {
-    v.serialize(typ, writer)
 }
 
 fn serialize_udt<'b>(

--- a/scylla-cql/src/types/serialize/writers.rs
+++ b/scylla-cql/src/types/serialize/writers.rs
@@ -3,14 +3,22 @@
 use thiserror::Error;
 
 /// An interface that facilitates writing values for a CQL query.
-pub trait RowWriter {
-    type CellWriter<'a>: CellWriter
-    where
-        Self: 'a;
+pub struct RowWriter<'buf> {
+    // Buffer that this value should be serialized to.
+    buf: &'buf mut Vec<u8>,
 
+    // Number of values written so far.
+    value_count: usize,
+}
+
+impl<'buf> RowWriter<'buf> {
     /// Appends a new value to the sequence and returns an object that allows
     /// to fill it in.
-    fn make_cell_writer(&mut self) -> Self::CellWriter<'_>;
+    #[inline]
+    pub fn make_cell_writer(&mut self) -> CellWriter<'_> {
+        self.value_count += 1;
+        CellWriter::new(self.buf)
+    }
 }
 
 /// Represents a handle to a CQL value that needs to be written into.
@@ -19,11 +27,11 @@ pub trait RowWriter {
 /// (via [`set_null`](CellWriter::set_null),
 /// [`set_unset`](CellWriter::set_unset)
 /// or [`set_value`](CellWriter::set_value) or transformed into
-/// the [`CellWriter::ValueBuilder`] in order to gradually initialize
+/// the [`CellValueBuilder`] in order to gradually initialize
 /// the value when the contents are not available straight away.
 ///
 /// After the value is fully initialized, the handle is consumed and
-/// a [`WrittenCellProof`](CellWriter::WrittenCellProof) object is returned
+/// a [`WrittenCellProof`] object is returned
 /// in its stead. This is a type-level proof that the value was fully initialized
 /// and is used in [`SerializeCql::serialize`](`super::value::SerializeCql::serialize`)
 /// in order to enforce the implementor to fully initialize the provided handle
@@ -31,33 +39,24 @@ pub trait RowWriter {
 ///
 /// Dropping this type without calling any of its methods will result
 /// in nothing being written.
-pub trait CellWriter {
-    /// The type of the value builder, returned by the [`CellWriter::set_value`]
-    /// method.
-    type ValueBuilder: CellValueBuilder<WrittenCellProof = Self::WrittenCellProof>;
+pub struct CellWriter<'buf> {
+    buf: &'buf mut Vec<u8>,
+}
 
-    /// An object that serves as a proof that the cell was fully initialized.
-    ///
-    /// This type is returned by [`set_null`](CellWriter::set_null),
-    /// [`set_unset`](CellWriter::set_unset),
-    /// [`set_value`](CellWriter::set_value)
-    /// and also [`CellValueBuilder::finish`] - generally speaking, after
-    /// the value is fully initialized and the `CellWriter` is destroyed.
-    ///
-    /// The purpose of this type is to enforce the contract of
-    /// [`SerializeCql::serialize`](super::value::SerializeCql::serialize): either
-    /// the method succeeds and returns a proof that it serialized itself
-    /// into the given value, or it fails and returns an error or panics.
-    /// The exact type of [`WrittenCellProof`](CellWriter::WrittenCellProof)
-    /// is not important as the value is not used at all - it's only
-    /// a compile-time check.
-    type WrittenCellProof;
-
+impl<'buf> CellWriter<'buf> {
     /// Sets this value to be null, consuming this object.
-    fn set_null(self) -> Self::WrittenCellProof;
+    #[inline]
+    pub fn set_null(self) -> WrittenCellProof<'buf> {
+        self.buf.extend_from_slice(&(-1i32).to_be_bytes());
+        WrittenCellProof::new()
+    }
 
     /// Sets this value to represent an unset value, consuming this object.
-    fn set_unset(self) -> Self::WrittenCellProof;
+    #[inline]
+    pub fn set_unset(self) -> WrittenCellProof<'buf> {
+        self.buf.extend_from_slice(&(-2i32).to_be_bytes());
+        WrittenCellProof::new()
+    }
 
     /// Sets this value to a non-zero, non-unset value with given contents.
     ///
@@ -67,7 +66,13 @@ pub trait CellWriter {
     ///
     /// Fails if the contents size overflows the maximum allowed CQL cell size
     /// (which is i32::MAX).
-    fn set_value(self, contents: &[u8]) -> Result<Self::WrittenCellProof, CellOverflowError>;
+    #[inline]
+    pub fn set_value(self, contents: &[u8]) -> Result<WrittenCellProof<'buf>, CellOverflowError> {
+        let value_len: i32 = contents.len().try_into().map_err(|_| CellOverflowError)?;
+        self.buf.extend_from_slice(&value_len.to_be_bytes());
+        self.buf.extend_from_slice(contents);
+        Ok(WrittenCellProof::new())
+    }
 
     /// Turns this writter into a [`CellValueBuilder`] which can be used
     /// to gradually initialize the CQL value.
@@ -75,7 +80,10 @@ pub trait CellWriter {
     /// This method should be used if you don't have all of the data
     /// up front, e.g. when serializing compound types such as collections
     /// or UDTs.
-    fn into_value_builder(self) -> Self::ValueBuilder;
+    #[inline]
+    pub fn into_value_builder(self) -> CellValueBuilder<'buf> {
+        CellValueBuilder::new(self.buf)
+    }
 }
 
 /// Allows appending bytes to a non-null, non-unset cell.
@@ -84,25 +92,41 @@ pub trait CellWriter {
 /// serialized. Failing to drop this value will result in a payload that will
 /// not be parsed by the database correctly, but otherwise should not cause
 /// data to be misinterpreted.
-pub trait CellValueBuilder {
-    type SubCellWriter<'a>: CellWriter
-    where
-        Self: 'a;
+pub struct CellValueBuilder<'buf> {
+    // Buffer that this value should be serialized to.
+    buf: &'buf mut Vec<u8>,
 
-    type WrittenCellProof;
+    // Starting position of the value in the buffer.
+    starting_pos: usize,
+}
 
+impl<'buf> CellValueBuilder<'buf> {
     /// Appends raw bytes to this cell.
-    fn append_bytes(&mut self, bytes: &[u8]);
+    #[inline]
+    pub fn append_bytes(&mut self, bytes: &[u8]) {
+        self.buf.extend_from_slice(bytes);
+    }
 
     /// Appends a sub-value to the end of the current contents of the cell
     /// and returns an object that allows to fill it in.
-    fn make_sub_writer(&mut self) -> Self::SubCellWriter<'_>;
+    #[inline]
+    pub fn make_sub_writer(&mut self) -> CellWriter<'_> {
+        CellWriter::new(self.buf)
+    }
 
     /// Finishes serializing the value.
     ///
     /// Fails if the constructed cell size overflows the maximum allowed
     /// CQL cell size (which is i32::MAX).
-    fn finish(self) -> Result<Self::WrittenCellProof, CellOverflowError>;
+    #[inline]
+    pub fn finish(self) -> Result<WrittenCellProof<'buf>, CellOverflowError> {
+        let value_len: i32 = (self.buf.len() - self.starting_pos - 4)
+            .try_into()
+            .map_err(|_| CellOverflowError)?;
+        self.buf[self.starting_pos..self.starting_pos + 4]
+            .copy_from_slice(&value_len.to_be_bytes());
+        Ok(WrittenCellProof::new())
+    }
 }
 
 /// An object that indicates a type-level proof that something was written
@@ -143,16 +167,7 @@ impl<'buf> WrittenCellProof<'buf> {
 #[error("CQL cell overflowed the maximum allowed size of 2^31 - 1")]
 pub struct CellOverflowError;
 
-/// A row writer backed by a buffer (vec).
-pub struct BufBackedRowWriter<'buf> {
-    // Buffer that this value should be serialized to.
-    buf: &'buf mut Vec<u8>,
-
-    // Number of values written so far.
-    value_count: usize,
-}
-
-impl<'buf> BufBackedRowWriter<'buf> {
+impl<'buf> RowWriter<'buf> {
     /// Creates a new row writer based on an existing Vec.
     ///
     /// The newly created row writer will append data to the end of the vec.
@@ -174,72 +189,17 @@ impl<'buf> BufBackedRowWriter<'buf> {
     }
 }
 
-impl<'buf> RowWriter for BufBackedRowWriter<'buf> {
-    type CellWriter<'a> = BufBackedCellWriter<'a> where Self: 'a;
-
-    #[inline]
-    fn make_cell_writer(&mut self) -> Self::CellWriter<'_> {
-        self.value_count += 1;
-        BufBackedCellWriter::new(self.buf)
-    }
-}
-
-/// A cell writer backed by a buffer (vec).
-pub struct BufBackedCellWriter<'buf> {
-    buf: &'buf mut Vec<u8>,
-}
-
-impl<'buf> BufBackedCellWriter<'buf> {
+impl<'buf> CellWriter<'buf> {
     /// Creates a new cell writer based on an existing Vec.
     ///
     /// The newly created row writer will append data to the end of the vec.
     #[inline]
     pub fn new(buf: &'buf mut Vec<u8>) -> Self {
-        BufBackedCellWriter { buf }
+        Self { buf }
     }
 }
 
-impl<'buf> CellWriter for BufBackedCellWriter<'buf> {
-    type ValueBuilder = BufBackedCellValueBuilder<'buf>;
-
-    type WrittenCellProof = WrittenCellProof<'buf>;
-
-    #[inline]
-    fn set_null(self) -> Self::WrittenCellProof {
-        self.buf.extend_from_slice(&(-1i32).to_be_bytes());
-        WrittenCellProof::new()
-    }
-
-    #[inline]
-    fn set_unset(self) -> Self::WrittenCellProof {
-        self.buf.extend_from_slice(&(-2i32).to_be_bytes());
-        WrittenCellProof::new()
-    }
-
-    #[inline]
-    fn set_value(self, bytes: &[u8]) -> Result<Self::WrittenCellProof, CellOverflowError> {
-        let value_len: i32 = bytes.len().try_into().map_err(|_| CellOverflowError)?;
-        self.buf.extend_from_slice(&value_len.to_be_bytes());
-        self.buf.extend_from_slice(bytes);
-        Ok(WrittenCellProof::new())
-    }
-
-    #[inline]
-    fn into_value_builder(self) -> Self::ValueBuilder {
-        BufBackedCellValueBuilder::new(self.buf)
-    }
-}
-
-/// A cell value builder backed by a buffer (vec).
-pub struct BufBackedCellValueBuilder<'buf> {
-    // Buffer that this value should be serialized to.
-    buf: &'buf mut Vec<u8>,
-
-    // Starting position of the value in the buffer.
-    starting_pos: usize,
-}
-
-impl<'buf> BufBackedCellValueBuilder<'buf> {
+impl<'buf> CellValueBuilder<'buf> {
     #[inline]
     fn new(buf: &'buf mut Vec<u8>) -> Self {
         // "Length" of a [bytes] frame can either be a non-negative i32,
@@ -250,46 +210,18 @@ impl<'buf> BufBackedCellValueBuilder<'buf> {
         // won't be misinterpreted.
         let starting_pos = buf.len();
         buf.extend_from_slice(&(-3i32).to_be_bytes());
-        BufBackedCellValueBuilder { buf, starting_pos }
-    }
-}
-
-impl<'buf> CellValueBuilder for BufBackedCellValueBuilder<'buf> {
-    type SubCellWriter<'a> = BufBackedCellWriter<'a>
-    where
-        Self: 'a;
-
-    type WrittenCellProof = WrittenCellProof<'buf>;
-
-    #[inline]
-    fn append_bytes(&mut self, bytes: &[u8]) {
-        self.buf.extend_from_slice(bytes);
-    }
-
-    #[inline]
-    fn make_sub_writer(&mut self) -> Self::SubCellWriter<'_> {
-        BufBackedCellWriter::new(self.buf)
-    }
-
-    #[inline]
-    fn finish(self) -> Result<Self::WrittenCellProof, CellOverflowError> {
-        let value_len: i32 = (self.buf.len() - self.starting_pos - 4)
-            .try_into()
-            .map_err(|_| CellOverflowError)?;
-        self.buf[self.starting_pos..self.starting_pos + 4]
-            .copy_from_slice(&value_len.to_be_bytes());
-        Ok(WrittenCellProof::new())
+        Self { buf, starting_pos }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BufBackedCellWriter, BufBackedRowWriter, CellValueBuilder, CellWriter, RowWriter};
+    use super::{CellWriter, RowWriter};
 
     #[test]
     fn test_cell_writer() {
         let mut data = Vec::new();
-        let writer = BufBackedCellWriter::new(&mut data);
+        let writer = CellWriter::new(&mut data);
         let mut sub_writer = writer.into_value_builder();
         sub_writer.make_sub_writer().set_null();
         sub_writer
@@ -313,7 +245,7 @@ mod tests {
     #[test]
     fn test_poisoned_appender() {
         let mut data = Vec::new();
-        let writer = BufBackedCellWriter::new(&mut data);
+        let writer = CellWriter::new(&mut data);
         let _ = writer.into_value_builder();
 
         assert_eq!(
@@ -327,7 +259,7 @@ mod tests {
     #[test]
     fn test_row_writer() {
         let mut data = Vec::new();
-        let mut writer = BufBackedRowWriter::new(&mut data);
+        let mut writer = RowWriter::new(&mut data);
         writer.make_cell_writer().set_null();
         writer.make_cell_writer().set_value(&[1, 2, 3, 4]).unwrap();
         writer.make_cell_writer().set_unset();


### PR DESCRIPTION
As @Lorak-mmk stated in https://github.com/scylladb/scylla-rust-driver/pull/858#issuecomment-1841662378, the new serialization traits are incompatible with dynamic dispatch - `dyn SerializeCql`/`dyn SerializeRow` just isn't usable, while this was supported for `Value`/`ValueList`.

This is due to the fact that Rust disallows using traits via `dyn` unless they meet some conditions - and our new traits don't meet them:

1. Both traits have two methods: `preliminary_type_check` and `serialize`. Having a separate type checking phase helps reduce the amount of actual type checking that needs to be performed when serializing (e.g. in case of collections). However, `preliminary_type_check` is an associated function instead of a method by design (i.e. it doesn't take a `self` parameter), and that prevents from making it object-safe.
2. The `serialize` method takes a generic "writer" parameter that it can use to serialize the object. The idea behind the generic writer was to have two implementations: one that doesn't write anything but only counts bytes, and the other that actually appends bytes into a byte buffer. This would allow us to use `serialize` for both things: calculating the needed buffer size and also to actually serialize. However, as Rust uses monomorphisation to implement generics, they cannot be directly used with dynamic dispatch.

While it would be possible to keep the current definitions intact and work around the problem by introducing "erased" versions of the traits (credit to [`erased_serde`](https://docs.rs/erased-serde/latest/erased_serde/) for inspiration), it increases complexity and could make serialization of type-erased types inefficient (due to the writers needing to be type-erased, too). Instead, let's simplify it:

1. In current design, it is perfectly fine to do type checking in `serialize`, so move all type checking there from the existing `preliminary_type_check` methods and then remove them. While it introduces more type checks than necessary, it is not clear whether they have a measurable performance impact and it will be possible to extend the trait to reintroduce the optimization in a backwards-compatible way - for now, let's keep it simple.
2. Remove the byte counting writers and only leave the "proper" ones, substituting the current writer traits with the latter ones. Later, we can consider introducing a `size_hint` method for the traits; it would be optional, but would have to be manually implemented (which is not a huge amount of work).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
