### PR TITLE
exec_profile: expose public getters for profile configuration

### DIFF
--- a/scylla/src/transport/execution_profile.rs
+++ b/scylla/src/transport/execution_profile.rs
@@ -457,6 +457,36 @@ impl ExecutionProfile {
     pub fn into_handle_with_label(self, label: String) -> ExecutionProfileHandle {
         ExecutionProfileHandle(Arc::new((ArcSwap::new(self.0), Some(label))))
     }
+
+    /// Gets client timeout associated with this profile.
+    pub fn get_request_timeout(&self) -> Option<Duration> {
+        self.0.request_timeout
+    }
+
+    /// Gets consistency associated with this profile.
+    pub fn get_consistency(&self) -> Consistency {
+        self.0.consistency
+    }
+
+    /// Gets serial consistency (if set) associated with this profile.
+    pub fn get_serial_consistency(&self) -> Option<SerialConsistency> {
+        self.0.serial_consistency
+    }
+
+    /// Gets load balancing policy associated with this profile.
+    pub fn get_load_balancing_policy(&self) -> &Arc<dyn LoadBalancingPolicy> {
+        &self.0.load_balancing_policy
+    }
+
+    /// Gets retry policy associated with this profile.
+    pub fn get_retry_policy(&self) -> &Arc<dyn RetryPolicy> {
+        &self.0.retry_policy
+    }
+
+    /// Gets speculative execution policy associated with this profile.
+    pub fn get_speculative_execution_policy(&self) -> Option<&Arc<dyn SpeculativeExecutionPolicy>> {
+        self.0.speculative_execution_policy.as_ref()
+    }
 }
 
 /// A handle that points to an ExecutionProfile.


### PR DESCRIPTION
Depends on: https://github.com/scylladb/scylla-rust-driver/pull/1103

There is a use case for this in cpp-rust-driver.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
