### PR TITLE
prepared: docs for `PreparedStatement`

### DIFF
--- a/docs/source/queries/prepared.md
+++ b/docs/source/queries/prepared.md
@@ -3,6 +3,12 @@
 Prepared queries provide much better performance than simple queries,
 but they need to be prepared before use.
 
+Benefits that prepared statements have to offer:
+- Type safety - thanks to metadata provided by the server, the driver can verify bound values' types before serialization. This way, we can be always sure that the Rust type provided by the user is compatible (and if not, the error is returned) with the destined native type. The same applies for deserialization.
+- Performance - when executing a simple query with non-empty values list, the driver
+prepares the statement before execution. The reason for this is to provide type safety for simple queries. However, this implies 2 round trips per simple query execution. On the other hand, the cost of prepared statement's execution is only 1 round trip.
+- Improved load-balancing - using the statement metadata, the driver can compute a set of destined replicas for current statement execution. These replicas will be preferred when choosing the node (and shard) to send the request to. For more insight on this, see [performance section](#performance).
+
 ```rust
 # extern crate scylla;
 # use scylla::Session;

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -839,7 +839,8 @@ impl Session {
     /// > must be sent as bound values
     /// > (see [performance section](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html#performance))
     ///
-    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html) for more information
+    /// See [the book](https://rust-driver.docs.scylladb.com/stable/queries/prepared.html) for more information.
+    /// See the documentation of [`PreparedStatement`].
     ///
     /// # Arguments
     /// * `query` - query to prepare, can be just a `&str` or the [Query] struct.


### PR DESCRIPTION
In response to https://github.com/scylladb/scylla-rust-driver/pull/970#discussion_r1570902278.

Added docstring for `PreparedStatement`, which mentions:
- how to prepare a statement
- benefits of using prepared statements
- statement repreparation that is handled by the driver
- prepared statement cloning
- correlation between prepared statements and schema altering 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
