### PR TITLE
Docs: Preprocessor for Python < 3.12

### DIFF
--- a/docs/sphinx_preprocessor.py
+++ b/docs/sphinx_preprocessor.py
@@ -48,7 +48,7 @@ def remove_sphinx_markdown(md_file_text, name):
 
 def process_section(section):
     if 'Chapter' in section:
-        print(f'Processing chapter {section['Chapter']['name']}', file=sys.stderr)
+        print(f'Processing chapter {section["Chapter"]["name"]}', file=sys.stderr)
         section['Chapter']['content'] = remove_sphinx_markdown(section['Chapter']['content'], section['Chapter']['name'])
         for s in section['Chapter']['sub_items']:
             process_section(s)


### PR DESCRIPTION
Preprocessor script was using syntax that works with Python 3.12 but not with older version.
Namely, string in format string using the same delimiter as outer string. Example: f'abc{'def'}xyz'

This commit changes delimiters of inner string to make script compatible with older versions of Python.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
