### PR TITLE
Pre-deserialization-refactor preparatory changes

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1524,6 +1524,7 @@ dependencies = [
 name = "scylla-cql"
 version = "0.2.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "bigdecimal",
  "byteorder",

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -28,7 +28,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 time = { version = "0.3", optional = true }
 
 [dev-dependencies]
-criterion = "0.4" # Note: v0.5 needs at least rust 1.70.0
+assert_matches = "1.5.0"
+criterion = "0.4"        # Note: v0.5 needs at least rust 1.70.0
 # Use large-dates feature to test potential edge cases
 time = { version = "0.3.21", features = ["large-dates"] }
 
@@ -43,7 +44,14 @@ chrono = ["dep:chrono"]
 num-bigint-03 = ["dep:num-bigint-03"]
 num-bigint-04 = ["dep:num-bigint-04"]
 bigdecimal-04 = ["dep:bigdecimal-04"]
-full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]
+full-serialization = [
+    "chrono",
+    "time",
+    "secret",
+    "num-bigint-03",
+    "num-bigint-04",
+    "bigdecimal-04",
+]
 
 [lints.rust]
 unreachable_pub = "warn"

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -302,11 +302,14 @@ pub fn write_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), ParseError> {
     Ok(())
 }
 
-pub fn write_bytes_opt(v: Option<&Vec<u8>>, buf: &mut impl BufMut) -> Result<(), ParseError> {
+pub fn write_bytes_opt(
+    v: Option<impl AsRef<[u8]>>,
+    buf: &mut impl BufMut,
+) -> Result<(), ParseError> {
     match v {
         Some(bytes) => {
-            write_int_length(bytes.len(), buf)?;
-            buf.put_slice(bytes);
+            write_int_length(bytes.as_ref().len(), buf)?;
+            buf.put_slice(bytes.as_ref());
         }
         None => write_int(-1, buf),
     }

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -10,6 +10,8 @@ use super::value::{
     CqlDate, CqlDuration, CqlTime, CqlTimestamp, LegacyBatchValues, LegacySerializedValues,
     MaybeUnset, SerializeValuesError, Unset, Value, ValueList, ValueTooBig,
 };
+#[cfg(test)]
+use assert_matches::assert_matches;
 use bytes::BufMut;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -1262,7 +1264,7 @@ fn serialized_values_value_list() {
     ser_values.add_value(&"qwertyuiop").unwrap();
 
     let ser_ser_values: Cow<LegacySerializedValues> = ser_values.serialized().unwrap();
-    assert!(matches!(ser_ser_values, Cow::Borrowed(_)));
+    assert_matches!(ser_ser_values, Cow::Borrowed(_));
 
     assert_eq!(&ser_values, ser_ser_values.as_ref());
 }
@@ -1272,7 +1274,7 @@ fn cow_serialized_values_value_list() {
     let cow_ser_values: Cow<LegacySerializedValues> = Cow::Owned(LegacySerializedValues::new());
 
     let serialized: Cow<LegacySerializedValues> = cow_ser_values.serialized().unwrap();
-    assert!(matches!(serialized, Cow::Borrowed(_)));
+    assert_matches!(serialized, Cow::Borrowed(_));
 
     assert_eq!(cow_ser_values.as_ref(), serialized.as_ref());
 }

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -865,6 +865,7 @@ mod tests {
     };
 
     use super::SerializedValues;
+    use assert_matches::assert_matches;
     use scylla_macros::SerializeRow;
 
     fn col_spec(name: &str, typ: ColumnType) -> ColumnSpec {
@@ -1044,13 +1045,13 @@ mod tests {
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<()>());
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::WrongColumnCount {
                 actual: 0,
                 asked_for: 1,
             }
-        ));
+        );
 
         // Non-unit tuple
         // Count mismatch
@@ -1059,13 +1060,13 @@ mod tests {
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<(&str,)>());
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::WrongColumnCount {
                 actual: 1,
                 asked_for: 2,
             }
-        ));
+        );
 
         // Serialization of one of the element fails
         let v = ("Ala ma kota", 123_i32);
@@ -1086,13 +1087,13 @@ mod tests {
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<Vec<&str>>());
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::WrongColumnCount {
                 actual: 1,
                 asked_for: 2,
             }
-        ));
+        );
 
         // Serialization of one of the element fails
         let v = vec!["Ala ma kota", "Kot ma pchły"];
@@ -1214,10 +1215,10 @@ mod tests {
         };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut row_writer).unwrap_err();
         let err = err.0.downcast_ref::<BuiltinTypeCheckError>().unwrap();
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::ValueMissingForColumn { .. }
-        ));
+        );
 
         let spec_duplicate_column = [
             col("a", ColumnType::Text),
@@ -1232,10 +1233,7 @@ mod tests {
         };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut row_writer).unwrap_err();
         let err = err.0.downcast_ref::<BuiltinTypeCheckError>().unwrap();
-        assert!(matches!(
-            err.kind,
-            BuiltinTypeCheckErrorKind::NoColumnWithName { .. }
-        ));
+        assert_matches!(err.kind, BuiltinTypeCheckErrorKind::NoColumnWithName { .. });
 
         let spec_wrong_type = [
             col("a", ColumnType::Text),
@@ -1248,10 +1246,10 @@ mod tests {
         };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut row_writer).unwrap_err();
         let err = err.0.downcast_ref::<BuiltinSerializationError>().unwrap();
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinSerializationErrorKind::ColumnSerializationFailed { .. }
-        ));
+        );
     }
 
     #[derive(SerializeRow)]
@@ -1325,10 +1323,10 @@ mod tests {
         let ctx = RowSerializationContext { columns: &spec };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut writer).unwrap_err();
         let err = err.0.downcast_ref::<BuiltinTypeCheckError>().unwrap();
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::ColumnNameMismatch { .. }
-        ));
+        );
 
         let spec_without_c = [
             col("a", ColumnType::Text),
@@ -1341,10 +1339,10 @@ mod tests {
         };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut writer).unwrap_err();
         let err = err.0.downcast_ref::<BuiltinTypeCheckError>().unwrap();
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::ValueMissingForColumn { .. }
-        ));
+        );
 
         let spec_duplicate_column = [
             col("a", ColumnType::Text),
@@ -1359,10 +1357,7 @@ mod tests {
         };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut writer).unwrap_err();
         let err = err.0.downcast_ref::<BuiltinTypeCheckError>().unwrap();
-        assert!(matches!(
-            err.kind,
-            BuiltinTypeCheckErrorKind::NoColumnWithName { .. }
-        ));
+        assert_matches!(err.kind, BuiltinTypeCheckErrorKind::NoColumnWithName { .. });
 
         let spec_wrong_type = [
             col("a", ColumnType::Text),
@@ -1375,10 +1370,10 @@ mod tests {
         };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut writer).unwrap_err();
         let err = err.0.downcast_ref::<BuiltinSerializationError>().unwrap();
-        assert!(matches!(
+        assert_matches!(
             err.kind,
             BuiltinSerializationErrorKind::ColumnSerializationFailed { .. }
-        ));
+        );
     }
 
     #[test]

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1574,17 +1574,21 @@ mod tests {
         assert_eq!(typed_data, erased_data);
     }
 
-    fn do_serialize<T: SerializeCql>(t: T, typ: &ColumnType) -> Vec<u8> {
+    fn do_serialize_result<T: SerializeCql>(
+        t: T,
+        typ: &ColumnType,
+    ) -> Result<Vec<u8>, SerializationError> {
         let mut ret = Vec::new();
         let writer = CellWriter::new(&mut ret);
-        t.serialize(typ, writer).unwrap();
-        ret
+        t.serialize(typ, writer).map(|_| ()).map(|()| ret)
+    }
+
+    fn do_serialize<T: SerializeCql>(t: T, typ: &ColumnType) -> Vec<u8> {
+        do_serialize_result(t, typ).unwrap()
     }
 
     fn do_serialize_err<T: SerializeCql>(t: T, typ: &ColumnType) -> SerializationError {
-        let mut ret = Vec::new();
-        let writer = CellWriter::new(&mut ret);
-        t.serialize(typ, writer).unwrap_err()
+        do_serialize_result(t, typ).unwrap_err()
     }
 
     #[test]

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1149,17 +1149,14 @@ impl Display for BuiltinTypeCheckErrorKind {
                 write!(f, "expected one of the CQL types: {expected:?}")
             }
             BuiltinTypeCheckErrorKind::NotEmptyable => {
-                write!(
-                    f,
-                    "the separate empty representation is not valid for this type"
-                )
+                f.write_str("the separate empty representation is not valid for this type")
             }
             BuiltinTypeCheckErrorKind::SetOrListError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::MapError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::TupleError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::UdtError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::CustomTypeUnsupported => {
-                write!(f, "custom CQL types are unsupported")
+                f.write_str("custom CQL types are unsupported")
             }
         }
     }
@@ -1217,16 +1214,10 @@ impl Display for BuiltinSerializationErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             BuiltinSerializationErrorKind::SizeOverflow => {
-                write!(
-                    f,
-                    "the Rust value is too big to be serialized in the CQL protocol format"
-                )
+                f.write_str("the Rust value is too big to be serialized in the CQL protocol format")
             }
             BuiltinSerializationErrorKind::ValueOverflow => {
-                write!(
-                    f,
-                    "the Rust value is out of range supported by the CQL type"
-                )
+                f.write_str("the Rust value is out of range supported by the CQL type")
             }
             BuiltinSerializationErrorKind::SetOrListError(err) => err.fmt(f),
             BuiltinSerializationErrorKind::MapError(err) => err.fmt(f),
@@ -1247,12 +1238,9 @@ pub enum MapTypeCheckErrorKind {
 impl Display for MapTypeCheckErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            MapTypeCheckErrorKind::NotMap => {
-                write!(
-                    f,
-                    "the CQL type the map was attempted to be serialized to was not map"
-                )
-            }
+            MapTypeCheckErrorKind::NotMap => f.write_str(
+                "the CQL type the Rust type was attempted to be type checked against was not a map",
+            ),
         }
     }
 }
@@ -1275,10 +1263,7 @@ impl Display for MapSerializationErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MapSerializationErrorKind::TooManyElements => {
-                write!(
-                    f,
-                    "the map contains too many elements to fit in CQL representation"
-                )
+                f.write_str("the map contains too many elements to fit in CQL representation")
             }
             MapSerializationErrorKind::KeySerializationFailed(err) => {
                 write!(f, "failed to serialize one of the keys: {}", err)
@@ -1302,10 +1287,7 @@ impl Display for SetOrListTypeCheckErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SetOrListTypeCheckErrorKind::NotSetOrList => {
-                write!(
-                    f,
-                    "the CQL type the tuple was attempted to was neither a set or a list"
-                )
+                f.write_str("the CQL type the Rust type was attempted to be type checked against was neither a set or a list")
             }
         }
     }
@@ -1325,12 +1307,9 @@ pub enum SetOrListSerializationErrorKind {
 impl Display for SetOrListSerializationErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SetOrListSerializationErrorKind::TooManyElements => {
-                write!(
-                    f,
-                    "the collection contains too many elements to fit in CQL representation"
-                )
-            }
+            SetOrListSerializationErrorKind::TooManyElements => f.write_str(
+                "the collection contains too many elements to fit in CQL representation",
+            ),
             SetOrListSerializationErrorKind::ElementSerializationFailed(err) => {
                 write!(f, "failed to serialize one of the elements: {err}")
             }
@@ -1362,14 +1341,10 @@ pub enum TupleTypeCheckErrorKind {
 impl Display for TupleTypeCheckErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TupleTypeCheckErrorKind::NotTuple => write!(
-                f,
-                "the CQL type the tuple was attempted to be serialized to is not a tuple"
+            TupleTypeCheckErrorKind::NotTuple => f.write_str(
+                "the CQL type the Rust type was attempted to be type checked against is not a tuple"
             ),
-            TupleTypeCheckErrorKind::WrongElementCount {
-                rust_type_el_count,
-                cql_type_el_count,
-            } => write!(
+            TupleTypeCheckErrorKind::WrongElementCount { rust_type_el_count, cql_type_el_count } => write!(
                 f,
                 "wrong tuple element count: CQL type has {cql_type_el_count}, the Rust tuple has {rust_type_el_count}"
             ),
@@ -1442,10 +1417,7 @@ pub enum UdtTypeCheckErrorKind {
 impl Display for UdtTypeCheckErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UdtTypeCheckErrorKind::NotUdt => write!(
-                f,
-                "the CQL type the tuple was attempted to be type checked against is not a UDT"
-            ),
+            UdtTypeCheckErrorKind::NotUdt => f.write_str("the CQL type the Rust type was attempted to be type checked against is not a UDT"),
             UdtTypeCheckErrorKind::NameMismatch {
                 keyspace,
                 type_name,

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 darling = "0.20.0"
 syn = "2.0"
-quote = "1.0" 
+quote = "1.0"
 proc-macro2 = "1.0"
 
 [lints.rust]

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,7 +17,15 @@ scylla-cql = { version = "0.2.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"
-tokio = { version = "1.12", features = ["net", "time", "io-util", "sync", "rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.12", features = [
+    "net",
+    "time",
+    "io-util",
+    "sync",
+    "rt",
+    "macros",
+    "rt-multi-thread",
+] }
 uuid = "1.0"
 thiserror = "1.0.32"
 bigdecimal = "0.4"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -16,14 +16,28 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 ssl = ["dep:tokio-openssl", "dep:openssl"]
-cloud = ["ssl", "scylla-cql/serde", "dep:serde_yaml", "dep:serde", "dep:url", "dep:base64"]
+cloud = [
+    "ssl",
+    "scylla-cql/serde",
+    "dep:serde_yaml",
+    "dep:serde",
+    "dep:url",
+    "dep:base64",
+]
 secret = ["scylla-cql/secret"]
 chrono = ["scylla-cql/chrono"]
 time = ["scylla-cql/time"]
 num-bigint-03 = ["scylla-cql/num-bigint-03"]
 num-bigint-04 = ["scylla-cql/num-bigint-04"]
 bigdecimal-04 = ["scylla-cql/bigdecimal-04"]
-full-serialization = ["chrono", "time", "secret", "num-bigint-03", "num-bigint-04", "bigdecimal-04"]
+full-serialization = [
+    "chrono",
+    "time",
+    "secret",
+    "num-bigint-03",
+    "num-bigint-04",
+    "bigdecimal-04",
+]
 
 [dependencies]
 scylla-macros = { version = "0.5.0", path = "../scylla-macros" }
@@ -33,7 +47,14 @@ bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
 histogram = "0.6.9"
-tokio = { version = "1.34", features = ["net", "time", "io-util", "sync", "rt", "macros"] }
+tokio = { version = "1.34", features = [
+    "net",
+    "time",
+    "io-util",
+    "sync",
+    "rt",
+    "macros",
+] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8.3"
@@ -62,7 +83,7 @@ num-bigint-04 = { package = "num-bigint", version = "0.4" }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4" }
 scylla-proxy = { version = "0.0.3", path = "../scylla-proxy" }
 ntest = "0.9.0"
-criterion = "0.4" # Note: v0.5 needs at least rust 1.70.0
+criterion = "0.4"                                                      # Note: v0.5 needs at least rust 1.70.0
 tokio = { version = "1.27", features = ["test-util"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 assert_matches = "1.5.0"

--- a/scylla/src/history.rs
+++ b/scylla/src/history.rs
@@ -465,6 +465,7 @@ mod tests {
         SpeculativeId, StructuredHistory, TimePoint,
     };
     use crate::test_utils::create_new_session_builder;
+    use assert_matches::assert_matches;
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
     use futures::StreamExt;
     use scylla_cql::{
@@ -642,10 +643,10 @@ mod tests {
         assert_eq!(history.queries.len(), 1);
         assert_eq!(history.queries[0].non_speculative_fiber.attempts.len(), 1);
         assert!(history.queries[0].speculative_fibers.is_empty());
-        assert!(matches!(
+        assert_matches!(
             history.queries[0].non_speculative_fiber.attempts[0].result,
             Some(AttemptResult::Success(_))
-        ));
+        );
 
         let displayed = "Queries History:
 === Query #0 ===

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -267,6 +267,8 @@ mod tests {
     };
     use std::convert::TryInto;
 
+    use assert_matches::assert_matches;
+
     // Returns specified number of rows, each one containing one int32 value.
     // Values are 0, 1, 2, 3, 4, ...
     fn make_rows(rows_num: usize) -> Vec<Row> {
@@ -483,10 +485,10 @@ mod tests {
             Ok((0,))
         );
 
-        assert!(matches!(
+        assert_matches!(
             make_string_rows_query_result(2).first_row_typed::<(i32,)>(),
             Err(FirstRowTypedError::FromRowError(_))
-        ));
+        );
     }
 
     #[test]
@@ -539,10 +541,10 @@ mod tests {
             Ok(Some((0,)))
         );
 
-        assert!(matches!(
+        assert_matches!(
             make_string_rows_query_result(1).maybe_first_row_typed::<(i32,)>(),
             Err(MaybeFirstRowTypedError::FromRowError(_))
-        ))
+        )
     }
 
     #[test]
@@ -594,9 +596,9 @@ mod tests {
             Err(SingleRowTypedError::BadNumberOfRows(3))
         );
 
-        assert!(matches!(
+        assert_matches!(
             make_string_rows_query_result(1).single_row_typed::<(i32,)>(),
             Err(SingleRowTypedError::FromRowError(_))
-        ));
+        );
     }
 }


### PR DESCRIPTION
This is a bunch of preparatory changes to come before the proper deserialization refactor.
To avoid the PR with the first deserialization refactor portion being so big, I extracted them here to be merged sooner.

### What's done:
- `types::write_bytes_opt()` becomes more generic;
- types: return `std::io::Error` instead of `ParseError` where possible - don't unnecessarily broaden the codomain of those functions (not to have to unnecessarily pattern match on their returned error type);
- scylla-cql: add `assert_matches` as dev-dep. It will be helpful in testing deserialization framework, and will also be used in serialization instead of `assert!(matches!(...))`;
- codewide: ditch assert!(matches!(...)) - as assert_matches!(...) provide superior experience (providing helpful debugging messages with how the mismatched type looked like), all `assert!(matches!(...))` occurences across the code were changed to `assert_matches!(...)`;
- serialize: deduplicate `do_serialize[_err]`;
- serialize errors:
  - names and error messages are changed to better reflect reality;
  - a bunch of typos are fixed, and some names are changed to be more explicit;
  - where possible, `write!(f, ...)` is replaced with `f.write_str(...)` for performance. 


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
