### PR TITLE
CI: fix clippy issues

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -27,5 +27,7 @@ jobs:
         options: --health-cmd "cqlsh --username cassandra --password cassandra --debug" --health-interval 5s --health-retries 30
     steps:
     - uses: actions/checkout@v3
+    - name: Update rust toolchain
+      run: rustup update
     - name: Run tests
       run: RUST_LOG=trace cargo test --verbose authenticate_superuser -- custom_authentication --ignored

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -27,6 +27,8 @@ jobs:
         options: --health-cmd "cqlsh --debug scylladb" --health-interval 5s --health-retries 10
     steps:
     - uses: actions/checkout@v3
+    - name: Update rust toolchain
+      run: rustup update
     - name: Install mdbook
       run: cargo install mdbook --no-default-features
     - name: Build the project

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -25,6 +25,8 @@ jobs:
       run: |
         docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait
       # A separate step for building to separate measuring time of compilation and testing
+    - name: Update rust toolchain
+      run: rustup update
     - name: Build the project
       run: cargo build --verbose --tests --features "full-serialization"
     - name: Run tests on cassandra

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
       run: |
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
         docker compose -f test/cluster/docker-compose.yml up -d --wait
+    - name: Update rust toolchain
+      run: rustup update
     - name: Print rustc version
       run: rustc --version
     - name: Print rustfmt version
@@ -98,5 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Update rust toolchain
+      run: rustup update
     - name: Compile docs
       run: RUSTDOCFLAGS=-Dwarnings cargo doc

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -56,6 +56,8 @@ jobs:
     # I don't know any way to do this using checkout action
     - name: Fetch PR base
       run: git fetch origin "$PR_BASE"
+    - name: Update rust toolchain
+      run: rustup update
     - name: Install semver-checks
       # Official action uses binary releases fetched from GitHub
       # If this pipeline becomes too slow, we should do this too
@@ -142,6 +144,8 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
+    - name: Update rust toolchain
+      run: rustup update
     - name: Install semver-checks
       run: cargo install cargo-semver-checks --no-default-features
     - name: Run semver-checks to see if it agrees with version updates

--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -29,7 +29,8 @@ jobs:
         run: |
           ccm create serverless -i 127.0.1. -n 1 --scylla -v release:5.1.6
           ccm start  --sni-proxy --sni-port 7777
-
+      - name: Update rust toolchain
+        run: rustup update
       - name: Check
         run: cargo check --verbose
       - name: Run cloud example

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -32,6 +32,8 @@ jobs:
       working-directory: ./scylla
     steps:
     - uses: actions/checkout@v3
+    - name: Update rust toolchain
+      run: rustup update
     - name: Check
       run: cargo check --verbose --features "ssl"
       working-directory: ${{env.working-directory}}

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -1,3 +1,6 @@
+// See: https://github.com/TedDriggs/darling/issues/293
+#![allow(clippy::manual_unwrap_or_default)]
+
 use std::collections::HashMap;
 
 use darling::FromAttributes;

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -1,3 +1,6 @@
+// See: https://github.com/TedDriggs/darling/issues/293
+#![allow(clippy::manual_unwrap_or_default)]
+
 use std::collections::HashMap;
 
 use darling::FromAttributes;

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1826,7 +1826,7 @@ struct StreamIdSet {
 
 impl StreamIdSet {
     fn new() -> Self {
-        const BITMAP_SIZE: usize = (std::i16::MAX as usize + 1) / 64;
+        const BITMAP_SIZE: usize = (i16::MAX as usize + 1) / 64;
         Self {
             used_bitmap: vec![0; BITMAP_SIZE].into_boxed_slice(),
         }


### PR DESCRIPTION
There were two clippy checks that were failing:
- not using `unwrap_or_default` in the code generated by `darling` crate. See the corresponding issue: https://github.com/TedDriggs/darling/issues/293
- usage of legacy numeric constant - `std::i16::MAX`, instead of `i16::MAX`

This PR fixes the issues and makes CI pass.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
