### PR TITLE
Revert "CI/Makefile: disable `uninlined_format_args` clippy lint"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Format check
       run: cargo fmt --verbose --all -- --check
     - name: Clippy check
-      run: cargo clippy --verbose --all-targets -- -Aclippy::uninlined_format_args
+      run: cargo clippy --verbose --all-targets
     - name: Cargo check without features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features ""
     - name: Cargo check with all serialization features

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ check-without-features:
 
 .PHONY: clippy
 clippy:
-	RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -Aclippy::uninlined_format_args
+	RUSTFLAGS=-Dwarnings cargo clippy --all-targets
 
 .PHONY: test
 test: up


### PR DESCRIPTION
This reverts commit 4964b4471c3d14bfea75e532b2e7c24cbd48cd65.

The main reason that `uninlined_format_args` lint was disabled in Rust Driver's CI/Makefile was that inlined variables in format strings had spotty support in rust-analyzer: rust-analyzer did not support renaming variables inside format strings.

Fortunately, rust-analyzer recently gained support for renaming  variables in format strings: rust-lang/rust-analyzer#16027, therefore 4964b4471 can now be reverted. 

Moreover, Rust 1.67.1 downgraded `uninlined_format_args` to pedantic,  meaning that it's disabled by default and we don't have to disable it manually. If it's ever promoted back to an enforced rule by default, we'll be ready to deal with it again (with a proper rust-analyzer  support) - not addressing it now to avoid merge conflicts with other bigger planned PRs.

Closes #643
