### PR TITLE
Fix unnamable types

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -55,4 +55,5 @@ full-serialization = [
 ]
 
 [lints.rust]
+unnameable_types = "warn"
 unreachable_pub = "warn"

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -18,4 +18,5 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [lints.rust]
+unnameable_types = "warn"
 unreachable_pub = "warn"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -95,5 +95,6 @@ name = "benchmark"
 harness = false
 
 [lints.rust]
+unnameable_types = "warn"
 unreachable_pub = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(scylla_cloud_tests)'] }

--- a/scylla/src/cloud/mod.rs
+++ b/scylla/src/cloud/mod.rs
@@ -2,7 +2,7 @@ mod config;
 
 use std::net::SocketAddr;
 
-pub(crate) use config::CloudConfig;
+pub use config::CloudConfig;
 pub use config::CloudConfigError;
 use openssl::{
     error::ErrorStack,

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -271,4 +271,4 @@ pub use transport::load_balancing;
 pub use transport::retry_policy;
 pub use transport::speculative_execution;
 
-pub use transport::metrics::Metrics;
+pub use transport::metrics::{Metrics, MetricsError};

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -27,7 +27,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use super::locator::tablets::{RawTablet, Tablet, TabletsInfo};
-use super::node::{KnownNode, NodeAddr};
+use super::node::{InternalKnownNode, NodeAddr};
 use super::NodeRef;
 
 use super::locator::ReplicaLocator;
@@ -145,7 +145,7 @@ struct UseKeyspaceRequest {
 
 impl Cluster {
     pub(crate) async fn new(
-        known_nodes: Vec<KnownNode>,
+        known_nodes: Vec<InternalKnownNode>,
         pool_config: PoolConfig,
         keyspaces_to_fetch: Vec<String>,
         fetch_schema_metadata: bool,

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -59,12 +59,6 @@ impl<'a> std::fmt::Debug for ClusterNeatDebug<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Datacenter {
-    pub nodes: Vec<Arc<Node>>,
-    pub rack_count: usize,
-}
-
 #[derive(Clone)]
 pub struct ClusterData {
     pub(crate) known_peers: HashMap<Uuid, Arc<Node>>, // Invariant: nonempty after Cluster::new()

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -381,25 +381,6 @@ impl ClusterData {
         &self.keyspaces
     }
 
-    /// Access datacenter details collected by the driver
-    /// Returned `HashMap` is indexed by names of datacenters
-    pub fn get_datacenters_info(&self) -> HashMap<String, Datacenter> {
-        self.locator
-            .datacenter_names()
-            .iter()
-            .map(|dc_name| {
-                let nodes = self
-                    .locator
-                    .unique_nodes_in_datacenter_ring(dc_name)
-                    .unwrap()
-                    .to_vec();
-                let rack_count = nodes.iter().map(|node| node.rack.as_ref()).unique().count();
-
-                (dc_name.clone(), Datacenter { nodes, rack_count })
-            })
-            .collect()
-    }
-
     /// Access details about nodes known to the driver
     pub fn get_nodes_info(&self) -> &[Arc<Node>] {
         self.locator.unique_nodes_in_global_ring()

--- a/scylla/src/transport/node.rs
+++ b/scylla/src/transport/node.rs
@@ -242,10 +242,10 @@ pub struct CloudEndpoint {
 
 /// Describes a database server known on Session startup, with already resolved address.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct ResolvedContactPoint {
-    pub address: SocketAddr,
-    pub datacenter: Option<String>,
+pub(crate) struct ResolvedContactPoint {
+    pub(crate) address: SocketAddr,
+    #[cfg_attr(not(feature = "cloud"), allow(unused))]
+    pub(crate) datacenter: Option<String>,
 }
 
 // Resolve the given hostname using a DNS lookup if necessary.

--- a/scylla/src/transport/session_builder.rs
+++ b/scylla/src/transport/session_builder.rs
@@ -29,6 +29,10 @@ use openssl::ssl::SslContext;
 use tracing::warn;
 
 mod sealed {
+    // This is a sealed trait - its whole purpose is to be unnameable.
+    // This means we need to disable the check.
+    #[allow(unknown_lints)] // Rust 1.66 doesn't know this lint
+    #[allow(unnameable_types)]
     pub trait Sealed {}
 }
 pub trait SessionBuilderKind: sealed::Sealed + Clone {}

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -8,7 +8,6 @@ use crate::routing::Token;
 use crate::statement::Consistency;
 use crate::test_utils::{scylla_supports_tablets, setup_tracing};
 use crate::tracing::TracingInfo;
-use crate::transport::cluster::Datacenter;
 use crate::transport::errors::{BadKeyspaceName, BadQuery, DbError, QueryError};
 use crate::transport::partitioner::{
     calculate_token_for_partition_key, Murmur3Partitioner, Partitioner, PartitionerName,
@@ -1874,10 +1873,11 @@ async fn test_turning_off_schema_fetching() {
     let cluster_data = &session.get_cluster_data();
     let keyspace = &cluster_data.get_keyspace_info()[&ks];
 
-    let datacenters: HashMap<String, Datacenter> = cluster_data.get_datacenters_info();
-    let datacenter_repfactors: HashMap<String, usize> = datacenters
-        .into_keys()
-        .map(|dc_name| (dc_name, 1))
+    let datacenter_repfactors: HashMap<String, usize> = cluster_data
+        .replica_locator()
+        .datacenter_names()
+        .iter()
+        .map(|dc_name| (dc_name.to_owned(), 1))
         .collect();
 
     assert_eq!(

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -33,7 +33,7 @@ use super::errors::{
     KeyspaceStrategyError, KeyspacesMetadataError, MetadataError, PeersMetadataError,
     ProtocolError, TablesMetadataError, UdtMetadataError, ViewsMetadataError,
 };
-use super::node::{KnownNode, NodeAddr, ResolvedContactPoint};
+use super::node::{InternalKnownNode, NodeAddr, ResolvedContactPoint};
 
 /// Allows to read current metadata from the cluster
 pub(crate) struct MetadataReader {
@@ -51,7 +51,7 @@ pub(crate) struct MetadataReader {
 
     // When no known peer is reachable, initial known nodes are resolved once again as a fallback
     // and establishing control connection to them is attempted.
-    initial_known_nodes: Vec<KnownNode>,
+    initial_known_nodes: Vec<InternalKnownNode>,
 
     // When a control connection breaks, the PoolRefiller of its pool uses the requester
     // to signal ClusterWorker that an immediate metadata refresh is advisable.
@@ -451,7 +451,7 @@ impl MetadataReader {
     /// Creates new MetadataReader, which connects to initially_known_peers in the background
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
-        initial_known_nodes: Vec<KnownNode>,
+        initial_known_nodes: Vec<InternalKnownNode>,
         control_connection_repair_requester: broadcast::Sender<()>,
         mut connection_config: ConnectionConfig,
         keepalive_interval: Option<Duration>,

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -75,9 +75,8 @@ pub struct Peer {
 
 /// An endpoint for a node that the driver is to issue connections to,
 /// possibly after prior address translation.
-#[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
 #[derive(Clone, Debug)]
-pub enum UntranslatedEndpoint {
+pub(crate) enum UntranslatedEndpoint {
     /// Provided by user in SessionConfig (initial contact points).
     ContactPoint(ResolvedContactPoint),
     /// Fetched in Metadata with `query_peers()`


### PR DESCRIPTION
This PR enables the `unnameable_types` lint. This lint catches types that are
- `pub`
- Used in some public API
- Not exported - and thus unusable by the user of the driver.

The only situation when this is desired that I know of is creating a sealed trait.
This PR fixes all occurrences of unnameable types and enables the lint so that
we don't introduce more in the future.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] I added appropriate `Fixes:` annotations to PR description.
