### PR TITLE
Fix semver checks

### DIFF
--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -66,7 +66,7 @@ jobs:
         set +e
         echo "output<<SEMVER_STDOUT_EOF" >> $GITHUB_OUTPUT
         # Weird sed strip ANSI colors from output
-        make semver-rev rev="$PR_BASE" |& tee /dev/tty | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" >> $GITHUB_OUTPUT
+        make semver-rev rev="$PR_BASE" |& tee /proc/self/fd/2 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" >> $GITHUB_OUTPUT
         exitcode=${PIPESTATUS[0]}
         echo "SEMVER_STDOUT_EOF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -72,8 +72,6 @@ jobs:
 
         echo "Semver checks exitcode: " $exitcode
         echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-        exit "$exitcode"
-      continue-on-error: true
 
   semver-pull-request-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -63,11 +63,16 @@ jobs:
     - name: Verify the API compatibilty with PR base
       id: semver-pr-check
       run: |
-        set +e
+        set -e # So that failed commands exit the script
+        set -o pipefail # So that if a command in a pipe fails, the whole command fails
+
         echo "output<<SEMVER_STDOUT_EOF" >> $GITHUB_OUTPUT
+        SEMVER_REV_OUTPUT=$(make semver-rev rev="$PR_BASE" 2>&1) && true # "&& true" preserves exit code but cancels effects of set -e
+        exitcode=$?
+
         # Weird sed strip ANSI colors from output
-        make semver-rev rev="$PR_BASE" |& tee /proc/self/fd/2 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" >> $GITHUB_OUTPUT
-        exitcode=${PIPESTATUS[0]}
+        # If any of the commands below fail, `set -e` and `set -o pipefail` should exit the script
+        echo "${SEMVER_REV_OUTPUT}" | tee /proc/self/fd/2 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" >> $GITHUB_OUTPUT
         echo "SEMVER_STDOUT_EOF" >> $GITHUB_OUTPUT
 
         echo "Semver checks exitcode: " $exitcode

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -69,6 +69,8 @@ jobs:
         make semver-rev rev="$PR_BASE" |& tee /dev/tty | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" >> $GITHUB_OUTPUT
         exitcode=${PIPESTATUS[0]}
         echo "SEMVER_STDOUT_EOF" >> $GITHUB_OUTPUT
+
+        echo "Semver checks exitcode: " $exitcode
         echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
         exit "$exitcode"
       continue-on-error: true


### PR DESCRIPTION
Previously semver checks CI used `/dev/tty` which seems unavailable in Github Actions.
Changed it to `/proc/self/fd/2` which I expect to be available pretty much anywhere.
Changed this CI step so that the job fails on errors. It wouldn't prevent #936 , because this command is part of pipeline, so it won't be affected by `set -e`, but I think it's a good change anyway.


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/936

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
