### PR TITLE
errors: Low level (de)ser errors

### DIFF
--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -188,7 +188,7 @@ pub fn parse_response_body_extensions(
 
     let trace_id = if flags & FLAG_TRACING != 0 {
         let buf = &mut &*body;
-        let trace_id = types::read_uuid(buf)?;
+        let trace_id = types::read_uuid(buf).map_err(frame_errors::ParseError::from)?;
         body.advance(16);
         Some(trace_id)
     } else {
@@ -198,7 +198,7 @@ pub fn parse_response_body_extensions(
     let warnings = if flags & FLAG_WARNING != 0 {
         let body_len = body.len();
         let buf = &mut &*body;
-        let warnings = types::read_string_list(buf)?;
+        let warnings = types::read_string_list(buf).map_err(frame_errors::ParseError::from)?;
         let buf_len = buf.len();
         body.advance(body_len - buf_len);
         warnings
@@ -209,7 +209,7 @@ pub fn parse_response_body_extensions(
     let custom_payload = if flags & FLAG_CUSTOM_PAYLOAD != 0 {
         let body_len = body.len();
         let buf = &mut &*body;
-        let payload_map = types::read_bytes_map(buf)?;
+        let payload_map = types::read_bytes_map(buf).map_err(frame_errors::ParseError::from)?;
         let buf_len = buf.len();
         body.advance(body_len - buf_len);
         Some(payload_map)

--- a/scylla-cql/src/frame/request/auth_response.rs
+++ b/scylla-cql/src/frame/request/auth_response.rs
@@ -12,6 +12,6 @@ impl SerializableRequest for AuthResponse {
     const OPCODE: RequestOpcode = RequestOpcode::AuthResponse;
 
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
-        write_bytes_opt(self.response.as_ref(), buf)
+        Ok(write_bytes_opt(self.response.as_ref(), buf)?)
     }
 }

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -785,13 +785,15 @@ pub fn deser_cql_value(typ: &ColumnType, buf: &mut &[u8]) -> StdResult<CqlValue,
             let t = type_names
                 .iter()
                 .map(|typ| {
-                    types::read_bytes_opt(buf).and_then(|v| {
-                        v.map(|v| {
-                            CqlValue::deserialize(typ, Some(FrameSlice::new_borrowed(v)))
-                                .map_err(Into::into)
+                    types::read_bytes_opt(buf)
+                        .map_err(ParseError::from)
+                        .and_then(|v| {
+                            v.map(|v| {
+                                CqlValue::deserialize(typ, Some(FrameSlice::new_borrowed(v)))
+                                    .map_err(Into::into)
+                            })
+                            .transpose()
                         })
-                        .transpose()
-                    })
                 })
                 .collect::<StdResult<_, _>>()?;
             CqlValue::Tuple(t)

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -189,7 +189,7 @@ pub fn read_int_length(buf: &mut &[u8]) -> Result<usize, ParseError> {
     Ok(v)
 }
 
-fn write_int_length(v: usize, buf: &mut impl BufMut) -> Result<(), ParseError> {
+fn write_int_length(v: usize, buf: &mut impl BufMut) -> Result<(), std::num::TryFromIntError> {
     let v: i32 = v.try_into()?;
 
     write_int(v, buf);
@@ -240,7 +240,7 @@ pub(crate) fn read_short_length(buf: &mut &[u8]) -> Result<usize, std::io::Error
     Ok(v)
 }
 
-fn write_short_length(v: usize, buf: &mut impl BufMut) -> Result<(), ParseError> {
+fn write_short_length(v: usize, buf: &mut impl BufMut) -> Result<(), std::num::TryFromIntError> {
     let v: u16 = v.try_into()?;
     write_short(v, buf);
     Ok(())
@@ -296,7 +296,7 @@ pub fn read_short_bytes<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], ParseError> 
     Ok(v)
 }
 
-pub fn write_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), ParseError> {
+pub fn write_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), std::num::TryFromIntError> {
     write_int_length(v.len(), buf)?;
     buf.put_slice(v);
     Ok(())
@@ -305,7 +305,7 @@ pub fn write_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), ParseError> {
 pub fn write_bytes_opt(
     v: Option<impl AsRef<[u8]>>,
     buf: &mut impl BufMut,
-) -> Result<(), ParseError> {
+) -> Result<(), std::num::TryFromIntError> {
     match v {
         Some(bytes) => {
             write_int_length(bytes.as_ref().len(), buf)?;
@@ -317,7 +317,7 @@ pub fn write_bytes_opt(
     Ok(())
 }
 
-pub fn write_short_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), ParseError> {
+pub fn write_short_bytes(v: &[u8], buf: &mut impl BufMut) -> Result<(), std::num::TryFromIntError> {
     write_short_length(v.len(), buf)?;
     buf.put_slice(v);
     Ok(())
@@ -334,7 +334,10 @@ pub fn read_bytes_map(buf: &mut &[u8]) -> Result<HashMap<String, Vec<u8>>, Parse
     Ok(v)
 }
 
-pub fn write_bytes_map<B>(v: &HashMap<String, B>, buf: &mut impl BufMut) -> Result<(), ParseError>
+pub fn write_bytes_map<B>(
+    v: &HashMap<String, B>,
+    buf: &mut impl BufMut,
+) -> Result<(), std::num::TryFromIntError>
 where
     B: AsRef<[u8]>,
 {
@@ -365,7 +368,7 @@ pub fn read_string<'a>(buf: &mut &'a [u8]) -> Result<&'a str, ParseError> {
     Ok(v)
 }
 
-pub fn write_string(v: &str, buf: &mut impl BufMut) -> Result<(), ParseError> {
+pub fn write_string(v: &str, buf: &mut impl BufMut) -> Result<(), std::num::TryFromIntError> {
     let raw = v.as_bytes();
     write_short_length(v.len(), buf)?;
     buf.put_slice(raw);
@@ -389,7 +392,7 @@ pub fn read_long_string<'a>(buf: &mut &'a [u8]) -> Result<&'a str, ParseError> {
     Ok(v)
 }
 
-pub fn write_long_string(v: &str, buf: &mut impl BufMut) -> Result<(), ParseError> {
+pub fn write_long_string(v: &str, buf: &mut impl BufMut) -> Result<(), std::num::TryFromIntError> {
     let raw = v.as_bytes();
     let len = raw.len();
     write_int_length(len, buf)?;
@@ -421,7 +424,7 @@ pub fn read_string_map(buf: &mut &[u8]) -> Result<HashMap<String, String>, Parse
 pub fn write_string_map(
     v: &HashMap<String, String>,
     buf: &mut impl BufMut,
-) -> Result<(), ParseError> {
+) -> Result<(), std::num::TryFromIntError> {
     let len = v.len();
     write_short_length(len, buf)?;
     for (key, val) in v.iter() {
@@ -451,7 +454,10 @@ pub fn read_string_list(buf: &mut &[u8]) -> Result<Vec<String>, ParseError> {
     Ok(v)
 }
 
-pub fn write_string_list(v: &[String], buf: &mut impl BufMut) -> Result<(), ParseError> {
+pub fn write_string_list(
+    v: &[String],
+    buf: &mut impl BufMut,
+) -> Result<(), std::num::TryFromIntError> {
     let len = v.len();
     write_short_length(len, buf)?;
     for v in v.iter() {
@@ -487,7 +493,7 @@ pub fn read_string_multimap(buf: &mut &[u8]) -> Result<HashMap<String, Vec<Strin
 pub fn write_string_multimap(
     v: &HashMap<String, Vec<String>>,
     buf: &mut impl BufMut,
-) -> Result<(), ParseError> {
+) -> Result<(), std::num::TryFromIntError> {
     let len = v.len();
     write_short_length(len, buf)?;
     for (key, val) in v.iter() {

--- a/scylla-cql/src/types/deserialize/frame_slice.rs
+++ b/scylla-cql/src/types/deserialize/frame_slice.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::LowLevelDeserializationError;
 use crate::frame::types;
 
 /// A reference to a part of the frame.
@@ -139,7 +139,9 @@ impl<'frame> FrameSlice<'frame> {
     ///
     /// If the operation fails then the slice remains unchanged.
     #[inline]
-    pub(super) fn read_cql_bytes(&mut self) -> Result<Option<FrameSlice<'frame>>, ParseError> {
+    pub(super) fn read_cql_bytes(
+        &mut self,
+    ) -> Result<Option<FrameSlice<'frame>>, LowLevelDeserializationError> {
         // We copy the slice reference, not to mutate the FrameSlice in case of an error.
         let mut slice = self.frame_subslice;
 

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -416,7 +416,6 @@ mod tests {
     use assert_matches::assert_matches;
     use bytes::Bytes;
 
-    use crate::frame::frame_errors::ParseError;
     use crate::frame::response::result::{ColumnSpec, ColumnType};
     use crate::types::deserialize::row::BuiltinDeserializationErrorKind;
     use crate::types::deserialize::{DeserializationError, FrameSlice};
@@ -651,13 +650,6 @@ mod tests {
             let err = super::super::value::tests::get_deser_err(err);
             assert_eq!(err.rust_name, std::any::type_name::<CqlValue>());
             assert_eq!(err.cql_type, ColumnType::BigInt);
-            let super::super::value::BuiltinDeserializationErrorKind::GenericParseError(
-                ParseError::DeserializationError(d),
-            ) = &err.kind
-            else {
-                panic!("unexpected error kind: {}", err.kind)
-            };
-            let err = super::super::value::tests::get_deser_err(d);
             let super::super::value::BuiltinDeserializationErrorKind::ByteLengthMismatch {
                 expected: 8,
                 got: 4,

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -1573,7 +1573,7 @@ pub struct BuiltinDeserializationError {
     pub kind: BuiltinDeserializationErrorKind,
 }
 
-fn mk_deser_err<T>(
+pub(crate) fn mk_deser_err<T>(
     cql_type: &ColumnType,
     kind: impl Into<BuiltinDeserializationErrorKind>,
 ) -> DeserializationError {

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -14,7 +14,7 @@ use std::fmt::Display;
 use thiserror::Error;
 
 use super::{make_error_replace_rust_name, DeserializationError, FrameSlice, TypeCheckError};
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::LowLevelDeserializationError;
 use crate::frame::response::result::{deser_cql_value, ColumnType, CqlValue};
 use crate::frame::types;
 use crate::frame::value::{
@@ -60,9 +60,7 @@ impl<'frame> DeserializeValue<'frame> for CqlValue {
         v: Option<FrameSlice<'frame>>,
     ) -> Result<Self, DeserializationError> {
         let mut val = ensure_not_null_slice::<Self>(typ, v)?;
-        let cql = deser_cql_value(typ, &mut val).map_err(|err| {
-            mk_deser_err::<Self>(typ, BuiltinDeserializationErrorKind::GenericParseError(err))
-        })?;
+        let cql = deser_cql_value(typ, &mut val).map_err(deser_error_replace_rust_name::<Self>)?;
         Ok(cql)
     }
 }
@@ -249,7 +247,7 @@ impl_emptiable_strict_type!(
         let scale = types::read_int(&mut val).map_err(|err| {
             mk_deser_err::<Self>(
                 typ,
-                BuiltinDeserializationErrorKind::GenericParseError(err.into()),
+                BuiltinDeserializationErrorKind::BadDecimalScale(err.into()),
             )
         })?;
         Ok(CqlDecimal::from_signed_be_bytes_slice_and_exponent(
@@ -267,7 +265,7 @@ impl_emptiable_strict_type!(
         let scale = types::read_int(&mut val).map_err(|err| {
             mk_deser_err::<Self>(
                 typ,
-                BuiltinDeserializationErrorKind::GenericParseError(err.into()),
+                BuiltinDeserializationErrorKind::BadDecimalScale(err.into()),
             )
         })? as i64;
         let int_value = bigdecimal_04::num_bigint::BigInt::from_signed_bytes_be(val);
@@ -381,25 +379,28 @@ impl_strict_type!(
         }
 
         let months_i64 = types::vint_decode(&mut val).map_err(|err| {
-            mk_err!(BuiltinDeserializationErrorKind::GenericParseError(
-                err.into()
-            ))
+            mk_err!(BuiltinDeserializationErrorKind::BadDate {
+                date_field: "months",
+                err: err.into()
+            })
         })?;
         let months = i32::try_from(months_i64)
             .map_err(|_| mk_err!(BuiltinDeserializationErrorKind::ValueOverflow))?;
 
         let days_i64 = types::vint_decode(&mut val).map_err(|err| {
-            mk_err!(BuiltinDeserializationErrorKind::GenericParseError(
-                err.into()
-            ))
+            mk_err!(BuiltinDeserializationErrorKind::BadDate {
+                date_field: "days",
+                err: err.into()
+            })
         })?;
         let days = i32::try_from(days_i64)
             .map_err(|_| mk_err!(BuiltinDeserializationErrorKind::ValueOverflow))?;
 
         let nanoseconds = types::vint_decode(&mut val).map_err(|err| {
-            mk_err!(BuiltinDeserializationErrorKind::GenericParseError(
-                err.into()
-            ))
+            mk_err!(BuiltinDeserializationErrorKind::BadDate {
+                date_field: "nanoseconds",
+                err: err.into()
+            })
         })?;
 
         Ok(CqlDuration {
@@ -727,7 +728,7 @@ where
         let raw = self.raw_iter.next()?.map_err(|err| {
             mk_deser_err::<Self>(
                 self.coll_typ,
-                BuiltinDeserializationErrorKind::GenericParseError(err),
+                BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
             )
         });
         Some(raw.and_then(|raw| {
@@ -906,7 +907,7 @@ where
             Some(Err(err)) => {
                 return Some(Err(mk_deser_err::<Self>(
                     self.coll_typ,
-                    BuiltinDeserializationErrorKind::GenericParseError(err),
+                    BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
                 )));
             }
             None => return None,
@@ -916,7 +917,7 @@ where
             Some(Err(err)) => {
                 return Some(Err(mk_deser_err::<Self>(
                     self.coll_typ,
-                    BuiltinDeserializationErrorKind::GenericParseError(err),
+                    BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
                 )));
             }
             None => return None,
@@ -1184,7 +1185,7 @@ impl<'frame> Iterator for UdtIterator<'frame> {
                     keyspace: self.keyspace.to_owned(),
                     field_types: self.all_fields.to_owned(),
                 },
-                BuiltinDeserializationErrorKind::GenericParseError(err),
+                BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
             )),
 
             // The field is just missing from the serialized form
@@ -1277,7 +1278,7 @@ impl<'frame> FixedLengthBytesSequenceIterator<'frame> {
 }
 
 impl<'frame> Iterator for FixedLengthBytesSequenceIterator<'frame> {
-    type Item = Result<Option<FrameSlice<'frame>>, ParseError>;
+    type Item = Result<Option<FrameSlice<'frame>>, LowLevelDeserializationError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.remaining = self.remaining.checked_sub(1)?;
@@ -1307,7 +1308,7 @@ impl<'frame> From<FrameSlice<'frame>> for BytesSequenceIterator<'frame> {
 }
 
 impl<'frame> Iterator for BytesSequenceIterator<'frame> {
-    type Item = Result<Option<FrameSlice<'frame>>, ParseError>;
+    type Item = Result<Option<FrameSlice<'frame>>, LowLevelDeserializationError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.slice.as_slice().is_empty() {
@@ -1596,8 +1597,20 @@ fn mk_deser_err_named(
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum BuiltinDeserializationErrorKind {
-    /// A generic deserialization failure - legacy error type.
-    GenericParseError(ParseError),
+    /// Failed to deserialize one of date's fields.
+    BadDate {
+        date_field: &'static str,
+        err: LowLevelDeserializationError,
+    },
+
+    /// Failed to deserialize decimal's scale.
+    BadDecimalScale(LowLevelDeserializationError),
+
+    /// Failed to deserialize raw bytes of cql value.
+    RawCqlBytesReadError(LowLevelDeserializationError),
+
+    /// Returned on attempt to deserialize a value of custom type.
+    CustomTypeNotSupported(String),
 
     /// Expected non-null value, got null.
     ExpectedNonNull,
@@ -1631,7 +1644,9 @@ pub enum BuiltinDeserializationErrorKind {
 impl Display for BuiltinDeserializationErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BuiltinDeserializationErrorKind::GenericParseError(err) => err.fmt(f),
+            BuiltinDeserializationErrorKind::BadDate { date_field, err } => write!(f, "malformed {} during 'date' deserialization: {}", date_field, err),
+            BuiltinDeserializationErrorKind::BadDecimalScale(err) => write!(f, "malformed decimal's scale: {}", err),
+            BuiltinDeserializationErrorKind::RawCqlBytesReadError(err) => write!(f, "failed to read raw cql value bytes: {}", err),
             BuiltinDeserializationErrorKind::ExpectedNonNull => {
                 f.write_str("expected a non-null value, got null")
             }
@@ -1656,6 +1671,7 @@ impl Display for BuiltinDeserializationErrorKind {
             BuiltinDeserializationErrorKind::SetOrListError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::MapError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::TupleError(err) => err.fmt(f),
+            BuiltinDeserializationErrorKind::CustomTypeNotSupported(typ) => write!(f, "Support for custom types is not yet implemented: {}", typ),
         }
     }
 }
@@ -2356,7 +2372,10 @@ pub(super) mod tests {
             .map_err(|typecheck_err| DeserializationError(typecheck_err.0))?;
         let mut frame_slice = FrameSlice::new(bytes);
         let value = frame_slice.read_cql_bytes().map_err(|err| {
-            mk_deser_err::<T>(typ, BuiltinDeserializationErrorKind::GenericParseError(err))
+            mk_deser_err::<T>(
+                typ,
+                BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
+            )
         })?;
         <T as DeserializeValue<'frame>>::deserialize(typ, value)
     }

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -5,6 +5,7 @@ use crate::frame::{
 };
 use crate::{RequestOpcode, TargetShard};
 use bytes::Bytes;
+use scylla_cql::frame::frame_errors::ParseError;
 use scylla_cql::frame::types::read_string_multimap;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -803,6 +804,7 @@ impl Doorkeeper {
             .map_err(DoorkeeperError::ObtainingShardNumberFrame)?;
 
         let options = read_string_multimap(&mut supported_frame.body.as_ref())
+            .map_err(ParseError::from)
             .map_err(DoorkeeperError::ObtainingShardNumberParseOptions)?;
 
         Ok(options)

--- a/scylla/src/transport/locator/tablets.rs
+++ b/scylla/src/transport/locator/tablets.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use scylla_cql::cql_to_rust::FromCqlVal;
-use scylla_cql::frame::frame_errors::ParseError;
 use scylla_cql::frame::response::result::{deser_cql_value, ColumnType, TableSpec};
+use scylla_cql::types::deserialize::DeserializationError;
 use thiserror::Error;
 use tracing::warn;
 use uuid::Uuid;
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[derive(Error, Debug)]
 pub(crate) enum TabletParsingError {
     #[error(transparent)]
-    Parse(#[from] ParseError),
+    Deserialization(#[from] DeserializationError),
     #[error("Shard id for tablet is negative: {0}")]
     ShardNum(i32),
 }
@@ -616,7 +616,7 @@ mod tests {
             HashMap::from([(CUSTOM_PAYLOAD_TABLETS_V1_KEY.to_string(), vec![1, 2, 3])]);
         assert_matches::assert_matches!(
             RawTablet::from_custom_payload(&custom_payload),
-            Some(Err(TabletParsingError::Parse(_)))
+            Some(Err(TabletParsingError::Deserialization(_)))
         );
     }
 
@@ -646,7 +646,7 @@ mod tests {
 
         assert_matches::assert_matches!(
             RawTablet::from_custom_payload(&custom_payload),
-            Some(Err(TabletParsingError::Parse(_)))
+            Some(Err(TabletParsingError::Deserialization(_)))
         );
     }
 


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

# Motivation

This commit is a small step forward to resolving the issues related to errors in rust driver. The main goal of this PR is to get rid of `ParseError` from `frame::types` module.

As a bonus, the newly introduced deserialization module is adjusted as well. Thanks to that, we remove the cycle in error types (`DeserializationError <-> ParseError`).

# Changes
- introduced new enum error type returned from types module: `LowLevelDeserializationError`
- changed the return error type of `types::read_*` functions to `LowLevelDeserializationError`
-  replaced `value::BuiltinDeserializationErrorKind::GenericParseError` with new variants
- changed the return error type of `deser_cql_value` to DeserializationError
- replaced `TabletsParsingError::Parse` with `TabletsParsingError::DeserializationError` 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~

