### PR TITLE
semver_checks: Edit comment instead of posting new one

### DIFF
--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -86,12 +86,29 @@ jobs:
     needs: semver-pull-request-check
     timeout-minutes: 3
     steps:
+    - name: Get ID of comment if posted previously.
+      uses: peter-evans/find-comment@v3
+      id: find-comment
+      with:
+          issue-number: ${{ env.PR_ID }}
+          comment-author: 'github-actions[bot]'
+          body-includes: semver
     - name: Remove breaking label on success
       run: gh pr edit "$PR_ID" --remove-label semver-checks-breaking
       if: needs.semver-pull-request-check.outputs.exitcode == '0'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
+    - name: Report that there were no breaks
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+          issue-number: ${{ env.PR_ID }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          body: |
+            `cargo semver-checks` found no API-breaking changes in this PR! 🎉🥳
+            Checked commit: ${{ env.PR_HEAD }}
+          edit-mode: replace
+      if: needs.semver-pull-request-check.outputs.exitcode == '0'
     - name: Add breaking label on failure
       run: gh pr edit "$PR_ID" --add-label semver-checks-breaking
       if: needs.semver-pull-request-check.outputs.exitcode != '0'
@@ -99,25 +116,25 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Post report on semver break
-      run: |
-        gh pr comment "$PR_ID" --body "\
-        \`cargo semver-checks\` detected some API incompatibilities in this PR.
-        See the following report for details:
-        <details>
-        <summary>cargo semver-checks output</summary>
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+          issue-number: ${{ env.PR_ID }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          body: |
+            `cargo semver-checks` detected some API incompatibilities in this PR.
+            Checked commit: ${{ env.PR_HEAD }}
 
-        \`\`\`
-        $SEMVER_OUTPUT
-        \`\`\`
+            See the following report for details:
+            <details>
+            <summary>cargo semver-checks output</summary>
 
-        </details>
-        "
+            ```
+            ${{ needs.semver-pull-request-check.outputs.output }}
+            ```
+
+            </details>
+          edit-mode: replace
       if: needs.semver-pull-request-check.outputs.exitcode != '0'
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_REPO: ${{ github.repository }}
-        SEMVER_OUTPUT: ${{ needs.semver-pull-request-check.outputs.output }}
-
 
   semver-push-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Up until now semver_checks CI posted a new comment after each push to a PR if such push resulted in PR (still) having breaking changes.
This was quite spammy for PRs that intentionally made breaking changes, because each and every push resulted in a new comment.

This commit changes the CI so that it edits already posted comment, and only posts a new one when there was none before.

If there are multiple comments already (as is the case with already open PRs) then the oldest one will be chosen for edit.
The aim is to always have semver status immediately below PR description.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/938

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
