### PR TITLE
errors: Replace `ParseError` with `CqlResponseParseError` in `frame::response` module

### DIFF
--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -39,6 +39,8 @@ pub enum ParseError {
     SetKeyspaceParseError(#[from] SetKeyspaceParseError),
     #[error("Schema change event deserialization failed: {0}")]
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
+    #[error("Table spec deserialization failed: {0}")]
+    TableSpecParseError(#[from] TableSpecParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -89,6 +91,17 @@ pub enum SchemaChangeEventParseError {
     FunctionArgumentParseError(LowLevelDeserializationError),
     #[error("Unknown target of schema change: {0}")]
     UnknownTargetOfSchemaChange(String),
+}
+
+/// An error type returned when deserialization
+/// of table specification fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum TableSpecParseError {
+    #[error("Malformed keyspace name: {0}")]
+    MalformedKeyspaceName(LowLevelDeserializationError),
+    #[error("Malformed table name: {0}")]
+    MalformedTableName(LowLevelDeserializationError),
 }
 
 /// A low level deserialization error.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -41,6 +41,8 @@ pub enum ParseError {
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
     #[error("Table spec deserialization failed: {0}")]
     TableSpecParseError(#[from] TableSpecParseError),
+    #[error(transparent)]
+    TypeParseError(#[from] CqlTypeParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -51,8 +53,6 @@ pub enum ParseError {
     DeserializationError(#[from] DeserializationError),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
-    #[error("type not yet implemented, id: {0}")]
-    TypeNotImplemented(u16),
     #[error(transparent)]
     SerializeValuesError(#[from] SerializeValuesError),
     #[error(transparent)]
@@ -102,6 +102,28 @@ pub enum TableSpecParseError {
     MalformedKeyspaceName(LowLevelDeserializationError),
     #[error("Malformed table name: {0}")]
     MalformedTableName(LowLevelDeserializationError),
+}
+
+/// An error type returned when deserialization of CQL type name fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlTypeParseError {
+    #[error("Malformed type id: {0}")]
+    TypeIdParseError(LowLevelDeserializationError),
+    #[error("Malformed custom type name: {0}")]
+    CustomTypeNameParseError(LowLevelDeserializationError),
+    #[error("Malformed name of UDT keyspace: {0}")]
+    UdtKeyspaceNameParseError(LowLevelDeserializationError),
+    #[error("Malformed UDT name: {0}")]
+    UdtNameParseError(LowLevelDeserializationError),
+    #[error("Malformed UDT fields count: {0}")]
+    UdtFieldsCountParseError(LowLevelDeserializationError),
+    #[error("Malformed UDT's field name: {0}")]
+    UdtFieldNameParseError(LowLevelDeserializationError),
+    #[error("Malformed tuple length: {0}")]
+    TupleLengthParseError(LowLevelDeserializationError),
+    #[error("CQL Type not yet implemented, id: {0}")]
+    TypeNotImplemented(u16),
 }
 
 /// A low level deserialization error.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -80,7 +80,7 @@ pub enum LowLevelDeserializationError {
     InvalidValueLength(i32),
     #[error("Unknown consistency: {0}")]
     UnknownConsistency(#[from] TryFromPrimitiveError<u16>),
-    #[error("Invalid inet bytes length: {0}")]
+    #[error("Invalid inet bytes length: {0}. Accepted lengths are 4 and 16 bytes.")]
     InvalidInetLength(u8),
     #[error("UTF8 deserialization failed: {0}")]
     UTF8DeserializationError(#[from] std::str::Utf8Error),

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -36,6 +36,8 @@ pub enum FrameError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error(transparent)]
+    CqlErrorParseError(#[from] CqlErrorParseError),
+    #[error(transparent)]
     CqlAuthChallengeParseError(#[from] CqlAuthChallengeParseError),
     #[error(transparent)]
     CqlAuthSuccessParseError(#[from] CqlAuthSuccessParseError),
@@ -63,6 +65,22 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error type returned when deserialization of ERROR response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlErrorParseError {
+    #[error("Malformed error code: {0}")]
+    ErrorCodeParseError(LowLevelDeserializationError),
+    #[error("Malformed error reason: {0}")]
+    ReasonParseError(LowLevelDeserializationError),
+    #[error("Malformed error field {field} of DB error {db_error}: {err}")]
+    MalformedErrorField {
+        db_error: &'static str,
+        field: &'static str,
+        err: LowLevelDeserializationError,
+    },
 }
 
 /// An error type returned when deserialization of AUTH_CHALLENGE response fails.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -37,6 +37,8 @@ pub enum FrameError {
 pub enum ParseError {
     #[error("Set keyspace response deserialization failed: {0}")]
     SetKeyspaceParseError(#[from] SetKeyspaceParseError),
+    #[error("Schema change event deserialization failed: {0}")]
+    SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -62,6 +64,31 @@ pub enum ParseError {
 pub enum SetKeyspaceParseError {
     #[error("Malformed keyspace name: {0}")]
     MalformedKeyspaceName(#[from] LowLevelDeserializationError),
+}
+
+/// An error type returned when deserialization of
+/// `RESULT::Schema_change` response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum SchemaChangeEventParseError {
+    #[error("Malformed schema change type string: {0}")]
+    TypeOfChangeParseError(LowLevelDeserializationError),
+    #[error("Malformed schema change target string:: {0}")]
+    TargetTypeParseError(LowLevelDeserializationError),
+    #[error("Malformed name of keyspace affected by schema change: {0}")]
+    AffectedKeyspaceParseError(LowLevelDeserializationError),
+    #[error("Malformed name of the table affected by schema change: {0}")]
+    AffectedTableNameParseError(LowLevelDeserializationError),
+    #[error("Malformed name of the target affected by schema change: {0}")]
+    AffectedTargetNameParseError(LowLevelDeserializationError),
+    #[error(
+        "Malformed number of arguments of the function/aggregate affected by schema change: {0}"
+    )]
+    ArgumentCountParseError(LowLevelDeserializationError),
+    #[error("Malformed argument of the function/aggregate affected by schema change: {0}")]
+    FunctionArgumentParseError(LowLevelDeserializationError),
+    #[error("Unknown target of schema change: {0}")]
+    UnknownTargetOfSchemaChange(String),
 }
 
 /// A low level deserialization error.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::TryFromPrimitiveError;
 use crate::cql_to_rust::CqlTypeError;
 use crate::frame::value::SerializeValuesError;
@@ -69,7 +71,7 @@ pub enum ParseError {
 
 /// An error type returned when deserialization of ERROR response fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlErrorParseError {
     #[error("Malformed error code: {0}")]
     ErrorCodeParseError(LowLevelDeserializationError),
@@ -85,7 +87,7 @@ pub enum CqlErrorParseError {
 
 /// An error type returned when deserialization of AUTH_CHALLENGE response fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlAuthChallengeParseError {
     #[error("Malformed authenticate message: {0}")]
     AuthMessageParseError(LowLevelDeserializationError),
@@ -93,7 +95,7 @@ pub enum CqlAuthChallengeParseError {
 
 /// An error type returned when deserialization of AUTH_SUCCESS response fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlAuthSuccessParseError {
     #[error("Malformed success message: {0}")]
     SuccessMessageParseError(LowLevelDeserializationError),
@@ -101,7 +103,7 @@ pub enum CqlAuthSuccessParseError {
 
 /// An error type returned when deserialization of AUTHENTICATE response fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlAuthenticateParseError {
     #[error("Malformed authenticator name: {0}")]
     AuthNameParseError(LowLevelDeserializationError),
@@ -109,7 +111,7 @@ pub enum CqlAuthenticateParseError {
 
 /// An error type returned when deserialization of SUPPORTED response fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlSupportedParseError {
     #[error("Malformed options map: {0}")]
     OptionsMapDeserialization(LowLevelDeserializationError),
@@ -117,7 +119,7 @@ pub enum CqlSupportedParseError {
 
 /// An error type returned when deserialization of RESULT response fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlResultParseError {
     #[error("Malformed RESULT response id: {0}")]
     ResultIdParseError(LowLevelDeserializationError),
@@ -136,7 +138,7 @@ pub enum CqlResultParseError {
 }
 
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum SetKeyspaceParseError {
     #[error("Malformed keyspace name: {0}")]
     MalformedKeyspaceName(#[from] LowLevelDeserializationError),
@@ -145,7 +147,7 @@ pub enum SetKeyspaceParseError {
 /// An error type returned when deserialization of
 /// `EVENT` response fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlEventParseError {
     #[error("Malformed event type string: {0}")]
     EventTypeParseError(LowLevelDeserializationError),
@@ -162,7 +164,7 @@ pub enum CqlEventParseError {
 /// An error type returned when deserialization of
 /// SchemaChangeEvent fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum SchemaChangeEventParseError {
     #[error("Malformed schema change type string: {0}")]
     TypeOfChangeParseError(LowLevelDeserializationError),
@@ -186,7 +188,7 @@ pub enum SchemaChangeEventParseError {
 
 /// An error type returned when deserialization of [Status/Topology]ChangeEvent fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum ClusterChangeEventParseError {
     #[error("Malformed type of change: {0}")]
     TypeOfChangeParseError(LowLevelDeserializationError),
@@ -199,7 +201,7 @@ pub enum ClusterChangeEventParseError {
 /// An error type returned when deserialization
 /// of `RESULT::`Prepared` response fails.
 #[non_exhaustive]
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum PreparedParseError {
     #[error("Malformed prepared statement's id length: {0}")]
     IdLengthParseError(LowLevelDeserializationError),
@@ -212,7 +214,7 @@ pub enum PreparedParseError {
 /// An error type returned when deserialization
 /// of `RESULT::Rows` response fails.
 #[non_exhaustive]
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum RowsParseError {
     #[error("Invalid result metadata: {0}")]
     ResultMetadataParseError(#[from] ResultMetadataParseError),
@@ -230,7 +232,7 @@ pub enum RowsParseError {
 /// An error type returned when deserialization
 /// of `[Result/Prepared]Metadata` failed.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum ResultMetadataParseError {
     #[error("Malformed metadata flags: {0}")]
     FlagsParseError(LowLevelDeserializationError),
@@ -251,7 +253,7 @@ pub enum ResultMetadataParseError {
 /// An error type returned when deserialization
 /// of table specification fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum TableSpecParseError {
     #[error("Malformed keyspace name: {0}")]
     MalformedKeyspaceName(LowLevelDeserializationError),
@@ -262,7 +264,7 @@ pub enum TableSpecParseError {
 /// An error type returned when deserialization
 /// of table column specifications fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[error("Column spec deserialization failed, column index: {column_index}, error: {kind}")]
 pub struct ColumnSpecParseError {
     pub column_index: usize,
@@ -272,7 +274,7 @@ pub struct ColumnSpecParseError {
 /// The type of error that appeared during deserialization
 /// of a column specification.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum ColumnSpecParseErrorKind {
     #[error("Invalid table spec: {0}")]
     TableSpecParseError(#[from] TableSpecParseError),
@@ -284,7 +286,7 @@ pub enum ColumnSpecParseErrorKind {
 
 /// An error type returned when deserialization of CQL type name fails.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum CqlTypeParseError {
     #[error("Malformed type id: {0}")]
     TypeIdParseError(LowLevelDeserializationError),
@@ -315,10 +317,10 @@ pub enum CqlTypeParseError {
 /// - conversion errors - e.g. slice-to-array or primitive-to-enum
 /// - not enough bytes in the buffer to deserialize a value
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum LowLevelDeserializationError {
     #[error(transparent)]
-    IoError(#[from] std::io::Error),
+    IoError(Arc<std::io::Error>),
     #[error(transparent)]
     TryFromIntError(#[from] std::num::TryFromIntError),
     #[error(transparent)]
@@ -333,4 +335,10 @@ pub enum LowLevelDeserializationError {
     InvalidInetLength(u8),
     #[error("UTF8 deserialization failed: {0}")]
     UTF8DeserializationError(#[from] std::str::Utf8Error),
+}
+
+impl From<std::io::Error> for LowLevelDeserializationError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IoError(Arc::new(value))
+    }
 }

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -36,6 +36,8 @@ pub enum FrameError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error(transparent)]
+    CqlSupportedParseError(#[from] CqlSupportedParseError),
+    #[error(transparent)]
     CqlEventParseError(#[from] CqlEventParseError),
     #[error(transparent)]
     CqlResultParseError(#[from] CqlResultParseError),
@@ -55,6 +57,14 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error type returned when deserialization of SUPPORTED response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlSupportedParseError {
+    #[error("Malformed options map: {0}")]
+    OptionsMapDeserialization(LowLevelDeserializationError),
 }
 
 /// An error type returned when deserialization of RESULT response fails.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -41,8 +41,8 @@ pub enum ParseError {
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
     #[error("PREPARED response deserialization failed: {0}")]
     PreparedParseError(#[from] PreparedParseError),
-    #[error("Failed to deserialize result metadata: {0}")]
-    ResultMetadataParseError(#[from] ResultMetadataParseError),
+    #[error("ROWS response deserialization failed: {0}")]
+    RowsParseError(#[from] RowsParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -104,6 +104,24 @@ pub enum PreparedParseError {
     ResultMetadataParseError(ResultMetadataParseError),
     #[error("Invalid prepared metadata: {0}")]
     PreparedMetadataParseError(ResultMetadataParseError),
+}
+
+/// An error type returned when deserialization
+/// of `RESULT::Rows` response fails.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum RowsParseError {
+    #[error("Invalid result metadata: {0}")]
+    ResultMetadataParseError(#[from] ResultMetadataParseError),
+    #[error("Invalid result metadata, server claims {col_count} columns, received {col_specs_count} col specs.")]
+    ColumnCountMismatch {
+        col_count: usize,
+        col_specs_count: usize,
+    },
+    #[error("Malformed rows count: {0}")]
+    RowsCountParseError(LowLevelDeserializationError),
+    #[error("Data deserialization failed: {0}")]
+    DataDeserializationError(#[from] DeserializationError),
 }
 
 /// An error type returned when deserialization

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -36,6 +36,8 @@ pub enum FrameError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error(transparent)]
+    CqlAuthChallengeParseError(#[from] CqlAuthChallengeParseError),
+    #[error(transparent)]
     CqlAuthSuccessParseError(#[from] CqlAuthSuccessParseError),
     #[error(transparent)]
     CqlAuthenticateParseError(#[from] CqlAuthenticateParseError),
@@ -61,6 +63,14 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error type returned when deserialization of AUTH_CHALLENGE response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlAuthChallengeParseError {
+    #[error("Malformed authenticate message: {0}")]
+    AuthMessageParseError(LowLevelDeserializationError),
 }
 
 /// An error type returned when deserialization of AUTH_SUCCESS response fails.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -35,6 +35,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Set keyspace response deserialization failed: {0}")]
+    SetKeyspaceParseError(#[from] SetKeyspaceParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -53,6 +55,13 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum SetKeyspaceParseError {
+    #[error("Malformed keyspace name: {0}")]
+    MalformedKeyspaceName(#[from] LowLevelDeserializationError),
 }
 
 /// A low level deserialization error.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -39,10 +39,8 @@ pub enum ParseError {
     SetKeyspaceParseError(#[from] SetKeyspaceParseError),
     #[error("Schema change event deserialization failed: {0}")]
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
-    #[error("Table spec deserialization failed: {0}")]
-    TableSpecParseError(#[from] TableSpecParseError),
-    #[error("Failed to deserialize column spec: {0}")]
-    ColumnSpecParseError(#[from] ColumnSpecParseError),
+    #[error("Failed to deserialize result metadata: {0}")]
+    ResultMetadataParseError(#[from] ResultMetadataParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -91,6 +89,27 @@ pub enum SchemaChangeEventParseError {
     FunctionArgumentParseError(LowLevelDeserializationError),
     #[error("Unknown target of schema change: {0}")]
     UnknownTargetOfSchemaChange(String),
+}
+
+/// An error type returned when deserialization
+/// of `[Result/Prepared]Metadata` failed.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ResultMetadataParseError {
+    #[error("Malformed metadata flags: {0}")]
+    FlagsParseError(LowLevelDeserializationError),
+    #[error("Malformed column count: {0}")]
+    ColumnCountParseError(LowLevelDeserializationError),
+    #[error("Malformed partition key count: {0}")]
+    PkCountParseError(LowLevelDeserializationError),
+    #[error("Malformed partition key index: {0}")]
+    PkIndexParseError(LowLevelDeserializationError),
+    #[error("Malformed paging state: {0}")]
+    PagingStateParseError(LowLevelDeserializationError),
+    #[error("Invalid global table spec: {0}")]
+    GlobalTableSpecParseError(#[from] TableSpecParseError),
+    #[error("Invalid column spec: {0}")]
+    ColumnSpecParseError(#[from] ColumnSpecParseError),
 }
 
 /// An error type returned when deserialization

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -72,7 +72,7 @@ pub enum LowLevelDeserializationError {
     IoError(#[from] std::io::Error),
     #[error(transparent)]
     TryFromIntError(#[from] std::num::TryFromIntError),
-    #[error("Failed to convert slice into array: {0}")]
+    #[error(transparent)]
     TryFromSliceError(#[from] std::array::TryFromSliceError),
     #[error("Not enough bytes! expected: {expected}, received: {received}")]
     TooFewBytesReceived { expected: usize, received: usize },

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -39,6 +39,8 @@ pub enum ParseError {
     CqlResultParseError(#[from] CqlResultParseError),
     #[error("Schema change event deserialization failed: {0}")]
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
+    #[error("Failed to deserialize cluster change event: {0}")]
+    ClusterChangeEventParseError(#[from] ClusterChangeEventParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -107,6 +109,18 @@ pub enum SchemaChangeEventParseError {
     FunctionArgumentParseError(LowLevelDeserializationError),
     #[error("Unknown target of schema change: {0}")]
     UnknownTargetOfSchemaChange(String),
+}
+
+/// An error type returned when deserialization of [Status/Topology]ChangeEvent fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ClusterChangeEventParseError {
+    #[error("Malformed type of change: {0}")]
+    TypeOfChangeParseError(LowLevelDeserializationError),
+    #[error("Malformed node address: {0}")]
+    NodeAddressParseError(LowLevelDeserializationError),
+    #[error("Unknown type of change: {0}")]
+    UnknownTypeOfChange(String),
 }
 
 /// An error type returned when deserialization

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -36,6 +36,8 @@ pub enum FrameError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error(transparent)]
+    CqlAuthSuccessParseError(#[from] CqlAuthSuccessParseError),
+    #[error(transparent)]
     CqlAuthenticateParseError(#[from] CqlAuthenticateParseError),
     #[error(transparent)]
     CqlSupportedParseError(#[from] CqlSupportedParseError),
@@ -59,6 +61,14 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error type returned when deserialization of AUTH_SUCCESS response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlAuthSuccessParseError {
+    #[error("Malformed success message: {0}")]
+    SuccessMessageParseError(LowLevelDeserializationError),
 }
 
 /// An error type returned when deserialization of AUTHENTICATE response fails.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -35,14 +35,10 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
-    #[error("Set keyspace response deserialization failed: {0}")]
-    SetKeyspaceParseError(#[from] SetKeyspaceParseError),
+    #[error(transparent)]
+    CqlResultParseError(#[from] CqlResultParseError),
     #[error("Schema change event deserialization failed: {0}")]
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
-    #[error("PREPARED response deserialization failed: {0}")]
-    PreparedParseError(#[from] PreparedParseError),
-    #[error("ROWS response deserialization failed: {0}")]
-    RowsParseError(#[from] RowsParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -59,6 +55,26 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error type returned when deserialization of RESULT response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlResultParseError {
+    #[error("Malformed RESULT response id: {0}")]
+    ResultIdParseError(LowLevelDeserializationError),
+    #[error("Unknown RESULT response id: {0}")]
+    UnknownResultId(i32),
+    #[error("'Set_keyspace' response deserialization failed: {0}")]
+    SetKeyspaceParseError(#[from] SetKeyspaceParseError),
+    // This is an error returned during deserialization of
+    // `RESULT::Schema_change` response, and not `EVENT` response.
+    #[error("'Schema_change' response deserialization failed: {0}")]
+    SchemaChangeParseError(#[from] SchemaChangeEventParseError),
+    #[error("'Prepared' response deserialization failed: {0}")]
+    PreparedParseError(#[from] PreparedParseError),
+    #[error("'Rows' response deserialization failed: {0}")]
+    RowsParseError(#[from] RowsParseError),
 }
 
 #[non_exhaustive]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -39,6 +39,8 @@ pub enum ParseError {
     SetKeyspaceParseError(#[from] SetKeyspaceParseError),
     #[error("Schema change event deserialization failed: {0}")]
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
+    #[error("PREPARED response deserialization failed: {0}")]
+    PreparedParseError(#[from] PreparedParseError),
     #[error("Failed to deserialize result metadata: {0}")]
     ResultMetadataParseError(#[from] ResultMetadataParseError),
     #[error("Low-level deserialization failed: {0}")]
@@ -89,6 +91,19 @@ pub enum SchemaChangeEventParseError {
     FunctionArgumentParseError(LowLevelDeserializationError),
     #[error("Unknown target of schema change: {0}")]
     UnknownTargetOfSchemaChange(String),
+}
+
+/// An error type returned when deserialization
+/// of `RESULT::`Prepared` response fails.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum PreparedParseError {
+    #[error("Malformed prepared statement's id length: {0}")]
+    IdLengthParseError(LowLevelDeserializationError),
+    #[error("Invalid result metadata: {0}")]
+    ResultMetadataParseError(ResultMetadataParseError),
+    #[error("Invalid prepared metadata: {0}")]
+    PreparedMetadataParseError(ResultMetadataParseError),
 }
 
 /// An error type returned when deserialization

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -37,20 +37,6 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
-    #[error(transparent)]
-    CqlErrorParseError(#[from] CqlErrorParseError),
-    #[error(transparent)]
-    CqlAuthChallengeParseError(#[from] CqlAuthChallengeParseError),
-    #[error(transparent)]
-    CqlAuthSuccessParseError(#[from] CqlAuthSuccessParseError),
-    #[error(transparent)]
-    CqlAuthenticateParseError(#[from] CqlAuthenticateParseError),
-    #[error(transparent)]
-    CqlSupportedParseError(#[from] CqlSupportedParseError),
-    #[error(transparent)]
-    CqlEventParseError(#[from] CqlEventParseError),
-    #[error(transparent)]
-    CqlResultParseError(#[from] CqlResultParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -67,6 +53,27 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error type returned when deserialization of CQL
+/// server response fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum CqlResponseParseError {
+    #[error("Failed to deserialize ERROR response: {0}")]
+    CqlErrorParseError(#[from] CqlErrorParseError),
+    #[error("Failed to deserialize AUTH_CHALLENGE response: {0}")]
+    CqlAuthChallengeParseError(#[from] CqlAuthChallengeParseError),
+    #[error("Failed to deserialize AUTH_SUCCESS response: {0}")]
+    CqlAuthSuccessParseError(#[from] CqlAuthSuccessParseError),
+    #[error("Failed to deserialize AUTHENTICATE response: {0}")]
+    CqlAuthenticateParseError(#[from] CqlAuthenticateParseError),
+    #[error("Failed to deserialize SUPPORTED response: {0}")]
+    CqlSupportedParseError(#[from] CqlSupportedParseError),
+    #[error("Failed to deserialize EVENT response: {0}")]
+    CqlEventParseError(#[from] CqlEventParseError),
+    #[error(transparent)]
+    CqlResultParseError(#[from] CqlResultParseError),
 }
 
 /// An error type returned when deserialization of ERROR response fails.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -41,8 +41,8 @@ pub enum ParseError {
     SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
     #[error("Table spec deserialization failed: {0}")]
     TableSpecParseError(#[from] TableSpecParseError),
-    #[error(transparent)]
-    TypeParseError(#[from] CqlTypeParseError),
+    #[error("Failed to deserialize column spec: {0}")]
+    ColumnSpecParseError(#[from] ColumnSpecParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -102,6 +102,29 @@ pub enum TableSpecParseError {
     MalformedKeyspaceName(LowLevelDeserializationError),
     #[error("Malformed table name: {0}")]
     MalformedTableName(LowLevelDeserializationError),
+}
+
+/// An error type returned when deserialization
+/// of table column specifications fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+#[error("Column spec deserialization failed, column index: {column_index}, error: {kind}")]
+pub struct ColumnSpecParseError {
+    pub column_index: usize,
+    pub kind: ColumnSpecParseErrorKind,
+}
+
+/// The type of error that appeared during deserialization
+/// of a column specification.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ColumnSpecParseErrorKind {
+    #[error("Invalid table spec: {0}")]
+    TableSpecParseError(#[from] TableSpecParseError),
+    #[error("Malformed column name: {0}")]
+    ColumnNameParseError(#[from] LowLevelDeserializationError),
+    #[error("Invalid column type: {0}")]
+    ColumnTypeParseError(#[from] CqlTypeParseError),
 }
 
 /// An error type returned when deserialization of CQL type name fails.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -36,11 +36,9 @@ pub enum FrameError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error(transparent)]
+    CqlEventParseError(#[from] CqlEventParseError),
+    #[error(transparent)]
     CqlResultParseError(#[from] CqlResultParseError),
-    #[error("Schema change event deserialization failed: {0}")]
-    SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
-    #[error("Failed to deserialize cluster change event: {0}")]
-    ClusterChangeEventParseError(#[from] ClusterChangeEventParseError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -87,7 +85,24 @@ pub enum SetKeyspaceParseError {
 }
 
 /// An error type returned when deserialization of
-/// `RESULT::Schema_change` response fails.
+/// `EVENT` response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlEventParseError {
+    #[error("Malformed event type string: {0}")]
+    EventTypeParseError(LowLevelDeserializationError),
+    #[error("Unknown event type: {0}")]
+    UnknownEventType(String),
+    #[error("Failed to deserialize schema change event: {0}")]
+    SchemaChangeEventParseError(#[from] SchemaChangeEventParseError),
+    #[error("Failed to deserialize topology change event: {0}")]
+    TopologyChangeEventParseError(ClusterChangeEventParseError),
+    #[error("Failed to deserialize status change event: {0}")]
+    StatusChangeEventParseError(ClusterChangeEventParseError),
+}
+
+/// An error type returned when deserialization of
+/// SchemaChangeEvent fails.
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum SchemaChangeEventParseError {

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -36,6 +36,8 @@ pub enum FrameError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error(transparent)]
+    CqlAuthenticateParseError(#[from] CqlAuthenticateParseError),
+    #[error(transparent)]
     CqlSupportedParseError(#[from] CqlSupportedParseError),
     #[error(transparent)]
     CqlEventParseError(#[from] CqlEventParseError),
@@ -57,6 +59,14 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error type returned when deserialization of AUTHENTICATE response fails.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum CqlAuthenticateParseError {
+    #[error("Malformed authenticator name: {0}")]
+    AuthNameParseError(LowLevelDeserializationError),
 }
 
 /// An error type returned when deserialization of SUPPORTED response fails.

--- a/scylla-cql/src/frame/response/authenticate.rs
+++ b/scylla-cql/src/frame/response/authenticate.rs
@@ -1,4 +1,6 @@
-use crate::frame::frame_errors::{CqlAuthSuccessParseError, CqlAuthenticateParseError, ParseError};
+use crate::frame::frame_errors::{
+    CqlAuthChallengeParseError, CqlAuthSuccessParseError, CqlAuthenticateParseError,
+};
 use crate::frame::types;
 
 // Implements Authenticate message.
@@ -38,8 +40,10 @@ pub struct AuthChallenge {
 }
 
 impl AuthChallenge {
-    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let authenticate_message = types::read_bytes_opt(buf)?.map(|b| b.to_owned());
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, CqlAuthChallengeParseError> {
+        let authenticate_message = types::read_bytes_opt(buf)
+            .map_err(CqlAuthChallengeParseError::AuthMessageParseError)?
+            .map(|b| b.to_owned());
 
         Ok(AuthChallenge {
             authenticate_message,

--- a/scylla-cql/src/frame/response/authenticate.rs
+++ b/scylla-cql/src/frame/response/authenticate.rs
@@ -1,4 +1,4 @@
-use crate::frame::frame_errors::{CqlAuthenticateParseError, ParseError};
+use crate::frame::frame_errors::{CqlAuthSuccessParseError, CqlAuthenticateParseError, ParseError};
 use crate::frame::types;
 
 // Implements Authenticate message.
@@ -23,8 +23,10 @@ pub struct AuthSuccess {
 }
 
 impl AuthSuccess {
-    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let success_message = types::read_bytes_opt(buf)?.map(|b| b.to_owned());
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, CqlAuthSuccessParseError> {
+        let success_message = types::read_bytes_opt(buf)
+            .map_err(CqlAuthSuccessParseError::SuccessMessageParseError)?
+            .map(ToOwned::to_owned);
 
         Ok(AuthSuccess { success_message })
     }

--- a/scylla-cql/src/frame/response/authenticate.rs
+++ b/scylla-cql/src/frame/response/authenticate.rs
@@ -1,4 +1,4 @@
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::{CqlAuthenticateParseError, ParseError};
 use crate::frame::types;
 
 // Implements Authenticate message.
@@ -8,8 +8,10 @@ pub struct Authenticate {
 }
 
 impl Authenticate {
-    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let authenticator_name = types::read_string(buf)?.to_string();
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, CqlAuthenticateParseError> {
+        let authenticator_name = types::read_string(buf)
+            .map_err(CqlAuthenticateParseError::AuthNameParseError)?
+            .to_string();
 
         Ok(Authenticate { authenticator_name })
     }

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -8,10 +8,12 @@ pub mod supported;
 pub use error::Error;
 pub use supported::Supported;
 
+use crate::errors::QueryError;
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::response::result::ResultMetadata;
 use crate::frame::TryFromPrimitiveError;
-use crate::{errors::QueryError, frame::frame_errors::ParseError};
+
+use super::frame_errors::CqlResponseParseError;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
@@ -65,7 +67,7 @@ impl Response {
         opcode: ResponseOpcode,
         buf: &mut &[u8],
         cached_metadata: Option<&ResultMetadata>,
-    ) -> Result<Response, ParseError> {
+    ) -> Result<Response, CqlResponseParseError> {
         let response = match opcode {
             ResponseOpcode::Error => Response::Error(Error::deserialize(features, buf)?),
             ResponseOpcode::Ready => Response::Ready,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1,5 +1,5 @@
 use crate::cql_to_rust::{FromRow, FromRowError};
-use crate::frame::frame_errors::SetKeyspaceParseError;
+use crate::frame::frame_errors::{SchemaChangeEventParseError, SetKeyspaceParseError};
 use crate::frame::response::event::SchemaChangeEvent;
 use crate::frame::value::{
     Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
@@ -873,7 +873,7 @@ fn deser_prepared(buf: &mut &[u8]) -> StdResult<Prepared, ParseError> {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn deser_schema_change(buf: &mut &[u8]) -> StdResult<SchemaChange, ParseError> {
+fn deser_schema_change(buf: &mut &[u8]) -> StdResult<SchemaChange, SchemaChangeEventParseError> {
     Ok(SchemaChange {
         event: SchemaChangeEvent::deserialize(buf)?,
     })

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -15,7 +15,7 @@ use crate::types::deserialize::value::{
 use crate::types::deserialize::{DeserializationError, FrameSlice};
 use bytes::{Buf, Bytes};
 use std::borrow::Cow;
-use std::{convert::TryInto, net::IpAddr, result::Result as StdResult, str};
+use std::{net::IpAddr, result::Result as StdResult, str};
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -613,7 +613,7 @@ fn deser_result_metadata(buf: &mut &[u8]) -> StdResult<ResultMetadata, ParseErro
     let has_more_pages = flags & 0x0002 != 0;
     let no_metadata = flags & 0x0004 != 0;
 
-    let col_count: usize = types::read_int(buf)?.try_into()?;
+    let col_count = types::read_int_length(buf)?;
 
     let paging_state = if has_more_pages {
         Some(types::read_bytes(buf)?.to_owned().into())
@@ -650,7 +650,7 @@ fn deser_prepared_metadata(buf: &mut &[u8]) -> StdResult<PreparedMetadata, Parse
 
     let col_count = types::read_int_length(buf)?;
 
-    let pk_count: usize = types::read_int(buf)?.try_into()?;
+    let pk_count: usize = types::read_int_length(buf)?;
 
     let mut pk_indexes = Vec::with_capacity(pk_count);
     for i in 0..pk_count {
@@ -864,7 +864,7 @@ fn deser_rows(
 
     let original_size = buf.len();
 
-    let rows_count: usize = types::read_int(buf)?.try_into()?;
+    let rows_count: usize = types::read_int_length(buf)?;
 
     let raw_rows_iter = RowIterator::new(
         rows_count,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1,4 +1,5 @@
 use crate::cql_to_rust::{FromRow, FromRowError};
+use crate::frame::frame_errors::SetKeyspaceParseError;
 use crate::frame::response::event::SchemaChangeEvent;
 use crate::frame::value::{
     Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
@@ -852,7 +853,7 @@ fn deser_rows(
     })
 }
 
-fn deser_set_keyspace(buf: &mut &[u8]) -> StdResult<SetKeyspace, ParseError> {
+fn deser_set_keyspace(buf: &mut &[u8]) -> StdResult<SetKeyspace, SetKeyspaceParseError> {
     let keyspace_name = types::read_string(buf)?.to_string();
 
     Ok(SetKeyspace { keyspace_name })

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -872,7 +872,6 @@ fn deser_prepared(buf: &mut &[u8]) -> StdResult<Prepared, ParseError> {
     })
 }
 
-#[allow(clippy::unnecessary_wraps)]
 fn deser_schema_change(buf: &mut &[u8]) -> StdResult<SchemaChange, SchemaChangeEventParseError> {
     Ok(SchemaChange {
         event: SchemaChangeEvent::deserialize(buf)?,

--- a/scylla-cql/src/frame/response/supported.rs
+++ b/scylla-cql/src/frame/response/supported.rs
@@ -1,4 +1,4 @@
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::CqlSupportedParseError;
 use crate::frame::types;
 use std::collections::HashMap;
 
@@ -8,8 +8,9 @@ pub struct Supported {
 }
 
 impl Supported {
-    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let options = types::read_string_multimap(buf)?;
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, CqlSupportedParseError> {
+        let options = types::read_string_multimap(buf)
+            .map_err(CqlSupportedParseError::OptionsMapDeserialization)?;
 
         Ok(Supported { options })
     }

--- a/scylla-cql/src/frame/server_event_type.rs
+++ b/scylla-cql/src/frame/server_event_type.rs
@@ -1,6 +1,7 @@
-use crate::frame::frame_errors::ParseError;
 use std::fmt;
 use std::str::FromStr;
+
+use super::frame_errors::CqlEventParseError;
 
 pub enum EventType {
     TopologyChange,
@@ -21,17 +22,14 @@ impl fmt::Display for EventType {
 }
 
 impl FromStr for EventType {
-    type Err = ParseError;
+    type Err = CqlEventParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "TOPOLOGY_CHANGE" => Ok(Self::TopologyChange),
             "STATUS_CHANGE" => Ok(Self::StatusChange),
             "SCHEMA_CHANGE" => Ok(Self::SchemaChange),
-            _ => Err(ParseError::BadIncomingData(format!(
-                "Invalid type event type: {}",
-                s
-            ))),
+            _ => Err(CqlEventParseError::UnknownEventType(s.to_string())),
         }
     }
 }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2689,6 +2689,7 @@ mod latency_awareness {
 
                 // "slow" errors, i.e. ones that are returned after considerable time of query being run
                 QueryError::DbError(_, _)
+                | QueryError::CqlResponseParseError(_)
                 | QueryError::InvalidMessage(_)
                 | QueryError::IoError(_)
                 | QueryError::ProtocolError(_)


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

Depends on: https://github.com/scylladb/scylla-rust-driver/pull/1017

# Motivation
We ultimately want to get rid of the `ParseError`. This error type is overloaded with a lot of variants which do not provide much context to the users. In addition, a lot of errors are stringified.

This PR gets rid of `ParseError` from the `frame::response` module which is responsible for CQL response deserialization. This is the place where the usage of `ParseError` is abused the most.

# Changes
## Types of response
There are multiple types of responses. We introduce a new error type for each of them, e.g. `CqlResultParseError` or `CqlSupportedParseError`. I follow a bottom-to-top approach, starting from implementing an error types for CQL column type deserialization.

Each commit introduces a new error type, which is firstly encapsulated by `ParseError` (so the higher level functions returning `ParseError` can apply ? operator). Once we exhaust all of the error variants that can be returned by some function, we introduce a new error type which encapsulates error types introduced in previous commits. These error types are then moved out of the `ParseError` (if possible, sometimes the functions are not exclusive to `frame::response` module which is the only module addressed in this PR).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
