### PR TITLE
Introduce support for Tablets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,10 +30,14 @@ jobs:
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
       run: cargo clippy --verbose --all-targets
+    - name: Clippy check with all features
+      run: cargo clippy --verbose --all-targets --all-features
     - name: Cargo check without features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features ""
     - name: Cargo check with all serialization features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "full-serialization"
+    - name: Cargo check with all features
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --all-features
     - name: Cargo check with secret feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secret"
     - name: Cargo check with chrono feature

--- a/.github/workflows/tablets.yml
+++ b/.github/workflows/tablets.yml
@@ -1,0 +1,38 @@
+name: Tablets
+
+on:
+  push:
+    branches:
+    - main
+    - 'branch-*'
+  pull_request:
+    branches:
+    - main
+    - 'branch-*'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install scylla-ccm
+        run: pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
+
+      - name: Create cluster with tablets enabled
+        run: |
+          ccm create tablets -i 127.0.1. -n 3 --scylla -v 'unstable/master:2024-05-01T18:26:10Z'
+          ccm updateconf 'experimental_features: [consistent-topology-changes, tablets]'
+          ccm start
+
+      - name: Check
+        run: cargo check --verbose
+      - name: Run tablets tests
+        run: SCYLLA_URI=127.0.1.1:9042 SCYLLA_URI2=127.0.1.2:9042 SCYLLA_URI3=127.0.1.3:9042 cargo test --verbose
+
+      - name: Remove tablets cluster
+        run: ccm remove tablets

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -465,7 +465,7 @@ checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -518,7 +518,7 @@ checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -806,9 +806,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -891,13 +891,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1380,7 +1380,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1631,12 +1631,12 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1783,9 +1783,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1797,14 +1797,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2146,6 +2146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +37,12 @@ checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -656,6 +674,10 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1431,8 +1453,10 @@ dependencies = [
  "criterion",
  "dashmap",
  "futures",
+ "hashbrown 0.14.0",
  "histogram",
  "itertools 0.11.0",
+ "lazy_static",
  "lz4_flex",
  "ntest",
  "num-bigint 0.3.3",
@@ -2245,6 +2269,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ COMPOSE := docker compose -f test/cluster/docker-compose.yml
 all: test
 
 .PHONY: ci
-ci: fmt-check check check-without-features clippy test build
+ci: fmt-check check check-without-features check-all-features clippy clippy-all-features test build
 
 .PHONY: dockerized-ci
-dockerized-ci: fmt-check check check-without-features clippy dockerized-test build
+dockerized-ci: fmt-check check check-without-features check-all-features clippy clippy-all-features dockerized-test build
 
 .PHONY: fmt
 fmt:
@@ -25,9 +25,17 @@ check:
 check-without-features:
 	cargo check --manifest-path "scylla/Cargo.toml" --features "" --all-targets
 
+.PHONY: check-all-features
+check-all-features:
+	cargo check --all-targets --all-features
+
 .PHONY: clippy
 clippy:
 	RUSTFLAGS=-Dwarnings cargo clippy --all-targets
+
+.PHONY: clippy-all-features
+clippy-all-features:
+	RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features
 
 .PHONY: test
 test: up

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
             "Token endpoints for query: {:?}",
             session
                 .get_cluster_data()
-                .get_token_endpoints("examples_ks", Token::new(t))
+                .get_token_endpoints("examples_ks", "compare_tokens", Token::new(t))
                 .iter()
                 .map(|(node, _shard)| node.address)
                 .collect::<Vec<NodeAddr>>()

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -36,7 +36,7 @@ pub struct SchemaChange {
     pub event: SchemaChangeEvent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableSpec<'a> {
     ks_name: Cow<'a, str>,
     table_name: Cow<'a, str>,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -7,6 +7,7 @@ use crate::frame::value::{
 use crate::frame::{frame_errors::ParseError, types};
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{Buf, Bytes};
+use std::borrow::Cow;
 use std::{
     convert::{TryFrom, TryInto},
     net::IpAddr,
@@ -36,9 +37,9 @@ pub struct SchemaChange {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TableSpec {
-    pub ks_name: String,
-    pub table_name: String,
+pub struct TableSpec<'a> {
+    ks_name: Cow<'a, str>,
+    table_name: Cow<'a, str>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -114,6 +115,40 @@ pub enum CqlValue {
     Tuple(Vec<Option<CqlValue>>),
     Uuid(Uuid),
     Varint(CqlVarint),
+}
+
+impl<'a> TableSpec<'a> {
+    pub const fn borrowed(ks: &'a str, table: &'a str) -> Self {
+        Self {
+            ks_name: Cow::Borrowed(ks),
+            table_name: Cow::Borrowed(table),
+        }
+    }
+
+    pub fn ks_name(&'a self) -> &'a str {
+        self.ks_name.as_ref()
+    }
+
+    pub fn table_name(&'a self) -> &'a str {
+        self.table_name.as_ref()
+    }
+
+    pub fn into_owned(self) -> TableSpec<'static> {
+        TableSpec::owned(self.ks_name.into_owned(), self.table_name.into_owned())
+    }
+
+    pub fn to_owned(&self) -> TableSpec<'static> {
+        TableSpec::owned(self.ks_name().to_owned(), self.table_name().to_owned())
+    }
+}
+
+impl TableSpec<'static> {
+    pub fn owned(ks_name: String, table_name: String) -> Self {
+        Self {
+            ks_name: Cow::Owned(ks_name),
+            table_name: Cow::Owned(table_name),
+        }
+    }
 }
 
 impl ColumnType {
@@ -381,7 +416,7 @@ impl CqlValue {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnSpec {
-    pub table_spec: TableSpec,
+    pub table_spec: TableSpec<'static>,
     pub name: String,
     pub typ: ColumnType,
 }
@@ -441,13 +476,10 @@ pub enum Result {
     SchemaChange(SchemaChange),
 }
 
-fn deser_table_spec(buf: &mut &[u8]) -> StdResult<TableSpec, ParseError> {
+fn deser_table_spec(buf: &mut &[u8]) -> StdResult<TableSpec<'static>, ParseError> {
     let ks_name = types::read_string(buf)?.to_owned();
     let table_name = types::read_string(buf)?.to_owned();
-    Ok(TableSpec {
-        ks_name,
-        table_name,
-    })
+    Ok(TableSpec::owned(ks_name, table_name))
 }
 
 fn deser_type(buf: &mut &[u8]) -> StdResult<ColumnType, ParseError> {
@@ -521,7 +553,7 @@ fn deser_type(buf: &mut &[u8]) -> StdResult<ColumnType, ParseError> {
 
 fn deser_col_specs(
     buf: &mut &[u8],
-    global_table_spec: &Option<TableSpec>,
+    global_table_spec: &Option<TableSpec<'static>>,
     col_count: usize,
 ) -> StdResult<Vec<ColumnSpec>, ParseError> {
     let mut col_specs = Vec::with_capacity(col_count);

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1077,10 +1077,7 @@ fn vec_value_list() {
 
 fn col_spec(name: &str, typ: ColumnType) -> ColumnSpec {
     ColumnSpec {
-        table_spec: TableSpec {
-            ks_name: "ks".to_string(),
-            table_name: "tbl".to_string(),
-        },
+        table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
         name: name.to_string(),
         typ,
     }

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -869,10 +869,7 @@ mod tests {
 
     fn col_spec(name: &str, typ: ColumnType) -> ColumnSpec {
         ColumnSpec {
-            table_spec: TableSpec {
-                ks_name: "ks".to_string(),
-                table_name: "tbl".to_string(),
-            },
+            table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
             name: name.to_string(),
             typ,
         }
@@ -994,10 +991,7 @@ mod tests {
 
     fn col(name: &str, typ: ColumnType) -> ColumnSpec {
         ColumnSpec {
-            table_spec: TableSpec {
-                ks_name: "ks".to_string(),
-                table_name: "tbl".to_string(),
-            },
+            table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
             name: name.to_string(),
             typ,
         }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
 histogram = "0.6.9"
-tokio = { version = "1.27", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
+tokio = { version = "1.34", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8.3"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -31,6 +31,7 @@ scylla-cql = { version = "0.1.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
+hashbrown = "0.14"
 histogram = "0.6.9"
 tokio = { version = "1.27", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
 snap = "1.0"
@@ -53,6 +54,7 @@ url = { version = "2.3.1", optional = true }
 base64 = { version = "0.21.1", optional = true }
 rand_pcg = "0.3.1"
 socket2 = { version = "0.5.3", features = ["all"] }
+lazy_static = "1"
 
 [dev-dependencies]
 num-bigint-03 = { package = "num-bigint", version = "0.3" }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -1,5 +1,8 @@
 use bytes::{Bytes, BytesMut};
 use scylla_cql::errors::{BadQuery, QueryError};
+use scylla_cql::frame::response::result::{
+    ColumnSpec, PartitionKeyIndex, ResultMetadata, TableSpec,
+};
 use scylla_cql::frame::types::RawValue;
 use scylla_cql::types::serialize::row::{RowSerializationContext, SerializeRow, SerializedValues};
 use scylla_cql::types::serialize::SerializationError;
@@ -9,8 +12,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use uuid::Uuid;
-
-use scylla_cql::frame::response::result::{ColumnSpec, PartitionKeyIndex, ResultMetadata};
 
 use super::StatementConfig;
 use crate::frame::response::result::PreparedMetadata;
@@ -206,6 +207,14 @@ impl PreparedStatement {
     ) -> Result<Option<Token>, QueryError> {
         self.extract_partition_key_and_calculate_token(&self.partitioner_name, values)
             .map(|opt| opt.map(|(_pk, token)| token))
+    }
+
+    /// Return keyspace name and table name this statement is operating on.
+    pub fn get_table_spec(&self) -> Option<&TableSpec> {
+        self.get_prepared_metadata()
+            .col_specs
+            .first()
+            .map(|spec| &spec.table_spec)
     }
 
     /// Returns the name of the keyspace this statement is operating on.

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -213,7 +213,7 @@ impl PreparedStatement {
         self.get_prepared_metadata()
             .col_specs
             .first()
-            .map(|col_spec| col_spec.table_spec.ks_name.as_str())
+            .map(|col_spec| col_spec.table_spec.ks_name())
     }
 
     /// Returns the name of the table this statement is operating on.
@@ -221,7 +221,7 @@ impl PreparedStatement {
         self.get_prepared_metadata()
             .col_specs
             .first()
-            .map(|col_spec| col_spec.table_spec.table_name.as_str())
+            .map(|col_spec| col_spec.table_spec.table_name())
     }
 
     /// Sets the consistency to be used when executing this statement.
@@ -540,10 +540,7 @@ mod tests {
         cols: impl IntoIterator<Item = ColumnType>,
         idx: impl IntoIterator<Item = usize>,
     ) -> PreparedMetadata {
-        let table_spec = TableSpec {
-            ks_name: "ks".to_owned(),
-            table_name: "t".to_owned(),
-        };
+        let table_spec = TableSpec::owned("ks".to_owned(), "t".to_owned());
         let col_specs: Vec<_> = cols
             .into_iter()
             .enumerate()

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -292,7 +292,6 @@ impl ClusterData {
             HashMap::with_capacity(metadata.peers.len());
         let mut ring: Vec<(Token, Arc<Node>)> = Vec::new();
         let mut datacenters: HashMap<String, Datacenter> = HashMap::new();
-        let mut all_nodes: Vec<Arc<Node>> = Vec::with_capacity(metadata.peers.len());
 
         for peer in metadata.peers {
             // Take existing Arc<Node> if possible, otherwise create new one
@@ -344,8 +343,6 @@ impl ClusterData {
             for token in peer_tokens {
                 ring.push((token, node.clone()));
             }
-
-            all_nodes.push(node);
         }
 
         Self::update_rack_count(&mut datacenters);

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1461,7 +1461,7 @@ async fn maybe_translated_addr(
 pub(crate) async fn open_connection(
     endpoint: UntranslatedEndpoint,
     source_port: Option<u16>,
-    config: ConnectionConfig,
+    config: &ConnectionConfig,
 ) -> Result<(Connection, ErrorReceiver), QueryError> {
     let addr = maybe_translated_addr(endpoint, config.address_translator.as_deref()).await?;
     open_named_connection(
@@ -1477,7 +1477,7 @@ pub(crate) async fn open_connection(
 pub(crate) async fn open_named_connection(
     addr: SocketAddr,
     source_port: Option<u16>,
-    config: ConnectionConfig,
+    config: &ConnectionConfig,
     driver_name: Option<String>,
     driver_version: Option<String>,
 ) -> Result<(Connection, ErrorReceiver), QueryError> {
@@ -1924,7 +1924,7 @@ mod tests {
                 datacenter: None,
             }),
             None,
-            ConnectionConfig::default(),
+            &ConnectionConfig::default(),
         )
         .await
         .unwrap();
@@ -2049,7 +2049,7 @@ mod tests {
                     datacenter: None,
                 }),
                 None,
-                ConnectionConfig {
+                &ConnectionConfig {
                     enable_write_coalescing: enable_coalescing,
                     ..ConnectionConfig::default()
                 },
@@ -2178,7 +2178,7 @@ mod tests {
 
         // We must interrupt the driver's full connection opening, because our proxy does not interact further after Startup.
         let (startup_without_lwt_optimisation, _shard) = select! {
-            _ = open_connection(UntranslatedEndpoint::ContactPoint(ResolvedContactPoint{address: proxy_addr, datacenter: None}), None, config.clone()) => unreachable!(),
+            _ = open_connection(UntranslatedEndpoint::ContactPoint(ResolvedContactPoint{address: proxy_addr, datacenter: None}), None, &config) => unreachable!(),
             startup = startup_rx.recv() => startup.unwrap(),
         };
 
@@ -2186,7 +2186,7 @@ mod tests {
             .change_request_rules(Some(make_rules(options_with_lwt_optimisation_support)));
 
         let (startup_with_lwt_optimisation, _shard) = select! {
-            _ = open_connection(UntranslatedEndpoint::ContactPoint(ResolvedContactPoint{address: proxy_addr, datacenter: None}), None, config.clone()) => unreachable!(),
+            _ = open_connection(UntranslatedEndpoint::ContactPoint(ResolvedContactPoint{address: proxy_addr, datacenter: None}), None, &config) => unreachable!(),
             startup = startup_rx.recv() => startup.unwrap(),
         };
 
@@ -2247,7 +2247,7 @@ mod tests {
                 datacenter: None,
             }),
             None,
-            config,
+            &config,
         )
         .await
         .unwrap();

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -217,6 +217,8 @@ pub(crate) struct QueryResponse {
     pub(crate) response: Response,
     pub(crate) tracing_id: Option<Uuid>,
     pub(crate) warnings: Vec<String>,
+    #[allow(dead_code)] // This is not exposed to user (yet?)
+    pub(crate) custom_payload: Option<HashMap<String, Vec<u8>>>,
 }
 
 // A QueryResponse in which response can not be Response::Error
@@ -1034,6 +1036,7 @@ impl Connection {
             response,
             warnings: body_with_ext.warnings,
             tracing_id: body_with_ext.trace_id,
+            custom_payload: body_with_ext.custom_payload,
         })
     }
 

--- a/scylla/src/transport/connection_pool.rs
+++ b/scylla/src/transport/connection_pool.rs
@@ -950,7 +950,8 @@ impl PoolRefiller {
             .boxed(),
             _ => async move {
                 let non_shard_aware_endpoint = endpoint_fut.await;
-                let result = connection::open_connection(non_shard_aware_endpoint, None, cfg).await;
+                let result =
+                    connection::open_connection(non_shard_aware_endpoint, None, &cfg).await;
                 OpenedConnectionEvent {
                     result,
                     requested_shard: None,
@@ -1242,8 +1243,7 @@ async fn open_connection_to_shard_aware_port(
 
     for port in source_port_iter {
         let connect_result =
-            connection::open_connection(endpoint.clone(), Some(port), connection_config.clone())
-                .await;
+            connection::open_connection(endpoint.clone(), Some(port), connection_config).await;
 
         match connect_result {
             Err(err) if err.is_address_unavailable_for_use() => continue, // If we can't use this port, try the next one

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -248,11 +248,12 @@ impl RowIterator {
                 }
             };
 
+            let table_spec = config.prepared.get_table_spec();
             let statement_info = RoutingInfo {
                 consistency,
                 serial_consistency,
                 token,
-                keyspace: config.prepared.get_keyspace_name(),
+                table: table_spec,
                 is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
             };
 
@@ -273,13 +274,13 @@ impl RowIterator {
             let serialized_values_size = config.values.buffer_size();
 
             let replicas: Option<smallvec::SmallVec<[_; 8]>> =
-                if let (Some(keyspace), Some(token)) =
-                    (statement_info.keyspace.as_ref(), statement_info.token)
+                if let (Some(table_spec), Some(token)) =
+                    (statement_info.table, statement_info.token)
                 {
                     Some(
                         config
                             .cluster_data
-                            .get_token_endpoints_iter(keyspace, token)
+                            .get_token_endpoints_iter(table_spec, token)
                             .map(|(node, shard)| (node.clone(), shard))
                             .collect(),
                     )

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -988,7 +988,10 @@ mod tests {
             routing::Token,
             test_utils::setup_tracing,
             transport::{
-                locator::test::{id_to_invalid_addr, mock_metadata_for_token_aware_tests},
+                locator::{
+                    tablets::TabletsInfo,
+                    test::{id_to_invalid_addr, mock_metadata_for_token_aware_tests},
+                },
                 topology::{Metadata, Peer},
                 ClusterData,
             },
@@ -1189,7 +1192,15 @@ mod tests {
         // based on locator mock cluster
         pub(crate) async fn mock_cluster_data_for_token_aware_tests() -> ClusterData {
             let metadata = mock_metadata_for_token_aware_tests();
-            ClusterData::new(metadata, &Default::default(), &HashMap::new(), &None, None).await
+            ClusterData::new(
+                metadata,
+                &Default::default(),
+                &HashMap::new(),
+                &None,
+                None,
+                TabletsInfo::new(),
+            )
+            .await
         }
 
         // creates ClusterData with info about 5 nodes living in 2 different datacenters
@@ -1211,7 +1222,15 @@ mod tests {
                 keyspaces: HashMap::new(),
             };
 
-            ClusterData::new(info, &Default::default(), &HashMap::new(), &None, None).await
+            ClusterData::new(
+                info,
+                &Default::default(),
+                &HashMap::new(),
+                &None,
+                None,
+                TabletsInfo::new(),
+            )
+            .await
         }
 
         pub(crate) fn get_plan_and_collect_node_identifiers(

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -9,7 +9,10 @@ use crate::{
 use itertools::{Either, Itertools};
 use rand::{prelude::SliceRandom, thread_rng, Rng};
 use rand_pcg::Pcg32;
-use scylla_cql::{errors::QueryError, frame::types::SerialConsistency, Consistency};
+use scylla_cql::errors::QueryError;
+use scylla_cql::frame::response::result::TableSpec;
+use scylla_cql::frame::types::SerialConsistency;
+use scylla_cql::Consistency;
 use std::hash::{Hash, Hasher};
 use std::{fmt, sync::Arc, time::Duration};
 use tracing::{debug, warn};
@@ -122,7 +125,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         } else {
             StatementType::NonLwt
         };
-        if let Some(ts) = &routing_info.token_with_strategy {
+        if let (Some(ts), Some(table_spec)) = (&routing_info.token_with_strategy, query.table) {
             if let NodeLocationPreference::DatacenterAndRack(dc, rack) = &self.preferences {
                 // Try to pick some alive local rack random replica.
                 let local_rack_picked = self.pick_replica(
@@ -131,6 +134,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                     |node, shard| (self.pick_predicate)(node, Some(shard)),
                     cluster,
                     statement_type,
+                    table_spec,
                 );
 
                 if let Some((alive_local_rack_replica, shard)) = local_rack_picked {
@@ -148,6 +152,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                     |node, shard| (self.pick_predicate)(node, Some(shard)),
                     cluster,
                     statement_type,
+                    table_spec,
                 );
 
                 if let Some((alive_local_replica, shard)) = picked {
@@ -166,6 +171,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                     |node, shard| (self.pick_predicate)(node, Some(shard)),
                     cluster,
                     statement_type,
+                    table_spec,
                 );
                 if let Some((alive_remote_replica, shard)) = picked {
                     return Some((alive_remote_replica, Some(shard)));
@@ -237,7 +243,9 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         };
 
         // If token is available, get a shuffled list of alive replicas.
-        let maybe_replicas = if let Some(ts) = &routing_info.token_with_strategy {
+        let maybe_replicas = if let (Some(ts), Some(table_spec)) =
+            (&routing_info.token_with_strategy, query.table)
+        {
             let maybe_local_rack_replicas =
                 if let NodeLocationPreference::DatacenterAndRack(dc, rack) = &self.preferences {
                     let local_rack_replicas = self.fallback_replicas(
@@ -246,6 +254,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                         |node, shard| Self::is_alive(node, Some(shard)),
                         cluster,
                         statement_type,
+                        table_spec,
                     );
                     Either::Left(local_rack_replicas)
                 } else {
@@ -262,6 +271,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                     |node, shard| Self::is_alive(node, Some(shard)),
                     cluster,
                     statement_type,
+                    table_spec,
                 );
                 Either::Left(local_replicas)
             } else {
@@ -278,6 +288,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                     |node, shard| Self::is_alive(node, Some(shard)),
                     cluster,
                     statement_type,
+                    table_spec,
                 );
                 Either::Left(remote_replicas)
             } else {
@@ -459,12 +470,13 @@ impl DefaultPolicy {
         ts: &TokenWithStrategy<'a>,
         replica_location: NodeLocationCriteria<'a>,
         cluster: &'a ClusterData,
+        table_spec: &TableSpec,
     ) -> ReplicaSet<'a> {
         let datacenter = replica_location.datacenter();
 
         cluster
             .replica_locator()
-            .replicas_for_token(ts.token, ts.strategy, datacenter)
+            .replicas_for_token(ts.token, ts.strategy, datacenter, table_spec)
     }
 
     /// Wraps the provided predicate, adding the requirement for rack to match.
@@ -502,16 +514,17 @@ impl DefaultPolicy {
         predicate: impl Fn(NodeRef<'a>, Shard) -> bool + 'a,
         cluster: &'a ClusterData,
         order: ReplicaOrder,
+        table_spec: &TableSpec,
     ) -> impl Iterator<Item = (NodeRef<'a>, Shard)> {
         let predicate = Self::make_sharded_rack_predicate(predicate, replica_location);
 
         let replica_iter = match order {
             ReplicaOrder::Arbitrary => Either::Left(
-                self.nonfiltered_replica_set(ts, replica_location, cluster)
+                self.nonfiltered_replica_set(ts, replica_location, cluster, table_spec)
                     .into_iter(),
             ),
             ReplicaOrder::RingOrder => Either::Right(
-                self.nonfiltered_replica_set(ts, replica_location, cluster)
+                self.nonfiltered_replica_set(ts, replica_location, cluster, table_spec)
                     .into_replicas_ordered()
                     .into_iter(),
             ),
@@ -526,11 +539,14 @@ impl DefaultPolicy {
         predicate: impl Fn(NodeRef<'a>, Shard) -> bool + 'a,
         cluster: &'a ClusterData,
         statement_type: StatementType,
+        table_spec: &TableSpec,
     ) -> Option<(NodeRef<'a>, Shard)> {
         match statement_type {
-            StatementType::Lwt => self.pick_first_replica(ts, replica_location, predicate, cluster),
+            StatementType::Lwt => {
+                self.pick_first_replica(ts, replica_location, predicate, cluster, table_spec)
+            }
             StatementType::NonLwt => {
-                self.pick_random_replica(ts, replica_location, predicate, cluster)
+                self.pick_random_replica(ts, replica_location, predicate, cluster, table_spec)
             }
         }
     }
@@ -553,6 +569,7 @@ impl DefaultPolicy {
         replica_location: NodeLocationCriteria<'a>,
         predicate: impl Fn(NodeRef<'a>, Shard) -> bool + 'a,
         cluster: &'a ClusterData,
+        table_spec: &TableSpec,
     ) -> Option<(NodeRef<'a>, Shard)> {
         match replica_location {
             NodeLocationCriteria::Any => {
@@ -566,7 +583,7 @@ impl DefaultPolicy {
                 // (computation of the remaining ones is expensive), in case that the primary replica
                 // does not satisfy the `predicate`, None is returned. All expensive computation
                 // is to be done only when `fallback()` is called.
-                self.nonfiltered_replica_set(ts, replica_location, cluster)
+                self.nonfiltered_replica_set(ts, replica_location, cluster, table_spec)
                     .into_replicas_ordered()
                     .into_iter()
                     .next()
@@ -586,6 +603,7 @@ impl DefaultPolicy {
                     predicate,
                     cluster,
                     ReplicaOrder::RingOrder,
+                    table_spec,
                 )
                 .next()
             }
@@ -598,10 +616,11 @@ impl DefaultPolicy {
         replica_location: NodeLocationCriteria<'a>,
         predicate: impl Fn(NodeRef<'a>, Shard) -> bool + 'a,
         cluster: &'a ClusterData,
+        table_spec: &TableSpec,
     ) -> Option<(NodeRef<'a>, Shard)> {
         let predicate = Self::make_sharded_rack_predicate(predicate, replica_location);
 
-        let replica_set = self.nonfiltered_replica_set(ts, replica_location, cluster);
+        let replica_set = self.nonfiltered_replica_set(ts, replica_location, cluster, table_spec);
 
         if let Some(fixed) = self.fixed_seed {
             let mut gen = Pcg32::new(fixed, 0);
@@ -618,13 +637,14 @@ impl DefaultPolicy {
         predicate: impl Fn(NodeRef<'_>, Shard) -> bool + 'a,
         cluster: &'a ClusterData,
         statement_type: StatementType,
+        table_spec: &TableSpec,
     ) -> impl Iterator<Item = (NodeRef<'_>, Shard)> {
         let order = match statement_type {
             StatementType::Lwt => ReplicaOrder::RingOrder,
             StatementType::NonLwt => ReplicaOrder::Arbitrary,
         };
 
-        let replicas = self.replicas(ts, replica_location, predicate, cluster, order);
+        let replicas = self.replicas(ts, replica_location, predicate, cluster, order, table_spec);
 
         match statement_type {
             // As an LWT optimisation: in order to reduce contention caused by Paxos conflicts,
@@ -930,7 +950,7 @@ struct TokenWithStrategy<'a> {
 impl<'a> TokenWithStrategy<'a> {
     fn new(query: &'a RoutingInfo, cluster: &'a ClusterData) -> Option<TokenWithStrategy<'a>> {
         let token = query.token?;
-        let keyspace_name = query.keyspace?;
+        let keyspace_name = query.table?.ks_name();
         let keyspace = cluster.get_keyspace_info().get(keyspace_name)?;
         let strategy = &keyspace.strategy;
         Some(TokenWithStrategy { strategy, token })
@@ -946,16 +966,14 @@ mod tests {
         get_plan_and_collect_node_identifiers, mock_cluster_data_for_token_unaware_tests,
         ExpectedGroups, ExpectedGroupsBuilder,
     };
+    use crate::transport::locator::test::{TABLE_NTS_RF_2, TABLE_NTS_RF_3, TABLE_SS_RF_2};
     use crate::{
         load_balancing::{
             default::tests::framework::mock_cluster_data_for_token_aware_tests, Plan, RoutingInfo,
         },
         routing::Token,
         test_utils::setup_tracing,
-        transport::{
-            locator::test::{KEYSPACE_NTS_RF_2, KEYSPACE_NTS_RF_3, KEYSPACE_SS_RF_2},
-            ClusterData,
-        },
+        transport::ClusterData,
     };
 
     use super::{DefaultPolicy, NodeLocationPreference};
@@ -1209,7 +1227,7 @@ mod tests {
 
     pub(crate) const EMPTY_ROUTING_INFO: RoutingInfo = RoutingInfo {
         token: None,
-        keyspace: None,
+        table: None,
         is_confirmed_lwt: false,
         consistency: Consistency::Quorum,
         serial_consistency: Some(SerialConsistency::Serial),
@@ -1316,7 +1334,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
@@ -1341,7 +1359,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
@@ -1365,7 +1383,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::LocalOne, // local Consistency forbids datacenter failover
                     ..Default::default()
                 },
@@ -1387,7 +1405,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::One,
                     ..Default::default()
                 },
@@ -1409,7 +1427,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1434,7 +1452,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1458,7 +1476,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1480,7 +1498,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
@@ -1504,7 +1522,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::LocalOne, // local Consistency forbids datacenter failover
                     ..Default::default()
                 },
@@ -1526,7 +1544,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: None, // no token
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1545,7 +1563,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: None, // no keyspace
+                    table: None, // no keyspace
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1564,7 +1582,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1586,7 +1604,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1605,7 +1623,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1627,7 +1645,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     ..Default::default()
                 },
@@ -1652,7 +1670,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::One,
                     ..Default::default()
                 },
@@ -1680,7 +1698,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(560)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::Two,
                     ..Default::default()
                 },
@@ -1707,7 +1725,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::One,
                     ..Default::default()
                 },
@@ -1733,7 +1751,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: None,
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::One,
                     ..Default::default()
                 },
@@ -1788,7 +1806,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Two,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1814,7 +1832,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Two,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1839,7 +1857,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::LocalOne, // local Consistency forbids datacenter failover
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1862,7 +1880,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::One,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1885,7 +1903,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1911,7 +1929,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1936,7 +1954,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1959,7 +1977,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::Two,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -1984,7 +2002,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::LocalOne, // local Consistency forbids datacenter failover
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2007,7 +2025,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: None, // no token
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2027,7 +2045,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: None, // no keyspace
+                    table: None, // no keyspace
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2047,7 +2065,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2070,7 +2088,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2090,7 +2108,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2113,7 +2131,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_2),
+                    table: Some(TABLE_NTS_RF_2),
                     consistency: Consistency::Quorum,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2139,7 +2157,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_NTS_RF_3),
+                    table: Some(TABLE_NTS_RF_3),
                     consistency: Consistency::One,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2168,7 +2186,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(760)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::Two,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2195,7 +2213,7 @@ mod tests {
                 },
                 routing_info: RoutingInfo {
                     token: Some(Token::new(160)),
-                    keyspace: Some(KEYSPACE_SS_RF_2),
+                    table: Some(TABLE_SS_RF_2),
                     consistency: Consistency::One,
                     is_confirmed_lwt: true,
                     ..Default::default()
@@ -2804,6 +2822,7 @@ mod latency_awareness {
             load_balancing::default::NodeLocationPreference,
             routing::Shard,
             test_utils::{create_new_session_builder, setup_tracing},
+            transport::locator::test::{TABLE_INVALID, TABLE_NTS_RF_2, TABLE_NTS_RF_3},
         };
         use crate::{
             load_balancing::{
@@ -2812,9 +2831,7 @@ mod latency_awareness {
             },
             routing::Token,
             transport::{
-                locator::test::{
-                    id_to_invalid_addr, A, B, C, D, E, F, G, KEYSPACE_NTS_RF_2, KEYSPACE_NTS_RF_3,
-                },
+                locator::test::{id_to_invalid_addr, A, B, C, D, E, F, G},
                 ClusterData, NodeAddr,
             },
             ExecutionProfile,
@@ -3407,7 +3424,7 @@ mod latency_awareness {
                     ],
                     routing_info: RoutingInfo {
                         token: Some(Token::new(160)),
-                        keyspace: Some(KEYSPACE_NTS_RF_3),
+                        table: Some(TABLE_NTS_RF_3),
                         consistency: Consistency::Quorum,
                         ..Default::default()
                     },
@@ -3427,7 +3444,7 @@ mod latency_awareness {
                     preset_min_avg: Some(100 * min_avg),
                     routing_info: RoutingInfo {
                         token: Some(Token::new(160)),
-                        keyspace: Some(KEYSPACE_NTS_RF_3),
+                        table: Some(TABLE_NTS_RF_3),
                         consistency: Consistency::Quorum,
                         ..Default::default()
                     },
@@ -3456,7 +3473,7 @@ mod latency_awareness {
                     ],
                     routing_info: RoutingInfo {
                         token: Some(Token::new(160)),
-                        keyspace: Some(KEYSPACE_NTS_RF_2),
+                        table: Some(TABLE_NTS_RF_2),
                         consistency: Consistency::Quorum,
                         ..Default::default()
                     },
@@ -3475,7 +3492,7 @@ mod latency_awareness {
                     preset_min_avg: None,
                     routing_info: RoutingInfo {
                         token: Some(Token::new(160)),
-                        keyspace: Some("invalid"),
+                        table: Some(TABLE_INVALID),
                         consistency: Consistency::Quorum,
                         ..Default::default()
                     },

--- a/scylla/src/transport/load_balancing/mod.rs
+++ b/scylla/src/transport/load_balancing/mod.rs
@@ -4,7 +4,10 @@
 
 use super::{cluster::ClusterData, NodeRef};
 use crate::routing::{Shard, Token};
-use scylla_cql::{errors::QueryError, frame::types};
+use scylla_cql::{
+    errors::QueryError,
+    frame::{response::result::TableSpec, types},
+};
 
 use std::time::Duration;
 
@@ -22,9 +25,11 @@ pub struct RoutingInfo<'a> {
     pub consistency: types::Consistency,
     pub serial_consistency: Option<types::SerialConsistency>,
 
-    /// Information about token and keyspace is the basis of token-aware routing.
+    /// Information that are the basis of token-aware routing:
+    /// - token, keyspace for vnodes-based routing;
+    /// - token, keyspace, table for tablets-based routing.
     pub token: Option<Token>,
-    pub keyspace: Option<&'a str>,
+    pub table: Option<&'a TableSpec<'a>>,
 
     /// If, while preparing, we received from the cluster information that the statement is an LWT,
     /// then we can use this information for routing optimisation. Namely, an optimisation

--- a/scylla/src/transport/load_balancing/plan.rs
+++ b/scylla/src/transport/load_balancing/plan.rs
@@ -179,7 +179,10 @@ mod tests {
     fn expected_nodes() -> Vec<(Arc<Node>, Shard)> {
         vec![(
             Arc::new(Node::new_for_test(
-                NodeAddr::Translatable(SocketAddr::from_str("127.0.0.1:9042").unwrap()),
+                None,
+                Some(NodeAddr::Translatable(
+                    SocketAddr::from_str("127.0.0.1:9042").unwrap(),
+                )),
                 None,
                 None,
             )),

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -1,6 +1,7 @@
 mod precomputed_replicas;
 mod replicas;
 mod replication_info;
+pub(crate) mod tablets;
 #[cfg(test)]
 pub(crate) mod test;
 mod token_ring;

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -10,6 +10,8 @@ use rand::{seq::IteratorRandom, Rng};
 use scylla_cql::frame::response::result::TableSpec;
 pub use token_ring::TokenRing;
 
+use self::tablets::TabletsInfo;
+
 use super::{topology::Strategy, Node, NodeRef};
 use crate::routing::{Shard, Token};
 use itertools::Itertools;
@@ -34,6 +36,8 @@ pub struct ReplicaLocator {
     precomputed_replicas: PrecomputedReplicas,
 
     datacenters: Vec<String>,
+
+    pub(crate) tablets: TabletsInfo,
 }
 
 impl ReplicaLocator {
@@ -43,6 +47,7 @@ impl ReplicaLocator {
     pub(crate) fn new<'a>(
         ring_iter: impl Iterator<Item = (Token, Arc<Node>)>,
         precompute_replica_sets_for: impl Iterator<Item = &'a Strategy>,
+        tablets: TabletsInfo,
     ) -> Self {
         let replication_data = ReplicationInfo::new(ring_iter);
         let precomputed_replicas =
@@ -60,6 +65,7 @@ impl ReplicaLocator {
             replication_data,
             precomputed_replicas,
             datacenters,
+            tablets,
         }
     }
 

--- a/scylla/src/transport/locator/tablets.rs
+++ b/scylla/src/transport/locator/tablets.rs
@@ -1,0 +1,726 @@
+#![allow(dead_code)]
+use lazy_static::lazy_static;
+use scylla_cql::cql_to_rust::FromCqlVal;
+use scylla_cql::frame::frame_errors::ParseError;
+use scylla_cql::frame::response::result::{deser_cql_value, ColumnType, TableSpec};
+use thiserror::Error;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::routing::{Shard, Token};
+use crate::transport::Node;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Error, Debug)]
+pub(crate) enum TabletParsingError {
+    #[error(transparent)]
+    Parse(#[from] ParseError),
+    #[error("Shard id for tablet is negative: {0}")]
+    ShardNum(i32),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RawTabletReplicas {
+    replicas: Vec<(Uuid, Shard)>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RawTablet {
+    /// First token belonging to the tablet, inclusive
+    first_token: Token,
+    /// Last token belonging to the tablet, inclusive
+    last_token: Token,
+    replicas: RawTabletReplicas,
+}
+
+type RawTabletPayload = (i64, i64, Vec<(Uuid, i32)>);
+
+lazy_static! {
+    static ref RAW_TABLETS_CQL_TYPE: ColumnType = ColumnType::Tuple(vec![
+        ColumnType::BigInt,
+        ColumnType::BigInt,
+        ColumnType::List(Box::new(ColumnType::Tuple(vec![
+            ColumnType::Uuid,
+            ColumnType::Int,
+        ]))),
+    ]);
+}
+
+const CUSTOM_PAYLOAD_TABLETS_V1_KEY: &str = "tablets-routing-v1";
+
+impl RawTablet {
+    pub(crate) fn from_custom_payload(
+        payload: &HashMap<String, Vec<u8>>,
+    ) -> Option<Result<RawTablet, TabletParsingError>> {
+        let payload = payload.get(CUSTOM_PAYLOAD_TABLETS_V1_KEY)?;
+        let cql_value = match deser_cql_value(&RAW_TABLETS_CQL_TYPE, &mut payload.as_slice()) {
+            Ok(r) => r,
+            Err(e) => return Some(Err(e.into())),
+        };
+
+        // This could only fail if the type was wrong, but we do pass correct type
+        // to `deser_cql_value`.
+        let (first_token, last_token, replicas): RawTabletPayload =
+            FromCqlVal::from_cql(cql_value).unwrap();
+
+        let replicas = match replicas
+            .into_iter()
+            .map(|(uuid, shard_num)| match shard_num.try_into() {
+                Ok(s) => Ok((uuid, s)),
+                Err(_) => Err(shard_num),
+            })
+            .collect::<Result<Vec<(Uuid, Shard)>, _>>()
+        {
+            Ok(r) => r,
+            Err(shard_num) => return Some(Err(TabletParsingError::ShardNum(shard_num))),
+        };
+
+        Some(Ok(RawTablet {
+            // +1 because Scylla sends left-open range, so received
+            // number is the last token not belonging to this tablet.
+            first_token: Token::new(first_token + 1),
+            last_token: Token::new(last_token),
+            replicas: RawTabletReplicas { replicas },
+        }))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(test, derive(Eq))]
+struct TabletReplicas {
+    all: Vec<(Arc<Node>, Shard)>,
+    per_dc: HashMap<String, Vec<(Arc<Node>, Shard)>>,
+}
+
+impl TabletReplicas {
+    pub(crate) fn from_raw_replicas(
+        raw_replicas: &RawTabletReplicas,
+        replica_translator: impl Fn(Uuid) -> Option<Arc<Node>>,
+    ) -> Self {
+        let all: Vec<_> = raw_replicas.replicas
+            .iter()
+            .filter_map(|(replica, shard)| if let Some(r) = replica_translator(*replica) {
+                Some((r, *shard as Shard))
+            } else {
+                // TODO: Should this be an error? When can this happen?
+                warn!("Node {replica} from system.tablets not present in ClusterData.known_peers. Skipping this replica");
+                None
+            })
+            .collect();
+
+        let mut per_dc: HashMap<String, Vec<(Arc<Node>, Shard)>> = HashMap::new();
+        all.iter().for_each(|(replica, shard)| {
+            if let Some(dc) = replica.datacenter.as_ref() {
+                if let Some(replicas) = per_dc.get_mut(dc) {
+                    replicas.push((Arc::clone(replica), *shard));
+                } else {
+                    per_dc.insert(dc.to_string(), vec![(Arc::clone(replica), *shard)]);
+                }
+            }
+        });
+
+        Self { all, per_dc }
+    }
+}
+
+// We can't use derive because it would use normal comparision while
+// comapring replicas needs to use `Arc::ptr_eq`. It's not enough to compare host ids,
+// because different `Node` objects nay have the same host id.
+// There is not reason to compare this outside of tests, so the `cfg(test)` is there
+// to prevent future contributors from doing something stupid like comparing it
+// in non-test driver code.
+#[cfg(test)]
+impl PartialEq for TabletReplicas {
+    fn eq(&self, other: &Self) -> bool {
+        if self.all.len() != other.all.len() {
+            return false;
+        }
+        for ((self_node, self_shard), (other_node, other_shard)) in
+            self.all.iter().zip(other.all.iter())
+        {
+            if self_shard != other_shard {
+                return false;
+            }
+            if !Arc::ptr_eq(self_node, other_node) {
+                return false;
+            }
+        }
+
+        // Implementations of `TableTablets`, `Tablet` and `TabletReplicas`
+        // guarantee that if `all` is the same then `per_dc` must be too.
+        // If it isn't then it is a bug.
+        // Comparing `TabletReplicas` happens only in tests so we can sacrifice
+        // a small bit of performance to verify this assumption.
+        assert_eq!(self.per_dc.len(), other.per_dc.len());
+        for (self_k, self_v) in self.per_dc.iter() {
+            let other_v = other.per_dc.get(self_k).unwrap();
+            for ((self_node, self_shard), (other_node, other_shard)) in
+                self_v.iter().zip(other_v.iter())
+            {
+                assert_eq!(self_shard, other_shard);
+                assert!(Arc::ptr_eq(self_node, other_node));
+            }
+        }
+
+        true
+    }
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub(crate) struct Tablet {
+    /// First token belonging to the tablet, inclusive
+    first_token: Token,
+    /// Last token belonging to the tablet, inclusive
+    last_token: Token,
+    replicas: TabletReplicas,
+}
+
+impl Tablet {
+    pub(crate) fn from_raw_tablet(
+        raw_tablet: &RawTablet,
+        replica_translator: impl Fn(Uuid) -> Option<Arc<Node>>,
+    ) -> Self {
+        Self {
+            first_token: raw_tablet.first_token,
+            last_token: raw_tablet.last_token,
+            replicas: TabletReplicas::from_raw_replicas(&raw_tablet.replicas, replica_translator),
+        }
+    }
+}
+
+/// Container for tablets of a single table.
+///
+/// It can be viewed as a set of non-overlapping Tablet objects.
+/// It has 2 basic operations:
+/// 1. Find a tablet for given Token
+/// 2. Add a new tablet.
+///
+/// Adding new Tablet will first remove all tablets that overlap with the new tablet.
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub(crate) struct TableTablets {
+    table_spec: TableSpec<'static>,
+    tablet_list: Vec<Tablet>,
+}
+
+impl TableTablets {
+    fn new(table_spec: TableSpec<'static>) -> Self {
+        Self {
+            table_spec,
+            tablet_list: Default::default(),
+        }
+    }
+
+    fn tablet_for_token(&self, token: Token) -> Option<&Tablet> {
+        let idx = self
+            .tablet_list
+            .partition_point(|tablet| tablet.last_token < token);
+        let tablet = self.tablet_list.get(idx);
+        tablet.filter(|t| t.first_token <= token)
+    }
+
+    pub(crate) fn replicas_for_token(&self, token: Token) -> Option<&[(Arc<Node>, Shard)]> {
+        self.tablet_for_token(token)
+            .map(|tablet| tablet.replicas.all.as_ref())
+    }
+
+    pub(crate) fn dc_replicas_for_token(
+        &self,
+        token: Token,
+        dc: &str,
+    ) -> Option<&[(Arc<Node>, Shard)]> {
+        self.tablet_for_token(token).map(|tablet| {
+            tablet
+                .replicas
+                .per_dc
+                .get(dc)
+                .map(|x| x.as_slice())
+                .unwrap_or(&[])
+        })
+    }
+
+    /// This method:
+    /// - first removes all tablets that overlap with `tablet` from `self`
+    /// - adds `tablet` to `self`
+    ///
+    /// This preserves the invariant that all tablets in `self` are non-overlapping.
+    fn add_tablet(&mut self, tablet: Tablet) {
+        // Smallest `left_idx` for which `tablet.first_token` is LESS OR EQUAL to `tablet_list[left_idx].last_token`.
+        // It implies that `tablet_list[left_idx]` overlaps with `tablet` iff `tablet.last_token`
+        // is GREATER OR EQUAL to `tablet_list[left_idx].first_token`.
+        let left_idx = self
+            .tablet_list
+            .partition_point(|t| t.last_token < tablet.first_token);
+        // Smallest `right_idx` for which `tablet.last_token` is LESS than `tablet_list[right_idx].first_token`.
+        // It means that `right_idx` is the index of first tablet that is "to the right" of `tablet` and doesn't overlap with it.
+        // From this it follows that if `tablet_list[left_idx]` turns out to not overlap with `tablet`, then `left_idx == right_idx`
+        // and we won't remove any tablets because `tablet` doesn't overlap with any existing tablets.
+        let right_idx = self
+            .tablet_list
+            .partition_point(|t| t.first_token <= tablet.last_token);
+        self.tablet_list.drain(left_idx..right_idx);
+        self.tablet_list.insert(left_idx, tablet);
+    }
+
+    #[cfg(test)]
+    fn new_for_test() -> Self {
+        Self::new(TableSpec::borrowed("test_ks", "test_table"))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TabletsInfo {
+    // We use hashbrown hashmap instead of std hashmap because with
+    // std one it is not possible to query map with key `TableSpec<'static>`
+    // using `TableSpec<'a>` for `'a` other than `'static`.
+    // This is because `std::hashmap` requires that the key implements `Borrow<Q>`
+    // where `&Q` is an argument to `.get(key)` method. It is not possible to write
+    // such `Borrow` impl for `TableSpec`.
+    // HashBrown on the other hand requires only `Q: Hash + Equivalent<K> + ?Sized`,
+    // and it is easy to create a wrapper type with required `Equivalent` impl.
+    tablets: hashbrown::HashMap<TableSpec<'static>, TableTablets>,
+}
+
+impl TabletsInfo {
+    pub(crate) fn new() -> Self {
+        Self {
+            tablets: hashbrown::HashMap::new(),
+        }
+    }
+
+    pub(crate) fn tablets_for_table<'a, 'b>(
+        &'a self,
+        table_spec: &'b TableSpec<'b>,
+    ) -> Option<&'a TableTablets> {
+        #[derive(Hash)]
+        struct TableSpecQueryKey<'a> {
+            table_spec: &'a TableSpec<'a>,
+        }
+
+        impl<'key, 'query> hashbrown::Equivalent<TableSpec<'key>> for TableSpecQueryKey<'query> {
+            fn equivalent(&self, key: &TableSpec<'key>) -> bool {
+                self.table_spec == key
+            }
+        }
+
+        let query_key = TableSpecQueryKey { table_spec };
+
+        let table_tablets = self.tablets.get(&query_key);
+
+        table_tablets
+    }
+
+    pub(crate) fn add_tablet(&mut self, table_spec: TableSpec<'static>, tablet: Tablet) {
+        self.tablets
+            .entry(table_spec)
+            .or_insert_with_key(|k| {
+                tracing::debug!(
+                    "Found new tablets table: {}.{}",
+                    k.ks_name(),
+                    k.table_name()
+                );
+                TableTablets::new(k.clone())
+            })
+            .add_tablet(tablet)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use scylla_cql::frame::response::result::{ColumnType, CqlValue};
+    use scylla_cql::types::serialize::{value::SerializeCql, CellWriter};
+    use tracing::debug;
+    use uuid::Uuid;
+
+    use crate::routing::Token;
+    use crate::transport::locator::tablets::{
+        RawTablet, RawTabletReplicas, TabletParsingError, CUSTOM_PAYLOAD_TABLETS_V1_KEY,
+        RAW_TABLETS_CQL_TYPE,
+    };
+    use crate::transport::Node;
+
+    use super::{TableTablets, Tablet, TabletReplicas};
+
+    const DC1: &str = "dc1";
+    const DC2: &str = "dc2";
+    const DC3: &str = "dc3";
+
+    #[test]
+    fn test_raw_tablet_deser_empty() {
+        let custom_payload = HashMap::new();
+        assert!(RawTablet::from_custom_payload(&custom_payload).is_none());
+    }
+
+    #[test]
+    fn test_raw_tablet_deser_trash() {
+        let custom_payload =
+            HashMap::from([(CUSTOM_PAYLOAD_TABLETS_V1_KEY.to_string(), vec![1, 2, 3])]);
+        assert_matches::assert_matches!(
+            RawTablet::from_custom_payload(&custom_payload),
+            Some(Err(TabletParsingError::Parse(_)))
+        );
+    }
+
+    #[test]
+    fn test_raw_tablet_deser_wrong_type() {
+        let mut custom_payload = HashMap::new();
+        let mut data = vec![];
+
+        let value = CqlValue::Tuple(vec![
+            Some(CqlValue::Ascii("asdderty".to_string())),
+            Some(CqlValue::BigInt(1234)),
+            Some(CqlValue::List(vec![])),
+        ]);
+        let col_type = ColumnType::Tuple(vec![
+            ColumnType::Ascii,
+            ColumnType::BigInt,
+            ColumnType::List(Box::new(ColumnType::Tuple(vec![
+                ColumnType::Uuid,
+                ColumnType::Int,
+            ]))),
+        ]);
+
+        SerializeCql::serialize(&value, &col_type, CellWriter::new(&mut data)).unwrap();
+        debug!("{:?}", data);
+
+        custom_payload.insert(CUSTOM_PAYLOAD_TABLETS_V1_KEY.to_string(), data);
+
+        assert_matches::assert_matches!(
+            RawTablet::from_custom_payload(&custom_payload),
+            Some(Err(TabletParsingError::Parse(_)))
+        );
+    }
+
+    #[test]
+    fn test_raw_tablet_deser_correct() {
+        let mut custom_payload = HashMap::new();
+        let mut data = vec![];
+
+        const FIRST_TOKEN: i64 = 1234;
+        const LAST_TOKEN: i64 = 5678;
+
+        let value = CqlValue::Tuple(vec![
+            Some(CqlValue::BigInt(FIRST_TOKEN)),
+            Some(CqlValue::BigInt(LAST_TOKEN)),
+            Some(CqlValue::List(vec![
+                CqlValue::Tuple(vec![
+                    Some(CqlValue::Uuid(Uuid::from_u64_pair(1, 2))),
+                    Some(CqlValue::Int(15)),
+                ]),
+                CqlValue::Tuple(vec![
+                    Some(CqlValue::Uuid(Uuid::from_u64_pair(3, 4))),
+                    Some(CqlValue::Int(19)),
+                ]),
+            ])),
+        ]);
+
+        SerializeCql::serialize(&value, &RAW_TABLETS_CQL_TYPE, CellWriter::new(&mut data)).unwrap();
+        tracing::debug!("{:?}", data);
+
+        custom_payload.insert(
+            CUSTOM_PAYLOAD_TABLETS_V1_KEY.to_string(),
+            // Skipping length because `SerializeCql::serialize` adds length at the
+            // start of serialized value while Scylla sends the value without initial
+            // length.
+            data[4..].to_vec(),
+        );
+
+        let tablet = RawTablet::from_custom_payload(&custom_payload)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            tablet,
+            RawTablet {
+                first_token: Token::new(FIRST_TOKEN + 1),
+                last_token: Token::new(LAST_TOKEN),
+                replicas: RawTabletReplicas {
+                    replicas: vec![
+                        (Uuid::from_u64_pair(1, 2), 15),
+                        (Uuid::from_u64_pair(3, 4), 19)
+                    ]
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn raw_replicas_to_replicas_groups_correctly() {
+        let nodes: HashMap<Uuid, Arc<Node>> = [
+            Node::new_for_test(
+                Some(Uuid::from_u64_pair(1, 1)),
+                None,
+                Some(DC1.to_string()),
+                None,
+            ),
+            Node::new_for_test(
+                Some(Uuid::from_u64_pair(1, 2)),
+                None,
+                Some(DC2.to_string()),
+                None,
+            ),
+            Node::new_for_test(
+                Some(Uuid::from_u64_pair(1, 3)),
+                None,
+                Some(DC3.to_string()),
+                None,
+            ),
+            Node::new_for_test(
+                Some(Uuid::from_u64_pair(1, 4)),
+                None,
+                Some(DC2.to_string()),
+                None,
+            ),
+            Node::new_for_test(
+                Some(Uuid::from_u64_pair(1, 5)),
+                None,
+                Some(DC2.to_string()),
+                None,
+            ),
+            Node::new_for_test(
+                Some(Uuid::from_u64_pair(1, 6)),
+                None,
+                Some(DC1.to_string()),
+                None,
+            ),
+        ]
+        .into_iter()
+        .map(|node| (node.host_id, Arc::new(node)))
+        .collect();
+
+        let translator = |uuid| nodes.get(&uuid).cloned();
+
+        let replicas_uids = [
+            Uuid::from_u64_pair(1, 1),
+            Uuid::from_u64_pair(1, 2),
+            Uuid::from_u64_pair(1, 3),
+            Uuid::from_u64_pair(1, 4),
+            Uuid::from_u64_pair(1, 5),
+            Uuid::from_u64_pair(1, 6),
+        ];
+
+        let raw_replicas = RawTabletReplicas {
+            replicas: replicas_uids.into_iter().map(|uid| (uid, 1)).collect(),
+        };
+
+        let replicas = TabletReplicas::from_raw_replicas(&raw_replicas, translator);
+
+        let mut per_dc = HashMap::new();
+        per_dc.insert(
+            "dc1".to_string(),
+            vec![
+                (translator(Uuid::from_u64_pair(1, 1)).unwrap(), 1),
+                (translator(Uuid::from_u64_pair(1, 6)).unwrap(), 1),
+            ],
+        );
+        per_dc.insert(
+            "dc2".to_string(),
+            vec![
+                (translator(Uuid::from_u64_pair(1, 2)).unwrap(), 1),
+                (translator(Uuid::from_u64_pair(1, 4)).unwrap(), 1),
+                (translator(Uuid::from_u64_pair(1, 5)).unwrap(), 1),
+            ],
+        );
+        per_dc.insert(
+            "dc3".to_string(),
+            vec![(translator(Uuid::from_u64_pair(1, 3)).unwrap(), 1)],
+        );
+
+        assert_eq!(
+            replicas,
+            TabletReplicas {
+                all: replicas_uids
+                    .iter()
+                    .cloned()
+                    .map(|replica| (translator(replica).unwrap(), 1))
+                    .collect(),
+                per_dc
+            }
+        );
+    }
+
+    #[test]
+    fn table_tablets_empty() {
+        let tablets: TableTablets = TableTablets::new_for_test();
+        assert_eq!(tablets.tablet_for_token(Token::new(1)), None);
+    }
+
+    fn verify_ranges(tablets: &TableTablets, ranges: &[(i64, i64)]) {
+        let mut ranges_iter = ranges.iter();
+        for tablet in tablets.tablet_list.iter() {
+            let range = ranges_iter.next().unwrap();
+            assert_eq!(tablet.first_token.value(), range.0);
+            assert_eq!(tablet.last_token.value(), range.1);
+        }
+        assert_eq!(ranges_iter.next(), None)
+    }
+
+    fn insert_ranges(tablets: &mut TableTablets, ranges: &[(i64, i64)]) {
+        for (first, last) in ranges.iter() {
+            tablets.add_tablet(Tablet {
+                first_token: Token::new(*first),
+                last_token: Token::new(*last),
+                replicas: Default::default(),
+            });
+        }
+    }
+
+    #[test]
+    fn table_tablets_single() {
+        let mut tablets = TableTablets::new_for_test();
+
+        insert_ranges(&mut tablets, &[(-200, 1000)]);
+        verify_ranges(&tablets, &[(-200, 1000)]);
+
+        assert_eq!(
+            tablets.tablet_for_token(Token::new(-1)),
+            Some(&tablets.tablet_list[0])
+        );
+        assert_eq!(
+            tablets.tablet_for_token(Token::new(0)),
+            Some(&tablets.tablet_list[0])
+        );
+        assert_eq!(
+            tablets.tablet_for_token(Token::new(1)),
+            Some(&tablets.tablet_list[0])
+        );
+        assert_eq!(
+            tablets.tablet_for_token(Token::new(-200)),
+            Some(&tablets.tablet_list[0])
+        );
+        assert_eq!(tablets.tablet_for_token(Token::new(-201)), None);
+        assert_eq!(
+            tablets.tablet_for_token(Token::new(1000)),
+            Some(&tablets.tablet_list[0])
+        );
+        assert_eq!(tablets.tablet_for_token(Token::new(1001)), None);
+    }
+
+    #[test]
+    fn test_adding_tablets_non_overlapping() {
+        let mut tablets = TableTablets::new_for_test();
+        const RANGES: &[(i64, i64)] = &[
+            (-2000000, -1900001),
+            (-1900000, -1700001),
+            (-1700000, -1),
+            (0, 19),
+            (20, 10000),
+        ];
+
+        insert_ranges(&mut tablets, RANGES);
+        verify_ranges(&tablets, RANGES);
+    }
+
+    #[test]
+    fn test_adding_tablet_same() {
+        let mut tablets = TableTablets::new_for_test();
+
+        insert_ranges(&mut tablets, &[(-2000000, -1800000), (-2000000, -1800000)]);
+        verify_ranges(&tablets, &[(-2000000, -1800000)]);
+    }
+
+    #[test]
+    fn test_adding_tablet_overlapping_one() {
+        let mut tablets = TableTablets::new_for_test();
+        insert_ranges(&mut tablets, &[(-2000000, -1800000)]);
+        verify_ranges(&tablets, &[(-2000000, -1800000)]);
+
+        // Replacing a tablet, overlaps right part of the old one
+        insert_ranges(&mut tablets, &[(-1900000, -1700000)]);
+        verify_ranges(&tablets, &[(-1900000, -1700000)]);
+
+        // Replacing a tablet, overlaps left part of the old one
+        insert_ranges(&mut tablets, &[(-2000000, -1800000)]);
+        verify_ranges(&tablets, &[(-2000000, -1800000)]);
+    }
+
+    #[test]
+    fn test_adding_tablet_fill_hole() {
+        let mut tablets = TableTablets::new_for_test();
+
+        // Fill a hole between two tablets
+        insert_ranges(
+            &mut tablets,
+            &[
+                (-2000000, -1800001),
+                (-1600000, -1400000), // Create a hole
+                (-1800000, -1600001), // Fully fill this hole
+            ],
+        );
+        verify_ranges(
+            &tablets,
+            &[
+                (-2000000, -1800001),
+                (-1800000, -1600001),
+                (-1600000, -1400000),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_adding_tablet_neighbours_not_removed() {
+        let mut tablets = TableTablets::new_for_test();
+        insert_ranges(
+            &mut tablets,
+            &[
+                (-2000000, -1800001),
+                (-1800000, -1600001),
+                (-1600000, -1400000),
+            ],
+        );
+
+        // Make sure neighbours are not removed when fully replacing tablet in the middle
+        insert_ranges(&mut tablets, &[(-1800000, -1600001)]);
+        verify_ranges(
+            &tablets,
+            &[
+                (-2000000, -1800001),
+                (-1800000, -1600001),
+                (-1600000, -1400000),
+            ],
+        );
+
+        // Make sure neighbours are not removed when new tablet is smaller than old one
+        insert_ranges(&mut tablets, &[(-1750000, -1650000)]);
+        verify_ranges(
+            &tablets,
+            &[
+                (-2000000, -1800001),
+                (-1750000, -1650000),
+                (-1600000, -1400000),
+            ],
+        );
+    }
+
+    #[test]
+    fn replace_multiple_tablets_middle() {
+        let mut tablets = TableTablets::new_for_test();
+        insert_ranges(
+            &mut tablets,
+            &[
+                (-2000000, -1800001),
+                (-1800000, -1600001),
+                (-1600000, -1400001),
+                (-1400000, -1200001),
+                (-1200000, -1000000),
+            ],
+        );
+
+        // Replacing 3 middle tablets
+        insert_ranges(&mut tablets, &[(-1750000, -1250000)]);
+        verify_ranges(
+            &tablets,
+            &[
+                (-2000000, -1800001),
+                (-1750000, -1250000),
+                (-1200000, -1000000),
+            ],
+        );
+    }
+}

--- a/scylla/src/transport/locator/tablets.rs
+++ b/scylla/src/transport/locator/tablets.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use scylla_cql::cql_to_rust::FromCqlVal;

--- a/scylla/src/transport/locator/test.rs
+++ b/scylla/src/transport/locator/test.rs
@@ -3,6 +3,7 @@ use rand_chacha::ChaCha8Rng;
 use scylla_cql::frame::response::result::TableSpec;
 use uuid::Uuid;
 
+use super::tablets::TabletsInfo;
 use super::{ReplicaLocator, ReplicaSet};
 use crate::routing::Token;
 use crate::test_utils::setup_tracing;
@@ -202,7 +203,7 @@ pub(crate) fn create_locator(metadata: &Metadata) -> ReplicaLocator {
     let ring = create_ring(metadata);
     let strategies = metadata.keyspaces.values().map(|ks| &ks.strategy);
 
-    ReplicaLocator::new(ring, strategies)
+    ReplicaLocator::new(ring, strategies, TabletsInfo::new())
 }
 
 #[tokio::test]

--- a/scylla/src/transport/locator/test.rs
+++ b/scylla/src/transport/locator/test.rs
@@ -1,5 +1,6 @@
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use scylla_cql::frame::response::result::TableSpec;
 use uuid::Uuid;
 
 use super::{ReplicaLocator, ReplicaSet};
@@ -22,6 +23,16 @@ use std::{
 pub(crate) const KEYSPACE_NTS_RF_2: &str = "keyspace_with_nts_rf_2";
 pub(crate) const KEYSPACE_NTS_RF_3: &str = "keyspace_with_nts_rf_3";
 pub(crate) const KEYSPACE_SS_RF_2: &str = "keyspace_with_ss_rf_2";
+
+// Those are references because otherwise I can't use them in Option without
+// additional binding.
+pub(crate) const TABLE_NTS_RF_2: &TableSpec<'static> =
+    &TableSpec::borrowed(KEYSPACE_NTS_RF_2, "table");
+pub(crate) const TABLE_NTS_RF_3: &TableSpec<'static> =
+    &TableSpec::borrowed(KEYSPACE_NTS_RF_3, "table");
+pub(crate) const TABLE_SS_RF_2: &TableSpec<'static> =
+    &TableSpec::borrowed(KEYSPACE_SS_RF_2, "table");
+pub(crate) const TABLE_INVALID: &TableSpec<'static> = &TableSpec::borrowed("invalid", "invalid");
 
 pub(crate) const A: u16 = 1;
 pub(crate) const B: u16 = 2;
@@ -245,6 +256,7 @@ fn test_simple_strategy_replicas(locator: &ReplicaLocator) {
                 replication_factor: 3,
             },
             None,
+            TABLE_INVALID,
         ),
         &[F, G, D],
     );
@@ -256,6 +268,7 @@ fn test_simple_strategy_replicas(locator: &ReplicaLocator) {
                 replication_factor: 4,
             },
             None,
+            TABLE_INVALID,
         ),
         &[F, G, D, B],
     );
@@ -267,6 +280,7 @@ fn test_simple_strategy_replicas(locator: &ReplicaLocator) {
                 replication_factor: 4,
             },
             None,
+            TABLE_INVALID,
         ),
         &[A, C, D, F],
     );
@@ -278,6 +292,7 @@ fn test_simple_strategy_replicas(locator: &ReplicaLocator) {
                 replication_factor: 0,
             },
             None,
+            TABLE_INVALID,
         ),
         &[],
     );
@@ -291,6 +306,7 @@ fn test_simple_strategy_replicas(locator: &ReplicaLocator) {
                 replication_factor: 1,
             },
             Some("us"),
+            TABLE_INVALID,
         ),
         &[],
     );
@@ -302,6 +318,7 @@ fn test_simple_strategy_replicas(locator: &ReplicaLocator) {
                 replication_factor: 3,
             },
             Some("us"),
+            TABLE_INVALID,
         ),
         &[E],
     );
@@ -313,6 +330,7 @@ fn test_simple_strategy_replicas(locator: &ReplicaLocator) {
                 replication_factor: 3,
             },
             Some("eu"),
+            TABLE_INVALID,
         ),
         &[A, B],
     );
@@ -328,6 +346,7 @@ fn test_network_topology_strategy_replicas(locator: &ReplicaLocator) {
                     .collect(),
             },
             Some("eu"),
+            TABLE_INVALID,
         ),
         &[B],
     );
@@ -341,6 +360,7 @@ fn test_network_topology_strategy_replicas(locator: &ReplicaLocator) {
                     .collect(),
             },
             Some("us"),
+            TABLE_INVALID,
         ),
         &[E],
     );
@@ -354,6 +374,7 @@ fn test_network_topology_strategy_replicas(locator: &ReplicaLocator) {
                     .collect(),
             },
             None,
+            TABLE_INVALID,
         ),
         &[B, E],
     );
@@ -367,6 +388,7 @@ fn test_network_topology_strategy_replicas(locator: &ReplicaLocator) {
                     .collect(),
             },
             None,
+            TABLE_INVALID,
         ),
         // Walking the ring from token 75, [B E F A C D A F G] is encountered.
         // NTS takes the first 2 nodes from that list - {B, E} and the last one - G because it is
@@ -383,6 +405,7 @@ fn test_network_topology_strategy_replicas(locator: &ReplicaLocator) {
                     .collect(),
             },
             None,
+            TABLE_INVALID,
         ),
         &[E],
     );
@@ -396,6 +419,7 @@ fn test_network_topology_strategy_replicas(locator: &ReplicaLocator) {
                     .collect(),
             },
             None,
+            TABLE_INVALID,
         ),
         &[G, E],
     );
@@ -411,6 +435,7 @@ fn test_replica_set_len(locator: &ReplicaLocator) {
                     .collect(),
             },
             None,
+            TABLE_INVALID,
         )
         .len();
     assert_eq!(merged_nts_len, 3);
@@ -426,6 +451,7 @@ fn test_replica_set_len(locator: &ReplicaLocator) {
                     .collect(),
             },
             None,
+            TABLE_INVALID,
         )
         .len();
     assert_eq!(capped_merged_nts_len, 5); // 5 = all eu nodes + 1 us node = 4 + 1.
@@ -439,6 +465,7 @@ fn test_replica_set_len(locator: &ReplicaLocator) {
                     .collect(),
             },
             Some("eu"),
+            TABLE_INVALID,
         )
         .len();
     assert_eq!(filtered_nts_len, 2);
@@ -450,6 +477,7 @@ fn test_replica_set_len(locator: &ReplicaLocator) {
                 replication_factor: 3,
             },
             None,
+            TABLE_INVALID,
         )
         .len();
     assert_eq!(ss_len, 3);
@@ -462,6 +490,7 @@ fn test_replica_set_len(locator: &ReplicaLocator) {
                 replication_factor: 3,
             },
             Some("eu"),
+            TABLE_INVALID,
         )
         .len();
     assert_eq!(filtered_ss_len, 1)
@@ -482,7 +511,8 @@ fn test_replica_set_choose(locator: &ReplicaLocator) {
     let mut rng = ChaCha8Rng::seed_from_u64(69);
 
     for strategy in strategies {
-        let replica_set_generator = || locator.replicas_for_token(Token::new(75), &strategy, None);
+        let replica_set_generator =
+            || locator.replicas_for_token(Token::new(75), &strategy, None, TABLE_INVALID);
 
         // Verify that after a certain number of random selections, the set of selected replicas
         // will contain all nodes in the ring (replica set was created using a strategy with
@@ -522,7 +552,8 @@ fn test_replica_set_choose_filtered(locator: &ReplicaLocator) {
     let mut rng = ChaCha8Rng::seed_from_u64(69);
 
     for strategy in strategies {
-        let replica_set_generator = || locator.replicas_for_token(Token::new(75), &strategy, None);
+        let replica_set_generator =
+            || locator.replicas_for_token(Token::new(75), &strategy, None, TABLE_INVALID);
 
         // Verify that after a certain number of random selections with a dc filter, the set of
         // selected replicas will contain all nodes in the specified dc ring.
@@ -554,6 +585,7 @@ fn test_replica_set_choose_filtered(locator: &ReplicaLocator) {
             Token::new(75),
             &Strategy::LocalStrategy,
             Some("unknown_dc_name"),
+            TABLE_INVALID,
         )
         .choose_filtered(&mut rng, |_| true);
     assert_eq!(empty, None);

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -331,13 +331,17 @@ mod tests {
 
     impl Node {
         pub(crate) fn new_for_test(
-            address: NodeAddr,
+            id: Option<Uuid>,
+            address: Option<NodeAddr>,
             datacenter: Option<String>,
             rack: Option<String>,
         ) -> Self {
             Self {
-                host_id: Uuid::new_v4(),
-                address,
+                host_id: id.unwrap_or(Uuid::new_v4()),
+                address: address.unwrap_or(NodeAddr::Translatable(SocketAddr::from((
+                    [255, 255, 255, 255],
+                    0,
+                )))),
                 datacenter,
                 rack,
                 pool: None,

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -293,10 +293,7 @@ mod tests {
     }
 
     fn make_not_rows_query_result() -> QueryResult {
-        let table_spec = TableSpec {
-            ks_name: "some_keyspace".to_string(),
-            table_name: "some_table".to_string(),
-        };
+        let table_spec = TableSpec::owned("some_keyspace".to_string(), "some_table".to_string());
 
         let column_spec = ColumnSpec {
             table_spec,

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -6,7 +6,7 @@ use crate::query::Query;
 use crate::retry_policy::{QueryInfo, RetryDecision, RetryPolicy, RetrySession};
 use crate::routing::Token;
 use crate::statement::Consistency;
-use crate::test_utils::setup_tracing;
+use crate::test_utils::{scylla_supports_tablets, setup_tracing};
 use crate::tracing::TracingInfo;
 use crate::transport::cluster::Datacenter;
 use crate::transport::errors::{BadKeyspaceName, BadQuery, DbError, QueryError};
@@ -518,7 +518,17 @@ async fn test_token_awareness() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks), &[]).await.unwrap();
+    // Need to disable tablets in this test because they make token routing
+    // work differently, and in this test we want to test the classic token ring
+    // behavior.
+    let mut create_ks = format!(
+        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+    );
+    if scylla_supports_tablets(&session).await {
+        create_ks += " AND TABLETS = {'enabled': false}"
+    }
+
+    session.query(create_ks, &[]).await.unwrap();
     session
         .query(
             format!("CREATE TABLE IF NOT EXISTS {}.t (a text primary key)", ks),
@@ -1670,10 +1680,15 @@ async fn test_table_partitioner_in_metadata() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session
-        .query(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks), &[])
-        .await
-        .unwrap();
+    // This test uses CDC which is not yet compatible with Scylla's tablets.
+    let mut create_ks = format!(
+        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+    );
+    if scylla_supports_tablets(&session).await {
+        create_ks += " AND TABLETS = {'enabled': false}";
+    }
+
+    session.query(create_ks, &[]).await.unwrap();
 
     session.query(format!("USE {}", ks), &[]).await.unwrap();
 
@@ -1834,7 +1849,14 @@ async fn test_prepared_partitioner() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.query(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks), &[]).await.unwrap();
+    // This test uses CDC which is not yet compatible with Scylla's tablets.
+    let mut create_ks = format!(
+        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}");
+    if scylla_supports_tablets(&session).await {
+        create_ks += " AND TABLETS = {'enabled': false}"
+    }
+
+    session.query(create_ks, &[]).await.unwrap();
     session.use_keyspace(ks, false).await.unwrap();
 
     session
@@ -2551,6 +2573,7 @@ async fn test_keyspaces_to_fetch() {
 // Reproduces the problem with execute_iter mentioned in #608.
 #[tokio::test]
 async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
+    setup_tracing();
     // It's difficult to reproduce the issue with a real downgrading consistency policy,
     // as it would require triggering a WriteTimeout. We just need the policy
     // to return IgnoreWriteError, so we will trigger a different error
@@ -2592,7 +2615,11 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
     // Create a keyspace with replication factor that is larger than the cluster size
     let cluster_size = session.get_cluster_data().get_nodes_info().len();
     let ks = unique_keyspace_name();
-    session.query(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {}}}", ks, cluster_size + 1), ()).await.unwrap();
+    let mut create_ks = format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {}}}", ks, cluster_size + 1);
+    if scylla_supports_tablets(&session).await {
+        create_ks += " and TABLETS = { 'enabled': false}";
+    }
+    session.query(create_ks, ()).await.unwrap();
     session.use_keyspace(ks, true).await.unwrap();
     session
         .query("CREATE TABLE t (pk int PRIMARY KEY, v int)", ())

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -141,7 +141,7 @@ async fn test_unprepared_statement() {
     assert_eq!(specs.len(), 3);
     for (spec, name) in specs.iter().zip(["a", "b", "c"]) {
         assert_eq!(spec.name, name); // Check column name.
-        assert_eq!(spec.table_spec.ks_name, ks);
+        assert_eq!(spec.table_spec.ks_name(), ks);
     }
     let mut results_from_manual_paging: Vec<Row> = vec![];
     let query = Query::new(format!("SELECT a, b, c FROM {}.t", ks)).with_page_size(1);
@@ -197,7 +197,7 @@ async fn test_prepared_statement() {
     assert_eq!(specs.len(), 3);
     for (spec, name) in specs.iter().zip(["a", "b", "c"]) {
         assert_eq!(spec.name, name); // Check column name.
-        assert_eq!(spec.table_spec.ks_name, ks);
+        assert_eq!(spec.table_spec.ks_name(), ks);
     }
 
     let prepared_statement = session

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 use crate::transport::session_builder::{GenericSessionBuilder, SessionBuilderKind};
-#[cfg(test)]
 use crate::Session;
 #[cfg(test)]
 use std::{num::NonZeroU32, time::Duration};
@@ -91,6 +90,20 @@ pub fn create_new_session_builder() -> GenericSessionBuilder<impl SessionBuilder
     session_builder
         .tracing_info_fetch_attempts(NonZeroU32::new(200).unwrap())
         .tracing_info_fetch_interval(Duration::from_millis(50))
+}
+
+pub async fn scylla_supports_tablets(session: &Session) -> bool {
+    let result = session
+        .query(
+            "select column_name from system_schema.columns where 
+                keyspace_name = 'system_schema'
+                and table_name = 'scylla_keyspaces'
+                and column_name = 'initial_tablets'",
+            &[],
+        )
+        .await
+        .unwrap();
+    result.single_row().is_ok()
 }
 
 #[cfg(test)]

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -8,6 +8,7 @@ use scylla::routing::{Shard, Token};
 use scylla::test_utils::unique_keyspace_name;
 use scylla::transport::session::Session;
 use scylla::transport::NodeRef;
+use scylla_cql::frame::response::result::TableSpec;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use scylla::statement::batch::BatchStatement;
@@ -341,7 +342,7 @@ pub(crate) struct OwnedRoutingInfo {
     serial_consistency: Option<SerialConsistency>,
 
     #[allow(unused)]
-    keyspace: Option<String>,
+    table: Option<TableSpec<'static>>,
     #[allow(unused)]
     token: Option<Token>,
     #[allow(unused)]
@@ -354,14 +355,14 @@ impl OwnedRoutingInfo {
             consistency,
             serial_consistency,
             token,
-            keyspace,
+            table,
             is_confirmed_lwt,
         } = info;
         Self {
             consistency,
             serial_consistency,
             token,
-            keyspace: keyspace.map(ToOwned::to_owned),
+            table: table.map(TableSpec::to_owned),
             is_confirmed_lwt,
         }
     }

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -7,4 +7,5 @@ mod retries;
 mod shards;
 mod silent_prepare_query;
 mod skip_metadata_optimization;
+mod tablets;
 pub(crate) mod utils;

--- a/scylla/tests/integration/tablets.rs
+++ b/scylla/tests/integration/tablets.rs
@@ -1,0 +1,614 @@
+use std::sync::Arc;
+
+use crate::utils::setup_tracing;
+use crate::utils::test_with_3_node_cluster;
+
+use futures::future::try_join_all;
+use futures::TryStreamExt;
+use itertools::Itertools;
+use scylla::load_balancing::FallbackPlan;
+use scylla::load_balancing::LoadBalancingPolicy;
+use scylla::load_balancing::RoutingInfo;
+use scylla::prepared_statement::PreparedStatement;
+use scylla::query::Query;
+use scylla::serialize::row::SerializeRow;
+use scylla::test_utils::unique_keyspace_name;
+use scylla::transport::ClusterData;
+use scylla::transport::Node;
+use scylla::transport::NodeRef;
+use scylla::ExecutionProfile;
+use scylla::QueryResult;
+use scylla::Session;
+
+use scylla_cql::errors::QueryError;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, ResponseFrame, ResponseOpcode, ResponseReaction, ResponseRule,
+    ShardAwareness, TargetShard, WorkerError,
+};
+
+use tokio::sync::mpsc;
+use tracing::info;
+use uuid::Uuid;
+
+#[derive(scylla::FromRow)]
+struct SelectedTablet {
+    last_token: i64,
+    replicas: Vec<(Uuid, i32)>,
+}
+
+struct Tablet {
+    first_token: i64,
+    last_token: i64,
+    replicas: Vec<(Arc<Node>, i32)>,
+}
+
+async fn get_tablets(session: &Session, ks: &str, table: &str) -> Vec<Tablet> {
+    let cluster_data = session.get_cluster_data();
+    let endpoints = cluster_data.get_nodes_info();
+    for endpoint in endpoints.iter() {
+        info!(
+            "Endpoint id: {}, address: {}",
+            endpoint.host_id,
+            endpoint.address.ip()
+        );
+    }
+
+    let selected_tablets_response = session.query_iter(
+        "select last_token, replicas from system.tablets WHERE keyspace_name = ? and table_name = ? ALLOW FILTERING",
+        &(ks, table)).await.unwrap();
+
+    let mut selected_tablets = selected_tablets_response
+        .into_typed::<SelectedTablet>()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    selected_tablets.sort_unstable_by(|a, b| a.last_token.cmp(&b.last_token));
+
+    let (tablets, _) = selected_tablets.iter().fold(
+        (Vec::new(), i64::MIN),
+        |(mut tablets, first_token), tablet| {
+            let replicas = tablet
+                .replicas
+                .iter()
+                .map(|(uuid, shard)| {
+                    (
+                        Arc::clone(
+                            endpoints
+                                .get(endpoints.iter().position(|e| e.host_id == *uuid).unwrap())
+                                .unwrap(),
+                        ),
+                        *shard,
+                    )
+                })
+                .collect();
+            let raw_tablet = Tablet {
+                first_token,
+                last_token: tablet.last_token,
+                replicas,
+            };
+
+            tablets.push(raw_tablet);
+            (tablets, tablet.last_token.wrapping_add(1))
+        },
+    );
+
+    // Print information about tablets, useful for debugging
+    for tablet in tablets.iter() {
+        info!(
+            "Tablet: [{}, {}]: {:?}",
+            tablet.first_token,
+            tablet.last_token,
+            tablet
+                .replicas
+                .iter()
+                .map(|(replica, shard)| { (replica.address.ip(), shard) })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    tablets
+}
+
+// Takes a prepared statements which accepts 2 arguments: i32 pk and i32 ck,
+// and calculates an example key for each of the tablets in the table.
+fn calculate_key_per_tablet(tablets: &[Tablet], prepared: &PreparedStatement) -> Vec<(i32, i32)> {
+    // Here we calculate a PK per token
+    let mut present_tablets = vec![false; tablets.len()];
+    let mut value_lists = vec![];
+    for i in 0..1000 {
+        let token_value = prepared.calculate_token(&(i, 1)).unwrap().unwrap().value();
+        let tablet_idx = tablets
+            .iter()
+            .position(|tablet| {
+                tablet.first_token <= token_value && token_value <= tablet.last_token
+            })
+            .unwrap();
+        if !present_tablets[tablet_idx] {
+            let values = (i, 1);
+            let tablet = &tablets[tablet_idx];
+            info!(
+                "Values: {:?}, token: {}, tablet index: {}, tablet: [{}, {}], replicas: {:?}",
+                values,
+                token_value,
+                tablet_idx,
+                tablet.first_token,
+                tablet.last_token,
+                tablet
+                    .replicas
+                    .iter()
+                    .map(|(replica, shard)| { (replica.address.ip(), shard) })
+                    .collect::<Vec<_>>()
+            );
+            value_lists.push(values);
+            present_tablets[tablet_idx] = true;
+        }
+    }
+
+    // This function tries 1000 keys and assumes that it is enough to cover all
+    // tablets. This is just a random number that seems to work in the tests,
+    // so the assert is here to catch the problem early if 1000 stops being enough
+    // for some reason.
+    assert!(present_tablets.iter().all(|x| *x));
+
+    value_lists
+}
+
+#[derive(Debug)]
+struct SingleTargetLBP {
+    target: (Arc<Node>, Option<u32>),
+}
+
+impl LoadBalancingPolicy for SingleTargetLBP {
+    fn pick<'a>(
+        &'a self,
+        _query: &'a RoutingInfo,
+        _cluster: &'a ClusterData,
+    ) -> Option<(NodeRef<'a>, Option<u32>)> {
+        Some((&self.target.0, self.target.1))
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        _query: &'a RoutingInfo,
+        _cluster: &'a ClusterData,
+    ) -> FallbackPlan<'a> {
+        Box::new(std::iter::empty())
+    }
+
+    fn name(&self) -> String {
+        "SingleTargetLBP".to_owned()
+    }
+}
+
+async fn send_statement_everywhere(
+    session: &Session,
+    cluster: &ClusterData,
+    statement: &PreparedStatement,
+    values: &dyn SerializeRow,
+) -> Result<Vec<QueryResult>, QueryError> {
+    let tasks = cluster.get_nodes_info().iter().flat_map(|node| {
+        let shard_count: u16 = node.sharder().unwrap().nr_shards.into();
+        (0..shard_count).map(|shard| {
+            let mut stmt = statement.clone();
+            let values_ref = &values;
+            let policy = SingleTargetLBP {
+                target: (node.clone(), Some(shard as u32)),
+            };
+            let execution_profile = ExecutionProfile::builder()
+                .load_balancing_policy(Arc::new(policy))
+                .build();
+            stmt.set_execution_profile_handle(Some(execution_profile.into_handle()));
+
+            async move { session.execute(&stmt, values_ref).await }
+        })
+    });
+
+    try_join_all(tasks).await
+}
+
+async fn send_unprepared_query_everywhere(
+    session: &Session,
+    cluster: &ClusterData,
+    query: &Query,
+) -> Result<Vec<QueryResult>, QueryError> {
+    let tasks = cluster.get_nodes_info().iter().flat_map(|node| {
+        let shard_count: u16 = node.sharder().unwrap().nr_shards.into();
+        (0..shard_count).map(|shard| {
+            let mut stmt = query.clone();
+            let policy = SingleTargetLBP {
+                target: (node.clone(), Some(shard as u32)),
+            };
+            let execution_profile = ExecutionProfile::builder()
+                .load_balancing_policy(Arc::new(policy))
+                .build();
+            stmt.set_execution_profile_handle(Some(execution_profile.into_handle()));
+
+            async move { session.query(stmt, &()).await }
+        })
+    });
+
+    try_join_all(tasks).await
+}
+
+fn frame_has_tablet_feedback(frame: ResponseFrame) -> bool {
+    let response =
+        scylla_cql::frame::parse_response_body_extensions(frame.params.flags, None, frame.body)
+            .unwrap();
+    match response.custom_payload {
+        Some(map) => map.contains_key("tablets-routing-v1"),
+        None => false,
+    }
+}
+
+fn count_tablet_feedbacks(
+    rx: &mut mpsc::UnboundedReceiver<(ResponseFrame, Option<TargetShard>)>,
+) -> usize {
+    std::iter::from_fn(|| rx.try_recv().ok())
+        .map(|(frame, _shard)| frame_has_tablet_feedback(frame))
+        .filter(|b| *b)
+        .count()
+}
+
+async fn prepare_schema(session: &Session, ks: &str, table: &str, tablet_count: usize) {
+    session
+        .query(
+            format!(
+                "CREATE KEYSPACE IF NOT EXISTS {} 
+            WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2}}
+            AND tablets = {{ 'initial': {} }}",
+                ks, tablet_count
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+    session
+        .query(
+            format!(
+                "CREATE TABLE IF NOT EXISTS {}.{} (a int, b int, c text, primary key (a, b))",
+                ks, table
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+}
+
+/// Tests that, when using DefaultPolicy with TokenAwareness and querying table
+/// that uses tablets:
+/// 1. When querying data that belongs to tablet we didn't receive yet we will
+///    receive this tablet at some point.
+/// 2. When we have all tablets info locally then we'll never receive tablet info.
+///
+/// The test first sends 100 queries per tablet and expects to receive tablet info.
+/// After that we know we have all the info. The test sends the statements again
+/// and expects to not receive any tablet info.
+#[cfg(not(scylla_cloud_tests))]
+#[tokio::test]
+#[ntest::timeout(30000)]
+async fn test_default_policy_is_tablet_aware() {
+    setup_tracing();
+    const TABLET_COUNT: usize = 16;
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = scylla::SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            if !scylla::test_utils::scylla_supports_tablets(&session).await {
+                tracing::warn!("Skipping test because this Scylla version doesn't support tablets");
+                return running_proxy;
+            }
+
+            let ks = unique_keyspace_name();
+
+            /* Prepare schema */
+            prepare_schema(&session, &ks, "t", TABLET_COUNT).await;
+
+            let tablets = get_tablets(&session, &ks, "t").await;
+
+            let prepared = session
+                .prepare(format!(
+                    "INSERT INTO {}.t (a, b, c) VALUES (?, ?, 'abc')",
+                    ks
+                ))
+                .await
+                .unwrap();
+
+            let value_lists = calculate_key_per_tablet(&tablets, &prepared);
+
+            let (feedback_txs, mut feedback_rxs): (Vec<_>, Vec<_>) = (0..3)
+                .map(|_| mpsc::unbounded_channel::<(ResponseFrame, Option<TargetShard>)>())
+                .unzip();
+            for (i, tx) in feedback_txs.iter().cloned().enumerate() {
+                running_proxy.running_nodes[i].change_response_rules(Some(vec![ResponseRule(
+                    Condition::ResponseOpcode(ResponseOpcode::Result)
+                        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent)),
+                    ResponseReaction::noop().with_feedback_when_performed(tx),
+                )]));
+            }
+
+            // When the driver never received tablet info for any tablet in a given table,
+            // then it will not be aware that the table is tablet-based and fall back
+            // to token-ring routing for this table.
+            // After it receives any tablet for this table:
+            // - tablet-aware routing will be used for tablets that the driver has locally
+            // - non-token-aware routing will be used for other tablets (which basically means
+            //   sending the requests to random nodes)
+            // In the following code I want to make sure that the driver fetches info
+            // about all the tablets in the table.
+            // Obvious way to do this would be to, for each tablet, send some requests (here some == 100)
+            // and expect that at least one will land on non-replica and return tablet feedback.
+            // This mostly works, but there is a problem: initially driver has no
+            // tablet information at all for this table so it will fall back to token-ring routing.
+            // It is possible that token-ring replicas and tablet replicas are the same
+            // for some tokens. If it happens for the first token that we use in this loop,
+            // then no matter how many requests we send we are not going to receive any tablet feedback.
+            // The solution is to iterate over tablets twice.
+            //
+            // First iteration guarantees that the driver will receive at least one tablet
+            // for this table (it is statistically improbable for all tokens used here to have the same
+            // set of replicas for tablets and token-ring). In practice it will receive all or almost all of the tablets.
+            //
+            // Second iteration will not use token-ring routing (because the driver has some tablets
+            // for this table, so it is aware that the table is tablet based),
+            // which means that for unknown tablets it will send requests to random nodes,
+            // and definitely fetch the rest of the tablets.
+            let mut total_tablets_with_feedback = 0;
+            for values in value_lists.iter().chain(value_lists.iter()) {
+                info!(
+                    "First loop, trying key {:?}, token: {}",
+                    values,
+                    prepared.calculate_token(&values).unwrap().unwrap().value()
+                );
+                try_join_all((0..100).map(|_| async { session.execute(&prepared, values).await }))
+                    .await
+                    .unwrap();
+                let feedbacks: usize = feedback_rxs.iter_mut().map(count_tablet_feedbacks).sum();
+                if feedbacks > 0 {
+                    total_tablets_with_feedback += 1;
+                }
+            }
+
+            assert_eq!(total_tablets_with_feedback, TABLET_COUNT);
+
+            // Now we must have info about all the tablets. It should not be
+            // possible to receive any feedback if DefaultPolicy is properly
+            // tablet-aware.
+            for values in value_lists.iter() {
+                info!(
+                    "Second loop, trying key {:?}, token: {}",
+                    values,
+                    prepared.calculate_token(&values).unwrap().unwrap().value()
+                );
+                try_join_all((0..100).map(|_| async { session.execute(&prepared, values).await }))
+                    .await
+                    .unwrap();
+                let feedbacks: usize = feedback_rxs.iter_mut().map(count_tablet_feedbacks).sum();
+                assert_eq!(feedbacks, 0);
+            }
+
+            running_proxy
+        },
+    )
+    .await;
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// This test verifies that Scylla never sends tablet info when receiving unprepared
+/// query - as it would make no sens to send it (driver can't do token awareness
+/// for unprepared queries).
+///
+/// The test sends a query to each shard of every node and verifies that no
+/// tablet info was sent in response.
+#[cfg(not(scylla_cloud_tests))]
+#[tokio::test]
+#[ntest::timeout(30000)]
+async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
+    setup_tracing();
+    const TABLET_COUNT: usize = 16;
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = scylla::SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            if !scylla::test_utils::scylla_supports_tablets(&session).await {
+                tracing::warn!("Skipping test because this Scylla version doesn't support tablets");
+                return running_proxy;
+            }
+
+            let ks = unique_keyspace_name();
+
+            /* Prepare schema */
+            prepare_schema(&session, &ks, "t", TABLET_COUNT).await;
+
+            let (feedback_txs, mut feedback_rxs): (Vec<_>, Vec<_>) = (0..3)
+                .map(|_| mpsc::unbounded_channel::<(ResponseFrame, Option<TargetShard>)>())
+                .unzip();
+            for (i, tx) in feedback_txs.iter().cloned().enumerate() {
+                running_proxy.running_nodes[i].change_response_rules(Some(vec![ResponseRule(
+                    Condition::ResponseOpcode(ResponseOpcode::Result)
+                        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent)),
+                    ResponseReaction::noop().with_feedback_when_performed(tx),
+                )]));
+            }
+
+            // I expect Scylla to not send feedback for unprepared queries,
+            // as such queries cannot be token-aware anyway
+            send_unprepared_query_everywhere(
+                &session,
+                session.get_cluster_data().as_ref(),
+                &Query::new(format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 1, 'abc')")),
+            )
+            .await
+            .unwrap();
+
+            let feedbacks: usize = feedback_rxs.iter_mut().map(count_tablet_feedbacks).sum();
+            assert!(feedbacks == 0);
+
+            running_proxy
+        },
+    )
+    .await;
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Verifies that LWT optimization (sending LWT queries to the replicas in a fixed order)
+/// works correctly for tablet tables when we have all tablet info locally.
+///
+/// The test first fetches all tablet info: by sending a query to each shard of each node,
+/// for every tablet.
+/// After that it sends 100 queries fro each tablet and verifies that only 1 shard on 1 node
+/// recevied requests for a given tablet.
+#[cfg(not(scylla_cloud_tests))]
+#[tokio::test]
+#[ntest::timeout(30000)]
+async fn test_lwt_optimization_works_with_tablets() {
+    setup_tracing();
+    const TABLET_COUNT: usize = 16;
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = scylla::SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            if !scylla::test_utils::scylla_supports_tablets(&session).await {
+                tracing::warn!("Skipping test because this Scylla version doesn't support tablets");
+                return running_proxy;
+            }
+
+            let ks = unique_keyspace_name();
+
+            /* Prepare schema */
+            prepare_schema(&session, &ks, "t", TABLET_COUNT).await;
+
+            let tablets = get_tablets(&session, &ks, "t").await;
+
+            let prepared_insert = session
+                .prepare(format!(
+                    "INSERT INTO {}.t (a, b, c) VALUES (?, ?, null)",
+                    ks
+                ))
+                .await
+                .unwrap();
+
+            let prepared_lwt_update = session
+                .prepare(format!(
+                    "UPDATE {}.t SET c = ? WHERE a = ? and b = ? IF c != null",
+                    ks
+                ))
+                .await
+                .unwrap();
+
+            let value_lists = calculate_key_per_tablet(&tablets, &prepared_insert);
+
+            let (feedback_txs, mut feedback_rxs): (Vec<_>, Vec<_>) = (0..3)
+                .map(|_| mpsc::unbounded_channel::<(ResponseFrame, Option<TargetShard>)>())
+                .unzip();
+            for (i, tx) in feedback_txs.iter().cloned().enumerate() {
+                running_proxy.running_nodes[i].change_response_rules(Some(vec![ResponseRule(
+                    Condition::ResponseOpcode(ResponseOpcode::Result)
+                        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent)),
+                    ResponseReaction::noop().with_feedback_when_performed(tx),
+                )]));
+            }
+
+            // Unlike test_tablet_awareness_works_with_full_info I use "send_statement_everywhere",
+            // in order to make the test faster (it sends one request per shard, not 100 requests).
+            for values in value_lists.iter() {
+                info!(
+                    "First loop, trying key {:?}, token: {}",
+                    values,
+                    prepared_insert
+                        .calculate_token(&values)
+                        .unwrap()
+                        .unwrap()
+                        .value()
+                );
+                send_statement_everywhere(
+                    &session,
+                    session.get_cluster_data().as_ref(),
+                    &prepared_insert,
+                    values,
+                )
+                .await
+                .unwrap();
+                let feedbacks: usize = feedback_rxs.iter_mut().map(count_tablet_feedbacks).sum();
+                assert!(feedbacks > 0);
+            }
+
+            // We have all the info about tablets.
+            // Executing LWT queries should not yield any more feedbacks.
+            // All queries for given key should also land in a single replica.
+            for (a, b) in value_lists.iter() {
+                info!(
+                    "Second loop, trying key {:?}, token: {}",
+                    (a, b),
+                    prepared_insert
+                        .calculate_token(&(a, b))
+                        .unwrap()
+                        .unwrap()
+                        .value()
+                );
+                try_join_all((0..100).map(|_| async {
+                    session.execute(&prepared_lwt_update, &("abc", a, b)).await
+                }))
+                .await
+                .unwrap();
+
+                let mut queried_nodes = 0;
+                feedback_rxs.iter_mut().for_each(|rx| {
+                    let frames = std::iter::from_fn(|| rx.try_recv().ok()).collect::<Vec<_>>();
+                    let feedbacks_count = frames
+                        .iter()
+                        .map(|(frame, _shard)| frame_has_tablet_feedback(frame.clone()))
+                        .filter(|b| *b)
+                        .count();
+                    assert_eq!(feedbacks_count, 0);
+
+                    let queried_shards =
+                        frames.iter().map(|(_frame, shard)| *shard).unique().count();
+                    assert!(queried_shards <= 1);
+
+                    if queried_shards == 1 {
+                        queried_nodes += 1;
+                    }
+                });
+
+                assert_eq!(queried_nodes, 1);
+            }
+
+            running_proxy
+        },
+    )
+    .await;
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}


### PR DESCRIPTION
This PR introduces support for tablets. The design as a bit different than in the other drivers.

### For information about what Tablets are see:
https://www.scylladb.com/2023/07/10/why-scylladb-is-moving-to-a-new-replication-algorithm-tablets/

### Driver context
To give a bit of context of how things are working in Rust Driver now:
`Session` has a `cluster: Cluster` field which in turn has `data: Arc<ArcSwap<ClusterData>>`.
`ClusterData` contains all the schema and topology information. It also contains `ReplicaLocator`, which uses token ring to return a list of replicas for a given token and replication strategy.
Driver can access `ClusterData` cheaply, without the need for any locks. It is used for performing queries and is also exposed to the user: https://docs.rs/scylla/latest/scylla/transport/session/struct.Session.html#method.get_cluster_data
This data is updated by `ClusterWorker`, running in a separate Tokio task. This worker handles server events, `use_keyspace` requests, manages control connection. When necessary (and also periodically) it re-fetches topology and schema
information, creates new `ClusterData` object and then swaps it atomically (for more information see https://docs.rs/arc-swap/latest/arc_swap/ ) with the old one - this way new queries will use new `ClusterData` without disrupting old ones.

### How does the driver interact with Tablets?
Information about Tablets are stored in `system.tablets`. Driver could fetch this information to have it always complete and up to date, but that could be overwhelming for the cluster.
This is because there is just one token ring - token ownership is tied to a node, but in tablets this information is per-table (my intuition about tablets is to see them as per-table token ring that can by dynamically changed). Also there may be more tablets than token ring elements.
Now imagine a scenario where a lot of clients try to reconnect to the cluster, which has a lot of tables. The amount of transferred data would be too big.
For this reason driver fetches tablets information lazily. When the driver send a statement to a non-replica node, it will receive tablet information in the custom payload of the response.
This information contains data about the tablet that the statement belongs to: first and last tokens of the tablet + list of tablet replicas (in the form `list<(uuid, shard)>` ).
Driver can then update it's internal tablet information using this feedback, so that the following statements will be sent to a correct replica.

### Implementation

Information about tablets is stored in `ReplicaLocator` (which is inside `ClusterData`), similarly to token ring data.
When a connection receives tablet feedback it sends this feedback trough a channel. Receiving end of this channel
is owned by `ClusterWorker`. When it receives something on this channel it clones `ClusterData` (because there is no other way to update it without introducing locks),
updates tablet info inside and stores it in `ArcSwap` - just like when topology is updated. As an optimisation it tries to retrieve several tablets from the channel at once,
so that when there is a lot of updates we don't perform clone + swap for each of them.

This way queries can be executed as before, without any locks and other costly operations, just accessing `ClusterData` which is mostly a simple data structure.

### Maintanance

Implementation chosen by Scylla makes things a bit more complicated for the driver.  We only update tablet info when we send a query to a wrong node.
This means that the information can sometimes become stale
- When a node is removed we would just keep sending queries to other replicas, never receiving new tablet.
- When a keyspace / table is dropped we would unnecessarily keep info about it.
- (may be Rust Driver only) When driver is not aware of one of the replicas yet (e.g. because the node is new and driver didn't yet fetch topology) and we skip this replica we'll increase load on other replicas indefinitely.
- (may be Rust Driver only) When a `Node` object is recreated (this happens when node changes Ip / DC / Rack) tablet info would still contain old objects.

To handle those scenarios driver fixes tablet information after fetching new topology. As far as I'm aware other driver don't handle those scenarios, we may need to fix it.
One scenario which I'm not sure how to handle (and if it's even problematic): what if user changes RF of a keyspace? How does it work with tablets?
If it just adds a replica to replica list, then we will not use this replica - we'll keep sending requests to other replicas and never receive new tablet info.
I'm not sure how we could detect it and if it's even a problem.

### Alternative solution

One alternative solution would be to use `RwLock` - take a read lock in `ReplicaLocator` to get list of replicas, take a write lock when handling custom payload tablet feedback to update info.
I decided against it because:
- It's possible we would hold a write lock often, slowing down queries. I also don't like the idea of taking a lock in a hot path (executing a query) in general.
- Most of `ClusterData` (pretty much all of it except `Node` objects) is a simple data, without any locks, which makes it simpler to reason about it. I didn't want to change this.
- It makes implementing tablet info maintenance much harder. Doing maintenance would require taking a write lock for a lot of time, hindering performance.

### Downsides of implemented solution

- We need to copy `ClusterData` to update tablet info. This won't increase max memory usage - because we already copy it when updating topology - but now we'll copy it more often. Implementing https://github.com/scylladb/scylla-rust-driver/issues/595 will largely mitigate this issue because we won't need to copy schema information, just topology.
- Received tablet info is not immediately used. There may be a brief period after we receive tablet information, but before it is present in `ClusterData` during which we'll keep sending data to wrong nodes. I don't think it's much of a problem - the same thing would happen with any implementation  if you send a few queries to the same parttition at once. The worst thing that happens is that some more queries will be sent to wrong nodes and we'll receive few more feedbacks.

### LWT
One note about LWT: with token ring the LWT optimisation (sending LWT prepared statements to the same node from any clients, to avoid conflicts) was working always. Now it requires having tablet info for a given partition - so a first LWT to a given partition will not use the optimisation.


TODO:
- [x] Proper commit messages
- [x] Verify content of each commit, change when necessary to ensure each passes CI - There are a few unused function warnings.
- [ ] Run SCT tests with this branch
- [ ] Is there any documentation / comments that need updating?
- [ ] ~~Benchmark possible tablets implementations: vector vs map~~
- [ ] Unit tests for maintenance code 
- [x] Don't unwrap when converting number type in Tablet info parsing
- [x] I recently learned that i64::MIN is not a valid token. Need to look into this to check if we properly change it to i64::MAX when hashing. I wonder if such check should instead be moved to `Token` struct.
- [x] CI for tablets, similar to serverless - because it needs unstable scylla version
- [x] Put tablets behind unstable feature flag until they are released in Scylla

## Past questions / considerations

During implementation I had some dillemas questions, mostly solved / answered now, which are outlined below.

### Tests with removed / decommisioned nodes

I'd like to test such scenarios, as suggested by @avelanarius , but I think we don't have a good way to do this now.
There is proxy, but afaik it can only simulate network errors.
It would be nice to use ccm (or something like this) in tests and have Rust API for it to manipulate cluster more easily.
Need to figure out a way to test it now.

Status: I'll run some SCT tests using cql-stress built using this branch of driver.

### Unknown replica

Is it possible to get a replica uuid in custom payload that we don't know about? What should we do in this case?
Right now I'm just ignoring this replica, but I don't like this. This will cause load to be distributed less evenly
because we skip one (or more) of replicas.

Status: Implemented tablet maintanance to guard against this and some other problems.

### What about `ReplicasOrdered`?

It returns replicas in ring order, which makes little sense in Tablets tables.
I'm thinking of just editing a comment to say that the order is just consistent, but doesn't have to be ring order.
`ReplicasOrdered` seems to only be used for LWT, so this should be fine.
To do this, I need to make sure that the order is actually consistent - because it's not obvious.

Also, I'd like to have some test that uses the path where it's used - probably neeed to use LWT with Tablet-enabled table?

Status: Assumed that replicas are returned in consistent order. Added integration tests performing LWT queries.

### Integration tests

I wrote an integration test for tablets (last commit) but it doesn't always work, and I'm not sure how to write a proper test.
The test first inserts some row. Each query is executed multiple times and the test checks that at least one execution
was sent to wrong node and recevied tablet feedback. This is not always the case and I'm not sure how to force it.

@avelanarius suggested that there is `"tablet_allocator_shuffle"` HTTP api, but the comment in Scylla tests says
` # Increases the chance of tablet migration concurrent with schema change` which doesn't sound helpful here.

In Python driver implementation the test looks into tracing to verify that the query was sent to a correct node.
I'm not a big fan of this approach, as it doesn't verify that we can send things to the wrong nodes when we don't have the data.

Status: Managed to write correct integration tests using one-shot LBPs to make sure I send queries to all nodes/shards.

### Wojciech's commits

What should I do with Wojciech's commits?
I'm considering squashing them (and introducing some changes to them so that resulting commit passes CI).
The changes are mostly mechanical and it would allow us to have atomic commits in this PR.

Status: Opened https://github.com/scylladb/scylla-rust-driver/pull/944 with his changes cleaned up


### Tablet feedback handled in Connection, not in Session

Tablet info is extracted from frame in Connection instead of Session + iterators.
I did look into moving that into session, but decided that it's too complicated and error-prone.
In the current implementation I can have certainty that we handle this for all requests.

Status: it will stay that way for now


### `FromCqlVal::from_cql` is tablets.rs

Is it possible for this to fail? I don't see how, but I'm not very familiar with this are of code.
If it can't fail, I could avoid introducing new error type.

Status: I added `.unwrap()`, it seems that this call can't fail.


### Parsing fail

What to do when parsing Tablet data from custom payload fails?
Erroring whole request seems excessive. Right now I just print a warning. Is it enough?

Status: Printing warning is enough, so I'll stick to that.

Fixes: #867 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
