### PR TITLE
docs: Add Counter UPDATE example

### DIFF
--- a/docs/source/data-types/counter.md
+++ b/docs/source/data-types/counter.md
@@ -11,6 +11,12 @@
 use futures::TryStreamExt;
 use scylla::frame::value::Counter;
 
+// Add to counter value
+let to_add: Counter = Counter(100);
+session
+    .query_unpaged("UPDATE keyspace.table SET c = c + ? WHERE pk = 15", (to_add,))
+    .await?;
+
 // Read counter from the table
 let mut iter = session.query_iter("SELECT c FROM keyspace.table", &[])
     .await?


### PR DESCRIPTION
Counter was the only data type that didn't have at least two examples: one for reading and one for writing.

This PR adds the missing example.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1099

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
