### PR TITLE
errors: expose pub getters for type-erased errors

### DIFF
--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -179,7 +179,6 @@ pub use row::DeserializeRow;
 pub use value::DeserializeValue;
 
 use std::error::Error;
-use std::fmt::Display;
 use std::sync::Arc;
 
 use thiserror::Error;
@@ -202,7 +201,7 @@ use thiserror::Error;
 ///   It won't be returned by the `Session` directly, but it might be nested
 ///   in the [`row::BuiltinTypeCheckError`].
 #[derive(Debug, Clone, Error)]
-#[error(transparent)]
+#[error("TypeCheckError: {0}")]
 pub struct TypeCheckError(pub(crate) Arc<dyn std::error::Error + Send + Sync>);
 
 impl TypeCheckError {
@@ -233,6 +232,7 @@ impl TypeCheckError {
 ///   It won't be returned by the `Session` directly, but it might be nested
 ///   in the [`row::BuiltinDeserializationError`].
 #[derive(Debug, Clone, Error)]
+#[error("DeserializationError: {0}")]
 pub struct DeserializationError(Arc<dyn Error + Send + Sync>);
 
 impl DeserializationError {
@@ -245,12 +245,6 @@ impl DeserializationError {
     /// Retrieve an error reason by downcasting to specific type.
     pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
         self.0.downcast_ref()
-    }
-}
-
-impl Display for DeserializationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DeserializationError: {}", self.0)
     }
 }
 

--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -211,6 +211,11 @@ impl TypeCheckError {
     pub fn new(err: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self(Arc::new(err))
     }
+
+    /// Retrieve an error reason by downcasting to specific type.
+    pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref()
+    }
 }
 
 /// An error indicating that a failure happened during deserialization.
@@ -235,6 +240,11 @@ impl DeserializationError {
     #[inline]
     pub fn new(err: impl Error + Send + Sync + 'static) -> Self {
         Self(Arc::new(err))
+    }
+
+    /// Retrieve an error reason by downcasting to specific type.
+    pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref()
     }
 }
 

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -41,6 +41,11 @@ impl SerializationError {
     pub fn new(err: impl Error + Send + Sync + 'static) -> SerializationError {
         SerializationError(Arc::new(err))
     }
+
+    /// Retrieve an error reason by downcasting to specific type.
+    pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref()
+    }
 }
 
 impl Display for SerializationError {

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -2,7 +2,7 @@
 
 //! Types and traits related to serialization of values to the CQL format.
 
-use std::{error::Error, fmt::Display, sync::Arc};
+use std::{error::Error, sync::Arc};
 
 use thiserror::Error;
 
@@ -33,6 +33,7 @@ pub use writers::{CellValueBuilder, CellWriter, RowWriter};
 ///   as an argument to the statement, and rewriting it using the new
 ///   `SerializeRow` interface fails.
 #[derive(Debug, Clone, Error)]
+#[error("SerializationError: {0}")]
 pub struct SerializationError(Arc<dyn Error + Send + Sync>);
 
 impl SerializationError {
@@ -45,11 +46,5 @@ impl SerializationError {
     /// Retrieve an error reason by downcasting to specific type.
     pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
         self.0.downcast_ref()
-    }
-}
-
-impl Display for SerializationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "SerializationError: {}", self.0)
     }
 }

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -2780,7 +2780,7 @@ mod tests {
         let err = error_receiver.await.unwrap();
         let err_inner: &BrokenConnectionErrorKind = match err {
             crate::transport::connection::ConnectionError::BrokenConnection(ref e) => {
-                e.get_reason().downcast_ref().unwrap()
+                e.downcast_ref().unwrap()
             }
             _ => panic!("Bad error type. Expected keepalive timeout."),
         };

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -728,15 +728,15 @@ impl ConnectionSetupRequestError {
 pub struct BrokenConnectionError(Arc<dyn Error + Sync + Send>);
 
 impl BrokenConnectionError {
-    /// Retrieve an error reason.
-    pub fn get_reason(&self) -> &Arc<dyn Error + Sync + Send> {
-        &self.0
+    /// Retrieve an error reason by downcasting to specific type.
+    pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref()
     }
 }
 
 /// A reason why connection was broken.
 ///
-/// See [`BrokenConnectionError::get_reason()`].
+/// See [`BrokenConnectionError::downcast_ref()`].
 /// You can retrieve the actual type by downcasting `Arc<dyn Error>`.
 #[derive(Error, Debug)]
 #[non_exhaustive]


### PR DESCRIPTION
## Motivation

Sometimes, user might want to downcast `Arc<dyn Error>` to specific error type.

Actually, there is a use case for this in cpp-rust-driver, where we need to define custom `SerializeRow` implementation. It returns a custom error type. We would like to match against it during rust-to-C error conversion - downcasting is thus required.

See: https://github.com/scylladb/cpp-rust-driver/pull/187

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
