### PR TITLE
Limit chrono version to avoid test failure

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -21,7 +21,7 @@ uuid = "1.0"
 thiserror = "1.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
-chrono = { version = "0.4.27", default-features = false, optional = true }
+chrono = { version = ">= 0.4.27, < 0.4.32", default-features = false, optional = true }
 lz4_flex = { version = "0.11.1" }
 async-trait = "0.1.57"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -39,7 +39,7 @@ itertools = "0.11.0"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
 tracing = "0.1.36"
-chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
+chrono = { version = ">= 0.4.20, < 0.4.32", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
 arc-swap = "1.3.0"


### PR DESCRIPTION
Chrono 0.4.32 introduced a breaking change which cause our tests to fail. Avoid using the new version until chrono is fixed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
