### PR TITLE
derive `FromRow` for structs with unnamed fields

### DIFF
--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -1000,4 +1000,24 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn unnamed_struct_from_row() {
+        #[derive(FromRow)]
+        struct MyRow(i32, Option<String>, Option<Vec<i32>>);
+
+        let row = Row {
+            columns: vec![
+                Some(CqlValue::Int(16)),
+                None,
+                Some(CqlValue::Set(vec![CqlValue::Int(1), CqlValue::Int(2)])),
+            ],
+        };
+
+        let my_row: MyRow = MyRow::from_row(row).unwrap();
+
+        assert_eq!(my_row.0, 16);
+        assert_eq!(my_row.1, None);
+        assert_eq!(my_row.2, Some(vec![1, 2]));
+    }
 }

--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -6,33 +6,43 @@ use syn::{spanned::Spanned, DeriveInput};
 pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, syn::Error> {
     let item = syn::parse::<DeriveInput>(tokens_input)?;
     let path = crate::parser::get_path(&item)?;
-    let struct_fields = crate::parser::parse_named_fields(&item, "FromRow")?;
+    let struct_fields = crate::parser::parse_struct_fields(&item, "FromRow")?;
 
     let struct_name = &item.ident;
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
-    // Generates tokens for field_name: field_type::from_cql(vals_iter.next().ok_or(...)?), ...
-    let set_fields_code = struct_fields.named.iter().map(|field| {
-        let field_name = &field.ident;
-        let field_type = &field.ty;
+    // Generates a token that sets the values of struct fields: field_type::from_cql(...)
+    let (fill_struct_code, fields_count) = match struct_fields {
+        crate::parser::StructFields::Named(fields) => {
+            let set_fields_code = fields.named.iter().map(|field| {
+                let field_name = &field.ident;
+                let field_type = &field.ty;
 
-        quote_spanned! {field.span() =>
-            #field_name: {
-                let (col_ix, col_value) = vals_iter
-                    .next()
-                    .unwrap(); // vals_iter size is checked before this code is reached, so
-                               // it is safe to unwrap
+                quote_spanned! {field.span() =>
+                    #field_name: {
+                        let (col_ix, col_value) = vals_iter
+                            .next()
+                            .unwrap(); // vals_iter size is checked before this code is reached, so
+                                    // it is safe to unwrap
 
-                <#field_type as FromCqlVal<::std::option::Option<CqlValue>>>::from_cql(col_value)
-                    .map_err(|e| FromRowError::BadCqlVal {
-                        err: e,
-                        column: col_ix,
-                    })?
-            },
+                        <#field_type as FromCqlVal<::std::option::Option<CqlValue>>>::from_cql(col_value)
+                            .map_err(|e| FromRowError::BadCqlVal {
+                                err: e,
+                                column: col_ix,
+                            })?
+                    },
+                }
+            });
+
+            // This generates: { field1: {field1_code}, field2: {field2_code}, ...}
+            let fill_struct_code = quote! {
+                {#(#set_fields_code)*}
+            };
+            (fill_struct_code, fields.named.len())
         }
-    });
+        crate::parser::StructFields::Unnamed(_fields) => todo!(),
+    };
 
-    let fields_count = struct_fields.named.len();
     let generated = quote! {
         impl #impl_generics #path::FromRow for #struct_name #ty_generics #where_clause {
             fn from_row(row: #path::Row)
@@ -49,9 +59,7 @@ pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, 
                 }
                 let mut vals_iter = row.columns.into_iter().enumerate();
 
-                Ok(#struct_name {
-                    #(#set_fields_code)*
-                })
+                Ok(#struct_name #fill_struct_code)
             }
         }
     };

--- a/scylla-macros/src/parser.rs
+++ b/scylla-macros/src/parser.rs
@@ -1,37 +1,25 @@
 use syn::{Data, DeriveInput, ExprLit, Fields, FieldsNamed, Lit};
 use syn::{Expr, Meta};
 
-/// Parses the tokens_input to a DeriveInput and returns the struct name from which it derives and
-/// the named fields
+/// Parses a struct DeriveInput and returns named fields of this struct.
 pub(crate) fn parse_named_fields<'a>(
     input: &'a DeriveInput,
     current_derive: &str,
 ) -> Result<&'a FieldsNamed, syn::Error> {
+    let create_err_msg = || {
+        format!(
+            "derive({}) works only for structs with named fields",
+            current_derive
+        )
+    };
+
     match &input.data {
         Data::Struct(data) => match &data.fields {
             Fields::Named(named_fields) => Ok(named_fields),
-            _ => Err(syn::Error::new_spanned(
-                data.struct_token,
-                format!(
-                    "derive({}) works only for structs with named fields",
-                    current_derive
-                ),
-            )),
+            _ => Err(syn::Error::new_spanned(data.struct_token, create_err_msg())),
         },
-        Data::Enum(e) => Err(syn::Error::new_spanned(
-            e.enum_token,
-            format!(
-                "derive({}) works only for structs with named fields",
-                current_derive
-            ),
-        )),
-        Data::Union(u) => Err(syn::Error::new_spanned(
-            u.union_token,
-            format!(
-                "derive({}) works only for structs with named fields",
-                current_derive
-            ),
-        )),
+        Data::Enum(e) => Err(syn::Error::new_spanned(e.enum_token, create_err_msg())),
+        Data::Union(u) => Err(syn::Error::new_spanned(u.union_token, create_err_msg())),
     }
 }
 

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -1,6 +1,8 @@
-/// #[derive(FromRow)] derives FromRow for struct
+/// Derive macro for the [`FromRow`](crate::frame::response::cql_to_rust::FromRow) trait
+/// which deserializes a row to given Rust structure.
 ///
-/// Works only on simple structs without generics etc
+/// It is supported for structs with either named or unnamed fields.
+/// It works only for simple structs without generics etc.
 ///
 /// ---
 ///


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/852

## Motivation

For some reason, users were not able to derive `FromRow` trait for structs with unnamed fields.
This PR fixes that.

## Changes
Adjusted `from_row_derive` function from `scylla-macros` so that it supports structs with unnamed fields as well.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
