### PR TITLE
Decrease pub visibility of `scylla-cql` definitions

### DIFF
--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -1,11 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use bytes::BytesMut;
-use scylla::{
-    frame::types,
-    transport::partitioner::{calculate_token_for_partition_key, Murmur3Partitioner},
+use scylla::transport::partitioner::{calculate_token_for_partition_key, Murmur3Partitioner};
+use scylla_cql::{
+    frame::{response::result::ColumnType, types},
+    types::serialize::row::SerializedValues,
 };
-use scylla_cql::{frame::response::result::ColumnType, types::serialize::row::SerializedValues};
 
 fn types_benchmark(c: &mut Criterion) {
     let mut buf = BytesMut::with_capacity(64);

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -114,8 +114,15 @@ pub mod frame {
     }
 
     pub mod response {
+        pub use scylla_cql::frame::response::cql_to_rust;
         pub(crate) use scylla_cql::frame::response::*;
-        pub use scylla_cql::frame::response::{cql_to_rust, result};
+
+        pub mod result {
+            pub(crate) use scylla_cql::frame::response::result::*;
+            pub use scylla_cql::frame::response::result::{
+                ColumnSpec, ColumnType, CqlValue, PartitionKeyIndex, Row, TableSpec,
+            };
+        }
     }
 }
 

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -103,7 +103,7 @@ pub mod macros;
 pub use macros::*;
 
 pub mod frame {
-    pub use scylla_cql::frame::{frame_errors, response, value, Authenticator, Compression};
+    pub use scylla_cql::frame::{frame_errors, value, Authenticator, Compression};
     pub(crate) use scylla_cql::frame::{
         parse_response_body_extensions, protocol_features, read_response_frame, request,
         server_event_type, FrameParams, SerializedRequest,
@@ -111,6 +111,11 @@ pub mod frame {
 
     pub mod types {
         pub use scylla_cql::frame::types::{Consistency, SerialConsistency};
+    }
+
+    pub mod response {
+        pub(crate) use scylla_cql::frame::response::*;
+        pub use scylla_cql::frame::response::{cql_to_rust, result};
     }
 }
 

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -103,11 +103,15 @@ pub mod macros;
 pub use macros::*;
 
 pub mod frame {
-    pub use scylla_cql::frame::{frame_errors, response, types, value, Authenticator, Compression};
+    pub use scylla_cql::frame::{frame_errors, response, value, Authenticator, Compression};
     pub(crate) use scylla_cql::frame::{
         parse_response_body_extensions, protocol_features, read_response_frame, request,
         server_event_type, FrameParams, SerializedRequest,
     };
+
+    pub mod types {
+        pub use scylla_cql::frame::types::{Consistency, SerialConsistency};
+    }
 }
 
 pub use scylla_cql::types::serialize;

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -102,7 +102,14 @@ pub mod macros;
 #[doc(inline)]
 pub use macros::*;
 
-pub use scylla_cql::frame;
+pub mod frame {
+    pub use scylla_cql::frame::{frame_errors, response, types, value, Authenticator, Compression};
+    pub(crate) use scylla_cql::frame::{
+        parse_response_body_extensions, protocol_features, read_response_frame, request,
+        server_event_type, FrameParams, SerializedRequest,
+    };
+}
+
 pub use scylla_cql::types::serialize;
 
 pub mod authentication;

--- a/scylla/tests/integration/lwt_optimisation.rs
+++ b/scylla/tests/integration/lwt_optimisation.rs
@@ -2,9 +2,10 @@ use crate::utils::{setup_tracing, test_with_3_node_cluster};
 
 use scylla::frame::types;
 use scylla::retry_policy::FallthroughRetryPolicy;
+use scylla::test_utils::unique_keyspace_name;
 use scylla::transport::session::Session;
-use scylla::{frame::protocol_features::ProtocolFeatures, test_utils::unique_keyspace_name};
 use scylla::{ExecutionProfile, SessionBuilder};
+use scylla_cql::frame::protocol_features::ProtocolFeatures;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 

--- a/scylla/tests/integration/lwt_optimisation.rs
+++ b/scylla/tests/integration/lwt_optimisation.rs
@@ -1,11 +1,10 @@
 use crate::utils::{setup_tracing, test_with_3_node_cluster};
-
-use scylla::frame::types;
 use scylla::retry_policy::FallthroughRetryPolicy;
 use scylla::test_utils::unique_keyspace_name;
 use scylla::transport::session::Session;
 use scylla::{ExecutionProfile, SessionBuilder};
 use scylla_cql::frame::protocol_features::ProtocolFeatures;
+use scylla_cql::frame::types;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 


### PR DESCRIPTION
## Motivation

Some definitions in `scylla-cql` crate need to be public, so the `scylla` crate can make use of them. However, currently all of the definitions are implicitly re-exported outside and can be seen by the driver users. The idea is to explicitly re-export the types/functions that should be visible outside (and leave the rest of the public definitions for the internal usage of `scylla` crate).

## re-exported types
The main difficulty was to decide on what types should be re-exported publicly. The types that got re-exported can be seen in the documentation (`cargo doc --open`).

### Error types
I wasn't sure whether error types such as `scylla_cql::frame::frame_errors::FrameError` should be public. As of now, they are left public but this can be further discussed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
