### PR TITLE
Deserialize: don't use i64 for Counter column

### DIFF
--- a/scylla-cql/src/types/deserialize/row_tests.rs
+++ b/scylla-cql/src/types/deserialize/row_tests.rs
@@ -320,7 +320,7 @@ fn test_tuple_errors() {
         assert_matches!(
             &err.kind,
             super::super::value::BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::BigInt, ColumnType::Counter]
+                expected: &[ColumnType::BigInt]
             }
         );
     }

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -207,7 +207,7 @@ impl_emptiable_strict_type!(
 impl_fixed_numeric_type!(i8, TinyInt);
 impl_fixed_numeric_type!(i16, SmallInt);
 impl_fixed_numeric_type!(i32, Int);
-impl_fixed_numeric_type!(i64, [BigInt | Counter]);
+impl_fixed_numeric_type!(i64, BigInt);
 impl_fixed_numeric_type!(f32, Float);
 impl_fixed_numeric_type!(f64, Double);
 

--- a/scylla-cql/src/types/deserialize/value_tests.rs
+++ b/scylla-cql/src/types/deserialize/value_tests.rs
@@ -1284,7 +1284,7 @@ fn test_set_or_list_errors() {
         assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::BigInt, ColumnType::Counter]
+                expected: &[ColumnType::BigInt]
             }
         );
     }
@@ -1363,7 +1363,7 @@ fn test_map_errors() {
         assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::BigInt, ColumnType::Counter]
+                expected: &[ColumnType::BigInt]
             }
         );
     }
@@ -1527,7 +1527,7 @@ fn test_tuple_errors() {
             assert_matches!(
                 err.kind,
                 BuiltinTypeCheckErrorKind::MismatchedType {
-                    expected: &[ColumnType::BigInt, ColumnType::Counter]
+                    expected: &[ColumnType::BigInt]
                 }
             );
         }


### PR DESCRIPTION
We have a dedicated type for that and such deserialization decreases type safety.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1099

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
