### PR TITLE
docs: Eradicate unpaged SELECTs and warn about their drawbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ The [documentation book](https://rust-driver.docs.scylladb.com/stable/index.html
 
 ## Examples
 ```rust
+use futures::TryStreamExt;
+
 let uri = "127.0.0.1:9042";
 
 let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-let result = session.query_unpaged("SELECT a, b, c FROM ks.t", &[]).await?;
-let mut iter = result.rows_typed::<(i32, i32, String)>()?;
-while let Some((a, b, c)) = iter.next().transpose()? {
+let raw_iter = session.query_iter("SELECT a, b, c FROM ks.t", &[]).await?;
+let mut iter = raw_iter.into_typed::<(i32, i32, String)>();
+while let Some((a, b, c)) = iter.try_next().await? {
     println!("a, b, c: {}, {}, {}", a, b, c);
 }
 ```

--- a/docs/source/data-types/collections.md
+++ b/docs/source/data-types/collections.md
@@ -5,10 +5,11 @@
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a list of ints into the table
 let my_list: Vec<i32> = vec![1, 2, 3, 4, 5];
@@ -17,9 +18,8 @@ session
     .await?;
 
 // Read a list of ints from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(Vec<i32>,)>()?;
-while let Some((list_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[]).await?.into_typed::<(Vec<i32>,)>();
+while let Some((list_value,)) = iter.try_next().await? {
     println!("{:?}", list_value);
 }
 # Ok(())
@@ -31,10 +31,11 @@ while let Some((list_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a set of ints into the table
 let my_set: Vec<i32> = vec![1, 2, 3, 4, 5];
@@ -43,10 +44,11 @@ session
     .await?;
 
 // Read a set of ints from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(Vec<i32>,)>()?;
-while let Some((list_value,)) = iter.next().transpose()? {
-    println!("{:?}", list_value);
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(Vec<i32>,)>();
+while let Some((set_value,)) = iter.try_next().await? {
+    println!("{:?}", set_value);
 }
 # Ok(())
 # }
@@ -54,10 +56,11 @@ while let Some((list_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 use std::collections::HashSet;
 
 // Insert a set of ints into the table
@@ -67,10 +70,11 @@ session
     .await?;
 
 // Read a set of ints from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(HashSet<i32>,)>()?;
-while let Some((list_value,)) = iter.next().transpose()? {
-    println!("{:?}", list_value);
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(HashSet<i32>,)>();
+while let Some((set_value,)) = iter.try_next().await? {
+    println!("{:?}", set_value);
 }
 # Ok(())
 # }
@@ -78,10 +82,11 @@ while let Some((list_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 use std::collections::BTreeSet;
 
 // Insert a set of ints into the table
@@ -91,10 +96,11 @@ session
     .await?;
 
 // Read a set of ints from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(BTreeSet<i32>,)>()?;
-while let Some((list_value,)) = iter.next().transpose()? {
-    println!("{:?}", list_value);
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(BTreeSet<i32>,)>();
+while let Some((set_value,)) = iter.try_next().await? {
+    println!("{:?}", set_value);
 }
 # Ok(())
 # }
@@ -105,10 +111,11 @@ while let Some((list_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 use std::collections::HashMap;
 
 // Insert a map of text and int into the table
@@ -120,9 +127,10 @@ session
     .await?;
 
 // Read a map from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(HashMap<String, i32>,)>()?;
-while let Some((map_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(HashMap<String, i32>,)>();
+while let Some((map_value,)) = iter.try_next().await? {
     println!("{:?}", map_value);
 }
 # Ok(())
@@ -131,10 +139,11 @@ while let Some((map_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 use std::collections::BTreeMap;
 
 // Insert a map of text and int into the table
@@ -146,9 +155,10 @@ session
     .await?;
 
 // Read a map from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(BTreeMap<String, i32>,)>()?;
-while let Some((map_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(BTreeMap<String, i32>,)>();
+while let Some((map_value,)) = iter.try_next().await? {
     println!("{:?}", map_value);
 }
 # Ok(())

--- a/docs/source/data-types/duration.md
+++ b/docs/source/data-types/duration.md
@@ -3,10 +3,11 @@
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 use scylla::frame::value::CqlDuration;
 
 // Insert some duration into the table
@@ -16,9 +17,10 @@ session
     .await?;
 
 // Read duration from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(CqlDuration,)>()?;
-while let Some((duration_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(CqlDuration,)>();
+while let Some((duration_value,)) = iter.try_next().await? {
     println!("{:?}", duration_value);
 }
 # Ok(())

--- a/docs/source/data-types/primitive.md
+++ b/docs/source/data-types/primitive.md
@@ -6,10 +6,11 @@
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a bool into the table
 let to_insert: bool = true;
@@ -18,10 +19,11 @@ session
     .await?;
 
 // Read a bool from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(bool,)>()?;
-while let Some((bool_value,)) = iter.next().transpose()? {
-    println!("{}", bool_value);
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(bool,)>();
+while let Some((bool_value,)) = iter.try_next().await? {
+    println!("{:?}", bool_value);
 }
 # Ok(())
 # }
@@ -33,10 +35,11 @@ while let Some((bool_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a tinyint into the table
 let to_insert: i8 = 123;
@@ -45,9 +48,10 @@ session
     .await?;
 
 // Read a tinyint from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(i8,)>()?;
-while let Some((tinyint_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(i8,)>();
+while let Some((tinyint_value,)) = iter.try_next().await? {
     println!("{:?}", tinyint_value);
 }
 # Ok(())
@@ -60,10 +64,11 @@ while let Some((tinyint_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a smallint into the table
 let to_insert: i16 = 12345;
@@ -72,9 +77,10 @@ session
     .await?;
 
 // Read a smallint from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(i16,)>()?;
-while let Some((smallint_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(i16,)>();
+while let Some((smallint_value,)) = iter.try_next().await? {
     println!("{}", smallint_value);
 }
 # Ok(())
@@ -87,10 +93,11 @@ while let Some((smallint_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert an int into the table
 let to_insert: i32 = 12345;
@@ -99,9 +106,10 @@ session
     .await?;
 
 // Read an int from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(i32,)>()?;
-while let Some((int_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(i32,)>();
+while let Some((int_value,)) = iter.try_next().await? {
     println!("{}", int_value);
 }
 # Ok(())
@@ -114,10 +122,11 @@ while let Some((int_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a bigint into the table
 let to_insert: i64 = 12345;
@@ -126,9 +135,10 @@ session
     .await?;
 
 // Read a bigint from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(i64,)>()?;
-while let Some((bigint_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(i64,)>();
+while let Some((bigint_value,)) = iter.try_next().await? {
     println!("{:?}", bigint_value);
 }
 # Ok(())
@@ -141,10 +151,11 @@ while let Some((bigint_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a float into the table
 let to_insert: f32 = 123.0;
@@ -153,9 +164,10 @@ session
     .await?;
 
 // Read a float from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(f32,)>()?;
-while let Some((float_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(f32,)>();
+while let Some((float_value,)) = iter.try_next().await? {
     println!("{:?}", float_value);
 }
 # Ok(())
@@ -168,10 +180,11 @@ while let Some((float_value,)) = iter.next().transpose()? {
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert a double into the table
 let to_insert: f64 = 12345.0;
@@ -180,9 +193,10 @@ session
     .await?;
 
 // Read a double from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(f64,)>()?;
-while let Some((double_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(f64,)>();
+while let Some((double_value,)) = iter.try_next().await? {
     println!("{:?}", double_value);
 }
 # Ok(())

--- a/docs/source/data-types/text.md
+++ b/docs/source/data-types/text.md
@@ -3,10 +3,11 @@
 
 ```rust
 # extern crate scylla;
+# extern crate futures;
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
+use futures::TryStreamExt;
 
 // Insert some text into the table as a &str
 let to_insert_str: &str = "abcdef";
@@ -21,9 +22,10 @@ session
     .await?;
 
 // Read ascii/text/varchar from the table
-let result = session.query_unpaged("SELECT a FROM keyspace.table", &[]).await?;
-let mut iter = result.rows_typed::<(String,)>()?;
-while let Some((text_value,)) = iter.next().transpose()? {
+let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .into_typed::<(String,)>();
+while let Some((text_value,)) = iter.try_next().await? {
     println!("{}", text_value);
 }
 # Ok(())

--- a/docs/source/queries/paged.md
+++ b/docs/source/queries/paged.md
@@ -80,7 +80,7 @@ On a `Query`:
 use scylla::query::Query;
 
 let mut query: Query = Query::new("SELECT a, b FROM ks.t");
-query.set_page_size(16.try_into().unwrap());
+query.set_page_size(16);
 
 let _ = session.query_iter(query, &[]).await?; // ...
 # Ok(())
@@ -99,7 +99,7 @@ let mut prepared: PreparedStatement = session
     .prepare("SELECT a, b FROM ks.t")
     .await?;
 
-prepared.set_page_size(16.try_into().unwrap());
+prepared.set_page_size(16);
 
 let _ = session.execute_iter(prepared, &[]).await?; // ...
 # Ok(())
@@ -121,7 +121,7 @@ use scylla::query::Query;
 use scylla::statement::{PagingState, PagingStateResponse};
 use std::ops::ControlFlow;
 
-let paged_query = Query::new("SELECT a, b, c FROM ks.t").with_page_size(6.try_into().unwrap());
+let paged_query = Query::new("SELECT a, b, c FROM ks.t").with_page_size(6);
 
 let mut paging_state = PagingState::start();
 loop {
@@ -165,7 +165,7 @@ use scylla::statement::{PagingState, PagingStateResponse};
 use std::ops::ControlFlow;
 
 let paged_prepared = session
-    .prepare(Query::new("SELECT a, b, c FROM ks.t").with_page_size(7.try_into().unwrap()))
+    .prepare(Query::new("SELECT a, b, c FROM ks.t").with_page_size(7))
     .await?;
 
 let mut paging_state = PagingState::start();

--- a/docs/source/queries/paged.md
+++ b/docs/source/queries/paged.md
@@ -2,9 +2,31 @@
 Sometimes query results might be so big that one prefers not to fetch them all at once,
 e.g. to reduce latency and/or memory footprint.
 Paged queries allow to receive the whole result page by page, with a configurable page size.
+In fact, most SELECTs queries should be done with paging, to avoid big load on cluster and large memory footprint.
 
-`Session::query_iter` and `Session::execute_iter` take a [simple query](simple.md)
-or a [prepared query](prepared.md) and return an `async` iterator over result `Rows`.
+> ***Warning***\
+> Issuing unpaged SELECTs (`Session::query_unpaged` or `Session::execute_unpaged`)
+> may have dramatic performance consequences! **BEWARE!**\
+> If the result set is big (or, e.g., there are a lot of tombstones), those atrocities can happen:
+> - cluster may experience high load,
+> - queries may time out,
+> - the driver may devour a lot of RAM,
+> - latency will likely spike.
+>
+> Stay safe. Page your SELECTs.
+
+## `RowIterator`
+
+The automated way to achieve that is `RowIterator`. It always fetches and enables access to one page,
+while prefetching the next one. This limits latency and is a convenient abstraction.
+
+> ***Note***\
+> `RowIterator` is quite heavy machinery, introducing considerable overhead. Therefore,
+> don't use it for statements that do not benefit from paging. In particular, avoid using it
+> for non-SELECTs.
+
+On API level, `Session::query_iter` and `Session::execute_iter` take a [simple query](simple.md)
+or a [prepared query](prepared.md), respectively, and return an `async` iterator over result `Rows`.
 
 > ***Warning***\
 > In case of unprepared variant (`Session::query_iter`) if the values are not empty
@@ -22,7 +44,6 @@ Use `query_iter` to perform a [simple query](simple.md) with paging:
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
 use futures::stream::StreamExt;
 
 let mut rows_stream = session
@@ -45,7 +66,6 @@ Use `execute_iter` to perform a [prepared query](prepared.md) with paging:
 # use scylla::Session;
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
-use scylla::IntoTypedRows;
 use scylla::prepared_statement::PreparedStatement;
 use futures::stream::StreamExt;
 
@@ -106,10 +126,10 @@ let _ = session.execute_iter(prepared, &[]).await?; // ...
 # }
 ```
 
-### Passing the paging state manually
-It's possible to fetch a single page from the table, extract the paging state
-from the result and manually pass it to the next query. That way, the next
-query will start fetching the results from where the previous one left off.
+## Manual paging
+It's possible to fetch a single page from the table, and manually pass paging state
+to the next query. That way, the next query will start fetching the results
+from where the previous one left off.
 
 On a `Query`:
 ```rust
@@ -197,5 +217,18 @@ loop {
 ```
 
 ### Performance
-Performance is the same as in non-paged variants.\
 For the best performance use [prepared queries](prepared.md).
+See [query types overview](queries.md).
+
+## Best practices
+
+| Query result fetching   | Unpaged                                                                                                                 | Paged manually                                                                                       | Paged automatically                                                                               |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| Exposed Session API     | `{query,execute}_unpaged`                                                                                               | `{query,execute}_single_page`                                                                        | `{query,execute}_iter`                                                                            |
+| Working                 | get all results in a single CQL frame, into a single Rust struct                                                        | get one page of results in a single CQL frame, into a single Rust struct                             | upon high-level iteration, fetch consecutive CQL frames and transparently iterate over their rows |
+| Cluster load            | potentially **HIGH** for large results, beware!                                                                         | normal                                                                                               | normal                                                                                            |
+| Driver overhead         | low - simple frame fetch                                                                                                | low - simple frame fetch                                                                             | considerable - `RowIteratorWorker` is a separate tokio task                                       |
+| Feature limitations     | none                                                                                                                    | none                                                                                                 | speculative execution not supported                                                               |
+| Driver memory footprint | potentially **BIG** - all results have to be stored at once!                                                            | small - only one page stored at a time                                                               | small - at most constant number of pages stored at a time                                         |
+| Latency                 | potentially **BIG** - all results have to be generated at once!                                                         | considerable on page boundary - new page needs to be fetched                                         | small - next page is always pre-fetched in background                                             |
+| Suitable operations     | - in general: operations with empty result set (non-SELECTs)</br> - as possible optimisation: SELECTs with LIMIT clause | - for advanced users who prefer more control over paging, with less overhead of `RowIteratorWorker`  | - in general: all SELECTs                                                                         |

--- a/docs/source/queries/queries.md
+++ b/docs/source/queries/queries.md
@@ -13,7 +13,8 @@ This driver supports all query types available in Scylla:
     * Run multiple queries at once
     * Can be prepared for better performance and load balancing
 * [Paged queries](paged.md)
-    * Allows to read result in multiple pages when it doesn't fit in a single response
+    * Allows to read result in multiple pages when it might be so big that one
+      prefers not to fetch it all at once
     * Can be prepared for better performance and load balancing
 
 Additionally there is special functionality to enable `USE KEYSPACE` queries:

--- a/docs/source/queries/queries.md
+++ b/docs/source/queries/queries.md
@@ -1,26 +1,95 @@
-# Making queries
+# Making queries - best practices
 
-This driver supports all query types available in Scylla:
-* [Simple queries](simple.md)
-    * Easy to use
-    * Poor performance
-    * Primitive load balancing
-* [Prepared queries](prepared.md)
-    * Need to be prepared before use
-    * Fast
-    * Properly load balanced
-* [Batch statements](batch.md)
-    * Run multiple queries at once
-    * Can be prepared for better performance and load balancing
-* [Paged queries](paged.md)
-    * Allows to read result in multiple pages when it might be so big that one
-      prefers not to fetch it all at once
-    * Can be prepared for better performance and load balancing
+Driver supports all kinds of statements supported by ScyllaDB. The following tables aim to bridge between DB concepts and driver's API.
+They include recommendations on which API to use in what cases.
 
-Additionally there is special functionality to enable `USE KEYSPACE` queries:
-[USE keyspace](usekeyspace.md)
+## Kinds of CQL statements (from the CQL protocol point of view):
 
-Queries are fully asynchronous - you can run as many of them in parallel as you wish.
+| Kind of CQL statement | Single              | Batch                                    |
+|-----------------------|---------------------|------------------------------------------|
+| Prepared              | `PreparedStatement` | `Batch` filled with `PreparedStatement`s |
+| Unprepared            | `Query`             | `Batch` filled with `Query`s             |
+
+This is **NOT** strictly related to content of the CQL query string.
+
+> ***Interesting note***\
+> In fact, any kind of CQL statement could contain any CQL query string.
+> Yet, some of such combinations don't make sense and will be rejected by the DB.
+> For example, SELECTs in a Batch are nonsense.
+
+### [Unprepared](simple.md) vs [Prepared](prepared.md)
+
+> ***GOOD TO KNOW***\
+> Each time a statement is executed by sending a query string to the DB, it needs to be parsed. Driver does not parse CQL, therefore it sees query strings as opaque.\
+> There is an option to *prepare* a statement, i.e. parse it once by the DB and associate it with an ID. After preparation, it's enough that driver sends the ID
+> and the DB already knows what operation to perform - no more expensive parsing necessary! Moreover, upon preparation driver receives valuable data for load balancing,
+> enabling advanced load balancing (so better performance!) of all further executions of that prepared statement.\
+> ***Key take-over:*** always prepare statements that you are going to execute multiple times.
+
+| Statement comparison | Unprepared                                | Prepared                                                                                                        |
+|----------------------|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| Exposed Session API  | `query_*`                                 | `execute_*`                                                                                                     |
+| Usability            | execute CQL statement string directly     | need to be separately prepared before use, in-background repreparations if statement falls off the server cache |
+| Performance          | poor (statement parsed each time)         | good (statement parsed only upon preparation)                                                                   |
+| Load balancing       | primitive (random choice of a node/shard) | advanced (proper node/shard, optimisations for LWT statements)                                                  |
+| Suitable operations  | one-shot operations                       | repeated operations                                                                                             |
+
+> ***Warning***\
+> If a statement contains bind markers (`?`), then it needs some values to be passed along the statement string.
+> If a statement is prepared, the metadata received from the DB can be used to verify validity of passed bind values.
+> In case of unprepared statements, this metadata is missing and thus verification is not feasible.
+> This used to allow some silent bugs sneaking in in user applications.
+>
+> To prevent that, the driver will silently prepare every unprepared statement prior to its execution.
+> This has an overhead, which further lessens advantages of unprepared statements over prepared statements.
+>
+> That behaviour is especially important in batches:
+> For each simple statement with a non-empty list of values in the batch,
+> the driver will send a prepare request, and it will be done **sequentially**!
+> Results of preparation are not cached between `Session::batch` calls.
+> Therefore, consider preparing the statements before putting them into the batch.
+
+### Single vs [Batch](batch.md)
+
+| Statement comparison | Single                                                | Batch                                                                                                                                                                                |
+|----------------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Exposed Session API  | `query_*`, `execute_*`                                | `batch`                                                                                                                                                                              |
+| Usability            | simple setup                                          | need to aggregate statements and binding values to each is more cumbersome                                                                                                           |
+| Performance          | good (DB is optimised for handling single statements) | good for small batches, may be worse for larger (also: higher risk of request timeout due to big portion of work)                                                                    |
+| Load balancing       | advanced if prepared, else primitive                  | advanced if prepared **and ALL** statements in the batch target the same partition, else primitive                                                                                   |
+| Suitable operations  | most of operations                                    | - a list of operations that needs to be executed atomically (batch LightWeight Transaction)</br> - a batch of operations targetting the same partition (as an advanced optimisation) |
+
+## CQL statements - operations (based on what the CQL string contains):
+
+| CQL data manipulation statement                | Recommended statement kind                                                                                                               | Recommended Session operation                                                                               |
+|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| SELECT                                         | `PreparedStatement` if repeated, `Query` if once                                                                                         | `{query,execute}_iter` (or `{query,execute}_single_page` in a manual loop for performance / more control)   |
+| INSERT, UPDATE                                 | `PreparedStatement` if repeated, `Query` if once, `Batch` if multiple statements are to be executed atomically (LightWeight Transaction) | `{query,execute}_unpaged` (paging is irrelevant, because the result set of such operation is empty)         |
+| CREATE/DROP {KEYSPACE, TABLE, TYPE, INDEX,...} | `Query`, `Batch` if multiple statements are to be executed atomically (LightWeight Transaction)                                          | `query_unpaged` (paging is irrelevant, because the result set of such operation is empty)                   |
+
+### [Paged](paged.md) vs Unpaged query
+
+> ***GOOD TO KNOW***\
+> SELECT statements return a [result set](result.md), possibly a large one. Therefore, paging is available to fetch it in chunks, relieving load on cluster and lowering latency.\
+> ***Key take-overs:***\
+> For SELECTs you had better **avoid unpaged queries**.\
+> For non-SELECTs, unpaged API is preferred.
+
+| Query result fetching | Unpaged                                                                                                                 | Paged                                                                                                                                                                |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Exposed Session API   | `{query,execute}_unpaged`                                                                                               | `{query,execute}_single_page`, `{query,execute}_iter`                                                                                                                |
+| Usability             | get all results in a single CQL frame, so into a [single Rust struct](result.md)                                        | need to fetch multiple CQL frames and iterate over them - using driver's abstractions (`{query,execute}_iter`) or manually (`{query,execute}_single_page` in a loop) |
+| Performance           | - for large results, puts **high load on the cluster**</br> - for small results, the same as paged                      | - for large results, relieves the cluster</br> - for small results, the same as unpaged                                                                              |
+| Memory footprint      | potentially big - all results have to be stored at once                                                                 | small - at most constant number of pages are stored by the driver at the same time                                                                                   |
+| Latency               | potentially big - all results have to be generated at once                                                              | small - at most one chunk of data must be generated at once, so latency of each chunk is small                                                                       |
+| Suitable operations   | - in general: operations with empty result set (non-SELECTs)</br> - as possible optimisation: SELECTs with LIMIT clause | - in general: all SELECTs                                                                                                                                            |
+
+For more detailed comparison and more best practices, see [doc page about paging](paged.md).
+
+### Queries are fully asynchronous - you can run as many of them in parallel as you wish.
+
+## `USE KEYSPACE`:
+There is a special functionality to enable [USE keyspace](usekeyspace.md).
 
 ```{eval-rst}
 .. toctree::

--- a/docs/source/queries/result.md
+++ b/docs/source/queries/result.md
@@ -3,6 +3,22 @@
 `Session::query_unpaged`, `Session::query_single_page`, `Session::execute_unpaged` and `Session::execute_single_page`
 return a `QueryResult` with rows represented as `Option<Vec<Row>>`.
 
+> ***Note***\
+> Using unpaged queries for SELECTs is discouraged in general.
+> Query results may be so big that it is not preferable to fetch them all at once.
+> Even with small results, if there are a lot of tombstones, then there can be similar bad consequences.
+> However, `query_unpaged` will return all results in one, possibly giant, piece
+> (unless a timeout occurs due to high load incurred by the cluster).
+> This:
+> - increases latency,
+> - has large memory footprint,
+> - puts high load on the cluster,
+> - is more likely to time out (because big work takes more time than little work,
+>   and returning one large piece of data is more work than returning one chunk of data).
+
+> To sum up, **for SELECTs** (especially those that may return a lot of data) **prefer paged queries**,
+> e.g. with `Session::query_iter()` (see [Paged queries](paged.md)).
+
 ### Basic representation
 `Row` is a basic representation of a received row. It can be used by itself, but it's a bit awkward to use:
 ```rust


### PR DESCRIPTION
Follow-up of #1061.

# Motivation

Unpaged SELECTs should be discouraged due to the following drawbacks:
> However, `query_unpaged` will return all results in one, possibly giant, piece
> (unless a timeout occurs due to high load incurred by the cluster).
> This:
> - increases latency,
> - has large memory footprint,
> - puts high load on the cluster,
> - is more likely to time out (because big work takes more time than little work,
>   and returning one large piece of data is more work than returning one chunk of data).

# What's done

- the above caveat is added in the documentation book,
- existing examples are modified to use `query_iter` instead,
- giant bonus: a broad overview over CQL statement kinds is added, together with best practices wrt preparing, batching and paging.

## Note to reviewers

Please make sure (by reading both crate docs and the docs book) that in all places it is clear enough that SELECTs by default should be done using `query_iter` rather than `query_unpaged`, and why so.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
