### PR TITLE
scylla: Add support for rustls Fixes #293

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -14,9 +14,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["rustls"]
 ssl = ["dep:tokio-openssl", "dep:openssl"]
-cloud = ["ssl", "scylla-cql/serde", "dep:serde_yaml", "dep:serde", "dep:url", "dep:base64"]
+rustls = ["dep:tokio-rustls"]
+cloud = ["scylla-cql/serde", "dep:serde_yaml", "dep:serde", "dep:url", "dep:base64"]
 secret = ["scylla-cql/secret"]
 chrono = ["scylla-cql/chrono"]
 time = ["scylla-cql/time"]
@@ -42,6 +43,7 @@ tracing = "0.1.36"
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
+tokio-rustls = { version = "0.25", optional = true }
 arc-swap = "1.3.0"
 dashmap = "5.2"
 strum = "0.23"

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -142,3 +142,9 @@ pub use transport::retry_policy;
 pub use transport::speculative_execution;
 
 pub use transport::metrics::Metrics;
+
+#[cfg(all(feature = "ssl", feature = "rustls"))]
+compile_error!("both rustls and ssl should not be enabled together.");
+
+#[cfg(all(feature = "cloud", not(any(feature = "ssl", feature = "rustls"))))]
+compile_error!("cloud feature requires either the rustls or ssl feature.");

--- a/scylla/src/transport/connection_pool.rs
+++ b/scylla/src/transport/connection_pool.rs
@@ -1282,7 +1282,7 @@ mod tests {
         let connection_config = ConnectionConfig {
             compression: None,
             tcp_nodelay: true,
-            #[cfg(feature = "ssl")]
+            #[cfg(any(feature = "ssl", feature = "rustls"))]
             ssl_config: None,
             ..Default::default()
         };


### PR DESCRIPTION
This PR adds support for [rustls](https://github.com/rustls/rustls) behind a feature. Rustls is a pure rust implementation of TLS. With this PR, it obviates the need for clients to install libssl separately, which can be advantageous for users who with to cross compile binaries or just want a simpler building process.

There is one breaking change:
* Since the rustls and ssl features cannot be used together, the `cloud` feature no longer automatically pulls in `ssl`. Instead a compiler error is generated when the `cloud` feature is enabled without either `rustls` or `ssl`. A compiler error is also generated when both `rustls` and `ssl` are enabled.

***This PR is not yet ready, trying to figure out how to test these changes***

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
