### PR TITLE
Add `skip` attribute to serialization proc macros

### DIFF
--- a/scylla-cql/src/macros.rs
+++ b/scylla-cql/src/macros.rs
@@ -117,6 +117,10 @@ pub use scylla_macros::ValueList;
 ///
 /// Serializes the field to the UDT struct field with given name instead of
 /// its Rust name.
+///
+/// `#[scylla(skip)]`
+///
+/// Don't use the field during serialization.
 pub use scylla_macros::SerializeCql;
 
 /// Derive macro for the [`SerializeRow`](crate::types::serialize::row::SerializeRow) trait

--- a/scylla-cql/src/macros.rs
+++ b/scylla-cql/src/macros.rs
@@ -215,6 +215,10 @@ pub use scylla_macros::SerializeCql;
 ///
 /// Serializes the field to the column / bind marker with given name instead of
 /// its Rust name.
+///
+/// `#[scylla(skip)]`
+///
+/// Don't use the field during serialization.
 pub use scylla_macros::SerializeRow;
 
 // Reexports for derive(IntoUserType)

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -1519,4 +1519,44 @@ mod tests {
 
         assert_eq!(reference, row);
     }
+
+    #[derive(SerializeRow, Debug)]
+    #[scylla(crate = crate)]
+    struct TestRowWithSkippedFields {
+        a: String,
+        b: i32,
+        #[scylla(skip)]
+        #[allow(dead_code)]
+        skipped: Vec<String>,
+        c: Vec<i64>,
+    }
+
+    #[test]
+    fn test_row_serialization_with_skipped_field() {
+        let spec = [
+            col("a", ColumnType::Text),
+            col("b", ColumnType::Int),
+            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
+        ];
+
+        let reference = do_serialize(
+            TestRowWithColumnSorting {
+                a: "Ala ma kota".to_owned(),
+                b: 42,
+                c: vec![1, 2, 3],
+            },
+            &spec,
+        );
+        let row = do_serialize(
+            TestRowWithSkippedFields {
+                a: "Ala ma kota".to_owned(),
+                b: 42,
+                skipped: vec!["abcd".to_owned(), "efgh".to_owned()],
+                c: vec![1, 2, 3],
+            },
+            &spec,
+        );
+
+        assert_eq!(reference, row);
+    }
 }

--- a/scylla-macros/src/serialize/cql.rs
+++ b/scylla-macros/src/serialize/cql.rs
@@ -51,6 +51,9 @@ impl Field {
 #[darling(attributes(scylla))]
 struct FieldAttributes {
     rename: Option<String>,
+
+    #[darling(default)]
+    skip: bool,
 }
 
 struct Context {
@@ -78,6 +81,9 @@ pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
                 attrs,
             })
         })
+        // Filter the fields now instead of at the places that use them later
+        // as it's less error prone - we just filter in one place instead of N places.
+        .filter(|f| f.as_ref().map(|f| !f.attrs.skip).unwrap_or(true))
         .collect::<Result<_, _>>()?;
     let ctx = Context { attributes, fields };
     ctx.validate(&input.ident)?;

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -48,6 +48,9 @@ impl Field {
 #[darling(attributes(scylla))]
 struct FieldAttributes {
     rename: Option<String>,
+
+    #[darling(default)]
+    skip: bool,
 }
 
 struct Context {
@@ -75,6 +78,9 @@ pub fn derive_serialize_row(tokens_input: TokenStream) -> Result<syn::ItemImpl, 
                 attrs,
             })
         })
+        // Filter the fields now instead of at the places that use them later
+        // as it's less error prone - we just filter in one place instead of N places.
+        .filter(|f| f.as_ref().map(|f| !f.attrs.skip).unwrap_or(true))
         .collect::<Result<_, _>>()?;
     let ctx = Context { attributes, fields };
     ctx.validate(&input.ident)?;


### PR DESCRIPTION
As requested in https://github.com/scylladb/scylla-rust-driver/issues/899, this PR adds a field attribute to `SerializeCql` and `SerializeRow` macros that allow to skip given field during serialization.
This can be useful for fields unrelated to database.

Fixes: #899 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
