### PR TITLE
clippy: ignore result_large_err clippy lint for Tablet::from_raw_tablet

### DIFF
--- a/scylla/src/transport/locator/tablets.rs
+++ b/scylla/src/transport/locator/tablets.rs
@@ -210,6 +210,12 @@ pub(crate) struct Tablet {
 }
 
 impl Tablet {
+    // Ignore clippy lints here. Clippy suggests to
+    // Box<> `Err` variant, because it's too large. It does not
+    // make much sense to do so, looking at the caller of this function.
+    // Tablet returned in `Err` variant is used as if no error appeared.
+    // The only difference is that we use node ids to emit some debug logs.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn from_raw_tablet(
         raw_tablet: RawTablet,
         replica_translator: impl Fn(Uuid) -> Option<Arc<Node>>,


### PR DESCRIPTION
With recent update of rust toolchain, new clippy lints were introduced - `result_large_err` being one of them.

See: https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

I decided to ignore the lint in `Tablet::from_raw_tablet`.
I justified this decision in the code:
```
// Ignore clippy lints here. Clippy suggests to
// Box<> `Err`` variant, because it's too large. It does not
// make much sense to do so, looking at the caller of this function.
// Tablet returned in `Err` variant is used as if no error appeared.
// The only difference is that we use node ids to emit some debug logs.
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
