### PR TITLE
Use prepared statement result metadata to decode rows

### DIFF
--- a/scylla-cql/benches/benchmark.rs
+++ b/scylla-cql/benches/benchmark.rs
@@ -14,6 +14,7 @@ fn make_query(contents: &str, values: SerializedValues) -> query::Query<'_> {
             consistency: scylla_cql::Consistency::LocalQuorum,
             serial_consistency: None,
             values: Cow::Owned(values),
+            skip_metadata: false,
             page_size: None,
             paging_state: None,
             timestamp: None,

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -150,6 +150,7 @@ mod tests {
             timestamp: None,
             page_size: Some(323),
             paging_state: Some(vec![2, 1, 3, 7].into()),
+            skip_metadata: false,
             values: {
                 let mut vals = SerializedValues::new();
                 vals.add_value(&2137, &ColumnType::Int).unwrap();
@@ -177,6 +178,7 @@ mod tests {
             timestamp: Some(3423434),
             page_size: None,
             paging_state: None,
+            skip_metadata: false,
             values: {
                 let mut vals = SerializedValues::new();
                 vals.add_value(&42, &ColumnType::Int).unwrap();
@@ -234,6 +236,7 @@ mod tests {
             timestamp: None,
             page_size: None,
             paging_state: None,
+            skip_metadata: false,
             values: Cow::Borrowed(SerializedValues::EMPTY),
         };
         let query = Query {

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -63,6 +63,7 @@ pub struct QueryParameters<'a> {
     pub timestamp: Option<i64>,
     pub page_size: Option<i32>,
     pub paging_state: Option<Bytes>,
+    pub skip_metadata: bool,
     pub values: Cow<'a, SerializedValues>,
 }
 
@@ -74,6 +75,7 @@ impl Default for QueryParameters<'_> {
             timestamp: None,
             page_size: None,
             paging_state: None,
+            skip_metadata: false,
             values: Cow::Borrowed(SerializedValues::EMPTY),
         }
     }
@@ -86,6 +88,10 @@ impl QueryParameters<'_> {
         let mut flags = 0;
         if !self.values.is_empty() {
             flags |= FLAG_VALUES;
+        }
+
+        if self.skip_metadata {
+            flags |= FLAG_SKIP_METADATA;
         }
 
         if self.page_size.is_some() {
@@ -143,6 +149,7 @@ impl<'q> QueryParameters<'q> {
             )));
         }
         let values_flag = (flags & FLAG_VALUES) != 0;
+        let skip_metadata = (flags & FLAG_SKIP_METADATA) != 0;
         let page_size_flag = (flags & FLAG_PAGE_SIZE) != 0;
         let paging_state_flag = (flags & FLAG_WITH_PAGING_STATE) != 0;
         let serial_consistency_flag = (flags & FLAG_WITH_SERIAL_CONSISTENCY) != 0;
@@ -192,6 +199,7 @@ impl<'q> QueryParameters<'q> {
             timestamp,
             page_size,
             paging_state,
+            skip_metadata,
             values,
         })
     }

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -386,7 +386,7 @@ pub struct ColumnSpec {
     pub typ: ColumnType,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ResultMetadata {
     col_count: usize,
     pub paging_state: Option<Bytes>,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -886,16 +886,28 @@ pub fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue,
     })
 }
 
-fn deser_rows(buf: &mut &[u8]) -> StdResult<Rows, ParseError> {
-    let metadata = deser_result_metadata(buf)?;
+fn deser_rows(
+    buf: &mut &[u8],
+    cached_metadata: Option<&ResultMetadata>,
+) -> StdResult<Rows, ParseError> {
+    let server_metadata = deser_result_metadata(buf)?;
+
+    let metadata = match cached_metadata {
+        Some(metadata) => metadata.clone(),
+        None => {
+            // No cached_metadata provided. Server is supposed to provide the result metadata.
+            if server_metadata.col_count != server_metadata.col_specs.len() {
+                return Err(ParseError::BadIncomingData(format!(
+                    "Bad result metadata provided in the response. Expected {} column specifications, received: {}",
+                    server_metadata.col_count,
+                    server_metadata.col_specs.len()
+                )));
+            }
+            server_metadata
+        }
+    };
 
     let original_size = buf.len();
-
-    // TODO: the protocol allows an optimization (which must be explicitly requested on query by
-    // the driver) where the column metadata is not sent with the result.
-    // Implement this optimization. We'll then need to take the column types by a parameter.
-    // Beware of races; our column types may be outdated.
-    assert!(metadata.col_count == metadata.col_specs.len());
 
     let rows_count: usize = types::read_int(buf)?.try_into()?;
 
@@ -946,11 +958,14 @@ fn deser_schema_change(buf: &mut &[u8]) -> StdResult<SchemaChange, ParseError> {
     })
 }
 
-pub fn deserialize(buf: &mut &[u8]) -> StdResult<Result, ParseError> {
+pub fn deserialize(
+    buf: &mut &[u8],
+    cached_metadata: Option<&ResultMetadata>,
+) -> StdResult<Result, ParseError> {
     use self::Result::*;
     Ok(match types::read_int(buf)? {
         0x0001 => Void,
-        0x0002 => Rows(deser_rows(buf)?),
+        0x0002 => Rows(deser_rows(buf, cached_metadata)?),
         0x0003 => SetKeyspace(deser_set_keyspace(buf)?),
         0x0004 => Prepared(deser_prepared(buf)?),
         0x0005 => SchemaChange(deser_schema_change(buf)?),

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -16,6 +16,7 @@ pub(crate) struct StatementConfig {
 
     pub(crate) is_idempotent: bool,
 
+    pub(crate) skip_result_metadata: bool,
     pub(crate) tracing: bool,
     pub(crate) timestamp: Option<i64>,
     pub(crate) request_timeout: Option<Duration>,

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use thiserror::Error;
 use uuid::Uuid;
 
-use scylla_cql::frame::response::result::ColumnSpec;
+use scylla_cql::frame::response::result::{ColumnSpec, PartitionKeyIndex};
 
 use super::StatementConfig;
 use crate::frame::response::result::PreparedMetadata;
@@ -301,9 +301,19 @@ impl PreparedStatement {
         self.partitioner_name = partitioner_name;
     }
 
-    /// Access metadata about this prepared statement as returned by the database
-    pub fn get_prepared_metadata(&self) -> &PreparedMetadata {
+    /// Access metadata about the bind variables of this statement as returned by the database
+    pub(crate) fn get_prepared_metadata(&self) -> &PreparedMetadata {
         &self.shared.metadata
+    }
+
+    /// Access column specifications of the bind variables of this statement
+    pub fn get_variable_col_specs(&self) -> &[ColumnSpec] {
+        &self.shared.metadata.col_specs
+    }
+
+    /// Access info about partition key indexes of the bind variables of this statement
+    pub fn get_variable_pk_indexes(&self) -> &[PartitionKeyIndex] {
+        &self.shared.metadata.pk_indexes
     }
 
     /// Get the name of the partitioner used for this statement.

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -270,6 +270,27 @@ impl PreparedStatement {
         self.config.tracing
     }
 
+    /// Make use of cached metadata to decode results
+    /// of the statement's execution.
+    ///
+    /// If true, the driver will request the server not to
+    /// attach the result metadata in response to the statement execution.
+    ///
+    /// The driver will cache the result metadata received from the server
+    /// after statement preparation and will use it
+    /// to deserialize the results of statement execution.
+    ///
+    /// This option is false by default.
+    pub fn set_use_cached_result_metadata(&mut self, use_cached_metadata: bool) {
+        self.config.skip_result_metadata = use_cached_metadata;
+    }
+
+    /// Gets the information whether the driver uses cached metadata
+    /// to decode the results of the statement's execution.
+    pub fn get_use_cached_result_metadata(&self) -> bool {
+        self.config.skip_result_metadata
+    }
+
     /// Sets the default timestamp for this statement in microseconds.
     /// If not None, it will replace the server side assigned timestamp as default timestamp
     /// If a statement contains a `USING TIMESTAMP` clause, calling this method won't change

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -8,7 +8,7 @@ use crate::{QueryResult, Session};
 use bytes::Bytes;
 use dashmap::DashMap;
 use futures::future::try_join_all;
-use scylla_cql::frame::response::result::PreparedMetadata;
+use scylla_cql::frame::response::result::{PreparedMetadata, ResultMetadata};
 use scylla_cql::types::serialize::batch::BatchValues;
 use scylla_cql::types::serialize::row::SerializeRow;
 use std::collections::hash_map::RandomState;
@@ -23,6 +23,7 @@ struct RawPreparedStatementData {
     id: Bytes,
     is_confirmed_lwt: bool,
     metadata: PreparedMetadata,
+    result_metadata: ResultMetadata,
     partitioner_name: PartitionerName,
 }
 
@@ -168,6 +169,7 @@ where
                 raw.id.clone(),
                 raw.is_confirmed_lwt,
                 raw.metadata.clone(),
+                raw.result_metadata.clone(),
                 query.contents,
                 page_size,
                 query.config,
@@ -195,6 +197,7 @@ where
                 id: prepared.get_id().clone(),
                 is_confirmed_lwt: prepared.is_confirmed_lwt(),
                 metadata: prepared.get_prepared_metadata().clone(),
+                result_metadata: prepared.get_result_metadata().clone(),
                 partitioner_name: prepared.get_partitioner_name().clone(),
             };
             self.cache.insert(query_contents, raw);

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -655,6 +655,7 @@ impl Connection {
                 values: Cow::Borrowed(SerializedValues::EMPTY),
                 page_size: query.get_page_size(),
                 paging_state,
+                skip_metadata: false,
                 timestamp: query.get_timestamp(),
             },
         };
@@ -699,6 +700,7 @@ impl Connection {
                 values: Cow::Borrowed(values),
                 page_size: prepared_statement.get_page_size(),
                 timestamp: prepared_statement.get_timestamp(),
+                skip_metadata: prepared_statement.get_use_cached_result_metadata(),
                 paging_state,
             },
         };

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -552,6 +552,7 @@ impl Connection {
                     .protocol_features
                     .prepared_flags_contain_lwt_mark(p.prepared_metadata.flags as u32),
                 p.prepared_metadata,
+                p.result_metadata,
                 query.contents.clone(),
                 query.get_page_size(),
                 query.config.clone(),

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -6,4 +6,5 @@ mod new_session;
 mod retries;
 mod shards;
 mod silent_prepare_query;
+mod skip_metadata_optimization;
 pub(crate) mod utils;

--- a/scylla/tests/integration/skip_metadata_optimization.rs
+++ b/scylla/tests/integration/skip_metadata_optimization.rs
@@ -1,0 +1,89 @@
+use crate::utils::test_with_3_node_cluster;
+use scylla::transport::session::Session;
+use scylla::SessionBuilder;
+use scylla::{prepared_statement::PreparedStatement, test_utils::unique_keyspace_name};
+use scylla_cql::frame::types;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, ResponseFrame, ResponseReaction, ShardAwareness, TargetShard,
+    WorkerError,
+};
+use std::sync::Arc;
+
+#[tokio::test]
+#[ntest::timeout(20000)]
+#[cfg(not(scylla_cloud_tests))]
+async fn test_skip_result_metadata() {
+    use scylla_proxy::{ResponseOpcode, ResponseRule};
+
+    const NO_METADATA_FLAG: i32 = 0x0004;
+
+    let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
+        // DB preparation phase
+        let session: Session = SessionBuilder::new()
+            .known_node(proxy_uris[0].as_str())
+            .address_translator(Arc::new(translation_map))
+            .build()
+            .await
+            .unwrap();
+
+        let ks = unique_keyspace_name();
+        session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks), &[]).await.unwrap();
+        session.use_keyspace(ks, false).await.unwrap();
+        session
+            .query("CREATE TABLE t (a int primary key, b int, c text)", &[])
+            .await
+            .unwrap();
+        session.query("INSERT INTO t (a, b, c) VALUES (1, 2, 'foo_filter_data')", &[]).await.unwrap();
+
+        let mut prepared = session.prepare("SELECT a, b, c FROM t").await.unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // We inserted this string to filter responses
+        let body_rows = b"foo_filter_data";
+        for node in running_proxy.running_nodes.iter_mut() {
+            let rule = ResponseRule(
+                Condition::ResponseOpcode(ResponseOpcode::Result).and(Condition::BodyContainsCaseSensitive(Box::new(*body_rows))),
+                ResponseReaction::noop().with_feedback_when_performed(tx.clone())
+            );
+            node.change_response_rules(Some(vec![rule]));
+        }
+
+        async fn test_with_flags_predicate(
+            session: &Session,
+            prepared: &PreparedStatement,
+            rx: &mut tokio::sync::mpsc::UnboundedReceiver<(ResponseFrame, Option<TargetShard>)>,
+            predicate: impl FnOnce(i32) -> bool
+        ) {
+            session.execute(prepared, &[]).await.unwrap();
+
+            let (frame, _shard) = rx.recv().await.unwrap();
+            let mut buf = &*frame.body;
+
+            // FIXME: make use of scylla_cql::frame utilities, instead of deserializing frame manually.
+            // This will probably be possible once https://github.com/scylladb/scylla-rust-driver/issues/462 is fixed.
+            match types::read_int(&mut buf).unwrap() {
+                0x0002 => (),
+                _ => panic!("Invalid result type"),
+            }
+            let result_metadata_flags = types::read_int(&mut buf).unwrap();
+            assert!(predicate(result_metadata_flags));
+        }
+
+        // Verify that server sends metadata when driver doesn't send SKIP_METADATA flag.
+        prepared.set_use_cached_result_metadata(false);
+        test_with_flags_predicate(&session, &prepared, &mut rx, |flags| flags & NO_METADATA_FLAG == 0).await;
+
+        // Verify that server doesn't send metadata when driver sends SKIP_METADATA flag.
+        prepared.set_use_cached_result_metadata(true);
+        test_with_flags_predicate(&session, &prepared, &mut rx, |flags| flags & NO_METADATA_FLAG != 0).await;
+
+        running_proxy
+    }).await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/169

## Motivation
Currently, the driver does not make a use of an optimization that CQL protocol offers during exeuction of prepared statements. The client is allowed to provide `SKIP_METADATA` flag during `Session::execute`, so the server doesn't attach a result set metadata. The driver can use the cached metadata (received in response to `Session::prepare`) to deserialize the results.

## Changes
### `PreparedStatement`
As mentioned previously, the driver can cache the prepared statement's result metadata. This is why we extend the `PreparedStatementSharedData` by `result_metadata` field which holds the metadata. The metadata is obtained from the server during statement preparation (`Session::prepare`). This metadata is eventually passed to the function which deserializes the results of query execution.

### Schema changes
Before introducing the optimization, the driver was immune to the problems related to prepared statement's result metadata and schema changes.

After some schema change, Scylla and Cassandra invalidate the server-side caches and discard all of the prepared statements. When the driver executes a prepared statement after the schema change for the first time, it receives the `UNPREPARED` error frame (server does not recognize the id of the prepared statement since it was discarded). Currently, Scylla drivers handle such case by repreparation of the statement. Notice that after the schema change, the result metadata may be changed (depends on the actual change of schema). Without the optimization, Scylla always provides a valid (updated during repreparation) result metadata in the response to statement execution so we don't need to worry about it.

This raises an issue when we try to cache the metadata on the client side. It should be mutable so the driver holds a metadata that is always up to date (should be updated during reprepares). However, looking at the other drivers we can see that the client-side metadata caches are immutable. This is why we follow the same approach and not care about the schema changes.

### Config
Extended and `StatementConfig` by `skip_result_metadata` boolean flag which defaults to `false`. When set to `true`, it enables the optimization. Thanks to that, the users can enable the optimization per-statement.

## Points to discuss
- should maybe `skip_result_metadata` flag be enabled by default? Since it's an optimization, it might make sense for it to be enabled by default.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
