### PR TITLE
errors: remove ParseError

### DIFF
--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 pub use super::request::{
     execute::ExecuteSerializationError,
+    prepare::PrepareSerializationError,
     query::{QueryParametersSerializationError, QuerySerializationError},
 };
 
@@ -43,6 +44,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize PREPARE request: {0}")]
+    PrepareSerialization(#[from] PrepareSerializationError),
     #[error("Failed to serialize EXECUTE request: {0}")]
     ExecuteSerialization(#[from] ExecuteSerializationError),
     #[error("Failed to serialize QUERY request: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -13,7 +13,6 @@ pub use super::request::{
 
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
-use crate::cql_to_rust::CqlTypeError;
 use crate::frame::value::SerializeValuesError;
 use crate::types::deserialize::{DeserializationError, TypeCheckError};
 use crate::types::serialize::SerializationError;
@@ -110,8 +109,6 @@ pub enum ParseError {
     SerializeValuesError(#[from] SerializeValuesError),
     #[error(transparent)]
     SerializationError(#[from] SerializationError),
-    #[error(transparent)]
-    CqlTypeError(#[from] CqlTypeError),
 }
 
 /// An error that occurred during CQL request serialization.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -22,8 +22,6 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum FrameError {
     #[error(transparent)]
-    CqlRequestSerialization(#[from] CqlRequestSerializationError),
-    #[error(transparent)]
     Parse(#[from] ParseError),
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,
@@ -39,8 +37,6 @@ pub enum FrameError {
     StdIoError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]
     TryFromPrimitiveError(#[from] TryFromPrimitiveError<u8>),
-    #[error("Snap compression error: {0}")]
-    SnapCompressError(Arc<dyn Error + Sync + Send>),
     #[error("Snap decompression error: {0}")]
     SnapDecompressError(Arc<dyn Error + Sync + Send>),
     #[error("Error decompressing lz4 data {0}")]
@@ -100,6 +96,10 @@ pub enum CqlRequestSerializationError {
     /// Failed to serialize QUERY request.
     #[error("Failed to serialize QUERY request: {0}")]
     QuerySerialization(#[from] QuerySerializationError),
+
+    /// Request body compression failed.
+    #[error("Snap compression error: {0}")]
+    SnapCompressError(Arc<dyn Error + Sync + Send>),
 }
 
 /// An error type returned when deserialization of CQL

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 pub use super::request::{
+    auth_response::AuthResponseSerializationError,
     batch::{BatchSerializationError, BatchStatementSerializationError},
     execute::ExecuteSerializationError,
     prepare::PrepareSerializationError,
@@ -45,6 +46,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize AUTH_RESPONSE request: {0}")]
+    AuthResponseSerialization(#[from] AuthResponseSerializationError),
     #[error("Failed to serialize BATCH request: {0}")]
     BatchSerialization(#[from] BatchSerializationError),
     #[error("Failed to serialize PREPARE request: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-pub use super::request::query::QueryParametersSerializationError;
+pub use super::request::query::{QueryParametersSerializationError, QuerySerializationError};
 
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
@@ -40,6 +40,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize QUERY request: {0}")]
+    QuerySerialization(#[from] QuerySerializationError),
     #[error("Failed to serialize query parameters: {0}")]
     QueryParametersSerialization(#[from] QueryParametersSerializationError),
     #[error("Low-level deserialization failed: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -41,8 +41,6 @@ pub enum FrameError {
     TryFromPrimitiveError(#[from] TryFromPrimitiveError<u8>),
     #[error("Snap compression error: {0}")]
     SnapCompressError(Arc<dyn Error + Sync + Send>),
-    #[error("Error compressing lz4 data {0}")]
-    Lz4CompressError(#[from] lz4_flex::block::CompressError),
     #[error("Snap decompression error: {0}")]
     SnapDecompressError(Arc<dyn Error + Sync + Send>),
     #[error("Error decompressing lz4 data {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -95,8 +95,6 @@ pub enum ParseError {
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not deserialize frame: {0}")]
     BadIncomingData(String),
-    #[error(transparent)]
-    IoError(#[from] std::io::Error),
 }
 
 /// An error that occurred during CQL request serialization.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+pub use super::request::query::QueryParametersSerializationError;
+
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
 use crate::cql_to_rust::CqlTypeError;
@@ -38,6 +40,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize query parameters: {0}")]
+    QueryParametersSerialization(#[from] QueryParametersSerializationError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -93,8 +93,6 @@ pub enum FrameHeaderParseError {
 pub enum ParseError {
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
-    #[error("Could not deserialize frame: {0}")]
-    BadIncomingData(String),
 }
 
 /// An error that occurred during CQL request serialization.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -19,18 +19,41 @@ use crate::types::deserialize::{DeserializationError, TypeCheckError};
 use crate::types::serialize::SerializationError;
 use thiserror::Error;
 
+/// An error returned by `parse_response_body_extensions`.
+///
+/// It represents an error that occurred during deserialization of
+/// frame body extensions. These extensions include tracing id,
+/// warnings and custom payload.
+///
+/// Possible error kinds:
+/// - failed to decompress frame body (decompression is required for further deserialization)
+/// - failed to deserialize tracing id (body ext.)
+/// - failed to deserialize warnings list (body ext.)
+/// - failed to deserialize custom payload map (body ext.)
 #[derive(Error, Debug)]
-pub enum FrameError {
+#[non_exhaustive]
+pub enum FrameBodyExtensionsParseError {
+    /// Frame is compressed, but no compression was negotiated for the connection.
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,
+
+    /// Failed to deserialize frame trace id.
     #[error("Malformed trace id: {0}")]
     TraceIdParse(LowLevelDeserializationError),
+
+    /// Failed to deserialize warnings attached to frame.
     #[error("Malformed warnings list: {0}")]
     WarningsListParse(LowLevelDeserializationError),
+
+    /// Failed to deserialize frame's custom payload.
     #[error("Malformed custom payload map: {0}")]
     CustomPayloadMapParse(LowLevelDeserializationError),
+
+    /// Failed to decompress frame body (snap).
     #[error("Snap decompression error: {0}")]
     SnapDecompressError(Arc<dyn Error + Sync + Send>),
+
+    /// Failed to decompress frame body (lz4).
     #[error("Error decompressing lz4 data {0}")]
     Lz4DecompressError(#[from] lz4_flex::block::DecompressError),
 }

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -13,9 +13,7 @@ pub use super::request::{
 
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
-use crate::frame::value::SerializeValuesError;
-use crate::types::deserialize::{DeserializationError, TypeCheckError};
-use crate::types::serialize::SerializationError;
+use crate::types::deserialize::DeserializationError;
 use thiserror::Error;
 
 /// An error returned by `parse_response_body_extensions`.
@@ -95,20 +93,10 @@ pub enum FrameHeaderParseError {
 pub enum ParseError {
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
-    #[error("Could not serialize frame: {0}")]
-    BadDataToSerialize(String),
     #[error("Could not deserialize frame: {0}")]
     BadIncomingData(String),
     #[error(transparent)]
-    DeserializationError(#[from] DeserializationError),
-    #[error(transparent)]
-    DeserializationTypeCheckError(#[from] TypeCheckError),
-    #[error(transparent)]
     IoError(#[from] std::io::Error),
-    #[error(transparent)]
-    SerializeValuesError(#[from] SerializeValuesError),
-    #[error(transparent)]
-    SerializationError(#[from] SerializationError),
 }
 
 /// An error that occurred during CQL request serialization.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -6,6 +6,7 @@ pub use super::request::{
     execute::ExecuteSerializationError,
     prepare::PrepareSerializationError,
     query::{QueryParametersSerializationError, QuerySerializationError},
+    register::RegisterSerializationError,
 };
 
 use super::response::CqlResponseKind;
@@ -46,6 +47,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize REGISTER request: {0}")]
+    RegisterSerialization(#[from] RegisterSerializationError),
     #[error("Failed to serialize AUTH_RESPONSE request: {0}")]
     AuthResponseSerialization(#[from] AuthResponseSerializationError),
     #[error("Failed to serialize BATCH request: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -21,10 +21,14 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum FrameError {
-    #[error(transparent)]
-    Parse(#[from] ParseError),
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,
+    #[error("Malformed trace id: {0}")]
+    TraceIdParse(LowLevelDeserializationError),
+    #[error("Malformed warnings list: {0}")]
+    WarningsListParse(LowLevelDeserializationError),
+    #[error("Malformed custom payload map: {0}")]
+    CustomPayloadMapParse(LowLevelDeserializationError),
     #[error("Received frame marked as coming from a client")]
     FrameFromClient,
     #[error("Received frame marked as coming from the server")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::sync::Arc;
 
 pub use super::request::{
@@ -34,16 +35,16 @@ pub enum FrameError {
     VersionNotSupported(u8),
     #[error("Connection was closed before body was read: missing {0} out of {1}")]
     ConnectionClosed(usize, usize),
-    #[error("Frame decompression failed.")]
-    FrameDecompression,
-    #[error("Frame compression failed.")]
-    FrameCompression,
     #[error(transparent)]
     StdIoError(#[from] std::io::Error),
     #[error("Unrecognized opcode{0}")]
     TryFromPrimitiveError(#[from] TryFromPrimitiveError<u8>),
+    #[error("Snap compression error: {0}")]
+    SnapCompressError(Arc<dyn Error + Sync + Send>),
     #[error("Error compressing lz4 data {0}")]
     Lz4CompressError(#[from] lz4_flex::block::CompressError),
+    #[error("Snap decompression error: {0}")]
+    SnapDecompressError(Arc<dyn Error + Sync + Send>),
     #[error("Error decompressing lz4 data {0}")]
     Lz4DecompressError(#[from] lz4_flex::block::DecompressError),
 }

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -90,10 +90,7 @@ pub enum FrameHeaderParseError {
 }
 
 #[derive(Error, Debug)]
-pub enum ParseError {
-    #[error("Low-level deserialization failed: {0}")]
-    LowLevelDeserializationError(#[from] LowLevelDeserializationError),
-}
+pub enum ParseError {}
 
 /// An error that occurred during CQL request serialization.
 #[non_exhaustive]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -21,6 +21,8 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum FrameError {
     #[error(transparent)]
+    CqlRequestSerialization(#[from] CqlRequestSerializationError),
+    #[error(transparent)]
     Parse(#[from] ParseError),
     #[error("Frame is compressed, but no compression negotiated for connection.")]
     NoCompressionNegotiated,
@@ -48,20 +50,6 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
-    #[error("Failed to serialize STARTUP request: {0}")]
-    StartupSerialization(#[from] StartupSerializationError),
-    #[error("Failed to serialize REGISTER request: {0}")]
-    RegisterSerialization(#[from] RegisterSerializationError),
-    #[error("Failed to serialize AUTH_RESPONSE request: {0}")]
-    AuthResponseSerialization(#[from] AuthResponseSerializationError),
-    #[error("Failed to serialize BATCH request: {0}")]
-    BatchSerialization(#[from] BatchSerializationError),
-    #[error("Failed to serialize PREPARE request: {0}")]
-    PrepareSerialization(#[from] PrepareSerializationError),
-    #[error("Failed to serialize EXECUTE request: {0}")]
-    ExecuteSerialization(#[from] ExecuteSerializationError),
-    #[error("Failed to serialize QUERY request: {0}")]
-    QuerySerialization(#[from] QuerySerializationError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]
@@ -80,6 +68,39 @@ pub enum ParseError {
     SerializationError(#[from] SerializationError),
     #[error(transparent)]
     CqlTypeError(#[from] CqlTypeError),
+}
+
+/// An error that occurred during CQL request serialization.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum CqlRequestSerializationError {
+    /// Failed to serialize STARTUP request.
+    #[error("Failed to serialize STARTUP request: {0}")]
+    StartupSerialization(#[from] StartupSerializationError),
+
+    /// Failed to serialize REGISTER request.
+    #[error("Failed to serialize REGISTER request: {0}")]
+    RegisterSerialization(#[from] RegisterSerializationError),
+
+    /// Failed to serialize AUTH_RESPONSE request.
+    #[error("Failed to serialize AUTH_RESPONSE request: {0}")]
+    AuthResponseSerialization(#[from] AuthResponseSerializationError),
+
+    /// Failed to serialize BATCH request.
+    #[error("Failed to serialize BATCH request: {0}")]
+    BatchSerialization(#[from] BatchSerializationError),
+
+    /// Failed to serialize PREPARE request.
+    #[error("Failed to serialize PREPARE request: {0}")]
+    PrepareSerialization(#[from] PrepareSerializationError),
+
+    /// Failed to serialize EXECUTE request.
+    #[error("Failed to serialize EXECUTE request: {0}")]
+    ExecuteSerialization(#[from] ExecuteSerializationError),
+
+    /// Failed to serialize QUERY request.
+    #[error("Failed to serialize QUERY request: {0}")]
+    QuerySerialization(#[from] QuerySerializationError),
 }
 
 /// An error type returned when deserialization of CQL

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -55,7 +55,7 @@ pub enum FrameBodyExtensionsParseError {
 
     /// Failed to decompress frame body (lz4).
     #[error("Error decompressing lz4 data {0}")]
-    Lz4DecompressError(#[from] lz4_flex::block::DecompressError),
+    Lz4DecompressError(Arc<dyn Error + Sync + Send>),
 }
 
 /// An error that occurred during frame header deserialization.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -37,8 +37,10 @@ pub enum FrameError {
     VersionNotSupported(u8),
     #[error("Connection was closed before body was read: missing {0} out of {1}")]
     ConnectionClosed(usize, usize),
-    #[error(transparent)]
-    StdIoError(#[from] std::io::Error),
+    #[error("Failed to read the frame header: {0}")]
+    HeaderIoError(std::io::Error),
+    #[error("Failed to read a chunk of response body. Expected {0} more bytes, error: {1}")]
+    BodyChunkIoError(usize, std::io::Error),
     #[error("Unrecognized opcode{0}")]
     TryFromPrimitiveError(#[from] TryFromPrimitiveError<u8>),
     #[error("Snap decompression error: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -89,9 +89,6 @@ pub enum FrameHeaderParseError {
     ConnectionClosed(usize, usize),
 }
 
-#[derive(Error, Debug)]
-pub enum ParseError {}
-
 /// An error that occurred during CQL request serialization.
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 pub use super::request::{
+    batch::{BatchSerializationError, BatchStatementSerializationError},
     execute::ExecuteSerializationError,
     prepare::PrepareSerializationError,
     query::{QueryParametersSerializationError, QuerySerializationError},
@@ -44,6 +45,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize BATCH request: {0}")]
+    BatchSerialization(#[from] BatchSerializationError),
     #[error("Failed to serialize PREPARE request: {0}")]
     PrepareSerialization(#[from] PrepareSerializationError),
     #[error("Failed to serialize EXECUTE request: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-pub use super::request::query::{QueryParametersSerializationError, QuerySerializationError};
+pub use super::request::{
+    execute::ExecuteSerializationError,
+    query::{QueryParametersSerializationError, QuerySerializationError},
+};
 
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
@@ -40,10 +43,10 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize EXECUTE request: {0}")]
+    ExecuteSerialization(#[from] ExecuteSerializationError),
     #[error("Failed to serialize QUERY request: {0}")]
     QuerySerialization(#[from] QuerySerializationError),
-    #[error("Failed to serialize query parameters: {0}")]
-    QueryParametersSerialization(#[from] QueryParametersSerializationError),
     #[error("Low-level deserialization failed: {0}")]
     LowLevelDeserializationError(#[from] LowLevelDeserializationError),
     #[error("Could not serialize frame: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 /// - failed to deserialize tracing id (body ext.)
 /// - failed to deserialize warnings list (body ext.)
 /// - failed to deserialize custom payload map (body ext.)
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum FrameBodyExtensionsParseError {
     /// Frame is compressed, but no compression was negotiated for the connection.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -7,6 +7,7 @@ pub use super::request::{
     prepare::PrepareSerializationError,
     query::{QueryParametersSerializationError, QuerySerializationError},
     register::RegisterSerializationError,
+    startup::StartupSerializationError,
 };
 
 use super::response::CqlResponseKind;
@@ -47,6 +48,8 @@ pub enum FrameError {
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Failed to serialize STARTUP request: {0}")]
+    StartupSerialization(#[from] StartupSerializationError),
     #[error("Failed to serialize REGISTER request: {0}")]
     RegisterSerialization(#[from] RegisterSerializationError),
     #[error("Failed to serialize AUTH_RESPONSE request: {0}")]

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -196,7 +196,7 @@ pub fn parse_response_body_extensions(
 
     let trace_id = if flags & FLAG_TRACING != 0 {
         let buf = &mut &*body;
-        let trace_id = types::read_uuid(buf).map_err(frame_errors::ParseError::from)?;
+        let trace_id = types::read_uuid(buf).map_err(FrameError::TraceIdParse)?;
         body.advance(16);
         Some(trace_id)
     } else {
@@ -206,7 +206,7 @@ pub fn parse_response_body_extensions(
     let warnings = if flags & FLAG_WARNING != 0 {
         let body_len = body.len();
         let buf = &mut &*body;
-        let warnings = types::read_string_list(buf).map_err(frame_errors::ParseError::from)?;
+        let warnings = types::read_string_list(buf).map_err(FrameError::WarningsListParse)?;
         let buf_len = buf.len();
         body.advance(body_len - buf_len);
         warnings
@@ -217,7 +217,7 @@ pub fn parse_response_body_extensions(
     let custom_payload = if flags & FLAG_CUSTOM_PAYLOAD != 0 {
         let body_len = body.len();
         let buf = &mut &*body;
-        let payload_map = types::read_bytes_map(buf).map_err(frame_errors::ParseError::from)?;
+        let payload_map = types::read_bytes_map(buf).map_err(FrameError::CustomPayloadMapParse)?;
         let buf_len = buf.len();
         body.advance(body_len - buf_len);
         Some(payload_map)

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -275,7 +275,8 @@ fn decompress(
     match compression {
         Compression::Lz4 => {
             let uncomp_len = comp_body.get_u32() as usize;
-            let uncomp_body = lz4_flex::decompress(comp_body, uncomp_len)?;
+            let uncomp_body = lz4_flex::decompress(comp_body, uncomp_len)
+                .map_err(|err| FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(err)))?;
             Ok(uncomp_body)
         }
         Compression::Snappy => snap::raw::Decoder::new()

--- a/scylla-cql/src/frame/request/auth_response.rs
+++ b/scylla-cql/src/frame/request/auth_response.rs
@@ -1,3 +1,7 @@
+use std::num::TryFromIntError;
+
+use thiserror::Error;
+
 use crate::frame::frame_errors::ParseError;
 
 use crate::frame::request::{RequestOpcode, SerializableRequest};
@@ -12,6 +16,16 @@ impl SerializableRequest for AuthResponse {
     const OPCODE: RequestOpcode = RequestOpcode::AuthResponse;
 
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
-        Ok(write_bytes_opt(self.response.as_ref(), buf)?)
+        Ok(write_bytes_opt(self.response.as_ref(), buf)
+            .map_err(AuthResponseSerializationError::ResponseSerialization)?)
     }
+}
+
+/// An error type returned when serialization of AUTH_RESPONSE request fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum AuthResponseSerializationError {
+    /// Maximum response's body length exceeded.
+    #[error("AUTH_RESPONSE body bytes length too big: {0}")]
+    ResponseSerialization(TryFromIntError),
 }

--- a/scylla-cql/src/frame/request/auth_response.rs
+++ b/scylla-cql/src/frame/request/auth_response.rs
@@ -2,7 +2,7 @@ use std::num::TryFromIntError;
 
 use thiserror::Error;
 
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::CqlRequestSerializationError;
 
 use crate::frame::request::{RequestOpcode, SerializableRequest};
 use crate::frame::types::write_bytes_opt;
@@ -15,7 +15,7 @@ pub struct AuthResponse {
 impl SerializableRequest for AuthResponse {
     const OPCODE: RequestOpcode = RequestOpcode::AuthResponse;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         Ok(write_bytes_opt(self.response.as_ref(), buf)
             .map_err(AuthResponseSerializationError::ResponseSerialization)?)
     }

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::{
     frame::{
-        frame_errors::{CqlRequestSerializationError, ParseError},
+        frame_errors::CqlRequestSerializationError,
         request::{RequestOpcode, SerializableRequest},
         types::{self, SerialConsistency},
     },
@@ -50,12 +50,6 @@ pub enum BatchType {
 #[error("Malformed batch type: {value}")]
 pub struct BatchTypeParseError {
     value: u8,
-}
-
-impl From<BatchTypeParseError> for ParseError {
-    fn from(err: BatchTypeParseError) -> Self {
-        Self::BadIncomingData(format!("Bad BatchType value: {}", err.value))
-    }
 }
 
 impl TryFrom<u8> for BatchType {

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::{
     frame::{
-        frame_errors::ParseError,
+        frame_errors::{CqlRequestSerializationError, ParseError},
         request::{RequestOpcode, SerializableRequest},
         types::{self, SerialConsistency},
     },
@@ -188,7 +188,7 @@ where
 {
     const OPCODE: RequestOpcode = RequestOpcode::Batch;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         self.do_serialize(buf)?;
         Ok(())
     }

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -1,6 +1,6 @@
 use std::num::TryFromIntError;
 
-use crate::frame::frame_errors::{CqlRequestSerializationError, ParseError};
+use crate::frame::frame_errors::CqlRequestSerializationError;
 use bytes::Bytes;
 use thiserror::Error;
 
@@ -11,7 +11,7 @@ use crate::{
 
 use super::{
     query::{QueryParameters, QueryParametersSerializationError},
-    DeserializableRequest,
+    DeserializableRequest, RequestDeserializationError,
 };
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -37,7 +37,7 @@ impl SerializableRequest for Execute<'_> {
 }
 
 impl<'e> DeserializableRequest for Execute<'e> {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, ParseError> {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, RequestDeserializationError> {
         let id = types::read_short_bytes(buf)?.to_vec().into();
         let parameters = QueryParameters::deserialize(buf)?;
 

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -1,6 +1,6 @@
 use std::num::TryFromIntError;
 
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::{CqlRequestSerializationError, ParseError};
 use bytes::Bytes;
 use thiserror::Error;
 
@@ -23,9 +23,10 @@ pub struct Execute<'a> {
 impl SerializableRequest for Execute<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Execute;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         // Serializing statement id
-        types::write_short_bytes(&self.id[..], buf)?;
+        types::write_short_bytes(&self.id[..], buf)
+            .map_err(ExecuteSerializationError::StatementIdSerialization)?;
 
         // Serializing params
         self.parameters

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -21,6 +21,7 @@ pub use startup::Startup;
 
 use self::batch::BatchStatement;
 
+use super::frame_errors::CqlRequestSerializationError;
 use super::types::SerialConsistency;
 use super::TryFromPrimitiveError;
 
@@ -92,9 +93,9 @@ impl TryFrom<u8> for RequestOpcode {
 pub trait SerializableRequest {
     const OPCODE: RequestOpcode;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError>;
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError>;
 
-    fn to_bytes(&self) -> Result<Bytes, ParseError> {
+    fn to_bytes(&self) -> Result<Bytes, CqlRequestSerializationError> {
         let mut v = Vec::new();
         self.serialize(&mut v)?;
         Ok(v.into())

--- a/scylla-cql/src/frame/request/options.rs
+++ b/scylla-cql/src/frame/request/options.rs
@@ -1,4 +1,4 @@
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::CqlRequestSerializationError;
 
 use crate::frame::request::{RequestOpcode, SerializableRequest};
 
@@ -7,7 +7,7 @@ pub struct Options;
 impl SerializableRequest for Options {
     const OPCODE: RequestOpcode = RequestOpcode::Options;
 
-    fn serialize(&self, _buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, _buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         Ok(())
     }
 }

--- a/scylla-cql/src/frame/request/prepare.rs
+++ b/scylla-cql/src/frame/request/prepare.rs
@@ -1,3 +1,7 @@
+use std::num::TryFromIntError;
+
+use thiserror::Error;
+
 use crate::frame::frame_errors::ParseError;
 
 use crate::{
@@ -13,7 +17,17 @@ impl<'a> SerializableRequest for Prepare<'a> {
     const OPCODE: RequestOpcode = RequestOpcode::Prepare;
 
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
-        types::write_long_string(self.query, buf)?;
+        types::write_long_string(self.query, buf)
+            .map_err(PrepareSerializationError::StatementStringSerialization)?;
         Ok(())
     }
+}
+
+/// An error type returned when serialization of PREPARE request fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum PrepareSerializationError {
+    /// Failed to serialize the CQL statement string.
+    #[error("Failed to serialize statement contents: {0}")]
+    StatementStringSerialization(TryFromIntError),
 }

--- a/scylla-cql/src/frame/request/prepare.rs
+++ b/scylla-cql/src/frame/request/prepare.rs
@@ -2,7 +2,7 @@ use std::num::TryFromIntError;
 
 use thiserror::Error;
 
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::CqlRequestSerializationError;
 
 use crate::{
     frame::request::{RequestOpcode, SerializableRequest},
@@ -16,7 +16,7 @@ pub struct Prepare<'a> {
 impl<'a> SerializableRequest for Prepare<'a> {
     const OPCODE: RequestOpcode = RequestOpcode::Prepare;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         types::write_long_string(self.query, buf)
             .map_err(PrepareSerializationError::StatementStringSerialization)?;
         Ok(())

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -1,7 +1,10 @@
 use std::{borrow::Cow, num::TryFromIntError, ops::ControlFlow, sync::Arc};
 
 use crate::{
-    frame::{frame_errors::ParseError, types::SerialConsistency},
+    frame::{
+        frame_errors::{CqlRequestSerializationError, ParseError},
+        types::SerialConsistency,
+    },
     types::serialize::row::SerializedValues,
 };
 use bytes::{Buf, BufMut};
@@ -39,7 +42,7 @@ pub struct Query<'q> {
 impl SerializableRequest for Query<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Query;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         types::write_long_string(&self.contents, buf)
             .map_err(QuerySerializationError::StatementStringSerialization)?;
         self.parameters

--- a/scylla-cql/src/frame/request/register.rs
+++ b/scylla-cql/src/frame/request/register.rs
@@ -3,7 +3,7 @@ use std::num::TryFromIntError;
 use thiserror::Error;
 
 use crate::frame::{
-    frame_errors::ParseError,
+    frame_errors::CqlRequestSerializationError,
     request::{RequestOpcode, SerializableRequest},
     server_event_type::EventType,
     types,
@@ -16,7 +16,7 @@ pub struct Register {
 impl SerializableRequest for Register {
     const OPCODE: RequestOpcode = RequestOpcode::Register;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         let event_types_list = self
             .event_types_to_register_for
             .iter()

--- a/scylla-cql/src/frame/request/register.rs
+++ b/scylla-cql/src/frame/request/register.rs
@@ -1,3 +1,7 @@
+use std::num::TryFromIntError;
+
+use thiserror::Error;
+
 use crate::frame::{
     frame_errors::ParseError,
     request::{RequestOpcode, SerializableRequest},
@@ -19,7 +23,17 @@ impl SerializableRequest for Register {
             .map(|event| event.to_string())
             .collect::<Vec<_>>();
 
-        types::write_string_list(&event_types_list, buf)?;
+        types::write_string_list(&event_types_list, buf)
+            .map_err(RegisterSerializationError::EventTypesSerialization)?;
         Ok(())
     }
+}
+
+/// An error type returned when serialization of REGISTER request fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum RegisterSerializationError {
+    /// Failed to serialize event types list.
+    #[error("Failed to serialize event types list: {0}")]
+    EventTypesSerialization(TryFromIntError),
 }

--- a/scylla-cql/src/frame/request/startup.rs
+++ b/scylla-cql/src/frame/request/startup.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::frame::frame_errors::ParseError;
+use crate::frame::frame_errors::CqlRequestSerializationError;
 
 use std::{borrow::Cow, collections::HashMap, num::TryFromIntError};
 
@@ -16,7 +16,7 @@ pub struct Startup<'a> {
 impl SerializableRequest for Startup<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Startup;
 
-    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
         types::write_string_map(&self.options, buf)
             .map_err(StartupSerializationError::OptionsSerialization)?;
         Ok(())

--- a/scylla-cql/src/frame/request/startup.rs
+++ b/scylla-cql/src/frame/request/startup.rs
@@ -1,6 +1,8 @@
+use thiserror::Error;
+
 use crate::frame::frame_errors::ParseError;
 
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, num::TryFromIntError};
 
 use crate::{
     frame::request::{RequestOpcode, SerializableRequest},
@@ -15,7 +17,17 @@ impl SerializableRequest for Startup<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Startup;
 
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ParseError> {
-        types::write_string_map(&self.options, buf)?;
+        types::write_string_map(&self.options, buf)
+            .map_err(StartupSerializationError::OptionsSerialization)?;
         Ok(())
     }
+}
+
+/// An error type returned when serialization of STARTUP request fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum StartupSerializationError {
+    /// Failed to serialize startup options.
+    #[error("Malformed startup options: {0}")]
+    OptionsSerialization(TryFromIntError),
 }

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -16,12 +16,6 @@ pub enum FromRowError {
     WrongRowSize { expected: usize, actual: usize },
 }
 
-#[derive(Error, Clone, Debug, PartialEq, Eq)]
-pub enum CqlTypeError {
-    #[error("Invalid number of set elements: {0}")]
-    InvalidNumberOfElements(i32),
-}
-
 /// This trait defines a way to convert CqlValue or `Option<CqlValue>` into some rust type
 // We can't use From trait because impl From<Option<CqlValue>> for String {...}
 // is forbidden since neither From nor String are defined in this crate

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -132,18 +132,6 @@ impl From<std::num::TryFromIntError> for ParseError {
     }
 }
 
-impl From<std::str::Utf8Error> for ParseError {
-    fn from(_err: std::str::Utf8Error) -> Self {
-        ParseError::BadIncomingData("UTF8 serialization failed".to_string())
-    }
-}
-
-impl From<std::array::TryFromSliceError> for ParseError {
-    fn from(_err: std::array::TryFromSliceError) -> Self {
-        ParseError::BadIncomingData("array try from slice failed".to_string())
-    }
-}
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RawValue<'a> {
     Null,

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -1,7 +1,6 @@
 //! CQL binary protocol in-wire types.
 
 use super::frame_errors::LowLevelDeserializationError;
-use super::frame_errors::ParseError;
 use super::TryFromPrimitiveError;
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{Buf, BufMut};
@@ -123,12 +122,6 @@ impl std::fmt::Display for Consistency {
 impl std::fmt::Display for SerialConsistency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl From<std::num::TryFromIntError> for ParseError {
-    fn from(_err: std::num::TryFromIntError) -> Self {
-        ParseError::BadIncomingData("Integer conversion out of range".to_string())
     }
 }
 

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -1,4 +1,3 @@
-use crate::frame::frame_errors::ParseError;
 use crate::frame::types;
 use bytes::BufMut;
 use std::borrow::Cow;
@@ -797,26 +796,6 @@ impl LegacySerializedValues {
 
     pub fn size(&self) -> usize {
         self.serialized_values.len()
-    }
-
-    /// Creates value list from the request frame
-    pub fn new_from_frame(buf: &mut &[u8], contains_names: bool) -> Result<Self, ParseError> {
-        let values_num = types::read_short(buf)?;
-        let values_beg = *buf;
-        for _ in 0..values_num {
-            if contains_names {
-                let _name = types::read_string(buf)?;
-            }
-            let _serialized = types::read_bytes_opt(buf)?;
-        }
-
-        let values_len_in_buf = values_beg.len() - buf.len();
-        let values_in_frame = &values_beg[0..values_len_in_buf];
-        Ok(LegacySerializedValues {
-            serialized_values: values_in_frame.to_vec(),
-            values_num,
-            contains_names,
-        })
     }
 
     pub fn iter_name_value_pairs(&self) -> impl Iterator<Item = (Option<&str>, RawValue)> {

--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -46,30 +46,31 @@
 //!
 //! ```rust
 //! # use scylla_cql::frame::response::result::ColumnType;
-//! # use scylla_cql::frame::frame_errors::ParseError;
 //! # use scylla_cql::types::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
 //! # use scylla_cql::types::deserialize::value::DeserializeValue;
+//! use thiserror::Error;
 //! struct MyVec(Vec<u8>);
+//! #[derive(Debug, Error)]
+//! enum MyDeserError {
+//!     #[error("Expected bytes")]
+//!     ExpectedBytes,
+//!     #[error("Expected non-null")]
+//!     ExpectedNonNull,
+//! }
 //! impl<'frame> DeserializeValue<'frame> for MyVec {
 //!     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
 //!          if let ColumnType::Blob = typ {
 //!              return Ok(());
 //!          }
-//!          Err(TypeCheckError::new(
-//!             ParseError::BadIncomingData("Expected bytes".to_owned())
-//!          ))
+//!          Err(TypeCheckError::new(MyDeserError::ExpectedBytes))
 //!      }
 //!
 //!      fn deserialize(
 //!          _typ: &'frame ColumnType,
 //!          v: Option<FrameSlice<'frame>>,
 //!      ) -> Result<Self, DeserializationError> {
-//!          v.ok_or_else(|| {
-//!              DeserializationError::new(
-//!                  ParseError::BadIncomingData("Expected non-null value".to_owned())
-//!              )
-//!          })
-//!          .map(|v| Self(v.as_slice().to_vec()))
+//!          v.ok_or_else(|| DeserializationError::new(MyDeserError::ExpectedNonNull))
+//!             .map(|v| Self(v.as_slice().to_vec()))
 //!      }
 //! }
 //! ```
@@ -85,11 +86,18 @@
 //! For example:
 //!
 //! ```rust
-//! # use scylla_cql::frame::frame_errors::ParseError;
 //! # use scylla_cql::frame::response::result::ColumnType;
 //! # use scylla_cql::types::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
 //! # use scylla_cql::types::deserialize::value::DeserializeValue;
+//! use thiserror::Error;
 //! struct MySlice<'a>(&'a [u8]);
+//! #[derive(Debug, Error)]
+//! enum MyDeserError {
+//!     #[error("Expected bytes")]
+//!     ExpectedBytes,
+//!     #[error("Expected non-null")]
+//!     ExpectedNonNull,
+//! }
 //! impl<'a, 'frame> DeserializeValue<'frame> for MySlice<'a>
 //! where
 //!     'frame: 'a,
@@ -98,21 +106,15 @@
 //!          if let ColumnType::Blob = typ {
 //!              return Ok(());
 //!          }
-//!          Err(TypeCheckError::new(
-//!              ParseError::BadIncomingData("Expected bytes".to_owned())
-//!          ))
+//!          Err(TypeCheckError::new(MyDeserError::ExpectedBytes))
 //!      }
 //!
 //!      fn deserialize(
 //!          _typ: &'frame ColumnType,
 //!          v: Option<FrameSlice<'frame>>,
 //!      ) -> Result<Self, DeserializationError> {
-//!          v.ok_or_else(|| {
-//!             DeserializationError::new(
-//!                 ParseError::BadIncomingData("Expected non-null value".to_owned())
-//!             )
-//!          })
-//!          .map(|v| Self(v.as_slice()))
+//!          v.ok_or_else(|| DeserializationError::new(MyDeserError::ExpectedNonNull))
+//!             .map(|v| Self(v.as_slice()))
 //!      }
 //! }
 //! ```
@@ -135,32 +137,36 @@
 //! Example:
 //!
 //! ```rust
-//! # use scylla_cql::frame::frame_errors::ParseError;
 //! # use scylla_cql::frame::response::result::ColumnType;
 //! # use scylla_cql::types::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
 //! # use scylla_cql::types::deserialize::value::DeserializeValue;
 //! # use bytes::Bytes;
+//! use thiserror::Error;
 //! struct MyBytes(Bytes);
+//! #[derive(Debug, Error)]
+//! enum MyDeserError {
+//!     #[error("Expected bytes")]
+//!     ExpectedBytes,
+//!     #[error("Expected non-null")]
+//!     ExpectedNonNull,
+//! }
 //! impl<'frame> DeserializeValue<'frame> for MyBytes {
 //!     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
 //!          if let ColumnType::Blob = typ {
 //!              return Ok(());
 //!          }
-//!          Err(TypeCheckError::new(ParseError::BadIncomingData("Expected bytes".to_owned())))
+//!          Err(TypeCheckError::new(MyDeserError::ExpectedBytes))
 //!      }
 //!
 //!      fn deserialize(
 //!          _typ: &'frame ColumnType,
 //!          v: Option<FrameSlice<'frame>>,
 //!      ) -> Result<Self, DeserializationError> {
-//!          v.ok_or_else(|| {
-//!              DeserializationError::new(ParseError::BadIncomingData("Expected non-null value".to_owned()))
-//!          })
-//!          .map(|v| Self(v.to_bytes()))
+//!          v.ok_or_else(|| DeserializationError::new(MyDeserError::ExpectedNonNull))
+//!             .map(|v| Self(v.to_bytes()))
 //!      }
 //! }
 //! ```
-// TODO: in the above module docstring, stop abusing ParseError once errors are refactored.
 
 pub mod frame_slice;
 pub mod result;

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, sync::Arc};
 use bytes::BufMut;
 use thiserror::Error;
 
-use crate::frame::frame_errors::ParseError;
+use crate::frame::request::RequestDeserializationError;
 use crate::frame::response::result::ColumnType;
 use crate::frame::response::result::PreparedMetadata;
 use crate::frame::types;
@@ -807,7 +807,8 @@ impl SerializedValues {
     }
 
     /// Creates value list from the request frame
-    pub(crate) fn new_from_frame(buf: &mut &[u8]) -> Result<Self, ParseError> {
+    /// This is used only for testing - request deserialization.
+    pub(crate) fn new_from_frame(buf: &mut &[u8]) -> Result<Self, RequestDeserializationError> {
         let values_num = types::read_short(buf)?;
         let values_beg = *buf;
         for _ in 0..values_num {

--- a/scylla-proxy/src/errors.rs
+++ b/scylla-proxy/src/errors.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use scylla_cql::frame::frame_errors::{FrameError, ParseError};
+use scylla_cql::frame::frame_errors::{FrameHeaderParseError, ParseError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -20,7 +20,7 @@ pub enum DoorkeeperError {
     #[error("Could not send Options frame for obtaining shards number: {0}")]
     ObtainingShardNumber(std::io::Error),
     #[error("Could not send read Supported frame for obtaining shards number: {0}")]
-    ObtainingShardNumberFrame(FrameError),
+    ObtainingShardNumberFrame(FrameHeaderParseError),
     #[error("Could not read Supported options: {0}")]
     ObtainingShardNumberParseOptions(ParseError),
     #[error("ShardInfo parameters missing")]

--- a/scylla-proxy/src/errors.rs
+++ b/scylla-proxy/src/errors.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use scylla_cql::frame::frame_errors::{FrameHeaderParseError, ParseError};
+use scylla_cql::frame::frame_errors::{FrameHeaderParseError, LowLevelDeserializationError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -22,7 +22,7 @@ pub enum DoorkeeperError {
     #[error("Could not send read Supported frame for obtaining shards number: {0}")]
     ObtainingShardNumberFrame(FrameHeaderParseError),
     #[error("Could not read Supported options: {0}")]
-    ObtainingShardNumberParseOptions(ParseError),
+    ObtainingShardNumberParseOptions(LowLevelDeserializationError),
     #[error("ShardInfo parameters missing")]
     ObtainingShardNumberNoShardInfo,
     #[error("Could not parse shard number: {0}")]

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use scylla_cql::frame::frame_errors::{FrameHeaderParseError, ParseError};
 use scylla_cql::frame::protocol_features::ProtocolFeatures;
-use scylla_cql::frame::request::Request;
 pub use scylla_cql::frame::request::RequestOpcode;
+use scylla_cql::frame::request::{Request, RequestDeserializationError};
 pub use scylla_cql::frame::response::ResponseOpcode;
 use scylla_cql::frame::{response::error::DbError, types};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -69,7 +69,7 @@ impl RequestFrame {
         .await
     }
 
-    pub fn deserialize(&self) -> Result<Request, ParseError> {
+    pub fn deserialize(&self) -> Result<Request, RequestDeserializationError> {
         Request::deserialize(&mut &self.body[..], self.opcode)
     }
 }

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -5,7 +5,6 @@ use crate::frame::{
 };
 use crate::{RequestOpcode, TargetShard};
 use bytes::Bytes;
-use scylla_cql::frame::frame_errors::ParseError;
 use scylla_cql::frame::types::read_string_multimap;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -806,7 +805,6 @@ impl Doorkeeper {
             .map_err(DoorkeeperError::ObtainingShardNumberFrame)?;
 
         let options = read_string_multimap(&mut supported_frame.body.as_ref())
-            .map_err(ParseError::from)
             .map_err(DoorkeeperError::ObtainingShardNumberParseOptions)?;
 
         Ok(options)

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1305,7 +1305,7 @@ mod tests {
     use bytes::{BufMut, BytesMut};
     use futures::future::{join, join3};
     use rand::RngCore;
-    use scylla_cql::frame::frame_errors::FrameError;
+    use scylla_cql::frame::frame_errors::FrameHeaderParseError;
     use scylla_cql::frame::types::write_string_multimap;
     use std::collections::HashMap;
     use std::mem;
@@ -1724,7 +1724,7 @@ mod tests {
             params: FrameParams,
             opcode: FrameOpcode,
             body: &Bytes,
-        ) -> Result<RequestFrame, FrameError> {
+        ) -> Result<RequestFrame, FrameHeaderParseError> {
             let (send_res, recv_res) = join(
                 write_frame(params, opcode, &body.clone(), driver),
                 read_request_frame(node),
@@ -1839,7 +1839,7 @@ mod tests {
             params: FrameParams,
             opcode: FrameOpcode,
             body: &Bytes,
-        ) -> Result<RequestFrame, FrameError> {
+        ) -> Result<RequestFrame, FrameHeaderParseError> {
             let (send_res, recv_res) = join(
                 write_frame(params, opcode, &body.clone(), driver),
                 read_request_frame(node),

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1618,7 +1618,7 @@ impl Connection {
         loop {
             let (params, opcode, body) = frame::read_response_frame(&mut read_half)
                 .await
-                .map_err(BrokenConnectionErrorKind::FrameError)?;
+                .map_err(BrokenConnectionErrorKind::FrameHeaderParseError)?;
             let response = TaskResponse {
                 params,
                 opcode,

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -781,7 +781,7 @@ impl Connection {
             },
             Err(e) => match e {
                 RequestError::CqlRequestSerialization(e) => return Err(err(e.into())),
-                RequestError::FrameError(e) => return Err(err(e.into())),
+                RequestError::BodyExtensionsParseError(e) => return Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     // Parsing of READY response cannot fail, since its body is empty.
                     // Remaining valid responses are AUTHENTICATE and ERROR.
@@ -831,7 +831,7 @@ impl Connection {
             },
             Err(e) => match e {
                 RequestError::CqlRequestSerialization(e) => return Err(err(e.into())),
-                RequestError::FrameError(e) => return Err(err(e.into())),
+                RequestError::BodyExtensionsParseError(e) => return Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     CqlResponseParseError::CqlSupportedParseError(e) => return Err(err(e.into())),
                     CqlResponseParseError::CqlErrorParseError(e) => return Err(err(e.into())),
@@ -942,7 +942,7 @@ impl Connection {
             },
             Err(e) => match e {
                 RequestError::CqlRequestSerialization(e) => return Err(err(e.into())),
-                RequestError::FrameError(e) => return Err(err(e.into())),
+                RequestError::BodyExtensionsParseError(e) => return Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     CqlResponseParseError::CqlAuthSuccessParseError(e) => {
                         return Err(err(e.into()))
@@ -1404,7 +1404,7 @@ impl Connection {
             },
             Err(e) => match e {
                 RequestError::CqlRequestSerialization(e) => Err(err(e.into())),
-                RequestError::FrameError(e) => Err(err(e.into())),
+                RequestError::BodyExtensionsParseError(e) => Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     // Parsing the READY response cannot fail. Only remaining valid response is ERROR.
                     CqlResponseParseError::CqlErrorParseError(e) => Err(err(e.into())),
@@ -1864,7 +1864,7 @@ impl Connection {
                 }
             },
             Err(e) => match e {
-                ResponseParseError::FrameError(e) => return Err(e.into()),
+                ResponseParseError::BodyExtensionsParseError(e) => return Err(e.into()),
                 ResponseParseError::CqlResponseParseError(e) => match e {
                     CqlResponseParseError::CqlEventParseError(e) => return Err(e.into()),
                     // Received a response other than EVENT, but failed to deserialize it.

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -780,6 +780,7 @@ impl Connection {
                 }
             },
             Err(e) => match e {
+                RequestError::CqlRequestSerialization(e) => return Err(err(e.into())),
                 RequestError::FrameError(e) => return Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     // Parsing of READY response cannot fail, since its body is empty.
@@ -829,6 +830,7 @@ impl Connection {
                 }
             },
             Err(e) => match e {
+                RequestError::CqlRequestSerialization(e) => return Err(err(e.into())),
                 RequestError::FrameError(e) => return Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     CqlResponseParseError::CqlSupportedParseError(e) => return Err(err(e.into())),
@@ -939,6 +941,7 @@ impl Connection {
                 }
             },
             Err(e) => match e {
+                RequestError::CqlRequestSerialization(e) => return Err(err(e.into())),
                 RequestError::FrameError(e) => return Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     CqlResponseParseError::CqlAuthSuccessParseError(e) => {
@@ -1400,6 +1403,7 @@ impl Connection {
                 ))),
             },
             Err(e) => match e {
+                RequestError::CqlRequestSerialization(e) => Err(err(e.into())),
                 RequestError::FrameError(e) => Err(err(e.into())),
                 RequestError::CqlResponseParseError(e) => match e {
                     // Parsing the READY response cannot fail. Only remaining valid response is ERROR.

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -23,10 +23,7 @@ use scylla_cql::{
         response::CqlResponseKind,
         value::SerializeValuesError,
     },
-    types::{
-        deserialize::{DeserializationError, TypeCheckError},
-        serialize::SerializationError,
-    },
+    types::serialize::SerializationError,
 };
 
 use thiserror::Error;
@@ -99,18 +96,6 @@ impl From<SerializeValuesError> for QueryError {
 impl From<SerializationError> for QueryError {
     fn from(serialized_err: SerializationError) -> QueryError {
         QueryError::BadQuery(BadQuery::SerializationError(serialized_err))
-    }
-}
-
-impl From<DeserializationError> for QueryError {
-    fn from(value: DeserializationError) -> Self {
-        Self::InvalidMessage(value.to_string())
-    }
-}
-
-impl From<TypeCheckError> for QueryError {
-    fn from(value: TypeCheckError) -> Self {
-        Self::InvalidMessage(value.to_string())
     }
 }
 

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -395,10 +395,9 @@ pub enum ConnectionSetupRequestErrorKind {
     #[error("Failed to serialize CQL request: {0}")]
     CqlRequestSerialization(#[from] CqlRequestSerializationError),
 
-    // TODO: Make FrameBodyExtensionsParseError clonable.
     /// Failed to deserialize frame body extensions.
     #[error(transparent)]
-    BodyExtensionsParseError(Arc<FrameBodyExtensionsParseError>),
+    BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
 
     /// Driver was unable to allocate a stream id to execute a setup request on.
     #[error("Unable to allocate stream id")]
@@ -453,12 +452,6 @@ pub enum ConnectionSetupRequestErrorKind {
     /// and/or [`SessionBuilder::authenticator_provider`](crate::transport::session_builder::SessionBuilder::authenticator_provider).
     #[error("Authentication is required. You can use SessionBuilder::user(\"user\", \"pass\") to provide credentials or SessionBuilder::authenticator_provider to provide custom authenticator")]
     MissingAuthentication,
-}
-
-impl From<FrameBodyExtensionsParseError> for ConnectionSetupRequestErrorKind {
-    fn from(value: FrameBodyExtensionsParseError) -> Self {
-        ConnectionSetupRequestErrorKind::BodyExtensionsParseError(Arc::new(value))
-    }
 }
 
 impl ConnectionSetupRequestError {

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -17,7 +17,7 @@ use scylla_cql::{
             CqlAuthChallengeParseError, CqlAuthSuccessParseError, CqlAuthenticateParseError,
             CqlErrorParseError, CqlEventParseError, CqlRequestSerializationError,
             CqlResponseParseError, CqlResultParseError, CqlSupportedParseError, FrameError,
-            ParseError,
+            FrameHeaderParseError, ParseError,
         },
         request::CqlRequestKind,
         response::CqlResponseKind,
@@ -511,7 +511,7 @@ pub enum BrokenConnectionErrorKind {
 
     /// Failed to deserialize response frame header.
     #[error("Failed to deserialize frame: {0}")]
-    FrameError(FrameError),
+    FrameHeaderParseError(FrameHeaderParseError),
 
     /// Failed to handle a CQL event (server response received on stream -1).
     #[error("Failed to handle server event: {0}")]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -49,6 +49,10 @@ pub enum QueryError {
     #[error("Failed to serialize CQL request: {0}")]
     CqlRequestSerialization(#[from] CqlRequestSerializationError),
 
+    /// Failed to deserialize frame body extensions.
+    #[error(transparent)]
+    BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
+
     /// Received a RESULT server response, but failed to deserialize it.
     #[error(transparent)]
     CqlResultParseError(#[from] CqlResultParseError),
@@ -116,12 +120,6 @@ impl From<ParseError> for QueryError {
     }
 }
 
-impl From<FrameBodyExtensionsParseError> for QueryError {
-    fn from(frame_error: FrameBodyExtensionsParseError) -> QueryError {
-        QueryError::InvalidMessage(format!("Frame error: {}", frame_error))
-    }
-}
-
 impl From<tokio::time::error::Elapsed> for QueryError {
     fn from(timer_error: tokio::time::error::Elapsed) -> QueryError {
         QueryError::RequestTimeout(format!("{}", timer_error))
@@ -157,6 +155,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::CqlRequestSerialization(e) => NewSessionError::CqlRequestSerialization(e),
             QueryError::CqlResultParseError(e) => NewSessionError::CqlResultParseError(e),
             QueryError::CqlErrorParseError(e) => NewSessionError::CqlErrorParseError(e),
+            QueryError::BodyExtensionsParseError(e) => NewSessionError::BodyExtensionsParseError(e),
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
             QueryError::InvalidMessage(m) => NewSessionError::InvalidMessage(m),
@@ -204,6 +203,10 @@ pub enum NewSessionError {
     /// Failed to serialize CQL request.
     #[error("Failed to serialize CQL request: {0}")]
     CqlRequestSerialization(#[from] CqlRequestSerializationError),
+
+    /// Failed to deserialize frame body extensions.
+    #[error(transparent)]
+    BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
 
     /// Received a RESULT server response, but failed to deserialize it.
     #[error(transparent)]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -17,7 +17,7 @@ use scylla_cql::{
             CqlAuthChallengeParseError, CqlAuthSuccessParseError, CqlAuthenticateParseError,
             CqlErrorParseError, CqlEventParseError, CqlRequestSerializationError,
             CqlResponseParseError, CqlResultParseError, CqlSupportedParseError,
-            FrameBodyExtensionsParseError, FrameHeaderParseError, ParseError,
+            FrameBodyExtensionsParseError, FrameHeaderParseError,
         },
         request::CqlRequestKind,
         response::CqlResponseKind,
@@ -96,12 +96,6 @@ impl From<SerializeValuesError> for QueryError {
 impl From<SerializationError> for QueryError {
     fn from(serialized_err: SerializationError) -> QueryError {
         QueryError::BadQuery(BadQuery::SerializationError(serialized_err))
-    }
-}
-
-impl From<ParseError> for QueryError {
-    fn from(parse_error: ParseError) -> QueryError {
-        QueryError::InvalidMessage(format!("Error parsing message: {}", parse_error))
     }
 }
 

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2855,6 +2855,7 @@ mod latency_awareness {
                 QueryError::DbError(_, _)
                 | QueryError::CqlResultParseError(_)
                 | QueryError::CqlErrorParseError(_)
+                | QueryError::BodyExtensionsParseError(_)
                 | QueryError::InvalidMessage(_)
                 | QueryError::ProtocolError(_)
                 | QueryError::TimeoutError

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2841,6 +2841,7 @@ mod latency_awareness {
             match error {
                 // "fast" errors, i.e. ones that are returned quickly after the query begins
                 QueryError::BadQuery(_)
+                | QueryError::CqlRequestSerialization(_)
                 | QueryError::BrokenConnection(_)
                 | QueryError::ConnectionPoolError(_)
                 | QueryError::UnableToAllocStreamId


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

This PR solves multiple issues:
## No context for request serialization
I introduced a `CqlRequestSerializationError`, with the corresponding variants for each request type. Previously, the request serialization module would return `ParseError`, which did not provide much context.

## Distinguishing between frame ser and deser errors
Decoupled `FrameError` (which originally was overloaded with variants corresponding to serialization and deserialization) into:
- `CqlRequestSerializationError` - in fact, I only moved the variant regarding frame body compression from `FrameError` to `CqlRequestSerializationError`
- `FrameHeaderParseError` - it corresponds to the errors that appear when `Connection::reader()` async task receives a frame, and tries to deserialize its header. It happens before the actual response handler is chosen (based on the stream id).
- `FrameBodyExtensionsParseError` - as the name suggests, it is returned when the driver fails to deserialize body extensions (e.g. frame warnings, or custom payload).

## Test utilities making use of ParseError
There were a couple of test utilities used by `scylla-proxy` that would depend on ParseError. In some cases, if needed, I introduced new error types (e.g. `RequestDeserializationError`). I provided a docstring, noting that this is intended for driver's internal use and testing (it has to be `pub`, because of `scylla-proxy` crate).

## Removing ParseError
With this PR, we could finally remove `ParseError` altogether! I believe that there are still some error-related issues to be addressed, but this is a huge step forward, as this was the most problematic error type.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
