### PR TITLE
Release 0.14

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1477,7 +1477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "sphinx-docs"
 description = "ScyllaDB Documentation"
-version = "0.13.2"
+version = "0.14"
 authors = ["ScyllaDB Documentation Contributors"]
 
 [tool.poetry.dependencies]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,14 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ['v0.12.0', 'v0.13.2']
+TAGS = ['v0.13.2', 'v0.14.0']
 BRANCHES = ['main']
 # Set the latest version.
-LATEST_VERSION = 'v0.13.2'
+LATEST_VERSION = 'v0.14.0'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['main']
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ['v0.12.0']
+DEPRECATED_VERSIONS = ['v0.13.2']
 
 # -- General configuration
 

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "0.13.2"
+scylla = "0.14"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "CQL data types and primitives, for interacting with Scylla."
 repository = "https://github.com/scylladb/scylla-rust-driver"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla-macros = { version = "0.5.0", path = "../scylla-macros" }
+scylla-macros = { version = "0.6.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 tokio = { version = "1.34", features = ["io-util", "time"] }

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "proc macros for scylla async CQL driver"
 repository = "https://github.com/scylladb/scylla-rust-driver"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "0.2.0", path = "../scylla-cql" }
+scylla-cql = { version = "0.3.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -41,7 +41,7 @@ full-serialization = [
 
 [dependencies]
 scylla-macros = { version = "0.6.0", path = "../scylla-macros" }
-scylla-cql = { version = "0.2.0", path = "../scylla-cql" }
+scylla-cql = { version = "0.3.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -40,7 +40,7 @@ full-serialization = [
 ]
 
 [dependencies]
-scylla-macros = { version = "0.5.0", path = "../scylla-macros" }
+scylla-macros = { version = "0.6.0", path = "../scylla-macros" }
 scylla-cql = { version = "0.2.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
Proposed release notes:
```
The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 0.14.0,
an asynchronous CQL driver for Rust, optimized for Scylla, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 2.103k downloads on crates!
- over 556 GitHub stars!

## Changes

**API cleanups / breaking changes:**
- Our session & paging API was revamped so that it is more intuitive and robust. Now the type of the query (paged / unpaged) is tied to the method used to execute it (`execute_unpaged` / `execute_single_page` / `execute_iter`) rather than the page size associated with the statement object. Other changes include ([#1061](https://github.com/scylladb/scylla-rust-driver/pull/1061)):
	- Introduced strongly typed paging state instead of using `Bytes`.
	- Paging state is explicitly returned from `execute_single_page` instead of being a field in `QueryResult`.
	- Made `page_size` on the statements mandatory and providing the default value.
	- Updated our docs and examples to point users towards paged queries and explaining the issues with unpaged SELECTs. ([#1069](https://github.com/scylladb/scylla-rust-driver/pull/1069), [#1068](https://github.com/scylladb/scylla-rust-driver/pull/1068))
- Trait `SerializeCql` was renamed to `SerializeValue` because old name turned out to be confusing for users. ([#1000](https://github.com/scylladb/scylla-rust-driver/pull/1000))
- Features `chrono`, `time` and `secret` were renamed to `chrono-04`, `time-03` and `secrecy-08` to allow us to support new major versions of those libraries in the future. ([#939](https://github.com/scylladb/scylla-rust-driver/pull/939))
- Some of our error types were restructured to be more strongly typed (instead of just containing a string) and better reflect the conditions that they appear in. This work will be continued in 0.15. ([#1017](https://github.com/scylladb/scylla-rust-driver/pull/1017), [#1026](https://github.com/scylladb/scylla-rust-driver/pull/1026))
- `QueryResult.col_specs` was changed from being a field to a method in order to allow sharing it with `PreparedStatement`. ([#1065](https://github.com/scylladb/scylla-rust-driver/pull/1065))
- Moved `ResultMetadata.paging_state` field to `Rows.paging_state_response`. This is because paging state is something that changes on each paged request and should not be cached by `PreparedStatement`. ([#1065](https://github.com/scylladb/scylla-rust-driver/pull/1065))
- Some parts of our upcoming deserialization refactor were merged, resulting in very minor breaking changes in our error types. The rest of deserialization refactor is planned for 0.15. ([#970](https://github.com/scylladb/scylla-rust-driver/pull/970), [#1004](https://github.com/scylladb/scylla-rust-driver/pull/1004), [#1024](https://github.com/scylladb/scylla-rust-driver/pull/1024), [#1065](https://github.com/scylladb/scylla-rust-driver/pull/1065))

**New features / enhancements:**
- Values that driver sends to server to identify itself in `STARTUP` message (`DRIVER_NAME`, `DRIVER_VERSION`) can now be configured using new `SelfIdentity` API in `SessionBuilder`. ([#1039](https://github.com/scylladb/scylla-rust-driver/pull/1039))
- Replaced some `.unwrap()`s with `.expect()`s in the code generated by our derive macros. This is done to avoid angering `unwrap_used` clippy lint and to provide better error messages if those panics are ever triggered. ([#1055](https://github.com/scylladb/scylla-rust-driver/pull/1055))
https://github.com/scylladb/scylla-rust-driver/pull/1019

**Documentation:**
- Documentation about using timeuuid type was improved. ([#980](https://github.com/scylladb/scylla-rust-driver/pull/980))
- Improved documentation about `PreparedStatement`. ([#986](https://github.com/scylladb/scylla-rust-driver/pull/986))
- Updated Scylla Sphinx theme to version 1.7. ([#994](https://github.com/scylladb/scylla-rust-driver/pull/994))
- Added support for building documentation on Mac. ([#927](https://github.com/scylladb/scylla-rust-driver/pull/927))

**CI / developer tool improvements:**
- [#1011](https://github.com/scylladb/scylla-rust-driver/pull/1011) fixed some issue with tests and CI:
	- CI now prints versions of used Rust tools so we don't have to wonder what version is running on Github Actions runners again.
	- Disabled tablets in tests that use LWT because Scylla doesn't support it yet, and other minor tablet-related changes.
	- Restricted Tokio version because of regression when `[tokio::test]` is used with `[ntest::timeout]`
- [#1019](https://github.com/scylladb/scylla-rust-driver/pull/1019) removed aforementioned Tokio version bounds after regression was fixed there.
- Clippy lints that were previously skipped in two places are enabled again because Darling crate that was triggering them was fixed. ([#1036](https://github.com/scylladb/scylla-rust-driver/pull/1036))

**Others:**
- Updated maintainers list in `CONTRIBUTING.md`. ([#997](https://github.com/scylladb/scylla-rust-driver/pull/997))

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

| commits | author            |
|---------|-------------------|
| 163     | Wojciech Przytuła |
| 55      | Mikołaj Uzarski   |
| 17      | Karol Baryła      |
| 3       | David Garcia      |
| 2       | Lucas Kent        |
| 2       | Piotr Dulikowski  |
| 1       | Daniel Reis       |
| 1       | Dmitry Kropachev  |
| 1       | Kailokk           |
```