### PR TITLE
Hide public usages of bigdecimal::BigDecimal behind a crate feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,8 @@ jobs:
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "num-bigint-03"
     - name: Cargo check with num-bigint-04 feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "num-bigint-04"
+    - name: Cargo check with bigdecimal-04 feature
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "bigdecimal-04"
     - name: Build scylla-cql
       run: cargo build --verbose --all-targets --manifest-path "scylla-cql/Cargo.toml" --features "full-serialization"
     - name: Build

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -116,11 +116,13 @@ checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bigdecimal"
-version = "0.2.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e50562e37200edf7c6c43e54a08e64a5553bfb59d9c297d5572512aa517256"
+checksum = "c06619be423ea5bb86c95f087d5707942791a08a85530df0db2209a3ecfb8bc9"
 dependencies = [
- "num-bigint 0.3.3",
+ "autocfg",
+ "libm",
+ "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
 ]
@@ -793,6 +795,12 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -26,7 +26,7 @@ Database types and their Rust equivalents:
 * `Time` <----> `value::CqlTime`, `chrono::NaiveTime`, `time::Time`
 * `Timestamp` <----> `value::CqlTimestamp`, `chrono::DateTime<Utc>`, `time::OffsetDateTime`
 * `Duration` <----> `value::CqlDuration`
-* `Decimal` <----> `bigdecimal::Decimal`
+* `Decimal` <----> `value::CqlDecimal`, `bigdecimal::Decimal`
 * `Varint` <----> `value::CqlVarint`, `num_bigint::BigInt` (v0.3 and v0.4)
 * `List` <----> `Vec<T>`
 * `Set` <----> `Vec<T>`

--- a/docs/source/data-types/decimal.md
+++ b/docs/source/data-types/decimal.md
@@ -1,5 +1,39 @@
 # Decimal
-`Decimal` is represented as [`bigdecimal::BigDecimal`](https://docs.rs/bigdecimal/0.2.0/bigdecimal/struct.BigDecimal.html)
+`Decimal` is represented as `value::CqlDecimal` or [`bigdecimal::BigDecimal`](https://docs.rs/bigdecimal/latest/bigdecimal/struct.BigDecimal.html)
+
+## value::CqlDecimal
+
+Without any feature flags, the user can interact with `decimal` type by making use of `value::CqlDecimal` which is a very simple wrapper representing the value as signed binary number in big-endian order with a 32-bit scale.
+
+```rust
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::IntoTypedRows;
+use scylla::frame::value::CqlDecimal;
+use std::str::FromStr;
+
+// Insert a decimal (123.456) into the table
+let to_insert: CqlDecimal =
+        CqlDecimal::from_signed_be_bytes_and_exponent(vec![0x01, 0xE2, 0x40], 3);
+session
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
+    .await?;
+
+// Read a decimal from the table
+if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
+    for row in rows.into_typed::<(CqlDecimal,)>() {
+        let (decimal_value,): (CqlDecimal,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+## bigdecimal::BigDecimal
+
+To make use of `bigdecimal::Bigdecimal` type, user should enable `bigdecimal-04` crate feature.
 
 ```rust
 # extern crate scylla;

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -12,7 +12,7 @@ scylla = "0.11"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"
-bigdecimal = "0.2.0"
+bigdecimal = "0.4"
 num-bigint = "0.3"
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3.6"
 openssl = "0.10.32"
 rustyline = "9"
 rustyline-derive = "0.6"
-scylla = {path = "../scylla", features = ["ssl", "cloud", "chrono", "time", "num-bigint-03", "num-bigint-04"]}
+scylla = {path = "../scylla", features = ["ssl", "cloud", "chrono", "time", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]}
 tokio = {version = "1.1.0", features = ["full"]}
 tracing = "0.1.25"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -19,7 +19,7 @@ secrecy = { version = "0.7.0", optional = true }
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"
-bigdecimal = "0.2.0"
+bigdecimal = "0.4"
 num-bigint-03 = { package = "num-bigint", version = "0.3", optional = true }
 num-bigint-04 = { package = "num-bigint", version = "0.4", optional = true }
 chrono = { version = "0.4.27", default-features = false, optional = true }

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -19,9 +19,9 @@ secrecy = { version = "0.7.0", optional = true }
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"
-bigdecimal = "0.4"
 num-bigint-03 = { package = "num-bigint", version = "0.3", optional = true }
 num-bigint-04 = { package = "num-bigint", version = "0.4", optional = true }
+bigdecimal-04 = { package = "bigdecimal", version = "0.4", optional = true }
 chrono = { version = "0.4.27", default-features = false, optional = true }
 lz4_flex = { version = "0.11.1" }
 async-trait = "0.1.57"
@@ -43,4 +43,5 @@ time = ["dep:time"]
 chrono = ["dep:chrono"]
 num-bigint-03 = ["dep:num-bigint-03"]
 num-bigint-04 = ["dep:num-bigint-04"]
-full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04"]
+bigdecimal-04 = ["dep:bigdecimal-04"]
+full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -2,7 +2,6 @@ use super::result::{CqlValue, Row};
 use crate::frame::value::{
     Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
 };
-use bigdecimal::BigDecimal;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
 use std::net::IpAddr;
@@ -169,7 +168,8 @@ impl FromCqlVal<CqlValue> for num_bigint_04::BigInt {
     }
 }
 
-impl FromCqlVal<CqlValue> for BigDecimal {
+#[cfg(feature = "bigdecimal-04")]
+impl FromCqlVal<CqlValue> for bigdecimal_04::BigDecimal {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         match cql_val {
             CqlValue::Decimal(cql_decimal) => Ok(cql_decimal.into()),
@@ -423,7 +423,6 @@ mod tests {
     use crate as scylla;
     use crate::frame::value::{Counter, CqlDate, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid};
     use crate::macros::FromRow;
-    use bigdecimal::BigDecimal;
     use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
@@ -511,12 +510,13 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "bigdecimal-04")]
     #[test]
     fn decimal_from_cql() {
-        let decimal = BigDecimal::from_str("123.4").unwrap();
+        let decimal = bigdecimal_04::BigDecimal::from_str("123.4").unwrap();
         assert_eq!(
             Ok(decimal.clone()),
-            BigDecimal::from_cql(CqlValue::Decimal(decimal.try_into().unwrap()))
+            bigdecimal_04::BigDecimal::from_cql(CqlValue::Decimal(decimal.try_into().unwrap()))
         );
     }
 

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -967,7 +967,6 @@ pub fn deserialize(buf: &mut &[u8]) -> StdResult<Result, ParseError> {
 mod tests {
     use crate as scylla;
     use crate::frame::value::{Counter, CqlDate, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid};
-    use bigdecimal::BigDecimal;
     use scylla::frame::response::result::{ColumnType, CqlValue};
     use std::str::FromStr;
     use uuid::Uuid;
@@ -1111,8 +1110,10 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "bigdecimal-04")]
     #[test]
     fn test_decimal() {
+        use bigdecimal_04::BigDecimal;
         struct Test<'a> {
             value: BigDecimal,
             encoding: &'a [u8],

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -958,6 +958,23 @@ impl Value for i64 {
     }
 }
 
+impl Value for CqlDecimal {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        let (bytes, scale) = self.as_signed_be_bytes_slice_and_exponent();
+
+        if bytes.len() > (i32::MAX - 4) as usize {
+            return Err(ValueTooBig);
+        }
+        let serialized_len: i32 = bytes.len() as i32 + 4;
+
+        buf.put_i32(serialized_len);
+        buf.put_i32(scale);
+        buf.extend_from_slice(bytes);
+
+        Ok(())
+    }
+}
+
 impl Value for BigDecimal {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         let (value, scale) = self.as_bigint_and_exponent();

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -886,9 +886,13 @@ impl Value for BigDecimal {
         let (value, scale) = self.as_bigint_and_exponent();
 
         let serialized = value.to_signed_bytes_be();
-        let serialized_len: i32 = serialized.len().try_into().map_err(|_| ValueTooBig)?;
 
-        buf.put_i32(serialized_len + 4);
+        if serialized.len() > (i32::MAX - 4) as usize {
+            return Err(ValueTooBig);
+        }
+        let serialized_len: i32 = serialized.len() as i32 + 4;
+
+        buf.put_i32(serialized_len);
         buf.put_i32(scale.try_into().map_err(|_| ValueTooBig)?);
         buf.extend_from_slice(&serialized);
 

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -10,7 +10,6 @@ use super::value::{
     CqlDate, CqlDuration, CqlTime, CqlTimestamp, LegacyBatchValues, LegacySerializedValues,
     MaybeUnset, SerializeValuesError, Unset, Value, ValueList, ValueTooBig,
 };
-use bigdecimal::BigDecimal;
 use bytes::BufMut;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -147,6 +146,11 @@ fn cql_varint_serialization() {
     }
 }
 
+#[cfg(any(
+    feature = "num-bigint-03",
+    feature = "num-bigint-04",
+    feature = "bigdecimal-04"
+))]
 fn varint_test_cases_from_spec() -> Vec<(i64, Vec<u8>)> {
     vec![
         (0, vec![0x00]),
@@ -191,8 +195,9 @@ fn bigint04_serialization() {
     generic_num_bigint_serialization::<num_bigint_04::BigInt>()
 }
 
+#[cfg(feature = "bigdecimal-04")]
 #[test]
-fn bigdecimal_serialization() {
+fn bigdecimal04_serialization() {
     // Bigint cases
     let cases_from_the_spec: &[(i64, Vec<u8>)] = &varint_test_cases_from_spec();
 
@@ -205,8 +210,8 @@ fn bigdecimal_serialization() {
                 .chain(serialized_digits)
                 .cloned()
                 .collect::<Vec<_>>();
-            let digits = bigdecimal::num_bigint::BigInt::from(*digits);
-            let x = BigDecimal::new(digits, exponent as i64);
+            let digits = bigdecimal_04::num_bigint::BigInt::from(*digits);
+            let x = bigdecimal_04::BigDecimal::new(digits, exponent as i64);
             assert_eq!(serialized(x, ColumnType::Decimal), repr);
         }
     }

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -21,7 +21,7 @@ num_enum = "0.5"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros", "rt-multi-thread"] }
 uuid = "1.0"
 thiserror = "1.0.32"
-bigdecimal = "0.2.0"
+bigdecimal = "0.4"
 num-bigint = "0.3"
 tracing = "0.1.25"
 chrono = { version = "0.4", default-features = false }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -38,7 +38,7 @@ uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8.3"
 thiserror = "1.0"
 itertools = "0.11.0"
-bigdecimal = "0.2.0"
+bigdecimal = "0.4"
 tracing = "0.1.36"
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -22,7 +22,8 @@ chrono = ["scylla-cql/chrono"]
 time = ["scylla-cql/time"]
 num-bigint-03 = ["scylla-cql/num-bigint-03"]
 num-bigint-04 = ["scylla-cql/num-bigint-04"]
-full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04"]
+bigdecimal-04 = ["scylla-cql/bigdecimal-04"]
+full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]
 
 [dependencies]
 scylla-macros = { version = "0.3.0", path = "../scylla-macros" }
@@ -38,7 +39,6 @@ uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8.3"
 thiserror = "1.0"
 itertools = "0.11.0"
-bigdecimal = "0.4"
 tracing = "0.1.36"
 chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }
@@ -60,6 +60,7 @@ socket2 = { version = "0.5.3", features = ["all"] }
 [dev-dependencies]
 num-bigint-03 = { package = "num-bigint", version = "0.3" }
 num-bigint-04 = { package = "num-bigint", version = "0.4" }
+bigdecimal-04 = { package = "bigdecimal", version = "0.4" }
 scylla-proxy = { version = "0.0.3", path = "../scylla-proxy" }
 ntest = "0.9.0"
 criterion = "0.4" # Note: v0.5 needs at least rust 1.70.0

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -7,7 +7,6 @@ use crate::test_utils::create_new_session_builder;
 use crate::transport::session::IntoTypedRows;
 use crate::transport::session::Session;
 use crate::utils::test_utils::unique_keyspace_name;
-use bigdecimal::BigDecimal;
 use itertools::Itertools;
 use scylla_cql::frame::value::{CqlTimeuuid, CqlVarint};
 use scylla_cql::types::serialize::value::SerializeCql;
@@ -218,6 +217,7 @@ async fn test_cql_varint() {
     }
 }
 
+#[cfg(feature = "bigdecimal-04")]
 #[tokio::test]
 async fn test_decimal() {
     let tests = [
@@ -229,7 +229,7 @@ async fn test_decimal() {
         "-123456789012345678901234567890.1234567890",
     ];
 
-    run_tests::<BigDecimal>(&tests, "decimal").await;
+    run_tests::<bigdecimal_04::BigDecimal>(&tests, "decimal").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Refs: https://github.com/scylladb/scylla-rust-driver/issues/771

## Changes
- introduced `value::CqlDecimal` type
- hidden public usages of `bigdecimal::Bigdecimal` behind crate feature.
- wrapped `CqlDecimal` with `CqlValue::Decimal`
- updated docs
- updated tests
- added docstrings

## Points to discuss
- how to implement `PartialEq` for `CqlDecimal`? Note that `CqlDecimal` makes use of `CqlVarint`, so the bytes normalization part can be delegated to `CqlVarint`. However, there is an additional issue, because there are multiple pairs (integer, scale) which can represent the same number. Take for example: `1e3` and `100e1`. I don't think it's trivial to implement the comparison without converting bytes (hexadecimal representation) to decimal number.
- Should I create some macros for code repetitions? There are some parts of code that are repeated for each version of the `bigdecimal` crate that unfortunately cannot be expressed using some generic function (e.g. usages of `BigDecimal::new()` constructor).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
