### PR TITLE
Fix clippy `expect_used` complains for `derive(FromRow)` macro

### DIFF
--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -941,6 +941,11 @@ mod tests {
         );
     }
 
+    // Enabling `expect_used` clippy lint,
+    // validates that `derive(FromRow)` macro definition does do not violates such rule under the hood.
+    // Could be removed after such rule will be applied for the whole crate.
+    // <https://rust-lang.github.io/rust-clippy/master/index.html#/expect_used>
+    #[deny(clippy::expect_used)]
     #[test]
     fn struct_from_row() {
         #[derive(FromRow)]

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -941,6 +941,11 @@ mod tests {
         );
     }
 
+    // Enabling `expect_used` clippy lint,
+    // validates that `derive(FromRow)` macro definition does do not violates such rule under the hood.
+    // Could be removed after such rule will be applied for the whole crate.
+    // <https://rust-lang.github.io/rust-clippy/master/index.html#/expect_used>
+    #[deny(clippy::expect_used)]
     #[test]
     fn struct_from_row() {
         #[derive(FromRow)]
@@ -965,6 +970,11 @@ mod tests {
         assert_eq!(my_row.c, Some(vec![1, 2]));
     }
 
+    // Enabling `expect_used` clippy lint,
+    // validates that `derive(FromRow)` macro definition does do not violates such rule under the hood.
+    // Could be removed after such rule will be applied for the whole crate.
+    // <https://rust-lang.github.io/rust-clippy/master/index.html#/expect_used>
+    #[deny(clippy::expect_used)]
     #[test]
     fn struct_from_row_wrong_size() {
         #[derive(FromRow, PartialEq, Eq, Debug)]
@@ -1004,6 +1014,11 @@ mod tests {
         );
     }
 
+    // Enabling `expect_used` clippy lint,
+    // validates that `derive(FromRow)` macro definition does do not violates such rule under the hood.
+    // Could be removed after such rule will be applied for the whole crate.
+    // <https://rust-lang.github.io/rust-clippy/master/index.html#/expect_used>
+    #[deny(clippy::expect_used)]
     #[test]
     fn unnamed_struct_from_row() {
         #[derive(FromRow)]

--- a/scylla-cql/src/frame/response/cql_to_rust.rs
+++ b/scylla-cql/src/frame/response/cql_to_rust.rs
@@ -941,11 +941,6 @@ mod tests {
         );
     }
 
-    // Enabling `expect_used` clippy lint,
-    // validates that `derive(FromRow)` macro definition does do not violates such rule under the hood.
-    // Could be removed after such rule will be applied for the whole crate.
-    // <https://rust-lang.github.io/rust-clippy/master/index.html#/expect_used>
-    #[deny(clippy::expect_used)]
     #[test]
     fn struct_from_row() {
         #[derive(FromRow)]

--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -44,7 +44,7 @@ pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, 
                 let field_type = &field.ty;
 
                 quote_spanned! {field.span() =>
-                    {   
+                    {
                         // To avoid unnecessary copy `std::mem::take` is used.
                         // Using explicit indexing operation is safe because `row_columns` is an array and `col_ix` is a litteral.
                         // <https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/builtin/static.UNCONDITIONAL_PANIC.html>

--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -20,6 +20,7 @@ pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, 
 
                 quote_spanned! {field.span() =>
                     #field_name: {
+                        #[allow(clippy::expect_used)]
                         let (col_ix, col_value) = vals_iter
                             .next()
                             .expect("BUG: Size validated iterator did not contain the expected number of values"); 
@@ -44,6 +45,7 @@ pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, 
 
                 quote_spanned! {field.span() =>
                     {
+                        #[allow(clippy::expect_used)]
                         let (col_ix, col_value) = vals_iter
                             .next()
                             .expect("BUG: Size validated iterator did not contain the expected number of values"); 

--- a/scylla-macros/src/from_row.rs
+++ b/scylla-macros/src/from_row.rs
@@ -69,13 +69,11 @@ pub(crate) fn from_row_derive(tokens_input: TokenStream) -> Result<TokenStream, 
                 use #path::{CqlValue, FromCqlVal, FromRow, FromRowError};
                 use ::std::result::Result::{Ok, Err};
                 use ::std::convert::TryInto;
-                use ::std::clone::Clone;
-                use ::std::option::Option;
                 use ::std::iter::{Iterator, IntoIterator};
 
 
                 let row_columns_len = row.columns.len();
-                let mut row_columns: [Option<CqlValue>; #fields_count] = row.columns.try_into().map_err(|_| FromRowError::WrongRowSize {
+                let mut row_columns: [_; #fields_count] = row.columns.try_into().map_err(|_| FromRowError::WrongRowSize {
                     expected: #fields_count,
                         actual: row_columns_len,
                 })?;


### PR DESCRIPTION
# Description

Disables `clippy::expect_used` clippy rule for the `derive(FromRow)` macro.
As right now inside `derive(FromRow)` definition, as a part of the produced by this macro code `expect()` is used,
so it also violates and affects the clients code.
For that cases when the consumer of this library enabled `clippy::expect_used` for their project,
it requires to somehow fix it and disable it for the `derive(FromRow)` produced code.

## Dependent issue
https://github.com/input-output-hk/catalyst-voices/issues/828

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
