### PR TITLE
retry_policy: replace all usages of `Box<dyn RetryPolicy>` with `Arc<...>`

### DIFF
--- a/docs/source/execution-profiles/maximal-example.md
+++ b/docs/source/execution-profiles/maximal-example.md
@@ -18,7 +18,7 @@ let profile = ExecutionProfile::builder()
     .consistency(Consistency::All)
     .serial_consistency(Some(SerialConsistency::Serial))
     .request_timeout(Some(Duration::from_secs(30)))
-    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .retry_policy(Arc::new(FallthroughRetryPolicy::new()))
     .load_balancing_policy(Arc::new(DefaultPolicy::default()))
     .speculative_execution_policy(
         Some(

--- a/docs/source/retry-policy/default.md
+++ b/docs/source/retry-policy/default.md
@@ -9,13 +9,14 @@ To use in `Session`:
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
 use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::DefaultRetryPolicy;
 
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .retry_policy(Arc::new(DefaultRetryPolicy::new()))
     .build()
     .into_handle();
 
@@ -45,7 +46,7 @@ my_query.set_retry_policy(Some(Arc::new(DefaultRetryPolicy::new())));
 
 // You can also set retry policy in an execution profile
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .retry_policy(Arc::new(DefaultRetryPolicy::new()))
     .build()
     .into_handle();
 my_query.set_execution_profile_handle(Some(handle));
@@ -76,7 +77,7 @@ prepared.set_retry_policy(Some(Arc::new(DefaultRetryPolicy::new())));
 
 // You can also set retry policy in an execution profile
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    .retry_policy(Arc::new(DefaultRetryPolicy::new()))
     .build()
     .into_handle();
 prepared.set_execution_profile_handle(Some(handle));

--- a/docs/source/retry-policy/downgrading-consistency.md
+++ b/docs/source/retry-policy/downgrading-consistency.md
@@ -50,13 +50,14 @@ To use in `Session`:
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
 use scylla::transport::ExecutionProfile;
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
 
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .retry_policy(Arc::new(DowngradingConsistencyRetryPolicy::new()))
     .build()
     .into_handle();
 
@@ -74,13 +75,14 @@ To use in a [simple query](../queries/simple.md):
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
 use scylla::transport::ExecutionProfile;
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
 
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .retry_policy(Arc::new(DowngradingConsistencyRetryPolicy::new()))
     .build()
     .into_handle();
 
@@ -100,13 +102,14 @@ To use in a [prepared query](../queries/prepared.md):
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::prepared_statement::PreparedStatement;
 use scylla::transport::ExecutionProfile;
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
 
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(DowngradingConsistencyRetryPolicy::new()))
+    .retry_policy(Arc::new(DowngradingConsistencyRetryPolicy::new()))
     .build()
     .into_handle();
 

--- a/docs/source/retry-policy/fallthrough.md
+++ b/docs/source/retry-policy/fallthrough.md
@@ -8,13 +8,14 @@ To use in `Session`:
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
 use scylla::{Session, SessionBuilder};
 use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::FallthroughRetryPolicy;
 
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .retry_policy(Arc::new(FallthroughRetryPolicy::new()))
     .build()
     .into_handle();
 
@@ -32,13 +33,14 @@ To use in a [simple query](../queries/simple.md):
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::query::Query;
 use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::FallthroughRetryPolicy;
 
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .retry_policy(Arc::new(FallthroughRetryPolicy::new()))
     .build()
     .into_handle();
 
@@ -58,13 +60,14 @@ To use in a [prepared query](../queries/prepared.md):
 # extern crate scylla;
 # use scylla::Session;
 # use std::error::Error;
+# use std::sync::Arc;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::prepared_statement::PreparedStatement;
 use scylla::transport::ExecutionProfile;
 use scylla::transport::retry_policy::FallthroughRetryPolicy;
 
 let handle = ExecutionProfile::builder()
-    .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+    .retry_policy(Arc::new(FallthroughRetryPolicy::new()))
     .build()
     .into_handle();
 

--- a/examples/execution_profile.rs
+++ b/examples/execution_profile.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         .serial_consistency(Some(SerialConsistency::Serial))
         .request_timeout(Some(Duration::from_secs(42)))
         .load_balancing_policy(Arc::new(load_balancing::DefaultPolicy::default()))
-        .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+        .retry_policy(Arc::new(FallthroughRetryPolicy::new()))
         .speculative_execution_policy(Some(Arc::new(PercentileSpeculativeExecutionPolicy {
             max_retry_count: 2,
             percentile: 42.0,
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
         .serial_consistency(None)
         .request_timeout(Some(Duration::from_secs(3)))
         .load_balancing_policy(Arc::new(load_balancing::DefaultPolicy::default()))
-        .retry_policy(Box::new(DefaultRetryPolicy::new()))
+        .retry_policy(Arc::new(DefaultRetryPolicy::new()))
         .speculative_execution_policy(None)
         .build();
 

--- a/scylla/src/transport/downgrading_consistency_retry_policy.rs
+++ b/scylla/src/transport/downgrading_consistency_retry_policy.rs
@@ -30,10 +30,6 @@ impl RetryPolicy for DowngradingConsistencyRetryPolicy {
     fn new_session(&self) -> Box<dyn RetrySession> {
         Box::new(DowngradingConsistencyRetrySession::new())
     }
-
-    fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
-        Box::new(DowngradingConsistencyRetryPolicy)
-    }
 }
 
 pub struct DowngradingConsistencyRetrySession {

--- a/scylla/src/transport/execution_profile.rs
+++ b/scylla/src/transport/execution_profile.rs
@@ -191,8 +191,8 @@ pub(crate) mod defaults {
     pub(crate) fn load_balancing_policy() -> Arc<dyn LoadBalancingPolicy> {
         Arc::new(load_balancing::DefaultPolicy::default())
     }
-    pub(crate) fn retry_policy() -> Box<dyn RetryPolicy> {
-        Box::new(DefaultRetryPolicy::new())
+    pub(crate) fn retry_policy() -> Arc<dyn RetryPolicy> {
+        Arc::new(DefaultRetryPolicy::new())
     }
     pub(crate) fn speculative_execution_policy() -> Option<Arc<dyn SpeculativeExecutionPolicy>> {
         None
@@ -218,10 +218,11 @@ pub(crate) mod defaults {
 /// ```
 /// # use scylla::transport::{ExecutionProfile, retry_policy::FallthroughRetryPolicy};
 /// # use scylla::statement::Consistency;
+/// # use std::sync::Arc;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let profile: ExecutionProfile = ExecutionProfile::builder()
 ///     .consistency(Consistency::Three) // as this is the number we shall count to
-///     .retry_policy(Box::new(FallthroughRetryPolicy::new()))
+///     .retry_policy(Arc::new(FallthroughRetryPolicy::new()))
 ///     .build();
 /// # Ok(())
 /// # }
@@ -232,7 +233,7 @@ pub struct ExecutionProfileBuilder {
     consistency: Option<Consistency>,
     serial_consistency: Option<Option<SerialConsistency>>,
     load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
-    retry_policy: Option<Box<dyn RetryPolicy>>,
+    retry_policy: Option<Arc<dyn RetryPolicy>>,
     speculative_execution_policy: Option<Option<Arc<dyn SpeculativeExecutionPolicy>>>,
 }
 
@@ -302,14 +303,15 @@ impl ExecutionProfileBuilder {
     /// ```
     /// use scylla::transport::retry_policy::DefaultRetryPolicy;
     /// # use scylla::transport::ExecutionProfile;
+    /// # use std::sync::Arc;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let profile: ExecutionProfile = ExecutionProfile::builder()
-    ///     .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    ///     .retry_policy(Arc::new(DefaultRetryPolicy::new()))
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
-    pub fn retry_policy(mut self, retry_policy: Box<dyn RetryPolicy>) -> Self {
+    pub fn retry_policy(mut self, retry_policy: Arc<dyn RetryPolicy>) -> Self {
         self.retry_policy = Some(retry_policy);
         self
     }
@@ -352,9 +354,10 @@ impl ExecutionProfileBuilder {
     /// ```
     /// use scylla::transport::retry_policy::DefaultRetryPolicy;
     /// # use scylla::transport::ExecutionProfile;
+    /// # use std::sync::Arc;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let profile: ExecutionProfile = ExecutionProfile::builder()
-    ///     .retry_policy(Box::new(DefaultRetryPolicy::new()))
+    ///     .retry_policy(Arc::new(DefaultRetryPolicy::new()))
     ///     .build();
     /// # Ok(())
     /// # }
@@ -402,7 +405,7 @@ pub(crate) struct ExecutionProfileInner {
     pub(crate) serial_consistency: Option<SerialConsistency>,
 
     pub(crate) load_balancing_policy: Arc<dyn LoadBalancingPolicy>,
-    pub(crate) retry_policy: Box<dyn RetryPolicy>,
+    pub(crate) retry_policy: Arc<dyn RetryPolicy>,
     pub(crate) speculative_execution_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
 }
 

--- a/scylla/src/transport/retry_policy.rs
+++ b/scylla/src/transport/retry_policy.rs
@@ -29,15 +29,6 @@ pub enum RetryDecision {
 pub trait RetryPolicy: std::fmt::Debug + Send + Sync {
     /// Called for each new query, starts a session of deciding about retries
     fn new_session(&self) -> Box<dyn RetrySession>;
-
-    /// Used to clone this RetryPolicy
-    fn clone_boxed(&self) -> Box<dyn RetryPolicy>;
-}
-
-impl Clone for Box<dyn RetryPolicy> {
-    fn clone(&self) -> Box<dyn RetryPolicy> {
-        self.clone_boxed()
-    }
 }
 
 /// Used throughout a single query to decide when to retry it
@@ -71,10 +62,6 @@ impl RetryPolicy for FallthroughRetryPolicy {
     fn new_session(&self) -> Box<dyn RetrySession> {
         Box::new(FallthroughRetrySession)
     }
-
-    fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
-        Box::new(FallthroughRetryPolicy)
-    }
 }
 
 impl RetrySession for FallthroughRetrySession {
@@ -105,10 +92,6 @@ impl Default for DefaultRetryPolicy {
 impl RetryPolicy for DefaultRetryPolicy {
     fn new_session(&self) -> Box<dyn RetrySession> {
         Box::new(DefaultRetrySession::new())
-    }
-
-    fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
-        Box::new(DefaultRetryPolicy)
     }
 }
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -2724,7 +2724,7 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
 
     let handle = ExecutionProfile::builder()
         .consistency(Consistency::All)
-        .retry_policy(Box::new(MyRetryPolicy(retried_flag.clone())))
+        .retry_policy(Arc::new(MyRetryPolicy(retried_flag.clone())))
         .build()
         .into_handle();
 

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -2708,9 +2708,6 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
         fn new_session(&self) -> Box<dyn RetrySession> {
             Box::new(MyRetrySession(self.0.clone()))
         }
-        fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
-            Box::new(MyRetryPolicy(self.0.clone()))
-        }
     }
 
     struct MyRetrySession(Arc<AtomicBool>);

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -288,7 +288,7 @@ async fn consistency_is_correctly_set_in_cql_requests() {
             }
 
             let fallthrough_exec_profile_builder =
-                ExecutionProfile::builder().retry_policy(Box::new(FallthroughRetryPolicy));
+                ExecutionProfile::builder().retry_policy(Arc::new(FallthroughRetryPolicy));
 
             let translation_map = Arc::new(translation_map);
 
@@ -421,7 +421,7 @@ async fn consistency_is_correctly_set_in_routing_info() {
     };
 
     let exec_profile_builder = ExecutionProfile::builder()
-        .retry_policy(Box::new(FallthroughRetryPolicy))
+        .retry_policy(Arc::new(FallthroughRetryPolicy))
         .load_balancing_policy(Arc::new(reporting_load_balancer));
 
     // DB preparation phase

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -95,10 +95,6 @@ impl<const NODE: u8> RetryPolicy for BoundToPredefinedNodePolicy<NODE> {
         self.report_node(Report::RetryPolicy);
         Box::new(self.clone())
     }
-
-    fn clone_boxed(&self) -> Box<dyn RetryPolicy> {
-        Box::new(self.clone())
-    }
 }
 
 impl<const NODE: u8> RetrySession for BoundToPredefinedNodePolicy<NODE> {

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -145,7 +145,7 @@ async fn test_execution_profiles() {
 
         let profile1 = ExecutionProfile::builder()
             .load_balancing_policy(policy1.clone())
-            .retry_policy(Box::new(policy1.deref().clone()))
+            .retry_policy(Arc::new(policy1.deref().clone()))
             .consistency(Consistency::One)
             .serial_consistency(None)
             .speculative_execution_policy(None)
@@ -153,7 +153,7 @@ async fn test_execution_profiles() {
 
         let profile2 = ExecutionProfile::builder()
             .load_balancing_policy(policy2.clone())
-            .retry_policy(Box::new(policy2.deref().clone()))
+            .retry_policy(Arc::new(policy2.deref().clone()))
             .consistency(Consistency::Two)
             .serial_consistency(Some(SerialConsistency::LocalSerial))
             .speculative_execution_policy(Some(policy2))

--- a/scylla/tests/integration/lwt_optimisation.rs
+++ b/scylla/tests/integration/lwt_optimisation.rs
@@ -47,7 +47,7 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
         });
 
         let handle = ExecutionProfile::builder()
-            .retry_policy(Box::new(FallthroughRetryPolicy))
+            .retry_policy(Arc::new(FallthroughRetryPolicy))
             .build()
             .into_handle();
 

--- a/scylla/tests/integration/retries.rs
+++ b/scylla/tests/integration/retries.rs
@@ -26,7 +26,7 @@ async fn speculative_execution_is_fired() {
         let simple_speculative_no_retry_profile = ExecutionProfile::builder().speculative_execution_policy(Some(Arc::new(SimpleSpeculativeExecutionPolicy {
             max_retry_count: 2,
             retry_interval: Duration::from_millis(10),
-        }))).retry_policy(Box::new(FallthroughRetryPolicy)).build();
+        }))).retry_policy(Arc::new(FallthroughRetryPolicy)).build();
         let session: Session = SessionBuilder::new()
             .known_node(proxy_uris[0].as_str())
             .default_execution_profile_handle(simple_speculative_no_retry_profile.into_handle())
@@ -180,7 +180,7 @@ async fn speculative_execution_panic_regression_test() {
         };
         let profile = ExecutionProfile::builder()
             .speculative_execution_policy(Some(Arc::new(se)))
-            .retry_policy(Box::new(FallthroughRetryPolicy))
+            .retry_policy(Arc::new(FallthroughRetryPolicy))
             .build();
         // DB preparation phase
         let session: Session = SessionBuilder::new()


### PR DESCRIPTION
This way, when user wants to reuse a retry policy in multiple places, there is no need for an additional allocation for Box (`RetryPolicy::clone_boxed`).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
