### PR TITLE
scylla: add scylla_cloud_tests to cfg allowlist

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -96,3 +96,4 @@ harness = false
 
 [lints.rust]
 unreachable_pub = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(scylla_cloud_tests)'] }


### PR DESCRIPTION
With rust 1.80, cfg parameters are checked by the compiler, so that warnings are emitted when unexpected cfg parameter is encountered. As we are using `cfg(scylla_cloud_tests)` to conditionally compile tests applicable for Scylla Serverless Cloud, that parameter is listed in Cargo.toml to prevent warnings.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.~~
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
