### PR TITLE
exec_profile_handle: allow public access to associated profile

### DIFF
--- a/scylla/src/transport/execution_profile.rs
+++ b/scylla/src/transport/execution_profile.rs
@@ -513,6 +513,11 @@ impl ExecutionProfileHandle {
         self.0 .0.load().to_builder()
     }
 
+    /// Returns execution profile pointed by this handle.
+    pub fn to_profile(&self) -> ExecutionProfile {
+        ExecutionProfile(self.access())
+    }
+
     /// Makes the handle point to a new execution profile.
     /// All entities (queries/Session) holding this handle will reflect the change.
     pub fn map_to_another_profile(&mut self, profile: ExecutionProfile) {


### PR DESCRIPTION
Last time, I introduced getters for `ExecutionProfile`. However, I forgot that in cpp-rust-driver use case, we only have an access to `ExecutionProfileHandle`...

Since, we can convert handle to builder, I see no objections against having the ability to convert it to well-defined execution profile.

Obviously, we need to clone an `Arc`. But only a single one. Notice, however, that when converting to builder,
we need to clone multiple Arcs anyway (e.g. retry or load balancing policies).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
