### PR TITLE
Remove `.with_current_subscriber()` calls

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -458,6 +458,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +514,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "env_logger",
  "futures",
  "openssl",
  "rand",
@@ -713,6 +727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +789,17 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ rustyline = "9"
 rustyline-derive = "0.6"
 scylla = {path = "../scylla", features = ["ssl", "cloud", "chrono", "time", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]}
 tokio = {version = "1.1.0", features = ["full"]}
-tracing = "0.1.25"
+tracing = { version = "0.1.25" , features = ["log"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 chrono = { version = "0.4", default-features = false }
 time = { version = "0.3.22" }
@@ -21,6 +21,7 @@ tower = "0.4"
 stats_alloc = "0.1"
 clap = { version = "3.2.4", features = ["derive"] }
 rand = "0.8.5"
+env_logger = "0.10"
 
 [[example]]
 name = "auth"
@@ -33,6 +34,10 @@ path = "basic.rs"
 [[example]]
 name = "logging"
 path = "logging.rs"
+
+[[example]]
+name = "logging_log"
+path = "logging_log.rs"
 
 [[example]]
 name = "tls"

--- a/examples/logging_log.rs
+++ b/examples/logging_log.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use scylla::transport::session::Session;
+use scylla::SessionBuilder;
+use std::env;
+use tracing::info;
+
+// To run this example, and view logged messages, RUST_LOG env var needs to be set
+// This can be done using shell command presented below
+// RUST_LOG=info cargo run --example logging_log
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Driver uses `tracing` for logging purposes, but it's possible to use `log`
+    // ecosystem to view the messages. This requires adding `tracing` crate to
+    // dependencies and enabling its "log" feature. Then you will be able to use
+    // loggers like `env_logger` to see driver's messages.
+    env_logger::init();
+
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+    info!("Connecting to {}", uri);
+
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+    session.query("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session.query("USE examples_ks", &[]).await?;
+
+    Ok(())
+}

--- a/scylla-proxy/examples/cmdline.rs
+++ b/scylla-proxy/examples/cmdline.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use scylla_proxy::{Node, Proxy, ShardAwareness};
-use tracing::instrument::WithSubscriber;
 
 fn init_logger() {
     tracing_subscriber::fmt::fmt()
@@ -53,7 +52,7 @@ async fn main() {
         None,
         None,
     )]);
-    let running_proxy = proxy.run().with_current_subscriber().await.unwrap();
+    let running_proxy = proxy.run().await.unwrap();
 
     pause().await;
     running_proxy.finish().await.unwrap();

--- a/scylla-proxy/examples/identity_proxy.rs
+++ b/scylla-proxy/examples/identity_proxy.rs
@@ -1,7 +1,6 @@
 use std::{net::SocketAddr, str::FromStr};
 
 use scylla_proxy::{Node, Proxy, ShardAwareness};
-use tracing::instrument::WithSubscriber;
 
 fn init_logger() {
     tracing_subscriber::fmt::fmt()
@@ -30,7 +29,7 @@ async fn main() {
                 .build(),
         )
         .build();
-    let running_proxy = proxy.run().with_current_subscriber().await.unwrap();
+    let running_proxy = proxy.run().await.unwrap();
 
     pause().await;
     running_proxy.finish().await.unwrap();

--- a/scylla-proxy/examples/identity_shard_aware_proxy.rs
+++ b/scylla-proxy/examples/identity_shard_aware_proxy.rs
@@ -1,7 +1,6 @@
 use std::{net::SocketAddr, str::FromStr};
 
 use scylla_proxy::{Node, Proxy, ShardAwareness};
-use tracing::instrument::WithSubscriber;
 
 fn init_logger() {
     tracing_subscriber::fmt::fmt()
@@ -27,7 +26,7 @@ async fn main() {
         None,
         None,
     )]);
-    let running_proxy = proxy.run().with_current_subscriber().await.unwrap();
+    let running_proxy = proxy.run().await.unwrap();
 
     pause().await;
     running_proxy.finish().await.unwrap();

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -24,7 +24,6 @@ use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::instrument::WithSubscriber;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -206,7 +205,7 @@ impl Cluster {
         };
 
         let (fut, worker_handle) = worker.work().remote_handle();
-        tokio::spawn(fut.with_current_subscriber());
+        tokio::spawn(fut);
 
         let result = Cluster {
             data: cluster_data,
@@ -647,7 +646,7 @@ impl ClusterWorker {
 
                             let cluster_data = self.cluster_data.load_full();
                             let use_keyspace_future = Self::handle_use_keyspace_request(cluster_data, request);
-                            tokio::spawn(use_keyspace_future.with_current_subscriber());
+                            tokio::spawn(use_keyspace_future);
                         },
                         None => return, // If use_keyspace_channel was closed then cluster was dropped, we can stop working
                     }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -13,7 +13,6 @@ use tokio::io::{split, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWrite
 use tokio::net::{TcpSocket, TcpStream};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
-use tracing::instrument::WithSubscriber;
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
@@ -1090,7 +1089,7 @@ impl Connection {
                 node_address,
             )
             .remote_handle();
-            tokio::task::spawn(task.with_current_subscriber());
+            tokio::task::spawn(task);
             return Ok(handle);
         }
 
@@ -1104,7 +1103,7 @@ impl Connection {
             node_address,
         )
         .remote_handle();
-        tokio::task::spawn(task.with_current_subscriber());
+        tokio::task::spawn(task);
         Ok(handle)
     }
 

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -16,7 +16,6 @@ use scylla_cql::types::serialize::row::SerializedValues;
 use std::result::Result;
 use thiserror::Error;
 use tokio::sync::mpsc;
-use tracing::instrument::WithSubscriber;
 
 use super::errors::QueryError;
 use super::execution_profile::ExecutionProfileInner;
@@ -387,7 +386,7 @@ impl RowIterator {
         worker_task: impl Future<Output = PageSendAttemptedProof> + Send + 'static,
         mut receiver: mpsc::Receiver<Result<ReceivedPage, QueryError>>,
     ) -> Result<RowIterator, QueryError> {
-        tokio::task::spawn(worker_task.with_current_subscriber());
+        tokio::task::spawn(worker_task);
 
         // This unwrap is safe because:
         // - The future returned by worker.work sends at least one item

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2269,7 +2269,7 @@ mod latency_awareness {
     use itertools::Either;
     use scylla_cql::errors::{DbError, QueryError};
     use tokio::time::{Duration, Instant};
-    use tracing::{instrument::WithSubscriber, trace, warn};
+    use tracing::{trace, warn};
     use uuid::Uuid;
 
     use crate::{load_balancing::NodeRef, routing::Shard, transport::node::Node};
@@ -2454,7 +2454,7 @@ mod latency_awareness {
                 }
             }
             .remote_handle();
-            tokio::task::spawn(updater_fut.with_current_subscriber());
+            tokio::task::spawn(updater_fut);
 
             Self {
                 _updater_handle: Some(updater_handle),

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use tracing::instrument::WithSubscriber;
 
 use scylla_proxy::{Node, Proxy, ProxyError, RunningProxy, ShardAwareness};
 
@@ -53,7 +52,7 @@ where
     );
 
     let translation_map = proxy.translation_map();
-    let running_proxy = proxy.run().with_current_subscriber().await.unwrap();
+    let running_proxy = proxy.run().await.unwrap();
 
     let running_proxy = test(
         [proxy1_uri, proxy2_uri, proxy3_uri],


### PR DESCRIPTION
Those calls were introduced in e5570956758503a8f0a7ed0ad1c649909f370a73,
with message:
```
Now, when the driver spawns a task to run a new future on it, that
future will use the same subscriber as the code that spawned the task in
the first place.
```

There is unfortunately no explanation about when it is necessary.
I don't see any problems after removing those - logs are still collected correctly using a tracing subscriber.
Those calls however have a harmful side-effect: they prevent usage of `log` loggers to listen to driver logs using `log` feature in `tracing` crate, which was reported in https://github.com/scylladb/scylla-rust-driver/issues/860 .
After reporting the problem to `tracing` crate (https://github.com/tokio-rs/tracing/issues/2913) one of maintainers said that using `.with_current_subscriber()` in a library is not necessary in general.

As I don't see any issue caused by removing these calls, but their existence cause an issue, they are removed in this PR.
The PR also introduces an example showing usage of the driver with `env_logger` and adjusts documentation about logging.

Fixes: #860 

@piodul if you remember why those calls were added please explain, because I have no idea in which scenario they could be necessary.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
