### PR TITLE
session_test: Increase tracing info timeout

### DIFF
--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -329,7 +329,7 @@ impl SessionConfig {
             #[cfg(feature = "cloud")]
             cloud_config: None,
             enable_write_coalescing: true,
-            tracing_info_fetch_attempts: NonZeroU32::new(5).unwrap(),
+            tracing_info_fetch_attempts: NonZeroU32::new(10).unwrap(),
             tracing_info_fetch_interval: Duration::from_millis(3),
             tracing_info_fetch_consistency: Consistency::One,
             cluster_metadata_refresh_interval: Duration::from_secs(60),

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -816,6 +816,10 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// Tracing info might not be available immediately on queried node - that's why
     /// the driver performs a few attempts with sleeps in between.
     ///
+    /// Cassandra users may want to increase this value - the default is good
+    /// for Scylla, but Cassandra sometimes needs more time for the data to
+    /// appear in tracing table.
+    ///
     /// # Example
     /// ```
     /// # use scylla::{Session, SessionBuilder};
@@ -840,6 +844,10 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     ///
     /// Tracing info might not be available immediately on queried node - that's why
     /// the driver performs a few attempts with sleeps in between.
+    ///
+    /// Cassandra users may want to increase this value - the default is good
+    /// for Scylla, but Cassandra sometimes needs more time for the data to
+    /// appear in tracing table.
     ///
     /// # Example
     /// ```

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -89,8 +89,8 @@ pub fn create_new_session_builder() -> GenericSessionBuilder<impl SessionBuilder
     // However, as Scylla usually gets TracingInfo ready really fast (our default interval is hence 3ms),
     // we stick to a not-so-much-terribly-long interval here.
     session_builder
-        .tracing_info_fetch_attempts(NonZeroU32::new(50).unwrap())
-        .tracing_info_fetch_interval(Duration::from_millis(200))
+        .tracing_info_fetch_attempts(NonZeroU32::new(200).unwrap())
+        .tracing_info_fetch_interval(Duration::from_millis(50))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Default values for fetching tracing info are quite strict in the driver: it will make 5 attempts to fetch the data, waiting 3ms between attempts.

For Scylla this is enough, but for Cassandra it is not. For this reason our tests sometimes fail.

This was partially (for one test) fixed previously: https://github.com/scylladb/scylla-rust-driver/commit/61ad8781f1a01c9ec5ff087296229c2245c429b3
This PR fixes other test case that might be affected.
Previous fix used 50 attempts with 200ms wait, I changed it to 200 attempts with 50ms wait in order to not slow down Scylla tests unnecessarily.

Increased default retry attempts in Session from 5 to 10 to make tracing fetching more reliable for Scylla users without increasing latency.
I didn't touch default sleep between attempts - for Scylla new values should be ok, and Cassandra users can change them in config. I added a warning in docs so that they are aware of the problem.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/957
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/709

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
