### PR TITLE
Fix panic in speculative execution

### DIFF
--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -127,21 +127,17 @@ where
                 }
             }
             res = async_tasks.select_next_some() => {
-                match res {
-                    Some(r) => {
-                        if !can_be_ignored(&r) {
-                            return r;
-                        } else {
-                            last_error = Some(r)
-                        }
-                    },
-                    None =>  {
-                        if async_tasks.is_empty() && retries_remaining == 0 {
-                            return last_error.unwrap_or({
-                                Err(EMPTY_PLAN_ERROR)
-                            });
-                        }
-                    },
+                if let Some(r) = res {
+                    if !can_be_ignored(&r) {
+                        return r;
+                    } else {
+                        last_error = Some(r)
+                    }
+                }
+                if async_tasks.is_empty() && retries_remaining == 0 {
+                    return last_error.unwrap_or({
+                        Err(EMPTY_PLAN_ERROR)
+                    });
                 }
             }
         }


### PR DESCRIPTION
This PR fixes linked bug by simplifying the logic inside the function.
The new logic always checks if the resolved task is the last one, and if so it returns, so it's not possible for the tasks to be exhausted without finishing the `select!`.

This PR also adds regression test for the issue. I verified that the test actually panics without the fix.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1085

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
