### PR TITLE
CI: Use Rust cache

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -27,5 +27,6 @@ jobs:
         options: --health-cmd "cqlsh --username cassandra --password cassandra --debug" --health-interval 5s --health-retries 30
     steps:
     - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: cargo test --verbose authenticate_superuser -- custom_authentication --ignored

--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -27,6 +27,9 @@ jobs:
         options: --health-cmd "cqlsh --username cassandra --password cassandra --debug" --health-interval 5s --health-retries 30
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: cargo test --verbose authenticate_superuser -- custom_authentication --ignored

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -27,9 +27,14 @@ jobs:
         options: --health-cmd "cqlsh --debug scylladb" --health-interval 5s --health-retries 10
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Install mdbook
-      run: cargo install mdbook --no-default-features
+      uses: taiki-e/install-action@v2
+      with:
+        tool: mdbook
     - name: Build the project
       run: cargo build --verbose --examples
     - name: Build the book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -27,6 +27,7 @@ jobs:
         options: --health-cmd "cqlsh --debug scylladb" --health-interval 5s --health-retries 10
     steps:
     - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
     - name: Install mdbook
       run: cargo install mdbook --no-default-features
     - name: Build the project

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait
       # A separate step for building to separate measuring time of compilation and testing
+    - uses: Swatinem/rust-cache@v2
     - name: Build the project
       run: cargo build --verbose --tests --features "full-serialization"
     - name: Run tests on cassandra

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -25,6 +25,9 @@ jobs:
       run: |
         docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait
       # A separate step for building to separate measuring time of compilation and testing
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Build the project
       run: cargo build --verbose --tests --features "full-serialization"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
         docker compose -f test/cluster/docker-compose.yml up -d --wait
+    - uses: Swatinem/rust-cache@v2
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
@@ -64,6 +65,7 @@ jobs:
       run: |
         rustup install ${{ env.rust_min }}
         rustup override set ${{ env.rust_min }}
+    - uses: Swatinem/rust-cache@v2
     - name: Print Rust version
       run: rustc --version
     - name: Use MSRV Cargo.lock
@@ -80,5 +82,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
     - name: Compile docs
       run: RUSTDOCFLAGS=-Dwarnings cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,10 @@ jobs:
       run: |
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
         docker compose -f test/cluster/docker-compose.yml up -d --wait
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
     - uses: Swatinem/rust-cache@v2
     - name: Format check
       run: cargo fmt --verbose --all -- --check
@@ -62,9 +66,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust ${{ env.rust_min }}
-      run: |
-        rustup install ${{ env.rust_min }}
-        rustup override set ${{ env.rust_min }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.rust_min }}
     - uses: Swatinem/rust-cache@v2
     - name: Print Rust version
       run: rustc --version
@@ -82,6 +86,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Compile docs
       run: RUSTDOCFLAGS=-Dwarnings cargo doc

--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -30,6 +30,9 @@ jobs:
           ccm create serverless -i 127.0.1. -n 1 --scylla -v release:5.1.6
           ccm start  --sni-proxy --sni-port 7777
 
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Check
         run: cargo check --verbose

--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -30,6 +30,7 @@ jobs:
           ccm create serverless -i 127.0.1. -n 1 --scylla -v release:5.1.6
           ccm start  --sni-proxy --sni-port 7777
 
+      - uses: Swatinem/rust-cache@v2
       - name: Check
         run: cargo check --verbose
       - name: Run cloud example

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -32,6 +32,9 @@ jobs:
       working-directory: ./scylla
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Check
       run: cargo check --verbose --features "ssl"

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -32,6 +32,7 @@ jobs:
       working-directory: ./scylla
     steps:
     - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
     - name: Check
       run: cargo check --verbose --features "ssl"
       working-directory: ${{env.working-directory}}


### PR DESCRIPTION
This adds [Swatinem/rust-cache@v2](https://github.com/Swatinem/rust-cache) to all CI jobs, with the intention of speeding them up. Hopefully we can compare some runs to get empirical data of the improvements it gives.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
