### PR TITLE
errors: fix driver's logic that bases on error variants returned from query execution

### DIFF
--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -785,9 +785,9 @@ pub(crate) fn use_keyspace_result(
         match result {
             Ok(()) => was_ok = true,
             Err(err) => match err {
-                QueryError::IoError(_)
-                | QueryError::BrokenConnection(_)
-                | QueryError::ConnectionPoolError(_) => broken_conn_error = Some(err),
+                QueryError::BrokenConnection(_) | QueryError::ConnectionPoolError(_) => {
+                    broken_conn_error = Some(err)
+                }
                 _ => return Err(err),
             },
         }

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -731,31 +731,7 @@ impl ClusterWorker {
         let use_keyspace_results: Vec<Result<(), QueryError>> =
             join_all(use_keyspace_futures).await;
 
-        // If there was at least one Ok and the rest were IoErrors we can return Ok
-        // keyspace name is correct and will be used on broken connection on the next reconnect
-
-        // If there were only IoErrors then return IoError
-        // If there was an error different than IoError return this error - something is wrong
-
-        let mut was_ok: bool = false;
-        let mut io_error: Option<Arc<std::io::Error>> = None;
-
-        for result in use_keyspace_results {
-            match result {
-                Ok(()) => was_ok = true,
-                Err(err) => match err {
-                    QueryError::IoError(io_err) => io_error = Some(io_err),
-                    _ => return Err(err),
-                },
-            }
-        }
-
-        if was_ok {
-            return Ok(());
-        }
-
-        // We can unwrap io_error because use_keyspace_futures must be nonempty
-        Err(QueryError::IoError(io_error.unwrap()))
+        use_keyspace_result(use_keyspace_results.into_iter())
     }
 
     async fn perform_refresh(&mut self) -> Result<(), QueryError> {
@@ -787,4 +763,38 @@ impl ClusterWorker {
     fn update_cluster_data(&mut self, new_cluster_data: Arc<ClusterData>) {
         self.cluster_data.store(new_cluster_data);
     }
+}
+
+/// Returns a result of use_keyspace operation, based on the query results
+/// returned from given node/connection.
+///
+/// This function assumes that `use_keyspace_results` iterator is NON-EMPTY!
+pub(crate) fn use_keyspace_result(
+    use_keyspace_results: impl Iterator<Item = Result<(), QueryError>>,
+) -> Result<(), QueryError> {
+    // If there was at least one Ok and the rest were IoErrors we can return Ok
+    // keyspace name is correct and will be used on broken connection on the next reconnect
+
+    // If there were only IoErrors then return IoError
+    // If there was an error different than IoError return this error - something is wrong
+
+    let mut was_ok: bool = false;
+    let mut io_error: Option<Arc<std::io::Error>> = None;
+
+    for result in use_keyspace_results {
+        match result {
+            Ok(()) => was_ok = true,
+            Err(err) => match err {
+                QueryError::IoError(io_err) => io_error = Some(io_err),
+                _ => return Err(err),
+            },
+        }
+    }
+
+    if was_ok {
+        return Ok(());
+    }
+
+    // We can unwrap io_error because use_keyspace_results must be nonempty
+    Err(QueryError::IoError(io_error.unwrap()))
 }

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -95,6 +95,8 @@ impl RetrySession for DowngradingConsistencyRetrySession {
             // Basic errors - there are some problems on this node
             // Retry on a different one if possible
             QueryError::IoError(_)
+            | QueryError::BrokenConnection(_)
+            | QueryError::ConnectionPoolError(_)
             | QueryError::DbError(DbError::Overloaded, _)
             | QueryError::DbError(DbError::ServerError, _)
             | QueryError::DbError(DbError::TruncateError, _) => {
@@ -186,7 +188,7 @@ mod tests {
     use bytes::Bytes;
 
     use crate::test_utils::setup_tracing;
-    use crate::transport::errors::BadQuery;
+    use crate::transport::errors::{BadQuery, BrokenConnectionErrorKind, ConnectionPoolError};
 
     use super::*;
 
@@ -328,6 +330,10 @@ mod tests {
             QueryError::DbError(DbError::Overloaded, String::new()),
             QueryError::DbError(DbError::TruncateError, String::new()),
             QueryError::DbError(DbError::ServerError, String::new()),
+            QueryError::BrokenConnection(
+                BrokenConnectionErrorKind::TooManyOrphanedStreamIds(5).into(),
+            ),
+            QueryError::ConnectionPoolError(ConnectionPoolError::Initializing),
             QueryError::IoError(Arc::new(std::io::Error::new(ErrorKind::Other, "test"))),
         ];
 

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -94,8 +94,7 @@ impl RetrySession for DowngradingConsistencyRetrySession {
         match query_info.error {
             // Basic errors - there are some problems on this node
             // Retry on a different one if possible
-            QueryError::IoError(_)
-            | QueryError::BrokenConnection(_)
+            QueryError::BrokenConnection(_)
             | QueryError::ConnectionPoolError(_)
             | QueryError::DbError(DbError::Overloaded, _)
             | QueryError::DbError(DbError::ServerError, _)
@@ -183,8 +182,6 @@ impl RetrySession for DowngradingConsistencyRetrySession {
 
 #[cfg(test)]
 mod tests {
-    use std::{io::ErrorKind, sync::Arc};
-
     use bytes::Bytes;
 
     use crate::test_utils::setup_tracing;
@@ -334,7 +331,6 @@ mod tests {
                 BrokenConnectionErrorKind::TooManyOrphanedStreamIds(5).into(),
             ),
             QueryError::ConnectionPoolError(ConnectionPoolError::Initializing),
-            QueryError::IoError(Arc::new(std::io::Error::new(ErrorKind::Other, "test"))),
         ];
 
         for &cl in CONSISTENCY_LEVELS {

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -52,10 +52,6 @@ pub enum QueryError {
     #[error("Failed to deserialize ERROR response: {0}")]
     CqlErrorParseError(#[from] CqlErrorParseError),
 
-    /// Input/Output error has occurred, connection broken etc.
-    #[error("IO Error: {0}")]
-    IoError(Arc<std::io::Error>),
-
     /// Selected node's connection pool is in invalid state.
     #[error("No connections in the pool: {0}")]
     ConnectionPoolError(#[from] ConnectionPoolError),
@@ -154,7 +150,6 @@ impl From<QueryError> for NewSessionError {
             QueryError::BadQuery(e) => NewSessionError::BadQuery(e),
             QueryError::CqlResultParseError(e) => NewSessionError::CqlResultParseError(e),
             QueryError::CqlErrorParseError(e) => NewSessionError::CqlErrorParseError(e),
-            QueryError::IoError(e) => NewSessionError::IoError(e),
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
             QueryError::InvalidMessage(m) => NewSessionError::InvalidMessage(m),
@@ -206,10 +201,6 @@ pub enum NewSessionError {
     /// Received an ERROR server response, but failed to deserialize it.
     #[error("Failed to deserialize ERROR response: {0}")]
     CqlErrorParseError(#[from] CqlErrorParseError),
-
-    /// Input/Output error has occurred, connection broken etc.
-    #[error("IO Error: {0}")]
-    IoError(Arc<std::io::Error>),
 
     /// Selected node's connection pool is in invalid state.
     #[error("No connections in the pool: {0}")]

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2855,7 +2855,6 @@ mod latency_awareness {
                 | QueryError::CqlResultParseError(_)
                 | QueryError::CqlErrorParseError(_)
                 | QueryError::InvalidMessage(_)
-                | QueryError::IoError(_)
                 | QueryError::ProtocolError(_)
                 | QueryError::TimeoutError
                 | QueryError::RequestTimeout(_) => true,

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -143,6 +143,8 @@ impl RetrySession for DefaultRetrySession {
             // Basic errors - there are some problems on this node
             // Retry on a different one if possible
             QueryError::IoError(_)
+            | QueryError::BrokenConnection(_)
+            | QueryError::ConnectionPoolError(_)
             | QueryError::DbError(DbError::Overloaded, _)
             | QueryError::DbError(DbError::ServerError, _)
             | QueryError::DbError(DbError::TruncateError, _) => {
@@ -221,7 +223,9 @@ mod tests {
     use super::{DefaultRetryPolicy, QueryInfo, RetryDecision, RetryPolicy};
     use crate::statement::Consistency;
     use crate::test_utils::setup_tracing;
-    use crate::transport::errors::{BadQuery, QueryError};
+    use crate::transport::errors::{
+        BadQuery, BrokenConnectionErrorKind, ConnectionPoolError, QueryError,
+    };
     use crate::transport::errors::{DbError, WriteType};
     use bytes::Bytes;
     use std::io::ErrorKind;
@@ -323,6 +327,10 @@ mod tests {
             QueryError::DbError(DbError::Overloaded, String::new()),
             QueryError::DbError(DbError::TruncateError, String::new()),
             QueryError::DbError(DbError::ServerError, String::new()),
+            QueryError::BrokenConnection(
+                BrokenConnectionErrorKind::TooManyOrphanedStreamIds(5).into(),
+            ),
+            QueryError::ConnectionPoolError(ConnectionPoolError::Initializing),
             QueryError::IoError(Arc::new(std::io::Error::new(ErrorKind::Other, "test"))),
         ];
 

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -142,8 +142,7 @@ impl RetrySession for DefaultRetrySession {
         match query_info.error {
             // Basic errors - there are some problems on this node
             // Retry on a different one if possible
-            QueryError::IoError(_)
-            | QueryError::BrokenConnection(_)
+            QueryError::BrokenConnection(_)
             | QueryError::ConnectionPoolError(_)
             | QueryError::DbError(DbError::Overloaded, _)
             | QueryError::DbError(DbError::ServerError, _)
@@ -228,8 +227,6 @@ mod tests {
     };
     use crate::transport::errors::{DbError, WriteType};
     use bytes::Bytes;
-    use std::io::ErrorKind;
-    use std::sync::Arc;
 
     fn make_query_info(error: &QueryError, is_idempotent: bool) -> QueryInfo<'_> {
         QueryInfo {
@@ -331,7 +328,6 @@ mod tests {
                 BrokenConnectionErrorKind::TooManyOrphanedStreamIds(5).into(),
             ),
             QueryError::ConnectionPoolError(ConnectionPoolError::Initializing),
-            QueryError::IoError(Arc::new(std::io::Error::new(ErrorKind::Other, "test"))),
         ];
 
         for error in idempotent_next_errors {

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -87,7 +87,6 @@ fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
         Ok(_) => false,
         Err(QueryError::BrokenConnection(_)) => true,
         Err(QueryError::ConnectionPoolError(_)) => true,
-        Err(QueryError::IoError(_)) => true,
         Err(QueryError::TimeoutError) => true,
         _ => false,
     }

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -85,6 +85,8 @@ impl SpeculativeExecutionPolicy for PercentileSpeculativeExecutionPolicy {
 fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
     match result {
         Ok(_) => false,
+        Err(QueryError::BrokenConnection(_)) => true,
+        Err(QueryError::ConnectionPoolError(_)) => true,
         Err(QueryError::IoError(_)) => true,
         Err(QueryError::TimeoutError) => true,
         _ => false,


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## Motivation
The error refactor that I'm currently working on, surprisingly changed driver's logic in some cases where the decision is made based on the error returned from query execution. There are three places where driver's logic was silently altered:
- retry_policy -> driver should retry execution in case of IoError
- use_keyspace -> if query execution returned IoErrors for some (not all) nodes/connections, these errors should be ignored
- speculative_exeuction -> driver should ignore IoErrors in this context

During error refactor I changed all places where `QueryError::IoError` was constructed. Now all of these IoErrors are represented as `BrokenConnectionError` and `ConnectionPoolError` types (and their variants). These types represent an error which implies that a corresponding connection/node is broken/unreachable.

## Changes
- Adjusted driver's logic in places mentioned above.
- Removed `[Query/NewSession]Error::IoError` variants altogether. They are no longer constructed anywhere - they were replaced by `ConnectionPoolError` and `BrokenConnection` variants during previous refactors.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
