### PR TITLE
treewide: silence mock structs unused warning

### DIFF
--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -1141,6 +1141,7 @@ mod tests {
     // Do not remove. It's not used in tests but we keep it here to check that
     // we properly ignore warnings about unused variables, unnecessary `mut`s
     // etc. that usually pop up when generating code for empty structs.
+    #[allow(unused)]
     #[derive(SerializeRow)]
     #[scylla(crate = crate)]
     struct TestRowWithNoColumns {}

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -2038,6 +2038,7 @@ mod tests {
     // Do not remove. It's not used in tests but we keep it here to check that
     // we properly ignore warnings about unused variables, unnecessary `mut`s
     // etc. that usually pop up when generating code for empty structs.
+    #[allow(unused)]
     #[derive(SerializeCql)]
     #[scylla(crate = crate)]
     struct TestUdtWithNoFields {}
@@ -2596,6 +2597,7 @@ mod tests {
         assert_eq!(reference, udt);
     }
 
+    #[allow(unused)]
     #[derive(SerializeCql, Debug)]
     #[scylla(crate = crate, flavor = "enforce_order", skip_name_checks)]
     struct TestUdtWithSkippedNameChecks {

--- a/scylla/tests/integration/hygiene.rs
+++ b/scylla/tests/integration/hygiene.rs
@@ -64,6 +64,7 @@ macro_rules! test_crate {
             assert_eq!(sv, sv2);
         }
 
+        #[allow(unused)]
         #[derive(_scylla::macros::SerializeCql, _scylla::macros::SerializeRow)]
         #[scylla(crate = _scylla)]
         struct TestStructNew {


### PR DESCRIPTION
With a new version of Rust toolchain (stable 1.78.0), our never constructed structs used for testing macros began to trigger rustc warnings. Now, they are silenced explicitly using `#[allow(unused)]`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
