### PR TITLE
Remove `histogram::Histogram` from public API

### DIFF
--- a/scylla/src/transport/metrics.rs
+++ b/scylla/src/transport/metrics.rs
@@ -1,30 +1,23 @@
 use histogram::Histogram;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::sync::{Arc, Mutex};
 
 const ORDER_TYPE: Ordering = Ordering::Relaxed;
 
 #[derive(Debug)]
-pub enum MetricsError<'a> {
-    Poison(PoisonError<MutexGuard<'a, Histogram>>),
-    Histogram(&'static str),
+pub struct MetricsError {
+    cause: &'static str,
 }
 
-impl<'a> From<PoisonError<MutexGuard<'a, Histogram>>> for MetricsError<'a> {
-    fn from(err: PoisonError<MutexGuard<'_, Histogram>>) -> MetricsError {
-        MetricsError::Poison(err)
-    }
-}
-
-impl From<&'static str> for MetricsError<'_> {
+impl From<&'static str> for MetricsError {
     fn from(err: &'static str) -> MetricsError {
-        MetricsError::Histogram(err)
+        MetricsError { cause: err }
     }
 }
 
-impl std::fmt::Display for MetricsError<'_> {
+impl std::fmt::Display for MetricsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "metrics error: {}", self.cause)
     }
 }
 


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/771

## Motivation
`histogram` is an unstable crate and the types introduced by this crate need to be removed from our public API. The only type being used is `histogram::Histogram`.

It's exposed publicly via `MetricsError::Poison`. However, the `MetricsError::Poison` value is never constructed since we always unwrap the `PoisonError` when trying to acquire the lock.

## Changes
Removed `MetricsError::Poison` and refactored `MetricsError` to be a struct holding an error cause (`&'static str` returned from the `histogram::Histogram` API).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
