### PR TITLE
Remove `strum` and `strum_macros` dependencies

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -240,7 +240,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -655,15 +655,6 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -1370,12 +1361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
 name = "rustyline"
 version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,8 +1448,6 @@ dependencies = [
  "smallvec",
  "snap",
  "socket2",
- "strum",
- "strum_macros",
  "thiserror",
  "time",
  "tokio",
@@ -1654,25 +1637,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "syn"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -44,8 +44,6 @@ openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
 arc-swap = "1.3.0"
 dashmap = "5.2"
-strum = "0.23"
-strum_macros = "0.23"
 lz4_flex = { version = "0.11.1" }
 smallvec = "1.8.0"
 async-trait = "0.1.56"

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -255,8 +255,7 @@ pub struct MissingUserDefinedType {
     pub keyspace: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, EnumString)]
-#[strum(serialize_all = "lowercase")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NativeType {
     Ascii,
     Boolean,
@@ -278,6 +277,40 @@ pub enum NativeType {
     Timeuuid,
     Uuid,
     Varint,
+}
+
+/// [NativeType] parse error
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NativeTypeFromStrError;
+
+impl std::str::FromStr for NativeType {
+    type Err = NativeTypeFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascii" => Ok(Self::Ascii),
+            "boolean" => Ok(Self::Boolean),
+            "blob" => Ok(Self::Blob),
+            "counter" => Ok(Self::Counter),
+            "date" => Ok(Self::Date),
+            "decimal" => Ok(Self::Decimal),
+            "double" => Ok(Self::Double),
+            "duration" => Ok(Self::Duration),
+            "float" => Ok(Self::Float),
+            "int" => Ok(Self::Int),
+            "bigint" => Ok(Self::BigInt),
+            "text" => Ok(Self::Text),
+            "timestamp" => Ok(Self::Timestamp),
+            "inet" => Ok(Self::Inet),
+            "smallint" => Ok(Self::SmallInt),
+            "tinyint" => Ok(Self::TinyInt),
+            "time" => Ok(Self::Time),
+            "timeuuid" => Ok(Self::Timeuuid),
+            "uuid" => Ok(Self::Uuid),
+            "varint" => Ok(Self::Varint),
+            _ => Err(NativeTypeFromStrError),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -26,7 +26,6 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use strum_macros::EnumString;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
@@ -348,13 +347,30 @@ pub enum CollectionType {
     Set(Box<CqlType>),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, EnumString)]
-#[strum(serialize_all = "snake_case")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ColumnKind {
     Regular,
     Static,
     Clustering,
     PartitionKey,
+}
+
+/// [ColumnKind] parse error
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ColumnKindFromStrError;
+
+impl std::str::FromStr for ColumnKind {
+    type Err = ColumnKindFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "regular" => Ok(Self::Regular),
+            "static" => Ok(Self::Static),
+            "clustering" => Ok(Self::Clustering),
+            "partition_key" => Ok(Self::PartitionKey),
+            _ => Err(ColumnKindFromStrError),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/771

## Motivation
`strum` and `strum_macros` are unstable crates and their usages need to be removed from the public API to stabilize it.

These crates are responsible for generating `FromStr` implementations for the types.

## Changes
Replaced `strum` usages for `NativeType` and `ColumnKind` types with our own implementations of `FromStr`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
