### PR TITLE
Remove unreachable pubs

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -44,3 +44,6 @@ num-bigint-03 = ["dep:num-bigint-03"]
 num-bigint-04 = ["dep:num-bigint-04"]
 bigdecimal-04 = ["dep:bigdecimal-04"]
 full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]
+
+[lints.rust]
+unreachable_pub = "warn"

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -16,3 +16,6 @@ darling = "0.20.0"
 syn = "2.0"
 quote = "1.0" 
 proc-macro2 = "1.0"
+
+[lints.rust]
+unreachable_pub = "warn"

--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -3,7 +3,7 @@ use quote::{quote, quote_spanned};
 use syn::{spanned::Spanned, DeriveInput};
 
 /// #[derive(FromRow)] derives FromRow for struct
-pub fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
+pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
     let item = syn::parse::<DeriveInput>(tokens_input)?;
     let path = crate::parser::get_path(&item)?;
     let struct_fields = crate::parser::parse_named_fields(&item, "FromRow")?;

--- a/scylla-macros/src/from_user_type.rs
+++ b/scylla-macros/src/from_user_type.rs
@@ -3,7 +3,7 @@ use quote::{quote, quote_spanned};
 use syn::{spanned::Spanned, DeriveInput};
 
 /// #[derive(FromUserType)] allows to parse a struct as User Defined Type
-pub fn from_user_type_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
+pub(crate) fn from_user_type_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
     let item = syn::parse::<DeriveInput>(tokens_input)?;
     let path = crate::parser::get_path(&item)?;
     let struct_fields = crate::parser::parse_named_fields(&item, "FromUserType")?;

--- a/scylla-macros/src/into_user_type.rs
+++ b/scylla-macros/src/into_user_type.rs
@@ -3,7 +3,7 @@ use quote::{quote, quote_spanned};
 use syn::{spanned::Spanned, DeriveInput};
 
 /// #[derive(IntoUserType)] allows to parse a struct as User Defined Type
-pub fn into_user_type_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
+pub(crate) fn into_user_type_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
     let item = syn::parse::<DeriveInput>(tokens_input)?;
     let path = crate::parser::get_path(&item)?;
     let struct_fields = crate::parser::parse_named_fields(&item, "IntoUserType")?;

--- a/scylla-macros/src/serialize/cql.rs
+++ b/scylla-macros/src/serialize/cql.rs
@@ -61,7 +61,7 @@ struct Context {
     fields: Vec<Field>,
 }
 
-pub fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, syn::Error> {
+pub(crate) fn derive_serialize_cql(tokens_input: TokenStream) -> Result<syn::ItemImpl, syn::Error> {
     let input: syn::DeriveInput = syn::parse(tokens_input)?;
     let struct_name = input.ident.clone();
     let named_fields = crate::parser::parse_named_fields(&input, "SerializeCql")?;

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -58,7 +58,7 @@ struct Context {
     fields: Vec<Field>,
 }
 
-pub fn derive_serialize_row(tokens_input: TokenStream) -> Result<syn::ItemImpl, syn::Error> {
+pub(crate) fn derive_serialize_row(tokens_input: TokenStream) -> Result<syn::ItemImpl, syn::Error> {
     let input: syn::DeriveInput = syn::parse(tokens_input)?;
     let struct_name = input.ident.clone();
     let named_fields = crate::parser::parse_named_fields(&input, "SerializeRow")?;

--- a/scylla-macros/src/value_list.rs
+++ b/scylla-macros/src/value_list.rs
@@ -4,7 +4,7 @@ use syn::DeriveInput;
 
 /// #[derive(ValueList)] allows to parse a struct as a list of values,
 /// which can be fed to the query directly.
-pub fn value_list_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
+pub(crate) fn value_list_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
     let item = syn::parse::<DeriveInput>(tokens_input)?;
     let path = crate::parser::get_path(&item)?;
     let struct_fields = crate::parser::parse_named_fields(&item, "ValueList")?;

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -32,3 +32,5 @@ ntest = "0.9.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 tokio = { version = "1.12", features = ["signal"] }
 
+[lints.rust]
+unreachable_pub = "warn"

--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -8,10 +8,7 @@ use crate::{
     frame::{FrameOpcode, FrameParams, RequestFrame, RequestOpcode, ResponseFrame, ResponseOpcode},
     TargetShard,
 };
-use scylla_cql::{
-    errors::{DbError, WriteType},
-    Consistency,
-};
+use scylla_cql::errors::DbError;
 
 /// Specifies when an associated [Reaction] will be performed.
 /// Conditions are subject to logic, with `not()`, `and()` and `or()`
@@ -407,8 +404,13 @@ impl RequestReaction {
     }
 }
 
-struct ExampleDbErrors;
-impl ExampleDbErrors {
+pub mod example_db_errors {
+    use bytes::Bytes;
+    use scylla_cql::{
+        errors::{DbError, WriteType},
+        Consistency,
+    };
+
     pub fn syntax_error() -> DbError {
         DbError::SyntaxError
     }
@@ -507,84 +509,84 @@ pub struct ResponseForger;
 
 impl ResponseForger {
     pub fn syntax_error(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::syntax_error())
+        RequestReaction::forge_with_error(example_db_errors::syntax_error())
     }
     pub fn invalid(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::invalid())
+        RequestReaction::forge_with_error(example_db_errors::invalid())
     }
     pub fn already_exists(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::already_exists())
+        RequestReaction::forge_with_error(example_db_errors::already_exists())
     }
     pub fn function_failure(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::function_failure())
+        RequestReaction::forge_with_error(example_db_errors::function_failure())
     }
     pub fn authentication_error(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::authentication_error())
+        RequestReaction::forge_with_error(example_db_errors::authentication_error())
     }
     pub fn unauthorized(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::unauthorized())
+        RequestReaction::forge_with_error(example_db_errors::unauthorized())
     }
     pub fn config_error(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::config_error())
+        RequestReaction::forge_with_error(example_db_errors::config_error())
     }
     pub fn unavailable(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::unavailable())
+        RequestReaction::forge_with_error(example_db_errors::unavailable())
     }
     pub fn overloaded(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::overloaded())
+        RequestReaction::forge_with_error(example_db_errors::overloaded())
     }
     pub fn is_bootstrapping(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::is_bootstrapping())
+        RequestReaction::forge_with_error(example_db_errors::is_bootstrapping())
     }
     pub fn truncate_error(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::truncate_error())
+        RequestReaction::forge_with_error(example_db_errors::truncate_error())
     }
     pub fn read_timeout(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::read_timeout())
+        RequestReaction::forge_with_error(example_db_errors::read_timeout())
     }
     pub fn write_timeout(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::write_timeout())
+        RequestReaction::forge_with_error(example_db_errors::write_timeout())
     }
     pub fn read_failure(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::read_failure())
+        RequestReaction::forge_with_error(example_db_errors::read_failure())
     }
     pub fn write_failure(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::write_failure())
+        RequestReaction::forge_with_error(example_db_errors::write_failure())
     }
     pub fn unprepared(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::unprepared())
+        RequestReaction::forge_with_error(example_db_errors::unprepared())
     }
     pub fn server_error(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::server_error())
+        RequestReaction::forge_with_error(example_db_errors::server_error())
     }
     pub fn protocol_error(&self) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::protocol_error())
+        RequestReaction::forge_with_error(example_db_errors::protocol_error())
     }
     pub fn other(&self, num: i32) -> RequestReaction {
-        RequestReaction::forge_with_error(ExampleDbErrors::other(num))
+        RequestReaction::forge_with_error(example_db_errors::other(num))
     }
     pub fn random_error(&self) -> RequestReaction {
         self.random_error_with_delay(None)
     }
     pub fn random_error_with_delay(&self, delay: Option<Duration>) -> RequestReaction {
         static ERRORS: &[fn() -> DbError] = &[
-            ExampleDbErrors::invalid,
-            ExampleDbErrors::already_exists,
-            ExampleDbErrors::function_failure,
-            ExampleDbErrors::authentication_error,
-            ExampleDbErrors::unauthorized,
-            ExampleDbErrors::config_error,
-            ExampleDbErrors::unavailable,
-            ExampleDbErrors::overloaded,
-            ExampleDbErrors::is_bootstrapping,
-            ExampleDbErrors::truncate_error,
-            ExampleDbErrors::read_timeout,
-            ExampleDbErrors::write_timeout,
-            ExampleDbErrors::write_failure,
-            ExampleDbErrors::unprepared,
-            ExampleDbErrors::server_error,
-            ExampleDbErrors::protocol_error,
-            || ExampleDbErrors::other(2137),
+            example_db_errors::invalid,
+            example_db_errors::already_exists,
+            example_db_errors::function_failure,
+            example_db_errors::authentication_error,
+            example_db_errors::unauthorized,
+            example_db_errors::config_error,
+            example_db_errors::unavailable,
+            example_db_errors::overloaded,
+            example_db_errors::is_bootstrapping,
+            example_db_errors::truncate_error,
+            example_db_errors::read_timeout,
+            example_db_errors::write_timeout,
+            example_db_errors::write_failure,
+            example_db_errors::unprepared,
+            example_db_errors::server_error,
+            example_db_errors::protocol_error,
+            || example_db_errors::other(2137),
         ];
         RequestReaction::forge_with_error_lazy_delay(
             Box::new(|| ERRORS[rand::thread_rng().next_u32() as usize % ERRORS.len()]()),

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -43,7 +43,7 @@ pub(crate) enum FrameType {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum FrameOpcode {
+pub(crate) enum FrameOpcode {
     Request(RequestOpcode),
     Response(ResponseOpcode),
 }

--- a/scylla-proxy/src/lib.rs
+++ b/scylla-proxy/src/lib.rs
@@ -6,7 +6,8 @@ mod proxy;
 pub type TargetShard = u16;
 
 pub use actions::{
-    Action, Condition, Reaction, RequestReaction, RequestRule, ResponseReaction, ResponseRule,
+    example_db_errors, Action, Condition, Reaction, RequestReaction, RequestRule, ResponseReaction,
+    ResponseRule,
 };
 pub use errors::{DoorkeeperError, ProxyError, WorkerError};
 pub use frame::{RequestFrame, RequestOpcode, ResponseFrame, ResponseOpcode};

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -70,3 +70,6 @@ time = "0.3"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[lints.rust]
+unreachable_pub = "warn"

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -301,7 +301,7 @@ mod ssl_config {
     // for the particular node. (The SslConfig must be different, because SNIs differ for different nodes.)
     // Thenceforth, all connections to that node share the same SslConfig.
     #[derive(Clone)]
-    pub struct SslConfig {
+    pub(crate) struct SslConfig {
         context: SslContext,
         #[cfg(feature = "cloud")]
         sni: Option<String>,
@@ -309,7 +309,7 @@ mod ssl_config {
 
     impl SslConfig {
         // Used in case when the user provided their own SslContext to be used in all connections.
-        pub fn new_with_global_context(context: SslContext) -> Self {
+        pub(crate) fn new_with_global_context(context: SslContext) -> Self {
             Self {
                 context,
                 #[cfg(feature = "cloud")]
@@ -349,24 +349,24 @@ mod ssl_config {
 }
 
 #[derive(Clone)]
-pub struct ConnectionConfig {
-    pub compression: Option<Compression>,
-    pub tcp_nodelay: bool,
-    pub tcp_keepalive_interval: Option<Duration>,
+pub(crate) struct ConnectionConfig {
+    pub(crate) compression: Option<Compression>,
+    pub(crate) tcp_nodelay: bool,
+    pub(crate) tcp_keepalive_interval: Option<Duration>,
     #[cfg(feature = "ssl")]
-    pub ssl_config: Option<SslConfig>,
-    pub connect_timeout: std::time::Duration,
+    pub(crate) ssl_config: Option<SslConfig>,
+    pub(crate) connect_timeout: std::time::Duration,
     // should be Some only in control connections,
-    pub event_sender: Option<mpsc::Sender<Event>>,
-    pub default_consistency: Consistency,
+    pub(crate) event_sender: Option<mpsc::Sender<Event>>,
+    pub(crate) default_consistency: Consistency,
     #[cfg(feature = "cloud")]
     pub(crate) cloud_config: Option<Arc<CloudConfig>>,
-    pub authenticator: Option<Arc<dyn AuthenticatorProvider>>,
-    pub address_translator: Option<Arc<dyn AddressTranslator>>,
-    pub enable_write_coalescing: bool,
+    pub(crate) authenticator: Option<Arc<dyn AuthenticatorProvider>>,
+    pub(crate) address_translator: Option<Arc<dyn AddressTranslator>>,
+    pub(crate) enable_write_coalescing: bool,
 
-    pub keepalive_interval: Option<Duration>,
-    pub keepalive_timeout: Option<Duration>,
+    pub(crate) keepalive_interval: Option<Duration>,
+    pub(crate) keepalive_timeout: Option<Duration>,
 }
 
 impl Default for ConnectionConfig {
@@ -395,7 +395,7 @@ impl Default for ConnectionConfig {
 
 impl ConnectionConfig {
     #[cfg(feature = "ssl")]
-    pub fn is_ssl(&self) -> bool {
+    fn is_ssl(&self) -> bool {
         #[cfg(feature = "cloud")]
         if self.cloud_config.is_some() {
             return true;
@@ -404,7 +404,7 @@ impl ConnectionConfig {
     }
 
     #[cfg(not(feature = "ssl"))]
-    pub fn is_ssl(&self) -> bool {
+    fn is_ssl(&self) -> bool {
         false
     }
 }

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -1531,8 +1531,8 @@ async fn test_udt_after_schema_update() {
     #[derive(SerializeCql, FromUserType, Debug, PartialEq)]
     #[scylla(crate = crate)]
     struct UdtV1 {
-        pub first: i32,
-        pub second: bool,
+        first: i32,
+        second: bool,
     }
 
     let v1 = UdtV1 {
@@ -1592,9 +1592,9 @@ async fn test_udt_after_schema_update() {
 
     #[derive(FromUserType, Debug, PartialEq)]
     struct UdtV2 {
-        pub first: i32,
-        pub second: bool,
-        pub third: Option<String>,
+        first: i32,
+        second: bool,
+        third: Option<String>,
     }
 
     let (read_udt,): (UdtV2,) = session
@@ -1748,17 +1748,17 @@ async fn test_udt_with_missing_field() {
 
     #[derive(FromUserType, Debug, PartialEq)]
     struct UdtFull {
-        pub first: i32,
-        pub second: bool,
-        pub third: Option<f32>,
-        pub fourth: Option<Vec<u8>>,
+        first: i32,
+        second: bool,
+        third: Option<f32>,
+        fourth: Option<Vec<u8>>,
     }
 
     #[derive(SerializeCql)]
     #[scylla(crate = crate)]
     struct UdtV1 {
-        pub first: i32,
-        pub second: bool,
+        first: i32,
+        second: bool,
     }
 
     verify_insert_select_identity(
@@ -1783,9 +1783,9 @@ async fn test_udt_with_missing_field() {
     #[derive(SerializeCql)]
     #[scylla(crate = crate)]
     struct UdtV2 {
-        pub first: i32,
-        pub second: bool,
-        pub third: Option<f32>,
+        first: i32,
+        second: bool,
+        third: Option<f32>,
     }
 
     verify_insert_select_identity(
@@ -1811,9 +1811,9 @@ async fn test_udt_with_missing_field() {
     #[derive(SerializeCql)]
     #[scylla(crate = crate)]
     struct UdtV3 {
-        pub first: i32,
-        pub second: bool,
-        pub fourth: Option<Vec<u8>>,
+        first: i32,
+        second: bool,
+        fourth: Option<Vec<u8>>,
     }
 
     verify_insert_select_identity(
@@ -1839,8 +1839,8 @@ async fn test_udt_with_missing_field() {
     #[derive(SerializeCql)]
     #[scylla(crate = crate, flavor="enforce_order")]
     struct UdtV4 {
-        pub first: i32,
-        pub second: bool,
+        first: i32,
+        second: bool,
     }
 
     verify_insert_select_identity(

--- a/scylla/src/transport/execution_profile.rs
+++ b/scylla/src/transport/execution_profile.rs
@@ -179,22 +179,22 @@ pub(crate) mod defaults {
     use scylla_cql::Consistency;
     use std::sync::Arc;
     use std::time::Duration;
-    pub fn consistency() -> Consistency {
+    pub(crate) fn consistency() -> Consistency {
         Consistency::LocalQuorum
     }
-    pub fn serial_consistency() -> Option<SerialConsistency> {
+    pub(crate) fn serial_consistency() -> Option<SerialConsistency> {
         Some(SerialConsistency::LocalSerial)
     }
-    pub fn request_timeout() -> Option<Duration> {
+    pub(crate) fn request_timeout() -> Option<Duration> {
         Some(Duration::from_secs(30))
     }
-    pub fn load_balancing_policy() -> Arc<dyn LoadBalancingPolicy> {
+    pub(crate) fn load_balancing_policy() -> Arc<dyn LoadBalancingPolicy> {
         Arc::new(load_balancing::DefaultPolicy::default())
     }
-    pub fn retry_policy() -> Box<dyn RetryPolicy> {
+    pub(crate) fn retry_policy() -> Box<dyn RetryPolicy> {
         Box::new(DefaultRetryPolicy::new())
     }
-    pub fn speculative_execution_policy() -> Option<Arc<dyn SpeculativeExecutionPolicy>> {
+    pub(crate) fn speculative_execution_policy() -> Option<Arc<dyn SpeculativeExecutionPolicy>> {
         None
     }
 

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -336,15 +336,15 @@ async fn consistency_is_correctly_set_in_cql_requests() {
 
 #[derive(Debug, Clone)]
 pub(crate) struct OwnedRoutingInfo {
-    pub consistency: Consistency,
-    pub serial_consistency: Option<SerialConsistency>,
+    consistency: Consistency,
+    serial_consistency: Option<SerialConsistency>,
 
     #[allow(unused)]
-    pub keyspace: Option<String>,
+    keyspace: Option<String>,
     #[allow(unused)]
-    pub token: Option<Token>,
+    token: Option<Token>,
     #[allow(unused)]
-    pub is_confirmed_lwt: bool,
+    is_confirmed_lwt: bool,
 }
 
 impl OwnedRoutingInfo {

--- a/scylla/tests/integration/hygiene.rs
+++ b/scylla/tests/integration/hygiene.rs
@@ -23,7 +23,7 @@ macro_rules! test_crate {
             use _scylla::frame::response::result::CqlValue;
             use _scylla::frame::value::{Value, ValueList};
 
-            pub fn derived<T>()
+            fn derived<T>()
             where
                 T: FromRow + FromCqlVal<CqlValue> + Value + ValueList,
             {

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -11,7 +11,7 @@ use tracing::instrument::WithSubscriber;
 
 use scylla_proxy::{Node, Proxy, ProxyError, RunningProxy, ShardAwareness};
 
-pub fn init_logger() {
+pub(crate) fn init_logger() {
     let _ = tracing_subscriber::fmt::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .without_time()
@@ -27,7 +27,7 @@ fn with_pseudorandom_shard(node: NodeRef) -> (NodeRef, Shard) {
 }
 
 #[derive(Debug)]
-pub struct FixedOrderLoadBalancer;
+pub(crate) struct FixedOrderLoadBalancer;
 impl LoadBalancingPolicy for FixedOrderLoadBalancer {
     fn pick<'a>(
         &'a self,
@@ -78,7 +78,7 @@ impl LoadBalancingPolicy for FixedOrderLoadBalancer {
     }
 }
 
-pub async fn test_with_3_node_cluster<F, Fut>(
+pub(crate) async fn test_with_3_node_cluster<F, Fut>(
     shard_awareness: ShardAwareness,
     test: F,
 ) -> Result<(), ProxyError>


### PR DESCRIPTION
Up until now some structs / fields etc were marked as pub despite not being a part of public API.
This is confusing when reading code: in order to know if something is truly public you need to check all the modules up to lib.rs to verify that each appears in some `pub use`.

This PR removes all such occurrences - now something is public if and only if it is marked as pub.
It also enables rustc lint `unreachable-pub` to prevent such occurences in the future.
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
