### PR TITLE
docs: adding context to timeuuid using v1 feature

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +1980,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
+ "atomic",
  "getrandom",
 ]
 

--- a/docs/source/data-types/timeuuid.md
+++ b/docs/source/data-types/timeuuid.md
@@ -1,8 +1,8 @@
 # Timeuuid
 
-`Timeuuid` is represented as `value::CqlTimeuuid`.
-`value::CqlTimeuuid` is a wrapper for `uuid::Uuid` (using the `v1` feature) with custom ordering logic
-which follows Scylla/Cassandra semantics.
+The `Timeuuid` type is represented as `value::CqlTimeuuid`.
+
+Also, `value::CqlTimeuuid` is a wrapper for `uuid::Uuid`  with custom ordering logic which follows Scylla/Cassandra semantics.
 
 ```rust
 # extern crate scylla;
@@ -29,7 +29,9 @@ if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.ro
 # }
 ```
 
-To use the Timeuuid on `uuid` crate, enable the feature `v1` in your crate using:
+## Creating your own Timeuuid
+
+To create your own `Timeuuid` objects from timestamp-based `uuid` v1, you need to enable the feature `v1` of `uuid` crate using:
 
 ```shell
 cargo add uuid -F v1
@@ -48,9 +50,13 @@ use scylla::frame::value::CqlTimeuuid;
 use uuid::Uuid;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 
-// Insert some timeuuid into the table
-let to_insert = CqlTimeuuid::from(Uuid::now_v1(&[1, 2, 3, 4, 5, 6]));
-session  
+// Tip: you can use random stable numbers or your MAC Address
+let node_id = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC];
+
+// Build your Timeuuid with the current timestamp
+let to_insert = CqlTimeuuid::from(Uuid::now_v1(&node_id));
+
+session
     .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))  
     .await?;
 
@@ -63,3 +69,5 @@ if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.ro
 # Ok(())
 # }
 ```
+
+Learn more about UUID::v1 [here](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

--- a/docs/source/data-types/timeuuid.md
+++ b/docs/source/data-types/timeuuid.md
@@ -2,7 +2,7 @@
 
 The `Timeuuid` type is represented as `value::CqlTimeuuid`.
 
-Also, `value::CqlTimeuuid` is a wrapper for `uuid::Uuid`  with custom ordering logic which follows Scylla/Cassandra semantics.
+Also, `value::CqlTimeuuid` is a wrapper for `uuid::Uuid` with custom ordering logic which follows Scylla/Cassandra semantics.
 
 ```rust
 # extern crate scylla;
@@ -15,15 +15,18 @@ use scylla::frame::value::CqlTimeuuid;
 
 // Insert some timeuuid into the table
 let to_insert: CqlTimeuuid = CqlTimeuuid::from_str("8e14e760-7fa8-11eb-bc66-000000000001")?;
+
 session
     .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
     .await?;
 
-// Read timeuuid from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(CqlTimeuuid,)>() {
-        let (timeuuid_value,): (CqlTimeuuid,) = row?;
-    }
+// Read Timeuuid from the table
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+
+let mut iter = result.rows_typed::<(CqlTimeuuid, )>()?;
+
+while let Some((timeuuid,)) = iter.next().transpose()? {
+    println!("Read a value from row: {}", timeuuid);
 }
 # Ok(())
 # }
@@ -60,11 +63,13 @@ session
     .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))  
     .await?;
 
-// Read timeuuid from the table
-if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
-    for row in rows.into_typed::<(CqlTimeuuid,)>() {
-        let (timeuuid_value,): (CqlTimeuuid,) = row?;
-    }
+// Read Timeuuid from the table
+let result = session.query("SELECT a FROM keyspace.table", &[]).await?;
+
+let mut iter = result.rows_typed::<(CqlTimeuuid, )>()?;
+
+while let Some((timeuuid,)) = iter.next().transpose()? {
+    println!("Read a value from row: {}", timeuuid);
 }
 # Ok(())
 # }

--- a/docs/source/data-types/timeuuid.md
+++ b/docs/source/data-types/timeuuid.md
@@ -1,7 +1,7 @@
 # Timeuuid
 
 `Timeuuid` is represented as `value::CqlTimeuuid`.
-`value::CqlTimeuuid` is a wrapper  for `uuid::Uuid` with custom ordering logic
+`value::CqlTimeuuid` is a wrapper for `uuid::Uuid` (using the `v1` feature) with custom ordering logic
 which follows Scylla/Cassandra semantics.
 
 ```rust
@@ -17,6 +17,41 @@ use scylla::frame::value::CqlTimeuuid;
 let to_insert: CqlTimeuuid = CqlTimeuuid::from_str("8e14e760-7fa8-11eb-bc66-000000000001")?;
 session
     .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))
+    .await?;
+
+// Read timeuuid from the table
+if let Some(rows) = session.query("SELECT a FROM keyspace.table", &[]).await?.rows {
+    for row in rows.into_typed::<(CqlTimeuuid,)>() {
+        let (timeuuid_value,): (CqlTimeuuid,) = row?;
+    }
+}
+# Ok(())
+# }
+```
+
+To use the Timeuuid on `uuid` crate, enable the feature `v1` in your crate using:
+
+```shell
+cargo add uuid -F v1
+```
+
+and now you're gonna be able to use the `uuid::v1` features: 
+
+```rust
+# extern crate uuid;
+# extern crate scylla;
+# use scylla::Session;
+# use std::error::Error;
+# use std::str::FromStr;
+use scylla::IntoTypedRows;
+use scylla::frame::value::CqlTimeuuid;
+use uuid::Uuid;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+
+// Insert some timeuuid into the table
+let to_insert = CqlTimeuuid::from(Uuid::now_v1(&[1, 2, 3, 4, 5, 6]));
+session  
+    .query("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert,))  
     .await?;
 
 // Read timeuuid from the table

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1.25"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 chrono = { version = "0.4", default-features = false }
 time = { version = "0.3.22" }
-uuid = "1.0"
+uuid = { version = "1.0", features = ["v1"]}
 tower = "0.4"
 stats_alloc = "0.1"
 clap = { version = "3.2.4", features = ["derive"] }


### PR DESCRIPTION
## Motivation

I decided to give more context for newcomers that want to try Timeuuid in the Rust Driver. Since I didn't had that much experience in the beginning and struggled for a while until understand how to use it.

Also I still didn't understand when and how I should generate the the node_id on `uuid::new_v1([])` parameters and IMHO it would be a great addition to the docs. 

### Fixes
- [x] Add context to `uuid::v1` usage
- [x] (Optional) Add context to `new_v1()` node_id numbers


## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
