### PR TITLE
result: fix bug: paging state taken from PREPARED response instead of RESULT

### DIFF
--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -812,7 +812,11 @@ fn deser_rows(
     let server_metadata = deser_result_metadata(buf)?;
 
     let metadata = match cached_metadata {
-        Some(metadata) => metadata.clone(),
+        Some(cached) => ResultMetadata {
+            col_count: cached.col_count,
+            paging_state: server_metadata.paging_state,
+            col_specs: cached.col_specs.clone(),
+        },
         None => {
             // No cached_metadata provided. Server is supposed to provide the result metadata.
             if server_metadata.col_count != server_metadata.col_specs.len() {


### PR DESCRIPTION
A bug is fixed that when `set_use_cached_result_metadata` flag is set, then the `ResultMetadata` would be taken from `PreparedStatement` including `paging_state`, effectively yielding empty paging state for every request with the flag set.
A related regression test is added.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
