### PR TITLE
Makefile: build and check benches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,15 @@ fmt-check:
 
 .PHONY: check
 check:
-	cargo check --examples --tests
+	cargo check --all-targets
 
 .PHONY: check-without-features
 check-without-features:
-	cargo check --manifest-path "scylla/Cargo.toml" --features ""
+	cargo check --manifest-path "scylla/Cargo.toml" --features "" --all-targets
 
 .PHONY: clippy
 clippy:
-	RUSTFLAGS=-Dwarnings cargo clippy --examples --tests -- -Aclippy::uninlined_format_args
+	RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -Aclippy::uninlined_format_args
 
 .PHONY: test
 test: up
@@ -42,7 +42,7 @@ dockerized-test: up
 
 .PHONY: build
 build:
-	cargo build --examples
+	cargo build --examples --benches
 
 .PHONY: docs
 docs:


### PR DESCRIPTION
In the current makefile benchmarks are not built or checked with `cargo check` / `cargo clippy` so any errors appearing in them will not be caught locally by a dev running `make ci` to perform checks / tests.

This PR adds benchmark building / checking to all relevant makefile targets.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
