### PR TITLE
result: fix wrong implied lifetime in `col_specs()`

### DIFF
--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -549,7 +549,7 @@ impl<'a> ResultMetadata<'a> {
     }
 
     #[inline]
-    pub fn col_specs(&self) -> &[ColumnSpec] {
+    pub fn col_specs(&self) -> &[ColumnSpec<'a>] {
         &self.col_specs
     }
 }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -407,7 +407,7 @@ impl PreparedStatement {
     }
 
     /// Access column specifications of the bind variables of this statement
-    pub fn get_variable_col_specs(&self) -> &[ColumnSpec] {
+    pub fn get_variable_col_specs(&self) -> &[ColumnSpec<'static>] {
         &self.shared.metadata.col_specs
     }
 
@@ -422,7 +422,7 @@ impl PreparedStatement {
     }
 
     /// Access column specifications of the result set returned after the execution of this statement
-    pub fn get_result_set_col_specs(&self) -> &[ColumnSpec] {
+    pub fn get_result_set_col_specs(&self) -> &[ColumnSpec<'static>] {
         self.shared.result_metadata.col_specs()
     }
 

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -396,7 +396,7 @@ impl RowIterator {
     }
 
     /// Returns specification of row columns
-    pub fn get_column_specs(&self) -> &[ColumnSpec] {
+    pub fn get_column_specs(&self) -> &[ColumnSpec<'static>] {
         self.current_page.metadata.col_specs()
     }
 
@@ -904,7 +904,7 @@ impl<RowT> TypedRowIterator<RowT> {
     }
 
     /// Returns specification of row columns
-    pub fn get_column_specs(&self) -> &[ColumnSpec] {
+    pub fn get_column_specs(&self) -> &[ColumnSpec<'static>] {
         self.row_iterator.get_column_specs()
     }
 }

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -138,7 +138,7 @@ impl QueryResult {
 
     /// Returns column specifications.
     #[inline]
-    pub fn col_specs(&self) -> &[ColumnSpec] {
+    pub fn col_specs(&self) -> &[ColumnSpec<'static>] {
         self.metadata
             .as_ref()
             .map(|metadata| metadata.col_specs())
@@ -147,7 +147,7 @@ impl QueryResult {
 
     /// Returns a column specification for a column with given name, or None if not found
     #[inline]
-    pub fn get_column_spec<'a>(&'a self, name: &str) -> Option<(usize, &'a ColumnSpec)> {
+    pub fn get_column_spec<'a>(&'a self, name: &str) -> Option<(usize, &'a ColumnSpec<'static>)> {
         self.col_specs()
             .iter()
             .enumerate()


### PR DESCRIPTION
As `ColumnSpec` is now parametrised by a lifetime, methods that return it implicitly bound its lifetime with lifetime of `&self`. This bug would lead to inefficiencies.
As a fix, an explicit lifetime is added in every method returning `ColumnSpec`.

Ref: https://github.com/scylladb/cpp-rust-driver/pull/200#discussion_r1819118480

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
