### PR TITLE
semver_checks: Revert previous workaround

### DIFF
--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -61,20 +61,7 @@ jobs:
     - name: Install semver-checks
       # Official action uses binary releases fetched from GitHub
       # If this pipeline becomes too slow, we should do this too.
-      #
-      # This works around the Semver violation in tame-index 0.12.2 that renders
-      # cargo-semver-checks incompilable. Once it gets fixed, revert back
-      # to using the newest release without customisations.
-      run: |
-        pushd ..
-        git clone https://github.com/obi1kenobi/cargo-semver-checks.git
-        cd cargo-semver-checks
-        git checkout v0.32.0
-        sed -i '0,/tame-index = { version = "0.12"/s//tame-index = { version = "=0.12.1"/' Cargo.toml
-        cargo build -r
-        cargo install --no-default-features --path .
-        popd
-
+      run: cargo install cargo-semver-checks --no-default-features --features gix-reqwest
     - name: Verify the API compatibilty with PR base
       id: semver-pr-check
       run: |
@@ -160,17 +147,6 @@ jobs:
     - name: Update rust toolchain
       run: rustup update
     - name: Install semver-checks
-      # This works around the Semver violation in tame-index 0.12.2 that renders
-      # cargo-semver-checks incompilable. Once it gets fixed, revert back
-      # to using the newest release without customisations.
-      run: |
-        pushd ..
-        git clone https://github.com/obi1kenobi/cargo-semver-checks.git
-        cd cargo-semver-checks
-        git checkout v0.32.0
-        sed -i '0,/tame-index = { version = "0.12"/s//tame-index = { version = "=0.12.1"/' Cargo.toml
-        cargo build -r
-        cargo install --no-default-features --path .
-        popd
+      run: cargo install cargo-semver-checks --no-default-features --features gix-reqwest
     - name: Run semver-checks to see if it agrees with version updates
       run: make semver-version


### PR DESCRIPTION
The change in semver-checks turned out to be intentional and `cargo install cargo-semver-checks --no-default-features` is no longer expected to work. 
The replacement command is `cargo install cargo-semver-checks --no-default-features --features gix-reqwest`.

See the release notes for v0.33.0: https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.33.0

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
