### PR TITLE
Remove Problematic Unwraps In Macros

### DIFF
--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -22,9 +22,7 @@ pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, 
                     #field_name: {
                         let (col_ix, col_value) = vals_iter
                             .next()
-                            .unwrap(); // vals_iter size is checked before this code is reached, so
-                                    // it is safe to unwrap
-
+                            .expect("BUG: Size validated iterator did not contain the expected number of values"); 
                         <#field_type as FromCqlVal<::std::option::Option<CqlValue>>>::from_cql(col_value)
                             .map_err(|e| FromRowError::BadCqlVal {
                                 err: e,
@@ -48,8 +46,7 @@ pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, 
                     {
                         let (col_ix, col_value) = vals_iter
                             .next()
-                            .unwrap(); // vals_iter size is checked before this code is reached, so
-                                    // it is safe to unwrap
+                            .expect("BUG: Size validated iterator did not contain the expected number of values"); 
 
                         <#field_type as FromCqlVal<::std::option::Option<CqlValue>>>::from_cql(col_value)
                             .map_err(|e| FromRowError::BadCqlVal {

--- a/scylla-macros/src/from_user_type.rs
+++ b/scylla-macros/src/from_user_type.rs
@@ -30,7 +30,7 @@ pub(crate) fn from_user_type_derive(tokens_input: TokenStream) -> Result<TokenSt
                     // field)
                     if let Some(received_field_name) = received_field_name {
                         if received_field_name == stringify!(#field_name) {
-                            let (_, value) = fields_iter.next().unwrap();
+                            let (_, value) = fields_iter.next().expect("BUG: Validated iterator did not contain expected number of values");
                             value
                         } else {
                             None


### PR DESCRIPTION
Using unwraps in macros means the code is compiled as part of the end users build.
This therefore means any lints a user uses will check the macro code as well.
These unwraps therefore the [clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used)  `unwrap_used` will throw a warning/error if the user has enabled it.

I wanted to enable this in a project that uses scylla, so i've created this merge request to try and fix this in the least invasive way possible.

I have returned error states where the unwraps were used, but if this feels more in the realm of a `panic` state, then it can simply be swapped for `panic`

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
