### PR TITLE
scylla-macros: attributes for better control over name checks

### DIFF
--- a/scylla-cql/src/macros.rs
+++ b/scylla-cql/src/macros.rs
@@ -87,6 +87,15 @@ pub use scylla_macros::ValueList;
 /// macro itself, so in those cases the user must provide an alternative path
 /// to either the `scylla` or `scylla-cql` crate.
 ///
+/// `#[scylla(skip_name_checks)]
+///
+/// _Specific only to the `enforce_order` flavor._
+///
+/// Skips checking Rust field names against names of the UDT fields. With this
+/// annotation, the generated implementation will allow mismatch between Rust
+/// struct field names and UDT field names, i.e. it's OK if i-th field has a
+/// different name in Rust and in the UDT. Fields are still being type-checked.
+///
 /// # Field attributes
 ///
 /// `#[scylla(rename = "name_in_the_udt")]`

--- a/scylla-cql/src/macros.rs
+++ b/scylla-cql/src/macros.rs
@@ -180,6 +180,16 @@ pub use scylla_macros::SerializeCql;
 /// macro itself, so in those cases the user must provide an alternative path
 /// to either the `scylla` or `scylla-cql` crate.
 ///
+/// `#[scylla(skip_name_checks)]
+///
+/// _Specific only to the `enforce_order` flavor._
+///
+/// Skips checking Rust field names against names of the columns / bind markers.
+/// With this annotation, the generated implementation will allow mismatch
+/// between Rust struct field names and the column / bind markers, i.e. it's
+/// OK if i-th Rust struct field has a different name than the column / bind
+/// marker. The values are still being type-checked.
+///
 /// # Field attributes
 ///
 /// `#[scylla(rename = "column_or_bind_marker_name")]`

--- a/scylla-cql/src/macros.rs
+++ b/scylla-cql/src/macros.rs
@@ -86,11 +86,11 @@ pub use scylla_macros::ValueList;
 /// It's not possible to automatically resolve those issues in the procedural
 /// macro itself, so in those cases the user must provide an alternative path
 /// to either the `scylla` or `scylla-cql` crate.
-/// 
+///
 /// # Field attributes
-/// 
+///
 /// `#[scylla(rename = "name_in_the_udt")]`
-/// 
+///
 /// Serializes the field to the UDT struct field with given name instead of
 /// its Rust name.
 pub use scylla_macros::SerializeCql;
@@ -130,7 +130,7 @@ pub use scylla_macros::SerializeCql;
 /// }
 /// ```
 ///
-/// # Attributes
+/// # Struct attributes
 ///
 /// `#[scylla(flavor = "flavor_name")]`
 ///
@@ -170,6 +170,13 @@ pub use scylla_macros::SerializeCql;
 /// It's not possible to automatically resolve those issues in the procedural
 /// macro itself, so in those cases the user must provide an alternative path
 /// to either the `scylla` or `scylla-cql` crate.
+///
+/// # Field attributes
+///
+/// `#[scylla(rename = "column_or_bind_marker_name")]`
+///
+/// Serializes the field to the column / bind marker with given name instead of
+/// its Rust name.
 pub use scylla_macros::SerializeRow;
 
 // Reexports for derive(IntoUserType)

--- a/scylla-cql/src/macros.rs
+++ b/scylla-cql/src/macros.rs
@@ -46,7 +46,7 @@ pub use scylla_macros::ValueList;
 /// }
 /// ```
 ///
-/// # Attributes
+/// # Struct attributes
 ///
 /// `#[scylla(flavor = "flavor_name")]`
 ///
@@ -86,6 +86,13 @@ pub use scylla_macros::ValueList;
 /// It's not possible to automatically resolve those issues in the procedural
 /// macro itself, so in those cases the user must provide an alternative path
 /// to either the `scylla` or `scylla-cql` crate.
+/// 
+/// # Field attributes
+/// 
+/// `#[scylla(rename = "name_in_the_udt")]`
+/// 
+/// Serializes the field to the UDT struct field with given name instead of
+/// its Rust name.
 pub use scylla_macros::SerializeCql;
 
 /// Derive macro for the [`SerializeRow`](crate::types::serialize::row::SerializeRow) trait

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -1381,4 +1381,52 @@ mod tests {
             .iter()
             .all(|v| v == RawValue::Value(&[0, 0, 0, 0, 0x07, 0x5b, 0xcd, 0x15])))
     }
+
+    #[derive(SerializeRow, Debug)]
+    #[scylla(crate = crate)]
+    struct TestRowWithColumnRename {
+        a: String,
+        #[scylla(rename = "x")]
+        b: i32,
+    }
+
+    #[derive(SerializeRow, Debug)]
+    #[scylla(crate = crate, flavor = "enforce_order")]
+    struct TestRowWithColumnRenameAndEnforceOrder {
+        a: String,
+        #[scylla(rename = "x")]
+        b: i32,
+    }
+
+    #[test]
+    fn test_row_serialization_with_column_rename() {
+        let spec = [col("x", ColumnType::Int), col("a", ColumnType::Text)];
+
+        let reference = do_serialize((42i32, "Ala ma kota"), &spec);
+        let row = do_serialize(
+            TestRowWithColumnRename {
+                a: "Ala ma kota".to_owned(),
+                b: 42,
+            },
+            &spec,
+        );
+
+        assert_eq!(reference, row);
+    }
+
+    #[test]
+    fn test_row_serialization_with_column_rename_and_enforce_order() {
+        let spec = [col("a", ColumnType::Text), col("x", ColumnType::Int)];
+
+        let reference = do_serialize(("Ala ma kota", 42i32), &spec);
+        let row = do_serialize(
+            TestRowWithColumnRenameAndEnforceOrder {
+                a: "Ala ma kota".to_owned(),
+                b: 42,
+            },
+            &spec,
+        );
+
+        assert_eq!(reference, row);
+    }
 }

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -1429,4 +1429,27 @@ mod tests {
 
         assert_eq!(reference, row);
     }
+
+    #[derive(SerializeRow, Debug)]
+    #[scylla(crate = crate, flavor = "enforce_order", skip_name_checks)]
+    struct TestRowWithSkippedNameChecks {
+        a: String,
+        b: i32,
+    }
+
+    #[test]
+    fn test_row_serialization_with_skipped_name_checks() {
+        let spec = [col("a", ColumnType::Text), col("x", ColumnType::Int)];
+
+        let reference = do_serialize(("Ala ma kota", 42i32), &spec);
+        let row = do_serialize(
+            TestRowWithSkippedNameChecks {
+                a: "Ala ma kota".to_owned(),
+                b: 42,
+            },
+            &spec,
+        );
+
+        assert_eq!(reference, row);
+    }
 }

--- a/scylla-macros/src/serialize/cql.rs
+++ b/scylla-macros/src/serialize/cql.rs
@@ -15,6 +15,9 @@ struct Attributes {
 
     #[darling(default)]
     flavor: Flavor,
+
+    #[darling(default)]
+    skip_name_checks: bool,
 }
 
 impl Attributes {
@@ -74,7 +77,7 @@ pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
         })
         .collect::<Result<_, _>>()?;
     let ctx = Context { attributes, fields };
-    ctx.validate()?;
+    ctx.validate(&input.ident)?;
 
     let gen: Box<dyn Generator> = match ctx.attributes.flavor {
         Flavor::MatchByName => Box::new(FieldSortingGenerator { ctx: &ctx }),
@@ -92,8 +95,30 @@ pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
 }
 
 impl Context {
-    fn validate(&self) -> Result<(), syn::Error> {
+    fn validate(&self, struct_ident: &syn::Ident) -> Result<(), syn::Error> {
         let mut errors = darling::Error::accumulator();
+
+        if self.attributes.skip_name_checks {
+            // Skipping name checks is only available in enforce_order mode
+            if self.attributes.flavor != Flavor::EnforceOrder {
+                let err = darling::Error::custom(
+                    "the `skip_name_checks` attribute is only allowed with the `enforce_order` flavor",
+                )
+                .with_span(struct_ident);
+                errors.push(err);
+            }
+
+            // `rename` annotations don't make sense with skipped name checks
+            for field in self.fields.iter() {
+                if field.attrs.rename.is_some() {
+                    let err = darling::Error::custom(
+                        "the `rename` annotations don't make sense with `skip_name_checks` attribute",
+                    )
+                    .with_span(&field.ident);
+                    errors.push(err);
+                }
+            }
+        }
 
         // Check for name collisions
         let mut used_names = HashMap::<String, &Field>::new();
@@ -330,10 +355,15 @@ impl<'a> Generator for FieldOrderedGenerator<'a> {
             let rust_field_ident = &field.ident;
             let rust_field_name = field.field_name();
             let typ = &field.ty;
+            let name_check_expression: syn::Expr = if !self.ctx.attributes.skip_name_checks {
+                parse_quote! { field_name == #rust_field_name }
+            } else {
+                parse_quote! { true }
+            };
             statements.push(parse_quote! {
                 match field_iter.next() {
                     Some((field_name, typ)) => {
-                        if field_name == #rust_field_name {
+                        if #name_check_expression {
                             let sub_builder = #crate_path::CellValueBuilder::make_sub_writer(&mut builder);
                             match <#typ as #crate_path::SerializeCql>::serialize(&self.#rust_field_ident, typ, sub_builder) {
                                 Ok(_proof) => {},

--- a/scylla-macros/src/serialize/cql.rs
+++ b/scylla-macros/src/serialize/cql.rs
@@ -13,7 +13,8 @@ struct Attributes {
     #[darling(rename = "crate")]
     crate_path: Option<syn::Path>,
 
-    flavor: Option<Flavor>,
+    #[darling(default)]
+    flavor: Flavor,
 }
 
 impl Attributes {
@@ -76,8 +77,8 @@ pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
     ctx.validate()?;
 
     let gen: Box<dyn Generator> = match ctx.attributes.flavor {
-        Some(Flavor::MatchByName) | None => Box::new(FieldSortingGenerator { ctx: &ctx }),
-        Some(Flavor::EnforceOrder) => Box::new(FieldOrderedGenerator { ctx: &ctx }),
+        Flavor::MatchByName => Box::new(FieldSortingGenerator { ctx: &ctx }),
+        Flavor::EnforceOrder => Box::new(FieldOrderedGenerator { ctx: &ctx }),
     };
 
     let serialize_item = gen.generate_serialize();

--- a/scylla-macros/src/serialize/cql.rs
+++ b/scylla-macros/src/serialize/cql.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use darling::FromAttributes;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
@@ -23,9 +25,30 @@ impl Attributes {
     }
 }
 
+struct Field {
+    ident: syn::Ident,
+    ty: syn::Type,
+    attrs: FieldAttributes,
+}
+
+impl Field {
+    fn field_name(&self) -> String {
+        match &self.attrs.rename {
+            Some(name) => name.clone(),
+            None => self.ident.to_string(),
+        }
+    }
+}
+
+#[derive(FromAttributes)]
+#[darling(attributes(scylla))]
+struct FieldAttributes {
+    rename: Option<String>,
+}
+
 struct Context {
     attributes: Attributes,
-    fields: Vec<syn::Field>,
+    fields: Vec<Field>,
 }
 
 pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, syn::Error> {
@@ -38,8 +61,19 @@ pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
     let crate_path = attributes.crate_path();
     let implemented_trait: syn::Path = parse_quote!(#crate_path::SerializeCql);
 
-    let fields = named_fields.named.iter().cloned().collect();
+    let fields = named_fields
+        .named
+        .iter()
+        .map(|f| {
+            FieldAttributes::from_attributes(&f.attrs).map(|attrs| Field {
+                ident: f.ident.clone().unwrap(),
+                ty: f.ty.clone(),
+                attrs,
+            })
+        })
+        .collect::<Result<_, _>>()?;
     let ctx = Context { attributes, fields };
+    ctx.validate()?;
 
     let gen: Box<dyn Generator> = match ctx.attributes.flavor {
         Some(Flavor::MatchByName) | None => Box::new(FieldSortingGenerator { ctx: &ctx }),
@@ -57,6 +91,27 @@ pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
 }
 
 impl Context {
+    fn validate(&self) -> Result<(), syn::Error> {
+        let mut errors = darling::Error::accumulator();
+
+        // Check for name collisions
+        let mut used_names = HashMap::<String, &Field>::new();
+        for field in self.fields.iter() {
+            let field_name = field.field_name();
+            if let Some(other_field) = used_names.get(&field_name) {
+                let other_field_ident = &other_field.ident;
+                let msg = format!("the UDT field name `{field_name}` used by this struct field is already used by field `{other_field_ident}`");
+                let err = darling::Error::custom(msg).with_span(&field.ident);
+                errors.push(err);
+            } else {
+                used_names.insert(field_name, field);
+            }
+        }
+
+        errors.finish()?;
+        Ok(())
+    }
+
     fn generate_udt_type_match(&self, err: syn::Expr) -> syn::Stmt {
         let crate_path = self.attributes.crate_path();
 
@@ -126,9 +181,11 @@ impl<'a> Generator for FieldSortingGenerator<'a> {
             .iter()
             .map(|f| f.ident.clone())
             .collect::<Vec<_>>();
-        let rust_field_names = rust_field_idents
+        let rust_field_names = self
+            .ctx
+            .fields
             .iter()
-            .map(|i| i.as_ref().unwrap().to_string())
+            .map(|f| f.field_name())
             .collect::<Vec<_>>();
         let udt_field_names = rust_field_names.clone(); // For now, it's the same
         let field_types = self.ctx.fields.iter().map(|f| &f.ty).collect::<Vec<_>>();
@@ -269,8 +326,8 @@ impl<'a> Generator for FieldOrderedGenerator<'a> {
 
         // Serialize each field
         for field in self.ctx.fields.iter() {
-            let rust_field_ident = field.ident.as_ref().unwrap();
-            let rust_field_name = rust_field_ident.to_string();
+            let rust_field_ident = &field.ident;
+            let rust_field_name = field.field_name();
             let typ = &field.ty;
             statements.push(parse_quote! {
                 match field_iter.next() {

--- a/scylla-macros/src/serialize/mod.rs
+++ b/scylla-macros/src/serialize/mod.rs
@@ -3,8 +3,9 @@ use darling::FromMeta;
 pub(crate) mod cql;
 pub(crate) mod row;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Default)]
 enum Flavor {
+    #[default]
     MatchByName,
     EnforceOrder,
 }

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use darling::FromAttributes;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
@@ -23,9 +25,30 @@ impl Attributes {
     }
 }
 
+struct Field {
+    ident: syn::Ident,
+    ty: syn::Type,
+    attrs: FieldAttributes,
+}
+
+impl Field {
+    fn column_name(&self) -> String {
+        match &self.attrs.rename {
+            Some(name) => name.clone(),
+            None => self.ident.to_string(),
+        }
+    }
+}
+
+#[derive(FromAttributes)]
+#[darling(attributes(scylla))]
+struct FieldAttributes {
+    rename: Option<String>,
+}
+
 struct Context {
     attributes: Attributes,
-    fields: Vec<syn::Field>,
+    fields: Vec<Field>,
 }
 
 pub fn derive_serialize_row(tokens_input: TokenStream) -> Result<syn::ItemImpl, syn::Error> {
@@ -38,8 +61,19 @@ pub fn derive_serialize_row(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
     let crate_path = attributes.crate_path();
     let implemented_trait: syn::Path = parse_quote!(#crate_path::SerializeRow);
 
-    let fields = named_fields.named.iter().cloned().collect();
+    let fields = named_fields
+        .named
+        .iter()
+        .map(|f| {
+            FieldAttributes::from_attributes(&f.attrs).map(|attrs| Field {
+                ident: f.ident.clone().unwrap(),
+                ty: f.ty.clone(),
+                attrs,
+            })
+        })
+        .collect::<Result<_, _>>()?;
     let ctx = Context { attributes, fields };
+    ctx.validate()?;
 
     let gen: Box<dyn Generator> = match ctx.attributes.flavor {
         Some(Flavor::MatchByName) | None => Box::new(ColumnSortingGenerator { ctx: &ctx }),
@@ -59,6 +93,27 @@ pub fn derive_serialize_row(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
 }
 
 impl Context {
+    fn validate(&self) -> Result<(), syn::Error> {
+        let mut errors = darling::Error::accumulator();
+
+        // Check for name collisions
+        let mut used_names = HashMap::<String, &Field>::new();
+        for field in self.fields.iter() {
+            let column_name = field.column_name();
+            if let Some(other_field) = used_names.get(&column_name) {
+                let other_field_ident = &other_field.ident;
+                let msg = format!("the column / bind marker name `{column_name}` used by this struct field is already used by field `{other_field_ident}`");
+                let err = darling::Error::custom(msg).with_span(&field.ident);
+                errors.push(err);
+            } else {
+                used_names.insert(column_name, field);
+            }
+        }
+
+        errors.finish()?;
+        Ok(())
+    }
+
     fn generate_mk_typck_err(&self) -> syn::Stmt {
         let crate_path = self.attributes.crate_path();
         parse_quote! {
@@ -114,9 +169,11 @@ impl<'a> Generator for ColumnSortingGenerator<'a> {
             .iter()
             .map(|f| f.ident.clone())
             .collect::<Vec<_>>();
-        let rust_field_names = rust_field_idents
+        let rust_field_names = self
+            .ctx
+            .fields
             .iter()
-            .map(|i| i.as_ref().unwrap().to_string())
+            .map(|f| f.column_name())
             .collect::<Vec<_>>();
         let udt_field_names = rust_field_names.clone(); // For now, it's the same
         let field_types = self.ctx.fields.iter().map(|f| &f.ty).collect::<Vec<_>>();
@@ -237,8 +294,8 @@ impl<'a> Generator for ColumnOrderedGenerator<'a> {
 
         // Serialize each field
         for field in self.ctx.fields.iter() {
-            let rust_field_ident = field.ident.as_ref().unwrap();
-            let rust_field_name = rust_field_ident.to_string();
+            let rust_field_ident = &field.ident;
+            let rust_field_name = field.column_name();
             let typ = &field.ty;
             statements.push(parse_quote! {
                 match column_iter.next() {

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -13,7 +13,8 @@ struct Attributes {
     #[darling(rename = "crate")]
     crate_path: Option<syn::Path>,
 
-    flavor: Option<Flavor>,
+    #[darling(default)]
+    flavor: Flavor,
 }
 
 impl Attributes {
@@ -76,8 +77,8 @@ pub fn derive_serialize_row(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
     ctx.validate()?;
 
     let gen: Box<dyn Generator> = match ctx.attributes.flavor {
-        Some(Flavor::MatchByName) | None => Box::new(ColumnSortingGenerator { ctx: &ctx }),
-        Some(Flavor::EnforceOrder) => Box::new(ColumnOrderedGenerator { ctx: &ctx }),
+        Flavor::MatchByName => Box::new(ColumnSortingGenerator { ctx: &ctx }),
+        Flavor::EnforceOrder => Box::new(ColumnOrderedGenerator { ctx: &ctx }),
     };
 
     let serialize_item = gen.generate_serialize();


### PR DESCRIPTION
The PR introduces two attributes related to matching Rust struct fields by name in the new `SerializeRow`/`SerializeCql` macros:

- `#[scylla(rename = "xyz")]` - instead of using the name of the field verbatim, the name provided in the attribute is used when matching to a column/bind marker/UDT field. This can be useful e.g. if the user has different naming convention in Rust code and in the schema definitions.
- `#[scylla(skip_name_checks)`] - in `enforce_order` flavor, skips checking the names of the fields as they are being serialized. With this attribute, the names of the corresponding fields in Rust struct and UDT/columns/bind markers don't have to match at all, but their _types_ still need to. This attribute is supposed to help migrate from the old `IntoUserType`/`ValueList` macros.

Refs: #802

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
