### PR TITLE
Rename `chrono`, `time` and `secret` features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,8 +48,8 @@ jobs:
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secrecy-08"
     - name: Cargo check with chrono feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "chrono"
-    - name: Cargo check with time feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "time"
+    - name: Cargo check with time-03 feature
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "time-03"
     - name: Cargo check with num-bigint-03 feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "num-bigint-03"
     - name: Cargo check with num-bigint-04 feature

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,8 @@ jobs:
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "full-serialization"
     - name: Cargo check with all features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --all-features
-    - name: Cargo check with secret feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secret"
+    - name: Cargo check with secrecy-08 feature
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secrecy-08"
     - name: Cargo check with chrono feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "chrono"
     - name: Cargo check with time feature

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,8 +46,8 @@ jobs:
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --all-features
     - name: Cargo check with secrecy-08 feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secrecy-08"
-    - name: Cargo check with chrono feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "chrono"
+    - name: Cargo check with chrono-04 feature
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "chrono-04"
     - name: Cargo check with time-03 feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "time-03"
     - name: Cargo check with num-bigint-03 feature

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ rustyline-derive = "0.6"
 scylla = { path = "../scylla", features = [
     "ssl",
     "cloud",
-    "chrono",
+    "chrono-04",
     "time-03",
     "num-bigint-03",
     "num-bigint-04",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ scylla = { path = "../scylla", features = [
     "ssl",
     "cloud",
     "chrono",
-    "time",
+    "time-03",
     "num-bigint-03",
     "num-bigint-04",
     "bigdecimal-04",

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 # FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
 tokio = { version = ">=1.34, <1.38", features = ["io-util", "time"] }
-secrecy = { version = "0.7.0", optional = true }
+secrecy = { version = "0.8", optional = true }
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0"
 num-bigint-03 = { package = "num-bigint", version = "0.3", optional = true }
 num-bigint-04 = { package = "num-bigint", version = "0.4", optional = true }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4", optional = true }
-chrono = { version = "0.4.32", default-features = false, optional = true }
+chrono-04 = { package = "chrono", version = "0.4.32", default-features = false, optional = true }
 lz4_flex = { version = "0.11.1" }
 async-trait = "0.1.57"
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -42,12 +42,12 @@ harness = false
 [features]
 secrecy-08 = ["dep:secrecy-08"]
 time-03 = ["dep:time-03"]
-chrono = ["dep:chrono"]
+chrono-04 = ["dep:chrono-04"]
 num-bigint-03 = ["dep:num-bigint-03"]
 num-bigint-04 = ["dep:num-bigint-04"]
 bigdecimal-04 = ["dep:bigdecimal-04"]
 full-serialization = [
-    "chrono",
+    "chrono-04",
     "time-03",
     "secrecy-08",
     "num-bigint-03",

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 # FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
 tokio = { version = ">=1.34, <1.38", features = ["io-util", "time"] }
-secrecy = { version = "0.8", optional = true }
+secrecy-08 = { package = "secrecy", version = "0.8", optional = true }
 snap = "1.0"
 uuid = "1.0"
 thiserror = "1.0"
@@ -40,7 +40,7 @@ name = "benchmark"
 harness = false
 
 [features]
-secret = ["secrecy"]
+secrecy-08 = ["dep:secrecy-08"]
 time = ["dep:time"]
 chrono = ["dep:chrono"]
 num-bigint-03 = ["dep:num-bigint-03"]
@@ -49,7 +49,7 @@ bigdecimal-04 = ["dep:bigdecimal-04"]
 full-serialization = [
     "chrono",
     "time",
-    "secret",
+    "secrecy-08",
     "num-bigint-03",
     "num-bigint-04",
     "bigdecimal-04",

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -26,13 +26,13 @@ chrono = { version = "0.4.32", default-features = false, optional = true }
 lz4_flex = { version = "0.11.1" }
 async-trait = "0.1.57"
 serde = { version = "1.0", features = ["derive"], optional = true }
-time = { version = "0.3", optional = true }
+time-03 = { package = "time", version = "0.3", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = "0.4"        # Note: v0.5 needs at least rust 1.70.0
 # Use large-dates feature to test potential edge cases
-time = { version = "0.3.21", features = ["large-dates"] }
+time-03 = { package = "time", version = "0.3.21", features = ["large-dates"] }
 uuid = { version = "1.0", features = ["v4"] }
 
 [[bench]]
@@ -41,14 +41,14 @@ harness = false
 
 [features]
 secrecy-08 = ["dep:secrecy-08"]
-time = ["dep:time"]
+time-03 = ["dep:time-03"]
 chrono = ["dep:chrono"]
 num-bigint-03 = ["dep:num-bigint-03"]
 num-bigint-04 = ["dep:num-bigint-04"]
 bigdecimal-04 = ["dep:bigdecimal-04"]
 full-serialization = [
     "chrono",
-    "time",
+    "time-03",
     "secrecy-08",
     "num-bigint-03",
     "num-bigint-04",

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -8,9 +8,6 @@ use std::net::IpAddr;
 use thiserror::Error;
 use uuid::Uuid;
 
-#[cfg(feature = "chrono")]
-use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
-
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum FromRowError {
     #[error("{err} in the column with index {column}")]
@@ -175,8 +172,8 @@ impl FromCqlVal<CqlValue> for bigdecimal_04::BigDecimal {
     }
 }
 
-#[cfg(feature = "chrono")]
-impl FromCqlVal<CqlValue> for NaiveDate {
+#[cfg(feature = "chrono-04")]
+impl FromCqlVal<CqlValue> for chrono_04::NaiveDate {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         match cql_val {
             CqlValue::Date(cql_date) => cql_date.try_into().map_err(|_| FromCqlValError::BadVal),
@@ -195,8 +192,8 @@ impl FromCqlVal<CqlValue> for time_03::Date {
     }
 }
 
-#[cfg(feature = "chrono")]
-impl FromCqlVal<CqlValue> for NaiveTime {
+#[cfg(feature = "chrono-04")]
+impl FromCqlVal<CqlValue> for chrono_04::NaiveTime {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         match cql_val {
             CqlValue::Time(cql_time) => cql_time.try_into().map_err(|_| FromCqlValError::BadVal),
@@ -215,8 +212,8 @@ impl FromCqlVal<CqlValue> for time_03::Time {
     }
 }
 
-#[cfg(feature = "chrono")]
-impl FromCqlVal<CqlValue> for DateTime<Utc> {
+#[cfg(feature = "chrono-04")]
+impl FromCqlVal<CqlValue> for chrono_04::DateTime<chrono_04::Utc> {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
         cql_val
             .as_cql_timestamp()
@@ -523,10 +520,10 @@ mod tests {
         assert_eq!(Ok(counter), Counter::from_cql(CqlValue::Counter(counter)));
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "chrono-04")]
     #[test]
-    fn naive_date_from_cql() {
-        use chrono::NaiveDate;
+    fn naive_date_04_from_cql() {
+        use chrono_04::NaiveDate;
 
         let unix_epoch: CqlValue = CqlValue::Date(CqlDate(2_u32.pow(31)));
         assert_eq!(
@@ -631,10 +628,10 @@ mod tests {
         assert_eq!(time_ns, CqlTime::from_cql(cql_value).unwrap().0);
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "chrono-04")]
     #[test]
-    fn naive_time_from_cql() {
-        use chrono::NaiveTime;
+    fn naive_time_04_from_cql() {
+        use chrono_04::NaiveTime;
 
         // Midnight
         let midnight = CqlValue::Time(CqlTime(0));
@@ -658,7 +655,7 @@ mod tests {
             NaiveTime::from_cql(late_night)
         );
 
-        // Bad values. Since value is out of `chrono::NaiveTime` range, it should return `BadVal` error
+        // Bad values. Since value is out of `chrono_04::NaiveTime` range, it should return `BadVal` error
         let bad_time1 = CqlValue::Time(CqlTime(-1));
         assert_eq!(Err(FromCqlValError::BadVal), NaiveTime::from_cql(bad_time1));
         let bad_time2 = CqlValue::Time(CqlTime(i64::MAX));
@@ -731,10 +728,10 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "chrono-04")]
     #[test]
-    fn datetime_from_cql() {
-        use chrono::{DateTime, NaiveDate, Utc};
+    fn datetime_04_from_cql() {
+        use chrono_04::{DateTime, NaiveDate, Utc};
         let naivedatetime_utc = NaiveDate::from_ymd_opt(2022, 12, 31)
             .unwrap()
             .and_hms_opt(2, 0, 0)

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -11,9 +11,6 @@ use uuid::Uuid;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 
-#[cfg(feature = "secret")]
-use secrecy::{Secret, Zeroize};
-
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum FromRowError {
     #[error("{err} in the column with index {column}")]
@@ -240,10 +237,10 @@ impl FromCqlVal<CqlValue> for time::OffsetDateTime {
     }
 }
 
-#[cfg(feature = "secret")]
-impl<V: FromCqlVal<CqlValue> + Zeroize> FromCqlVal<CqlValue> for Secret<V> {
+#[cfg(feature = "secrecy-08")]
+impl<V: FromCqlVal<CqlValue> + secrecy_08::Zeroize> FromCqlVal<CqlValue> for secrecy_08::Secret<V> {
     fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
-        Ok(Secret::new(FromCqlVal::from_cql(cql_val)?))
+        Ok(secrecy_08::Secret::new(FromCqlVal::from_cql(cql_val)?))
     }
 }
 

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -192,8 +192,8 @@ impl CqlValue {
         self.as_cql_date().and_then(|date| date.try_into().ok())
     }
 
-    #[cfg(feature = "time")]
-    pub fn as_date(&self) -> Option<time::Date> {
+    #[cfg(feature = "time-03")]
+    pub fn as_date(&self) -> Option<time_03::Date> {
         self.as_cql_date().and_then(|date| date.try_into().ok())
     }
 
@@ -209,8 +209,8 @@ impl CqlValue {
         self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
     }
 
-    #[cfg(feature = "time")]
-    pub fn as_offset_date_time(&self) -> Option<time::OffsetDateTime> {
+    #[cfg(feature = "time-03")]
+    pub fn as_offset_date_time(&self) -> Option<time_03::OffsetDateTime> {
         self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
     }
 
@@ -226,8 +226,8 @@ impl CqlValue {
         self.as_cql_time().and_then(|ts| ts.try_into().ok())
     }
 
-    #[cfg(feature = "time")]
-    pub fn as_time(&self) -> Option<time::Time> {
+    #[cfg(feature = "time-03")]
+    pub fn as_time(&self) -> Option<time_03::Time> {
         self.as_cql_time().and_then(|ts| ts.try_into().ok())
     }
 
@@ -1318,13 +1318,13 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "time")]
+    #[cfg(feature = "time-03")]
     #[test]
-    fn test_date_from_cql() {
-        use time::Date;
-        use time::Month::*;
+    fn test_date_03_from_cql() {
+        use time_03::Date;
+        use time_03::Month::*;
 
-        // 2^31 when converted to time::Date is 1970-01-01
+        // 2^31 when converted to time_03::Date is 1970-01-01
         let unix_epoch = Date::from_calendar_date(1970, January, 1).unwrap();
         let date =
             super::deser_cql_value(&ColumnType::Date, &mut (1u32 << 31).to_be_bytes().as_ref())
@@ -1332,7 +1332,7 @@ mod tests {
 
         assert_eq!(date.as_date(), Some(unix_epoch));
 
-        // 2^31 - 30 when converted to time::Date is 1969-12-02
+        // 2^31 - 30 when converted to time_03::Date is 1969-12-02
         let before_epoch = Date::from_calendar_date(1969, December, 2).unwrap();
         let date = super::deser_cql_value(
             &ColumnType::Date,
@@ -1342,7 +1342,7 @@ mod tests {
 
         assert_eq!(date.as_date(), Some(before_epoch));
 
-        // 2^31 + 30 when converted to time::Date is 1970-01-31
+        // 2^31 + 30 when converted to time_03::Date is 1970-01-31
         let after_epoch = Date::from_calendar_date(1970, January, 31).unwrap();
         let date = super::deser_cql_value(
             &ColumnType::Date,
@@ -1431,10 +1431,10 @@ mod tests {
         assert_eq!(time.as_naive_time(), Some(midnight));
     }
 
-    #[cfg(feature = "time")]
+    #[cfg(feature = "time-03")]
     #[test]
-    fn test_primitive_time_from_cql() {
-        use time::Time;
+    fn test_primitive_time_03_from_cql() {
+        use time_03::Time;
 
         // 0 when converted to NaiveTime is 0:0:0.0
         let midnight = Time::from_hms_nano(0, 0, 0, 0).unwrap();
@@ -1542,10 +1542,10 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "time")]
+    #[cfg(feature = "time-03")]
     #[test]
-    fn test_offset_datetime_from_cql() {
-        use time::{Date, Month::*, OffsetDateTime, PrimitiveDateTime, Time};
+    fn test_offset_datetime_03_from_cql() {
+        use time_03::{Date, Month::*, OffsetDateTime, PrimitiveDateTime, Time};
 
         // 0 when converted to OffsetDateTime is 1970-01-01 0:00:00.00
         let unix_epoch = OffsetDateTime::from_unix_timestamp(0).unwrap();

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -12,9 +12,6 @@ use std::borrow::Cow;
 use std::{convert::TryInto, net::IpAddr, result::Result as StdResult, str};
 use uuid::Uuid;
 
-#[cfg(feature = "chrono")]
-use chrono::{DateTime, NaiveDate, Utc};
-
 #[derive(Debug)]
 pub struct SetKeyspace {
     pub keyspace_name: String,
@@ -187,8 +184,8 @@ impl CqlValue {
         }
     }
 
-    #[cfg(feature = "chrono")]
-    pub fn as_naive_date(&self) -> Option<NaiveDate> {
+    #[cfg(feature = "chrono-04")]
+    pub fn as_naive_date(&self) -> Option<chrono_04::NaiveDate> {
         self.as_cql_date().and_then(|date| date.try_into().ok())
     }
 
@@ -205,8 +202,8 @@ impl CqlValue {
         }
     }
 
-    #[cfg(feature = "chrono")]
-    pub fn as_datetime(&self) -> Option<DateTime<Utc>> {
+    #[cfg(feature = "chrono-04")]
+    pub fn as_datetime(&self) -> Option<chrono_04::DateTime<chrono_04::Utc>> {
         self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
     }
 
@@ -223,8 +220,8 @@ impl CqlValue {
         }
     }
 
-    #[cfg(feature = "chrono")]
-    pub fn as_naive_time(&self) -> Option<chrono::NaiveTime> {
+    #[cfg(feature = "chrono-04")]
+    pub fn as_naive_time(&self) -> Option<chrono_04::NaiveTime> {
         self.as_cql_time().and_then(|ts| ts.try_into().ok())
     }
 
@@ -1272,10 +1269,10 @@ mod tests {
         assert_eq!(date.as_cql_date(), Some(max_date));
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "chrono-04")]
     #[test]
-    fn test_naive_date_from_cql() {
-        use chrono::NaiveDate;
+    fn test_naive_date_04_from_cql() {
+        use chrono_04::NaiveDate;
 
         // 2^31 when converted to NaiveDate is 1970-01-01
         let unix_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
@@ -1395,10 +1392,10 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "chrono-04")]
     #[test]
-    fn test_naive_time_from_cql() {
-        use chrono::NaiveTime;
+    fn test_naive_time_04_from_cql() {
+        use chrono_04::NaiveTime;
 
         // 0 when converted to NaiveTime is 0:0:0.0
         let midnight = NaiveTime::from_hms_nano_opt(0, 0, 0, 0).unwrap();
@@ -1486,10 +1483,10 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "chrono-04")]
     #[test]
-    fn test_datetime_from_cql() {
-        use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
+    fn test_datetime_04_from_cql() {
+        use chrono_04::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
 
         // 0 when converted to DateTime is 1970-01-01 0:00:00.00
         let unix_epoch = DateTime::from_timestamp(0, 0).unwrap();

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -184,8 +184,9 @@ impl CqlValue {
         }
     }
 
+    #[cfg(test)]
     #[cfg(feature = "chrono-04")]
-    pub fn as_naive_date(&self) -> Option<chrono_04::NaiveDate> {
+    fn as_naive_date_04(&self) -> Option<chrono_04::NaiveDate> {
         self.as_cql_date().and_then(|date| date.try_into().ok())
     }
 
@@ -202,8 +203,9 @@ impl CqlValue {
         }
     }
 
+    #[cfg(test)]
     #[cfg(feature = "chrono-04")]
-    pub fn as_datetime(&self) -> Option<chrono_04::DateTime<chrono_04::Utc>> {
+    fn as_datetime_04(&self) -> Option<chrono_04::DateTime<chrono_04::Utc>> {
         self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
     }
 
@@ -220,8 +222,9 @@ impl CqlValue {
         }
     }
 
+    #[cfg(test)]
     #[cfg(feature = "chrono-04")]
-    pub fn as_naive_time(&self) -> Option<chrono_04::NaiveTime> {
+    fn as_naive_time_04(&self) -> Option<chrono_04::NaiveTime> {
         self.as_cql_time().and_then(|ts| ts.try_into().ok())
     }
 
@@ -1280,7 +1283,7 @@ mod tests {
             super::deser_cql_value(&ColumnType::Date, &mut (1u32 << 31).to_be_bytes().as_ref())
                 .unwrap();
 
-        assert_eq!(date.as_naive_date(), Some(unix_epoch));
+        assert_eq!(date.as_naive_date_04(), Some(unix_epoch));
 
         // 2^31 - 30 when converted to NaiveDate is 1969-12-02
         let before_epoch = NaiveDate::from_ymd_opt(1969, 12, 2).unwrap();
@@ -1290,7 +1293,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_naive_date(), Some(before_epoch));
+        assert_eq!(date.as_naive_date_04(), Some(before_epoch));
 
         // 2^31 + 30 when converted to NaiveDate is 1970-01-31
         let after_epoch = NaiveDate::from_ymd_opt(1970, 1, 31).unwrap();
@@ -1300,20 +1303,20 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_naive_date(), Some(after_epoch));
+        assert_eq!(date.as_naive_date_04(), Some(after_epoch));
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
             super::deser_cql_value(&ColumnType::Date, &mut 0_u32.to_be_bytes().as_ref())
                 .unwrap()
-                .as_naive_date(),
+                .as_naive_date_04(),
             None
         );
 
         assert_eq!(
             super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
                 .unwrap()
-                .as_naive_date(),
+                .as_naive_date_04(),
             None
         );
     }
@@ -1402,7 +1405,7 @@ mod tests {
         let time =
             super::deser_cql_value(&ColumnType::Time, &mut (0i64).to_be_bytes().as_ref()).unwrap();
 
-        assert_eq!(time.as_naive_time(), Some(midnight));
+        assert_eq!(time.as_naive_time_04(), Some(midnight));
 
         // 10:10:30.500,000,001
         let (h, m, s, n) = (10, 10, 30, 500_000_001);
@@ -1415,7 +1418,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(time.as_naive_time(), Some(midnight));
+        assert_eq!(time.as_naive_time_04(), Some(midnight));
 
         // 23:59:59.999,999,999
         let (h, m, s, n) = (23, 59, 59, 999_999_999);
@@ -1428,7 +1431,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(time.as_naive_time(), Some(midnight));
+        assert_eq!(time.as_naive_time_04(), Some(midnight));
     }
 
     #[cfg(feature = "time-03")]
@@ -1493,7 +1496,7 @@ mod tests {
         let date = super::deser_cql_value(&ColumnType::Timestamp, &mut 0i64.to_be_bytes().as_ref())
             .unwrap();
 
-        assert_eq!(date.as_datetime(), Some(unix_epoch));
+        assert_eq!(date.as_datetime_04(), Some(unix_epoch));
 
         // When converted to NaiveDateTime, this is 1969-12-01 11:29:29.5
         let timestamp: i64 = -((((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500);
@@ -1508,7 +1511,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_datetime(), Some(before_epoch));
+        assert_eq!(date.as_datetime_04(), Some(before_epoch));
 
         // when converted to NaiveDateTime, this is is 1970-01-31 12:30:30.5
         let timestamp: i64 = (((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500;
@@ -1523,20 +1526,20 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_datetime(), Some(after_epoch));
+        assert_eq!(date.as_datetime_04(), Some(after_epoch));
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
             super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MIN.to_be_bytes().as_ref())
                 .unwrap()
-                .as_datetime(),
+                .as_datetime_04(),
             None
         );
 
         assert_eq!(
             super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MAX.to_be_bytes().as_ref())
                 .unwrap()
-                .as_datetime(),
+                .as_datetime_04(),
             None
         );
     }

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -192,8 +192,9 @@ impl CqlValue {
         self.as_cql_date().and_then(|date| date.try_into().ok())
     }
 
+    #[cfg(test)]
     #[cfg(feature = "time-03")]
-    pub fn as_date(&self) -> Option<time_03::Date> {
+    fn as_date_03(&self) -> Option<time_03::Date> {
         self.as_cql_date().and_then(|date| date.try_into().ok())
     }
 
@@ -209,8 +210,9 @@ impl CqlValue {
         self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
     }
 
+    #[cfg(test)]
     #[cfg(feature = "time-03")]
-    pub fn as_offset_date_time(&self) -> Option<time_03::OffsetDateTime> {
+    fn as_offset_date_time_03(&self) -> Option<time_03::OffsetDateTime> {
         self.as_cql_timestamp().and_then(|ts| ts.try_into().ok())
     }
 
@@ -226,8 +228,9 @@ impl CqlValue {
         self.as_cql_time().and_then(|ts| ts.try_into().ok())
     }
 
+    #[cfg(test)]
     #[cfg(feature = "time-03")]
-    pub fn as_time(&self) -> Option<time_03::Time> {
+    fn as_time_03(&self) -> Option<time_03::Time> {
         self.as_cql_time().and_then(|ts| ts.try_into().ok())
     }
 
@@ -1330,7 +1333,7 @@ mod tests {
             super::deser_cql_value(&ColumnType::Date, &mut (1u32 << 31).to_be_bytes().as_ref())
                 .unwrap();
 
-        assert_eq!(date.as_date(), Some(unix_epoch));
+        assert_eq!(date.as_date_03(), Some(unix_epoch));
 
         // 2^31 - 30 when converted to time_03::Date is 1969-12-02
         let before_epoch = Date::from_calendar_date(1969, December, 2).unwrap();
@@ -1340,7 +1343,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_date(), Some(before_epoch));
+        assert_eq!(date.as_date_03(), Some(before_epoch));
 
         // 2^31 + 30 when converted to time_03::Date is 1970-01-31
         let after_epoch = Date::from_calendar_date(1970, January, 31).unwrap();
@@ -1350,20 +1353,20 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_date(), Some(after_epoch));
+        assert_eq!(date.as_date_03(), Some(after_epoch));
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
             super::deser_cql_value(&ColumnType::Date, &mut 0_u32.to_be_bytes().as_ref())
                 .unwrap()
-                .as_date(),
+                .as_date_03(),
             None
         );
 
         assert_eq!(
             super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
                 .unwrap()
-                .as_date(),
+                .as_date_03(),
             None
         );
     }
@@ -1441,8 +1444,7 @@ mod tests {
         let time =
             super::deser_cql_value(&ColumnType::Time, &mut (0i64).to_be_bytes().as_ref()).unwrap();
 
-        dbg!(&time);
-        assert_eq!(time.as_time(), Some(midnight));
+        assert_eq!(time.as_time_03(), Some(midnight));
 
         // 10:10:30.500,000,001
         let (h, m, s, n) = (10, 10, 30, 500_000_001);
@@ -1455,7 +1457,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(time.as_time(), Some(midnight));
+        assert_eq!(time.as_time_03(), Some(midnight));
 
         // 23:59:59.999,999,999
         let (h, m, s, n) = (23, 59, 59, 999_999_999);
@@ -1468,7 +1470,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(time.as_time(), Some(midnight));
+        assert_eq!(time.as_time_03(), Some(midnight));
     }
 
     #[test]
@@ -1552,7 +1554,7 @@ mod tests {
         let date = super::deser_cql_value(&ColumnType::Timestamp, &mut 0i64.to_be_bytes().as_ref())
             .unwrap();
 
-        assert_eq!(date.as_offset_date_time(), Some(unix_epoch));
+        assert_eq!(date.as_offset_date_time_03(), Some(unix_epoch));
 
         // When converted to NaiveDateTime, this is 1969-12-01 11:29:29.5
         let timestamp: i64 = -((((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500);
@@ -1567,7 +1569,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_offset_date_time(), Some(before_epoch));
+        assert_eq!(date.as_offset_date_time_03(), Some(before_epoch));
 
         // when converted to NaiveDateTime, this is is 1970-01-31 12:30:30.5
         let timestamp: i64 = (((30 * 24 + 12) * 60 + 30) * 60 + 30) * 1000 + 500;
@@ -1582,20 +1584,20 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(date.as_offset_date_time(), Some(after_epoch));
+        assert_eq!(date.as_offset_date_time_03(), Some(after_epoch));
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
             super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MIN.to_be_bytes().as_ref())
                 .unwrap()
-                .as_offset_date_time(),
+                .as_offset_date_time_03(),
             None
         );
 
         assert_eq!(
             super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MAX.to_be_bytes().as_ref())
                 .unwrap()
-                .as_offset_date_time(),
+                .as_offset_date_time_03(),
             None
         );
     }

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -548,17 +548,19 @@ impl TryInto<NaiveTime> for CqlTime {
     }
 }
 
-#[cfg(feature = "time")]
-impl From<time::Date> for CqlDate {
-    fn from(value: time::Date) -> Self {
+#[cfg(feature = "time-03")]
+impl From<time_03::Date> for CqlDate {
+    fn from(value: time_03::Date) -> Self {
         const JULIAN_DAY_OFFSET: i64 =
-            (1 << 31) - time::OffsetDateTime::UNIX_EPOCH.date().to_julian_day() as i64;
+            (1 << 31) - time_03::OffsetDateTime::UNIX_EPOCH.date().to_julian_day() as i64;
 
         // Statically assert that no possible value will ever overflow
-        const _: () =
-            assert!(time::Date::MAX.to_julian_day() as i64 + JULIAN_DAY_OFFSET < u32::MAX as i64);
-        const _: () =
-            assert!(time::Date::MIN.to_julian_day() as i64 + JULIAN_DAY_OFFSET > u32::MIN as i64);
+        const _: () = assert!(
+            time_03::Date::MAX.to_julian_day() as i64 + JULIAN_DAY_OFFSET < u32::MAX as i64
+        );
+        const _: () = assert!(
+            time_03::Date::MIN.to_julian_day() as i64 + JULIAN_DAY_OFFSET > u32::MIN as i64
+        );
 
         let days = value.to_julian_day() as i64 + JULIAN_DAY_OFFSET;
 
@@ -566,29 +568,29 @@ impl From<time::Date> for CqlDate {
     }
 }
 
-#[cfg(feature = "time")]
-impl TryInto<time::Date> for CqlDate {
+#[cfg(feature = "time-03")]
+impl TryInto<time_03::Date> for CqlDate {
     type Error = ValueOverflow;
 
-    fn try_into(self) -> Result<time::Date, Self::Error> {
+    fn try_into(self) -> Result<time_03::Date, Self::Error> {
         const JULIAN_DAY_OFFSET: i64 =
-            (1 << 31) - time::OffsetDateTime::UNIX_EPOCH.date().to_julian_day() as i64;
+            (1 << 31) - time_03::OffsetDateTime::UNIX_EPOCH.date().to_julian_day() as i64;
 
         let julian_days = (self.0 as i64 - JULIAN_DAY_OFFSET)
             .try_into()
             .map_err(|_| ValueOverflow)?;
 
-        time::Date::from_julian_day(julian_days).map_err(|_| ValueOverflow)
+        time_03::Date::from_julian_day(julian_days).map_err(|_| ValueOverflow)
     }
 }
 
-#[cfg(feature = "time")]
-impl From<time::OffsetDateTime> for CqlTimestamp {
-    fn from(value: time::OffsetDateTime) -> Self {
+#[cfg(feature = "time-03")]
+impl From<time_03::OffsetDateTime> for CqlTimestamp {
+    fn from(value: time_03::OffsetDateTime) -> Self {
         // Statically assert that no possible value will ever overflow. OffsetDateTime doesn't allow offset to overflow
         // the UTC PrimitiveDateTime value value
         const _: () = assert!(
-            time::PrimitiveDateTime::MAX
+            time_03::PrimitiveDateTime::MAX
                 .assume_utc()
                 .unix_timestamp_nanos()
                 // Nanos to millis
@@ -596,7 +598,7 @@ impl From<time::OffsetDateTime> for CqlTimestamp {
                 < i64::MAX as i128
         );
         const _: () = assert!(
-            time::PrimitiveDateTime::MIN
+            time_03::PrimitiveDateTime::MIN
                 .assume_utc()
                 .unix_timestamp_nanos()
                 / 1_000_000
@@ -608,19 +610,19 @@ impl From<time::OffsetDateTime> for CqlTimestamp {
     }
 }
 
-#[cfg(feature = "time")]
-impl TryInto<time::OffsetDateTime> for CqlTimestamp {
+#[cfg(feature = "time-03")]
+impl TryInto<time_03::OffsetDateTime> for CqlTimestamp {
     type Error = ValueOverflow;
 
-    fn try_into(self) -> Result<time::OffsetDateTime, Self::Error> {
-        time::OffsetDateTime::from_unix_timestamp_nanos(self.0 as i128 * 1_000_000)
+    fn try_into(self) -> Result<time_03::OffsetDateTime, Self::Error> {
+        time_03::OffsetDateTime::from_unix_timestamp_nanos(self.0 as i128 * 1_000_000)
             .map_err(|_| ValueOverflow)
     }
 }
 
-#[cfg(feature = "time")]
-impl From<time::Time> for CqlTime {
-    fn from(value: time::Time) -> Self {
+#[cfg(feature = "time-03")]
+impl From<time_03::Time> for CqlTime {
+    fn from(value: time_03::Time) -> Self {
         let (h, m, s, n) = value.as_hms_nano();
 
         // no need for checked arithmetic as all these types are guaranteed to fit in i64 without overflow
@@ -630,17 +632,17 @@ impl From<time::Time> for CqlTime {
     }
 }
 
-#[cfg(feature = "time")]
-impl TryInto<time::Time> for CqlTime {
+#[cfg(feature = "time-03")]
+impl TryInto<time_03::Time> for CqlTime {
     type Error = ValueOverflow;
 
-    fn try_into(self) -> Result<time::Time, Self::Error> {
+    fn try_into(self) -> Result<time_03::Time, Self::Error> {
         let h = self.0 / 3_600_000_000_000;
         let m = self.0 / 60_000_000_000 % 60;
         let s = self.0 / 1_000_000_000 % 60;
         let n = self.0 % 1_000_000_000;
 
-        time::Time::from_hms_nano(
+        time_03::Time::from_hms_nano(
             h.try_into().map_err(|_| ValueOverflow)?,
             m as u8,
             s as u8,
@@ -1020,8 +1022,8 @@ impl Value for CqlDate {
     }
 }
 
-#[cfg(feature = "time")]
-impl Value for time::Date {
+#[cfg(feature = "time-03")]
+impl Value for time_03::Date {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         CqlDate::from(*self).serialize(buf)
     }
@@ -1050,8 +1052,8 @@ impl Value for DateTime<Utc> {
     }
 }
 
-#[cfg(feature = "time")]
-impl Value for time::OffsetDateTime {
+#[cfg(feature = "time-03")]
+impl Value for time_03::OffsetDateTime {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         CqlTimestamp::from(*self).serialize(buf)
     }
@@ -1066,8 +1068,8 @@ impl Value for NaiveTime {
     }
 }
 
-#[cfg(feature = "time")]
-impl Value for time::Time {
+#[cfg(feature = "time-03")]
+impl Value for time_03::Time {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
         CqlTime::from(*self).serialize(buf)
     }

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -16,9 +16,6 @@ use super::response::result::CqlValue;
 use super::types::vint_encode;
 use super::types::RawValue;
 
-#[cfg(feature = "secret")]
-use secrecy::{ExposeSecret, Secret, Zeroize};
-
 /// Every value being sent in a query must implement this trait
 /// serialize() should write the Value as [bytes] to the provided buffer
 pub trait Value {
@@ -1076,9 +1073,10 @@ impl Value for time::Time {
     }
 }
 
-#[cfg(feature = "secret")]
-impl<V: Value + Zeroize> Value for Secret<V> {
+#[cfg(feature = "secrecy-08")]
+impl<V: Value + secrecy_08::Zeroize> Value for secrecy_08::Secret<V> {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
+        use secrecy_08::ExposeSecret;
         self.expose_secret().serialize(buf)
     }
 }

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -306,10 +306,10 @@ fn ipaddr_serialization() {
     );
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono-04")]
 #[test]
-fn naive_date_serialization() {
-    use chrono::NaiveDate;
+fn naive_date_04_serialization() {
+    use chrono_04::NaiveDate;
     // 1970-01-31 is 2^31
     let unix_epoch: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
     assert_eq!(
@@ -412,10 +412,10 @@ fn cql_time_serialization() {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono-04")]
 #[test]
-fn naive_time_serialization() {
-    use chrono::NaiveTime;
+fn naive_time_04_serialization() {
+    use chrono_04::NaiveTime;
 
     let midnight_time: i64 = 0;
     let max_time: i64 = 24 * 60 * 60 * 1_000_000_000 - 1;
@@ -492,10 +492,10 @@ fn cql_timestamp_serialization() {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono-04")]
 #[test]
-fn date_time_serialization() {
-    use chrono::{DateTime, Utc};
+fn date_time_04_serialization() {
+    use chrono_04::{DateTime, Utc};
     let test_cases: [(DateTime<Utc>, [u8; 8]); 7] = [
         (
             // Max time serialized without error

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -872,11 +872,10 @@ fn cqlvalue_serialization() {
     );
 }
 
-#[cfg(feature = "secret")]
+#[cfg(feature = "secrecy-08")]
 #[test]
 fn secret_serialization() {
-    use secrecy::Secret;
-    let secret = Secret::new(987654i32);
+    let secret = secrecy_08::Secret::new(987654i32);
     assert_eq!(
         serialized(secret, ColumnType::Int),
         vec![0, 0, 0, 4, 0x00, 0x0f, 0x12, 0x06]

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -335,11 +335,11 @@ fn naive_date_serialization() {
     assert_eq!((2_u32.pow(31) + 30).to_be_bytes(), [128, 0, 0, 30]);
 }
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 #[test]
-fn date_serialization() {
+fn date_03_serialization() {
     // 1970-01-31 is 2^31
-    let unix_epoch = time::Date::from_ordinal_date(1970, 1).unwrap();
+    let unix_epoch = time_03::Date::from_ordinal_date(1970, 1).unwrap();
     assert_eq!(
         serialized(unix_epoch, ColumnType::Date),
         vec![0, 0, 0, 4, 128, 0, 0, 0]
@@ -347,7 +347,8 @@ fn date_serialization() {
     assert_eq!(2_u32.pow(31).to_be_bytes(), [128, 0, 0, 0]);
 
     // 1969-12-02 is 2^31 - 30
-    let before_epoch = time::Date::from_calendar_date(1969, time::Month::December, 2).unwrap();
+    let before_epoch =
+        time_03::Date::from_calendar_date(1969, time_03::Month::December, 2).unwrap();
     assert_eq!(
         serialized(before_epoch, ColumnType::Date),
         vec![0, 0, 0, 4, 127, 255, 255, 226]
@@ -355,15 +356,16 @@ fn date_serialization() {
     assert_eq!((2_u32.pow(31) - 30).to_be_bytes(), [127, 255, 255, 226]);
 
     // 1970-01-31 is 2^31 + 30
-    let after_epoch = time::Date::from_calendar_date(1970, time::Month::January, 31).unwrap();
+    let after_epoch = time_03::Date::from_calendar_date(1970, time_03::Month::January, 31).unwrap();
     assert_eq!(
         serialized(after_epoch, ColumnType::Date),
         vec![0, 0, 0, 4, 128, 0, 0, 30]
     );
     assert_eq!((2_u32.pow(31) + 30).to_be_bytes(), [128, 0, 0, 30]);
 
-    // Min date represented by time::Date (without large-dates feature)
-    let long_before_epoch = time::Date::from_calendar_date(-9999, time::Month::January, 1).unwrap();
+    // Min date represented by time_03::Date (without large-dates feature)
+    let long_before_epoch =
+        time_03::Date::from_calendar_date(-9999, time_03::Month::January, 1).unwrap();
     let days_till_epoch = (unix_epoch - long_before_epoch).whole_days();
     assert_eq!(
         (2_u32.pow(31) - days_till_epoch as u32).to_be_bytes(),
@@ -374,8 +376,9 @@ fn date_serialization() {
         vec![0, 0, 0, 4, 127, 189, 75, 125]
     );
 
-    // Max date represented by time::Date (without large-dates feature)
-    let long_after_epoch = time::Date::from_calendar_date(9999, time::Month::December, 31).unwrap();
+    // Max date represented by time_03::Date (without large-dates feature)
+    let long_after_epoch =
+        time_03::Date::from_calendar_date(9999, time_03::Month::December, 31).unwrap();
     let days_since_epoch = (long_after_epoch - unix_epoch).whole_days();
     assert_eq!(
         (2_u32.pow(31) + days_since_epoch as u32).to_be_bytes(),
@@ -446,20 +449,20 @@ fn naive_time_serialization() {
     )
 }
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 #[test]
-fn time_serialization() {
+fn time_03_serialization() {
     let midnight_time: i64 = 0;
     let max_time: i64 = 24 * 60 * 60 * 1_000_000_000 - 1;
     let any_time: i64 = (3600 + 2 * 60 + 3) * 1_000_000_000 + 4;
     let test_cases = [
-        (time::Time::MIDNIGHT, midnight_time.to_be_bytes()),
+        (time_03::Time::MIDNIGHT, midnight_time.to_be_bytes()),
         (
-            time::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap(),
+            time_03::Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap(),
             max_time.to_be_bytes(),
         ),
         (
-            time::Time::from_hms_nano(1, 2, 3, 4).unwrap(),
+            time_03::Time::from_hms_nano(1, 2, 3, 4).unwrap(),
             any_time.to_be_bytes(),
         ),
     ];
@@ -541,14 +544,14 @@ fn date_time_serialization() {
     }
 }
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 #[test]
-fn offset_date_time_serialization() {
-    use time::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
+fn offset_date_time_03_serialization() {
+    use time_03::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
     let offset_max =
-        PrimitiveDateTime::MAX.assume_offset(time::UtcOffset::from_hms(-23, -59, -59).unwrap());
+        PrimitiveDateTime::MAX.assume_offset(time_03::UtcOffset::from_hms(-23, -59, -59).unwrap());
     let offset_min =
-        PrimitiveDateTime::MIN.assume_offset(time::UtcOffset::from_hms(23, 59, 59).unwrap());
+        PrimitiveDateTime::MIN.assume_offset(time_03::UtcOffset::from_hms(23, 59, 59).unwrap());
     let test_cases = [
         (
             // Max time serialized without error

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -616,10 +616,10 @@ impl_emptiable_strict_type!(
 );
 
 // secrecy
-#[cfg(feature = "secret")]
-impl<'frame, T> DeserializeValue<'frame> for secrecy::Secret<T>
+#[cfg(feature = "secrecy-08")]
+impl<'frame, T> DeserializeValue<'frame> for secrecy_08::Secret<T>
 where
-    T: DeserializeValue<'frame> + secrecy::Zeroize,
+    T: DeserializeValue<'frame> + secrecy_08::Zeroize,
 {
     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
         <T as DeserializeValue<'frame>>::type_check(typ)
@@ -629,7 +629,7 @@ where
         typ: &'frame ColumnType,
         v: Option<FrameSlice<'frame>>,
     ) -> Result<Self, DeserializationError> {
-        <T as DeserializeValue<'frame>>::deserialize(typ, v).map(secrecy::Secret::new)
+        <T as DeserializeValue<'frame>>::deserialize(typ, v).map(secrecy_08::Secret::new)
     }
 }
 

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -421,7 +421,7 @@ impl_emptiable_strict_type!(
     }
 );
 
-#[cfg(any(feature = "chrono", feature = "time"))]
+#[cfg(any(feature = "chrono", feature = "time-03"))]
 fn get_days_since_epoch_from_date_column<T>(
     typ: &ColumnType,
     v: Option<FrameSlice<'_>>,
@@ -449,14 +449,14 @@ impl_emptiable_strict_type!(
     }
 );
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 impl_emptiable_strict_type!(
-    time::Date,
+    time_03::Date,
     Date,
     |typ: &'frame ColumnType, v: Option<FrameSlice<'frame>>| {
         let days_since_epoch =
-            time::Duration::days(get_days_since_epoch_from_date_column::<Self>(typ, v)?);
-        time::Date::from_calendar_date(1970, time::Month::January, 1)
+            time_03::Duration::days(get_days_since_epoch_from_date_column::<Self>(typ, v)?);
+        time_03::Date::from_calendar_date(1970, time_03::Month::January, 1)
             .unwrap()
             .checked_add(days_since_epoch)
             .ok_or_else(|| {
@@ -508,14 +508,14 @@ impl_emptiable_strict_type!(
     }
 );
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 impl_emptiable_strict_type!(
-    time::Time,
+    time_03::Time,
     Time,
     |typ: &'frame ColumnType, v: Option<FrameSlice<'frame>>| {
-        let nanoseconds = get_nanos_from_time_column::<time::Time>(typ, v)?;
+        let nanoseconds = get_nanos_from_time_column::<time_03::Time>(typ, v)?;
 
-        let time: time::Time = CqlTime(nanoseconds).try_into().map_err(|_| {
+        let time: time_03::Time = CqlTime(nanoseconds).try_into().map_err(|_| {
             mk_deser_err::<Self>(typ, BuiltinDeserializationErrorKind::ValueOverflow)
         })?;
         Ok(time)
@@ -560,13 +560,13 @@ impl_emptiable_strict_type!(
     }
 );
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 impl_emptiable_strict_type!(
-    time::OffsetDateTime,
+    time_03::OffsetDateTime,
     Timestamp,
     |typ: &'frame ColumnType, v: Option<FrameSlice<'frame>>| {
         let millis = get_millis_from_timestamp_column::<Self>(typ, v)?;
-        time::OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000)
+        time_03::OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000)
             .map_err(|_| mk_deser_err::<Self>(typ, BuiltinDeserializationErrorKind::ValueOverflow))
     }
 );
@@ -1979,10 +1979,10 @@ pub(super) mod tests {
             &mut Bytes::new(),
         );
 
-        #[cfg(feature = "time")]
+        #[cfg(feature = "time-03")]
         assert_ser_de_identity(
             &ColumnType::Date,
-            &time::Date::from_ordinal_date(1999, 99).unwrap(),
+            &time_03::Date::from_ordinal_date(1999, 99).unwrap(),
             &mut Bytes::new(),
         );
 
@@ -1996,10 +1996,10 @@ pub(super) mod tests {
             &mut Bytes::new(),
         );
 
-        #[cfg(feature = "time")]
+        #[cfg(feature = "time-03")]
         assert_ser_de_identity(
             &ColumnType::Time,
-            &time::Time::from_hms_micro(21, 37, 21, 37).unwrap(),
+            &time_03::Time::from_hms_micro(21, 37, 21, 37).unwrap(),
             &mut Bytes::new(),
         );
 
@@ -2017,10 +2017,10 @@ pub(super) mod tests {
             &mut Bytes::new(),
         );
 
-        #[cfg(feature = "time")]
+        #[cfg(feature = "time-03")]
         assert_ser_de_identity(
             &ColumnType::Timestamp,
-            &time::OffsetDateTime::from_unix_timestamp(0xdead_cafe).unwrap(),
+            &time_03::OffsetDateTime::from_unix_timestamp(0xdead_cafe).unwrap(),
             &mut Bytes::new(),
         );
     }

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -9,9 +9,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
-#[cfg(feature = "chrono")]
-use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
-
 use crate::frame::response::result::{ColumnType, CqlValue};
 use crate::frame::types::vint_encode;
 use crate::frame::value::{
@@ -19,7 +16,7 @@ use crate::frame::value::{
     MaybeUnset, Unset, Value,
 };
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono-04")]
 use crate::frame::value::ValueOverflow;
 
 use super::writers::WrittenCellProof;
@@ -157,22 +154,22 @@ impl SerializeValue for CqlTime {
         writer.set_value(me.0.to_be_bytes().as_slice()).unwrap()
     });
 }
-#[cfg(feature = "chrono")]
-impl SerializeValue for NaiveDate {
+#[cfg(feature = "chrono-04")]
+impl SerializeValue for chrono_04::NaiveDate {
     impl_serialize_via_writer!(|me, typ, writer| {
         exact_type_check!(typ, Date);
         <CqlDate as SerializeValue>::serialize(&(*me).into(), typ, writer)?
     });
 }
-#[cfg(feature = "chrono")]
-impl SerializeValue for DateTime<Utc> {
+#[cfg(feature = "chrono-04")]
+impl SerializeValue for chrono_04::DateTime<chrono_04::Utc> {
     impl_serialize_via_writer!(|me, typ, writer| {
         exact_type_check!(typ, Timestamp);
         <CqlTimestamp as SerializeValue>::serialize(&(*me).into(), typ, writer)?
     });
 }
-#[cfg(feature = "chrono")]
-impl SerializeValue for NaiveTime {
+#[cfg(feature = "chrono-04")]
+impl SerializeValue for chrono_04::NaiveTime {
     impl_serialize_via_writer!(|me, typ, writer| {
         exact_type_check!(typ, Time);
         let cql_time = CqlTime::try_from(*me).map_err(|_: ValueOverflow| {

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -12,9 +12,6 @@ use uuid::Uuid;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 
-#[cfg(feature = "secret")]
-use secrecy::{ExposeSecret, Secret, Zeroize};
-
 use crate::frame::response::result::{ColumnType, CqlValue};
 use crate::frame::types::vint_encode;
 use crate::frame::value::{
@@ -205,13 +202,14 @@ impl SerializeValue for time::Time {
         <CqlTime as SerializeValue>::serialize(&(*me).into(), typ, writer)?
     });
 }
-#[cfg(feature = "secret")]
-impl<V: SerializeValue + Zeroize> SerializeValue for Secret<V> {
+#[cfg(feature = "secrecy-08")]
+impl<V: SerializeValue + secrecy_08::Zeroize> SerializeValue for secrecy_08::Secret<V> {
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
+        use secrecy_08::ExposeSecret;
         V::serialize(self.expose_secret(), typ, writer)
     }
 }

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -181,22 +181,22 @@ impl SerializeValue for NaiveTime {
         <CqlTime as SerializeValue>::serialize(&cql_time, typ, writer)?
     });
 }
-#[cfg(feature = "time")]
-impl SerializeValue for time::Date {
+#[cfg(feature = "time-03")]
+impl SerializeValue for time_03::Date {
     impl_serialize_via_writer!(|me, typ, writer| {
         exact_type_check!(typ, Date);
         <CqlDate as SerializeValue>::serialize(&(*me).into(), typ, writer)?
     });
 }
-#[cfg(feature = "time")]
-impl SerializeValue for time::OffsetDateTime {
+#[cfg(feature = "time-03")]
+impl SerializeValue for time_03::OffsetDateTime {
     impl_serialize_via_writer!(|me, typ, writer| {
         exact_type_check!(typ, Timestamp);
         <CqlTimestamp as SerializeValue>::serialize(&(*me).into(), typ, writer)?
     });
 }
-#[cfg(feature = "time")]
-impl SerializeValue for time::Time {
+#[cfg(feature = "time-03")]
+impl SerializeValue for time_03::Time {
     impl_serialize_via_writer!(|me, typ, writer| {
         exact_type_check!(typ, Time);
         <CqlTime as SerializeValue>::serialize(&(*me).into(), typ, writer)?

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -24,7 +24,7 @@ cloud = [
     "dep:url",
     "dep:base64",
 ]
-secret = ["scylla-cql/secret"]
+secrecy-08 = ["scylla-cql/secrecy-08"]
 chrono = ["scylla-cql/chrono"]
 time = ["scylla-cql/time"]
 num-bigint-03 = ["scylla-cql/num-bigint-03"]
@@ -33,7 +33,7 @@ bigdecimal-04 = ["scylla-cql/bigdecimal-04"]
 full-serialization = [
     "chrono",
     "time",
-    "secret",
+    "secrecy-08",
     "num-bigint-03",
     "num-bigint-04",
     "bigdecimal-04",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -25,13 +25,13 @@ cloud = [
     "dep:base64",
 ]
 secrecy-08 = ["scylla-cql/secrecy-08"]
-chrono = ["scylla-cql/chrono"]
+chrono-04 = ["scylla-cql/chrono-04"]
 time-03 = ["scylla-cql/time-03"]
 num-bigint-03 = ["scylla-cql/num-bigint-03"]
 num-bigint-04 = ["scylla-cql/num-bigint-04"]
 bigdecimal-04 = ["scylla-cql/bigdecimal-04"]
 full-serialization = [
-    "chrono",
+    "chrono-04",
     "time-03",
     "secrecy-08",
     "num-bigint-03",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -26,13 +26,13 @@ cloud = [
 ]
 secrecy-08 = ["scylla-cql/secrecy-08"]
 chrono = ["scylla-cql/chrono"]
-time = ["scylla-cql/time"]
+time-03 = ["scylla-cql/time-03"]
 num-bigint-03 = ["scylla-cql/num-bigint-03"]
 num-bigint-04 = ["scylla-cql/num-bigint-04"]
 bigdecimal-04 = ["scylla-cql/bigdecimal-04"]
 full-serialization = [
     "chrono",
-    "time",
+    "time-03",
     "secrecy-08",
     "num-bigint-03",
     "num-bigint-04",

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -293,9 +293,9 @@ async fn test_counter() {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono-04")]
 #[tokio::test]
-async fn test_naive_date() {
+async fn test_naive_date_04() {
     setup_tracing();
     use chrono::Datelike;
     use chrono::NaiveDate;
@@ -620,9 +620,9 @@ async fn test_cql_time() {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono-04")]
 #[tokio::test]
-async fn test_naive_time() {
+async fn test_naive_time_04() {
     setup_tracing();
     use chrono::NaiveTime;
 
@@ -842,9 +842,9 @@ async fn test_cql_timestamp() {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono-04")]
 #[tokio::test]
-async fn test_date_time() {
+async fn test_date_time_04() {
     setup_tracing();
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -448,9 +448,9 @@ async fn test_cql_date() {
         .unwrap_err();
 }
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 #[tokio::test]
-async fn test_date() {
+async fn test_date_03() {
     setup_tracing();
     use time::{Date, Month::*};
 
@@ -700,9 +700,9 @@ async fn test_naive_time() {
         .unwrap_err();
 }
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 #[tokio::test]
-async fn test_time() {
+async fn test_time_03() {
     setup_tracing();
     use time::Time;
 
@@ -1003,9 +1003,9 @@ async fn test_date_time() {
         .unwrap_err();
 }
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time-03")]
 #[tokio::test]
-async fn test_offset_date_time() {
+async fn test_offset_date_time_03() {
     setup_tracing();
     use time::{Date, Month::*, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/771

## Motivation

To follow the same naming conventions as for other features, we want to add a crate version numbers to the remaining dependencies hidden behind crate features: `chrono`, `time` and `secrecy`.

## Changes
### Dependecies versions
I bumped `secrecy` crate version from `0.7.0` to `0.8.0` which is the most recent version.

### Feature names
Renamed following features (and dependencies):
- feature `chrono` => feature `chrono-04`, dependency `chrono` => dependency `chrono_04` (scylla-cql)
- feature `time` => feature `time-03`, dependency `time` => dependency `time_03` (scylla-cql)
- feature `secret` => feature `secrecy-08`, dependency `secrecy` => dependency `secrecy_08` 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
