### PR TITLE
errors: refactor error types on a connection level

### DIFF
--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -366,6 +366,37 @@ pub enum BadQuery {
     Other(String),
 }
 
+/// Possible CQL responses received from the server
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum CqlResponseKind {
+    Error,
+    Ready,
+    Authenticate,
+    Supported,
+    Result,
+    Event,
+    AuthChallenge,
+    AuthSuccess,
+}
+
+impl std::fmt::Display for CqlResponseKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kind_str = match self {
+            CqlResponseKind::Error => "ERROR",
+            CqlResponseKind::Ready => "READY",
+            CqlResponseKind::Authenticate => "AUTHENTICATE",
+            CqlResponseKind::Supported => "SUPPORTED",
+            CqlResponseKind::Result => "RESULT",
+            CqlResponseKind::Event => "EVENT",
+            CqlResponseKind::AuthChallenge => "AUTH_CHALLENGE",
+            CqlResponseKind::AuthSuccess => "AUTH_SUCCESS",
+        };
+
+        f.write_str(kind_str)
+    }
+}
+
 /// Error that occurred during session creation
 #[derive(Error, Debug, Clone)]
 pub enum NewSessionError {

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -523,9 +523,6 @@ pub enum ConnectionError {
     BrokenConnection(#[from] BrokenConnectionError),
     #[error(transparent)]
     ConnectionSetupRequestError(#[from] ConnectionSetupRequestError),
-    // TODO: remove it or change it later.
-    #[error(transparent)]
-    QueryError(#[from] QueryError),
 }
 
 impl ConnectionError {

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -796,17 +796,6 @@ impl From<tokio::time::error::Elapsed> for QueryError {
     }
 }
 
-impl From<RequestError> for QueryError {
-    fn from(value: RequestError) -> Self {
-        match value {
-            RequestError::FrameError(e) => e.into(),
-            RequestError::CqlResponseParseError(e) => e.into(),
-            RequestError::BrokenConnection(e) => e.into(),
-            RequestError::UnableToAllocStreamId => QueryError::UnableToAllocStreamId,
-        }
-    }
-}
-
 impl From<UserRequestError> for QueryError {
     fn from(value: UserRequestError) -> Self {
         match value {

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -1,8 +1,9 @@
 //! This module contains various errors which can be returned by `scylla::Session`
 
 use crate::frame::frame_errors::{
-    CqlAuthenticateParseError, CqlErrorParseError, CqlEventParseError, CqlResponseParseError,
-    CqlSupportedParseError, FrameError, ParseError,
+    CqlAuthChallengeParseError, CqlAuthSuccessParseError, CqlAuthenticateParseError,
+    CqlErrorParseError, CqlEventParseError, CqlResponseParseError, CqlSupportedParseError,
+    FrameError, ParseError,
 };
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::value::SerializeValuesError;
@@ -553,6 +554,8 @@ pub struct ConnectionSetupRequestError {
     error: ConnectionSetupRequestErrorKind,
 }
 
+type AuthError = String;
+
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum ConnectionSetupRequestErrorKind {
@@ -570,8 +573,20 @@ pub enum ConnectionSetupRequestErrorKind {
     CqlSupportedParseError(#[from] CqlSupportedParseError),
     #[error("Failed to deserialize AUTHENTICATE response: {0}")]
     CqlAuthenticateParseError(#[from] CqlAuthenticateParseError),
+    #[error("Failed to deserialize AUTH_SUCCESS response: {0}")]
+    CqlAuthSuccessParseError(#[from] CqlAuthSuccessParseError),
+    #[error("Failed to deserialize AUTH_CHALLENGE response: {0}")]
+    CqlAuthChallengeParseError(#[from] CqlAuthChallengeParseError),
     #[error("Failed to deserialize ERROR response: {0}")]
     CqlErrorParseError(#[from] CqlErrorParseError),
+    #[error("Failed to start client's auth session: {0}")]
+    StartAuthSessionError(AuthError),
+    #[error("Failed to evaluate auth challenge on client side: {0}")]
+    AuthChallengeEvaluationError(AuthError),
+    #[error("Failed to finish auth challenge on client side: {0}")]
+    AuthFinishError(AuthError),
+    #[error("Authentication is required. You can use SessionBuilder::user(\"user\", \"pass\") to provide credentials or SessionBuilder::authenticator_provider to provide custom authenticator")]
+    MissingAuthentication,
 }
 
 impl ConnectionSetupRequestError {

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -87,6 +87,8 @@ pub enum UserRequestError {
     FrameError(#[from] FrameError),
     #[error("Unable to allocate stream id")]
     UnableToAllocStreamId,
+    #[error("Prepared statement Id changed, md5 sum should stay the same")]
+    RepreparedIdChanged,
 }
 
 /// An error sent from the database in response to a query
@@ -824,6 +826,9 @@ impl From<UserRequestError> for QueryError {
             }
             UserRequestError::FrameError(e) => e.into(),
             UserRequestError::UnableToAllocStreamId => QueryError::UnableToAllocStreamId,
+            UserRequestError::RepreparedIdChanged => QueryError::ProtocolError(
+                "Prepared statement Id changed, md5 sum should stay the same",
+            ),
         }
     }
 }

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -1,6 +1,8 @@
 //! This module contains various errors which can be returned by `scylla::Session`
 
-use crate::frame::frame_errors::{CqlResponseParseError, FrameError, ParseError};
+use crate::frame::frame_errors::{
+    CqlEventParseError, CqlResponseParseError, FrameError, ParseError,
+};
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::value::SerializeValuesError;
 use crate::types::deserialize::{DeserializationError, TypeCheckError};
@@ -508,17 +510,19 @@ pub enum BrokenConnectionErrorKind {
 
 /// Failed to handle a CQL event received on a stream -1.
 /// Possible error kinds are:
-/// - failed to deserialize server response
+/// - failed to deserialize response's frame header
+/// - failed to deserialize CQL event response
 /// - received invalid server response
 /// - failed to send an event info via channel (connection is probably broken)
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum CqlEventHandlingError {
-    // FIXME: ResponseParseError -> CqlEventParseError
-    #[error(transparent)]
-    QueryError(#[from] ResponseParseError),
+    #[error("Failed to deserialize EVENT response: {0}")]
+    CqlEventParseError(#[from] CqlEventParseError),
     #[error("Received unexpected server response on stream -1: {0}. Expected EVENT response")]
     UnexpectedResponse(CqlResponseKind),
+    #[error("Failed to deserialize a header of frame received on stream -1: {0}")]
+    FrameError(#[from] FrameError),
     #[error("Failed to send event info via channel. The channel is probably closed, which is caused by connection being broken")]
     SendError,
 }

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -792,12 +792,6 @@ impl std::fmt::Display for WriteType {
     }
 }
 
-impl From<std::io::Error> for QueryError {
-    fn from(io_error: std::io::Error) -> QueryError {
-        QueryError::IoError(Arc::new(io_error))
-    }
-}
-
 impl From<SerializeValuesError> for QueryError {
     fn from(serialized_err: SerializeValuesError) -> QueryError {
         QueryError::BadQuery(BadQuery::SerializeValuesError(serialized_err))

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -1,8 +1,8 @@
 //! This module contains various errors which can be returned by `scylla::Session`
 
 use crate::frame::frame_errors::{
-    CqlErrorParseError, CqlEventParseError, CqlResponseParseError, CqlSupportedParseError,
-    FrameError, ParseError,
+    CqlAuthenticateParseError, CqlErrorParseError, CqlEventParseError, CqlResponseParseError,
+    CqlSupportedParseError, FrameError, ParseError,
 };
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::value::SerializeValuesError;
@@ -568,6 +568,8 @@ pub enum ConnectionSetupRequestErrorKind {
     UnexpectedResponse(CqlResponseKind),
     #[error("Failed to deserialize SUPPORTED response: {0}")]
     CqlSupportedParseError(#[from] CqlSupportedParseError),
+    #[error("Failed to deserialize AUTHENTICATE response: {0}")]
+    CqlAuthenticateParseError(#[from] CqlAuthenticateParseError),
     #[error("Failed to deserialize ERROR response: {0}")]
     CqlErrorParseError(#[from] CqlErrorParseError),
 }

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -58,10 +58,6 @@ pub enum QueryError {
     /// Client timeout occurred before any response arrived
     #[error("Request timeout: {0}")]
     RequestTimeout(String),
-
-    /// Address translation failed
-    #[error("Address translation failed: {0}")]
-    TranslationError(#[from] TranslationError),
 }
 
 /// An error sent from the database in response to a query
@@ -457,10 +453,6 @@ pub enum NewSessionError {
     /// during `Session` creation.
     #[error("Client timeout: {0}")]
     RequestTimeout(String),
-
-    /// Address translation failed
-    #[error("Address translation failed: {0}")]
-    TranslationError(#[from] TranslationError),
 }
 
 /// Invalid keyspace name given to `Session::use_keyspace()`
@@ -706,7 +698,6 @@ impl From<QueryError> for NewSessionError {
             QueryError::BrokenConnection(e) => NewSessionError::BrokenConnection(e),
             QueryError::UnableToAllocStreamId => NewSessionError::UnableToAllocStreamId,
             QueryError::RequestTimeout(msg) => NewSessionError::RequestTimeout(msg),
-            QueryError::TranslationError(e) => NewSessionError::TranslationError(e),
         }
     }
 }

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -708,23 +708,6 @@ impl From<BadKeyspaceName> for QueryError {
     }
 }
 
-impl QueryError {
-    /// Checks if this error indicates that a chosen source port/address cannot be bound.
-    /// This is caused by one of the following:
-    /// - The source address is already used by another socket,
-    /// - The source address is reserved and the process does not have sufficient privileges to use it.
-    pub fn is_address_unavailable_for_use(&self) -> bool {
-        if let QueryError::IoError(io_error) = self {
-            match io_error.kind() {
-                ErrorKind::AddrInUse | ErrorKind::PermissionDenied => return true,
-                _ => {}
-            }
-        }
-
-        false
-    }
-}
-
 impl From<u8> for OperationType {
     fn from(operation_type: u8) -> OperationType {
         match operation_type {

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -341,6 +341,37 @@ pub enum WriteType {
     Other(String),
 }
 
+/// Possible requests sent by the client.
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum CqlRequestKind {
+    Startup,
+    AuthResponse,
+    Options,
+    Query,
+    Prepare,
+    Execute,
+    Batch,
+    Register,
+}
+
+impl std::fmt::Display for CqlRequestKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kind_str = match self {
+            CqlRequestKind::Startup => "STARTUP",
+            CqlRequestKind::AuthResponse => "AUTH_RESPONSE",
+            CqlRequestKind::Options => "OPTIONS",
+            CqlRequestKind::Query => "QUERY",
+            CqlRequestKind::Prepare => "PREPARE",
+            CqlRequestKind::Execute => "EXECUTE",
+            CqlRequestKind::Batch => "BATCH",
+            CqlRequestKind::Register => "REGISTER",
+        };
+
+        f.write_str(kind_str)
+    }
+}
+
 /// Error caused by caller creating an invalid query
 #[derive(Error, Debug, Clone)]
 #[error("Invalid query passed to Session")]

--- a/scylla-cql/src/errors.rs
+++ b/scylla-cql/src/errors.rs
@@ -494,6 +494,8 @@ pub enum ConnectionError {
     NoSourcePortForShard(u32),
     #[error("Address translation failed: {0}")]
     TranslationError(#[from] TranslationError),
+    #[error(transparent)]
+    BrokenConnection(#[from] BrokenConnectionError),
     // TODO: remove it or change it later.
     #[error(transparent)]
     QueryError(#[from] QueryError),
@@ -519,6 +521,12 @@ impl ConnectionError {
 #[derive(Error, Debug, Clone)]
 #[error("Connection broken, reason: {0}")]
 pub struct BrokenConnectionError(Arc<dyn Error + Sync + Send>);
+
+impl BrokenConnectionError {
+    pub fn get_inner(&self) -> &Arc<dyn Error + Sync + Send> {
+        &self.0
+    }
+}
 
 #[derive(Error, Debug)]
 #[non_exhaustive]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::TryFromPrimitiveError;
 use crate::cql_to_rust::CqlTypeError;
+use crate::errors::CqlResponseKind;
 use crate::frame::value::SerializeValuesError;
 use crate::types::deserialize::{DeserializationError, TypeCheckError};
 use crate::types::serialize::SerializationError;
@@ -76,6 +77,20 @@ pub enum CqlResponseParseError {
     CqlEventParseError(#[from] CqlEventParseError),
     #[error(transparent)]
     CqlResultParseError(#[from] CqlResultParseError),
+}
+
+impl CqlResponseParseError {
+    pub fn to_response_kind(&self) -> CqlResponseKind {
+        match self {
+            CqlResponseParseError::CqlErrorParseError(_) => CqlResponseKind::Error,
+            CqlResponseParseError::CqlAuthChallengeParseError(_) => CqlResponseKind::AuthChallenge,
+            CqlResponseParseError::CqlAuthSuccessParseError(_) => CqlResponseKind::AuthSuccess,
+            CqlResponseParseError::CqlAuthenticateParseError(_) => CqlResponseKind::Authenticate,
+            CqlResponseParseError::CqlSupportedParseError(_) => CqlResponseKind::Supported,
+            CqlResponseParseError::CqlEventParseError(_) => CqlResponseKind::Event,
+            CqlResponseParseError::CqlResultParseError(_) => CqlResponseKind::Result,
+        }
+    }
 }
 
 /// An error type returned when deserialization of ERROR response fails.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -149,15 +149,15 @@ pub enum CqlResultParseError {
     ResultIdParseError(LowLevelDeserializationError),
     #[error("Unknown RESULT response id: {0}")]
     UnknownResultId(i32),
-    #[error("'Set_keyspace' response deserialization failed: {0}")]
+    #[error("RESULT:Set_keyspace response deserialization failed: {0}")]
     SetKeyspaceParseError(#[from] SetKeyspaceParseError),
     // This is an error returned during deserialization of
     // `RESULT::Schema_change` response, and not `EVENT` response.
-    #[error("'Schema_change' response deserialization failed: {0}")]
+    #[error("RESULT:Schema_change response deserialization failed: {0}")]
     SchemaChangeParseError(#[from] SchemaChangeEventParseError),
-    #[error("'Prepared' response deserialization failed: {0}")]
+    #[error("RESULT:Prepared response deserialization failed: {0}")]
     PreparedParseError(#[from] PreparedParseError),
-    #[error("'Rows' response deserialization failed: {0}")]
+    #[error("RESULT:Rows response deserialization failed: {0}")]
     RowsParseError(#[from] RowsParseError),
 }
 

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 pub use error::Error;
 pub use supported::Supported;
 
-use crate::errors::QueryError;
+use crate::errors::{CqlResponseKind, QueryError};
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::response::result::ResultMetadata;
 use crate::frame::TryFromPrimitiveError;
@@ -64,6 +64,19 @@ pub enum Response {
 }
 
 impl Response {
+    pub fn to_response_kind(&self) -> CqlResponseKind {
+        match self {
+            Response::Error(_) => CqlResponseKind::Error,
+            Response::Ready => CqlResponseKind::Ready,
+            Response::Result(_) => CqlResponseKind::Result,
+            Response::Authenticate(_) => CqlResponseKind::Authenticate,
+            Response::AuthSuccess(_) => CqlResponseKind::AuthSuccess,
+            Response::AuthChallenge(_) => CqlResponseKind::AuthChallenge,
+            Response::Supported(_) => CqlResponseKind::Supported,
+            Response::Event(_) => CqlResponseKind::Event,
+        }
+    }
+
     pub fn deserialize(
         features: &ProtocolFeatures,
         opcode: ResponseOpcode,
@@ -117,4 +130,18 @@ pub enum NonErrorResponse {
     AuthChallenge(authenticate::AuthChallenge),
     Supported(Supported),
     Event(event::Event),
+}
+
+impl NonErrorResponse {
+    pub fn to_response_kind(&self) -> CqlResponseKind {
+        match self {
+            NonErrorResponse::Ready => CqlResponseKind::Ready,
+            NonErrorResponse::Result(_) => CqlResponseKind::Result,
+            NonErrorResponse::Authenticate(_) => CqlResponseKind::Authenticate,
+            NonErrorResponse::AuthSuccess(_) => CqlResponseKind::AuthSuccess,
+            NonErrorResponse::AuthChallenge(_) => CqlResponseKind::AuthChallenge,
+            NonErrorResponse::Supported(_) => CqlResponseKind::Supported,
+            NonErrorResponse::Event(_) => CqlResponseKind::Event,
+        }
+    }
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -656,7 +656,7 @@ impl Connection {
             None => tokio::time::timeout(config.connect_timeout, TcpStream::connect(addr)).await,
         };
         let stream = match stream_connector {
-            Ok(stream) => stream.map_err(ConnectionError::IoError)?,
+            Ok(stream) => stream?,
             Err(_) => {
                 return Err(ConnectionError::ConnectTimeout);
             }
@@ -688,8 +688,7 @@ impl Connection {
             router_handle.clone(),
             addr.ip(),
         )
-        .await
-        .map_err(ConnectionError::IoError)?;
+        .await?;
 
         let connection = Connection {
             _worker_handle,

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1820,11 +1820,6 @@ pub(crate) async fn open_connection(
     // Get OPTIONS SUPPORTED by the cluster.
     let options_result = connection.get_options().await?;
 
-    let shard_aware_port_key = match config.is_ssl() {
-        true => options::SCYLLA_SHARD_AWARE_PORT_SSL,
-        false => options::SCYLLA_SHARD_AWARE_PORT,
-    };
-
     let mut supported = match options_result {
         Response::Supported(supported) => supported,
         Response::Error(Error { error, reason }) => {
@@ -1836,6 +1831,11 @@ pub(crate) async fn open_connection(
             )
             .into());
         }
+    };
+
+    let shard_aware_port_key = match config.is_ssl() {
+        true => options::SCYLLA_SHARD_AWARE_PORT_SSL,
+        false => options::SCYLLA_SHARD_AWARE_PORT,
     };
 
     // If this is ScyllaDB that we connected to, we received sharding information.

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1018,6 +1018,7 @@ impl Connection {
 
         self.query_raw_unpaged(&query, PagingState::start())
             .await
+            .map_err(Into::into)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -1025,7 +1026,7 @@ impl Connection {
         &self,
         query: &Query,
         paging_state: PagingState,
-    ) -> Result<QueryResponse, QueryError> {
+    ) -> Result<QueryResponse, UserRequestError> {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.query_raw_with_consistency(
             query,
@@ -1046,7 +1047,7 @@ impl Connection {
         serial_consistency: Option<SerialConsistency>,
         page_size: Option<PageSize>,
         paging_state: PagingState,
-    ) -> Result<QueryResponse, QueryError> {
+    ) -> Result<QueryResponse, UserRequestError> {
         let query_frame = query::Query {
             contents: Cow::Borrowed(&query.contents),
             parameters: query::QueryParameters {
@@ -1076,6 +1077,7 @@ impl Connection {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.execute_raw_unpaged(prepared, values, PagingState::start())
             .await
+            .map_err(Into::into)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -1085,7 +1087,7 @@ impl Connection {
         prepared: &PreparedStatement,
         values: SerializedValues,
         paging_state: PagingState,
-    ) -> Result<QueryResponse, QueryError> {
+    ) -> Result<QueryResponse, UserRequestError> {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.execute_raw_with_consistency(
             prepared,
@@ -1108,7 +1110,7 @@ impl Connection {
         serial_consistency: Option<SerialConsistency>,
         page_size: Option<PageSize>,
         paging_state: PagingState,
-    ) -> Result<QueryResponse, QueryError> {
+    ) -> Result<QueryResponse, UserRequestError> {
         let execute_frame = execute::Execute {
             id: prepared_statement.get_id().to_owned(),
             parameters: query::QueryParameters {

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -895,15 +895,13 @@ impl Connection {
         &self,
         query: impl Into<Query>,
         previous_prepared: &PreparedStatement,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), UserRequestError> {
         let reprepare_query: Query = query.into();
         let reprepared = self.prepare(&reprepare_query).await?;
         // Reprepared statement should keep its id - it's the md5 sum
         // of statement contents
         if reprepared.get_id() != previous_prepared.get_id() {
-            Err(QueryError::ProtocolError(
-                "Prepared statement Id changed, md5 sum should stay the same",
-            ))
+            Err(UserRequestError::RepreparedIdChanged)
         } else {
             Ok(())
         }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1677,7 +1677,7 @@ impl Connection {
         let event = match response {
             Response::Event(e) => e,
             _ => {
-                warn!("Expected to receive Event response, got {:?}", response);
+                error!("Expected to receive Event response, got {:?}", response);
                 return Ok(());
             }
         };

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1265,7 +1265,8 @@ impl Connection {
         loop {
             let query_response = self
                 .send_request(&batch_frame, true, batch.config.tracing, None)
-                .await?;
+                .await
+                .map_err(UserRequestError::from)?;
 
             return match query_response.response {
                 Response::Error(err) => match err.error {

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -657,7 +657,6 @@ where
         let query_response =
             (self.page_query)(connection.clone(), consistency, self.paging_state.clone())
                 .await
-                .map_err(Into::into)
                 .and_then(QueryResponse::into_non_error_query_response);
 
         let elapsed = query_start.elapsed();
@@ -707,6 +706,7 @@ where
                 Ok(ControlFlow::Continue(()))
             }
             Err(err) => {
+                let err = err.into();
                 self.metrics.inc_failed_paged_queries();
                 self.execution_profile
                     .load_balancing_policy

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -535,7 +535,7 @@ where
                         error = %e,
                         "Choosing connection failed"
                     );
-                    last_error = e;
+                    last_error = e.into();
                     // Broken connection doesn't count as a failed query, don't log in metrics
                     continue 'nodes_in_plan;
                 }

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use scylla_cql::errors::UserRequestError;
 use scylla_cql::frame::response::NonErrorResponse;
 use scylla_cql::types::serialize::row::SerializedValues;
 use std::result::Result;
@@ -479,7 +480,7 @@ struct RowIteratorWorker<'a, QueryFunc, SpanCreatorFunc> {
     sender: ProvingSender<Result<ReceivedPage, QueryError>>,
 
     // Closure used to perform a single page query
-    // AsyncFn(Arc<Connection>, Option<Arc<[u8]>>) -> Result<QueryResponse, QueryError>
+    // AsyncFn(Arc<Connection>, Option<Arc<[u8]>>) -> Result<QueryResponse, UserRequestError>
     page_query: QueryFunc,
 
     statement_info: RoutingInfo<'a>,
@@ -502,7 +503,7 @@ struct RowIteratorWorker<'a, QueryFunc, SpanCreatorFunc> {
 impl<QueryFunc, QueryFut, SpanCreator> RowIteratorWorker<'_, QueryFunc, SpanCreator>
 where
     QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
-    QueryFut: Future<Output = Result<QueryResponse, QueryError>>,
+    QueryFut: Future<Output = Result<QueryResponse, UserRequestError>>,
     SpanCreator: Fn() -> RequestSpan,
 {
     // Contract: this function MUST send at least one item through self.sender
@@ -656,6 +657,7 @@ where
         let query_response =
             (self.page_query)(connection.clone(), consistency, self.paging_state.clone())
                 .await
+                .map_err(Into::into)
                 .and_then(QueryResponse::into_non_error_query_response);
 
         let elapsed = query_start.elapsed();
@@ -826,7 +828,7 @@ struct SingleConnectionRowIteratorWorker<Fetcher> {
 impl<Fetcher, FetchFut> SingleConnectionRowIteratorWorker<Fetcher>
 where
     Fetcher: Fn(PagingState) -> FetchFut + Send + Sync,
-    FetchFut: Future<Output = Result<QueryResponse, QueryError>> + Send,
+    FetchFut: Future<Output = Result<QueryResponse, UserRequestError>> + Send,
 {
     async fn work(mut self) -> PageSendAttemptedProof {
         match self.do_work().await {

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2848,7 +2848,8 @@ mod latency_awareness {
 
                 // "slow" errors, i.e. ones that are returned after considerable time of query being run
                 QueryError::DbError(_, _)
-                | QueryError::CqlResponseParseError(_)
+                | QueryError::CqlResultParseError(_)
+                | QueryError::CqlErrorParseError(_)
                 | QueryError::InvalidMessage(_)
                 | QueryError::IoError(_)
                 | QueryError::ProtocolError(_)

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2838,6 +2838,7 @@ mod latency_awareness {
                 // "fast" errors, i.e. ones that are returned quickly after the query begins
                 QueryError::BadQuery(_)
                 | QueryError::BrokenConnection(_)
+                | QueryError::ConnectionPoolError(_)
                 | QueryError::TooManyOrphanedStreamIds(_)
                 | QueryError::UnableToAllocStreamId
                 | QueryError::DbError(DbError::IsBootstrapping, _)

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2843,7 +2843,6 @@ mod latency_awareness {
                 | QueryError::DbError(DbError::IsBootstrapping, _)
                 | QueryError::DbError(DbError::Unavailable { .. }, _)
                 | QueryError::DbError(DbError::Unprepared { .. }, _)
-                | QueryError::TranslationError(_)
                 | QueryError::DbError(DbError::Overloaded { .. }, _)
                 | QueryError::DbError(DbError::RateLimitReached { .. }, _) => false,
 

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2837,6 +2837,7 @@ mod latency_awareness {
             match error {
                 // "fast" errors, i.e. ones that are returned quickly after the query begins
                 QueryError::BadQuery(_)
+                | QueryError::BrokenConnection(_)
                 | QueryError::TooManyOrphanedStreamIds(_)
                 | QueryError::UnableToAllocStreamId
                 | QueryError::DbError(DbError::IsBootstrapping, _)

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -1,3 +1,4 @@
+use scylla_cql::errors::ConnectionPoolError;
 use tokio::net::lookup_host;
 use tracing::warn;
 use uuid::Uuid;
@@ -157,7 +158,7 @@ impl Node {
     pub(crate) async fn connection_for_shard(
         &self,
         shard: Shard,
-    ) -> Result<Arc<Connection>, std::io::Error> {
+    ) -> Result<Arc<Connection>, ConnectionPoolError> {
         self.get_pool()?.connection_for_shard(shard)
     }
 
@@ -186,7 +187,9 @@ impl Node {
         Ok(())
     }
 
-    pub(crate) fn get_working_connections(&self) -> Result<Vec<Arc<Connection>>, std::io::Error> {
+    pub(crate) fn get_working_connections(
+        &self,
+    ) -> Result<Vec<Arc<Connection>>, ConnectionPoolError> {
         self.get_pool()?.get_working_connections()
     }
 
@@ -196,14 +199,10 @@ impl Node {
         }
     }
 
-    fn get_pool(&self) -> Result<&NodeConnectionPool, std::io::Error> {
-        self.pool.as_ref().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "No connections in the pool: the node has been disabled \
-                by the host filter",
-            )
-        })
+    fn get_pool(&self) -> Result<&NodeConnectionPool, ConnectionPoolError> {
+        self.pool
+            .as_ref()
+            .ok_or(ConnectionPoolError::NodeDisabledByHostFilter)
     }
 }
 

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -157,7 +157,7 @@ impl Node {
     pub(crate) async fn connection_for_shard(
         &self,
         shard: Shard,
-    ) -> Result<Arc<Connection>, QueryError> {
+    ) -> Result<Arc<Connection>, std::io::Error> {
         self.get_pool()?.connection_for_shard(shard)
     }
 
@@ -186,7 +186,7 @@ impl Node {
         Ok(())
     }
 
-    pub(crate) fn get_working_connections(&self) -> Result<Vec<Arc<Connection>>, QueryError> {
+    pub(crate) fn get_working_connections(&self) -> Result<Vec<Arc<Connection>>, std::io::Error> {
         self.get_pool()?.get_working_connections()
     }
 
@@ -196,13 +196,13 @@ impl Node {
         }
     }
 
-    fn get_pool(&self) -> Result<&NodeConnectionPool, QueryError> {
+    fn get_pool(&self) -> Result<&NodeConnectionPool, std::io::Error> {
         self.pool.as_ref().ok_or_else(|| {
-            QueryError::IoError(Arc::new(std::io::Error::new(
+            std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "No connections in the pool: the node has been disabled \
                 by the host filter",
-            )))
+            )
         })
     }
 }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -76,7 +76,7 @@ pub use crate::transport::connection_pool::PoolSize;
 use crate::authentication::AuthenticatorProvider;
 #[cfg(feature = "ssl")]
 use openssl::ssl::SslContext;
-use scylla_cql::errors::BadQuery;
+use scylla_cql::errors::{BadQuery, UserRequestError};
 
 pub(crate) const TABLET_CHANNEL_SIZE: usize = 8192;
 
@@ -975,7 +975,7 @@ impl Session {
 
         // Safety: there is at least one node in the cluster, and `Cluster::iter_working_connections()`
         // returns either an error or an iterator with at least one connection, so there will be at least one result.
-        let first_ok: Result<PreparedStatement, QueryError> =
+        let first_ok: Result<PreparedStatement, UserRequestError> =
             results.by_ref().find_or_first(Result::is_ok).unwrap();
         let mut prepared: PreparedStatement = first_ok?;
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -773,8 +773,8 @@ impl Session {
                                     paging_state_ref.clone(),
                                 )
                                 .await
-                                .map_err(Into::into)
                                 .and_then(QueryResponse::into_non_error_query_response)
+                                .map_err(Into::into)
                         } else {
                             let prepared = connection.prepare(query_ref).await?;
                             let serialized = prepared.serialize_values(values_ref)?;
@@ -789,8 +789,8 @@ impl Session {
                                     paging_state_ref.clone(),
                                 )
                                 .await
-                                .map_err(Into::into)
                                 .and_then(QueryResponse::into_non_error_query_response)
+                                .map_err(Into::into)
                         }
                     }
                 },
@@ -1228,8 +1228,8 @@ impl Session {
                                 paging_state_ref.clone(),
                             )
                             .await
-                            .map_err(Into::into)
                             .and_then(QueryResponse::into_non_error_query_response)
+                            .map_err(Into::into)
                     }
                 },
                 &span,

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1873,7 +1873,7 @@ impl Session {
                             error = %e,
                             "Choosing connection failed"
                         );
-                        last_error = Some(e);
+                        last_error = Some(e.into());
                         // Broken connection doesn't count as a failed query, don't log in metrics
                         continue 'nodes_in_plan;
                     }

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -773,6 +773,7 @@ impl Session {
                                     paging_state_ref.clone(),
                                 )
                                 .await
+                                .map_err(Into::into)
                                 .and_then(QueryResponse::into_non_error_query_response)
                         } else {
                             let prepared = connection.prepare(query_ref).await?;
@@ -788,6 +789,7 @@ impl Session {
                                     paging_state_ref.clone(),
                                 )
                                 .await
+                                .map_err(Into::into)
                                 .and_then(QueryResponse::into_non_error_query_response)
                         }
                     }
@@ -1226,6 +1228,7 @@ impl Session {
                                 paging_state_ref.clone(),
                             )
                             .await
+                            .map_err(Into::into)
                             .and_then(QueryResponse::into_non_error_query_response)
                     }
                 },


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

# Motivation
My main motivation for this PR, was the @Lorak-mmk comment, that currently the `QueryError` contains a `CqlResponseParseError`. `CqlResponseParseError` contains variants which represent a parsing errors which SHOULD NOT appear when executing requests via user API e.g. `CqlAuthChallengeParseError`, which can only happen during connection setup (unless a protocol error appeared, and server sent us an incorrect response, with an incorrect type).

Since `QueryError` is abused everywhere, a lot of changes needed to be introduced before getting rid of the variants mentioned above. However, there are some positives, since we could address some other issues as well.

## BrokenConnectionError
One of the main entry points for a connection is a `Connection::router` function, which starts 4 main async tasks (reader, writer, keepaliver, orphaner). With current driver's design, if one of them fails, the whole connection is treated as broken, and closed. Before this PR, all of these tasks would return a QueryError, which is a really broad type destined for the users. It contains serialization errors, which cannot appear during connection's async tasks work. This is why I introduced a `BrokenConnectionError` type, returned if one of these 4 tasks fail.

In this PR, we perform an error transition refactor in two places:
- `PoolRefiller` <-> `Connection` layer
- `Session` (user) <-> `Connection` layer (addresses the issue mentioned in PR's motivation)

# PoolRefiller <-> Connection
There are some errors that can appear on a connection level which will not reach user's end. They are handled and logged by PoolRefiller of a corresponding node. This is why, it's a great place to introduce a new error type destined specifically for this case - `ConnectionError`.

The most important variant of this error is `ConnectionSetupRequestError` (with the type of the same name). Once again, the `CqlResponseParseError` contains some variants which are not applicable here - e.g. `CqlResultParseError`. I added more context for the errors that can appear during connection setup (STARTUP, OPTIONS, AUTH requests).

# Session <-> Connection
This is completely analogous to the above transition. We need to filter out some errors types which are not applicable in this case, and add some context to the errors. The most important error type here is `UserRequestError` which corresponds to the errors that can appear when executing one of PREPARE, QUERY, EXECUTE or BATCH requests.

# Transition error types
To achieve all the things listed above, we also needed to introduce some driver's internal transition error types, such as `RequestError` or `ResponseParseError` They were created only to narrow the error types of some driver's internal functions.

 
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
