### PR TITLE
Remove `async_trait` dependency

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -66,17 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-trait"
-version = "0.1.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1410,6 @@ version = "0.12.0"
 dependencies = [
  "arc-swap",
  "assert_matches",
- "async-trait",
  "base64",
  "bigdecimal",
  "byteorder",
@@ -1462,7 +1450,6 @@ dependencies = [
 name = "scylla-cql"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "bigdecimal",
  "byteorder",
  "bytes",

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -23,7 +23,6 @@ num-bigint-04 = { package = "num-bigint", version = "0.4", optional = true }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4", optional = true }
 chrono = { version = "0.4.27", default-features = false, optional = true }
 lz4_flex = { version = "0.11.1" }
-async-trait = "0.1.57"
 serde = { version = "1.0", features = ["derive"], optional = true }
 time = { version = "0.3", optional = true }
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -46,7 +46,6 @@ arc-swap = "1.3.0"
 dashmap = "5.2"
 lz4_flex = { version = "0.11.1" }
 smallvec = "1.8.0"
-async-trait = "0.1.56"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.9.14", optional = true }
 url = { version = "2.3.1", optional = true }

--- a/scylla/src/authentication/mod.rs
+++ b/scylla/src/authentication/mod.rs
@@ -6,6 +6,9 @@ use crate::utils::futures::BoxedFuture;
 /// Type to represent an authentication error message.
 pub type AuthError = String;
 
+/// Type to represent an initial auth response with an authenticator session.
+pub(crate) type AuthInitialResponseAndSession = (Option<Vec<u8>>, Box<dyn AuthenticatorSession>);
+
 /// Trait used to represent a user-defined custom authentication.
 pub trait AuthenticatorSession: Send + Sync {
     /// To handle an authentication challenge initiated by the server.
@@ -36,7 +39,7 @@ pub trait AuthenticatorProvider: Sync + Send {
     async fn start_authentication_session(
         &self,
         authenticator_name: &str,
-    ) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError>;
+    ) -> Result<AuthInitialResponseAndSession, AuthError>;
 }
 
 struct PlainTextAuthenticatorSession;
@@ -77,7 +80,7 @@ impl AuthenticatorProvider for PlainTextAuthenticator {
     async fn start_authentication_session(
         &self,
         _authenticator_name: &str,
-    ) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError> {
+    ) -> Result<AuthInitialResponseAndSession, AuthError> {
         let mut response = BytesMut::new();
         let username_as_bytes = self.username.as_bytes();
         let password_as_bytes = self.password.as_bytes();

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -122,6 +122,8 @@ pub(crate) mod utils;
 #[doc(hidden)]
 pub use utils::test_utils;
 
+pub use utils::futures::BoxedFuture;
+
 pub use statement::batch;
 pub use statement::prepared_statement;
 pub use statement::query;

--- a/scylla/src/transport/authenticate_test.rs
+++ b/scylla/src/transport/authenticate_test.rs
@@ -1,4 +1,6 @@
-use crate::authentication::{AuthError, AuthenticatorProvider, AuthenticatorSession};
+use crate::authentication::{
+    AuthError, AuthInitialResponseAndSession, AuthenticatorProvider, AuthenticatorSession,
+};
 use crate::utils::futures::BoxedFuture;
 use crate::utils::test_utils::unique_keyspace_name;
 use async_trait::async_trait;
@@ -52,7 +54,7 @@ impl AuthenticatorProvider for CustomAuthenticatorProvider {
     async fn start_authentication_session(
         &self,
         _authenticator_name: &str,
-    ) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError> {
+    ) -> Result<AuthInitialResponseAndSession, AuthError> {
         let mut response = BytesMut::new();
         let cred = "\0cassandra\0cassandra";
 

--- a/scylla/src/transport/authenticate_test.rs
+++ b/scylla/src/transport/authenticate_test.rs
@@ -1,4 +1,5 @@
 use crate::authentication::{AuthError, AuthenticatorProvider, AuthenticatorSession};
+use crate::utils::futures::BoxedFuture;
 use crate::utils::test_utils::unique_keyspace_name;
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
@@ -28,17 +29,19 @@ async fn authenticate_superuser() {
 
 struct CustomAuthenticator;
 
-#[async_trait]
 impl AuthenticatorSession for CustomAuthenticator {
-    async fn evaluate_challenge(
-        &mut self,
-        _token: Option<&[u8]>,
-    ) -> Result<Option<Vec<u8>>, AuthError> {
-        Err("Challenges are not expected".to_string())
+    fn evaluate_challenge<'a>(
+        &'a mut self,
+        _token: Option<&'a [u8]>,
+    ) -> BoxedFuture<'_, Result<Option<Vec<u8>>, AuthError>> {
+        Box::pin(async move { Err("Challenges are not expected".to_string()) })
     }
 
-    async fn success(&mut self, _token: Option<&[u8]>) -> Result<(), AuthError> {
-        Ok(())
+    fn success<'a>(
+        &'a mut self,
+        _token: Option<&'a [u8]>,
+    ) -> BoxedFuture<'_, Result<(), AuthError>> {
+        Box::pin(async move { Ok(()) })
     }
 }
 

--- a/scylla/src/utils/futures.rs
+++ b/scylla/src/utils/futures.rs
@@ -1,0 +1,4 @@
+use std::future::Future;
+use std::pin::Pin;
+
+pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;

--- a/scylla/src/utils/mod.rs
+++ b/scylla/src/utils/mod.rs
@@ -1,4 +1,4 @@
+pub(crate) mod futures;
 pub(crate) mod parse;
-
 pub(crate) mod pretty;
 pub mod test_utils;


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/771

## Motivation
`async-trait` is an unstable crate and so needs to be removed from public API to stabilize our API.

## Solution
### Rust 1.75 async traits
In 1.75 release release of rust, it allows us to define traits with async functions. However, such traits are not object safe, and so they cannot be used in the trait objects (`dyn Trait`). Unfortunately, all of the traits using `async_trait` are actually used in the trait objects. This means that we cannot simply remove the `async_trait` macro and expect everything to compile.
### Boxed futures
The other solution is to box the futures - the exact same thing that `async_trait` does for us.
This is why, for each of the trait that used `async_trait` we replace the signatures of async functions from:
```rust
#[async_trait]
trait Foo {
    async fn foo(&self, some_ref: &SomeType) -> ReturnType;
}
```
to:
```rust
trait Foo {
    fn foo<'a>(&'a self, some_ref: &'a SomeType) -> futures::BoxFuture<'_, ReturnType>;
}
```

Notice that some trait functions, apart from `&self` reference, accept some additional reference. In result, we need to introduce a lifetime annotation to the signatures so the compiler can deduce the lifetime parameter of the `futures::BoxFuture`. Unfortunately, implementors of such traits will need to introduce these lifetime annotations as well. I'm not sure if there is a better solution to the issue.

In addition, the implementors of the traits will need to explicitly box the returned futures like in the following example (or by using some `std::pin::Pin` utilities):
```rust
use futures::FutureExt;
struct Bar;
impl Foo for Bar {
    fn foo<'a>(&'a self, some_ref: &'a SomeType) -> futures::BoxFuture<'_, ReturnType> {
         async move { /* ... code that returns ReturnType */ }.boxed()
    }
}
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
