### PR TITLE
[.github/workflow/rust.yml] Add docker credentials to avoid rate limit

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -25,9 +25,13 @@ jobs:
         ports:
           - 9042:9042
         options: --health-cmd "cqlsh --username cassandra --password cassandra --debug" --health-interval 5s --health-retries 30
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - name: Update rust toolchain
       run: rustup update
     - name: Run tests
       run: RUST_LOG=trace cargo test --verbose authenticate_superuser -- custom_authentication --ignored
+

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -25,6 +25,9 @@ jobs:
         ports:
           - 9042:9042
         options: --health-cmd "cqlsh --debug scylladb" --health-interval 5s --health-retries 10
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - name: Update rust toolchain

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Setup 3-node Cassandra cluster
       run: |
         docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
       # A separate step for building to separate measuring time of compilation and testing
     - name: Update rust toolchain
       run: rustup update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,14 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: DOCKERHUB_USERNAME
+        password: DOCKERHUB_PASSWORD
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Setup 3-node Scylla cluster
       run: |
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -30,6 +30,9 @@ jobs:
           --health-retries 10
     env:
       working-directory: ./scylla
+    with:
+      username: ${{ secrets.DOCKERHUB_USERNAME }}
+      password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - name: Update rust toolchain


### PR DESCRIPTION
To avoid errors such
```
Error toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

we should add a login to our Scylladb docker hub

Adding it
