### PR TITLE
errors: replace `RowsParseError` and narrow the return types after deserialization refactor

### DIFF
--- a/docs/source/queries/paged.md
+++ b/docs/source/queries/paged.md
@@ -202,7 +202,7 @@ loop {
         .execute_single_page(&paged_prepared, &[], paging_state)
         .await?;
 
-    let rows_res = res.into_rows_result()?.unwrap();
+    let rows_res = res.into_rows_result()?;
 
     println!(
         "Paging state response from the prepared statement execution: {:#?} ({} rows)",

--- a/docs/source/queries/result.md
+++ b/docs/source/queries/result.md
@@ -41,20 +41,18 @@ Additionally, [`QueryResult`](https://docs.rs/scylla/latest/scylla/transport/que
 let result = session
     .query_unpaged("SELECT a from ks.tab", &[])
     .await?
-    .into_rows_result()?
-    .unwrap();
+    .into_rows_result()?;
 
 for row in result.rows::<(i32,)>()? {
     let (int_value,): (i32,) = row?;
 }
 
 // first_row gets the first row and parses it as the given type
-let first_int_val: Option<(i32,)> = session
+let first_int_val: (i32,) = session
     .query_unpaged("SELECT a from ks.tab", &[])
     .await?
     .into_rows_result()?
-    .map(|res| res.first_row::<(i32,)>())
-    .transpose()?;
+    .first_row::<(i32,)>()?;
 
 // result_not_rows fails when the response is rows
 session.query_unpaged("INSERT INTO ks.tab (a) VALUES (0)", &[]).await?.result_not_rows()?;
@@ -75,13 +73,13 @@ To properly handle `NULL` values parse column as an `Option<>`:
 use scylla::IntoTypedRows;
 
 // Parse row as two columns containing an int and text which might be null
-if let Some(rows_result) = session.query_unpaged("SELECT a, b from ks.tab", &[])
+let rows_result = session
+    .query_unpaged("SELECT a, b from ks.tab", &[])
     .await?
-    .into_rows_result()?
-{
-    for row in rows_result.rows::<(i32, Option<&str>)>()? {
-        let (int_value, str_or_null): (i32, Option<&str>) = row?;
-    }
+    .into_rows_result()?;
+
+for row in rows_result.rows::<(i32, Option<&str>)>()? {
+    let (int_value, str_or_null): (i32, Option<&str>) = row?;
 }
 # Ok(())
 # }
@@ -111,13 +109,13 @@ struct MyRow {
 }
 
 // Parse row as two columns containing an int and text which might be null
-if let Some(result_rows) = session.query_unpaged("SELECT a, b from ks.tab", &[])
+let result_rows = session
+    .query_unpaged("SELECT a, b from ks.tab", &[])
     .await?
-    .into_rows_result()?
-{
-    for row in result_rows.rows::<MyRow>()? {
-        let my_row: MyRow = row?;
-    }
+    .into_rows_result()?;
+
+for row in result_rows.rows::<MyRow>()? {
+    let my_row: MyRow = row?;
 }
 # Ok(())
 # }

--- a/docs/source/queries/simple.md
+++ b/docs/source/queries/simple.md
@@ -103,8 +103,8 @@ use scylla::IntoTypedRows;
 // Query rows from the table and print them
 let result = session.query_unpaged("SELECT a FROM ks.tab", &[])
     .await?
-    .into_rows_result()?
-    .unwrap();
+    .into_rows_result()?;
+
 let mut iter = result.rows::<(i32,)>()?;
 while let Some(read_row) = iter.next().transpose()? {
     println!("Read a value from row: {}", read_row.0);

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -52,7 +52,6 @@ async fn main() -> Result<()> {
             )
             .await?
             .into_rows_result()?
-            .expect("Got not Rows result")
             .single_row()?;
         assert_eq!(t, qt);
         println!("token for {}: {}", pk, t);

--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -196,7 +196,7 @@ fn print_result(result: QueryResult) -> Result<(), IntoRowsResultError> {
             }
             Ok(())
         }
-        Err(IntoRowsResultError::ResultNotRows) => Ok(println!("OK")),
+        Err(IntoRowsResultError::ResultNotRows(_)) => Ok(println!("OK")),
         Err(e) => Err(e),
     }
 }

--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -4,9 +4,10 @@ use rustyline::error::ReadlineError;
 use rustyline::{CompletionType, Config, Context, Editor};
 use rustyline_derive::{Helper, Highlighter, Hinter, Validator};
 use scylla::frame::response::result::Row;
+use scylla::transport::query_result::IntoRowsResultError;
 use scylla::transport::session::Session;
 use scylla::transport::Compression;
-use scylla::QueryRowsResult;
+use scylla::QueryResult;
 use scylla::SessionBuilder;
 use std::env;
 
@@ -176,24 +177,27 @@ impl Completer for CqlHelper {
     }
 }
 
-fn print_result(result: Option<&QueryRowsResult>) {
-    if let Some(rows_result) = result {
-        for row in rows_result.rows::<Row>().unwrap() {
-            let row = row.unwrap();
-            for column in &row.columns {
-                print!("|");
-                print!(
-                    " {:16}",
-                    match column {
-                        None => "null".to_owned(),
-                        Some(value) => format!("{:?}", value),
-                    }
-                );
+fn print_result(result: QueryResult) -> Result<(), IntoRowsResultError> {
+    match result.into_rows_result() {
+        Ok(rows_result) => {
+            for row in rows_result.rows::<Row>().unwrap() {
+                let row = row.unwrap();
+                for column in &row.columns {
+                    print!("|");
+                    print!(
+                        " {:16}",
+                        match column {
+                            None => "null".to_owned(),
+                            Some(value) => format!("{:?}", value),
+                        }
+                    );
+                }
+                println!("|");
             }
-            println!("|")
+            Ok(())
         }
-    } else {
-        println!("OK");
+        Err(IntoRowsResultError::ResultNotRows) => Ok(println!("OK")),
+        Err(e) => Err(e),
     }
 }
 
@@ -226,10 +230,7 @@ async fn main() -> Result<()> {
                 let maybe_res = session.query_unpaged(line, &[]).await;
                 match maybe_res {
                     Err(err) => println!("Error: {}", err),
-                    Ok(res) => {
-                        let rows_res = res.into_rows_result()?;
-                        print_result(rows_res.as_ref())
-                    }
+                    Ok(res) => print_result(res)?,
                 }
             }
             Err(ReadlineError::Interrupted) => continue,

--- a/examples/custom_deserialization.rs
+++ b/examples/custom_deserialization.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use scylla::deserialize::DeserializeValue;
 use scylla::frame::response::result::ColumnType;
 use scylla::transport::session::Session;
@@ -55,8 +55,7 @@ async fn main() -> Result<()> {
             (),
         )
         .await?
-        .into_rows_result()?
-        .context("Expected Result:Rows response, got a different Result response.")?;
+        .into_rows_result()?;
 
     let (v,) = rows_result.single_row::<(MyType,)>()?;
     assert_eq!(v, MyType("asdf"));

--- a/examples/get_by_name.rs
+++ b/examples/get_by_name.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{anyhow, Result};
 use scylla::frame::response::result::Row;
 use scylla::transport::session::Session;
 use scylla::SessionBuilder;
@@ -39,8 +39,7 @@ async fn main() -> Result<()> {
     let rows_result = session
         .query_unpaged("SELECT pk, ck, value FROM examples_ks.get_by_name", &[])
         .await?
-        .into_rows_result()?
-        .context("Response is not of Rows type")?;
+        .into_rows_result()?;
     let col_specs = rows_result.column_specs();
     let (ck_idx, _) = col_specs
         .get_by_name("ck")

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -51,9 +51,7 @@ async fn main() -> Result<()> {
             .query_single_page(paged_query.clone(), &[], paging_state)
             .await?;
 
-        let res = res
-            .into_rows_result()?
-            .expect("Got result different than Rows");
+        let res = res.into_rows_result()?;
 
         println!(
             "Paging state: {:#?} ({} rows)",
@@ -85,9 +83,7 @@ async fn main() -> Result<()> {
             .execute_single_page(&paged_prepared, &[], paging_state)
             .await?;
 
-        let res = res
-            .into_rows_result()?
-            .expect("Got result different than Rows");
+        let res = res.into_rows_result()?;
 
         println!(
             "Paging state from the prepared statement execution: {:#?} ({} rows)",

--- a/examples/tower.rs
+++ b/examples/tower.rs
@@ -45,8 +45,7 @@ async fn main() -> anyhow::Result<()> {
     let rows_result = session
         .call("SELECT keyspace_name, table_name FROM system_schema.tables;".into())
         .await?
-        .into_rows_result()?
-        .expect("Got result different than Rows");
+        .into_rows_result()?;
 
     let print_text = |t: &Option<scylla::frame::response::result::CqlValue>| {
         t.as_ref()

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -340,11 +340,6 @@ pub enum RawRowsAndPagingStateResponseParseError {
 pub enum RowsParseError {
     #[error("Invalid result metadata: {0}")]
     ResultMetadataParseError(#[from] ResultMetadataParseError),
-    #[error("Invalid result metadata, server claims {col_count} columns, received {col_specs_count} col specs.")]
-    ColumnCountMismatch {
-        col_count: usize,
-        col_specs_count: usize,
-    },
     #[error("Malformed rows count: {0}")]
     RowsCountParseError(LowLevelDeserializationError),
     #[error("Data type check prior to deserialization failed: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -14,7 +14,6 @@ pub use super::request::{
 use super::response::result::TableSpec;
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
-use crate::types::deserialize::{DeserializationError, TypeCheckError};
 use thiserror::Error;
 
 /// An error returned by `parse_response_body_extensions`.
@@ -228,11 +227,6 @@ pub enum CqlResultParseError {
     PreparedParseError(#[from] PreparedParseError),
     #[error("RESULT:Rows response deserialization failed: {0}")]
     RawRowsParseError(#[from] RawRowsAndPagingStateResponseParseError),
-
-    // TODO: This is required for `From<RowsParseError> for QueryError conversion`.
-    // It will be removed in later commits.
-    #[error("RESULT:Rows response deserialization failed: {0}")]
-    RowsParseError(#[from] RowsParseError),
 }
 
 #[non_exhaustive]
@@ -331,21 +325,6 @@ pub enum RawRowsAndPagingStateResponseParseError {
     /// Failed to parse paging state response.
     #[error("Malformed paging state: {0}")]
     PagingStateParseError(LowLevelDeserializationError),
-}
-
-/// An error type returned when deserialization
-/// of `RESULT::Rows` response fails.
-#[non_exhaustive]
-#[derive(Debug, Error, Clone)]
-pub enum RowsParseError {
-    #[error("Invalid result metadata: {0}")]
-    ResultMetadataParseError(#[from] ResultMetadataParseError),
-    #[error("Malformed rows count: {0}")]
-    RowsCountParseError(LowLevelDeserializationError),
-    #[error("Data type check prior to deserialization failed: {0}")]
-    IncomingDataTypeCheckError(#[from] TypeCheckError),
-    #[error("Data deserialization failed: {0}")]
-    DataDeserializationError(#[from] DeserializationError),
 }
 
 /// An error type returned when deserialization

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -301,7 +301,7 @@ pub enum PreparedParseError {
     #[error("Invalid result metadata: {0}")]
     ResultMetadataParseError(ResultMetadataParseError),
     #[error("Invalid prepared metadata: {0}")]
-    PreparedMetadataParseError(ResultMetadataParseError),
+    PreparedMetadataParseError(PreparedMetadataParseError),
     #[error("Non-zero paging state in result metadata: {0:?}")]
     NonZeroPagingState(Arc<[u8]>),
 }
@@ -327,22 +327,57 @@ pub enum RowsParseError {
 }
 
 /// An error type returned when deserialization
-/// of `[Result/Prepared]Metadata` failed.
+/// of statement's prepared metadata failed.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum PreparedMetadataParseError {
+    /// Failed to parse metadata flags.
+    #[error("Malformed metadata flags: {0}")]
+    FlagsParseError(LowLevelDeserializationError),
+
+    /// Failed to parse column count.
+    #[error("Malformed column count: {0}")]
+    ColumnCountParseError(LowLevelDeserializationError),
+
+    /// Failed to parse partition key count.
+    #[error("Malformed partition key count: {0}")]
+    PkCountParseError(LowLevelDeserializationError),
+
+    /// Failed to parse partition key index.
+    #[error("Malformed partition key index: {0}")]
+    PkIndexParseError(LowLevelDeserializationError),
+
+    /// Failed to parse global table spec.
+    #[error("Invalid global table spec: {0}")]
+    GlobalTableSpecParseError(#[from] TableSpecParseError),
+
+    /// Failed to parse column spec.
+    #[error("Invalid column spec: {0}")]
+    ColumnSpecParseError(#[from] ColumnSpecParseError),
+}
+
+/// An error type returned when deserialization
+/// of result metadata failed.
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]
 pub enum ResultMetadataParseError {
+    /// Failed to parse metadata flags.
     #[error("Malformed metadata flags: {0}")]
     FlagsParseError(LowLevelDeserializationError),
+
+    /// Failed to parse column count.
     #[error("Malformed column count: {0}")]
     ColumnCountParseError(LowLevelDeserializationError),
-    #[error("Malformed partition key count: {0}")]
-    PkCountParseError(LowLevelDeserializationError),
-    #[error("Malformed partition key index: {0}")]
-    PkIndexParseError(LowLevelDeserializationError),
+
+    /// Failed to parse paging state response.
     #[error("Malformed paging state: {0}")]
     PagingStateParseError(LowLevelDeserializationError),
+
+    /// Failed to parse global table spec.
     #[error("Invalid global table spec: {0}")]
     GlobalTableSpecParseError(#[from] TableSpecParseError),
+
+    /// Failed to parse column spec.
     #[error("Invalid column spec: {0}")]
     ColumnSpecParseError(#[from] ColumnSpecParseError),
 }

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -378,6 +378,20 @@ pub enum PreparedMetadataParseError {
     ColumnSpecParseError(#[from] ColumnSpecParseError),
 }
 
+/// An error returned when lazy deserialization of
+/// result metadata and rows count fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum ResultMetadataAndRowsCountParseError {
+    /// Failed to deserialize result metadata.
+    #[error("Failed to lazily deserialize result metadata: {0}")]
+    ResultMetadataParseError(#[from] ResultMetadataParseError),
+
+    /// Received malformed rows count from the server.
+    #[error("Malformed rows count: {0}")]
+    RowsCountParseError(LowLevelDeserializationError),
+}
+
 /// An error type returned when deserialization
 /// of result metadata failed.
 #[non_exhaustive]

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1204,12 +1204,6 @@ impl RawMetadataAndRawRows {
                     col_specs,
                 }
             };
-            if server_metadata.col_count() != server_metadata.col_specs().len() {
-                return Err(RowsParseError::ColumnCountMismatch {
-                    col_count: server_metadata.col_count(),
-                    col_specs_count: server_metadata.col_specs().len(),
-                });
-            }
             Ok(server_metadata)
         }
     }

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1,8 +1,9 @@
 use crate::cql_to_rust::{FromRow, FromRowError};
 use crate::frame::frame_errors::{
     ColumnSpecParseError, ColumnSpecParseErrorKind, CqlResultParseError, CqlTypeParseError,
-    LowLevelDeserializationError, PreparedParseError, ResultMetadataParseError, RowsParseError,
-    SchemaChangeEventParseError, SetKeyspaceParseError, TableSpecParseError,
+    LowLevelDeserializationError, PreparedMetadataParseError, PreparedParseError,
+    ResultMetadataParseError, RowsParseError, SchemaChangeEventParseError, SetKeyspaceParseError,
+    TableSpecParseError,
 };
 use crate::frame::request::query::PagingStateResponse;
 use crate::frame::response::event::SchemaChangeEvent;
@@ -1274,22 +1275,22 @@ impl RawMetadataAndRawRows {
 
 fn deser_prepared_metadata(
     buf: &mut &[u8],
-) -> StdResult<PreparedMetadata, ResultMetadataParseError> {
+) -> StdResult<PreparedMetadata, PreparedMetadataParseError> {
     let flags = types::read_int(buf)
-        .map_err(|err| ResultMetadataParseError::FlagsParseError(err.into()))?;
+        .map_err(|err| PreparedMetadataParseError::FlagsParseError(err.into()))?;
     let global_tables_spec = flags & 0x0001 != 0;
 
     let col_count =
-        types::read_int_length(buf).map_err(ResultMetadataParseError::ColumnCountParseError)?;
+        types::read_int_length(buf).map_err(PreparedMetadataParseError::ColumnCountParseError)?;
 
     let pk_count: usize =
-        types::read_int_length(buf).map_err(ResultMetadataParseError::PkCountParseError)?;
+        types::read_int_length(buf).map_err(PreparedMetadataParseError::PkCountParseError)?;
 
     let mut pk_indexes = Vec::with_capacity(pk_count);
     for i in 0..pk_count {
         pk_indexes.push(PartitionKeyIndex {
             index: types::read_short(buf)
-                .map_err(|err| ResultMetadataParseError::PkIndexParseError(err.into()))?
+                .map_err(|err| PreparedMetadataParseError::PkIndexParseError(err.into()))?
                 as u16,
             sequence: i as u16,
         });

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -616,7 +616,7 @@ impl Row {
 ///
 /// Flags and paging state are deserialized, remaining part of metadata
 /// as well as rows remain serialized.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RawMetadataAndRawRows {
     // Already deserialized part of metadata:
     col_count: usize,

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -347,7 +347,7 @@ pub enum BuiltinTypeCheckErrorKind {
 
     /// Duplicated column in DB metadata.
     DuplicatedColumn {
-        /// Column index of the second occurence of the column with the same name.
+        /// Column index of the second occurrence of the column with the same name.
         column_index: usize,
 
         /// The name of the duplicated column.
@@ -401,7 +401,7 @@ impl Display for BuiltinTypeCheckErrorKind {
             ),
             BuiltinTypeCheckErrorKind::DuplicatedColumn { column_name, column_index } => write!(
                 f,
-                "column {} occurs more than once in DB metadata; second occurence is at column index {}",
+                "column {} occurs more than once in DB metadata; second occurrence is at column index {}",
                 column_name,
                 column_index,
             ),

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -1572,7 +1572,7 @@ pub enum TupleTypeCheckErrorKind {
         /// The index of the field whose type check failed.
         position: usize,
 
-        /// The type check error that occured.
+        /// The type check error that occurred.
         err: TypeCheckError,
     },
 }
@@ -1651,7 +1651,7 @@ pub enum UdtTypeCheckErrorKind {
         /// The name of the field whose type check failed.
         field_name: String,
 
-        /// Inner type check error that occured.
+        /// Inner type check error that occurred.
         err: TypeCheckError,
     },
 }

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -82,12 +82,9 @@
 //!     .await?
 //!     .into_rows_result()?;
 //!     
-//!
-//! if let Some(rows) = query_rows {
-//!     for row in rows.rows()? {
-//!         // Parse row as int and text \
-//!         let (int_val, text_val): (i32, &str) = row?;
-//!     }
+//! for row in query_rows.rows()? {
+//!     // Parse row as int and text \
+//!     let (int_val, text_val): (i32, &str) = row?;
 //! }
 //! # Ok(())
 //! # }

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -428,7 +428,7 @@ mod tests {
             .execute_unpaged("select * from test_table", &[])
             .await
             .unwrap();
-        let result_rows = result.into_rows_result().unwrap().unwrap();
+        let result_rows = result.into_rows_result().unwrap();
 
         assert_eq!(1, session.cache.len());
         assert_eq!(1, result_rows.rows_num());
@@ -438,7 +438,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_rows = result.into_rows_result().unwrap().unwrap();
+        let result_rows = result.into_rows_result().unwrap();
 
         assert_eq!(1, session.cache.len());
         assert_eq!(1, result_rows.rows_num());
@@ -485,7 +485,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, session.cache.len());
-        assert_eq!(1, result.into_rows_result().unwrap().unwrap().rows_num());
+        assert_eq!(1, result.into_rows_result().unwrap().rows_num());
     }
 
     async fn assert_test_batch_table_rows_contain(
@@ -497,7 +497,6 @@ mod tests {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .rows::<(i32, i32)>()
             .unwrap()
@@ -709,7 +708,6 @@ mod tests {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .rows::<(i32, i64)>()
             .unwrap()

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1434,7 +1434,12 @@ impl Connection {
         let (version_id,) = self
             .query_unpaged(LOCAL_VERSION)
             .await?
-            .into_rows_result()?
+            .into_rows_result()
+            .map_err(|err| {
+                QueryError::ProtocolError(ProtocolError::SchemaVersionFetch(
+                    SchemaVersionFetchError::ResultMetadataParseError(err),
+                ))
+            })?
             .ok_or(QueryError::ProtocolError(
                 ProtocolError::SchemaVersionFetch(SchemaVersionFetchError::ResultNotRows),
             ))?

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -1437,12 +1437,9 @@ impl Connection {
             .into_rows_result()
             .map_err(|err| {
                 QueryError::ProtocolError(ProtocolError::SchemaVersionFetch(
-                    SchemaVersionFetchError::ResultMetadataParseError(err),
+                    SchemaVersionFetchError::TracesEventsIntoRowsResultError(err),
                 ))
             })?
-            .ok_or(QueryError::ProtocolError(
-                ProtocolError::SchemaVersionFetch(SchemaVersionFetchError::ResultNotRows),
-            ))?
             .single_row::<(Uuid,)>()
             .map_err(|err| {
                 ProtocolError::SchemaVersionFetch(SchemaVersionFetchError::SingleRowError(err))
@@ -2624,7 +2621,6 @@ mod tests {
                 .await
                 .unwrap()
                 .into_rows_result()
-                .unwrap()
                 .unwrap()
                 .rows::<(i32, Vec<u8>)>()
                 .unwrap()

--- a/scylla/src/transport/cql_collections_test.rs
+++ b/scylla/src/transport/cql_collections_test.rs
@@ -52,7 +52,6 @@ async fn insert_and_select<InsertT, SelectT>(
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .single_row::<(SelectT,)>()
         .unwrap()
         .0;

--- a/scylla/src/transport/cql_types_test.rs
+++ b/scylla/src/transport/cql_types_test.rs
@@ -101,7 +101,6 @@ where
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .rows::<(T,)>()
             .unwrap()
             .map(Result::unwrap)
@@ -222,7 +221,6 @@ async fn test_cql_varint() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .rows::<(CqlVarint,)>()
             .unwrap()
             .map(Result::unwrap)
@@ -299,7 +297,6 @@ async fn test_counter() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .rows::<(Counter,)>()
             .unwrap()
@@ -379,7 +376,6 @@ async fn test_naive_date_04() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .rows::<(NaiveDate,)>()
             .unwrap()
             .next()
@@ -404,7 +400,6 @@ async fn test_naive_date_04() {
                 .await
                 .unwrap()
                 .into_rows_result()
-                .unwrap()
                 .unwrap()
                 .single_row::<(NaiveDate,)>()
                 .unwrap();
@@ -446,7 +441,6 @@ async fn test_cql_date() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(CqlDate,)>()
             .unwrap();
@@ -533,7 +527,6 @@ async fn test_date_03() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .first_row::<(Date,)>()
             .ok()
             .map(|val| val.0);
@@ -555,7 +548,6 @@ async fn test_date_03() {
                 .await
                 .unwrap()
                 .into_rows_result()
-                .unwrap()
                 .unwrap()
                 .first_row::<(Date,)>()
                 .unwrap();
@@ -602,7 +594,6 @@ async fn test_cql_time() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .single_row::<(CqlTime,)>()
             .unwrap();
 
@@ -622,7 +613,6 @@ async fn test_cql_time() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(CqlTime,)>()
             .unwrap();
@@ -704,7 +694,6 @@ async fn test_naive_time_04() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .first_row::<(NaiveTime,)>()
             .unwrap();
 
@@ -724,7 +713,6 @@ async fn test_naive_time_04() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .first_row::<(NaiveTime,)>()
             .unwrap();
@@ -790,7 +778,6 @@ async fn test_time_03() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .first_row::<(Time,)>()
             .unwrap();
 
@@ -810,7 +797,6 @@ async fn test_time_03() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .first_row::<(Time,)>()
             .unwrap();
@@ -867,7 +853,6 @@ async fn test_cql_timestamp() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .single_row::<(CqlTimestamp,)>()
             .unwrap();
 
@@ -887,7 +872,6 @@ async fn test_cql_timestamp() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(CqlTimestamp,)>()
             .unwrap();
@@ -968,7 +952,6 @@ async fn test_date_time_04() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .first_row::<(DateTime<Utc>,)>()
             .unwrap();
 
@@ -988,7 +971,6 @@ async fn test_date_time_04() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .first_row::<(DateTime<Utc>,)>()
             .unwrap();
@@ -1020,7 +1002,6 @@ async fn test_date_time_04() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .first_row::<(DateTime<Utc>,)>()
         .unwrap();
     assert_eq!(read_datetime, nanosecond_precision_1st_half_rounded);
@@ -1048,7 +1029,6 @@ async fn test_date_time_04() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .first_row::<(DateTime<Utc>,)>()
         .unwrap();
@@ -1141,7 +1121,6 @@ async fn test_offset_date_time_03() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .first_row::<(OffsetDateTime,)>()
             .unwrap();
 
@@ -1161,7 +1140,6 @@ async fn test_offset_date_time_03() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .first_row::<(OffsetDateTime,)>()
             .unwrap();
@@ -1193,7 +1171,6 @@ async fn test_offset_date_time_03() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .first_row::<(OffsetDateTime,)>()
         .unwrap();
     assert_eq!(read_datetime, nanosecond_precision_1st_half_rounded);
@@ -1221,7 +1198,6 @@ async fn test_offset_date_time_03() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .first_row::<(OffsetDateTime,)>()
         .unwrap();
@@ -1274,7 +1250,6 @@ async fn test_timeuuid() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .single_row::<(CqlTimeuuid,)>()
             .unwrap();
 
@@ -1295,7 +1270,6 @@ async fn test_timeuuid() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(CqlTimeuuid,)>()
             .unwrap();
@@ -1367,7 +1341,6 @@ async fn test_timeuuid_ordering() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .rows::<(CqlTimeuuid,)>()
         .unwrap()
@@ -1450,7 +1423,6 @@ async fn test_inet() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .single_row::<(IpAddr,)>()
             .unwrap();
 
@@ -1467,7 +1439,6 @@ async fn test_inet() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(IpAddr,)>()
             .unwrap();
@@ -1522,7 +1493,6 @@ async fn test_blob() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .single_row::<(Vec<u8>,)>()
             .unwrap();
 
@@ -1539,7 +1509,6 @@ async fn test_blob() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(Vec<u8>,)>()
             .unwrap();
@@ -1631,7 +1600,6 @@ async fn test_udt_after_schema_update() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .single_row::<(UdtV1,)>()
         .unwrap();
 
@@ -1650,7 +1618,6 @@ async fn test_udt_after_schema_update() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .single_row::<(UdtV1,)>()
         .unwrap();
@@ -1674,7 +1641,6 @@ async fn test_udt_after_schema_update() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .single_row::<(UdtV2,)>()
         .unwrap();
@@ -1708,7 +1674,6 @@ async fn test_empty() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .first_row::<(CqlValue,)>()
         .unwrap();
 
@@ -1727,7 +1692,6 @@ async fn test_empty() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .first_row::<(CqlValue,)>()
         .unwrap();
@@ -1816,7 +1780,6 @@ async fn test_udt_with_missing_field() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(TR,)>()
             .unwrap()

--- a/scylla/src/transport/cql_value_test.rs
+++ b/scylla/src/transport/cql_value_test.rs
@@ -62,7 +62,6 @@ async fn test_cqlvalue_udt() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap();
 
     let (received_udt_cql_value,) = rows_result.single_row::<(CqlValue,)>().unwrap();
@@ -115,7 +114,6 @@ async fn test_cqlvalue_duration() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap();
 
     let mut rows_iter = rows_result.rows::<(CqlValue,)>().unwrap();

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -113,12 +113,6 @@ pub enum QueryError {
     #[error("An error occurred during async iteration over rows of result: {0}")]
     NextRowError(#[from] NextRowError),
 
-    // TODO: This should not belong here, but it requires changes to error types
-    // returned in `iter` API. It's going to be addressed later in this PR.
-    /// Failed to lazily deserialize result metadata.
-    #[error("Failed to lazily deserialize result metadata: {0}")]
-    ResultMetadataParseError(#[from] ResultMetadataAndRowsCountParseError),
-
     /// Failed to convert [`QueryResult`][crate::transport::query_result::QueryResult]
     /// into [`LegacyQueryResult`][crate::transport::legacy_query_result::LegacyQueryResult].
     #[error("Failed to convert `QueryResult` into `LegacyQueryResult`: {0}")]
@@ -190,7 +184,6 @@ impl From<QueryError> for NewSessionError {
             QueryError::IntoLegacyQueryResultError(e) => {
                 NewSessionError::IntoLegacyQueryResultError(e)
             }
-            QueryError::ResultMetadataParseError(e) => NewSessionError::ResultMetadataParseError(e),
             QueryError::NextRowError(e) => NewSessionError::NextRowError(e),
         }
     }
@@ -302,12 +295,6 @@ pub enum NewSessionError {
     /// An error occurred during async iteration over rows of result.
     #[error("An error occurred during async iteration over rows of result: {0}")]
     NextRowError(#[from] NextRowError),
-
-    // TODO: This should not belong here, but it requires changes to error types
-    // returned in `iter` API. This should be handled in separate PR.
-    /// Failed to lazily deserialize result metadata.
-    #[error("Failed to lazily deserialize result metadata: {0}")]
-    ResultMetadataParseError(#[from] ResultMetadataAndRowsCountParseError),
 
     /// Failed to convert [`QueryResult`][crate::transport::query_result::QueryResult]
     /// into [`LegacyQueryResult`][crate::transport::legacy_query_result::LegacyQueryResult].

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -477,6 +477,14 @@ pub enum MetadataError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum PeersMetadataError {
+    /// system.peers has invalid column type.
+    #[error("system.peers has invalid column type: {0}")]
+    SystemPeersInvalidColumnType(TypeCheckError),
+
+    /// system.local has invalid column type.
+    #[error("system.local has invalid column type: {0}")]
+    SystemLocalInvalidColumnType(TypeCheckError),
+
     /// Empty peers list returned during peers metadata fetch.
     #[error("Peers list is empty")]
     EmptyPeers,

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -19,7 +19,7 @@ use scylla_cql::{
             CqlErrorParseError, CqlEventParseError, CqlRequestSerializationError,
             CqlResponseParseError, CqlResultParseError, CqlSupportedParseError,
             FrameBodyExtensionsParseError, FrameHeaderParseError,
-            ResultMetadataAndRowsCountParseError, RowsParseError,
+            ResultMetadataAndRowsCountParseError,
         },
         request::CqlRequestKind,
         response::CqlResponseKind,
@@ -198,18 +198,6 @@ impl From<BadKeyspaceName> for QueryError {
 impl From<response::Error> for QueryError {
     fn from(error: response::Error) -> QueryError {
         QueryError::DbError(error.error, error.reason)
-    }
-}
-
-impl From<RowsParseError> for QueryError {
-    fn from(err: RowsParseError) -> Self {
-        let err: CqlResultParseError = err.into();
-        let err: CqlResponseParseError = err.into();
-        let err: RequestError = err.into();
-        let err: UserRequestError = err.into();
-        let err: QueryError = err.into();
-
-        err
     }
 }
 

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -1104,7 +1104,7 @@ mod legacy {
 
     /// Couldn't get next typed row from the iterator
     #[derive(Error, Debug, Clone)]
-    pub enum NextRowError {
+    pub enum LegacyNextRowError {
         /// Query to fetch next page has failed
         #[error(transparent)]
         QueryError(#[from] QueryError),
@@ -1117,7 +1117,7 @@ mod legacy {
     /// Fetching pages is asynchronous so `LegacyTypedRowIterator` does not implement the `Iterator` trait.\
     /// Instead it uses the asynchronous `Stream` trait
     impl<RowT: FromRow> Stream for LegacyTypedRowIterator<RowT> {
-        type Item = Result<RowT, NextRowError>;
+        type Item = Result<RowT, LegacyNextRowError>;
 
         fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
             let mut s = self.as_mut();
@@ -1131,4 +1131,4 @@ mod legacy {
     // LegacyTypedRowIterator can be moved freely for any RowT so it's Unpin
     impl<RowT> Unpin for LegacyTypedRowIterator<RowT> {}
 }
-pub use legacy::{LegacyRowIterator, LegacyTypedRowIterator, NextRowError};
+pub use legacy::{LegacyNextRowError, LegacyRowIterator, LegacyTypedRowIterator};

--- a/scylla/src/transport/iterator.rs
+++ b/scylla/src/transport/iterator.rs
@@ -8,12 +8,12 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
-use scylla_cql::frame::frame_errors::RowsParseError;
+use scylla_cql::frame::frame_errors::{ResultMetadataAndRowsCountParseError, RowsParseError};
 use scylla_cql::frame::response::result::RawMetadataAndRawRows;
 use scylla_cql::frame::response::NonErrorResponse;
 use scylla_cql::types::deserialize::result::RawRowLendingIterator;
 use scylla_cql::types::deserialize::row::{ColumnIterator, DeserializeRow};
-use scylla_cql::types::deserialize::TypeCheckError;
+use scylla_cql::types::deserialize::{DeserializationError, TypeCheckError};
 use scylla_cql::types::serialize::row::SerializedValues;
 use std::result::Result;
 use thiserror::Error;
@@ -587,7 +587,7 @@ impl QueryPager {
             self.current_page
                 .next()
                 .unwrap()
-                .map_err(|e| RowsParseError::from(e).into()),
+                .map_err(|err| NextRowError::RowDeserializationError(err).into()),
         )
     }
 
@@ -622,7 +622,14 @@ impl QueryPager {
         let mut s = self.as_mut();
 
         let received_page = ready_some_ok!(Pin::new(&mut s.page_receiver).poll_recv(cx));
-        let raw_rows_with_deserialized_metadata = received_page.rows.deserialize_metadata()?;
+
+        // TODO: see my other comment next to QueryError::NextRowError
+        // This is the place where conversion happens. To fix this, we need to refactor error types in iterator API.
+        // The `page_receiver`'s error type should be narrowed from QueryError to some other error type.
+        let raw_rows_with_deserialized_metadata =
+            received_page.rows.deserialize_metadata().map_err(|err| {
+                NextRowError::NextPageError(NextPageError::ResultMetadataParseError(err))
+            })?;
         s.current_page = RawRowLendingIterator::new(raw_rows_with_deserialized_metadata);
 
         if let Some(tracing_id) = received_page.tracing_id {
@@ -935,7 +942,10 @@ impl QueryPager {
         // - That future is polled in a tokio::task which isn't going to be
         //   cancelled
         let page_received = receiver.recv().await.unwrap()?;
-        let raw_rows_with_deserialized_metadata = page_received.rows.deserialize_metadata()?;
+        let raw_rows_with_deserialized_metadata =
+            page_received.rows.deserialize_metadata().map_err(|err| {
+                NextRowError::NextPageError(NextPageError::ResultMetadataParseError(err))
+            })?;
 
         Ok(Self {
             current_page: RawRowLendingIterator::new(raw_rows_with_deserialized_metadata),
@@ -1018,7 +1028,7 @@ where
             self.raw_row_lending_stream.next().await.map(|res| {
                 res.and_then(|column_iterator| {
                     <RowT as DeserializeRow>::deserialize(column_iterator)
-                        .map_err(|err| RowsParseError::from(err).into())
+                        .map_err(|err| NextRowError::RowDeserializationError(err).into())
                 })
             })
         };
@@ -1027,6 +1037,31 @@ where
         let value = ready_some_ok!(next_fut.poll(cx));
         Poll::Ready(Some(Ok(value)))
     }
+}
+
+/// An error returned that occurred during next page fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum NextPageError {
+    /// Failed to deserialize result metadata associated with next page response.
+    #[error("Failed to deserialize result metadata associated with next page response: {0}")]
+    ResultMetadataParseError(#[from] ResultMetadataAndRowsCountParseError),
+    // TODO: This should also include a variant representing an error that occurred during
+    // query that fetches the next page. However, as of now, it would require that we include QueryError here.
+    // This would introduce a cyclic dependency: QueryError -> NextRowError -> NextPageError -> QueryError.
+}
+
+/// An error returned by async iterator API.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum NextRowError {
+    /// Failed to fetch next page of result.
+    #[error("Failed to fetch next page of result: {0}")]
+    NextPageError(#[from] NextPageError),
+
+    /// An error occurred during row deserialization.
+    #[error("Row deserialization error: {0}")]
+    RowDeserializationError(#[from] DeserializationError),
 }
 
 mod legacy {

--- a/scylla/src/transport/legacy_query_result.rs
+++ b/scylla/src/transport/legacy_query_result.rs
@@ -1,7 +1,7 @@
 use crate::frame::response::cql_to_rust::{FromRow, FromRowError};
 use crate::frame::response::result::ColumnSpec;
 use crate::frame::response::result::Row;
-use scylla_cql::frame::frame_errors::RowsParseError;
+use scylla_cql::frame::frame_errors::ResultMetadataAndRowsCountParseError;
 use scylla_cql::frame::response::result::{self, ResultMetadataHolder};
 use scylla_cql::types::deserialize::{DeserializationError, TypeCheckError};
 use thiserror::Error;
@@ -181,10 +181,9 @@ impl LegacyQueryResult {
 #[non_exhaustive]
 #[derive(Error, Clone, Debug)]
 pub enum IntoLegacyQueryResultError {
-    // TODO: Replace RowsParseError with narrower error. Done in later commit.
     /// Failed to lazily deserialize result metadata.
     #[error("Failed to lazily deserialize result metadata: {0}")]
-    ResultMetadataParseError(#[from] RowsParseError),
+    ResultMetadataAndRowsCountParseError(#[from] ResultMetadataAndRowsCountParseError),
 
     /// Failed to perform the typecheck against [`Row`] type.
     #[error("Typecheck error: {0}")]

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2862,6 +2862,7 @@ mod latency_awareness {
                 | QueryError::TimeoutError
                 | QueryError::RequestTimeout(_)
                 | QueryError::ResultMetadataParseError(_)
+                | QueryError::NextRowError(_)
                 | QueryError::IntoLegacyQueryResultError(_) => true,
             }
         }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2861,7 +2861,6 @@ mod latency_awareness {
                 | QueryError::ProtocolError(_)
                 | QueryError::TimeoutError
                 | QueryError::RequestTimeout(_)
-                | QueryError::ResultMetadataParseError(_)
                 | QueryError::NextRowError(_)
                 | QueryError::IntoLegacyQueryResultError(_) => true,
             }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2861,6 +2861,7 @@ mod latency_awareness {
                 | QueryError::ProtocolError(_)
                 | QueryError::TimeoutError
                 | QueryError::RequestTimeout(_)
+                | QueryError::ResultMetadataParseError(_)
                 | QueryError::IntoLegacyQueryResultError(_) => true,
             }
         }

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -2860,7 +2860,8 @@ mod latency_awareness {
                 | QueryError::MetadataError(_)
                 | QueryError::ProtocolError(_)
                 | QueryError::TimeoutError
-                | QueryError::RequestTimeout(_) => true,
+                | QueryError::RequestTimeout(_)
+                | QueryError::IntoLegacyQueryResultError(_) => true,
             }
         }
     }

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -11,7 +11,7 @@ use scylla_cql::types::deserialize::result::TypedRowIterator;
 use scylla_cql::types::deserialize::row::DeserializeRow;
 use scylla_cql::types::deserialize::{DeserializationError, TypeCheckError};
 
-use super::legacy_query_result::LegacyQueryResult;
+use super::legacy_query_result::{IntoLegacyQueryResultError, LegacyQueryResult};
 
 /// A view over specification of a table in the database.
 #[derive(Debug, Clone, Copy)]
@@ -243,7 +243,7 @@ impl QueryResult {
     /// Transforms itself into the legacy result type, by eagerly deserializing rows
     /// into the Row type. This is inefficient, and should only be used during transition
     /// period to the new API.
-    pub fn into_legacy_result(self) -> Result<LegacyQueryResult, RowsParseError> {
+    pub fn into_legacy_result(self) -> Result<LegacyQueryResult, IntoLegacyQueryResultError> {
         if let Some(raw_rows) = self.raw_metadata_and_rows {
             let raw_rows_with_metadata = raw_rows.deserialize_metadata()?;
 

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use thiserror::Error;
 use uuid::Uuid;
 
-use scylla_cql::frame::frame_errors::RowsParseError;
+use scylla_cql::frame::frame_errors::ResultMetadataAndRowsCountParseError;
 use scylla_cql::frame::response::result::{
     ColumnSpec, ColumnType, DeserializedMetadataAndRawRows, RawMetadataAndRawRows, Row, TableSpec,
 };
@@ -222,7 +222,9 @@ impl QueryResult {
     /// # }
     ///
     /// ```
-    pub fn into_rows_result(self) -> Result<Option<QueryRowsResult>, RowsParseError> {
+    pub fn into_rows_result(
+        self,
+    ) -> Result<Option<QueryRowsResult>, ResultMetadataAndRowsCountParseError> {
         let QueryResult {
             raw_metadata_and_rows,
             tracing_id,

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -1799,7 +1799,12 @@ where
 
         // Get tracing info
         let maybe_tracing_info: Option<TracingInfo> = traces_session_res
-            .into_rows_result()?
+            .into_rows_result()
+            .map_err(|err| {
+                ProtocolError::Tracing(TracingProtocolError::TracesSessionResultMetadataParseError(
+                    err,
+                ))
+            })?
             .ok_or(ProtocolError::Tracing(
                 TracingProtocolError::TracesSessionNotRows,
             ))?
@@ -1819,12 +1824,16 @@ where
         };
 
         // Get tracing events
-        let tracing_event_rows_result =
-            traces_events_res
-                .into_rows_result()?
-                .ok_or(ProtocolError::Tracing(
-                    TracingProtocolError::TracesEventsNotRows,
-                ))?;
+        let tracing_event_rows_result = traces_events_res
+            .into_rows_result()
+            .map_err(|err| {
+                ProtocolError::Tracing(TracingProtocolError::TracesEventsResultMetadataParseError(
+                    err,
+                ))
+            })?
+            .ok_or(ProtocolError::Tracing(
+                TracingProtocolError::TracesEventsNotRows,
+            ))?;
         let tracing_event_rows = tracing_event_rows_result.rows().map_err(|err| match err {
             RowsError::TypeCheckFailed(err) => {
                 ProtocolError::Tracing(TracingProtocolError::TracesEventsInvalidColumnType(err))

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -109,7 +109,7 @@ async fn test_unprepared_statement() {
         .await
         .unwrap();
 
-    let rows = query_result.into_rows_result().unwrap().unwrap();
+    let rows = query_result.into_rows_result().unwrap();
 
     let col_specs = rows.column_specs();
     assert_eq!(col_specs.get_by_name("a").unwrap().0, 0);
@@ -153,7 +153,6 @@ async fn test_unprepared_statement() {
             .unwrap();
         let mut page_results = rs_manual
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .rows::<(i32, i32, String)>()
             .unwrap()
@@ -244,7 +243,6 @@ async fn test_prepared_statement() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .single_row::<(i64,)>()
             .unwrap();
         let token = Token::new(value);
@@ -265,7 +263,6 @@ async fn test_prepared_statement() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(i64,)>()
             .unwrap();
@@ -291,7 +288,6 @@ async fn test_prepared_statement() {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .rows::<(i32, i32, String)>()
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
@@ -311,7 +307,6 @@ async fn test_prepared_statement() {
                 .unwrap();
             let mut page_results = rs_manual
                 .into_rows_result()
-                .unwrap()
                 .unwrap()
                 .rows::<(i32, i32, String)>()
                 .unwrap()
@@ -335,7 +330,6 @@ async fn test_prepared_statement() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(i32, i32, String, i32, Option<i32>)>()
             .unwrap();
@@ -384,7 +378,6 @@ async fn test_prepared_statement() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row()
             .unwrap();
@@ -509,7 +502,6 @@ async fn test_batch() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(i32, i32, String)>()
         .unwrap()
         .collect::<Result<_, _>>()
@@ -548,7 +540,6 @@ async fn test_batch() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .rows::<(i32, i32, String)>()
         .unwrap()
@@ -604,7 +595,6 @@ async fn test_token_calculation() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .single_row::<(i64,)>()
             .unwrap();
@@ -716,7 +706,6 @@ async fn test_use_keyspace() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(String,)>()
         .unwrap()
         .map(|res| res.unwrap().0)
@@ -767,7 +756,6 @@ async fn test_use_keyspace() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .rows::<(String,)>()
         .unwrap()
@@ -831,7 +819,6 @@ async fn test_use_keyspace_case_sensitivity() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(String,)>()
         .unwrap()
         .map(|row| row.unwrap().0)
@@ -848,7 +835,6 @@ async fn test_use_keyspace_case_sensitivity() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .rows::<(String,)>()
         .unwrap()
@@ -892,7 +878,6 @@ async fn test_raw_use_keyspace() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .rows::<(String,)>()
         .unwrap()
@@ -1188,7 +1173,6 @@ async fn assert_in_tracing_table(session: &Session, tracing_uuid: Uuid) {
             .unwrap()
             .into_rows_result()
             .unwrap()
-            .unwrap()
             .rows_num();
         if rows_num > 0 {
             // Ok there was some row for this tracing_uuid
@@ -1302,7 +1286,6 @@ async fn test_timestamp() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap();
 
     let mut results = query_rows_result
@@ -1961,7 +1944,6 @@ async fn test_named_bind_markers() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(i32, i32, i32)>()
         .unwrap()
         .map(|res| res.unwrap())
@@ -2115,7 +2097,6 @@ async fn test_unprepared_reprepare_in_execute() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(i32, i32, i32)>()
         .unwrap()
         .map(|r| r.unwrap())
@@ -2172,7 +2153,6 @@ async fn test_unusual_valuelists() {
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .rows::<(i32, i32, String)>()
         .unwrap()
@@ -2247,7 +2227,6 @@ async fn test_unprepared_reprepare_in_batch() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(i32, i32, i32)>()
         .unwrap()
         .map(|r| r.unwrap())
@@ -2317,7 +2296,6 @@ async fn test_unprepared_reprepare_in_caching_session_execute() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(i32, i32, i32)>()
         .unwrap()
         .map(|r| r.unwrap())
@@ -2386,7 +2364,6 @@ async fn assert_test_batch_table_rows_contain(sess: &Session, expected_rows: &[(
         .await
         .unwrap()
         .into_rows_result()
-        .unwrap()
         .unwrap()
         .rows::<(i32, i32)>()
         .unwrap()
@@ -2616,7 +2593,7 @@ async fn test_batch_lwts() {
     batch.append_statement("UPDATE tab SET r1 = 1 WHERE p1 = 0 AND c1 = 0 IF r2 = 0");
 
     let batch_res: QueryResult = session.batch(&batch, ((), (), ())).await.unwrap();
-    let batch_deserializer = batch_res.into_rows_result().unwrap().unwrap();
+    let batch_deserializer = batch_res.into_rows_result().unwrap();
 
     // Scylla returns 5 columns, but Cassandra returns only 1
     let is_scylla: bool = batch_deserializer.column_specs().len() == 5;
@@ -2659,7 +2636,6 @@ async fn test_batch_lwts_for_scylla(
     let prepared_batch_res_rows: Vec<(bool, IntOrNull, IntOrNull, IntOrNull, IntOrNull)> =
         prepared_batch_res
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .rows()
             .unwrap()
@@ -2704,7 +2680,6 @@ async fn test_batch_lwts_for_cassandra(
     let prepared_batch_res_rows: Vec<(bool, IntOrNull, IntOrNull, IntOrNull, IntOrNull)> =
         prepared_batch_res
             .into_rows_result()
-            .unwrap()
             .unwrap()
             .rows()
             .unwrap()
@@ -2972,7 +2947,6 @@ async fn simple_strategy_test() {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(i32, i32, i32)>()
         .unwrap()
         .map(|r| r.unwrap())
@@ -3128,7 +3102,6 @@ async fn test_deserialize_empty_collections() {
             .await
             .unwrap()
             .into_rows_result()
-            .unwrap()
             .unwrap();
         let (collection,) = query_rows_result.first_row::<(Collection,)>().unwrap();
 

--- a/scylla/src/transport/silent_prepare_batch_test.rs
+++ b/scylla/src/transport/silent_prepare_batch_test.rs
@@ -98,7 +98,6 @@ async fn assert_test_batch_table_rows_contain(sess: &Session, expected_rows: &[(
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .rows::<(i32, i32)>()
         .unwrap()
         .map(|r| r.unwrap())

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -96,7 +96,6 @@ fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
         Err(e) => match e {
             // Errors that will almost certainly appear for other nodes as well
             QueryError::BadQuery(_)
-            | QueryError::ResultMetadataParseError(_)
             | QueryError::CqlRequestSerialization(_)
             | QueryError::BodyExtensionsParseError(_)
             | QueryError::CqlResultParseError(_)

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -96,6 +96,7 @@ fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
         Err(e) => match e {
             // Errors that will almost certainly appear for other nodes as well
             QueryError::BadQuery(_)
+            | QueryError::ResultMetadataParseError(_)
             | QueryError::CqlRequestSerialization(_)
             | QueryError::BodyExtensionsParseError(_)
             | QueryError::CqlResultParseError(_)

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -110,7 +110,8 @@ fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
             QueryError::EmptyPlan => false,
 
             // Errors that should not appear here, thus should not be ignored
-            QueryError::TimeoutError
+            QueryError::IntoLegacyQueryResultError(_)
+            | QueryError::TimeoutError
             | QueryError::RequestTimeout(_)
             | QueryError::MetadataError(_) => false,
 

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -111,7 +111,8 @@ fn can_be_ignored<ResT>(result: &Result<ResT, QueryError>) -> bool {
             QueryError::EmptyPlan => false,
 
             // Errors that should not appear here, thus should not be ignored
-            QueryError::IntoLegacyQueryResultError(_)
+            QueryError::NextRowError(_)
+            | QueryError::IntoLegacyQueryResultError(_)
             | QueryError::TimeoutError
             | QueryError::RequestTimeout(_)
             | QueryError::MetadataError(_) => false,

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -50,7 +50,6 @@ pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
         .unwrap()
         .into_rows_result()
         .unwrap()
-        .unwrap()
         .single_row()
         .unwrap();
 
@@ -108,10 +107,9 @@ pub async fn scylla_supports_tablets(session: &Session) -> bool {
         )
         .await
         .unwrap()
-        .into_rows_result()
-        .unwrap();
+        .into_rows_result();
 
-    result.map_or(false, |rows_result| rows_result.single_row::<Row>().is_ok())
+    result.is_ok_and(|rows_result| rows_result.single_row::<Row>().is_ok())
 }
 
 #[cfg(test)]

--- a/scylla/tests/integration/skip_metadata_optimization.rs
+++ b/scylla/tests/integration/skip_metadata_optimization.rs
@@ -115,7 +115,6 @@ async fn test_skip_result_metadata() {
                     .unwrap()
                     .into_rows_result()
                     .unwrap()
-                    .unwrap()
                     .rows::<RowT>()
                     .unwrap()
                     .collect::<Result<Vec<_>, _>>()
@@ -134,7 +133,6 @@ async fn test_skip_result_metadata() {
                         .unwrap();
                     results_from_manual_paging.extend(
                         rs_manual.into_rows_result()
-                            .unwrap()
                             .unwrap()
                             .rows::<RowT>()
                             .unwrap()


### PR DESCRIPTION
## Motivation

After deserialization refactor, the `RowsParseError` was widely abused in multiple places, namely:
- `deser_rows()` - initial deserialization of RESULT:Rows response
- `QueryResult::into_rows_result()` - lazy deserialization of metadata
- `QueryResult::into_legacy_result()` - lazy metadata deserialization, rows deserialization etc.
- everytime we needed to convert `Typecheck/DeserializationError`s to `QueryError` - widely abused in iterator API

This PR fixes that by narrowing the return types of functions originally depending on `RowsParseError`. The `RowsParseError` is removed at the end of this PR.

## `QueryResult::into_rows_result()` return type

The last two commits adjust the API of `QueryResult`:
1. Flattened the return type of `QueryResult::into_rows_result()` to `Result<_, IntoRowsResultError>`. I believe that this API is cleaner than returning `Option<Result<...>>`.
2. ***[postponed]*** Introduced `QueryResult::into_rows_result_with_recovery()` - it does the same as `into_rows_result()`, but recovers `self` in case error occurred.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
