### PR TITLE
examples: replace `query_unpaged` for SELECT queries

### DIFF
--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use futures::TryStreamExt;
 use scylla::transport::session::Session;
 use scylla::SessionBuilder;
 use std::env;
@@ -86,11 +87,11 @@ async fn main() -> Result<()> {
         .await?;
 
     // Rows can be parsed as tuples
-    let result = session
-        .query_unpaged("SELECT a, b, c FROM examples_ks.tls", &[])
-        .await?;
-    let mut iter = result.rows_typed::<(i32, i32, String)>()?;
-    while let Some((a, b, c)) = iter.next().transpose()? {
+    let mut iter = session
+        .query_iter("SELECT a, b, c FROM examples_ks.tls", &[])
+        .await?
+        .into_typed::<(i32, i32, String)>();
+    while let Some((a, b, c)) = iter.try_next().await? {
         println!("a, b, c: {}, {}, {}", a, b, c);
     }
 

--- a/examples/value_list.rs
+++ b/examples/value_list.rs
@@ -1,23 +1,23 @@
+use anyhow::Result;
 use scylla::{Session, SessionBuilder};
 use std::env;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
     println!("Connecting to {} ...", uri);
 
-    let session: Session = SessionBuilder::new().known_node(uri).build().await.unwrap();
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
-    session.query_unpaged("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await.unwrap();
+    session.query_unpaged("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
     session
         .query_unpaged(
             "CREATE TABLE IF NOT EXISTS examples_ks.my_type (k int, my text, primary key (k))",
             &[],
         )
-        .await
-        .unwrap();
+        .await?;
 
     #[derive(scylla::SerializeRow)]
     struct MyType<'a> {
@@ -35,8 +35,7 @@ async fn main() {
             "INSERT INTO examples_ks.my_type (k, my) VALUES (?, ?)",
             to_insert,
         )
-        .await
-        .unwrap();
+        .await?;
 
     // You can also use type generics:
     #[derive(scylla::SerializeRow)]
@@ -55,13 +54,13 @@ async fn main() {
             "INSERT INTO examples_ks.my_type (k, my) VALUES (?, ?)",
             to_insert_2,
         )
-        .await
-        .unwrap();
+        .await?;
 
     let q = session
         .query_unpaged("SELECT * FROM examples_ks.my_type", &[])
-        .await
-        .unwrap();
+        .await?;
 
     println!("Q: {:?}", q.rows);
+
+    Ok(())
 }


### PR DESCRIPTION
Follow-up of https://github.com/scylladb/scylla-rust-driver/pull/1068

In this PR we replace `query_unpaged` occurrences for SELECTs with either `query_iter`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
