### PR TITLE
errors: protocol error refactor

### DIFF
--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -18,7 +18,7 @@ use crate::frame::types::{Consistency, SerialConsistency};
 use crate::history::HistoryListener;
 use crate::retry_policy::RetryPolicy;
 use crate::routing::Token;
-use crate::transport::errors::{BadQuery, QueryError};
+use crate::transport::errors::{BadQuery, ProtocolError, QueryError};
 use crate::transport::execution_profile::ExecutionProfileHandle;
 use crate::transport::partitioner::{Partitioner, PartitionerHasher, PartitionerName};
 
@@ -241,7 +241,7 @@ impl PreparedStatement {
             self.extract_partition_key(serialized_values)
                 .map_err(|err| match err {
                     PartitionKeyExtractionError::NoPkIndexValue(_, _) => {
-                        QueryError::ProtocolError("No pk indexes - can't calculate token")
+                        ProtocolError::PartitionKeyExtraction
                     }
                 })?;
         let token = partition_key

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -905,7 +905,11 @@ impl Connection {
         // Reprepared statement should keep its id - it's the md5 sum
         // of statement contents
         if reprepared.get_id() != previous_prepared.get_id() {
-            Err(UserRequestError::RepreparedIdChanged)
+            Err(UserRequestError::RepreparedIdChanged {
+                statement: reprepare_query.contents,
+                expected_id: previous_prepared.get_id().clone().into(),
+                reprepared_id: reprepared.get_id().clone().into(),
+            })
         } else {
             Ok(())
         }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -49,7 +49,6 @@ use std::{
 use super::errors::{ProtocolError, UseKeyspaceProtocolError};
 use super::iterator::RowIterator;
 use super::locator::tablets::{RawTablet, TabletParsingError};
-use super::query_result::SingleRowTypedError;
 use super::session::AddressTranslator;
 use super::topology::{PeerEndpoint, UntranslatedEndpoint, UntranslatedPeer};
 use super::NodeAddr;
@@ -1443,17 +1442,7 @@ impl Connection {
             .query_unpaged(LOCAL_VERSION)
             .await?
             .single_row_typed()
-            .map_err(|err| match err {
-                SingleRowTypedError::RowsExpected(_) => {
-                    QueryError::ProtocolError("Version query returned not rows")
-                }
-                SingleRowTypedError::BadNumberOfRows(_) => {
-                    QueryError::ProtocolError("system.local query returned a wrong number of rows")
-                }
-                SingleRowTypedError::FromRowError(_) => {
-                    QueryError::ProtocolError("Row is not uuid type as it should be")
-                }
-            })?;
+            .map_err(ProtocolError::SchemaVersionFetch)?;
         Ok(version_id)
     }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1295,9 +1295,10 @@ impl Connection {
                     _ => Err(err.into()),
                 },
                 Response::Result(_) => Ok(query_response.into_query_result()?),
-                _ => Err(QueryError::ProtocolError(
-                    "BATCH: Unexpected server response",
-                )),
+                _ => Err(ProtocolError::UnexpectedResponse(
+                    query_response.response.to_response_kind(),
+                )
+                .into()),
             };
         }
     }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1362,8 +1362,9 @@ impl Connection {
 
         match query_response.response {
             Response::Result(result::Result::SetKeyspace(set_keyspace)) => {
-                if set_keyspace.keyspace_name.to_lowercase()
-                    != keyspace_name.as_str().to_lowercase()
+                if !set_keyspace
+                    .keyspace_name
+                    .eq_ignore_ascii_case(keyspace_name.as_str())
                 {
                     return Err(QueryError::ProtocolError(
                         "USE <keyspace_name> returned response with different keyspace name",

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -299,10 +299,11 @@ impl NonErrorQueryResponse {
         let (result, paging_state) = self.into_query_result_and_paging_state()?;
 
         if !paging_state.finished() {
-            let error_msg = "Internal driver API misuse or a server bug: nonfinished paging state\
-                             would be discarded by `NonErrorQueryResponse::into_query_result`";
-            error!(error_msg);
-            return Err(QueryError::ProtocolError(error_msg));
+            error!(
+                "Internal driver API misuse or a server bug: nonfinished paging state\
+                would be discarded by `NonErrorQueryResponse::into_query_result`"
+            );
+            return Err(ProtocolError::NonfinishedPagingState.into());
         }
 
         Ok(result)

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1289,9 +1289,7 @@ impl Connection {
                             self.reprepare(p.get_statement(), p).await?;
                             continue;
                         } else {
-                            return Err(QueryError::ProtocolError(
-                                "The server returned a prepared statement Id that did not exist in the batch",
-                            ));
+                            return Err(ProtocolError::RepreparedIdMissingInBatch.into());
                         }
                     }
                     _ => Err(err.into()),

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -185,7 +185,9 @@ mod tests {
     use bytes::Bytes;
 
     use crate::test_utils::setup_tracing;
-    use crate::transport::errors::{BadQuery, BrokenConnectionErrorKind, ConnectionPoolError};
+    use crate::transport::errors::{
+        BadQuery, BrokenConnectionErrorKind, ConnectionPoolError, ProtocolError,
+    };
 
     use super::*;
 
@@ -284,7 +286,7 @@ mod tests {
                 cl,
             );
             downgrading_consistency_policy_assert_never_retries(
-                QueryError::ProtocolError("test"),
+                ProtocolError::NonfinishedPagingState.into(),
                 cl,
             );
         }

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -264,6 +264,12 @@ pub enum NewSessionError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum ProtocolError {
+    /// Prepared statement id mismatch.
+    #[error(
+        "Prepared statement id mismatch between multiple connections - all result ids should be equal."
+    )]
+    PreparedStatementIdsMismatch,
+
     /// USE KEYSPACE protocol error.
     #[error("USE KEYSPACE protocol error: {0}")]
     UseKeyspace(#[from] UseKeyspaceProtocolError),

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -8,6 +8,7 @@ use std::{
     error::Error,
     io::ErrorKind,
     net::{AddrParseError, IpAddr, SocketAddr},
+    num::ParseIntError,
     sync::Arc,
 };
 
@@ -420,6 +421,30 @@ pub enum KeyspacesMetadataError {
     /// system_schema.keyspaces has invalid column type.
     #[error("system_schema.keyspaces has invalid column type: {0}")]
     SchemaKeyspacesInvalidColumnType(FromRowError),
+
+    /// Bad keyspace replication strategy.
+    #[error("Bad keyspace <{keyspace}> replication strategy: {error}")]
+    Strategy {
+        keyspace: String,
+        error: KeyspaceStrategyError,
+    },
+}
+
+/// An error that occurred during specific keyspace's metadata fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum KeyspaceStrategyError {
+    /// Keyspace strategy map missing a `class` field.
+    #[error("keyspace strategy definition is missing a 'class' field")]
+    MissingClassForStrategyDefinition,
+
+    /// Missing replication factor for SimpleStrategy.
+    #[error("Missing replication factor field for SimpleStrategy")]
+    MissingReplicationFactorForSimpleStrategy,
+
+    /// Replication factor could not be parsed as unsigned integer.
+    #[error("Failed to parse a replication factor as unsigned integer: {0}")]
+    ReplicationFactorParseError(ParseIntError),
 }
 
 /// Error caused by caller creating an invalid query

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -66,6 +66,10 @@ pub enum QueryError {
     #[error("Protocol Error: {0}")]
     ProtocolError(&'static str),
 
+    /// Protocol error.
+    #[error("Protocol error: {0}")]
+    ProtocolErrorTyped(#[from] ProtocolError),
+
     /// Invalid message received
     #[error("Invalid message: {0}")]
     InvalidMessage(String),
@@ -137,6 +141,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::BodyExtensionsParseError(e) => NewSessionError::BodyExtensionsParseError(e),
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
+            QueryError::ProtocolErrorTyped(e) => NewSessionError::ProtocolErrorTyped(e),
             QueryError::InvalidMessage(m) => NewSessionError::InvalidMessage(m),
             QueryError::TimeoutError => NewSessionError::TimeoutError,
             QueryError::BrokenConnection(e) => NewSessionError::BrokenConnection(e),
@@ -203,6 +208,10 @@ pub enum NewSessionError {
     #[error("Protocol Error: {0}")]
     ProtocolError(&'static str),
 
+    /// Protocol error.
+    #[error("Protocol error: {0}")]
+    ProtocolErrorTyped(#[from] ProtocolError),
+
     /// Invalid message received
     #[error("Invalid message: {0}")]
     InvalidMessage(String),
@@ -224,6 +233,16 @@ pub enum NewSessionError {
     #[error("Client timeout: {0}")]
     RequestTimeout(String),
 }
+
+/// A protocol error.
+///
+/// It indicates an inconsistency between CQL protocol
+/// and server's behavior.
+/// In some cases, it could also represent a misuse
+/// of internal driver API - a driver bug.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum ProtocolError {}
 
 /// Error caused by caller creating an invalid query
 #[derive(Error, Debug, Clone)]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -307,6 +307,10 @@ pub enum ProtocolError {
         position: usize,
         reason: String,
     },
+
+    /// Unable extract a partition key based on prepared statement's metadata.
+    #[error("Unable extract a partition key based on prepared statement's metadata")]
+    PartitionKeyExtraction,
 }
 
 /// A protocol error that occurred during `USE KEYSPACE <>` request.

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -403,6 +403,10 @@ pub enum MetadataError {
     /// Bad UDTs metadata.
     #[error("Bad UDTs metadata: {0}")]
     Udts(#[from] UdtMetadataError),
+
+    /// Bad tables metadata.
+    #[error("Bad tables metadata: {0}")]
+    Tables(#[from] TablesMetadataError),
 }
 
 /// An error that occurred during peers metadata fetch.
@@ -467,6 +471,28 @@ pub enum UdtMetadataError {
     /// Circular UDT dependency detected.
     #[error("Detected circular dependency between user defined types - toposort is impossible!")]
     CircularTypeDependency,
+}
+
+/// An error that occurred during tables metadata fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum TablesMetadataError {
+    /// system_schema.tables has invalid column type.
+    #[error("system_schema.tables has invalid column type: {0}")]
+    SchemaTablesInvalidColumnType(FromRowError),
+
+    /// system_schema.columns has invalid column type.
+    #[error("system_schema.columns has invalid column type: {0}")]
+    SchemaColumnsInvalidColumnType(FromRowError),
+
+    /// Unknown column kind.
+    #[error("Unknown column kind '{column_kind}' for {keyspace_name}.{table_name}.{column_name}")]
+    UnknownColumnKind {
+        keyspace_name: String,
+        table_name: String,
+        column_name: String,
+        column_kind: String,
+    },
 }
 
 /// Error caused by caller creating an invalid query

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -129,9 +129,8 @@ impl From<UserRequestError> for QueryError {
             UserRequestError::CqlResultParseError(e) => e.into(),
             UserRequestError::CqlErrorParseError(e) => e.into(),
             UserRequestError::BrokenConnectionError(e) => e.into(),
-            UserRequestError::UnexpectedResponse(_) => {
-                // FIXME: make it typed. It needs to wait for ProtocolError refactor.
-                QueryError::ProtocolError("Received unexpected response from the server. Expected RESULT or ERROR response.")
+            UserRequestError::UnexpectedResponse(response) => {
+                ProtocolError::UnexpectedResponse(response).into()
             }
             UserRequestError::BodyExtensionsParseError(e) => e.into(),
             UserRequestError::UnableToAllocStreamId => QueryError::UnableToAllocStreamId,
@@ -272,6 +271,12 @@ pub enum NewSessionError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum ProtocolError {
+    /// Received an unexpected response when RESULT or ERROR was expected.
+    #[error(
+        "Received unexpected response from the server: {0}. Expected RESULT or ERROR response."
+    )]
+    UnexpectedResponse(CqlResponseKind),
+
     /// Prepared statement id mismatch.
     #[error(
         "Prepared statement id mismatch between multiple connections - all result ids should be equal."

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -407,6 +407,10 @@ pub enum MetadataError {
     /// Bad tables metadata.
     #[error("Bad tables metadata: {0}")]
     Tables(#[from] TablesMetadataError),
+
+    /// Bad views metadata.
+    #[error("Bad views metadata: {0}")]
+    Views(#[from] ViewsMetadataError),
 }
 
 /// An error that occurred during peers metadata fetch.
@@ -493,6 +497,15 @@ pub enum TablesMetadataError {
         column_name: String,
         column_kind: String,
     },
+}
+
+/// An error that occurred during views metadata fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum ViewsMetadataError {
+    /// system_schema.views has invalid column type.
+    #[error("system_schema.views has invalid column type: {0}")]
+    SchemaViewsInvalidColumnType(FromRowError),
 }
 
 /// Error caused by caller creating an invalid query

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -87,10 +87,6 @@ pub enum QueryError {
     #[error("Protocol error: {0}")]
     ProtocolErrorTyped(#[from] ProtocolError),
 
-    /// Invalid message received
-    #[error("Invalid message: {0}")]
-    InvalidMessage(String),
-
     /// Timeout error has occurred, function didn't complete in time.
     #[error("Timeout Error")]
     TimeoutError,
@@ -167,7 +163,6 @@ impl From<QueryError> for NewSessionError {
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
             QueryError::ProtocolErrorTyped(e) => NewSessionError::ProtocolErrorTyped(e),
-            QueryError::InvalidMessage(m) => NewSessionError::InvalidMessage(m),
             QueryError::TimeoutError => NewSessionError::TimeoutError,
             QueryError::BrokenConnection(e) => NewSessionError::BrokenConnection(e),
             QueryError::UnableToAllocStreamId => NewSessionError::UnableToAllocStreamId,
@@ -249,10 +244,6 @@ pub enum NewSessionError {
     /// Protocol error.
     #[error("Protocol error: {0}")]
     ProtocolErrorTyped(#[from] ProtocolError),
-
-    /// Invalid message received
-    #[error("Invalid message: {0}")]
-    InvalidMessage(String),
 
     /// Timeout error has occurred, couldn't connect to node in time.
     #[error("Timeout Error")]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -81,7 +81,7 @@ pub enum QueryError {
 
     /// Protocol error.
     #[error("Protocol error: {0}")]
-    ProtocolErrorTyped(#[from] ProtocolError),
+    ProtocolError(#[from] ProtocolError),
 
     /// Timeout error has occurred, function didn't complete in time.
     #[error("Timeout Error")]
@@ -157,7 +157,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::EmptyPlan => NewSessionError::EmptyPlan,
             QueryError::MetadataError(e) => NewSessionError::MetadataError(e),
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
-            QueryError::ProtocolErrorTyped(e) => NewSessionError::ProtocolErrorTyped(e),
+            QueryError::ProtocolError(e) => NewSessionError::ProtocolError(e),
             QueryError::TimeoutError => NewSessionError::TimeoutError,
             QueryError::BrokenConnection(e) => NewSessionError::BrokenConnection(e),
             QueryError::UnableToAllocStreamId => NewSessionError::UnableToAllocStreamId,
@@ -234,7 +234,7 @@ pub enum NewSessionError {
 
     /// Protocol error.
     #[error("Protocol error: {0}")]
-    ProtocolErrorTyped(#[from] ProtocolError),
+    ProtocolError(#[from] ProtocolError),
 
     /// Timeout error has occurred, couldn't connect to node in time.
     #[error("Timeout Error")]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -390,7 +390,24 @@ pub enum TracingProtocolError {
 /// - views
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
-pub enum MetadataError {}
+pub enum MetadataError {
+    /// Bad peers metadata.
+    #[error("Bad peers metadata: {0}")]
+    Peers(#[from] PeersMetadataError),
+}
+
+/// An error that occurred during peers metadata fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum PeersMetadataError {
+    /// Empty peers list returned during peers metadata fetch.
+    #[error("Peers list is empty")]
+    EmptyPeers,
+
+    /// All peers have empty token lists.
+    #[error("All peers have empty token lists")]
+    EmptyTokenLists,
+}
 
 /// Error caused by caller creating an invalid query
 #[derive(Error, Debug, Clone)]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -242,7 +242,24 @@ pub enum NewSessionError {
 /// of internal driver API - a driver bug.
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
-pub enum ProtocolError {}
+pub enum ProtocolError {
+    /// USE KEYSPACE protocol error.
+    #[error("USE KEYSPACE protocol error: {0}")]
+    UseKeyspace(#[from] UseKeyspaceProtocolError),
+}
+
+/// A protocol error that occurred during `USE KEYSPACE <>` request.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum UseKeyspaceProtocolError {
+    #[error("Keyspace name mismtach; expected: {expected_keyspace_name_lowercase}, received: {result_keyspace_name_lowercase}")]
+    KeyspaceNameMismatch {
+        expected_keyspace_name_lowercase: String,
+        result_keyspace_name_lowercase: String,
+    },
+    #[error("Received unexpected response: {0}. Expected RESULT:Set_keyspace")]
+    UnexpectedResponse(CqlResponseKind),
+}
 
 /// Error caused by caller creating an invalid query
 #[derive(Error, Debug, Clone)]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -30,6 +30,8 @@ use thiserror::Error;
 
 use crate::{authentication::AuthError, frame::response};
 
+use super::query_result::SingleRowTypedError;
+
 /// Error that occurred during query execution
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
@@ -246,6 +248,10 @@ pub enum ProtocolError {
     /// USE KEYSPACE protocol error.
     #[error("USE KEYSPACE protocol error: {0}")]
     UseKeyspace(#[from] UseKeyspaceProtocolError),
+
+    /// A protocol error appeared during schema version fetch.
+    #[error("Schema version fetch protocol error: {0}")]
+    SchemaVersionFetch(SingleRowTypedError),
 }
 
 /// A protocol error that occurred during `USE KEYSPACE <>` request.

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -445,6 +445,11 @@ pub enum KeyspaceStrategyError {
     /// Replication factor could not be parsed as unsigned integer.
     #[error("Failed to parse a replication factor as unsigned integer: {0}")]
     ReplicationFactorParseError(ParseIntError),
+
+    /// Received an unexpected NTS option.
+    /// Driver expects only 'class' and replication factor per dc ('dc': rf)
+    #[error("Unexpected NetworkTopologyStrategy option: '{key}': '{value}'")]
+    UnexpectedNetworkTopologyStrategyOption { key: String, value: String },
 }
 
 /// Error caused by caller creating an invalid query

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -70,6 +70,10 @@ pub enum QueryError {
     #[error("Failed to deserialize ERROR response: {0}")]
     CqlErrorParseError(#[from] CqlErrorParseError),
 
+    /// A metadata error occurred during schema agreement.
+    #[error("Cluster metadata fetch error occurred during automatic schema agreement: {0}")]
+    MetadataError(#[from] MetadataError),
+
     /// Selected node's connection pool is in invalid state.
     #[error("No connections in the pool: {0}")]
     ConnectionPoolError(#[from] ConnectionPoolError),
@@ -158,6 +162,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::CqlErrorParseError(e) => NewSessionError::CqlErrorParseError(e),
             QueryError::BodyExtensionsParseError(e) => NewSessionError::BodyExtensionsParseError(e),
             QueryError::EmptyPlan => NewSessionError::EmptyPlan,
+            QueryError::MetadataError(e) => NewSessionError::MetadataError(e),
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
             QueryError::ProtocolErrorTyped(e) => NewSessionError::ProtocolErrorTyped(e),
@@ -219,6 +224,10 @@ pub enum NewSessionError {
     /// Failed to deserialize frame body extensions.
     #[error(transparent)]
     BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
+
+    /// Failed to perform initial cluster metadata fetch.
+    #[error("Failed to perform initial cluster metadata fetch: {0}")]
+    MetadataError(#[from] MetadataError),
 
     /// Received a RESULT server response, but failed to deserialize it.
     #[error(transparent)]
@@ -370,6 +379,18 @@ pub enum TracingProtocolError {
     )]
     EmptyResults,
 }
+
+/// An error that occurred during cluster metadata fetch.
+///
+/// An error can occur during metadata fetch of:
+/// - peers
+/// - keyspaces
+/// - UDTs
+/// - tables
+/// - views
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum MetadataError {}
 
 /// Error caused by caller creating an invalid query
 #[derive(Error, Debug, Clone)]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -79,10 +79,6 @@ pub enum QueryError {
     #[error("No connections in the pool: {0}")]
     ConnectionPoolError(#[from] ConnectionPoolError),
 
-    /// Unexpected message received
-    #[error("Protocol Error: {0}")]
-    ProtocolError(&'static str),
-
     /// Protocol error.
     #[error("Protocol error: {0}")]
     ProtocolErrorTyped(#[from] ProtocolError),
@@ -161,7 +157,6 @@ impl From<QueryError> for NewSessionError {
             QueryError::EmptyPlan => NewSessionError::EmptyPlan,
             QueryError::MetadataError(e) => NewSessionError::MetadataError(e),
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
-            QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
             QueryError::ProtocolErrorTyped(e) => NewSessionError::ProtocolErrorTyped(e),
             QueryError::TimeoutError => NewSessionError::TimeoutError,
             QueryError::BrokenConnection(e) => NewSessionError::BrokenConnection(e),
@@ -236,10 +231,6 @@ pub enum NewSessionError {
     /// Selected node's connection pool is in invalid state.
     #[error("No connections in the pool: {0}")]
     ConnectionPoolError(#[from] ConnectionPoolError),
-
-    /// Unexpected message received
-    #[error("Protocol Error: {0}")]
-    ProtocolError(&'static str),
 
     /// Protocol error.
     #[error("Protocol error: {0}")]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -299,6 +299,14 @@ pub enum ProtocolError {
     /// A result with nonfinished paging state received for unpaged query.
     #[error("Unpaged query returned a non-empty paging state! This is a driver-side or server-side bug.")]
     NonfinishedPagingState,
+
+    /// Failed to parse CQL type.
+    #[error("Failed to parse a CQL type '{typ}', at position {position}: {reason}")]
+    InvalidCqlType {
+        typ: String,
+        position: usize,
+        reason: String,
+    },
 }
 
 /// A protocol error that occurred during `USE KEYSPACE <>` request.

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -52,6 +52,15 @@ pub enum QueryError {
     #[error(transparent)]
     BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
 
+    /// Load balancing policy returned an empty plan.
+    #[error(
+        "Load balancing policy returned an empty plan.\
+        First thing to investigate should be the logic of custom LBP implementation.\
+        If you think that your LBP implementation is correct, or you make use of `DefaultPolicy`,\
+        then this is most probably a driver bug!"
+    )]
+    EmptyPlan,
+
     /// Received a RESULT server response, but failed to deserialize it.
     #[error(transparent)]
     CqlResultParseError(#[from] CqlResultParseError),
@@ -141,6 +150,7 @@ impl From<QueryError> for NewSessionError {
             QueryError::CqlResultParseError(e) => NewSessionError::CqlResultParseError(e),
             QueryError::CqlErrorParseError(e) => NewSessionError::CqlErrorParseError(e),
             QueryError::BodyExtensionsParseError(e) => NewSessionError::BodyExtensionsParseError(e),
+            QueryError::EmptyPlan => NewSessionError::EmptyPlan,
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
             QueryError::ProtocolError(m) => NewSessionError::ProtocolError(m),
             QueryError::ProtocolErrorTyped(e) => NewSessionError::ProtocolErrorTyped(e),
@@ -189,6 +199,15 @@ pub enum NewSessionError {
     /// Failed to serialize CQL request.
     #[error("Failed to serialize CQL request: {0}")]
     CqlRequestSerialization(#[from] CqlRequestSerializationError),
+
+    /// Load balancing policy returned an empty plan.
+    #[error(
+        "Load balancing policy returned an empty plan.\
+        First thing to investigate should be the logic of custom LBP implementation.\
+        If you think that your LBP implementation is correct, or you make use of `DefaultPolicy`,\
+        then this is most probably a driver bug!"
+    )]
+    EmptyPlan,
 
     /// Failed to deserialize frame body extensions.
     #[error(transparent)]

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -252,6 +252,10 @@ pub enum ProtocolError {
     /// A protocol error appeared during schema version fetch.
     #[error("Schema version fetch protocol error: {0}")]
     SchemaVersionFetch(SingleRowTypedError),
+
+    /// A result with nonfinished paging state received for unpaged query.
+    #[error("Unpaged query returned a non-empty paging state! This is a driver-side or server-side bug.")]
+    NonfinishedPagingState,
 }
 
 /// A protocol error that occurred during `USE KEYSPACE <>` request.

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -316,6 +316,11 @@ pub enum ProtocolError {
     /// A protocol error occurred during tracing info fetch.
     #[error("Tracing info fetch protocol error: {0}")]
     Tracing(#[from] TracingProtocolError),
+
+    /// Driver tried to reprepare a statement in the batch, but the reprepared
+    /// statement's id is not included in the batch.
+    #[error("Reprepared statement's id does not exist in the batch.")]
+    RepreparedIdMissingInBatch,
 }
 
 /// A protocol error that occurred during `USE KEYSPACE <>` request.

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -399,6 +399,10 @@ pub enum MetadataError {
     /// Bad keyspaces metadata.
     #[error("Bad keyspaces metadata: {0}")]
     Keyspaces(#[from] KeyspacesMetadataError),
+
+    /// Bad UDTs metadata.
+    #[error("Bad UDTs metadata: {0}")]
+    Udts(#[from] UdtMetadataError),
 }
 
 /// An error that occurred during peers metadata fetch.
@@ -450,6 +454,19 @@ pub enum KeyspaceStrategyError {
     /// Driver expects only 'class' and replication factor per dc ('dc': rf)
     #[error("Unexpected NetworkTopologyStrategy option: '{key}': '{value}'")]
     UnexpectedNetworkTopologyStrategyOption { key: String, value: String },
+}
+
+/// An error that occurred during UDTs metadata fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum UdtMetadataError {
+    /// system_schema.types has invalid column type.
+    #[error("system_schema.types has invalid column type: {0}")]
+    SchemaTypesInvalidColumnType(FromRowError),
+
+    /// Circular UDT dependency detected.
+    #[error("Detected circular dependency between user defined types - toposort is impossible!")]
+    CircularTypeDependency,
 }
 
 /// Error caused by caller creating an invalid query

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -394,6 +394,10 @@ pub enum MetadataError {
     /// Bad peers metadata.
     #[error("Bad peers metadata: {0}")]
     Peers(#[from] PeersMetadataError),
+
+    /// Bad keyspaces metadata.
+    #[error("Bad keyspaces metadata: {0}")]
+    Keyspaces(#[from] KeyspacesMetadataError),
 }
 
 /// An error that occurred during peers metadata fetch.
@@ -407,6 +411,15 @@ pub enum PeersMetadataError {
     /// All peers have empty token lists.
     #[error("All peers have empty token lists")]
     EmptyTokenLists,
+}
+
+/// An error that occurred during keyspaces metadata fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum KeyspacesMetadataError {
+    /// system_schema.keyspaces has invalid column type.
+    #[error("system_schema.keyspaces has invalid column type: {0}")]
+    SchemaKeyspacesInvalidColumnType(FromRowError),
 }
 
 /// Error caused by caller creating an invalid query

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -511,8 +511,7 @@ where
         let query_plan =
             load_balancing::Plan::new(load_balancer.as_ref(), &statement_info, &cluster_data);
 
-        let mut last_error: QueryError =
-            QueryError::ProtocolError("Empty query plan - driver bug!");
+        let mut last_error: QueryError = QueryError::EmptyPlan;
         let mut current_consistency: Consistency = self.query_consistency;
 
         self.log_query_start();

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -28,7 +28,7 @@ use crate::statement::{prepared_statement::PreparedStatement, query::Query};
 use crate::statement::{Consistency, PagingState, SerialConsistency};
 use crate::transport::cluster::ClusterData;
 use crate::transport::connection::{Connection, NonErrorQueryResponse, QueryResponse};
-use crate::transport::errors::{QueryError, UserRequestError};
+use crate::transport::errors::{ProtocolError, QueryError, UserRequestError};
 use crate::transport::load_balancing::{self, RoutingInfo};
 use crate::transport::metrics::Metrics;
 use crate::transport::retry_policy::{QueryInfo, RetryDecision, RetrySession};
@@ -722,9 +722,10 @@ where
                 let (proof, _) = self.sender.send_empty_page(tracing_id).await;
                 Ok(ControlFlow::Break(proof))
             }
-            Ok(_) => {
+            Ok(response) => {
                 self.metrics.inc_failed_paged_queries();
-                let err = QueryError::ProtocolError("Unexpected response to next page query");
+                let err =
+                    ProtocolError::UnexpectedResponse(response.response.to_response_kind()).into();
                 self.execution_profile
                     .load_balancing_policy
                     .on_query_failure(&self.statement_info, elapsed, node, &err);
@@ -878,9 +879,10 @@ where
                     return Ok(proof);
                 }
                 _ => {
-                    return Err(QueryError::ProtocolError(
-                        "Unexpected response to next page query",
-                    ));
+                    return Err(ProtocolError::UnexpectedResponse(
+                        response.response.to_response_kind(),
+                    )
+                    .into());
                 }
             }
         }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2858,7 +2858,6 @@ mod latency_awareness {
                 | QueryError::CqlErrorParseError(_)
                 | QueryError::BodyExtensionsParseError(_)
                 | QueryError::MetadataError(_)
-                | QueryError::InvalidMessage(_)
                 | QueryError::ProtocolError(_)
                 | QueryError::ProtocolErrorTyped(_)
                 | QueryError::TimeoutError

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2858,7 +2858,6 @@ mod latency_awareness {
                 | QueryError::CqlErrorParseError(_)
                 | QueryError::BodyExtensionsParseError(_)
                 | QueryError::MetadataError(_)
-                | QueryError::ProtocolError(_)
                 | QueryError::ProtocolErrorTyped(_)
                 | QueryError::TimeoutError
                 | QueryError::RequestTimeout(_) => true,

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2858,7 +2858,7 @@ mod latency_awareness {
                 | QueryError::CqlErrorParseError(_)
                 | QueryError::BodyExtensionsParseError(_)
                 | QueryError::MetadataError(_)
-                | QueryError::ProtocolErrorTyped(_)
+                | QueryError::ProtocolError(_)
                 | QueryError::TimeoutError
                 | QueryError::RequestTimeout(_) => true,
             }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2857,6 +2857,7 @@ mod latency_awareness {
                 | QueryError::CqlResultParseError(_)
                 | QueryError::CqlErrorParseError(_)
                 | QueryError::BodyExtensionsParseError(_)
+                | QueryError::MetadataError(_)
                 | QueryError::InvalidMessage(_)
                 | QueryError::ProtocolError(_)
                 | QueryError::ProtocolErrorTyped(_)

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2858,6 +2858,7 @@ mod latency_awareness {
                 | QueryError::BodyExtensionsParseError(_)
                 | QueryError::InvalidMessage(_)
                 | QueryError::ProtocolError(_)
+                | QueryError::ProtocolErrorTyped(_)
                 | QueryError::TimeoutError
                 | QueryError::RequestTimeout(_) => true,
             }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2844,6 +2844,7 @@ mod latency_awareness {
                 | QueryError::CqlRequestSerialization(_)
                 | QueryError::BrokenConnection(_)
                 | QueryError::ConnectionPoolError(_)
+                | QueryError::EmptyPlan
                 | QueryError::UnableToAllocStreamId
                 | QueryError::DbError(DbError::IsBootstrapping, _)
                 | QueryError::DbError(DbError::Unavailable { .. }, _)

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -223,7 +223,7 @@ mod tests {
     use crate::statement::Consistency;
     use crate::test_utils::setup_tracing;
     use crate::transport::errors::{
-        BadQuery, BrokenConnectionErrorKind, ConnectionPoolError, QueryError,
+        BadQuery, BrokenConnectionErrorKind, ConnectionPoolError, ProtocolError, QueryError,
     };
     use crate::transport::errors::{DbError, WriteType};
     use bytes::Bytes;
@@ -299,7 +299,7 @@ mod tests {
                         (got 1 values, 2 statements)"
                 .to_owned(),
         )));
-        default_policy_assert_never_retries(QueryError::ProtocolError("test"));
+        default_policy_assert_never_retries(ProtocolError::NonfinishedPagingState.into());
     }
 
     // Asserts that for this error policy retries on next on idempotent queries only

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1822,9 +1822,7 @@ impl Session {
                         },
                     )
                     .await
-                    .unwrap_or(Err(QueryError::ProtocolError(
-                        "Empty query plan - driver bug!",
-                    )))
+                    .unwrap_or(Err(QueryError::EmptyPlan))
                 }
             }
         };

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -992,9 +992,7 @@ impl Session {
         // Validate prepared ids equality
         for statement in results.flatten() {
             if prepared.get_id() != statement.get_id() {
-                return Err(QueryError::ProtocolError(
-                    "Prepared statement Ids differ, all should be equal",
-                ));
+                return Err(ProtocolError::PreparedStatementIdsMismatch.into());
             }
 
             // Collect all tracing ids from prepare() queries in the final result

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -92,7 +92,7 @@ fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
     }
 }
 
-const EMPTY_PLAN_ERROR: QueryError = QueryError::ProtocolError("Empty query plan - driver bug!");
+const EMPTY_PLAN_ERROR: QueryError = QueryError::EmptyPlan;
 
 pub(crate) async fn execute<QueryFut, ResT>(
     policy: &dyn SpeculativeExecutionPolicy,

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -29,7 +29,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
-use super::errors::ProtocolError;
+use super::errors::{MetadataError, PeersMetadataError, ProtocolError};
 use super::node::{KnownNode, NodeAddr, ResolvedContactPoint};
 
 /// Allows to read current metadata from the cluster
@@ -752,16 +752,12 @@ async fn query_metadata(
 
     // There must be at least one peer
     if peers.is_empty() {
-        return Err(QueryError::ProtocolError(
-            "Bad Metadata: peers list is empty",
-        ));
+        return Err(MetadataError::Peers(PeersMetadataError::EmptyPeers).into());
     }
 
     // At least one peer has to have some tokens
     if peers.iter().all(|peer| peer.tokens.is_empty()) {
-        return Err(QueryError::ProtocolError(
-            "Bad Metadata: All peers have empty token list",
-        ));
+        return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists).into());
     }
 
     Ok(Metadata { peers, keyspaces })

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -29,6 +29,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
+use super::errors::ProtocolError;
 use super::node::{KnownNode, NodeAddr, ResolvedContactPoint};
 
 /// Allows to read current metadata from the cluster
@@ -404,11 +405,12 @@ impl fmt::Display for InvalidCqlType {
 
 impl From<InvalidCqlType> for QueryError {
     fn from(e: InvalidCqlType) -> Self {
-        // FIXME: The correct error type is QueryError:ProtocolError but at the moment it accepts only &'static str
-        QueryError::InvalidMessage(format!(
-            "error parsing type \"{:?}\" at position {}: {}",
-            e.type_, e.position, e.reason
-        ))
+        ProtocolError::InvalidCqlType {
+            typ: e.type_,
+            position: e.position,
+            reason: e.reason,
+        }
+        .into()
     }
 }
 

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -29,7 +29,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
-use super::errors::{MetadataError, PeersMetadataError, ProtocolError};
+use super::errors::{KeyspacesMetadataError, MetadataError, PeersMetadataError, ProtocolError};
 use super::node::{KnownNode, NodeAddr, ResolvedContactPoint};
 
 /// Allows to read current metadata from the cluster
@@ -955,8 +955,10 @@ async fn query_keyspaces(
 
     rows.map(|row_result| {
         let row = row_result?;
-        let (keyspace_name, strategy_map) = row.into_typed().map_err(|_| {
-            QueryError::ProtocolError("system_schema.keyspaces has invalid column type")
+        let (keyspace_name, strategy_map) = row.into_typed().map_err(|err| {
+            MetadataError::Keyspaces(KeyspacesMetadataError::SchemaKeyspacesInvalidColumnType(
+                err,
+            ))
         })?;
 
         let strategy: Strategy = strategy_from_string_map(strategy_map)?;

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 
 use super::errors::{
     KeyspaceStrategyError, KeyspacesMetadataError, MetadataError, PeersMetadataError,
-    ProtocolError, TablesMetadataError, UdtMetadataError,
+    ProtocolError, TablesMetadataError, UdtMetadataError, ViewsMetadataError,
 };
 use super::node::{KnownNode, NodeAddr, ResolvedContactPoint};
 
@@ -1408,8 +1408,8 @@ async fn query_views(
 
     rows.map(|row_result| {
         let row = row_result?;
-        let (keyspace_name, view_name, base_table_name) = row.into_typed().map_err(|_| {
-            QueryError::ProtocolError("system_schema.views has invalid column type")
+        let (keyspace_name, view_name, base_table_name) = row.into_typed().map_err(|err| {
+            MetadataError::Views(ViewsMetadataError::SchemaViewsInvalidColumnType(err))
         })?;
 
         let keyspace_and_view_name = (keyspace_name, view_name);


### PR DESCRIPTION
ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## QueryError::ProtocolError
In this PR we do a refactor of the `QueryError::ProtocolError` variant, which was represented simply as `&'static str`. In this PR, we create a new type `ProtocolError` which will represent all posible kinds of protocol errors. We simply replace all occurrences of `QueryError::ProtocolError` with a corresponding `ProtocolError` variant.

## QueryError::InvalidMessage
This variant is no longer use after the fixes. Previously, this variant was constructed for some protocol errors due to limitations of the `QueryError::ProtocolError` variant type (`&'static str`, when `String` was needed). After introducing `ProtocolError` type, this is no longer an issue. This variant can be safely removed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
