### PR TITLE
CI: cargo clean before tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,9 @@ jobs:
     - name: Build
       run: cargo build --verbose --all-targets --features "full-serialization"
     - name: Run tests
-      run: SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose --features "full-serialization"
+      run: |
+        cargo clean
+        SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --verbose --features "full-serialization"
     - name: Stop the cluster
       if: ${{ always() }}
       run: docker compose -f test/cluster/docker-compose.yml stop


### PR DESCRIPTION
## Motivation

Recently, a new issue with CI have arisen. During the `Run tests` step in `build` job, the CI fails due to lack of space on the GH runner machine.

Here is the output of `du -sh target/debug/* && df -h` executed right before the tests on the runner machine:
```
133M	target/debug/build
2.2G	target/debug/deps
3.1G	target/debug/examples
4.6G	target/debug/incremental
8.0K	target/debug/libscylla.d
4.0K	target/debug/libscylla_cql.d
4.0K	target/debug/libscylla_macros.d
8.0K	target/debug/libscylla_proxy.d
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   66G  7.0G  91% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.4M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

We see that there is 7GB left on the disk. However, it's still not enough to compile the tests and examples in the debug mode:
```
 = note: /usr/bin/ld: final link failed: No space left on device
          collect2: error: ld returned 1 exit status
          

error: could not compile `scylla-proxy` (example "cmdline") due to previous error
```

## Changes
- execute `cargo clean` before running the tests in `Run tests` step.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
