### PR TITLE
Remove num_enum dependency

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1003,48 +1003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,7 +1451,6 @@ dependencies = [
  "ntest",
  "num-bigint 0.3.3",
  "num-bigint 0.4.4",
- "num_enum 0.6.1",
  "openssl",
  "rand",
  "rand_chacha",
@@ -1531,7 +1488,6 @@ dependencies = [
  "lz4_flex",
  "num-bigint 0.3.3",
  "num-bigint 0.4.4",
- "num_enum 0.6.1",
  "scylla-macros",
  "secrecy",
  "serde",
@@ -1564,7 +1520,6 @@ dependencies = [
  "futures",
  "ntest",
  "num-bigint 0.3.3",
- "num_enum 0.5.11",
  "rand",
  "scylla-cql",
  "thiserror",

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -13,7 +13,6 @@ license = "MIT OR Apache-2.0"
 scylla-macros = { version = "0.4.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
-num_enum = "0.6"
 tokio = { version = "1.12", features = ["io-util", "time"] }
 secrecy = { version = "0.7.0", optional = true }
 snap = "1.0"

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,4 +1,4 @@
-use super::response;
+use super::TryFromPrimitiveError;
 use crate::cql_to_rust::CqlTypeError;
 use crate::frame::value::SerializeValuesError;
 use crate::types::serialize::SerializationError;
@@ -25,7 +25,7 @@ pub enum FrameError {
     #[error(transparent)]
     StdIoError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]
-    TryFromPrimitiveError(#[from] num_enum::TryFromPrimitiveError<response::ResponseOpcode>),
+    TryFromPrimitiveError(#[from] TryFromPrimitiveError<u8>),
     #[error("Error compressing lz4 data {0}")]
     Lz4CompressError(#[from] lz4_flex::block::CompressError),
     #[error("Error decompressing lz4 data {0}")]

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -11,6 +11,7 @@ mod value_tests;
 
 use crate::frame::frame_errors::FrameError;
 use bytes::{Buf, BufMut, Bytes};
+use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use uuid::Uuid;
 
@@ -257,6 +258,14 @@ fn decompress(mut comp_body: &[u8], compression: Compression) -> Result<Vec<u8>,
             .decompress_vec(comp_body)
             .map_err(|_| FrameError::FrameDecompression),
     }
+}
+
+/// An error type for parsing an enum value from a primitive.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[error("No discrimant in enum `{enum_name}` matches the value `{primitive:?}`")]
+pub struct TryFromPrimitiveError<T: Copy + std::fmt::Debug> {
+    enum_name: &'static str,
+    primitive: T,
 }
 
 #[cfg(test)]

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -10,7 +10,6 @@ pub mod startup;
 use crate::types::serialize::row::SerializedValues;
 use crate::{frame::frame_errors::ParseError, Consistency};
 use bytes::Bytes;
-use num_enum::TryFromPrimitive;
 
 pub use auth_response::AuthResponse;
 pub use batch::Batch;
@@ -23,8 +22,9 @@ pub use startup::Startup;
 use self::batch::BatchStatement;
 
 use super::types::SerialConsistency;
+use super::TryFromPrimitiveError;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum RequestOpcode {
     Startup = 0x01,
@@ -35,6 +35,27 @@ pub enum RequestOpcode {
     Register = 0x0B,
     Batch = 0x0D,
     AuthResponse = 0x0F,
+}
+
+impl TryFrom<u8> for RequestOpcode {
+    type Error = TryFromPrimitiveError<u8>;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(Self::Startup),
+            0x05 => Ok(Self::Options),
+            0x07 => Ok(Self::Query),
+            0x09 => Ok(Self::Prepare),
+            0x0A => Ok(Self::Execute),
+            0x0B => Ok(Self::Register),
+            0x0D => Ok(Self::Batch),
+            0x0F => Ok(Self::AuthResponse),
+            _ => Err(TryFromPrimitiveError {
+                enum_name: "RequestOpcode",
+                primitive: value,
+            }),
+        }
+    }
 }
 
 pub trait SerializableRequest {

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -6,13 +6,14 @@ pub mod result;
 pub mod supported;
 
 use crate::{errors::QueryError, frame::frame_errors::ParseError};
-use num_enum::TryFromPrimitive;
 
 use crate::frame::protocol_features::ProtocolFeatures;
 pub use error::Error;
 pub use supported::Supported;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
+use super::TryFromPrimitiveError;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum ResponseOpcode {
     Error = 0x00,
@@ -23,6 +24,27 @@ pub enum ResponseOpcode {
     Event = 0x0C,
     AuthChallenge = 0x0E,
     AuthSuccess = 0x10,
+}
+
+impl TryFrom<u8> for ResponseOpcode {
+    type Error = TryFromPrimitiveError<u8>;
+
+    fn try_from(value: u8) -> Result<Self, TryFromPrimitiveError<u8>> {
+        match value {
+            0x00 => Ok(Self::Error),
+            0x02 => Ok(Self::Ready),
+            0x03 => Ok(Self::Authenticate),
+            0x06 => Ok(Self::Supported),
+            0x08 => Ok(Self::Result),
+            0x0C => Ok(Self::Event),
+            0x0E => Ok(Self::AuthChallenge),
+            0x10 => Ok(Self::AuthSuccess),
+            _ => Err(TryFromPrimitiveError {
+                enum_name: "ResponseOpcode",
+                primitive: value,
+            }),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,7 +17,6 @@ scylla-cql = { version = "0.1.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"
-num_enum = "0.5"
 tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros", "rt-multi-thread"] }
 uuid = "1.0"
 thiserror = "1.0.32"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -32,7 +32,6 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 histogram = "0.6.9"
-num_enum = "0.6"
 tokio = { version = "1.27", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/771
I believe this PR closes https://github.com/scylladb/scylla-rust-driver/pull/857.

## Motivation
To stabilize our API, we need to get rid of pre-1.0 crates. One of them is [num_enum](https://docs.rs/num_enum/latest/num_enum/).

This crate allows us to automatically generate conversions from primitive types to enum values - however, its usages needs to be removed from the library.

## Changes
To get rid of the dependency, we needed to implement converters ourselves.

This is why, we introduce a `TryFromPrimitiveError` struct which holds the information about the enum name and the actual value that we tried to parse.

Apart from that, we implement `TryFrom` for the types that used the `num_enum` crate:
- `impl TryFrom<u16> for Consistency`
- `impl TryFrom<i16> for SerialConsistency`
- `impl TryFrom<u8> for RequestOpcode`
- `impl TryFrom<u8> for ResponseOpcode`

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
