### PR TITLE
Release 0.13

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1440,7 +1440,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bigdecimal",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "sphinx-docs"
 description = "ScyllaDB Documentation"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["ScyllaDB Documentation Contributors"]
 
 [tool.poetry.dependencies]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,14 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ['v0.11.1', 'v0.12.0']
+TAGS = ['v0.12.0', 'v0.13.0']
 BRANCHES = ['main']
 # Set the latest version.
-LATEST_VERSION = 'v0.12.0'
+LATEST_VERSION = 'v0.13.0'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['main']
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ['v0.11.1']
+DEPRECATED_VERSIONS = ['v0.12.0']
 
 # -- General configuration
 

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "0.12"
+scylla = "0.13"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla-macros = { version = "0.4.0", path = "../scylla-macros" }
+scylla-macros = { version = "0.5.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 tokio = { version = "1.12", features = ["io-util", "time"] }

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "CQL data types and primitives, for interacting with Scylla."
 repository = "https://github.com/scylladb/scylla-rust-driver"

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "proc macros for scylla async CQL driver"
 repository = "https://github.com/scylladb/scylla-rust-driver"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "0.1.0", path = "../scylla-cql" }
+scylla-cql = { version = "0.2.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"
 repository = "https://github.com/scylladb/scylla-rust-driver"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -27,7 +27,7 @@ full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-0
 
 [dependencies]
 scylla-macros = { version = "0.5.0", path = "../scylla-macros" }
-scylla-cql = { version = "0.1.0", path = "../scylla-cql" }
+scylla-cql = { version = "0.2.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -26,7 +26,7 @@ bigdecimal-04 = ["scylla-cql/bigdecimal-04"]
 full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]
 
 [dependencies]
-scylla-macros = { version = "0.4.0", path = "../scylla-macros" }
+scylla-macros = { version = "0.5.0", path = "../scylla-macros" }
 scylla-cql = { version = "0.1.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"


### PR DESCRIPTION
This is a draft for 0.13 release. 
Steps I'll perform after approval:

```
# Perform fast-forward merge
git checkout main
git merge --ff-only branch-0.13.x

# Create the tag
git tag -a v0.13.0
git push origin v0.13.0

# Push the branch - need to push after the tag because otherwise docs will fail to build
git push origin main

# Now verify that docs was built and published successfully

# Publish new version to crates.io
cargo publish -p scylla-macros
cargo publish -p scylla-cql
cargo publish -p scylla

# Create a github release with previously approved release notes

# Create post on the forum about release
```

Proposed release notes:

---

The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 0.13.0,
an asynchronous CQL driver for Rust, optimized for Scylla, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 1,615k downloads on crates!
- over 520 GitHub stars!

## Changes

**API cleanups / breaking changes:**

- Implemented support for Tablets, a new major architectural feature of Scylla that will be a part of upcoming 6.0 release. This support is required for token (and shard) awareness to work with Tablet-based tables. You can read more about Tablets [in a blogpost by Tomasz Grabiec](https://www.scylladb.com/2023/07/10/why-scylladb-is-moving-to-a-new-replication-algorithm-tablets/) or watch a [presentation by Avi Kivity](https://www.scylladb.com/presentations/tablets-rethinking-replication/)  ([#937](https://github.com/scylladb/scylla-rust-driver/pull/937))
- Enabled *shard-selecting* load balancing. Before, a `LoadBalancingPolicy` would return a `Plan` consisting of `Node`s;
now, together with a `Node` it can optionally specify the `Shard` to contact as well. This is crucial for proper Tablets support (see above). Main PR [#944](https://github.com/scylladb/scylla-rust-driver/pull/944), with follow up [#969](https://github.com/scylladb/scylla-rust-driver/pull/969)
- `Token`: added constructor and normalization to increase type-safety ([#948](https://github.com/scylladb/scylla-rust-driver/pull/948))
- Removed another unstable dependency, `histogram::Histogram`, from public API ([#935](https://github.com/scylladb/scylla-rust-driver/pull/935))
- Implemented CQL protocol-level optimisation: prepared statement result metadata can be now used to decode rows. **This saves network bandwidth if that option is enabled, because result metadata need not be sent with each DB query result.** ([#925](https://github.com/scylladb/scylla-rust-driver/pull/925))
- Removed `num_enum` dependency. It was unstable, and we managed to do without it, so it no longer appears in the public API. ([#931](https://github.com/scylladb/scylla-rust-driver/pull/931))
- Decreased pub visibility of `scylla-cql` definitions which weren't intended for access from outside the driver. ([#933](https://github.com/scylladb/scylla-rust-driver/pull/933))

**New features / enhancements:**

- Improved the `FromRow` derive macro to suppport structs with unnamed fields. Before, only structs with named fields were supported. ([#985](https://github.com/scylladb/scylla-rust-driver/pull/985))
- testing: Increased timeout for fetching tracing info - Cassandra was so slow in tests that our CI used to fail sometimes... ([#966](https://github.com/scylladb/scylla-rust-driver/pull/966))
- Removed `strum` and `strum_macros` dependencies. They were unstable, and we managed to do without it. ([#934](https://github.com/scylladb/scylla-rust-driver/pull/934))

**Documentation:**

- Got rid of (most) uses of `QueryResult::rows`. The preferred method is the more type safe `QueryResult::rows_typed`. Moreover, **`QueryResult::rows` is going to be deprecated** in the next release, once the new lazy deserialization framework is introduced. We thus recommend switching to `rows_typed` wherever possible. ([#955](https://github.com/scylladb/scylla-rust-driver/pull/955))

**CI / developer tool improvements:**

- Removed unreachable `pub`s ([#958](https://github.com/scylladb/scylla-rust-driver/pull/958))
- Dealed with `chrono` deprecations ([#951](https://github.com/scylladb/scylla-rust-driver/pull/951))
- CI: run `cargo clean` before tests ([#929](https://github.com/scylladb/scylla-rust-driver/pull/929))
- CI: small fixes in semver checks ([#942](https://github.com/scylladb/scylla-rust-driver/pull/942))
- CI: semver_checks now edits its comment instead of posting new one, so that the PR wall is less cluttered. ([#952](https://github.com/scylladb/scylla-rust-driver/pull/952))
- CI: Tracing output is now shown for a test iff the test failed. This is a major aid in debugging in CI. ([#959](https://github.com/scylladb/scylla-rust-driver/pull/959))
- Reverted *"CI/Makefile: disable `uninlined_format_args` clippy lint"*, as `rust-analyzer` now properly supports semantic analysis of such format args. ([#945](https://github.com/scylladb/scylla-rust-driver/pull/945))
- Appeased Clippy again ([#971](https://github.com/scylladb/scylla-rust-driver/pull/971))

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

|commits|author|
|----|--|
| 40 | Karol Baryła |
| 24 | Mikołaj Uzarski |
| 10 | Wojciech Przytuła |
| 1 | Piotr Dulikowski |
| 1 | Piotr Grabowski |









