### PR TITLE
docs: support for Mac

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,7 +25,7 @@ setupenv:
 setup:
 	$(POETRY) install
 	$(POETRY) update
-	@if [ ! -d "$(SOURCEDIR)" ]; then mkdir -p "$(SOURCEDIR)"; fi
+	mkdir -p $(SOURCEDIR)
 	cp -RL source/* $(SOURCEDIR)
 	python _utils/prepare_sphinx_source.py _source
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,7 +25,8 @@ setupenv:
 setup:
 	$(POETRY) install
 	$(POETRY) update
-	cp -TLr source $(SOURCEDIR)
+	@if [ ! -d "$(SOURCEDIR)" ]; then mkdir -p "$(SOURCEDIR)"; fi
+	cp -RL source/* $(SOURCEDIR)
 	python _utils/prepare_sphinx_source.py _source
 
 # Clean commands


### PR DESCRIPTION
## Motivation

Related issues: https://github.com/scylladb/sphinx-scylladb-theme/issues/862

This PR addresses an error encountered while building the docs on Mac OS:

> cp -TLr source _source
cp: illegal option -- T

## How to test

The PR build runs without errors.