### PR TITLE
scylla/lib.rs: Remove stars in serialization frameworks imports

### DIFF
--- a/scylla-cql/src/types/serialize/batch.rs
+++ b/scylla-cql/src/types/serialize/batch.rs
@@ -1,6 +1,9 @@
 //! Contains the [`BatchValues`] and [`BatchValuesIterator`] trait and their
 //! implementations.
 
+// Note: When editing above doc-comment edit the corresponding comment on
+// re-export module in scylla crate too.
+
 use crate::frame::value::{LegacyBatchValues, LegacyBatchValuesIterator};
 
 use super::row::{RowSerializationContext, SerializeRow};

--- a/scylla-cql/src/types/serialize/raw_batch.rs
+++ b/scylla-cql/src/types/serialize/raw_batch.rs
@@ -1,6 +1,9 @@
 //! Contains the [`RawBatchValues`] and [`RawBatchValuesIterator`] trait and their
 //! implementations.
 
+// Note: When editing above doc-comment edit the corresponding comment on
+// re-export module in scylla crate too.
+
 use super::batch::{BatchValues, BatchValuesIterator};
 use super::row::{RowSerializationContext, SerializedValues};
 use super::{RowWriter, SerializationError};

--- a/scylla-cql/src/types/serialize/raw_batch.rs
+++ b/scylla-cql/src/types/serialize/raw_batch.rs
@@ -1,9 +1,6 @@
 //! Contains the [`RawBatchValues`] and [`RawBatchValuesIterator`] trait and their
 //! implementations.
 
-// Note: When editing above doc-comment edit the corresponding comment on
-// re-export module in scylla crate too.
-
 use super::batch::{BatchValues, BatchValuesIterator};
 use super::row::{RowSerializationContext, SerializedValues};
 use super::{RowWriter, SerializationError};

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -1,5 +1,8 @@
 //! Contains the [`SerializeRow`] trait and its implementations.
 
+// Note: When editing above doc-comment edit the corresponding comment on
+// re-export module in scylla crate too.
+
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Display;

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1,5 +1,8 @@
 //! Contains the [`SerializeValue`] trait and its implementations.
 
+// Note: When editing above doc-comment edit the corresponding comment on
+// re-export module in scylla crate too.
+
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
 use std::hash::BuildHasher;

--- a/scylla-cql/src/types/serialize/writers.rs
+++ b/scylla-cql/src/types/serialize/writers.rs
@@ -1,5 +1,8 @@
 //! Contains types and traits used for safe serialization of values for a CQL statement.
 
+// Note: When editing above doc-comment edit the corresponding comment on
+// re-export module in scylla crate too.
+
 use thiserror::Error;
 
 use super::row::SerializedValues;

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -150,15 +150,6 @@ pub mod serialize {
         };
     }
 
-    /// Contains the [RawBatchValues][raw_batch::RawBatchValues] and [RawBatchValuesIterator][raw_batch::RawBatchValuesIterator]
-    /// trait and their implementations.
-    pub mod raw_batch {
-        pub use scylla_cql::types::serialize::raw_batch::{
-            RawBatchValues, RawBatchValuesAdapter, RawBatchValuesIterator,
-            RawBatchValuesIteratorAdapter,
-        };
-    }
-
     /// Contains the [SerializeRow][row::SerializeRow] trait and its implementations.
     pub mod row {
         // Main types

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -63,8 +63,7 @@
 //! # Ok(())
 //! # }
 //! ```
-//! But the driver will accept anything implementing the trait [SerializeRow]
-//! (crate::serialize::row::SerializeRow)
+//! But the driver will accept anything implementing the trait [SerializeRow].
 //!
 //! ### Receiving results
 //! The easiest way to read rows returned by a query is to cast each row to a tuple of values:

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -131,8 +131,84 @@ pub mod frame {
 }
 
 /// Serializing bound values of a query to be sent to the DB.
+// Note: When editing comment on submodules here edit corresponding comments
+// on scylla-cql modules too.
 pub mod serialize {
-    pub use scylla_cql::types::serialize::*;
+    pub use scylla_cql::types::serialize::SerializationError;
+    /// Contains the [BatchValues][batch::BatchValues] and [BatchValuesIterator][batch::BatchValuesIterator] trait and their
+    /// implementations.
+    pub mod batch {
+        // Main types
+        pub use scylla_cql::types::serialize::batch::{
+            BatchValues, BatchValuesFromIterator, BatchValuesIterator,
+            BatchValuesIteratorFromIterator, TupleValuesIter,
+        };
+
+        // Legacy migration types - to be removed when removing legacy framework
+        pub use scylla_cql::types::serialize::batch::{
+            LegacyBatchValuesAdapter, LegacyBatchValuesIteratorAdapter,
+        };
+    }
+
+    /// Contains the [RawBatchValues][raw_batch::RawBatchValues] and [RawBatchValuesIterator][raw_batch::RawBatchValuesIterator]
+    /// trait and their implementations.
+    pub mod raw_batch {
+        pub use scylla_cql::types::serialize::raw_batch::{
+            RawBatchValues, RawBatchValuesAdapter, RawBatchValuesIterator,
+            RawBatchValuesIteratorAdapter,
+        };
+    }
+
+    /// Contains the [SerializeRow][row::SerializeRow] trait and its implementations.
+    pub mod row {
+        // Main types
+        pub use scylla_cql::types::serialize::row::{RowSerializationContext, SerializeRow};
+
+        // Errors
+        pub use scylla_cql::types::serialize::row::{
+            BuiltinSerializationError, BuiltinSerializationErrorKind, BuiltinTypeCheckError,
+            BuiltinTypeCheckErrorKind,
+        };
+
+        // Legacy migration types - to be removed when removing legacy framework
+        pub use scylla_cql::types::serialize::row::{
+            // Legacy migration types - to be removed when removing legacy framework
+            serialize_legacy_row,
+            ValueListAdapter,
+            ValueListToSerializeRowAdapterError,
+        };
+
+        // Not part of the old framework, but something that we should
+        // still aim to remove from public API.
+        pub use scylla_cql::types::serialize::row::{SerializedValues, SerializedValuesIterator};
+    }
+
+    /// Contains the [SerializeValue][value::SerializeValue] trait and its implementations.
+    pub mod value {
+        // Main types
+        pub use scylla_cql::types::serialize::value::SerializeValue;
+
+        // Errors
+        pub use scylla_cql::types::serialize::value::{
+            BuiltinSerializationError, BuiltinSerializationErrorKind, BuiltinTypeCheckError,
+            BuiltinTypeCheckErrorKind, MapSerializationErrorKind, MapTypeCheckErrorKind,
+            SetOrListSerializationErrorKind, SetOrListTypeCheckErrorKind,
+            TupleSerializationErrorKind, TupleTypeCheckErrorKind, UdtSerializationErrorKind,
+            UdtTypeCheckErrorKind,
+        };
+
+        // Legacy migration types - to be removed when removing legacy framework
+        pub use scylla_cql::types::serialize::value::{
+            serialize_legacy_value, ValueAdapter, ValueToSerializeValueAdapterError,
+        };
+    }
+
+    /// Contains types and traits used for safe serialization of values for a CQL statement.
+    pub mod writers {
+        pub use scylla_cql::types::serialize::writers::{
+            CellOverflowError, CellValueBuilder, CellWriter, RowWriter, WrittenCellProof,
+        };
+    }
 }
 
 /// Deserializing DB response containing CQL query results.


### PR DESCRIPTION
It is easier to see what is imported, and decide if it should be, if one can see what exactly is imported. This is hard to do with stars, so, as part of API stabilization effort, those are removed here.

This PR also removes raw_batch re-export. This module should not be needed by users.

I verified using semver-checks that the first commit doesn't introduce any breaking changes.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] ~~All commits compile, pass static checks and pass test.~~
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
