### PR TITLE
Bump msrv to 1.70

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: full
-  rust_min: 1.66.0 # <- Update this when bumping up MSRV
+  rust_min: 1.70.0 # <- Update this when bumping up MSRV
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ Ongoing efforts:
 Please join the `#rust-driver` channel on [ScyllaDB Slack] to discuss any issues or questions you might have.
 
 ## Supported Rust Versions
-Our driver's minimum supported Rust version (MSRV) is 1.70.0. Any changes will be explicitly published and will only happen during major releases.
+Our driver's minimum supported Rust version (MSRV) is 1.70.0. Any changes:
+- Will be announced in release notes.
+- Before 1.0 will only happen in major releases.
+- After 1.0 will also happen in minor, but not patch releases.
+
+Exact MSRV policy after 1.0 is not yet decided.
 
 ## Reference Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # ScyllaDB Rust Driver
 
 [![Crates.io](https://img.shields.io/crates/v/scylla.svg)](https://crates.io/crates/scylla) [![docs.rs](https://docs.rs/scylla/badge.svg)](https://docs.rs/scylla)
-[![minimum rustc version](https://img.shields.io/badge/rustc-1.66-orange.svg)](https://crates.io/crates/scylla)
+[![minimum rustc version](https://img.shields.io/badge/rustc-1.70-orange.svg)](https://crates.io/crates/scylla)
 
 This is a client-side driver for [ScyllaDB] written in pure Rust with a fully async API using [Tokio].
 Although optimized for ScyllaDB, the driver is also compatible with [Apache Cassandra®].
@@ -66,7 +66,7 @@ Ongoing efforts:
 Please join the `#rust-driver` channel on [ScyllaDB Slack] to discuss any issues or questions you might have.
 
 ## Supported Rust Versions
-Our driver's minimum supported Rust version (MSRV) is 1.66.0. Any changes will be explicitly published and will only happen during major releases.
+Our driver's minimum supported Rust version (MSRV) is 1.70.0. Any changes will be explicitly published and will only happen during major releases.
 
 ## Reference Documentation
 

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "scylla-cql"
 version = "0.3.0"
 edition = "2021"
+rust-version = "1.70"
 description = "CQL data types and primitives, for interacting with Scylla."
 repository = "https://github.com/scylladb/scylla-rust-driver"
 readme = "../README.md"

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "scylla-macros"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.70"
 description = "proc macros for scylla async CQL driver"
 repository = "https://github.com/scylladb/scylla-rust-driver"
 readme = "../README.md"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "scylla-proxy"
 version = "0.0.3"
 edition = "2021"
+rust-version = "1.70"
 description = "Proxy layer between Scylla driver and cluster that enables testing Scylla drivers' behaviour in unfavourable conditions"
 repository = "https://github.com/scylladb/scylla-rust-driver"
 readme = "../README.md"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -2,6 +2,7 @@
 name = "scylla"
 version = "0.14.0"
 edition = "2021"
+rust-version = "1.70"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"
 repository = "https://github.com/scylladb/scylla-rust-driver"
 readme = "../README.md"


### PR DESCRIPTION
Checking MSRV locally is frustrating, because it requires switching toolchain and renaming files, but it is even more frustrating because updating cargo index before 1.70 is so sloooooow.
1.70 switched to sparse cargo index protocol by default, which makes checking the crate much faster. Let's bump MSRV to improve developer experience.

I also added "rust-version" field to Cargo.toml files, because this is the official place to specify MSRV and in the future will be used by Cargo during dependency resolving.

1.70 is over a year old (released on 1st June 2023), so I doubt this bump will cause any problems.
Related: we will need to decide on MSRV policy past 1.0. I propose to settle on 6 month policy (= our MSRV must always be at least 6 months old). 
Rust ecosystem seems to not be very conservative on this:
- Tokio has the exact same MSRV policy that I propose here: https://github.com/tokio-rs/tokio
- time crate guarantess support of current stable and 2 previous versions (= minimum 4 months )
- chrono is a bit more conservative, with 1.61 MSRV: https://docs.rs/chrono/latest/chrono/

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
