### PR TITLE
Parametrize `Deserialize{Value,Row}` with two lifetimes: `'frame` and `'metadata` separately

### DIFF
--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1013,7 +1013,7 @@ pub fn deser_cql_value(
             CqlValue::List(l)
         }
         Map(_key_type, _value_type) => {
-            let iter = MapIterator::<'_, CqlValue, CqlValue>::deserialize(typ, v)?;
+            let iter = MapIterator::<'_, '_, CqlValue, CqlValue>::deserialize(typ, v)?;
             let m: Vec<(CqlValue, CqlValue)> = iter.collect::<StdResult<_, _>>()?;
             CqlValue::Map(m)
         }

--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Deserialization is based on two traits:
 //!
-//! - A type that implements `DeserializeValue<'frame>` can be deserialized
+//! - A type that implements `DeserializeValue<'frame, 'metadata>` can be deserialized
 //!   from a single _CQL value_ - i.e. an element of a row in the query result,
 //! - A type that implements `DeserializeRow<'frame>` can be deserialized
 //!   from a single _row_ of a query result.
@@ -57,7 +57,7 @@
 //!     #[error("Expected non-null")]
 //!     ExpectedNonNull,
 //! }
-//! impl<'frame> DeserializeValue<'frame> for MyVec {
+//! impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for MyVec {
 //!     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
 //!          if let ColumnType::Blob = typ {
 //!              return Ok(());
@@ -66,7 +66,7 @@
 //!      }
 //!
 //!      fn deserialize(
-//!          _typ: &'frame ColumnType,
+//!          _typ: &'metadata ColumnType<'metadata>,
 //!          v: Option<FrameSlice<'frame>>,
 //!      ) -> Result<Self, DeserializationError> {
 //!          v.ok_or_else(|| DeserializationError::new(MyDeserError::ExpectedNonNull))
@@ -98,7 +98,7 @@
 //!     #[error("Expected non-null")]
 //!     ExpectedNonNull,
 //! }
-//! impl<'a, 'frame> DeserializeValue<'frame> for MySlice<'a>
+//! impl<'a, 'frame, 'metadata> DeserializeValue<'frame, 'metadata> for MySlice<'a>
 //! where
 //!     'frame: 'a,
 //! {
@@ -110,7 +110,7 @@
 //!      }
 //!
 //!      fn deserialize(
-//!          _typ: &'frame ColumnType,
+//!          _typ: &'metadata ColumnType<'metadata>,
 //!          v: Option<FrameSlice<'frame>>,
 //!      ) -> Result<Self, DeserializationError> {
 //!          v.ok_or_else(|| DeserializationError::new(MyDeserError::ExpectedNonNull))
@@ -150,7 +150,7 @@
 //!     #[error("Expected non-null")]
 //!     ExpectedNonNull,
 //! }
-//! impl<'frame> DeserializeValue<'frame> for MyBytes {
+//! impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for MyBytes {
 //!     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
 //!          if let ColumnType::Blob = typ {
 //!              return Ok(());
@@ -159,7 +159,7 @@
 //!      }
 //!
 //!      fn deserialize(
-//!          _typ: &'frame ColumnType,
+//!          _typ: &'metadata ColumnType<'metadata>,
 //!          v: Option<FrameSlice<'frame>>,
 //!      ) -> Result<Self, DeserializationError> {
 //!          v.ok_or_else(|| DeserializationError::new(MyDeserError::ExpectedNonNull))

--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - A type that implements `DeserializeValue<'frame, 'metadata>` can be deserialized
 //!   from a single _CQL value_ - i.e. an element of a row in the query result,
-//! - A type that implements `DeserializeRow<'frame>` can be deserialized
+//! - A type that implements `DeserializeRow<'frame, 'metadata>` can be deserialized
 //!   from a single _row_ of a query result.
 //!
 //! Those traits are quite similar to each other, both in the idea behind them

--- a/scylla-cql/src/types/deserialize/result.rs
+++ b/scylla-cql/src/types/deserialize/result.rs
@@ -42,7 +42,7 @@ impl<'frame> RowIterator<'frame> {
 }
 
 impl<'frame> Iterator for RowIterator<'frame> {
-    type Item = Result<ColumnIterator<'frame>, DeserializationError>;
+    type Item = Result<ColumnIterator<'frame, 'frame>, DeserializationError>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -85,7 +85,7 @@ pub struct TypedRowIterator<'frame, R> {
 
 impl<'frame, R> TypedRowIterator<'frame, R>
 where
-    R: DeserializeRow<'frame>,
+    R: DeserializeRow<'frame, 'frame>,
 {
     /// Creates a new [TypedRowIterator] from given [RowIterator].
     ///
@@ -115,7 +115,7 @@ where
 
 impl<'frame, R> Iterator for TypedRowIterator<'frame, R>
 where
-    R: DeserializeRow<'frame>,
+    R: DeserializeRow<'frame, 'frame>,
 {
     type Item = Result<R, DeserializationError>;
 

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -10,26 +10,29 @@ use crate::frame::response::result::{ColumnSpec, ColumnType, CqlValue, Row};
 
 /// Represents a raw, unparsed column value.
 #[non_exhaustive]
-pub struct RawColumn<'frame> {
+pub struct RawColumn<'frame, 'metadata> {
     pub index: usize,
-    pub spec: &'frame ColumnSpec<'frame>,
+    pub spec: &'metadata ColumnSpec<'metadata>,
     pub slice: Option<FrameSlice<'frame>>,
 }
 
 /// Iterates over columns of a single row.
 #[derive(Clone, Debug)]
-pub struct ColumnIterator<'frame> {
-    specs: std::iter::Enumerate<std::slice::Iter<'frame, ColumnSpec<'frame>>>,
+pub struct ColumnIterator<'frame, 'metadata> {
+    specs: std::iter::Enumerate<std::slice::Iter<'metadata, ColumnSpec<'metadata>>>,
     slice: FrameSlice<'frame>,
 }
 
-impl<'frame> ColumnIterator<'frame> {
+impl<'frame, 'metadata> ColumnIterator<'frame, 'metadata> {
     /// Creates a new iterator over a single row.
     ///
     /// - `specs` - information about columns of the serialized response,
     /// - `slice` - a [FrameSlice] which points to the serialized row.
     #[inline]
-    pub(crate) fn new(specs: &'frame [ColumnSpec], slice: FrameSlice<'frame>) -> Self {
+    pub(crate) fn new(
+        specs: &'metadata [ColumnSpec<'metadata>],
+        slice: FrameSlice<'frame>,
+    ) -> Self {
         Self {
             specs: specs.iter().enumerate(),
             slice,
@@ -44,8 +47,8 @@ impl<'frame> ColumnIterator<'frame> {
     }
 }
 
-impl<'frame> Iterator for ColumnIterator<'frame> {
-    type Item = Result<RawColumn<'frame>, DeserializationError>;
+impl<'frame, 'metadata> Iterator for ColumnIterator<'frame, 'metadata> {
+    type Item = Result<RawColumn<'frame, 'metadata>, DeserializationError>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -84,7 +87,7 @@ impl<'frame> Iterator for ColumnIterator<'frame> {
 /// The crate also provides a derive macro which allows to automatically
 /// implement the trait for a custom type. For more details on what the macro
 /// is capable of, see its documentation.
-pub trait DeserializeRow<'frame>
+pub trait DeserializeRow<'frame, 'metadata>
 where
     Self: Sized,
 {
@@ -100,7 +103,7 @@ where
     /// the row's type. Note that `deserialize` is not an unsafe function,
     /// so it should not use the assumption about `type_check` being called
     /// as an excuse to run `unsafe` code.
-    fn deserialize(row: ColumnIterator<'frame>) -> Result<Self, DeserializationError>;
+    fn deserialize(row: ColumnIterator<'frame, 'metadata>) -> Result<Self, DeserializationError>;
 }
 
 // raw deserialization as ColumnIterator
@@ -111,14 +114,14 @@ where
 // Implementing DeserializeRow for it allows us to simplify our interface. For example,
 // we have `QueryResult::rows<T: DeserializeRow>()` - you can put T = ColumnIterator
 // instead of having a separate rows_raw function or something like this.
-impl<'frame> DeserializeRow<'frame> for ColumnIterator<'frame> {
+impl<'frame, 'metadata> DeserializeRow<'frame, 'metadata> for ColumnIterator<'frame, 'metadata> {
     #[inline]
     fn type_check(_specs: &[ColumnSpec]) -> Result<(), TypeCheckError> {
         Ok(())
     }
 
     #[inline]
-    fn deserialize(row: ColumnIterator<'frame>) -> Result<Self, DeserializationError> {
+    fn deserialize(row: ColumnIterator<'frame, 'metadata>) -> Result<Self, DeserializationError> {
         Ok(row)
     }
 }
@@ -140,7 +143,7 @@ make_error_replace_rust_name!(
 /// While no longer encouraged (because the new framework encourages deserializing
 /// directly into desired types, entirely bypassing [CqlValue]), this can be indispensable
 /// for some use cases, i.e. those involving dynamic parsing (ORMs?).
-impl<'frame> DeserializeRow<'frame> for Row {
+impl<'frame, 'metadata> DeserializeRow<'frame, 'metadata> for Row {
     #[inline]
     fn type_check(_specs: &[ColumnSpec]) -> Result<(), TypeCheckError> {
         // CqlValues accept all types, no type checking needed.
@@ -148,7 +151,9 @@ impl<'frame> DeserializeRow<'frame> for Row {
     }
 
     #[inline]
-    fn deserialize(mut row: ColumnIterator<'frame>) -> Result<Self, DeserializationError> {
+    fn deserialize(
+        mut row: ColumnIterator<'frame, 'metadata>,
+    ) -> Result<Self, DeserializationError> {
         let mut columns = Vec::with_capacity(row.size_hint().0);
         while let Some(column) = row
             .next()
@@ -181,9 +186,9 @@ impl<'frame> DeserializeRow<'frame> for Row {
 /// and needed conversions, issuing meaningful errors in case something goes wrong.
 macro_rules! impl_tuple {
     ($($Ti:ident),*; $($idx:literal),*; $($idf:ident),*) => {
-        impl<'frame, $($Ti),*> DeserializeRow<'frame> for ($($Ti,)*)
+        impl<'frame, 'metadata, $($Ti),*> DeserializeRow<'frame, 'metadata> for ($($Ti,)*)
         where
-            $($Ti: DeserializeValue<'frame, 'frame>),*
+            $($Ti: DeserializeValue<'frame, 'metadata>),*
         {
             fn type_check(specs: &[ColumnSpec]) -> Result<(), TypeCheckError> {
                 const TUPLE_LEN: usize = (&[$($idx),*] as &[i32]).len();
@@ -191,7 +196,7 @@ macro_rules! impl_tuple {
                 let column_types_iter = || specs.iter().map(|spec| spec.typ().clone().into_owned());
                 if let [$($idf),*] = &specs {
                     $(
-                        <$Ti as DeserializeValue<'frame, 'frame>>::type_check($idf.typ())
+                        <$Ti as DeserializeValue<'frame, 'metadata>>::type_check($idf.typ())
                             .map_err(|err| mk_typck_err::<Self>(column_types_iter(), BuiltinTypeCheckErrorKind::ColumnTypeCheckFailed {
                                 column_index: $idx,
                                 column_name: specs[$idx].name().to_owned(),
@@ -206,7 +211,7 @@ macro_rules! impl_tuple {
                 }
             }
 
-            fn deserialize(mut row: ColumnIterator<'frame>) -> Result<Self, DeserializationError> {
+            fn deserialize(mut row: ColumnIterator<'frame, 'metadata>) -> Result<Self, DeserializationError> {
                 const TUPLE_LEN: usize = (&[$($idx),*] as &[i32]).len();
 
                 let ret = (
@@ -217,7 +222,7 @@ macro_rules! impl_tuple {
                             $idx
                         )).map_err(deser_error_replace_rust_name::<Self>)?;
 
-                        <$Ti as DeserializeValue<'frame, 'frame>>::deserialize(column.spec.typ(), column.slice)
+                        <$Ti as DeserializeValue<'frame, 'metadata>>::deserialize(column.spec.typ(), column.slice)
                             .map_err(|err| mk_deser_err::<Self>(BuiltinDeserializationErrorKind::ColumnDeserializationFailed {
                                 column_index: column.index,
                                 column_name: column.spec.name().to_owned(),

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -183,7 +183,7 @@ macro_rules! impl_tuple {
     ($($Ti:ident),*; $($idx:literal),*; $($idf:ident),*) => {
         impl<'frame, $($Ti),*> DeserializeRow<'frame> for ($($Ti,)*)
         where
-            $($Ti: DeserializeValue<'frame>),*
+            $($Ti: DeserializeValue<'frame, 'frame>),*
         {
             fn type_check(specs: &[ColumnSpec]) -> Result<(), TypeCheckError> {
                 const TUPLE_LEN: usize = (&[$($idx),*] as &[i32]).len();
@@ -191,7 +191,7 @@ macro_rules! impl_tuple {
                 let column_types_iter = || specs.iter().map(|spec| spec.typ().clone().into_owned());
                 if let [$($idf),*] = &specs {
                     $(
-                        <$Ti as DeserializeValue<'frame>>::type_check($idf.typ())
+                        <$Ti as DeserializeValue<'frame, 'frame>>::type_check($idf.typ())
                             .map_err(|err| mk_typck_err::<Self>(column_types_iter(), BuiltinTypeCheckErrorKind::ColumnTypeCheckFailed {
                                 column_index: $idx,
                                 column_name: specs[$idx].name().to_owned(),
@@ -217,7 +217,7 @@ macro_rules! impl_tuple {
                             $idx
                         )).map_err(deser_error_replace_rust_name::<Self>)?;
 
-                        <$Ti as DeserializeValue<'frame>>::deserialize(column.spec.typ(), column.slice)
+                        <$Ti as DeserializeValue<'frame, 'frame>>::deserialize(column.spec.typ(), column.slice)
                             .map_err(|err| mk_deser_err::<Self>(BuiltinDeserializationErrorKind::ColumnDeserializationFailed {
                                 column_index: column.index,
                                 column_name: column.spec.name().to_owned(),

--- a/scylla-cql/src/types/deserialize/row_tests.rs
+++ b/scylla-cql/src/types/deserialize/row_tests.rs
@@ -251,18 +251,18 @@ fn val_str(s: &str) -> Option<Vec<u8>> {
     Some(s.as_bytes().to_vec())
 }
 
-fn deserialize<'frame, R>(
-    specs: &'frame [ColumnSpec],
+fn deserialize<'frame, 'metadata, R>(
+    specs: &'metadata [ColumnSpec<'metadata>],
     byts: &'frame Bytes,
 ) -> Result<R, DeserializationError>
 where
-    R: DeserializeRow<'frame>,
+    R: DeserializeRow<'frame, 'metadata>,
 {
-    <R as DeserializeRow<'frame>>::type_check(specs)
+    <R as DeserializeRow<'frame, 'metadata>>::type_check(specs)
         .map_err(|typecheck_err| DeserializationError(typecheck_err.0))?;
     let slice = FrameSlice::new(byts);
     let iter = ColumnIterator::new(specs, slice);
-    <R as DeserializeRow<'frame>>::deserialize(iter)
+    <R as DeserializeRow<'frame, 'metadata>>::deserialize(iter)
 }
 
 #[track_caller]

--- a/scylla-macros/src/deserialize/mod.rs
+++ b/scylla-macros/src/deserialize/mod.rs
@@ -114,29 +114,12 @@ where
         let trait_: syn::Path = parse_quote!(#macro_internal::#trait_);
         let items = items.into_iter();
 
-        // This `if` is purely temporary. When in a next commit DeserializeRow receives a 'metadata lifetime,
-        // the handling of both traits is unified again.
-        if trait_
-            .segments
-            .last()
-            .is_some_and(|name| name.ident == "DeserializeValue")
-        {
-            parse_quote! {
-                impl<#frame_lifetime, #metadata_lifetime, #impl_generics>
-                    #trait_<#frame_lifetime, #metadata_lifetime> for #struct_name #ty_generics
-                where #(#predicates),*
-                {
-                    #(#items)*
-                }
-            }
-        } else {
-            parse_quote! {
-                impl<#frame_lifetime, #impl_generics>
-                    #trait_<#frame_lifetime> for #struct_name #ty_generics
-                where #(#predicates),*
-                {
-                    #(#items)*
-                }
+        parse_quote! {
+            impl<#frame_lifetime, #metadata_lifetime, #impl_generics>
+                #trait_<#frame_lifetime, #metadata_lifetime> for #struct_name #ty_generics
+            where #(#predicates),*
+            {
+                #(#items)*
             }
         }
     }

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -242,7 +242,7 @@ impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
                             #name_verifications
 
                             // Verify the type
-                            <#required_fields_deserializers as #macro_internal::DeserializeValue<#constraint_lifetime>>::type_check(#required_fields_idents.typ())
+                            <#required_fields_deserializers as #macro_internal::DeserializeValue<#constraint_lifetime, #constraint_lifetime>>::type_check(#required_fields_idents.typ())
                                 .map_err(|err| #macro_internal::mk_row_typck_err::<Self>(
                                     column_types_iter(),
                                     #macro_internal::DeserBuiltinRowTypeCheckErrorKind::ColumnTypeCheckFailed {
@@ -301,7 +301,7 @@ impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
 
                 #name_check
 
-                <#deserializer as #macro_internal::DeserializeValue<#constraint_lifetime>>::deserialize(col.spec.typ(), col.slice)
+                <#deserializer as #macro_internal::DeserializeValue<#constraint_lifetime, #constraint_lifetime>>::deserialize(col.spec.typ(), col.slice)
                     .map_err(|err| #macro_internal::mk_row_deser_err::<Self>(
                         #macro_internal::BuiltinRowDeserializationErrorKind::ColumnDeserializationFailed {
                             column_index: #field_index,
@@ -373,7 +373,7 @@ impl<'sd> TypeCheckUnorderedGenerator<'sd> {
             parse_quote! {
                 {
                     if !#visited_flag {
-                        <#typ as #macro_internal::DeserializeValue<#constraint_lifetime>>::type_check(spec.typ())
+                        <#typ as #macro_internal::DeserializeValue<#constraint_lifetime, #constraint_lifetime>>::type_check(spec.typ())
                             .map_err(|err| {
                                 #macro_internal::mk_row_typck_err::<Self>(
                                     column_types_iter(),
@@ -529,7 +529,7 @@ impl<'sd> DeserializeUnorderedGenerator<'sd> {
                 );
 
                 #deserialize_field = ::std::option::Option::Some(
-                    <#deserializer as #macro_internal::DeserializeValue<#constraint_lifetime>>::deserialize(col.spec.typ(), col.slice)
+                    <#deserializer as #macro_internal::DeserializeValue<#constraint_lifetime, #constraint_lifetime>>::deserialize(col.spec.typ(), col.slice)
                         .map_err(|err| {
                             #macro_internal::mk_row_deser_err::<Self>(
                                 #macro_internal::BuiltinRowDeserializationErrorKind::ColumnDeserializationFailed {

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -206,7 +206,7 @@ impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
         // of the columns correspond fields' names/types.
 
         let macro_internal = self.0.struct_attrs().macro_internal_path();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
 
         let required_fields_iter = || {
             self.0
@@ -281,7 +281,7 @@ impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
         let macro_internal = self.0.struct_attrs().macro_internal_path();
         let cql_name_literal = field.cql_name_literal();
         let deserializer = field.deserialize_target();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
 
         let name_check: Option<syn::Stmt> = (!self.0.struct_attrs().skip_name_checks).then(|| parse_quote! {
             if col.spec.name() != #cql_name_literal {
@@ -315,7 +315,7 @@ impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
 
     fn generate(&self) -> syn::ImplItemFn {
         let macro_internal = self.0.struct_attrs().macro_internal_path();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
 
         let fields = self.0.fields();
         let field_idents = fields.iter().map(|f| f.ident.as_ref().unwrap());
@@ -362,7 +362,7 @@ impl<'sd> TypeCheckUnorderedGenerator<'sd> {
     fn generate_type_check(&self, field: &Field) -> Option<syn::Block> {
         (!field.skip).then(|| {
             let macro_internal = self.0.struct_attrs().macro_internal_path();
-            let constraint_lifetime = self.0.constraint_lifetime();
+            let (constraint_lifetime, _) = self.0.constraint_lifetimes();
             let visited_flag = Self::visited_flag_variable(field);
             let typ = field.deserialize_target();
             let cql_name_literal = field.cql_name_literal();
@@ -516,7 +516,7 @@ impl<'sd> DeserializeUnorderedGenerator<'sd> {
     fn generate_deserialization(&self, column_index: usize, field: &Field) -> syn::Expr {
         assert!(!field.skip);
         let macro_internal = self.0.struct_attrs().macro_internal_path();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
         let deserialize_field = Self::deserialize_field_variable(field);
         let deserializer = field.deserialize_target();
 
@@ -557,7 +557,7 @@ impl<'sd> DeserializeUnorderedGenerator<'sd> {
 
     fn generate(&self) -> syn::ImplItemFn {
         let macro_internal = self.0.struct_attrs().macro_internal_path();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
         let fields = self.0.fields();
 
         let deserialize_field_decls = fields

--- a/scylla-macros/src/deserialize/value.rs
+++ b/scylla-macros/src/deserialize/value.rs
@@ -229,7 +229,7 @@ impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
     // Generates name and type validation for given Rust struct's field.
     fn generate_field_validation(&self, rust_field_idx: usize, field: &Field) -> syn::Expr {
         let macro_internal = self.0.struct_attrs().macro_internal_path();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
         let rust_field_name = field.cql_name_literal();
         let rust_field_typ = field.deserialize_target();
         let default_when_missing = field.default_when_missing;
@@ -413,7 +413,7 @@ impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
         let macro_internal = self.0.struct_attrs().macro_internal_path();
         let cql_name_literal = field.cql_name_literal();
         let deserializer = field.deserialize_target();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
         let default_when_missing = field.default_when_missing;
         let default_when_null = field.default_when_null;
         let skip_name_checks = self.0.attrs.skip_name_checks;
@@ -532,7 +532,7 @@ impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
         // We can assume that type_check was called.
 
         let macro_internal = self.0.struct_attrs().macro_internal_path();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
         let fields = self.0.fields();
 
         let field_idents = fields.iter().map(|f| f.ident.as_ref().unwrap());
@@ -592,7 +592,7 @@ impl<'sd> TypeCheckUnorderedGenerator<'sd> {
     fn generate_type_check(&self, field: &Field) -> Option<syn::Block> {
         (!field.skip).then(|| {
             let macro_internal = self.0.struct_attrs().macro_internal_path();
-            let constraint_lifetime = self.0.constraint_lifetime();
+            let (constraint_lifetime, _) = self.0.constraint_lifetimes();
             let visited_flag = Self::visited_flag_variable(field);
             let typ = field.deserialize_target();
             let cql_name_literal = field.cql_name_literal();
@@ -770,7 +770,7 @@ impl<'sd> DeserializeUnorderedGenerator<'sd> {
     fn generate_deserialization(&self, field: &Field) -> Option<syn::Expr> {
         (!field.skip).then(|| {
             let macro_internal = self.0.struct_attrs().macro_internal_path();
-            let constraint_lifetime = self.0.constraint_lifetime();
+            let (constraint_lifetime, _) = self.0.constraint_lifetimes();
             let deserialize_field = Self::deserialize_field_variable(field);
             let cql_name_literal = field.cql_name_literal();
             let deserializer = field.deserialize_target();
@@ -833,7 +833,7 @@ impl<'sd> DeserializeUnorderedGenerator<'sd> {
 
     fn generate(&self) -> syn::ImplItemFn {
         let macro_internal = self.0.struct_attrs().macro_internal_path();
-        let constraint_lifetime = self.0.constraint_lifetime();
+        let (constraint_lifetime, _) = self.0.constraint_lifetimes();
         let fields = self.0.fields();
 
         let deserialize_field_decls = fields.iter().map(Self::generate_deserialize_field_decl);


### PR DESCRIPTION
Refs: #462

## Tl;dr
A second lifetime parameter is introduced to entities comprising the bottom part of the new deserialization framework: `'metadata`.

## Deserialization traits - recap

`DeserializeValue` requires two types of data in order to perform deserialization:
1) a reference to the CQL frame (a `FrameSlice`),
2) the type of the column being deserialized, being part of the result metadata.

Similarly, `DeserializeRow` requires two types of data in order to perform deserialization:
1) a reference to the CQL frame (a `FrameSlice`),
2) a slice of specifications of all columns in the row, being part of the result metadata.

### Observation

When deserializing owned types, both the frame and the metadata can have any lifetime and it's not important. When deserializing borrowed types, however, they borrow from the frame, so their lifetime must necessarily be bound by the lifetime of the frame. Metadata is only needed for the deserialization, so its lifetime does not abstractly bound the deserialized value.

### Problem

Up to this PR, `Deserialize{Value, Row}` were only parametrized by one lifetime: `'frame`, which bounded both the frame slice and the metadata. This was done that way due to an assumption that both the metadata and the frame (shared using `Bytes`) will be owned by the same entity. However, the new idea of deserializing result metadata to a borrowed form (to save allocations) makes result metadata's lifetime shorter than the frame's lifetime.

### Implemented solution

Not to unnecessarily shorten the deserialized values' lifetime, a separate lifetime parameter is introduced for result metadata: `'metadata`.

The PR is large, but the changes are mostly mechanical, by adding
the second lifetime parameter.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [ ] I have adjusted the documentation in `./docs/source/`. <-- _not yet, will be done at the end of the deserialization refactor_
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
