### PR TITLE
codewide: appease Clippy

### DIFF
--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use uuid::Uuid;
 
+use std::fmt::Display;
 use std::{collections::HashMap, convert::TryFrom};
 
 use request::SerializableRequest;
@@ -47,11 +48,11 @@ pub enum Compression {
     Snappy,
 }
 
-impl ToString for Compression {
-    fn to_string(&self) -> String {
+impl Display for Compression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Compression::Lz4 => "lz4".to_owned(),
-            Compression::Snappy => "snappy".to_owned(),
+            Compression::Lz4 => f.write_str("lz4"),
+            Compression::Snappy => f.write_str("snappy"),
         }
     }
 }

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -699,6 +699,12 @@ pub trait ValueList {
     }
 }
 
+impl Default for LegacySerializedValues {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LegacySerializedValues {
     /// Creates empty value list
     pub const fn new() -> Self {

--- a/scylla/src/transport/connection_pool.rs
+++ b/scylla/src/transport/connection_pool.rs
@@ -973,7 +973,7 @@ impl PoolRefiller {
             new_sharder,
         );
 
-        self.sharder = new_sharder.clone();
+        self.sharder.clone_from(&new_sharder);
 
         // If the sharder has changed, we can throw away all previous connections.
         // All connections to the same live node will have the same sharder,

--- a/scylla/src/utils/parse.rs
+++ b/scylla/src/utils/parse.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 /// An error that can occur during parsing.
 #[derive(Copy, Clone)]
 pub(crate) struct ParseError {
@@ -27,11 +29,11 @@ pub(crate) enum ParseErrorCause {
     Other(&'static str),
 }
 
-impl ToString for ParseErrorCause {
-    fn to_string(&self) -> String {
+impl Display for ParseErrorCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParseErrorCause::Expected(e) => format!("expected {:?}", e),
-            ParseErrorCause::Other(e) => e.to_string(),
+            ParseErrorCause::Expected(e) => write!(f, "expected {:?}", e),
+            ParseErrorCause::Other(e) => f.write_str(e),
         }
     }
 }


### PR DESCRIPTION
Clippy started to complain again:
- direct impl of ToString instead of taking advantage of blanked impl over Display,
- no Default impl for LegacySerializedValues,
- assigning result of clone() instead of using clone_from().

The suggestions were applied.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
