### PR TITLE
Remove tokio version bounds

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "ntest"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8ec6d2b73d45307e926f5af46809768581044384637af6b3f3fe7c3c88f512"
+checksum = "fb183f0a1da7a937f672e5ee7b7edb727bf52b8a52d531374ba8ebb9345c0330"
 dependencies = [
  "ntest_test_cases",
  "ntest_timeout",
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "ntest_test_cases"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7d33be719c6f4d09e64e27c1ef4e73485dc4cc1f4d22201f89860a7fe22e22"
+checksum = "16d0d3f2a488592e5368ebbe996e7f1d44aa13156efad201f5b4d84e150eaa93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "ntest_timeout"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066b468120587a402f0b47d8f80035c921f6a46f8209efd0632a89a16f5188a4"
+checksum = "fcc7c92f190c97f79b4a332f5e81dcf68c8420af2045c936c9be0bc9de6f63b5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigdecimal"
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1492,7 +1492,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.0",
  "histogram",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "lazy_static",
  "lz4_flex",
  "ntest",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,8 +19,7 @@ scylla = { path = "../scylla", features = [
     "num-bigint-04",
     "bigdecimal-04",
 ] }
-# FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
-tokio = { version = ">=1.34, <1.38", features = ["full"] }
+tokio = { version = "1.34", features = ["full"] }
 tracing = { version = "0.1.25", features = ["log"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 chrono = { version = "0.4", default-features = false }

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -13,8 +13,7 @@ license = "MIT OR Apache-2.0"
 scylla-macros = { version = "0.5.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
-# FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
-tokio = { version = ">=1.34, <1.38", features = ["io-util", "time"] }
+tokio = { version = "1.34", features = ["io-util", "time"] }
 secrecy-08 = { package = "secrecy", version = "0.8", optional = true }
 snap = "1.0"
 uuid = "1.0"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,8 +17,7 @@ scylla-cql = { version = "0.2.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"
-# FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
-tokio = { version = ">=1.34, <1.38", features = [
+tokio = { version = "1.34", features = [
     "net",
     "time",
     "io-util",
@@ -37,10 +36,9 @@ rand = "0.8.5"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ntest = "0.9.0"
+ntest = "0.9.3"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
-# FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
-tokio = { version = ">=1.34, <1.38", features = ["signal"] }
+tokio = { version = "1.34", features = ["signal"] }
 
 [lints.rust]
 unreachable_pub = "warn"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -47,8 +47,7 @@ bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
 histogram = "0.6.9"
-# FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
-tokio = { version = ">=1.34, <1.38", features = [
+tokio = { version = "1.34", features = [
     "net",
     "time",
     "io-util",
@@ -83,10 +82,9 @@ num-bigint-03 = { package = "num-bigint", version = "0.3" }
 num-bigint-04 = { package = "num-bigint", version = "0.4" }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4" }
 scylla-proxy = { version = "0.0.3", path = "../scylla-proxy" }
-ntest = "0.9.0"
+ntest = "0.9.3"
 criterion = "0.4"                                              # Note: v0.5 needs at least rust 1.70.0
-# FIXME: Remove <1.38 once https://github.com/tokio-rs/tokio/issues/6610 is fixed
-tokio = { version = ">=1.34, <1.38", features = ["test-util"] }
+tokio = { version = "1.34", features = ["test-util"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 assert_matches = "1.5.0"
 rand_chacha = "0.3.1"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -59,7 +59,7 @@ snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8.3"
 thiserror = "1.0"
-itertools = "0.11.0"
+itertools = "0.13.0"
 tracing = "0.1.36"
 chrono = { version = "0.4.32", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }
@@ -72,7 +72,7 @@ async-trait = "0.1.56"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.9.14", optional = true }
 url = { version = "2.3.1", optional = true }
-base64 = { version = "0.21.1", optional = true }
+base64 = { version = "0.22.1", optional = true }
 rand_pcg = "0.3.1"
 socket2 = { version = "0.5.3", features = ["all"] }
 lazy_static = "1"


### PR DESCRIPTION
This is fine now since https://github.com/tokio-rs/tokio/issues/6610 is resolved via https://github.com/becheran/ntest/pull/28 which has now been released in ntest 0.9.3
This PR also bumps the itertools + base64 versions, since they are trivial upgrades

The latest git main branch of scylla-rust-driver fails to build in my project due to the version restriction, these kinds of version restrictions often cause problems like this, so it would be bad for such a version restriction to end up in a release.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
