### PR TITLE
serialization: implement new, type-safe variants of BatchValues

### DIFF
--- a/scylla-cql/src/frame/request/auth_response.rs
+++ b/scylla-cql/src/frame/request/auth_response.rs
@@ -1,5 +1,4 @@
 use crate::frame::frame_errors::ParseError;
-use bytes::BufMut;
 
 use crate::frame::request::{RequestOpcode, SerializableRequest};
 use crate::frame::types::write_bytes_opt;
@@ -12,7 +11,7 @@ pub struct AuthResponse {
 impl SerializableRequest for AuthResponse {
     const OPCODE: RequestOpcode = RequestOpcode::AuthResponse;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
         write_bytes_opt(self.response.as_ref(), buf)
     }
 }

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -5,7 +5,7 @@ use crate::frame::{
     frame_errors::ParseError,
     request::{RequestOpcode, SerializableRequest},
     types::{self, SerialConsistency},
-    value::{BatchValues, BatchValuesIterator, LegacySerializedValues},
+    value::{LegacyBatchValues, LegacyBatchValuesIterator, LegacySerializedValues},
 };
 
 use super::DeserializableRequest;
@@ -20,7 +20,7 @@ pub struct Batch<'b, Statement, Values>
 where
     BatchStatement<'b>: From<&'b Statement>,
     Statement: Clone,
-    Values: BatchValues,
+    Values: LegacyBatchValues,
 {
     pub statements: Cow<'b, [Statement]>,
     pub batch_type: BatchType,
@@ -72,7 +72,7 @@ impl<Statement, Values> SerializableRequest for Batch<'_, Statement, Values>
 where
     for<'s> BatchStatement<'s>: From<&'s Statement>,
     Statement: Clone,
-    Values: BatchValues,
+    Values: LegacyBatchValues,
 {
     const OPCODE: RequestOpcode = RequestOpcode::Batch;
 

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -76,7 +76,7 @@ where
 {
     const OPCODE: RequestOpcode = RequestOpcode::Batch;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
         // Serializing type of batch
         buf.put_u8(self.batch_type as u8);
 

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -1,5 +1,5 @@
 use crate::frame::frame_errors::ParseError;
-use bytes::{BufMut, Bytes};
+use bytes::Bytes;
 
 use crate::{
     frame::request::{query, RequestOpcode, SerializableRequest},
@@ -17,7 +17,7 @@ pub struct Execute<'a> {
 impl SerializableRequest for Execute<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Execute;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
         // Serializing statement id
         types::write_short_bytes(&self.id[..], buf)?;
 

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -7,6 +7,7 @@ pub mod query;
 pub mod register;
 pub mod startup;
 
+use crate::types::serialize::row::SerializedValues;
 use crate::{frame::frame_errors::ParseError, Consistency};
 use bytes::Bytes;
 use num_enum::TryFromPrimitive;
@@ -22,7 +23,6 @@ pub use startup::Startup;
 use self::batch::BatchStatement;
 
 use super::types::SerialConsistency;
-use super::value::LegacySerializedValues;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
 #[repr(u8)]
@@ -59,7 +59,7 @@ pub trait DeserializableRequest: SerializableRequest + Sized {
 pub enum Request<'r> {
     Query(Query<'r>),
     Execute(Execute<'r>),
-    Batch(Batch<'r, BatchStatement<'r>, Vec<LegacySerializedValues>>),
+    Batch(Batch<'r, BatchStatement<'r>, Vec<SerializedValues>>),
 }
 
 impl<'r> Request<'r> {
@@ -190,8 +190,8 @@ mod tests {
 
             // Not execute's values, because named values are not supported in batches.
             values: vec![
-                query.parameters.values.deref().to_old_serialized_values(),
-                query.parameters.values.deref().to_old_serialized_values(),
+                query.parameters.values.deref().clone(),
+                query.parameters.values.deref().clone(),
             ],
         };
         {
@@ -262,7 +262,7 @@ mod tests {
             serial_consistency: None,
             timestamp: None,
 
-            values: vec![query.parameters.values.deref().to_old_serialized_values()],
+            values: vec![query.parameters.values.deref().clone()],
         };
         {
             let mut buf = Vec::new();

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -8,7 +8,7 @@ pub mod register;
 pub mod startup;
 
 use crate::{frame::frame_errors::ParseError, Consistency};
-use bytes::{BufMut, Bytes};
+use bytes::Bytes;
 use num_enum::TryFromPrimitive;
 
 pub use auth_response::AuthResponse;
@@ -40,7 +40,7 @@ pub enum RequestOpcode {
 pub trait SerializableRequest {
     const OPCODE: RequestOpcode;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError>;
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError>;
 
     fn to_bytes(&self) -> Result<Bytes, ParseError> {
         let mut v = Vec::new();

--- a/scylla-cql/src/frame/request/options.rs
+++ b/scylla-cql/src/frame/request/options.rs
@@ -1,5 +1,4 @@
 use crate::frame::frame_errors::ParseError;
-use bytes::BufMut;
 
 use crate::frame::request::{RequestOpcode, SerializableRequest};
 
@@ -8,7 +7,7 @@ pub struct Options;
 impl SerializableRequest for Options {
     const OPCODE: RequestOpcode = RequestOpcode::Options;
 
-    fn serialize(&self, _buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, _buf: &mut Vec<u8>) -> Result<(), ParseError> {
         Ok(())
     }
 }

--- a/scylla-cql/src/frame/request/prepare.rs
+++ b/scylla-cql/src/frame/request/prepare.rs
@@ -1,5 +1,4 @@
 use crate::frame::frame_errors::ParseError;
-use bytes::BufMut;
 
 use crate::{
     frame::request::{RequestOpcode, SerializableRequest},
@@ -13,7 +12,7 @@ pub struct Prepare<'a> {
 impl<'a> SerializableRequest for Prepare<'a> {
     const OPCODE: RequestOpcode = RequestOpcode::Prepare;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
         types::write_long_string(self.query, buf)?;
         Ok(())
     }

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -38,7 +38,7 @@ pub struct Query<'q> {
 impl SerializableRequest for Query<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Query;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
         types::write_long_string(&self.contents, buf)?;
         self.parameters.serialize(buf)?;
         Ok(())

--- a/scylla-cql/src/frame/request/register.rs
+++ b/scylla-cql/src/frame/request/register.rs
@@ -1,5 +1,3 @@
-use bytes::BufMut;
-
 use crate::frame::{
     frame_errors::ParseError,
     request::{RequestOpcode, SerializableRequest},
@@ -14,7 +12,7 @@ pub struct Register {
 impl SerializableRequest for Register {
     const OPCODE: RequestOpcode = RequestOpcode::Register;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
         let event_types_list = self
             .event_types_to_register_for
             .iter()

--- a/scylla-cql/src/frame/request/startup.rs
+++ b/scylla-cql/src/frame/request/startup.rs
@@ -1,5 +1,4 @@
 use crate::frame::frame_errors::ParseError;
-use bytes::BufMut;
 
 use std::collections::HashMap;
 
@@ -15,7 +14,7 @@ pub struct Startup {
 impl SerializableRequest for Startup {
     const OPCODE: RequestOpcode = RequestOpcode::Startup;
 
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
         types::write_string_map(&self.options, buf)?;
         Ok(())
     }

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -454,15 +454,15 @@ impl<'a> Iterator for LegacySerializedValuesIterator<'a> {
 }
 
 /// Represents List of ValueList for Batch statement
-pub trait BatchValues {
+pub trait LegacyBatchValues {
     /// For some unknown reason, this type, when not resolved to a concrete type for a given async function,
     /// cannot live across await boundaries while maintaining the corresponding future `Send`, unless `'r: 'static`
     ///
     /// See <https://github.com/scylladb/scylla-rust-driver/issues/599> for more details
-    type BatchValuesIter<'r>: BatchValuesIterator<'r>
+    type LegacyBatchValuesIter<'r>: LegacyBatchValuesIterator<'r>
     where
         Self: 'r;
-    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_>;
+    fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_>;
 }
 
 /// An iterator-like for `ValueList`
@@ -473,7 +473,7 @@ pub trait BatchValues {
 /// It's just essentially making methods from `ValueList` accessible instead of being an actual iterator because of
 /// compiler limitations that would otherwise be very complex to overcome.
 /// (specifically, types being different would require yielding enums for tuple impls)
-pub trait BatchValuesIterator<'a> {
+pub trait LegacyBatchValuesIterator<'a> {
     fn next_serialized(&mut self) -> Option<SerializedResult<'a>>;
     fn write_next_to_request(
         &mut self,
@@ -496,11 +496,11 @@ pub trait BatchValuesIterator<'a> {
 ///
 /// Essentially used internally by this lib to provide implementers of `BatchValuesIterator` for cases
 /// that always serialize the same concrete `ValueList` type
-pub struct BatchValuesIteratorFromIterator<IT: Iterator> {
+pub struct LegacyBatchValuesIteratorFromIterator<IT: Iterator> {
     it: IT,
 }
 
-impl<'r, 'a: 'r, IT, VL> BatchValuesIterator<'r> for BatchValuesIteratorFromIterator<IT>
+impl<'r, 'a: 'r, IT, VL> LegacyBatchValuesIterator<'r> for LegacyBatchValuesIteratorFromIterator<IT>
 where
     IT: Iterator<Item = &'a VL>,
     VL: ValueList + 'a,
@@ -519,13 +519,13 @@ where
     }
 }
 
-impl<IT> From<IT> for BatchValuesIteratorFromIterator<IT>
+impl<IT> From<IT> for LegacyBatchValuesIteratorFromIterator<IT>
 where
     IT: Iterator,
     IT::Item: ValueList,
 {
     fn from(it: IT) -> Self {
-        BatchValuesIteratorFromIterator { it }
+        LegacyBatchValuesIteratorFromIterator { it }
     }
 }
 
@@ -1192,12 +1192,12 @@ impl<'b> ValueList for Cow<'b, LegacySerializedValues> {
 /// The underlying iterator will always be cloned at least once, once to compute the length if it can't be known
 /// in advance, and be re-cloned at every retry.
 /// It is consequently expected that the provided iterator is cheap to clone (e.g. `slice.iter().map(...)`).
-pub struct BatchValuesFromIter<'a, IT> {
+pub struct LegacyBatchValuesFromIter<'a, IT> {
     it: IT,
     _spooky: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a, IT, VL> BatchValuesFromIter<'a, IT>
+impl<'a, IT, VL> LegacyBatchValuesFromIter<'a, IT>
 where
     IT: Iterator<Item = &'a VL> + Clone,
     VL: ValueList + 'a,
@@ -1210,7 +1210,7 @@ where
     }
 }
 
-impl<'a, IT, VL> From<IT> for BatchValuesFromIter<'a, IT>
+impl<'a, IT, VL> From<IT> for LegacyBatchValuesFromIter<'a, IT>
 where
     IT: Iterator<Item = &'a VL> + Clone,
     VL: ValueList + 'a,
@@ -1220,38 +1220,38 @@ where
     }
 }
 
-impl<'a, IT, VL> BatchValues for BatchValuesFromIter<'a, IT>
+impl<'a, IT, VL> LegacyBatchValues for LegacyBatchValuesFromIter<'a, IT>
 where
     IT: Iterator<Item = &'a VL> + Clone,
     VL: ValueList + 'a,
 {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<IT> where Self: 'r;
-    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<IT> where Self: 'r;
+    fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         self.it.clone().into()
     }
 }
 
 // Implement BatchValues for slices of ValueList types
-impl<T: ValueList> BatchValues for [T] {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
-    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+impl<T: ValueList> LegacyBatchValues for [T] {
+    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+    fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         self.iter().into()
     }
 }
 
 // Implement BatchValues for Vec<ValueList>
-impl<T: ValueList> BatchValues for Vec<T> {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
-    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
-        BatchValues::batch_values_iter(self.as_slice())
+impl<T: ValueList> LegacyBatchValues for Vec<T> {
+    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+    fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
+        LegacyBatchValues::batch_values_iter(self.as_slice())
     }
 }
 
 // Here is an example implementation for (T0, )
 // Further variants are done using a macro
-impl<T0: ValueList> BatchValues for (T0,) {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::iter::Once<&'r T0>> where Self: 'r;
-    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+impl<T0: ValueList> LegacyBatchValues for (T0,) {
+    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<std::iter::Once<&'r T0>> where Self: 'r;
+    fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         std::iter::once(&self.0).into()
     }
 }
@@ -1263,19 +1263,19 @@ pub struct TupleValuesIter<'a, T> {
 
 macro_rules! impl_batch_values_for_tuple {
     ( $($Ti:ident),* ; $($FieldI:tt),* ; $TupleSize:tt) => {
-        impl<$($Ti),+> BatchValues for ($($Ti,)+)
+        impl<$($Ti),+> LegacyBatchValues for ($($Ti,)+)
         where
             $($Ti: ValueList),+
         {
-            type BatchValuesIter<'r> = TupleValuesIter<'r, ($($Ti,)+)> where Self: 'r;
-            fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+            type LegacyBatchValuesIter<'r> = TupleValuesIter<'r, ($($Ti,)+)> where Self: 'r;
+            fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
                 TupleValuesIter {
                     tuple: self,
                     idx: 0,
                 }
             }
         }
-        impl<'r, $($Ti),+> BatchValuesIterator<'r> for TupleValuesIter<'r, ($($Ti,)+)>
+        impl<'r, $($Ti),+> LegacyBatchValuesIterator<'r> for TupleValuesIter<'r, ($($Ti,)+)>
         where
             $($Ti: ValueList),+
         {
@@ -1338,10 +1338,10 @@ impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T
                              0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15; 16);
 
 // Every &impl BatchValues should also implement BatchValues
-impl<'a, T: BatchValues + ?Sized> BatchValues for &'a T {
-    type BatchValuesIter<'r> = <T as BatchValues>::BatchValuesIter<'r> where Self: 'r;
-    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
-        <T as BatchValues>::batch_values_iter(*self)
+impl<'a, T: LegacyBatchValues + ?Sized> LegacyBatchValues for &'a T {
+    type LegacyBatchValuesIter<'r> = <T as LegacyBatchValues>::LegacyBatchValuesIter<'r> where Self: 'r;
+    fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
+        <T as LegacyBatchValues>::batch_values_iter(*self)
     }
 }
 
@@ -1351,12 +1351,12 @@ impl<'a, T: BatchValues + ?Sized> BatchValues for &'a T {
 /// Once that is done, we can use that instead of re-serializing.
 ///
 /// This struct implements both `BatchValues` and `BatchValuesIterator` for that purpose
-pub struct BatchValuesFirstSerialized<'f, T> {
+pub struct LegacyBatchValuesFirstSerialized<'f, T> {
     first: Option<&'f LegacySerializedValues>,
     rest: T,
 }
 
-impl<'f, T: BatchValues> BatchValuesFirstSerialized<'f, T> {
+impl<'f, T: LegacyBatchValues> LegacyBatchValuesFirstSerialized<'f, T> {
     pub fn new(
         batch_values: T,
         already_serialized_first: Option<&'f LegacySerializedValues>,
@@ -1368,19 +1368,19 @@ impl<'f, T: BatchValues> BatchValuesFirstSerialized<'f, T> {
     }
 }
 
-impl<'f, BV: BatchValues> BatchValues for BatchValuesFirstSerialized<'f, BV> {
-    type BatchValuesIter<'r> =
-        BatchValuesFirstSerialized<'f, <BV as BatchValues>::BatchValuesIter<'r>> where Self: 'r;
-    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
-        BatchValuesFirstSerialized {
+impl<'f, BV: LegacyBatchValues> LegacyBatchValues for LegacyBatchValuesFirstSerialized<'f, BV> {
+    type LegacyBatchValuesIter<'r> =
+        LegacyBatchValuesFirstSerialized<'f, <BV as LegacyBatchValues>::LegacyBatchValuesIter<'r>> where Self: 'r;
+    fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
+        LegacyBatchValuesFirstSerialized {
             first: self.first,
             rest: self.rest.batch_values_iter(),
         }
     }
 }
 
-impl<'a, 'f: 'a, IT: BatchValuesIterator<'a>> BatchValuesIterator<'a>
-    for BatchValuesFirstSerialized<'f, IT>
+impl<'a, 'f: 'a, IT: LegacyBatchValuesIterator<'a>> LegacyBatchValuesIterator<'a>
+    for LegacyBatchValuesFirstSerialized<'f, IT>
 {
     fn next_serialized(&mut self) -> Option<SerializedResult<'a>> {
         match self.first.take() {

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1,12 +1,12 @@
-use crate::frame::{response::result::CqlValue, types::RawValue, value::BatchValuesIterator};
+use crate::frame::{response::result::CqlValue, types::RawValue, value::LegacyBatchValuesIterator};
 use crate::types::serialize::row::{RowSerializationContext, SerializeRow};
 use crate::types::serialize::value::SerializeCql;
 use crate::types::serialize::{CellWriter, RowWriter};
 
 use super::response::result::{ColumnSpec, ColumnType, TableSpec};
 use super::value::{
-    BatchValues, CqlDate, CqlDuration, CqlTime, CqlTimestamp, LegacySerializedValues, MaybeUnset,
-    SerializeValuesError, Unset, Value, ValueList, ValueTooBig,
+    CqlDate, CqlDuration, CqlTime, CqlTimestamp, LegacyBatchValues, LegacySerializedValues,
+    MaybeUnset, SerializeValuesError, Unset, Value, ValueList, ValueTooBig,
 };
 use bigdecimal::BigDecimal;
 use bytes::BufMut;
@@ -1235,7 +1235,7 @@ fn vec_batch_values() {
 
 #[test]
 fn tuple_batch_values() {
-    fn check_twoi32_tuple(tuple: impl BatchValues, size: usize) {
+    fn check_twoi32_tuple(tuple: impl LegacyBatchValues, size: usize) {
         let mut it = tuple.batch_values_iter();
         for i in 0..size {
             let mut request: Vec<u8> = Vec::new();
@@ -1428,8 +1428,8 @@ fn ref_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
 
     return check_ref_bv::<&&&&&[&[i8]]>(&&&&batch_values);
-    fn check_ref_bv<B: BatchValues>(batch_values: B) {
-        let mut it = <B as BatchValues>::batch_values_iter(&batch_values);
+    fn check_ref_bv<B: LegacyBatchValues>(batch_values: B) {
+        let mut it = <B as LegacyBatchValues>::batch_values_iter(&batch_values);
 
         let mut request: Vec<u8> = Vec::new();
         it.write_next_to_request(&mut request).unwrap().unwrap();
@@ -1440,7 +1440,7 @@ fn ref_batch_values() {
 #[test]
 #[allow(clippy::needless_borrow)]
 fn check_ref_tuple() {
-    fn assert_has_batch_values<BV: BatchValues>(bv: BV) {
+    fn assert_has_batch_values<BV: LegacyBatchValues>(bv: BV) {
         let mut it = bv.batch_values_iter();
         let mut request: Vec<u8> = Vec::new();
         while let Some(res) = it.write_next_to_request(&mut request) {
@@ -1457,7 +1457,7 @@ fn check_ref_tuple() {
 #[test]
 fn check_batch_values_iterator_is_not_lending() {
     // This is an interesting property if we want to improve the batch shard selection heuristic
-    fn f(bv: impl BatchValues) {
+    fn f(bv: impl LegacyBatchValues) {
         let mut it = bv.batch_values_iter();
         let mut it2 = bv.batch_values_iter();
         // Make sure we can hold all these at the same time

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1,4 +1,5 @@
 use crate::frame::{response::result::CqlValue, types::RawValue, value::LegacyBatchValuesIterator};
+use crate::types::serialize::batch::{BatchValues, BatchValuesIterator, LegacyBatchValuesAdapter};
 use crate::types::serialize::row::{RowSerializationContext, SerializeRow};
 use crate::types::serialize::value::SerializeCql;
 use crate::types::serialize::{CellWriter, RowWriter};
@@ -1178,19 +1179,79 @@ fn cow_serialized_values_value_list() {
     assert_eq!(cow_ser_values.as_ref(), serialized.as_ref());
 }
 
+fn make_batch_value_iters<'bv, BV: BatchValues + LegacyBatchValues>(
+    bv: &'bv BV,
+    adapter_bv: &'bv LegacyBatchValuesAdapter<&'bv BV>,
+) -> (
+    BV::LegacyBatchValuesIter<'bv>,
+    BV::BatchValuesIter<'bv>,
+    <LegacyBatchValuesAdapter<&'bv BV> as BatchValues>::BatchValuesIter<'bv>,
+) {
+    (
+        <BV as LegacyBatchValues>::batch_values_iter(bv),
+        <BV as BatchValues>::batch_values_iter(bv),
+        <_ as BatchValues>::batch_values_iter(adapter_bv),
+    )
+}
+
+fn serialize_batch_value_iterators<'a>(
+    (legacy_bvi, bvi, bvi_adapted): &mut (
+        impl LegacyBatchValuesIterator<'a>,
+        impl BatchValuesIterator<'a>,
+        impl BatchValuesIterator<'a>,
+    ),
+    columns: &[ColumnSpec],
+) -> Vec<u8> {
+    let mut legacy_data = Vec::new();
+    legacy_bvi
+        .write_next_to_request(&mut legacy_data)
+        .unwrap()
+        .unwrap();
+
+    fn serialize_bvi<'bv>(
+        bvi: &mut impl BatchValuesIterator<'bv>,
+        ctx: &RowSerializationContext,
+    ) -> Vec<u8> {
+        let mut data = vec![0, 0];
+        let mut writer = RowWriter::new(&mut data);
+        bvi.serialize_next(ctx, &mut writer).unwrap().unwrap();
+        let value_count: u16 = writer.value_count().try_into().unwrap();
+        data[0..2].copy_from_slice(&value_count.to_be_bytes());
+        data
+    }
+
+    let ctx = RowSerializationContext { columns };
+    let data = serialize_bvi(bvi, &ctx);
+    let adapted_data = serialize_bvi(bvi_adapted, &ctx);
+
+    assert_eq!(legacy_data, data);
+    assert_eq!(adapted_data, data);
+    data
+}
+
 #[test]
 fn slice_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
-    let mut it = batch_values.batch_values_iter();
+    let legacy_batch_values = LegacyBatchValuesAdapter(&batch_values);
+
+    let mut iters = make_batch_value_iters(&batch_values, &legacy_batch_values);
     {
-        let mut request: Vec<u8> = Vec::new();
-        it.write_next_to_request(&mut request).unwrap().unwrap();
+        let cols = &[
+            col_spec("a", ColumnType::TinyInt),
+            col_spec("b", ColumnType::TinyInt),
+        ];
+        let request = serialize_batch_value_iterators(&mut iters, cols);
         assert_eq!(request, vec![0, 2, 0, 0, 0, 1, 1, 0, 0, 0, 1, 2]);
     }
 
     {
-        let mut request: Vec<u8> = Vec::new();
-        it.write_next_to_request(&mut request).unwrap().unwrap();
+        let cols = &[
+            col_spec("a", ColumnType::TinyInt),
+            col_spec("b", ColumnType::TinyInt),
+            col_spec("c", ColumnType::TinyInt),
+            col_spec("d", ColumnType::TinyInt),
+        ];
+        let request = serialize_batch_value_iterators(&mut iters, cols);
         assert_eq!(
             request,
             vec![0, 4, 0, 0, 0, 1, 2, 0, 0, 0, 1, 3, 0, 0, 0, 1, 4, 0, 0, 0, 1, 5]
@@ -1198,28 +1259,42 @@ fn slice_batch_values() {
     }
 
     {
-        let mut request: Vec<u8> = Vec::new();
-        it.write_next_to_request(&mut request).unwrap().unwrap();
+        let cols = &[col_spec("a", ColumnType::TinyInt)];
+        let request = serialize_batch_value_iterators(&mut iters, cols);
         assert_eq!(request, vec![0, 1, 0, 0, 0, 1, 6]);
     }
 
-    assert_eq!(it.write_next_to_request(&mut Vec::new()), None);
+    assert_eq!(iters.0.write_next_to_request(&mut Vec::new()), None);
+
+    let ctx = RowSerializationContext { columns: &[] };
+    let mut data = Vec::new();
+    let mut writer = RowWriter::new(&mut data);
+    assert!(iters.1.serialize_next(&ctx, &mut writer).is_none());
 }
 
 #[test]
 fn vec_batch_values() {
     let batch_values: Vec<Vec<i8>> = vec![vec![1, 2], vec![2, 3, 4, 5], vec![6]];
+    let legacy_batch_values = LegacyBatchValuesAdapter(&batch_values);
 
-    let mut it = batch_values.batch_values_iter();
+    let mut iters = make_batch_value_iters(&batch_values, &legacy_batch_values);
     {
-        let mut request: Vec<u8> = Vec::new();
-        it.write_next_to_request(&mut request).unwrap().unwrap();
+        let cols = &[
+            col_spec("a", ColumnType::TinyInt),
+            col_spec("b", ColumnType::TinyInt),
+        ];
+        let request = serialize_batch_value_iterators(&mut iters, cols);
         assert_eq!(request, vec![0, 2, 0, 0, 0, 1, 1, 0, 0, 0, 1, 2]);
     }
 
     {
-        let mut request: Vec<u8> = Vec::new();
-        it.write_next_to_request(&mut request).unwrap().unwrap();
+        let cols = &[
+            col_spec("a", ColumnType::TinyInt),
+            col_spec("b", ColumnType::TinyInt),
+            col_spec("c", ColumnType::TinyInt),
+            col_spec("d", ColumnType::TinyInt),
+        ];
+        let request = serialize_batch_value_iterators(&mut iters, cols);
         assert_eq!(
             request,
             vec![0, 4, 0, 0, 0, 1, 2, 0, 0, 0, 1, 3, 0, 0, 0, 1, 4, 0, 0, 0, 1, 5]
@@ -1227,19 +1302,24 @@ fn vec_batch_values() {
     }
 
     {
-        let mut request: Vec<u8> = Vec::new();
-        it.write_next_to_request(&mut request).unwrap().unwrap();
+        let cols = &[col_spec("a", ColumnType::TinyInt)];
+        let request = serialize_batch_value_iterators(&mut iters, cols);
         assert_eq!(request, vec![0, 1, 0, 0, 0, 1, 6]);
     }
 }
 
 #[test]
 fn tuple_batch_values() {
-    fn check_twoi32_tuple(tuple: impl LegacyBatchValues, size: usize) {
-        let mut it = tuple.batch_values_iter();
+    fn check_twoi32_tuple(tuple: impl BatchValues + LegacyBatchValues, size: usize) {
+        let legacy_tuple = LegacyBatchValuesAdapter(&tuple);
+        let mut iters = make_batch_value_iters(&tuple, &legacy_tuple);
         for i in 0..size {
-            let mut request: Vec<u8> = Vec::new();
-            it.write_next_to_request(&mut request).unwrap().unwrap();
+            let cols = &[
+                col_spec("a", ColumnType::Int),
+                col_spec("b", ColumnType::Int),
+            ];
+
+            let request = serialize_batch_value_iterators(&mut iters, cols);
 
             let mut expected: Vec<u8> = Vec::new();
             let i: i32 = i.try_into().unwrap();
@@ -1426,13 +1506,17 @@ fn tuple_batch_values() {
 #[allow(clippy::needless_borrow)]
 fn ref_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
+    let cols = &[
+        col_spec("a", ColumnType::TinyInt),
+        col_spec("b", ColumnType::TinyInt),
+    ];
 
-    return check_ref_bv::<&&&&&[&[i8]]>(&&&&batch_values);
-    fn check_ref_bv<B: LegacyBatchValues>(batch_values: B) {
-        let mut it = <B as LegacyBatchValues>::batch_values_iter(&batch_values);
+    return check_ref_bv::<&&&&&[&[i8]]>(&&&&batch_values, cols);
+    fn check_ref_bv<B: BatchValues + LegacyBatchValues>(batch_values: B, cols: &[ColumnSpec]) {
+        let legacy_batch_values = LegacyBatchValuesAdapter(&batch_values);
+        let mut iters = make_batch_value_iters(&batch_values, &legacy_batch_values);
 
-        let mut request: Vec<u8> = Vec::new();
-        it.write_next_to_request(&mut request).unwrap().unwrap();
+        let request = serialize_batch_value_iterators(&mut iters, cols);
         assert_eq!(request, vec![0, 2, 0, 0, 0, 1, 1, 0, 0, 0, 1, 2]);
     }
 }
@@ -1440,18 +1524,32 @@ fn ref_batch_values() {
 #[test]
 #[allow(clippy::needless_borrow)]
 fn check_ref_tuple() {
-    fn assert_has_batch_values<BV: LegacyBatchValues>(bv: BV) {
-        let mut it = bv.batch_values_iter();
-        let mut request: Vec<u8> = Vec::new();
-        while let Some(res) = it.write_next_to_request(&mut request) {
-            res.unwrap()
+    fn assert_has_batch_values<BV: BatchValues + LegacyBatchValues>(
+        bv: BV,
+        cols: &[&[ColumnSpec]],
+    ) {
+        let legacy_bv = LegacyBatchValuesAdapter(&bv);
+        let mut iters = make_batch_value_iters(&bv, &legacy_bv);
+        for cols in cols {
+            serialize_batch_value_iterators(&mut iters, cols);
         }
     }
     let s = String::from("hello");
     let tuple: ((&str,),) = ((&s,),);
-    assert_has_batch_values::<&_>(&tuple);
+    let cols: &[&[ColumnSpec]] = &[&[col_spec("a", ColumnType::Text)]];
+    assert_has_batch_values::<&_>(&tuple, cols);
     let tuple2: ((&str, &str), (&str, &str)) = ((&s, &s), (&s, &s));
-    assert_has_batch_values::<&_>(&tuple2);
+    let cols: &[&[ColumnSpec]] = &[
+        &[
+            col_spec("a", ColumnType::Text),
+            col_spec("b", ColumnType::Text),
+        ],
+        &[
+            col_spec("a", ColumnType::Text),
+            col_spec("b", ColumnType::Text),
+        ],
+    ];
+    assert_has_batch_values::<&_>(&tuple2, cols);
 }
 
 #[test]
@@ -1469,5 +1567,24 @@ fn check_batch_values_iterator_is_not_lending() {
         ];
         let _ = v;
     }
-    f(((10,), (11,)))
+    fn g(bv: impl BatchValues) {
+        let mut it = bv.batch_values_iter();
+        let mut it2 = bv.batch_values_iter();
+
+        let columns = &[col_spec("a", ColumnType::Int)];
+        let ctx = RowSerializationContext { columns };
+        let mut data = Vec::new();
+        let mut writer = RowWriter::new(&mut data);
+
+        // Make sure we can hold all these at the same time
+        let v = vec![
+            it.serialize_next(&ctx, &mut writer).unwrap().unwrap(),
+            it2.serialize_next(&ctx, &mut writer).unwrap().unwrap(),
+            it.serialize_next(&ctx, &mut writer).unwrap().unwrap(),
+            it2.serialize_next(&ctx, &mut writer).unwrap().unwrap(),
+        ];
+        let _ = v;
+    }
+    f(((10,), (11,)));
+    g(((10,), (11,)));
 }

--- a/scylla-cql/src/types/serialize/batch.rs
+++ b/scylla-cql/src/types/serialize/batch.rs
@@ -1,0 +1,307 @@
+//! Contains the [`BatchValues`] and [`BatchValuesIterator`] trait and their
+//! implementations.
+
+use super::row::{RowSerializationContext, SerializeRow};
+use super::{RowWriter, SerializationError};
+
+/// Represents a list of sets of values for a batch statement.
+///
+/// The data in the object can be consumed with an iterator-like object returned
+/// by the [`BatchValues::batch_values_iter`] method.
+pub trait BatchValues {
+    /// An `Iterator`-like object over the values from the parent `BatchValues` object.
+    // For some unknown reason, this type, when not resolved to a concrete type for a given async function,
+    // cannot live across await boundaries while maintaining the corresponding future `Send`, unless `'r: 'static`
+    //
+    // See <https://github.com/scylladb/scylla-rust-driver/issues/599> for more details
+    type BatchValuesIter<'r>: BatchValuesIterator<'r>
+    where
+        Self: 'r;
+
+    /// Returns an iterator over the data contained in this object.
+    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_>;
+}
+
+/// An `Iterator`-like object over the values from the parent [`BatchValues`] object.
+///
+/// It's not a true [`Iterator`] because it does not provide direct access to the
+/// items being iterated over, instead it allows calling methods of the underlying
+/// [`SerializeRow`] trait while advancing the iterator.
+pub trait BatchValuesIterator<'bv> {
+    /// Serializes the next set of values in the sequence and advances the iterator.
+    fn serialize_next(
+        &mut self,
+        ctx: &RowSerializationContext<'_>,
+        writer: &mut RowWriter,
+    ) -> Option<Result<(), SerializationError>>;
+
+    /// Returns whether the next set of values is empty or not and advances the iterator.
+    fn is_empty_next(&mut self) -> Option<bool>;
+
+    /// Skips the next set of values.
+    fn skip_next(&mut self) -> Option<()>;
+
+    /// Return the number of sets of values, consuming the iterator in the process.
+    #[inline]
+    fn count(mut self) -> usize
+    where
+        Self: Sized,
+    {
+        let mut count = 0;
+        while self.skip_next().is_some() {
+            count += 1;
+        }
+        count
+    }
+}
+
+/// Implements `BatchValuesIterator` from an `Iterator` over references to things that implement `SerializeRow`
+///
+/// Essentially used internally by this lib to provide implementers of `BatchValuesIterator` for cases
+/// that always serialize the same concrete `SerializeRow` type
+pub struct BatchValuesIteratorFromIterator<IT: Iterator> {
+    it: IT,
+}
+
+impl<'bv, 'sr: 'bv, IT, SR> BatchValuesIterator<'bv> for BatchValuesIteratorFromIterator<IT>
+where
+    IT: Iterator<Item = &'sr SR>,
+    SR: SerializeRow + 'sr,
+{
+    #[inline]
+    fn serialize_next(
+        &mut self,
+        ctx: &RowSerializationContext<'_>,
+        writer: &mut RowWriter,
+    ) -> Option<Result<(), SerializationError>> {
+        self.it.next().map(|sr| sr.serialize(ctx, writer))
+    }
+
+    #[inline]
+    fn is_empty_next(&mut self) -> Option<bool> {
+        self.it.next().map(|sr| sr.is_empty())
+    }
+
+    #[inline]
+    fn skip_next(&mut self) -> Option<()> {
+        self.it.next().map(|_| ())
+    }
+
+    #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.it.count()
+    }
+}
+
+impl<IT> From<IT> for BatchValuesIteratorFromIterator<IT>
+where
+    IT: Iterator,
+    IT::Item: SerializeRow,
+{
+    #[inline]
+    fn from(it: IT) -> Self {
+        BatchValuesIteratorFromIterator { it }
+    }
+}
+
+//
+// BatchValues impls
+//
+
+/// Implements `BatchValues` from an `Iterator` over references to things that implement `SerializeRow`
+///
+/// This is to avoid requiring allocating a new `Vec` containing all the `SerializeRow`s directly:
+/// with this, one can write:
+/// `session.batch(&batch, BatchValuesFromIter::from(lines_to_insert.iter().map(|l| &l.value_list)))`
+/// where `lines_to_insert` may also contain e.g. data to pick the statement...
+///
+/// The underlying iterator will always be cloned at least once, once to compute the length if it can't be known
+/// in advance, and be re-cloned at every retry.
+/// It is consequently expected that the provided iterator is cheap to clone (e.g. `slice.iter().map(...)`).
+pub struct BatchValuesFromIterator<'sr, IT> {
+    it: IT,
+
+    // Without artificially introducing a lifetime to the struct, I couldn't get
+    // impl BatchValues for BatchValuesFromIterator to work. I wish I understood
+    // why it's needed.
+    _phantom: std::marker::PhantomData<&'sr ()>,
+}
+
+impl<'sr, IT, SR> BatchValuesFromIterator<'sr, IT>
+where
+    IT: Iterator<Item = &'sr SR> + Clone,
+    SR: SerializeRow + 'sr,
+{
+    /// Creates a new `BatchValuesFromIter`` object.
+    #[inline]
+    pub fn new(into_iter: impl IntoIterator<IntoIter = IT>) -> Self {
+        Self {
+            it: into_iter.into_iter(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'sr, IT, SR> From<IT> for BatchValuesFromIterator<'sr, IT>
+where
+    IT: Iterator<Item = &'sr SR> + Clone,
+    SR: SerializeRow + 'sr,
+{
+    #[inline]
+    fn from(it: IT) -> Self {
+        Self::new(it)
+    }
+}
+
+impl<'sr, IT, SR> BatchValues for BatchValuesFromIterator<'sr, IT>
+where
+    IT: Iterator<Item = &'sr SR> + Clone,
+    SR: SerializeRow + 'sr,
+{
+    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<IT> where Self: 'r;
+
+    #[inline]
+    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+        self.it.clone().into()
+    }
+}
+
+// Implement BatchValues for slices of SerializeRow types
+impl<T: SerializeRow> BatchValues for [T] {
+    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+
+    #[inline]
+    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+        self.iter().into()
+    }
+}
+
+// Implement BatchValues for Vec<SerializeRow>
+impl<T: SerializeRow> BatchValues for Vec<T> {
+    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+
+    #[inline]
+    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+        BatchValues::batch_values_iter(self.as_slice())
+    }
+}
+
+// Here is an example implementation for (T0, )
+// Further variants are done using a macro
+impl<T0: SerializeRow> BatchValues for (T0,) {
+    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::iter::Once<&'r T0>> where Self: 'r;
+
+    #[inline]
+    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+        std::iter::once(&self.0).into()
+    }
+}
+
+/// A [`BatchValuesIterator`] over a tuple.
+pub struct TupleValuesIter<'sr, T> {
+    tuple: &'sr T,
+    idx: usize,
+}
+
+macro_rules! impl_batch_values_for_tuple {
+    ( $($Ti:ident),* ; $($FieldI:tt),* ; $TupleSize:tt) => {
+        impl<$($Ti),+> BatchValues for ($($Ti,)+)
+        where
+            $($Ti: SerializeRow),+
+        {
+            type BatchValuesIter<'r> = TupleValuesIter<'r, ($($Ti,)+)> where Self: 'r;
+
+            #[inline]
+            fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+                TupleValuesIter {
+                    tuple: self,
+                    idx: 0,
+                }
+            }
+        }
+
+        impl<'bv, $($Ti),+> BatchValuesIterator<'bv> for TupleValuesIter<'bv, ($($Ti,)+)>
+        where
+            $($Ti: SerializeRow),+
+        {
+            #[inline]
+            fn serialize_next(
+                &mut self,
+                ctx: &RowSerializationContext<'_>,
+                writer: &mut RowWriter,
+            ) -> Option<Result<(), SerializationError>> {
+                let ret = match self.idx {
+                    $(
+                        $FieldI => self.tuple.$FieldI.serialize(ctx, writer),
+                    )*
+                    _ => return None,
+                };
+                self.idx += 1;
+                Some(ret)
+            }
+
+            #[inline]
+            fn is_empty_next(&mut self) -> Option<bool> {
+                let ret = match self.idx {
+                    $(
+                        $FieldI => self.tuple.$FieldI.is_empty(),
+                    )*
+                    _ => return None,
+                };
+                self.idx += 1;
+                Some(ret)
+            }
+
+            #[inline]
+            fn skip_next(&mut self) -> Option<()> {
+                if self.idx < $TupleSize {
+                    self.idx += 1;
+                    Some(())
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn count(self) -> usize {
+                $TupleSize - self.idx
+            }
+        }
+    }
+}
+
+impl_batch_values_for_tuple!(T0, T1; 0, 1; 2);
+impl_batch_values_for_tuple!(T0, T1, T2; 0, 1, 2; 3);
+impl_batch_values_for_tuple!(T0, T1, T2, T3; 0, 1, 2, 3; 4);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4; 0, 1, 2, 3, 4; 5);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5; 0, 1, 2, 3, 4, 5; 6);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6; 0, 1, 2, 3, 4, 5, 6; 7);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7; 0, 1, 2, 3, 4, 5, 6, 7; 8);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8; 0, 1, 2, 3, 4, 5, 6, 7, 8; 9);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9;
+                             0, 1, 2, 3, 4, 5, 6, 7, 8, 9; 10);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10;
+                             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10; 11);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11;
+                             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11; 12);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12;
+                             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12; 13);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13;
+                             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13; 14);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14;
+                             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14; 15);
+impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15;
+                             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15; 16);
+
+// Every &impl BatchValues should also implement BatchValues
+impl<'a, T: BatchValues + ?Sized> BatchValues for &'a T {
+    type BatchValuesIter<'r> = <T as BatchValues>::BatchValuesIter<'r> where Self: 'r;
+
+    #[inline]
+    fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
+        <T as BatchValues>::batch_values_iter(*self)
+    }
+}

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -6,6 +6,8 @@ use std::{error::Error, fmt::Display, sync::Arc};
 
 use thiserror::Error;
 
+pub mod batch;
+pub mod raw_batch;
 pub mod row;
 pub mod value;
 pub mod writers;

--- a/scylla-cql/src/types/serialize/raw_batch.rs
+++ b/scylla-cql/src/types/serialize/raw_batch.rs
@@ -1,15 +1,16 @@
 //! Contains the [`RawBatchValues`] and [`RawBatchValuesIterator`] trait and their
 //! implementations.
 
-use super::row::SerializedValues;
+use super::batch::{BatchValues, BatchValuesIterator};
+use super::row::{RowSerializationContext, SerializedValues};
 use super::{RowWriter, SerializationError};
 
 /// Represents a list of sets of values for a batch statement.
 ///
-/// Unlike [`BatchValues`](super::batch::BatchValues), it doesn't require type
+/// Unlike [`BatchValues`]), it doesn't require type
 /// information from the statements of the batch in order to be serialized.
 ///
-/// This is a lower level trait than [`BatchValues`](super::batch::BatchValues)
+/// This is a lower level trait than [`BatchValues`])
 /// and is only used for interaction between the code in `scylla` and
 /// `scylla-cql` crates. If you are a regular user of the driver, you shouldn't
 /// care about this trait at all.
@@ -33,7 +34,7 @@ pub trait RawBatchValues {
 /// items being iterated over, instead it allows calling methods of the underlying
 /// [`SerializeRow`](super::row::SerializeRow) trait while advancing the iterator.
 ///
-/// Unlike [`BatchValuesIterator`](super::batch::BatchValuesIterator), it doesn't
+/// Unlike [`BatchValuesIterator`], it doesn't
 /// need type information for serialization.
 pub trait RawBatchValuesIterator<'a> {
     /// Serializes the next set of values in the sequence and advances the iterator.
@@ -59,7 +60,7 @@ pub trait RawBatchValuesIterator<'a> {
     }
 }
 
-/// An implementation used by `scylla-proxy`
+// An implementation used by `scylla-proxy`
 impl RawBatchValues for Vec<SerializedValues> {
     type RawBatchValuesIter<'r> = std::slice::Iter<'r, SerializedValues>
     where
@@ -91,5 +92,71 @@ impl<'r> RawBatchValuesIterator<'r> for std::slice::Iter<'r, SerializedValues> {
     #[inline]
     fn count(self) -> usize {
         <_ as Iterator>::count(self)
+    }
+}
+
+/// Takes `BatchValues` and an iterator over contexts, and turns them into a `RawBatchValues`.
+pub struct RawBatchValuesAdapter<BV, CTX> {
+    batch_values: BV,
+    contexts: CTX,
+}
+
+impl<BV, CTX> RawBatchValuesAdapter<BV, CTX> {
+    /// Creates a new `RawBatchValuesAdapter` object.
+    #[inline]
+    pub fn new(batch_values: BV, contexts: CTX) -> Self {
+        Self {
+            batch_values,
+            contexts,
+        }
+    }
+}
+
+impl<'ctx, BV, CTX> RawBatchValues for RawBatchValuesAdapter<BV, CTX>
+where
+    BV: BatchValues,
+    CTX: Iterator<Item = RowSerializationContext<'ctx>> + Clone,
+{
+    type RawBatchValuesIter<'r> = RawBatchValuesIteratorAdapter<BV::BatchValuesIter<'r>, CTX>
+    where
+        Self: 'r;
+
+    #[inline]
+    fn batch_values_iter(&self) -> Self::RawBatchValuesIter<'_> {
+        RawBatchValuesIteratorAdapter {
+            batch_values_iterator: self.batch_values.batch_values_iter(),
+            contexts: self.contexts.clone(),
+        }
+    }
+}
+
+/// Takes `BatchValuesIterator` and an iterator over contexts, and turns them into a `RawBatchValuesIterator`.
+pub struct RawBatchValuesIteratorAdapter<BVI, CTX> {
+    batch_values_iterator: BVI,
+    contexts: CTX,
+}
+
+impl<'bvi, 'ctx, BVI, CTX> RawBatchValuesIterator<'bvi> for RawBatchValuesIteratorAdapter<BVI, CTX>
+where
+    BVI: BatchValuesIterator<'bvi>,
+    CTX: Iterator<Item = RowSerializationContext<'ctx>>,
+{
+    #[inline]
+    fn serialize_next(&mut self, writer: &mut RowWriter) -> Option<Result<(), SerializationError>> {
+        let ctx = self.contexts.next()?;
+        self.batch_values_iterator.serialize_next(&ctx, writer)
+    }
+
+    fn is_empty_next(&mut self) -> Option<bool> {
+        self.contexts.next()?;
+        let ret = self.batch_values_iterator.is_empty_next()?;
+        Some(ret)
+    }
+
+    #[inline]
+    fn skip_next(&mut self) -> Option<()> {
+        self.contexts.next()?;
+        self.batch_values_iterator.skip_next()?;
+        Some(())
     }
 }

--- a/scylla-cql/src/types/serialize/raw_batch.rs
+++ b/scylla-cql/src/types/serialize/raw_batch.rs
@@ -1,0 +1,95 @@
+//! Contains the [`RawBatchValues`] and [`RawBatchValuesIterator`] trait and their
+//! implementations.
+
+use super::row::SerializedValues;
+use super::{RowWriter, SerializationError};
+
+/// Represents a list of sets of values for a batch statement.
+///
+/// Unlike [`BatchValues`](super::batch::BatchValues), it doesn't require type
+/// information from the statements of the batch in order to be serialized.
+///
+/// This is a lower level trait than [`BatchValues`](super::batch::BatchValues)
+/// and is only used for interaction between the code in `scylla` and
+/// `scylla-cql` crates. If you are a regular user of the driver, you shouldn't
+/// care about this trait at all.
+pub trait RawBatchValues {
+    /// An `Iterator`-like object over the values from the parent `BatchValues` object.
+    // For some unknown reason, this type, when not resolved to a concrete type for a given async function,
+    // cannot live across await boundaries while maintaining the corresponding future `Send`, unless `'r: 'static`
+    //
+    // See <https://github.com/scylladb/scylla-rust-driver/issues/599> for more details
+    type RawBatchValuesIter<'r>: RawBatchValuesIterator<'r>
+    where
+        Self: 'r;
+
+    /// Returns an iterator over the data contained in this object.
+    fn batch_values_iter(&self) -> Self::RawBatchValuesIter<'_>;
+}
+
+/// An `Iterator`-like object over the values from the parent [`RawBatchValues`] object.
+///
+/// It's not a true [`Iterator`] because it does not provide direct access to the
+/// items being iterated over, instead it allows calling methods of the underlying
+/// [`SerializeRow`](super::row::SerializeRow) trait while advancing the iterator.
+///
+/// Unlike [`BatchValuesIterator`](super::batch::BatchValuesIterator), it doesn't
+/// need type information for serialization.
+pub trait RawBatchValuesIterator<'a> {
+    /// Serializes the next set of values in the sequence and advances the iterator.
+    fn serialize_next(&mut self, writer: &mut RowWriter) -> Option<Result<(), SerializationError>>;
+
+    /// Returns whether the next set of values is empty or not and advances the iterator.
+    fn is_empty_next(&mut self) -> Option<bool>;
+
+    /// Skips the next set of values.
+    fn skip_next(&mut self) -> Option<()>;
+
+    /// Return the number of sets of values, consuming the iterator in the process.
+    #[inline]
+    fn count(mut self) -> usize
+    where
+        Self: Sized,
+    {
+        let mut count = 0;
+        while self.skip_next().is_some() {
+            count += 1;
+        }
+        count
+    }
+}
+
+/// An implementation used by `scylla-proxy`
+impl RawBatchValues for Vec<SerializedValues> {
+    type RawBatchValuesIter<'r> = std::slice::Iter<'r, SerializedValues>
+    where
+        Self: 'r;
+
+    fn batch_values_iter(&self) -> Self::RawBatchValuesIter<'_> {
+        self.iter()
+    }
+}
+
+impl<'r> RawBatchValuesIterator<'r> for std::slice::Iter<'r, SerializedValues> {
+    #[inline]
+    fn serialize_next(&mut self, writer: &mut RowWriter) -> Option<Result<(), SerializationError>> {
+        self.next().map(|sv| {
+            writer.append_serialize_row(sv);
+            Ok(())
+        })
+    }
+
+    fn is_empty_next(&mut self) -> Option<bool> {
+        self.next().map(|sv| sv.is_empty())
+    }
+
+    #[inline]
+    fn skip_next(&mut self) -> Option<()> {
+        self.next().map(|_| ())
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        <_ as Iterator>::count(self)
+    }
+}

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -34,6 +34,13 @@ impl<'a> RowSerializationContext<'a> {
         }
     }
 
+    /// Constructs an empty `RowSerializationContext`, as if for a statement
+    /// with no bind markers.
+    #[inline]
+    pub const fn empty() -> Self {
+        Self { columns: &[] }
+    }
+
     /// Returns column/bind marker specifications for given query.
     #[inline]
     pub fn columns(&self) -> &'a [ColumnSpec] {

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -734,6 +734,11 @@ impl SerializedValues {
         buf.put(self.serialized_values.as_slice())
     }
 
+    // Gets the serialized values as raw bytes, without the preceding u16 length.
+    pub(crate) fn get_contents(&self) -> &[u8] {
+        &self.serialized_values
+    }
+
     /// Serializes value and appends it to the list
     pub fn add_value<T: SerializeCql>(
         &mut self,

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -794,14 +794,6 @@ impl SerializedValues {
             element_count: values_num,
         })
     }
-
-    /// Temporary function, to be removed when we implement new batching API (right now it is needed in frame::request::mod.rs tests)
-    // TODO: Remove
-    pub fn to_old_serialized_values(&self) -> LegacySerializedValues {
-        let mut frame = Vec::new();
-        self.write_to_request(&mut frame);
-        LegacySerializedValues::new_from_frame(&mut frame.as_slice(), false).unwrap()
-    }
 }
 
 impl Default for SerializedValues {

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -691,16 +691,14 @@ impl SerializedValues {
         row: &T,
     ) -> Result<Self, SerializationError> {
         let mut data = Vec::new();
-        let element_count = {
-            let mut writer = RowWriter::new(&mut data);
-            row.serialize(ctx, &mut writer)?;
-            match writer.value_count().try_into() {
-                Ok(n) => n,
-                Err(_) => {
-                    return Err(SerializationError(Arc::new(
-                        SerializeValuesError::TooManyValues,
-                    )))
-                }
+        let mut writer = RowWriter::new(&mut data);
+        row.serialize(ctx, &mut writer)?;
+        let element_count = match writer.value_count().try_into() {
+            Ok(n) => n,
+            Err(_) => {
+                return Err(SerializationError(Arc::new(
+                    SerializeValuesError::TooManyValues,
+                )))
             }
         };
 

--- a/scylla-cql/src/types/serialize/writers.rs
+++ b/scylla-cql/src/types/serialize/writers.rs
@@ -2,6 +2,8 @@
 
 use thiserror::Error;
 
+use super::row::SerializedValues;
+
 /// An interface that facilitates writing values for a CQL query.
 pub struct RowWriter<'buf> {
     // Buffer that this value should be serialized to.
@@ -38,6 +40,14 @@ impl<'buf> RowWriter<'buf> {
     pub fn make_cell_writer(&mut self) -> CellWriter<'_> {
         self.value_count += 1;
         CellWriter::new(self.buf)
+    }
+
+    /// Appends the values from an existing [`SerializedValues`] object to the
+    /// current `RowWriter`.
+    #[inline]
+    pub fn append_serialize_row(&mut self, sv: &SerializedValues) {
+        self.value_count += sv.element_count() as usize;
+        self.buf.extend_from_slice(sv.get_contents())
     }
 }
 

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -212,7 +212,6 @@ pub(crate) mod batch_values {
         rest: BV,
     }
 
-    #[allow(dead_code)]
     pub(crate) fn new_batch_values_first_serialized(
         rest: impl BatchValues,
         first: Option<SerializedValues>,

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -192,11 +192,17 @@ impl PreparedStatement {
     // For internal purposes, `PartitionKey::calculate_token()` is preferred, as `PartitionKey`
     // is either way used internally, among others for display in traces.
     pub fn calculate_token(&self, values: &impl SerializeRow) -> Result<Option<Token>, QueryError> {
-        self.extract_partition_key_and_calculate_token(
-            &self.partitioner_name,
-            &self.serialize_values(values)?,
-        )
-        .map(|opt| opt.map(|(_pk, token)| token))
+        self.calculate_token_untyped(&self.serialize_values(values)?)
+    }
+
+    // A version of calculate_token which skips serialization and uses SerializedValues directly.
+    // Not type-safe, so not exposed to users.
+    pub(crate) fn calculate_token_untyped(
+        &self,
+        values: &SerializedValues,
+    ) -> Result<Option<Token>, QueryError> {
+        self.extract_partition_key_and_calculate_token(&self.partitioner_name, values)
+            .map(|opt| opt.map(|(_pk, token)| token))
     }
 
     /// Returns the name of the keyspace this statement is operating on.

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -1,5 +1,4 @@
 use crate::batch::{Batch, BatchStatement};
-use crate::frame::value::LegacyBatchValues;
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::transport::errors::QueryError;
@@ -10,6 +9,7 @@ use bytes::Bytes;
 use dashmap::DashMap;
 use futures::future::try_join_all;
 use scylla_cql::frame::response::result::PreparedMetadata;
+use scylla_cql::types::serialize::batch::BatchValues;
 use scylla_cql::types::serialize::row::SerializeRow;
 use std::collections::hash_map::RandomState;
 use std::hash::BuildHasher;
@@ -108,7 +108,7 @@ where
     pub async fn batch(
         &self,
         batch: &Batch,
-        values: impl LegacyBatchValues,
+        values: impl BatchValues,
     ) -> Result<QueryResult, QueryError> {
         let all_prepared: bool = batch
             .statements

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -1,5 +1,5 @@
 use crate::batch::{Batch, BatchStatement};
-use crate::frame::value::BatchValues;
+use crate::frame::value::LegacyBatchValues;
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::transport::errors::QueryError;
@@ -108,7 +108,7 @@ where
     pub async fn batch(
         &self,
         batch: &Batch,
-        values: impl BatchValues,
+        values: impl LegacyBatchValues,
     ) -> Result<QueryResult, QueryError> {
         let all_prepared: bool = batch
             .statements

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -4,7 +4,9 @@ use scylla_cql::errors::TranslationError;
 use scylla_cql::frame::request::options::Options;
 use scylla_cql::frame::response::Error;
 use scylla_cql::frame::types::SerialConsistency;
-use scylla_cql::types::serialize::row::SerializedValues;
+use scylla_cql::types::serialize::batch::{BatchValues, BatchValuesIterator};
+use scylla_cql::types::serialize::raw_batch::RawBatchValuesAdapter;
+use scylla_cql::types::serialize::row::{RowSerializationContext, SerializedValues};
 use socket2::{SockRef, TcpKeepalive};
 use tokio::io::{split, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{TcpSocket, TcpStream};
@@ -53,7 +55,6 @@ use crate::frame::{
     request::{self, batch, execute, query, register, SerializableRequest},
     response::{event::Event, result, NonErrorResponse, Response, ResponseOpcode},
     server_event_type::EventType,
-    value::{LegacyBatchValues, LegacyBatchValuesIterator},
     FrameParams, SerializedRequest,
 };
 use crate::query::Query;
@@ -763,7 +764,7 @@ impl Connection {
     pub(crate) async fn batch(
         &self,
         batch: &Batch,
-        values: impl LegacyBatchValues,
+        values: impl BatchValues,
     ) -> Result<QueryResult, QueryError> {
         self.batch_with_consistency(
             batch,
@@ -779,11 +780,20 @@ impl Connection {
     pub(crate) async fn batch_with_consistency(
         &self,
         init_batch: &Batch,
-        values: impl LegacyBatchValues,
+        values: impl BatchValues,
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,
     ) -> Result<QueryResult, QueryError> {
         let batch = self.prepare_batch(init_batch, &values).await?;
+
+        let contexts = batch.statements.iter().map(|bs| match bs {
+            BatchStatement::Query(_) => RowSerializationContext::empty(),
+            BatchStatement::PreparedStatement(ps) => {
+                RowSerializationContext::from_prepared(ps.get_prepared_metadata())
+            }
+        });
+
+        let values = RawBatchValuesAdapter::new(values, contexts);
 
         let batch_frame = batch::Batch {
             statements: Cow::Borrowed(&batch.statements),
@@ -831,7 +841,7 @@ impl Connection {
     async fn prepare_batch<'b>(
         &self,
         init_batch: &'b Batch,
-        values: impl LegacyBatchValues,
+        values: impl BatchValues,
     ) -> Result<Cow<'b, Batch>, QueryError> {
         let mut to_prepare = HashSet::<&str>::new();
 
@@ -839,11 +849,8 @@ impl Connection {
             let mut values_iter = values.batch_values_iter();
             for stmt in &init_batch.statements {
                 if let BatchStatement::Query(query) = stmt {
-                    let value = values_iter.next_serialized().transpose()?;
-                    if let Some(v) = value {
-                        if v.len() > 0 {
-                            to_prepare.insert(&query.contents);
-                        }
+                    if let Some(false) = values_iter.is_empty_next() {
+                        to_prepare.insert(&query.contents);
                     }
                 } else {
                     values_iter.skip_next();

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -53,7 +53,7 @@ use crate::frame::{
     request::{self, batch, execute, query, register, SerializableRequest},
     response::{event::Event, result, NonErrorResponse, Response, ResponseOpcode},
     server_event_type::EventType,
-    value::{BatchValues, BatchValuesIterator},
+    value::{LegacyBatchValues, LegacyBatchValuesIterator},
     FrameParams, SerializedRequest,
 };
 use crate::query::Query;
@@ -763,7 +763,7 @@ impl Connection {
     pub(crate) async fn batch(
         &self,
         batch: &Batch,
-        values: impl BatchValues,
+        values: impl LegacyBatchValues,
     ) -> Result<QueryResult, QueryError> {
         self.batch_with_consistency(
             batch,
@@ -779,7 +779,7 @@ impl Connection {
     pub(crate) async fn batch_with_consistency(
         &self,
         init_batch: &Batch,
-        values: impl BatchValues,
+        values: impl LegacyBatchValues,
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,
     ) -> Result<QueryResult, QueryError> {
@@ -831,7 +831,7 @@ impl Connection {
     async fn prepare_batch<'b>(
         &self,
         init_batch: &'b Batch,
-        values: impl BatchValues,
+        values: impl LegacyBatchValues,
     ) -> Result<Cow<'b, Batch>, QueryError> {
         let mut to_prepare = HashSet::<&str>::new();
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -47,7 +47,9 @@ use super::NodeRef;
 use crate::cql_to_rust::FromRow;
 use crate::frame::response::cql_to_rust::FromRowError;
 use crate::frame::response::result;
-use crate::frame::value::{BatchValues, BatchValuesFirstSerialized, BatchValuesIterator};
+use crate::frame::value::{
+    LegacyBatchValues, LegacyBatchValuesFirstSerialized, LegacyBatchValuesIterator,
+};
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::routing::Token;
@@ -1165,7 +1167,7 @@ impl Session {
     pub async fn batch(
         &self,
         batch: &Batch,
-        values: impl BatchValues,
+        values: impl LegacyBatchValues,
     ) -> Result<QueryResult, QueryError> {
         // Shard-awareness behavior for batch will be to pick shard based on first batch statement's shard
         // If users batch statements by shard, they will be rewarded with full shard awareness
@@ -1216,7 +1218,7 @@ impl Session {
 
         // Reuse first serialized value when serializing query, and delegate to `BatchValues::write_next_to_request`
         // directly for others (if they weren't already serialized, possibly don't even allocate the `LegacySerializedValues`)
-        let values = BatchValuesFirstSerialized::new(&values, first_serialized_value);
+        let values = LegacyBatchValuesFirstSerialized::new(&values, first_serialized_value);
         let values_ref = &values;
 
         let span = RequestSpan::new_batch();

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1181,7 +1181,6 @@ impl Session {
         }
         // Extract first serialized_value
         let first_serialized_value = values.batch_values_iter().next_serialized().transpose()?;
-        let first_serialized_value = first_serialized_value.as_deref();
 
         let execution_profile = batch
             .get_execution_profile_handle()
@@ -1199,7 +1198,7 @@ impl Session {
             .unwrap_or(execution_profile.serial_consistency);
 
         let (first_value_token, keyspace_name) =
-            match (first_serialized_value, batch.statements.first()) {
+            match (first_serialized_value.as_deref(), batch.statements.first()) {
                 (Some(first_serialized_value), Some(BatchStatement::PreparedStatement(ps))) => {
                     let token = ps.calculate_token(first_serialized_value)?;
                     (token, ps.get_keyspace_name())
@@ -1216,7 +1215,8 @@ impl Session {
 
         // Reuse first serialized value when serializing query, and delegate to `BatchValues::write_next_to_request`
         // directly for others (if they weren't already serialized, possibly don't even allocate the `LegacySerializedValues`)
-        let values = LegacyBatchValuesFirstSerialized::new(&values, first_serialized_value);
+        let values =
+            LegacyBatchValuesFirstSerialized::new(&values, first_serialized_value.as_deref());
         let values_ref = &values;
 
         let span = RequestSpan::new_batch();

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1200,13 +1200,15 @@ impl Session {
             let first_serialized_value =
                 values.batch_values_iter().next_serialized().transpose()?;
 
-            match (first_serialized_value, batch.statements.first()) {
+            // The temporary "p" is necessary because lifetimes
+            let p = match (first_serialized_value, batch.statements.first()) {
                 (Some(first_serialized_value), Some(BatchStatement::PreparedStatement(ps))) => {
                     let token = ps.calculate_token(&first_serialized_value)?;
                     (Some(first_serialized_value), token, ps.get_keyspace_name())
                 }
                 _ => (None, None, None),
-            }
+            };
+            p
         };
         let statement_info = RoutingInfo {
             consistency,


### PR DESCRIPTION
This PR replaces the existing BatchValues API with one that leverages the recently introduced `SerializeCql`/`SerializeRow` infrastructure and is type-safe.

Refs: #801

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
