### PR TITLE
ci: fix semver checks by pinning working dep version

### DIFF
--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -60,8 +60,21 @@ jobs:
       run: rustup update
     - name: Install semver-checks
       # Official action uses binary releases fetched from GitHub
-      # If this pipeline becomes too slow, we should do this too
-      run: cargo install cargo-semver-checks --no-default-features
+      # If this pipeline becomes too slow, we should do this too.
+      #
+      # This works around the Semver violation in tame-index 0.12.2 that renders
+      # cargo-semver-checks incompilable. Once it gets fixed, revert back
+      # to using the newest release without customisations.
+      run: |
+        pushd ..
+        git clone https://github.com/obi1kenobi/cargo-semver-checks.git
+        cd cargo-semver-checks
+        git checkout v0.32.0
+        sed -i '0,/tame-index = { version = "0.12"/s//tame-index = { version = "=0.12.1"/' Cargo.toml
+        cargo build -r
+        cargo install --no-default-features --path .
+        popd
+
     - name: Verify the API compatibilty with PR base
       id: semver-pr-check
       run: |
@@ -147,6 +160,17 @@ jobs:
     - name: Update rust toolchain
       run: rustup update
     - name: Install semver-checks
-      run: cargo install cargo-semver-checks --no-default-features
+      # This works around the Semver violation in tame-index 0.12.2 that renders
+      # cargo-semver-checks incompilable. Once it gets fixed, revert back
+      # to using the newest release without customisations.
+      run: |
+        pushd ..
+        git clone https://github.com/obi1kenobi/cargo-semver-checks.git
+        cd cargo-semver-checks
+        git checkout v0.32.0
+        sed -i '0,/tame-index = { version = "0.12"/s//tame-index = { version = "=0.12.1"/' Cargo.toml
+        cargo build -r
+        cargo install --no-default-features --path .
+        popd
     - name: Run semver-checks to see if it agrees with version updates
       run: make semver-version


### PR DESCRIPTION
It appears that the update of tame-index from 0.12.1 to 0.12.2 contains API-breaking changes, which result in cargo-semver-checks compilation error. To work around this, a custom setup of cargo-semver-checks is done that pins tame-index to 0.12.1 version.

This should be reverted once tame-index issues 0.12.3 that reverts back the breaking changes, or once cargo-semver-checks issues a new release that works around the problem.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
