### PR TITLE
keepalive: trace in case of success

### DIFF
--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1839,6 +1839,11 @@ impl Connection {
                     );
                     return Err(err);
                 }
+
+                trace!(
+                    "Keepalive request successful on connection to node {}",
+                    node_address
+                );
             }
         } else {
             // No keepalives are to be sent.


### PR DESCRIPTION
cpp-rust-driver tests sometimes depend on logs emitted by the driver. HeartbeatTests are on of them. Tests look for a following log: `logger_.add_critera("Heartbeat completed on host " + ccm_->get_ip_prefix());`.

Before this commit, rust-driver was not emitting any logs in case of keepalive request success. I think it's not a bad idea to add a trace log here, considering that keepalive intervals are rather long (default is 30s).

Obviously, the logger criteria will need to
be adjusted in `cpp-rust-driver` tests as well.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
