### PR TITLE
CI: use container hostname in healthcheck

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -24,7 +24,7 @@ jobs:
         image: scylladb/scylla
         ports:
           - 9042:9042
-        options: --health-cmd "cqlsh --debug" --health-interval 5s --health-retries 10
+        options: --health-cmd "cqlsh --debug scylladb" --health-interval 5s --health-retries 10
     steps:
     - uses: actions/checkout@v3
     - name: Install mdbook

--- a/test/cluster/docker-compose.yml
+++ b/test/cluster/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       --smp 2
       --memory 1G
     healthcheck:
-      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla1", "-e", "select * from system.local" ]
       interval: 5s
       timeout: 5s
       retries: 60
@@ -41,7 +41,7 @@ services:
       --smp 2
       --memory 1G
     healthcheck:
-      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla2", "-e", "select * from system.local" ]
       interval: 5s
       timeout: 5s
       retries: 60
@@ -62,7 +62,7 @@ services:
       --smp 2
       --memory 1G
     healthcheck:
-      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla3", "-e", "select * from system.local" ]
       interval: 5s
       timeout: 5s
       retries: 60


### PR DESCRIPTION
As a workaround for scylladb/scylladb#16329, pass the hostname of the container when checking for its health with `cqlsh`. We need to do this in order to unblock the CI.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
