### PR TITLE
scylla: Enable `log` feature in `tracing`

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = "1.0"
 itertools = "0.11.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
-tracing = "0.1.36"
+tracing = { version = "0.1.36", features = ["log"] }
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }


### PR DESCRIPTION
This allows applications using `log` ecosystem to receive logs from the driver.
There shouldn't be a significant performance penalty, because `log` events are emitted only if there is not `Subscriber` active.

TODO: Look intro tracing code to see if enabling this looks costly, or setup some benchmark.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
