### PR TITLE
make `ResultMetadata` lifetime-generic

### DIFF
--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -11,6 +11,7 @@ pub use super::request::{
     startup::StartupSerializationError,
 };
 
+use super::response::result::TableSpec;
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
 use crate::types::deserialize::DeserializationError;
@@ -372,6 +373,8 @@ pub struct ColumnSpecParseError {
 pub enum ColumnSpecParseErrorKind {
     #[error("Invalid table spec: {0}")]
     TableSpecParseError(#[from] TableSpecParseError),
+    #[error("Table spec differs across columns - got specs: {0:?} and {1:?}")]
+    TableSpecDiffersAcrossColumns(TableSpec<'static>, TableSpec<'static>),
     #[error("Malformed column name: {0}")]
     ColumnNameParseError(#[from] LowLevelDeserializationError),
     #[error("Invalid column type: {0}")]

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -111,7 +111,7 @@ impl Response {
         features: &ProtocolFeatures,
         opcode: ResponseOpcode,
         buf_bytes: bytes::Bytes,
-        cached_metadata: Option<&Arc<ResultMetadata>>,
+        cached_metadata: Option<&Arc<ResultMetadata<'static>>>,
     ) -> Result<Response, CqlResponseParseError> {
         let buf = &mut &*buf_bytes;
         let response = match opcode {

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -424,9 +424,38 @@ impl CqlValue {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnSpec {
-    pub table_spec: TableSpec<'static>,
-    pub name: String,
-    pub typ: ColumnType,
+    pub(crate) table_spec: TableSpec<'static>,
+    pub(crate) name: String,
+    pub(crate) typ: ColumnType,
+}
+
+impl ColumnSpec {
+    #[inline]
+    pub fn table_spec(&self) -> &TableSpec<'static> {
+        &self.table_spec
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[inline]
+    pub fn typ(&self) -> &ColumnType {
+        &self.typ
+    }
+}
+
+// Test utils for scylla crate.
+impl ColumnSpec {
+    #[doc(hidden)]
+    pub fn new_for_test(table_spec: TableSpec<'static>, name: String, typ: ColumnType) -> Self {
+        Self {
+            table_spec,
+            name,
+            typ,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -603,16 +603,6 @@ pub enum Result {
     SchemaChange(SchemaChange),
 }
 
-fn deser_table_spec(buf: &mut &[u8]) -> StdResult<TableSpec<'static>, TableSpecParseError> {
-    let ks_name = types::read_string(buf)
-        .map_err(TableSpecParseError::MalformedKeyspaceName)?
-        .to_owned();
-    let table_name = types::read_string(buf)
-        .map_err(TableSpecParseError::MalformedTableName)?
-        .to_owned();
-    Ok(TableSpec::owned(ks_name, table_name))
-}
-
 macro_rules! generate_deser_type {
     ($deser_type: ident, $l: lifetime, $read_string: expr) => {
         fn $deser_type<'frame>(
@@ -707,6 +697,16 @@ generate_deser_type!(deser_type_owned, 'static, |buf| types::read_string(buf).ma
 
 // This is going to be used for deserializing borrowed result metadata.
 generate_deser_type!(_deser_type_borrowed, 'frame, types::read_string);
+
+fn deser_table_spec(buf: &mut &[u8]) -> StdResult<TableSpec<'static>, TableSpecParseError> {
+    let ks_name = types::read_string(buf)
+        .map_err(TableSpecParseError::MalformedKeyspaceName)?
+        .to_owned();
+    let table_name = types::read_string(buf)
+        .map_err(TableSpecParseError::MalformedTableName)?
+        .to_owned();
+    Ok(TableSpec::owned(ks_name, table_name))
+}
 
 fn mk_col_spec_parse_error(
     col_idx: usize,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -762,11 +762,9 @@ fn deser_result_metadata(
     let col_specs = if no_metadata {
         vec![]
     } else {
-        let global_table_spec = if global_tables_spec {
-            Some(deser_table_spec(buf)?)
-        } else {
-            None
-        };
+        let global_table_spec = global_tables_spec
+            .then(|| deser_table_spec(buf))
+            .transpose()?;
 
         deser_col_specs(buf, global_table_spec, col_count)?
     };
@@ -802,11 +800,9 @@ fn deser_prepared_metadata(
     }
     pk_indexes.sort_unstable_by_key(|pki| pki.index);
 
-    let global_table_spec = if global_tables_spec {
-        Some(deser_table_spec(buf)?)
-    } else {
-        None
-    };
+    let global_table_spec = global_tables_spec
+        .then(|| deser_table_spec(buf))
+        .transpose()?;
 
     let col_specs = deser_col_specs(buf, global_table_spec, col_count)?;
 

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -522,7 +522,7 @@ impl<'frame> ColumnSpec<'frame> {
 #[derive(Debug, Clone)]
 pub struct ResultMetadata {
     col_count: usize,
-    pub col_specs: Vec<ColumnSpec<'static>>,
+    col_specs: Vec<ColumnSpec<'static>>,
 }
 
 impl ResultMetadata {
@@ -541,6 +541,16 @@ impl ResultMetadata {
             col_count,
             col_specs,
         }
+    }
+
+    #[inline]
+    pub fn col_count(&self) -> usize {
+        self.col_count
+    }
+
+    #[inline]
+    pub fn col_specs(&self) -> &[ColumnSpec] {
+        &self.col_specs
     }
 }
 

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -810,11 +810,11 @@ fn cqlvalue_serialization() {
         ],
     };
     let typ = ColumnType::UserDefinedType {
-        type_name: "t".to_string(),
-        keyspace: "ks".to_string(),
+        type_name: "t".into(),
+        keyspace: "ks".into(),
         field_types: vec![
-            ("foo".to_string(), ColumnType::Int),
-            ("bar".to_string(), ColumnType::Text),
+            ("foo".into(), ColumnType::Int),
+            ("bar".into(), ColumnType::Text),
         ],
     };
 
@@ -1079,7 +1079,7 @@ fn vec_value_list() {
     );
 }
 
-fn col_spec(name: &str, typ: ColumnType) -> ColumnSpec {
+fn col_spec(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
     ColumnSpec {
         table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
         name: name.to_string(),

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1079,11 +1079,11 @@ fn vec_value_list() {
     );
 }
 
-fn col_spec(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
+fn col_spec<'a>(name: impl Into<Cow<'a, str>>, typ: ColumnType<'a>) -> ColumnSpec<'a> {
     ColumnSpec {
-        table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
-        name: name.to_string(),
+        name: name.into(),
         typ,
+        table_spec: TableSpec::borrowed("ks", "tbl"),
     }
 }
 
@@ -1134,7 +1134,7 @@ fn tuple_value_list() {
         let typs = expected
             .clone()
             .enumerate()
-            .map(|(i, _)| col_spec(&format!("col_{i}"), ColumnType::TinyInt))
+            .map(|(i, _)| col_spec(format!("col_{i}"), ColumnType::TinyInt))
             .collect::<Vec<_>>();
         let serialized = serialize_values(tuple, &typs);
         assert_eq!(serialized.len() as usize, expected.len());

--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -296,11 +296,7 @@ mod tests {
         bytes.freeze()
     }
 
-    pub(super) fn spec(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
-        ColumnSpec {
-            name: name.to_owned(),
-            typ,
-            table_spec: TableSpec::borrowed("ks", "tbl"),
-        }
+    pub(super) fn spec<'a>(name: &'a str, typ: ColumnType<'a>) -> ColumnSpec<'a> {
+        ColumnSpec::borrowed(name, typ, TableSpec::borrowed("ks", "tbl"))
     }
 }

--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -296,7 +296,7 @@ mod tests {
         bytes.freeze()
     }
 
-    pub(super) fn spec(name: &str, typ: ColumnType) -> ColumnSpec {
+    pub(super) fn spec(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
         ColumnSpec {
             name: name.to_owned(),
             typ,

--- a/scylla-cql/src/types/deserialize/result.rs
+++ b/scylla-cql/src/types/deserialize/result.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 /// Iterates over the whole result, returning rows.
 #[derive(Debug)]
 pub struct RowIterator<'frame> {
-    specs: &'frame [ColumnSpec],
+    specs: &'frame [ColumnSpec<'frame>],
     remaining: usize,
     slice: FrameSlice<'frame>,
 }

--- a/scylla-cql/src/types/deserialize/result.rs
+++ b/scylla-cql/src/types/deserialize/result.rs
@@ -56,7 +56,7 @@ impl<'frame> Iterator for RowIterator<'frame> {
                 return Some(Err(mk_deser_err::<Self>(
                     BuiltinDeserializationErrorKind::RawColumnDeserializationFailed {
                         column_index,
-                        column_name: spec.name.clone(),
+                        column_name: spec.name().to_owned(),
                         err: DeserializationError::new(err),
                     },
                 )));

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -188,7 +188,7 @@ macro_rules! impl_tuple {
             fn type_check(specs: &[ColumnSpec]) -> Result<(), TypeCheckError> {
                 const TUPLE_LEN: usize = (&[$($idx),*] as &[i32]).len();
 
-                let column_types_iter = || specs.iter().map(|spec| spec.typ().clone());
+                let column_types_iter = || specs.iter().map(|spec| spec.typ().clone().into_owned());
                 if let [$($idf),*] = &specs {
                     $(
                         <$Ti as DeserializeValue<'frame>>::type_check($idf.typ())
@@ -256,7 +256,7 @@ pub struct BuiltinTypeCheckError {
     pub rust_name: &'static str,
 
     /// The CQL types of the values that the Rust type was being deserialized from.
-    pub cql_types: Vec<ColumnType>,
+    pub cql_types: Vec<ColumnType<'static>>,
 
     /// Detailed information about the failure.
     pub kind: BuiltinTypeCheckErrorKind,
@@ -265,7 +265,7 @@ pub struct BuiltinTypeCheckError {
 // Not part of the public API; used in derive macros.
 #[doc(hidden)]
 pub fn mk_typck_err<T>(
-    cql_types: impl IntoIterator<Item = ColumnType>,
+    cql_types: impl IntoIterator<Item = ColumnType<'static>>,
     kind: impl Into<BuiltinTypeCheckErrorKind>,
 ) -> TypeCheckError {
     mk_typck_err_named(std::any::type_name::<T>(), cql_types, kind)
@@ -273,7 +273,7 @@ pub fn mk_typck_err<T>(
 
 fn mk_typck_err_named(
     name: &'static str,
-    cql_types: impl IntoIterator<Item = ColumnType>,
+    cql_types: impl IntoIterator<Item = ColumnType<'static>>,
     kind: impl Into<BuiltinTypeCheckErrorKind>,
 ) -> TypeCheckError {
     TypeCheckError::new(BuiltinTypeCheckError {

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -12,14 +12,14 @@ use crate::frame::response::result::{ColumnSpec, ColumnType, CqlValue, Row};
 #[non_exhaustive]
 pub struct RawColumn<'frame> {
     pub index: usize,
-    pub spec: &'frame ColumnSpec,
+    pub spec: &'frame ColumnSpec<'frame>,
     pub slice: Option<FrameSlice<'frame>>,
 }
 
 /// Iterates over columns of a single row.
 #[derive(Clone, Debug)]
 pub struct ColumnIterator<'frame> {
-    specs: std::iter::Enumerate<std::slice::Iter<'frame, ColumnSpec>>,
+    specs: std::iter::Enumerate<std::slice::Iter<'frame, ColumnSpec<'frame>>>,
     slice: FrameSlice<'frame>,
 }
 

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -62,7 +62,7 @@ impl<'frame> Iterator for ColumnIterator<'frame> {
                     mk_deser_err::<Self>(
                         BuiltinDeserializationErrorKind::RawColumnDeserializationFailed {
                             column_index,
-                            column_name: spec.name.clone(),
+                            column_name: spec.name().to_owned(),
                             err: DeserializationError::new(err),
                         },
                     )
@@ -156,15 +156,17 @@ impl<'frame> DeserializeRow<'frame> for Row {
             .map_err(deser_error_replace_rust_name::<Self>)?
         {
             columns.push(
-                <Option<CqlValue>>::deserialize(&column.spec.typ, column.slice).map_err(|err| {
-                    mk_deser_err::<Self>(
-                        BuiltinDeserializationErrorKind::ColumnDeserializationFailed {
-                            column_index: column.index,
-                            column_name: column.spec.name.clone(),
-                            err,
-                        },
-                    )
-                })?,
+                <Option<CqlValue>>::deserialize(column.spec.typ(), column.slice).map_err(
+                    |err| {
+                        mk_deser_err::<Self>(
+                            BuiltinDeserializationErrorKind::ColumnDeserializationFailed {
+                                column_index: column.index,
+                                column_name: column.spec.name().to_owned(),
+                                err,
+                            },
+                        )
+                    },
+                )?,
             );
         }
         Ok(Self { columns })
@@ -186,13 +188,13 @@ macro_rules! impl_tuple {
             fn type_check(specs: &[ColumnSpec]) -> Result<(), TypeCheckError> {
                 const TUPLE_LEN: usize = (&[$($idx),*] as &[i32]).len();
 
-                let column_types_iter = || specs.iter().map(|spec| spec.typ.clone());
+                let column_types_iter = || specs.iter().map(|spec| spec.typ().clone());
                 if let [$($idf),*] = &specs {
                     $(
-                        <$Ti as DeserializeValue<'frame>>::type_check(&$idf.typ)
+                        <$Ti as DeserializeValue<'frame>>::type_check($idf.typ())
                             .map_err(|err| mk_typck_err::<Self>(column_types_iter(), BuiltinTypeCheckErrorKind::ColumnTypeCheckFailed {
                                 column_index: $idx,
-                                column_name: specs[$idx].name.clone(),
+                                column_name: specs[$idx].name().to_owned(),
                                 err
                             }))?;
                     )*
@@ -215,10 +217,10 @@ macro_rules! impl_tuple {
                             $idx
                         )).map_err(deser_error_replace_rust_name::<Self>)?;
 
-                        <$Ti as DeserializeValue<'frame>>::deserialize(&column.spec.typ, column.slice)
+                        <$Ti as DeserializeValue<'frame>>::deserialize(column.spec.typ(), column.slice)
                             .map_err(|err| mk_deser_err::<Self>(BuiltinDeserializationErrorKind::ColumnDeserializationFailed {
                                 column_index: column.index,
-                                column_name: column.spec.name.clone(),
+                                column_name: column.spec.name().to_owned(),
                                 err,
                             }))?
                     },)*

--- a/scylla-cql/src/types/deserialize/row_tests.rs
+++ b/scylla-cql/src/types/deserialize/row_tests.rs
@@ -64,18 +64,18 @@ fn test_deserialization_as_column_iterator() {
     let mut iter = deserialize::<ColumnIterator>(&col_specs, &serialized_values).unwrap();
 
     let col1 = iter.next().unwrap().unwrap();
-    assert_eq!(col1.spec.name, "i1");
-    assert_eq!(col1.spec.typ, ColumnType::Int);
+    assert_eq!(col1.spec.name(), "i1");
+    assert_eq!(col1.spec.typ(), &ColumnType::Int);
     assert_eq!(col1.slice.unwrap().as_slice(), &123i32.to_be_bytes());
 
     let col2 = iter.next().unwrap().unwrap();
-    assert_eq!(col2.spec.name, "i2");
-    assert_eq!(col2.spec.typ, ColumnType::Text);
+    assert_eq!(col2.spec.name(), "i2");
+    assert_eq!(col2.spec.typ(), &ColumnType::Text);
     assert_eq!(col2.slice.unwrap().as_slice(), "ScyllaDB".as_bytes());
 
     let col3 = iter.next().unwrap().unwrap();
-    assert_eq!(col3.spec.name, "i3");
-    assert_eq!(col3.spec.typ, ColumnType::Counter);
+    assert_eq!(col3.spec.name(), "i3");
+    assert_eq!(col3.spec.typ(), &ColumnType::Counter);
     assert!(col3.slice.is_none());
 
     assert!(iter.next().is_none());
@@ -301,7 +301,7 @@ fn test_tuple_errors() {
             err.cql_types,
             specs
                 .iter()
-                .map(|spec| spec.typ.clone())
+                .map(|spec| spec.typ().clone())
                 .collect::<Vec<_>>()
         );
         let BuiltinTypeCheckErrorKind::ColumnTypeCheckFailed {
@@ -435,7 +435,7 @@ fn test_row_errors() {
 }
 
 fn specs_to_types(specs: &[ColumnSpec]) -> Vec<ColumnType> {
-    specs.iter().map(|spec| spec.typ.clone()).collect()
+    specs.iter().map(|spec| spec.typ().clone()).collect()
 }
 
 #[test]

--- a/scylla-cql/src/types/deserialize/row_tests.rs
+++ b/scylla-cql/src/types/deserialize/row_tests.rs
@@ -434,7 +434,7 @@ fn test_row_errors() {
     }
 }
 
-fn specs_to_types(specs: &[ColumnSpec]) -> Vec<ColumnType<'static>> {
+fn specs_to_types<'a>(specs: &[ColumnSpec<'a>]) -> Vec<ColumnType<'a>> {
     specs.iter().map(|spec| spec.typ().clone()).collect()
 }
 

--- a/scylla-cql/src/types/deserialize/row_tests.rs
+++ b/scylla-cql/src/types/deserialize/row_tests.rs
@@ -434,7 +434,7 @@ fn test_row_errors() {
     }
 }
 
-fn specs_to_types(specs: &[ColumnSpec]) -> Vec<ColumnType> {
+fn specs_to_types(specs: &[ColumnSpec]) -> Vec<ColumnType<'static>> {
     specs.iter().map(|spec| spec.typ().clone()).collect()
 }
 

--- a/scylla-cql/src/types/deserialize/value_tests.rs
+++ b/scylla-cql/src/types/deserialize/value_tests.rs
@@ -2,6 +2,7 @@ use assert_matches::assert_matches;
 use bytes::{BufMut, Bytes, BytesMut};
 use uuid::Uuid;
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -580,11 +581,11 @@ fn test_tuples() {
 }
 
 fn udt_def_with_fields(
-    fields: impl IntoIterator<Item = (impl Into<String>, ColumnType)>,
-) -> ColumnType {
+    fields: impl IntoIterator<Item = (impl Into<Cow<'static, str>>, ColumnType<'static>)>,
+) -> ColumnType<'static> {
     ColumnType::UserDefinedType {
-        type_name: "udt".to_owned(),
-        keyspace: "ks".to_owned(),
+        type_name: "udt".into(),
+        keyspace: "ks".into(),
         field_types: fields.into_iter().map(|(s, t)| (s.into(), t)).collect(),
     }
 }

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -51,7 +51,7 @@ impl<'a> RowSerializationContext<'a> {
     // TODO: change RowSerializationContext to make this faster
     #[inline]
     pub fn column_by_name(&self, target: &str) -> Option<&ColumnSpec> {
-        self.columns.iter().find(|&c| c.name == target)
+        self.columns.iter().find(|&c| c.name() == target)
     }
 }
 
@@ -148,11 +148,11 @@ macro_rules! impl_serialize_row_for_slice {
                 ));
             }
             for (col, val) in ctx.columns().iter().zip(self.iter()) {
-                <T as SerializeValue>::serialize(val, &col.typ, writer.make_cell_writer())
+                <T as SerializeValue>::serialize(val, col.typ(), writer.make_cell_writer())
                     .map_err(|err| {
                         mk_ser_err::<Self>(
                             BuiltinSerializationErrorKind::ColumnSerializationFailed {
-                                name: col.name.clone(),
+                                name: col.name().to_owned(),
                                 err,
                             },
                         )
@@ -189,25 +189,25 @@ macro_rules! impl_serialize_row_for_map {
             let mut unused_columns: HashSet<&str> = self.keys().map(|k| k.as_ref()).collect();
 
             for col in ctx.columns.iter() {
-                match self.get(col.name.as_str()) {
+                match self.get(col.name()) {
                     None => {
                         return Err(mk_typck_err::<Self>(
                             BuiltinTypeCheckErrorKind::ValueMissingForColumn {
-                                name: col.name.clone(),
+                                name: col.name().to_owned(),
                             },
                         ))
                     }
                     Some(v) => {
-                        <T as SerializeValue>::serialize(v, &col.typ, writer.make_cell_writer())
+                        <T as SerializeValue>::serialize(v, col.typ(), writer.make_cell_writer())
                             .map_err(|err| {
-                                mk_ser_err::<Self>(
-                                    BuiltinSerializationErrorKind::ColumnSerializationFailed {
-                                        name: col.name.clone(),
-                                        err,
-                                    },
-                                )
-                            })?;
-                        let _ = unused_columns.remove(col.name.as_str());
+                            mk_ser_err::<Self>(
+                                BuiltinSerializationErrorKind::ColumnSerializationFailed {
+                                    name: col.name().to_owned(),
+                                    err,
+                                },
+                            )
+                        })?;
+                        let _ = unused_columns.remove(col.name());
                     }
                 }
             }
@@ -295,9 +295,9 @@ macro_rules! impl_tuple {
                 };
                 let ($($fidents,)*) = self;
                 $(
-                    <$typs as SerializeValue>::serialize($fidents, &$tidents.typ, writer.make_cell_writer()).map_err(|err| {
+                    <$typs as SerializeValue>::serialize($fidents, $tidents.typ(), writer.make_cell_writer()).map_err(|err| {
                         mk_ser_err::<Self>(BuiltinSerializationErrorKind::ColumnSerializationFailed {
-                            name: $tidents.name.clone(),
+                            name: $tidents.name().to_owned(),
                             err,
                         })
                     })?;
@@ -493,10 +493,10 @@ pub fn serialize_legacy_row<T: ValueList>(
         let mut unused_count = values_by_name.len();
 
         for col in ctx.columns() {
-            let (val, visited) = values_by_name.get_mut(col.name.as_str()).ok_or_else(|| {
+            let (val, visited) = values_by_name.get_mut(col.name()).ok_or_else(|| {
                 SerializationError(Arc::new(
                     ValueListToSerializeRowAdapterError::ValueMissingForBindMarker {
-                        name: col.name.clone(),
+                        name: col.name().to_owned(),
                     },
                 ))
             })?;

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -22,7 +22,7 @@ use super::{CellWriter, RowWriter, SerializationError};
 
 /// Contains information needed to serialize a row.
 pub struct RowSerializationContext<'a> {
-    pub(crate) columns: &'a [ColumnSpec],
+    pub(crate) columns: &'a [ColumnSpec<'a>],
 }
 
 impl<'a> RowSerializationContext<'a> {
@@ -868,12 +868,8 @@ mod tests {
     use assert_matches::assert_matches;
     use scylla_macros::SerializeRow;
 
-    fn col_spec(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
-        ColumnSpec {
-            table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
-            name: name.to_string(),
-            typ,
-        }
+    fn col_spec<'a>(name: &'a str, typ: ColumnType<'a>) -> ColumnSpec<'a> {
+        ColumnSpec::borrowed(name, typ, TableSpec::borrowed("ks", "tbl"))
     }
 
     #[test]
@@ -990,12 +986,8 @@ mod tests {
         t.serialize(&ctx, &mut builder).unwrap_err()
     }
 
-    fn col(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
-        ColumnSpec {
-            table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
-            name: name.to_string(),
-            typ,
-        }
+    fn col<'a>(name: &'a str, typ: ColumnType<'a>) -> ColumnSpec<'a> {
+        ColumnSpec::borrowed(name, typ, TableSpec::borrowed("ks", "tbl"))
     }
 
     #[test]

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -868,7 +868,7 @@ mod tests {
     use assert_matches::assert_matches;
     use scylla_macros::SerializeRow;
 
-    fn col_spec(name: &str, typ: ColumnType) -> ColumnSpec {
+    fn col_spec(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
         ColumnSpec {
             table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
             name: name.to_string(),
@@ -990,7 +990,7 @@ mod tests {
         t.serialize(&ctx, &mut builder).unwrap_err()
     }
 
-    fn col(name: &str, typ: ColumnType) -> ColumnSpec {
+    fn col(name: &str, typ: ColumnType<'static>) -> ColumnSpec {
         ColumnSpec {
             table_spec: TableSpec::owned("ks".to_string(), "tbl".to_string()),
             name: name.to_string(),
@@ -1262,7 +1262,7 @@ mod tests {
     #[test]
     fn test_row_serialization_with_generics() {
         // A minimal smoke test just to test that it works.
-        fn check_with_type<T: SerializeValue + Copy>(typ: ColumnType, t: T) {
+        fn check_with_type<T: SerializeValue + Copy>(typ: ColumnType<'static>, t: T) {
             let spec = [col("a", ColumnType::Text), col("b", typ)];
             let reference = do_serialize(("Ala ma kota", t), &spec);
             let row = do_serialize(

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -233,7 +233,7 @@ impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
             fn type_check(
                 specs: &[#macro_internal::ColumnSpec],
             ) -> ::std::result::Result<(), #macro_internal::TypeCheckError> {
-                let column_types_iter = || specs.iter().map(|spec| ::std::clone::Clone::clone(spec.typ()));
+                let column_types_iter = || specs.iter().map(|spec| ::std::clone::Clone::clone(spec.typ()).into_owned());
 
                 match specs {
                     [#(#required_fields_idents),*] => {
@@ -441,7 +441,7 @@ impl<'sd> TypeCheckUnorderedGenerator<'sd> {
                 // For each required field, generate a "visited" boolean flag
                 #(#visited_field_declarations)*
 
-                let column_types_iter = || specs.iter().map(|spec| ::std::clone::Clone::clone(spec.typ()));
+                let column_types_iter = || specs.iter().map(|spec| ::std::clone::Clone::clone(spec.typ()).into_owned());
 
                 for (column_index, spec) in specs.iter().enumerate() {
                     // Pattern match on the name and verify that the type is correct.

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -169,7 +169,7 @@ impl Context {
                 #crate_path::SerializationError::new(
                     #crate_path::BuiltinTypeTypeCheckError {
                         rust_name: ::std::any::type_name::<Self>(),
-                        got: <_ as ::std::clone::Clone>::clone(typ),
+                        got: <_ as ::std::clone::Clone>::clone(typ).into_owned(),
                         kind: #crate_path::BuiltinTypeTypeCheckErrorKind::UdtError(kind),
                     }
                 )
@@ -184,7 +184,7 @@ impl Context {
                 #crate_path::SerializationError::new(
                     #crate_path::BuiltinTypeSerializationError {
                         rust_name: ::std::any::type_name::<Self>(),
-                        got: <_ as ::std::clone::Clone>::clone(typ),
+                        got: <_ as ::std::clone::Clone>::clone(typ).into_owned(),
                         kind: #crate_path::BuiltinTypeSerializationErrorKind::UdtError(kind),
                     }
                 )
@@ -231,7 +231,7 @@ impl<'a> Generator for FieldSortingGenerator<'a> {
             parse_quote! {
                 return ::std::result::Result::Err(mk_typck_err(
                     #crate_path::UdtTypeCheckErrorKind::NoSuchFieldInUdt {
-                        field_name: <_ as ::std::clone::Clone>::clone(field_name),
+                        field_name: <_ as ::std::clone::Clone>::clone(field_name).into_owned(),
                     }
                 ))
             }
@@ -302,7 +302,7 @@ impl<'a> Generator for FieldSortingGenerator<'a> {
         // the field name.
         statements.push(parse_quote! {
             for (field_name, field_type) in field_types {
-                match ::std::string::String::as_str(field_name) {
+                match ::std::ops::Deref::deref(field_name) {
                     #(
                         #udt_field_names => {
                             #serialize_missing_nulls_statement
@@ -312,7 +312,7 @@ impl<'a> Generator for FieldSortingGenerator<'a> {
                                 ::std::result::Result::Err(err) => {
                                     return ::std::result::Result::Err(mk_ser_err(
                                         #crate_path::UdtSerializationErrorKind::FieldSerializationFailed {
-                                            field_name: <_ as ::std::clone::Clone>::clone(field_name),
+                                            field_name: <_ as ::std::clone::Clone>::clone(field_name).into_owned(),
                                             err,
                                         }
                                     ));
@@ -357,7 +357,7 @@ impl<'a> Generator for FieldSortingGenerator<'a> {
                     .map_err(|_| #crate_path::SerializationError::new(
                         #crate_path::BuiltinTypeSerializationError {
                             rust_name: ::std::any::type_name::<Self>(),
-                            got: <_ as ::std::clone::Clone>::clone(typ),
+                            got: <_ as ::std::clone::Clone>::clone(typ).into_owned(),
                             kind: #crate_path::BuiltinTypeSerializationErrorKind::SizeOverflow,
                         }
                     ) as #crate_path::SerializationError)?;
@@ -419,7 +419,7 @@ impl<'a> Generator for FieldOrderedGenerator<'a> {
                                 Err(err) => {
                                     return ::std::result::Result::Err(mk_ser_err(
                                         #crate_path::UdtSerializationErrorKind::FieldSerializationFailed {
-                                            field_name: <_ as ::std::clone::Clone>::clone(field_name),
+                                            field_name: <_ as ::std::clone::Clone>::clone(field_name).into_owned(),
                                             err,
                                         }
                                     ));
@@ -429,7 +429,7 @@ impl<'a> Generator for FieldOrderedGenerator<'a> {
                             return ::std::result::Result::Err(mk_typck_err(
                                 #crate_path::UdtTypeCheckErrorKind::FieldNameMismatch {
                                     rust_field_name: <_ as ::std::string::ToString>::to_string(#rust_field_name),
-                                    db_field_name: <_ as ::std::clone::Clone>::clone(field_name),
+                                    db_field_name: <_ as ::std::clone::Clone>::clone(field_name).into_owned(),
                                 }
                             ));
                         }
@@ -451,7 +451,7 @@ impl<'a> Generator for FieldOrderedGenerator<'a> {
                 if let Some((field_name, typ)) = field_iter.next() {
                     return ::std::result::Result::Err(mk_typck_err(
                         #crate_path::UdtTypeCheckErrorKind::NoSuchFieldInUdt {
-                            field_name: <_ as ::std::clone::Clone>::clone(field_name),
+                            field_name: <_ as ::std::clone::Clone>::clone(field_name).into_owned(),
                         }
                     ));
                 }
@@ -469,7 +469,7 @@ impl<'a> Generator for FieldOrderedGenerator<'a> {
                     .map_err(|_| #crate_path::SerializationError::new(
                         #crate_path::BuiltinTypeSerializationError {
                             rust_name: ::std::any::type_name::<Self>(),
-                            got: <_ as ::std::clone::Clone>::clone(typ),
+                            got: <_ as ::std::clone::Clone>::clone(typ).into_owned(),
                             kind: #crate_path::BuiltinTypeSerializationErrorKind::SizeOverflow,
                         }
                     ) as #crate_path::SerializationError)?;

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -423,7 +423,7 @@ impl PreparedStatement {
 
     /// Access column specifications of the result set returned after the execution of this statement
     pub fn get_result_set_col_specs(&self) -> &[ColumnSpec] {
-        &self.shared.result_metadata.col_specs
+        self.shared.result_metadata.col_specs()
     }
 
     /// Get the name of the partitioner used for this statement.

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -513,13 +513,13 @@ impl From<SerializationError> for PartitionKeyError {
     }
 }
 
-pub(crate) type PartitionKeyValue<'ps> = (&'ps [u8], &'ps ColumnSpec);
+pub(crate) type PartitionKeyValue<'ps> = (&'ps [u8], &'ps ColumnSpec<'ps>);
 
 pub(crate) struct PartitionKey<'ps> {
     pk_values: SmallVec<[Option<PartitionKeyValue<'ps>>; PartitionKey::SMALLVEC_ON_STACK_SIZE]>,
 }
 
-impl<'ps> PartitionKey<'ps> {
+impl<'ps, 'spec: 'ps> PartitionKey<'ps> {
     const SMALLVEC_ON_STACK_SIZE: usize = 8;
 
     fn new(
@@ -620,7 +620,7 @@ mod tests {
         let col_specs: Vec<_> = cols
             .into_iter()
             .enumerate()
-            .map(|(i, typ)| ColumnSpec::new_for_test(table_spec.clone(), format!("col_{}", i), typ))
+            .map(|(i, typ)| ColumnSpec::owned(format!("col_{}", i), typ, table_spec.clone()))
             .collect();
         let mut pk_indexes = idx
             .into_iter()

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -281,7 +281,7 @@ impl PreparedStatement {
         self.get_prepared_metadata()
             .col_specs
             .first()
-            .map(|spec| &spec.table_spec)
+            .map(|spec| spec.table_spec())
     }
 
     /// Returns the name of the keyspace this statement is operating on.
@@ -289,7 +289,7 @@ impl PreparedStatement {
         self.get_prepared_metadata()
             .col_specs
             .first()
-            .map(|col_spec| col_spec.table_spec.ks_name())
+            .map(|col_spec| col_spec.table_spec().ks_name())
     }
 
     /// Returns the name of the table this statement is operating on.
@@ -297,7 +297,7 @@ impl PreparedStatement {
         self.get_prepared_metadata()
             .col_specs
             .first()
-            .map(|col_spec| col_spec.table_spec.table_name())
+            .map(|col_spec| col_spec.table_spec().table_name())
     }
 
     /// Sets the consistency to be used when executing this statement.
@@ -620,11 +620,7 @@ mod tests {
         let col_specs: Vec<_> = cols
             .into_iter()
             .enumerate()
-            .map(|(i, typ)| ColumnSpec {
-                name: format!("col_{}", i),
-                table_spec: table_spec.clone(),
-                typ,
-            })
+            .map(|(i, typ)| ColumnSpec::new_for_test(table_spec.clone(), format!("col_{}", i), typ))
             .collect();
         let mut pk_indexes = idx
             .into_iter()

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -613,7 +613,7 @@ mod tests {
     use crate::{prepared_statement::PartitionKey, test_utils::setup_tracing};
 
     fn make_meta(
-        cols: impl IntoIterator<Item = ColumnType>,
+        cols: impl IntoIterator<Item = ColumnType<'static>>,
         idx: impl IntoIterator<Item = usize>,
     ) -> PreparedMetadata {
         let table_spec = TableSpec::owned("ks".to_owned(), "t".to_owned());

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -102,7 +102,7 @@ pub struct PreparedStatement {
 #[derive(Debug)]
 struct PreparedStatementSharedData {
     metadata: PreparedMetadata,
-    result_metadata: Arc<ResultMetadata>,
+    result_metadata: Arc<ResultMetadata<'static>>,
     statement: String,
 }
 
@@ -125,7 +125,7 @@ impl PreparedStatement {
         id: Bytes,
         is_lwt: bool,
         metadata: PreparedMetadata,
-        result_metadata: Arc<ResultMetadata>,
+        result_metadata: Arc<ResultMetadata<'static>>,
         statement: String,
         page_size: PageSize,
         config: StatementConfig,
@@ -417,7 +417,7 @@ impl PreparedStatement {
     }
 
     /// Access metadata about the result of prepared statement returned by the database
-    pub(crate) fn get_result_metadata(&self) -> &Arc<ResultMetadata> {
+    pub(crate) fn get_result_metadata(&self) -> &Arc<ResultMetadata<'static>> {
         &self.shared.result_metadata
     }
 

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -25,7 +25,7 @@ struct RawPreparedStatementData {
     id: Bytes,
     is_confirmed_lwt: bool,
     metadata: PreparedMetadata,
-    result_metadata: Arc<ResultMetadata>,
+    result_metadata: Arc<ResultMetadata<'static>>,
     partitioner_name: PartitionerName,
 }
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1444,7 +1444,7 @@ impl Connection {
         request: &impl SerializableRequest,
         compress: bool,
         tracing: bool,
-        cached_metadata: Option<&Arc<ResultMetadata>>,
+        cached_metadata: Option<&Arc<ResultMetadata<'static>>>,
     ) -> Result<QueryResponse, RequestError> {
         let compression = if compress {
             self.config.compression
@@ -1471,7 +1471,7 @@ impl Connection {
         task_response: TaskResponse,
         compression: Option<Compression>,
         features: &ProtocolFeatures,
-        cached_metadata: Option<&Arc<ResultMetadata>>,
+        cached_metadata: Option<&Arc<ResultMetadata<'static>>>,
     ) -> Result<QueryResponse, ResponseParseError> {
         let body_with_ext = frame::parse_response_body_extensions(
             task_response.params.flags,

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -397,7 +397,7 @@ impl RowIterator {
 
     /// Returns specification of row columns
     pub fn get_column_specs(&self) -> &[ColumnSpec] {
-        &self.current_page.metadata.col_specs
+        self.current_page.metadata.col_specs()
     }
 
     fn is_current_page_exhausted(&self) -> bool {

--- a/scylla/src/transport/locator/tablets.rs
+++ b/scylla/src/transport/locator/tablets.rs
@@ -38,7 +38,7 @@ pub(crate) struct RawTablet {
 type RawTabletPayload = (i64, i64, Vec<(Uuid, i32)>);
 
 lazy_static! {
-    static ref RAW_TABLETS_CQL_TYPE: ColumnType = ColumnType::Tuple(vec![
+    static ref RAW_TABLETS_CQL_TYPE: ColumnType<'static> = ColumnType::Tuple(vec![
         ColumnType::BigInt,
         ColumnType::BigInt,
         ColumnType::List(Box::new(ColumnType::Tuple(vec![

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -21,7 +21,7 @@ pub struct QueryResult {
     /// CQL Tracing uuid - can only be Some if tracing is enabled for this query
     pub tracing_id: Option<Uuid>,
     /// Metadata returned along with this response.
-    pub(crate) metadata: Option<Arc<ResultMetadata>>,
+    pub(crate) metadata: Option<Arc<ResultMetadata<'static>>>,
     /// The original size of the serialized rows in request
     pub serialized_size: usize,
 }
@@ -314,7 +314,7 @@ mod tests {
         rows
     }
 
-    fn make_test_metadata() -> ResultMetadata {
+    fn make_test_metadata() -> ResultMetadata<'static> {
         let table_spec = TableSpec::borrowed("some_keyspace", "some_table");
 
         let column_spec = ColumnSpec::borrowed("column0", ColumnType::Int, table_spec);

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -317,8 +317,7 @@ mod tests {
     fn make_test_metadata() -> ResultMetadata {
         let table_spec = TableSpec::borrowed("some_keyspace", "some_table");
 
-        let column_spec =
-            ColumnSpec::new_for_test(table_spec, "column0".to_owned(), ColumnType::Int);
+        let column_spec = ColumnSpec::borrowed("column0", ColumnType::Int, table_spec);
 
         ResultMetadata::new_for_test(1, vec![column_spec])
     }

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -151,7 +151,7 @@ impl QueryResult {
         self.col_specs()
             .iter()
             .enumerate()
-            .find(|(_id, spec)| spec.name == name)
+            .find(|(_id, spec)| spec.name() == name)
     }
 }
 
@@ -317,11 +317,8 @@ mod tests {
     fn make_test_metadata() -> ResultMetadata {
         let table_spec = TableSpec::borrowed("some_keyspace", "some_table");
 
-        let column_spec = ColumnSpec {
-            table_spec,
-            name: "column0".to_string(),
-            typ: ColumnType::Int,
-        };
+        let column_spec =
+            ColumnSpec::new_for_test(table_spec, "column0".to_owned(), ColumnType::Int);
 
         ResultMetadata::new_for_test(1, vec![column_spec])
     }

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -141,7 +141,7 @@ impl QueryResult {
     pub fn col_specs(&self) -> &[ColumnSpec] {
         self.metadata
             .as_ref()
-            .map(|metadata| metadata.col_specs.as_slice())
+            .map(|metadata| metadata.col_specs())
             .unwrap_or_default()
     }
 

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -2244,7 +2244,7 @@ fn partition_key_displayer<'ps, 'res>(
         std::iter::from_fn(move || {
             pk_values_iter
                 .next()
-                .map(|(mut cell, spec)| deser_cql_value(&spec.typ, &mut cell))
+                .map(|(mut cell, spec)| deser_cql_value(spec.typ(), &mut cell))
         })
         .map(|c| match c {
             Ok(c) => Either::Left(CqlValueDisplayer(c)),

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -2115,8 +2115,8 @@ impl RequestSpan {
         }
     }
 
-    pub(crate) fn new_prepared<'ps>(
-        partition_key: Option<impl Iterator<Item = (&'ps [u8], &'ps ColumnSpec)> + Clone>,
+    pub(crate) fn new_prepared<'ps, 'spec: 'ps>(
+        partition_key: Option<impl Iterator<Item = (&'ps [u8], &'ps ColumnSpec<'spec>)> + Clone>,
         token: Option<Token>,
         request_size: usize,
     ) -> Self {
@@ -2237,8 +2237,8 @@ impl Drop for RequestSpan {
     }
 }
 
-fn partition_key_displayer<'ps, 'res>(
-    mut pk_values_iter: impl Iterator<Item = (&'ps [u8], &'ps ColumnSpec)> + 'res + Clone,
+fn partition_key_displayer<'ps, 'res, 'spec: 'ps>(
+    mut pk_values_iter: impl Iterator<Item = (&'ps [u8], &'ps ColumnSpec<'spec>)> + 'res + Clone,
 ) -> impl Display + 'res {
     CommaSeparatedDisplayer(
         std::iter::from_fn(move || {

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -140,8 +140,8 @@ async fn test_unprepared_statement() {
     let specs = query_result.get_column_specs();
     assert_eq!(specs.len(), 3);
     for (spec, name) in specs.iter().zip(["a", "b", "c"]) {
-        assert_eq!(spec.name, name); // Check column name.
-        assert_eq!(spec.table_spec.ks_name(), ks);
+        assert_eq!(spec.name(), name); // Check column name.
+        assert_eq!(spec.table_spec().ks_name(), ks);
     }
     let mut results_from_manual_paging: Vec<Row> = vec![];
     let query = Query::new(format!("SELECT a, b, c FROM {}.t", ks)).with_page_size(1);
@@ -199,8 +199,8 @@ async fn test_prepared_statement() {
     let specs = query_result.get_column_specs();
     assert_eq!(specs.len(), 3);
     for (spec, name) in specs.iter().zip(["a", "b", "c"]) {
-        assert_eq!(spec.name, name); // Check column name.
-        assert_eq!(spec.table_spec.ks_name(), ks);
+        assert_eq!(spec.name(), name); // Check column name.
+        assert_eq!(spec.table_spec().ks_name(), ks);
     }
 
     let prepared_statement = session


### PR DESCRIPTION
Ref: #462 

This is a necessary step towards non-allocating (in fact less-allocating) result metadata deserialization.

# What's done

- `ColumnType` is made ownership-generic; there will be two distinct functions to deserialize owned and borrowed `ColumnType`;
- `ColumnSpec` is made ownership-generic; in a follow-up PR, there will be a distinct function to deserialize borrowed `Vec<ColumnSpec<'frame>>`.
- `ResultMetadata` is made ownership-generic;
- `deser_table_spec` no longer allocates; it's up to `deser_col_specs` to allocate or not, depending on desired ownership of deserialized metadata;
- `deser_col_specs` verifies that table specs are the same for all columns. We assume it's true, but the CQL protocol does not enforce it. With that check, we will be able to hold only one table spec per query, not one per column; this will reduce memory footprint. TODO in a follow-up.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
