### PR TITLE
codewide: appease clippy again

### DIFF
--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -39,6 +39,7 @@ pub use scylla_cql::macros::IntoUserType;
 /// - serialization will succed if suffix of UDT fields is missing. If there are missing fields in the
 ///   middle it will fail. Note that if "skip_name_checks" is enabled, and the types happen to match,
 ///   it is possible for serialization to succeed with unexpected result.
+///
 /// This behavior is the default to support ALTERing UDTs by adding new fields.
 /// You can require exact match of fields using `force_exact_match` attribute.
 ///

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -31,16 +31,16 @@ use crate::transport::partitioner::{Partitioner, PartitionerHasher, PartitionerN
 ///
 /// Benefits that prepared statements have to offer:
 /// * Performance - a prepared statement holds information about metadata
-/// that allows to carry out a statement execution in a type safe manner.
-/// When [`Session::query`](crate::transport::session::Session::query) is called with
-/// non-empty bound values, the driver has to prepare the statement before execution (to provide type safety).
-/// This implies 2 round trips per [`Session::query`](crate::transport::session::Session::query).
-/// On the other hand, the cost of [`Session::execute`](crate::transport::session::Session::execute) is only 1 round trip.
+///   that allows to carry out a statement execution in a type safe manner.
+///   When [`Session::query`](crate::transport::session::Session::query) is called with
+///   non-empty bound values, the driver has to prepare the statement before execution (to provide type safety).
+///   This implies 2 round trips per [`Session::query`](crate::transport::session::Session::query).
+///   On the other hand, the cost of [`Session::execute`](crate::transport::session::Session::execute) is only 1 round trip.
 /// * Increased type-safety - bound values' types are validated with
-/// the [`PreparedMetadata`] received from the server during the serialization.
+///   the [`PreparedMetadata`] received from the server during the serialization.
 /// * Improved load balancing - thanks to statement metadata, the driver is able
-/// to compute a set of destined replicas for the statement execution. These replicas
-/// will be preferred when choosing the node (and shard) to send the request to.
+///   to compute a set of destined replicas for the statement execution. These replicas
+///   will be preferred when choosing the node (and shard) to send the request to.
 /// * Result deserialization optimization - see [`PreparedStatement::set_use_cached_result_metadata`].
 ///
 /// # Clone implementation
@@ -81,7 +81,7 @@ use crate::transport::partitioner::{Partitioner, PartitionerHasher, PartitionerN
 /// This raises two issues:
 /// * bound values serialization errors - since [`PreparedMetadata`] is not updated
 /// * result deserialization errors - when [`PreparedStatement::set_use_cached_result_metadata`] is enabled,
-/// since [`ResultMetadata`] is not updated
+///   since [`ResultMetadata`] is not updated
 ///
 /// So, to mitigate those issues, drop the outdated [`PreparedStatement`] manually
 /// and prepare it again against the new schema.

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -453,7 +453,7 @@ impl Session {
     /// instead of calling `Session::connect` directly, because it's more convenient.
     /// # Arguments
     /// * `config` - Connection configuration - known nodes, Compression, etc.
-    /// Must contain at least one known node.
+    ///   Must contain at least one known node.
     ///
     /// # Example
     /// ```rust
@@ -1335,7 +1335,7 @@ impl Session {
     /// # Arguments
     ///
     /// * `keyspace_name` - keyspace name to use,
-    /// keyspace names can have up to 48 alphanumeric characters and contain underscores
+    ///   keyspace names can have up to 48 alphanumeric characters and contain underscores
     /// * `case_sensitive` - if set to true the generated query will put keyspace name in quotes
     /// # Example
     /// ```rust


### PR DESCRIPTION
This time clippy got angry about bad indentation in docstrings' lists.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
