### PR TITLE
treewide: get rid of (most) uses of `QueryResult::rows`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ let uri = "127.0.0.1:9042";
 
 let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-if let Some(rows) = session.query("SELECT a, b, c FROM ks.t", &[]).await?.rows {
-    for row in rows.into_typed::<(i32, i32, String)>() {
-        let (a, b, c) = row?;
-        println!("a, b, c: {}, {}, {}", a, b, c);
-    }
+let result = session.query("SELECT a, b, c FROM ks.t", &[]).await?;
+let mut iter = result.rows_typed::<(i32, i32, String)>()?;
+while let Some((a, b, c)) = iter.next().transpose()? {
+    println!("a, b, c: {}, {}, {}", a, b, c);
 }
 ```
 

--- a/docs/source/data-types/blob.md
+++ b/docs/source/data-types/blob.md
@@ -17,10 +17,10 @@ session
     .await?;
 
 // Read blobs from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(Vec<u8>,)>() {
-        let (blob_value,): (Vec<u8>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(Vec<u8>,)>()?;
+while let Some((blob_value,)) = iter.next().transpose()? {
+    println!("{:?}", blob_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/collections.md
+++ b/docs/source/data-types/collections.md
@@ -17,10 +17,10 @@ session
     .await?;
 
 // Read a list of ints from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(Vec<i32>,)>() {
-        let (list_value,): (Vec<i32>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(Vec<i32>,)>()?;
+while let Some((list_value,)) = iter.next().transpose()? {
+    println!("{:?}", list_value);
 }
 # Ok(())
 # }
@@ -43,10 +43,10 @@ session
     .await?;
 
 // Read a set of ints from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(Vec<i32>,)>() {
-        let (set_value,): (Vec<i32>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(Vec<i32>,)>()?;
+while let Some((list_value,)) = iter.next().transpose()? {
+    println!("{:?}", list_value);
 }
 # Ok(())
 # }
@@ -67,10 +67,10 @@ session
     .await?;
 
 // Read a set of ints from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(HashSet<i32>,)>() {
-        let (set_value,): (HashSet<i32>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(HashSet<i32>,)>()?;
+while let Some((list_value,)) = iter.next().transpose()? {
+    println!("{:?}", list_value);
 }
 # Ok(())
 # }
@@ -91,10 +91,10 @@ session
     .await?;
 
 // Read a set of ints from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(BTreeSet<i32>,)>() {
-        let (set_value,): (BTreeSet<i32>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(BTreeSet<i32>,)>()?;
+while let Some((list_value,)) = iter.next().transpose()? {
+    println!("{:?}", list_value);
 }
 # Ok(())
 # }
@@ -120,10 +120,10 @@ session
     .await?;
 
 // Read a map from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(HashMap<String, i32>,)>() {
-        let (map_value,): (HashMap<String, i32>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(HashMap<String, i32>,)>()?;
+while let Some((map_value,)) = iter.next().transpose()? {
+    println!("{:?}", map_value);
 }
 # Ok(())
 # }
@@ -146,10 +146,10 @@ session
     .await?;
 
 // Read a map from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(BTreeMap<String, i32>,)>() {
-        let (map_value,): (BTreeMap<String, i32>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(BTreeMap<String, i32>,)>()?;
+while let Some((map_value,)) = iter.next().transpose()? {
+    println!("{:?}", map_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/counter.md
+++ b/docs/source/data-types/counter.md
@@ -11,11 +11,11 @@ use scylla::IntoTypedRows;
 use scylla::frame::value::Counter;
 
 // Read counter from the table
-if let Some(rows) = session.query("SELECT c FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(Counter,)>() {
-        let (counter_value,): (Counter,) = row?;
-        let counter_int_value: i64 = counter_value.0;
-    }
+let result = session.query("SELECT c FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(Counter,)>()?;
+while let Some((counter_value,)) = iter.next().transpose()? {
+    let counter_int_value: i64 = counter_value.0;
+    println!("{}", counter_int_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/date.md
+++ b/docs/source/data-types/date.md
@@ -67,14 +67,10 @@ session
     .await?;
 
 // Read NaiveDate from the table
-if let Some(rows) = session
-    .query("SELECT a FROM keyspace.table", &[])
-    .await?
-    .rows
-{
-    for row in rows.into_typed::<(NaiveDate,)>() {
-        let (date_value,): (NaiveDate,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(NaiveDate,)>()?;
+while let Some((date_value,)) = iter.next().transpose()? {
+    println!("{:?}", date_value);
 }
 # Ok(())
 # }
@@ -105,14 +101,10 @@ session
     .await?;
 
 // Read Date from the table
-if let Some(rows) = session
-    .query("SELECT a FROM keyspace.table", &[])
-    .await?
-    .rows
-{
-    for row in rows.into_typed::<(Date,)>() {
-        let (date_value,): (Date,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(Date,)>()?;
+while let Some((date_value,)) = iter.next().transpose()? {
+    println!("{:?}", date_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/decimal.md
+++ b/docs/source/data-types/decimal.md
@@ -52,10 +52,10 @@ session
     .await?;
 
 // Read a decimal from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(BigDecimal,)>() {
-        let (decimal_value,): (BigDecimal,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(BigDecimal,)>()?;
+while let Some((decimal_value,)) = iter.next().transpose()? {
+    println!("{:?}", decimal_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/duration.md
+++ b/docs/source/data-types/duration.md
@@ -9,17 +9,17 @@
 use scylla::IntoTypedRows;
 use scylla::frame::value::CqlDuration;
 
-// Insert some ip address into the table
+// Insert some duration into the table
 let to_insert: CqlDuration = CqlDuration { months: 1, days: 2, nanoseconds: 3 };
 session
     .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
     .await?;
 
-// Read inet from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(CqlDuration,)>() {
-        let (cql_duration,): (CqlDuration,) = row?;
-    }
+// Read duration from the table
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(CqlDuration,)>()?;
+while let Some((duration_value,)) = iter.next().transpose()? {
+    println!("{:?}", duration_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/inet.md
+++ b/docs/source/data-types/inet.md
@@ -16,10 +16,10 @@ session
     .await?;
 
 // Read inet from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(IpAddr,)>() {
-        let (inet_value,): (IpAddr,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(IpAddr,)>()?;
+while let Some((inet_value,)) = iter.next().transpose()? {
+    println!("{:?}", inet_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/primitive.md
+++ b/docs/source/data-types/primitive.md
@@ -1,6 +1,7 @@
 # Bool, Tinyint, Smallint, Int, Bigint, Float, Double
 
 ### Bool
+
 `Bool` is represented as rust `bool`
 
 ```rust
@@ -17,16 +18,17 @@ session
     .await?;
 
 // Read a bool from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(bool,)>() {
-        let (bool_value,): (bool,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(bool,)>()?;
+while let Some((bool_value,)) = iter.next().transpose()? {
+    println!("{}", bool_value);
 }
 # Ok(())
 # }
 ```
 
 ### Tinyint
+
 `Tinyint` is represented as rust `i8`
 
 ```rust
@@ -43,16 +45,17 @@ session
     .await?;
 
 // Read a tinyint from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(i8,)>() {
-        let (tinyint_value,): (i8,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(i8,)>()?;
+while let Some((tinyint_value,)) = iter.next().transpose()? {
+    println!("{:?}", tinyint_value);
 }
 # Ok(())
 # }
 ```
 
 ### Smallint
+
 `Smallint` is represented as rust `i16`
 
 ```rust
@@ -69,16 +72,17 @@ session
     .await?;
 
 // Read a smallint from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(i16,)>() {
-        let (smallint_value,): (i16,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(i16,)>()?;
+while let Some((smallint_value,)) = iter.next().transpose()? {
+    println!("{}", smallint_value);
 }
 # Ok(())
 # }
 ```
 
 ### Int
+
 `Int` is represented as rust `i32`
 
 ```rust
@@ -95,16 +99,17 @@ session
     .await?;
 
 // Read an int from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(i32,)>() {
-        let (int_value,): (i32,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(i32,)>()?;
+while let Some((int_value,)) = iter.next().transpose()? {
+    println!("{}", int_value);
 }
 # Ok(())
 # }
 ```
 
 ### Bigint
+
 `Bigint` is represented as rust `i64`
 
 ```rust
@@ -121,16 +126,17 @@ session
     .await?;
 
 // Read a bigint from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(i64,)>() {
-        let (bigint_value,): (i64,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(i64,)>()?;
+while let Some((bigint_value,)) = iter.next().transpose()? {
+    println!("{:?}", bigint_value);
 }
 # Ok(())
 # }
 ```
 
-### Float 
+### Float
+
 `Float` is represented as rust `f32`
 
 ```rust
@@ -147,16 +153,17 @@ session
     .await?;
 
 // Read a float from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(f32,)>() {
-        let (float_value,): (f32,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(f32,)>()?;
+while let Some((float_value,)) = iter.next().transpose()? {
+    println!("{:?}", float_value);
 }
 # Ok(())
 # }
 ```
 
 ### Double
+
 `Double` is represented as rust `f64`
 
 ```rust
@@ -173,10 +180,10 @@ session
     .await?;
 
 // Read a double from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(f64,)>() {
-        let (double_value,): (f64,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(f64,)>()?;
+while let Some((double_value,)) = iter.next().transpose()? {
+    println!("{:?}", double_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/text.md
+++ b/docs/source/data-types/text.md
@@ -21,10 +21,10 @@ session
     .await?;
 
 // Read ascii/text/varchar from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(String,)>() {
-        let (text_value,): (String,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(String,)>()?;
+while let Some((text_value,)) = iter.next().transpose()? {
+    println!("{}", text_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/time.md
+++ b/docs/source/data-types/time.md
@@ -67,14 +67,10 @@ session
     .await?;
 
 // Read time from the table
-if let Some(rows) = session
-    .query("SELECT a FROM keyspace.table", &[])
-    .await?
-    .rows
-{
-    for row in rows.into_typed::<(NaiveTime,)>() {
-        let (time_value,): (NaiveTime,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(NaiveTime,)>()?;
+while let Some((time_value,)) = iter.next().transpose()? {
+    println!("{:?}", time_value);
 }
 # Ok(())
 # }
@@ -103,14 +99,10 @@ session
     .await?;
 
 // Read time from the table
-if let Some(rows) = session
-    .query("SELECT a FROM keyspace.table", &[])
-    .await?
-    .rows
-{
-    for row in rows.into_typed::<(Time,)>() {
-        let (time_value,): (Time,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(Time,)>()?;
+while let Some((time_value,)) = iter.next().transpose()? {
+    println!("{:?}", time_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/timestamp.md
+++ b/docs/source/data-types/timestamp.md
@@ -72,14 +72,10 @@ session
     .await?;
 
 // Read timestamp from the table
-if let Some(rows) = session
-    .query("SELECT a FROM keyspace.table", &[])
-    .await?
-    .rows
-{
-    for row in rows.into_typed::<(DateTime<Utc>,)>() {
-        let (timestamp_value,): (DateTime<Utc>,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(DateTime<Utc>,)>()?;
+while let Some((timestamp_value,)) = iter.next().transpose()? {
+    println!("{:?}", timestamp_value);
 }
 # Ok(())
 # }
@@ -115,14 +111,10 @@ session
     .await?;
 
 // Read timestamp from the table
-if let Some(rows) = session
-    .query("SELECT a FROM keyspace.table", &[])
-    .await?
-    .rows
-{
-    for row in rows.into_typed::<(OffsetDateTime,)>() {
-        let (timestamp_value,): (OffsetDateTime,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(OffsetDateTime,)>()?;
+while let Some((timestamp_value,)) = iter.next().transpose()? {
+    println!("{:?}", timestamp_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/tuple.md
+++ b/docs/source/data-types/tuple.md
@@ -1,4 +1,5 @@
 # Tuple
+
 `Tuple` is represented as rust tuples of max 16 elements.
 
 ```rust
@@ -15,13 +16,12 @@ session
     .await?;
 
 // Read a tuple of int and string from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<((i32, String),)>() {
-        let (tuple_value,): ((i32, String),) = row?;
-
-        let int_value: i32 = tuple_value.0;
-        let string_value: String = tuple_value.1;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<((i32, String),)>()?;
+while let Some((tuple_value,)) = iter.next().transpose()? {
+    let int_value: i32 = tuple_value.0;
+    let string_value: String = tuple_value.1;
+    println!("({}, {})", int_value, string_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/udt.md
+++ b/docs/source/data-types/udt.md
@@ -70,10 +70,10 @@ session
     .await?;
 
 // Read MyType from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(MyType,)>() {
-        let (my_type_value,): (MyType,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(MyType,)>()?;
+while let Some((my_type_value,)) = iter.next().transpose()? {
+    println!("{:?}", my_type_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/uuid.md
+++ b/docs/source/data-types/uuid.md
@@ -18,10 +18,10 @@ session
     .await?;
 
 // Read uuid from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(Uuid,)>() {
-        let (uuid_value,): (Uuid,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(Uuid,)>()?;
+while let Some((uuid_value,)) = iter.next().transpose()? {
+    println!("{:?}", uuid_value);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/varint.md
+++ b/docs/source/data-types/varint.md
@@ -29,10 +29,10 @@ session
     .await?;
 
 // Read a varint from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(BigInt,)>() {
-        let (varint_value,): (BigInt,) = row?;
-    }
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+let mut iter = result.rows_typed::<(BigInt,)>()?;
+while let Some((varint_value,)) = iter.next().transpose()? {
+    println!("{:?}", varint_value);
 }
 # Ok(())
 # }

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -75,7 +75,7 @@ See [Query values](values.md) for more information about sending values in queri
 
 ### Query result
 `Session::query` returns `QueryResult` with rows represented as `Option<Vec<Row>>`.\
-Each row can be parsed as a tuple of rust types using `into_typed`:
+Each row can be parsed as a tuple of rust types using `rows_typed`:
 ```rust
 # extern crate scylla;
 # use scylla::Session;
@@ -84,12 +84,10 @@ Each row can be parsed as a tuple of rust types using `into_typed`:
 use scylla::IntoTypedRows;
 
 // Query rows from the table and print them
-if let Some(rows) = session.query("SELECT a FROM ks.tab", &[]).await?.rows {
-    // Parse each row as a tuple containing single i32
-    for row in rows.into_typed::<(i32,)>() {
-        let read_row: (i32,) = row?;
-        println!("Read a value from row: {}", read_row.0);
-    }
+let result = session.query("SELECT a FROM ks.tab", &[]).await?;
+let mut iter = result.rows_typed::<(i32,)>()?;
+while let Some(read_row) = iter.next().transpose()? {
+    println!("Read a value from row: {}", read_row.0);
 }
 # Ok(())
 # }

--- a/docs/source/quickstart/example.md
+++ b/docs/source/quickstart/example.md
@@ -43,12 +43,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?;
 
     // Query rows from the table and print them
-    if let Some(rows) = session.query("SELECT a FROM ks.extab", &[]).await?.rows {
-        // Parse each row as a tuple containing single i32
-        for row in rows.into_typed::<(i32,)>() {
-            let read_row: (i32,) = row?;
-            println!("Read a value from row: {}", read_row.0);
-        }
+    let result = session.query("SELECT a FROM ks.extab", &[]).await?;
+    let mut iter = result.rows_typed::<(i32,)>()?;
+    while let Some(read_row) = iter.next().transpose()? {
+        println!("Read a value from row: {}", read_row.0);
     }
 
     Ok(())

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use scylla::macros::FromRow;
-use scylla::transport::session::{IntoTypedRows, Session};
+use scylla::transport::session::Session;
 use scylla::SessionBuilder;
 use std::env;
 
@@ -49,15 +49,12 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    if let Some(rows) = session
+    let result = session
         .query("SELECT a, b, c FROM examples_ks.basic", &[])
-        .await?
-        .rows
-    {
-        for row in rows.into_typed::<(i32, i32, String)>() {
-            let (a, b, c) = row?;
-            println!("a, b, c: {}, {}, {}", a, b, c);
-        }
+        .await?;
+    let mut iter = result.rows_typed::<(i32, i32, String)>()?;
+    while let Some((a, b, c)) = iter.next().transpose()? {
+        println!("a, b, c: {}, {}, {}", a, b, c);
     }
 
     // Or as custom structs that derive FromRow
@@ -68,32 +65,27 @@ async fn main() -> Result<()> {
         _c: String,
     }
 
-    if let Some(rows) = session
+    let result = session
         .query("SELECT a, b, c FROM examples_ks.basic", &[])
-        .await?
-        .rows
-    {
-        for row_data in rows.into_typed::<RowData>() {
-            let row_data = row_data?;
-            println!("row_data: {:?}", row_data);
-        }
+        .await?;
+    let mut iter = result.rows_typed::<RowData>()?;
+    while let Some(row_data) = iter.next().transpose()? {
+        println!("row_data: {:?}", row_data);
     }
 
     // Or simply as untyped rows
-    if let Some(rows) = session
+    let result = session
         .query("SELECT a, b, c FROM examples_ks.basic", &[])
-        .await?
-        .rows
-    {
-        for row in rows {
-            let a = row.columns[0].as_ref().unwrap().as_int().unwrap();
-            let b = row.columns[1].as_ref().unwrap().as_int().unwrap();
-            let c = row.columns[2].as_ref().unwrap().as_text().unwrap();
-            println!("a, b, c: {}, {}, {}", a, b, c);
+        .await?;
+    let rows = result.rows.unwrap();
+    for row in rows {
+        let a = row.columns[0].as_ref().unwrap().as_int().unwrap();
+        let b = row.columns[1].as_ref().unwrap().as_int().unwrap();
+        let c = row.columns[2].as_ref().unwrap().as_text().unwrap();
+        println!("a, b, c: {}, {}, {}", a, b, c);
 
-            // Alternatively each row can be parsed individually
-            // let (a2, b2, c2) = row.into_typed::<(i32, i32, String)>() ?;
-        }
+        // Alternatively each row can be parsed individually
+        // let (a2, b2, c2) = row.into_typed::<(i32, i32, String)>() ?;
     }
 
     let metrics = session.get_metrics();

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -45,24 +45,13 @@ async fn main() -> Result<()> {
                 .collect::<Vec<NodeAddr>>()
         );
 
-        let qt = session
+        let (qt,) = session
             .query(
-                format!(
-                    "SELECT token(pk) FROM examples_ks.compare_tokens where pk = {}",
-                    pk
-                ),
-                &[],
+                "SELECT token(pk) FROM examples_ks.compare_tokens where pk = ?",
+                (pk,),
             )
             .await?
-            .rows
-            .unwrap()
-            .first()
-            .expect("token query no rows!")
-            .columns[0]
-            .as_ref()
-            .expect("token query null value!")
-            .as_bigint()
-            .expect("token wrong type!");
+            .single_row_typed::<(i64,)>()?;
         assert_eq!(t, qt);
         println!("token for {}: {}", pk, t);
     }

--- a/examples/schema_agreement.rs
+++ b/examples/schema_agreement.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use scylla::transport::errors::QueryError;
-use scylla::transport::session::{IntoTypedRows, Session};
+use scylla::transport::session::Session;
 use scylla::SessionBuilder;
 use std::env;
 use std::time::Duration;
@@ -66,16 +66,14 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    if let Some(rows) = session
+    let result = session
         .query("SELECT a, b, c FROM examples_ks.schema_agreement", &[])
-        .await?
-        .rows
-    {
-        for row in rows.into_typed::<(i32, i32, String)>() {
-            let (a, b, c) = row?;
-            println!("a, b, c: {}, {}, {}", a, b, c);
-        }
+        .await?;
+    let mut iter = result.rows_typed::<(i32, i32, String)>()?;
+    while let Some((a, b, c)) = iter.next().transpose()? {
+        println!("a, b, c: {}, {}, {}", a, b, c);
     }
+
     println!("Ok.");
 
     let schema_version = session.await_schema_agreement().await?;

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     println!(
         "Paging state: {:#?} ({} rows)",
         res1.paging_state,
-        res1.rows.unwrap().len()
+        res1.rows_num()?,
     );
     let res2 = session
         .query_paged(paged_query.clone(), &[], res1.paging_state)
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     println!(
         "Paging state: {:#?} ({} rows)",
         res2.paging_state,
-        res2.rows.unwrap().len()
+        res2.rows_num()?,
     );
     let res3 = session
         .query_paged(paged_query.clone(), &[], res2.paging_state)
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
     println!(
         "Paging state: {:#?} ({} rows)",
         res3.paging_state,
-        res3.rows.unwrap().len()
+        res3.rows_num()?,
     );
 
     let paged_prepared = session
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     println!(
         "Paging state from the prepared statement execution: {:#?} ({} rows)",
         res4.paging_state,
-        res4.rows.unwrap().len()
+        res4.rows_num()?,
     );
     let res5 = session
         .execute_paged(&paged_prepared, &[], res4.paging_state)
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
     println!(
         "Paging state from the second prepared statement execution: {:#?} ({} rows)",
         res5.paging_state,
-        res5.rows.unwrap().len()
+        res5.rows_num()?,
     );
     let res6 = session
         .execute_paged(&paged_prepared, &[], res5.paging_state)
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
     println!(
         "Paging state from the third prepared statement execution: {:#?} ({} rows)",
         res6.paging_state,
-        res6.rows.unwrap().len()
+        res6.rows_num()?,
     );
     println!("Ok.");
 

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -322,7 +322,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, session.cache.len());
-        assert_eq!(1, result.rows.unwrap().len());
+        assert_eq!(1, result.rows_num().unwrap());
 
         let result = session
             .execute("select * from test_table", &[])
@@ -330,7 +330,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, session.cache.len());
-        assert_eq!(1, result.rows.unwrap().len());
+        assert_eq!(1, result.rows_num().unwrap());
     }
 
     /// Checks that caching works with execute_iter
@@ -364,7 +364,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, session.cache.len());
-        assert_eq!(1, result.rows.unwrap().len());
+        assert_eq!(1, result.rows_num().unwrap());
     }
 
     async fn assert_test_batch_table_rows_contain(

--- a/scylla/src/transport/cql_collections_test.rs
+++ b/scylla/src/transport/cql_collections_test.rs
@@ -1,7 +1,7 @@
 use crate::cql_to_rust::FromCqlVal;
 use crate::test_utils::create_new_session_builder;
 use crate::utils::test_utils::unique_keyspace_name;
-use crate::{frame::response::result::CqlValue, IntoTypedRows, Session};
+use crate::{frame::response::result::CqlValue, Session};
 use scylla_cql::types::serialize::value::SerializeCql;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
@@ -48,11 +48,7 @@ async fn insert_and_select<InsertT, SelectT>(
         .query(format!("SELECT val FROM {} WHERE p = 0", table_name), ())
         .await
         .unwrap()
-        .rows
-        .unwrap()
-        .into_typed::<(SelectT,)>()
-        .next()
-        .unwrap()
+        .single_row_typed::<(SelectT,)>()
         .unwrap()
         .0;
 

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -4,7 +4,6 @@ use crate::frame::response::result::CqlValue;
 use crate::frame::value::{Counter, CqlDate, CqlTime, CqlTimestamp};
 use crate::macros::FromUserType;
 use crate::test_utils::create_new_session_builder;
-use crate::transport::session::IntoTypedRows;
 use crate::transport::session::Session;
 use crate::utils::test_utils::unique_keyspace_name;
 use itertools::Itertools;
@@ -90,9 +89,8 @@ where
             .query(select_values, &[])
             .await
             .unwrap()
-            .rows
+            .rows_typed::<(T,)>()
             .unwrap()
-            .into_typed::<(T,)>()
             .map(Result::unwrap)
             .map(|row| row.0)
             .collect::<Vec<_>>();
@@ -206,9 +204,8 @@ async fn test_cql_varint() {
             .execute(&prepared_select, &[])
             .await
             .unwrap()
-            .rows
+            .rows_typed::<(CqlVarint,)>()
             .unwrap()
-            .into_typed::<(CqlVarint,)>()
             .map(Result::unwrap)
             .map(|row| row.0)
             .collect::<Vec<_>>();
@@ -278,9 +275,8 @@ async fn test_counter() {
             .query(select_values, (i as i32,))
             .await
             .unwrap()
-            .rows
+            .rows_typed::<(Counter,)>()
             .unwrap()
-            .into_typed::<(Counter,)>()
             .map(Result::unwrap)
             .map(|row| row.0)
             .collect::<Vec<_>>();
@@ -354,9 +350,8 @@ async fn test_naive_date() {
             .query("SELECT val from chrono_naive_date_tests", &[])
             .await
             .unwrap()
-            .rows
+            .rows_typed::<(NaiveDate,)>()
             .unwrap()
-            .into_typed::<(NaiveDate,)>()
             .next()
             .unwrap()
             .ok()
@@ -378,11 +373,7 @@ async fn test_naive_date() {
                 .query("SELECT val from chrono_naive_date_tests", &[])
                 .await
                 .unwrap()
-                .rows
-                .unwrap()
-                .into_typed::<(NaiveDate,)>()
-                .next()
-                .unwrap()
+                .single_row_typed::<(NaiveDate,)>()
                 .unwrap();
             assert_eq!(read_date, *naive_date);
         }
@@ -568,11 +559,7 @@ async fn test_cql_time() {
             .query("SELECT val from cql_time_tests", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(CqlTime,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(CqlTime,)>()
             .unwrap();
 
         assert_eq!(read_time, *time_duration);
@@ -590,11 +577,7 @@ async fn test_cql_time() {
             .query("SELECT val from cql_time_tests", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(CqlTime,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(CqlTime,)>()
             .unwrap();
 
         assert_eq!(read_time, *time_duration);
@@ -820,11 +803,7 @@ async fn test_cql_timestamp() {
             .query("SELECT val from cql_timestamp_tests", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(CqlTimestamp,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(CqlTimestamp,)>()
             .unwrap();
 
         assert_eq!(read_timestamp, *timestamp_duration);
@@ -842,11 +821,7 @@ async fn test_cql_timestamp() {
             .query("SELECT val from cql_timestamp_tests", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(CqlTimestamp,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(CqlTimestamp,)>()
             .unwrap();
 
         assert_eq!(read_timestamp, *timestamp_duration);
@@ -1202,11 +1177,7 @@ async fn test_timeuuid() {
             .query("SELECT val from timeuuid_tests", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(CqlTimeuuid,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(CqlTimeuuid,)>()
             .unwrap();
 
         assert_eq!(read_timeuuid.as_bytes(), timeuuid_bytes);
@@ -1225,11 +1196,7 @@ async fn test_timeuuid() {
             .query("SELECT val from timeuuid_tests", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(CqlTimeuuid,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(CqlTimeuuid,)>()
             .unwrap();
 
         assert_eq!(read_timeuuid.as_bytes(), timeuuid_bytes);
@@ -1372,11 +1339,7 @@ async fn test_inet() {
             .query("SELECT val from inet_tests WHERE id = 0", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(IpAddr,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(IpAddr,)>()
             .unwrap();
 
         assert_eq!(read_inet, *inet);
@@ -1391,11 +1354,7 @@ async fn test_inet() {
             .query("SELECT val from inet_tests WHERE id = 0", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(IpAddr,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(IpAddr,)>()
             .unwrap();
 
         assert_eq!(read_inet, *inet);
@@ -1445,11 +1404,7 @@ async fn test_blob() {
             .query("SELECT val from blob_tests WHERE id = 0", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(Vec<u8>,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(Vec<u8>,)>()
             .unwrap();
 
         assert_eq!(read_blob, *blob);
@@ -1464,11 +1419,7 @@ async fn test_blob() {
             .query("SELECT val from blob_tests WHERE id = 0", &[])
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(Vec<u8>,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(Vec<u8>,)>()
             .unwrap();
 
         assert_eq!(read_blob, *blob);
@@ -1555,11 +1506,7 @@ async fn test_udt_after_schema_update() {
         .query(format!("SELECT val from {} WHERE id = 0", table_name), &[])
         .await
         .unwrap()
-        .rows
-        .unwrap()
-        .into_typed::<(UdtV1,)>()
-        .next()
-        .unwrap()
+        .single_row_typed::<(UdtV1,)>()
         .unwrap();
 
     assert_eq!(read_udt, v1);
@@ -1576,11 +1523,7 @@ async fn test_udt_after_schema_update() {
         .query(format!("SELECT val from {} WHERE id = 0", table_name), &[])
         .await
         .unwrap()
-        .rows
-        .unwrap()
-        .into_typed::<(UdtV1,)>()
-        .next()
-        .unwrap()
+        .single_row_typed::<(UdtV1,)>()
         .unwrap();
 
     assert_eq!(read_udt, v1);
@@ -1601,11 +1544,7 @@ async fn test_udt_after_schema_update() {
         .query(format!("SELECT val from {} WHERE id = 0", table_name), &[])
         .await
         .unwrap()
-        .rows
-        .unwrap()
-        .into_typed::<(UdtV2,)>()
-        .next()
-        .unwrap()
+        .single_row_typed::<(UdtV2,)>()
         .unwrap();
 
     assert_eq!(
@@ -1736,11 +1675,7 @@ async fn test_udt_with_missing_field() {
             )
             .await
             .unwrap()
-            .rows
-            .unwrap()
-            .into_typed::<(TR,)>()
-            .next()
-            .unwrap()
+            .single_row_typed::<(TR,)>()
             .unwrap()
             .0;
         assert_eq!(expected, result);

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -44,6 +44,7 @@ use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle, Executi
 use super::node::CloudEndpoint;
 use super::node::KnownNode;
 use super::partitioner::PartitionerName;
+use super::query_result::MaybeFirstRowTypedError;
 use super::topology::UntranslatedPeer;
 use super::NodeRef;
 use crate::cql_to_rust::FromRow;
@@ -1464,30 +1465,26 @@ impl Session {
         )?;
 
         // Get tracing info
-        let tracing_info_row_res: Option<Result<TracingInfo, _>> = traces_session_res
-            .rows
-            .ok_or(QueryError::ProtocolError(
-                "Response to system_traces.sessions query was not Rows",
-            ))?
-            .into_typed::<TracingInfo>()
-            .next();
-
-        let mut tracing_info: TracingInfo = match tracing_info_row_res {
-            Some(tracing_info_row_res) => tracing_info_row_res.map_err(|_| {
-                QueryError::ProtocolError(
+        let maybe_tracing_info: Option<TracingInfo> = traces_session_res
+            .maybe_first_row_typed()
+            .map_err(|err| match err {
+                MaybeFirstRowTypedError::RowsExpected(_) => QueryError::ProtocolError(
+                    "Response to system_traces.sessions query was not Rows",
+                ),
+                MaybeFirstRowTypedError::FromRowError(_) => QueryError::ProtocolError(
                     "Columns from system_traces.session have an unexpected type",
-                )
-            })?,
+                ),
+            })?;
+
+        let mut tracing_info = match maybe_tracing_info {
             None => return Ok(None),
+            Some(tracing_info) => tracing_info,
         };
 
         // Get tracing events
-        let tracing_event_rows = traces_events_res
-            .rows
-            .ok_or(QueryError::ProtocolError(
-                "Response to system_traces.events query was not Rows",
-            ))?
-            .into_typed::<TracingEvent>();
+        let tracing_event_rows = traces_events_res.rows_typed().map_err(|_| {
+            QueryError::ProtocolError("Response to system_traces.events query was not Rows")
+        })?;
 
         for event in tracing_event_rows {
             let tracing_event: TracingEvent = event.map_err(|_| {


### PR DESCRIPTION
Part of #462.

### This PR serves two purposes:

- Modernizes the existing examples and internal uses of `QueryResult` in the driver. We have had helpers such as rows_typed etc. for a long time and they are supposed to offer superior experience, although many of our tests still use `QueryResult::rows` directly.
- Prepares for the iterator-based deserialization refactor. The representation of `QueryResult` will change and the rows field will not be available anymore - instead, the helper methods very similar to the current ones will be mandatory.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
