### PR TITLE
Unify macro attributes between serialization and deserialization derive macros

### DIFF
--- a/docs/source/data-types/udt.md
+++ b/docs/source/data-types/udt.md
@@ -20,13 +20,14 @@ and `DeserializeValue` macros documentation.
 ```rust
 # extern crate scylla;
 # async fn check_only_compiles() {
-use scylla::macros::{FromUserType, SerializeValue};
+use scylla::macros::{DeserializeValue, SerializeValue};
 
 // Define a custom struct that matches the User Defined Type created earlier.
-// Fields must be in the same order as they are in the database and also
-// have the same names.
+// Fields don't have to be in the same order as they are in the database.
+// By default, they must have the same names, but this can be worked around
+// using `#[rename] field attribute.
 // Wrapping a field in Option will gracefully handle null field values.
-#[derive(Debug, FromUserType, SerializeValue)]
+#[derive(Debug, DeserializeValue, SerializeValue)]
 struct MyType {
     int_val: i32,
     text_val: Option<String>,

--- a/docs/source/migration-guides/0.11-serialization.md
+++ b/docs/source/migration-guides/0.11-serialization.md
@@ -42,8 +42,6 @@ The driver comes a set of `impl`s of those traits which allow to represent any C
 
 By default, the `SerializeRow` and `SerializeValue` **will match the fields in the Rust struct by name to bind marker names** (in case of `SerializeRow`) **or UDT field names** (in case of `SerializeValue`). This is different from the old `ValueList` and `IntoUserType` macros which did not look at the field names at all and would expect the user to order the fields correctly. While the new behavior is much more ergonomic, you might have reasons not to use it.
 
-> **NOTE:**  The deserialization macro counterparts `FromRow` and `FromUserType` have the same limitation as the old serialization macros - they require struct fields to be properly ordered. While a similar rework is planned for the deserialization traits in a future release, for the time being it might not be worth keeping the column names in sync with the database.
-
 In order to bring the old behavior to the new macros (the only difference being type checking which cannot be disabled right now) you can configure it using attributes, as shown in the snippet below:
 
 ```rust

--- a/scylla-cql/src/types/deserialize/mod.rs
+++ b/scylla-cql/src/types/deserialize/mod.rs
@@ -323,7 +323,7 @@ macro_rules! make_error_replace_rust_name {
 use make_error_replace_rust_name;
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use bytes::{Bytes, BytesMut};
 
     use crate::frame::response::result::{ColumnSpec, ColumnType, TableSpec};
@@ -342,7 +342,7 @@ mod tests {
         bytes.freeze()
     }
 
-    pub(super) const fn spec<'a>(name: &'a str, typ: ColumnType<'a>) -> ColumnSpec<'a> {
+    pub(crate) const fn spec<'a>(name: &'a str, typ: ColumnType<'a>) -> ColumnSpec<'a> {
         ColumnSpec::borrowed(name, typ, TableSpec::borrowed("ks", "tbl"))
     }
 }

--- a/scylla-cql/src/types/deserialize/row.rs
+++ b/scylla-cql/src/types/deserialize/row.rs
@@ -496,7 +496,7 @@ impl Display for BuiltinDeserializationErrorKind {
 
 #[cfg(test)]
 #[path = "row_tests.rs"]
-mod tests;
+pub(crate) mod tests;
 
 /// ```compile_fail
 ///

--- a/scylla-cql/src/types/deserialize/row_tests.rs
+++ b/scylla-cql/src/types/deserialize/row_tests.rs
@@ -251,7 +251,7 @@ fn val_str(s: &str) -> Option<Vec<u8>> {
     Some(s.as_bytes().to_vec())
 }
 
-fn deserialize<'frame, 'metadata, R>(
+pub(crate) fn deserialize<'frame, 'metadata, R>(
     specs: &'metadata [ColumnSpec<'metadata>],
     byts: &'frame Bytes,
 ) -> Result<R, DeserializationError>

--- a/scylla-cql/src/types/deserialize/row_tests.rs
+++ b/scylla-cql/src/types/deserialize/row_tests.rs
@@ -91,7 +91,7 @@ struct TestUdtWithNoFieldsUnordered {}
 
 #[allow(unused)]
 #[derive(DeserializeRow)]
-#[scylla(crate = crate, enforce_order)]
+#[scylla(crate = crate, flavor = "enforce_order")]
 struct TestUdtWithNoFieldsOrdered {}
 
 #[test]
@@ -143,7 +143,7 @@ fn test_struct_deserialization_loose_ordering() {
 #[test]
 fn test_struct_deserialization_strict_ordering() {
     #[derive(DeserializeRow, PartialEq, Eq, Debug)]
-    #[scylla(crate = "crate", enforce_order)]
+    #[scylla(crate = "crate", flavor = "enforce_order")]
     struct MyRow<'a> {
         a: &'a str,
         b: Option<i32>,
@@ -180,7 +180,7 @@ fn test_struct_deserialization_strict_ordering() {
 #[test]
 fn test_struct_deserialization_no_name_check() {
     #[derive(DeserializeRow, PartialEq, Eq, Debug)]
-    #[scylla(crate = "crate", enforce_order, skip_name_checks)]
+    #[scylla(crate = "crate", flavor = "enforce_order", skip_name_checks)]
     struct MyRow<'a> {
         a: &'a str,
         b: Option<i32>,
@@ -623,7 +623,7 @@ fn test_struct_deserialization_errors() {
     // Strict ordering
     {
         #[derive(scylla_macros::DeserializeRow, PartialEq, Eq, Debug)]
-        #[scylla(crate = "crate", enforce_order)]
+        #[scylla(crate = "crate", flavor = "enforce_order")]
         struct MyRow<'a> {
             a: &'a str,
             #[scylla(skip)]

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -1963,7 +1963,7 @@ fn _test_udt_bad_attributes_skip_name_check_requires_enforce_order() {}
 /// ```compile_fail
 ///
 /// #[derive(scylla_macros::DeserializeValue)]
-/// #[scylla(crate = scylla_cql, enforce_order, skip_name_checks)]
+/// #[scylla(crate = scylla_cql, flavor = "enforce_order", skip_name_checks)]
 /// struct TestUdt {
 ///     #[scylla(rename = "b")]
 ///     a: i32,
@@ -1999,7 +1999,7 @@ fn _test_udt_bad_attributes_rename_collision_with_another_rename() {}
 /// ```compile_fail
 ///
 /// #[derive(scylla_macros::DeserializeValue)]
-/// #[scylla(crate = scylla_cql, enforce_order, skip_name_checks)]
+/// #[scylla(crate = scylla_cql, flavor = "enforce_order", skip_name_checks)]
 /// struct TestUdt {
 ///     a: i32,
 ///     #[scylla(allow_missing)]

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -1950,7 +1950,7 @@ impl From<UdtDeserializationErrorKind> for BuiltinDeserializationErrorKind {
 
 #[cfg(test)]
 #[path = "value_tests.rs"]
-pub(super) mod tests;
+pub(crate) mod tests;
 
 /// ```compile_fail
 ///

--- a/scylla-cql/src/types/deserialize/value_tests.rs
+++ b/scylla-cql/src/types/deserialize/value_tests.rs
@@ -585,7 +585,7 @@ fn test_tuples() {
     );
 }
 
-fn udt_def_with_fields(
+pub(crate) fn udt_def_with_fields(
     fields: impl IntoIterator<Item = (impl Into<Cow<'static, str>>, ColumnType<'static>)>,
 ) -> ColumnType<'static> {
     ColumnType::UserDefinedType {
@@ -1044,7 +1044,7 @@ fn test_custom_type_parser() {
     assert_eq!(tup, SwappedPair("foo", 42));
 }
 
-fn deserialize<'frame, 'metadata, T>(
+pub(crate) fn deserialize<'frame, 'metadata, T>(
     typ: &'metadata ColumnType<'metadata>,
     bytes: &'frame Bytes,
 ) -> Result<T, DeserializationError>

--- a/scylla-cql/src/types/deserialize/value_tests.rs
+++ b/scylla-cql/src/types/deserialize/value_tests.rs
@@ -632,7 +632,7 @@ struct TestUdtWithNoFieldsUnordered {}
 
 #[allow(unused)]
 #[derive(scylla_macros::DeserializeValue)]
-#[scylla(crate = crate, enforce_order)]
+#[scylla(crate = crate, flavor = "enforce_order")]
 struct TestUdtWithNoFieldsOrdered {}
 
 #[test]
@@ -786,7 +786,7 @@ fn test_udt_loose_ordering() {
 #[test]
 fn test_udt_strict_ordering() {
     #[derive(scylla_macros::DeserializeValue, PartialEq, Eq, Debug)]
-    #[scylla(crate = "crate", enforce_order)]
+    #[scylla(crate = "crate", flavor = "enforce_order")]
     struct Udt<'a> {
         #[scylla(default_when_null)]
         a: &'a str,
@@ -860,7 +860,7 @@ fn test_udt_strict_ordering() {
     // An excess field at the end of UDT, when such are forbidden
     {
         #[derive(scylla_macros::DeserializeValue, PartialEq, Eq, Debug)]
-        #[scylla(crate = "crate", enforce_order, forbid_excess_udt_fields)]
+        #[scylla(crate = "crate", flavor = "enforce_order", forbid_excess_udt_fields)]
         struct Udt<'a> {
             a: &'a str,
             #[scylla(skip)]
@@ -934,7 +934,7 @@ fn test_udt_strict_ordering() {
 #[test]
 fn test_udt_no_name_check() {
     #[derive(scylla_macros::DeserializeValue, PartialEq, Eq, Debug)]
-    #[scylla(crate = "crate", enforce_order, skip_name_checks)]
+    #[scylla(crate = "crate", flavor = "enforce_order", skip_name_checks)]
     struct Udt<'a> {
         a: &'a str,
         #[scylla(skip)]
@@ -1762,7 +1762,7 @@ fn test_udt_errors() {
     // Strict ordering
     {
         #[derive(scylla_macros::DeserializeValue, PartialEq, Eq, Debug)]
-        #[scylla(crate = "crate", enforce_order, forbid_excess_udt_fields)]
+        #[scylla(crate = "crate", flavor = "enforce_order", forbid_excess_udt_fields)]
         struct Udt<'a> {
             a: &'a str,
             #[scylla(skip)]

--- a/scylla-cql/src/types/mod.rs
+++ b/scylla-cql/src/types/mod.rs
@@ -1,2 +1,5 @@
 pub mod deserialize;
 pub mod serialize;
+
+#[cfg(test)]
+mod types_tests;

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -915,7 +915,7 @@ mod doctests {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::borrow::Cow;
     use std::collections::BTreeMap;
 
@@ -1037,7 +1037,7 @@ mod tests {
         assert_eq!(typed_data, erased_data);
     }
 
-    fn do_serialize<T: SerializeRow>(t: T, columns: &[ColumnSpec]) -> Vec<u8> {
+    pub(crate) fn do_serialize<T: SerializeRow>(t: T, columns: &[ColumnSpec]) -> Vec<u8> {
         let ctx = RowSerializationContext { columns };
         let mut ret = Vec::new();
         let mut builder = RowWriter::new(&mut ret);

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -867,6 +867,53 @@ impl<'a> Iterator for SerializedValuesIterator<'a> {
     }
 }
 
+mod doctests {
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeRow)]
+    /// #[scylla(crate = scylla_cql, skip_name_checks)]
+    /// struct TestRow {}
+    /// ```
+    fn _test_struct_deserialization_name_check_skip_requires_enforce_order() {}
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeRow)]
+    /// #[scylla(crate = scylla_cql, skip_name_checks)]
+    /// struct TestRow {
+    ///     #[scylla(rename = "b")]
+    ///     a: i32,
+    /// }
+    /// ```
+    fn _test_struct_deserialization_skip_name_check_conflicts_with_rename() {}
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeRow)]
+    /// #[scylla(crate = scylla_cql)]
+    /// struct TestRow {
+    ///     #[scylla(rename = "b")]
+    ///     a: i32,
+    ///     b: String,
+    /// }
+    /// ```
+    fn _test_struct_deserialization_skip_rename_collision_with_field() {}
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeRow)]
+    /// #[scylla(crate = scylla_cql)]
+    /// struct TestRow {
+    ///     #[scylla(rename = "c")]
+    ///     a: i32,
+    ///     #[scylla(rename = "c")]
+    ///     b: String,
+    /// }
+    /// ```
+    fn _test_struct_deserialization_rename_collision_with_another_rename() {}
+}
+
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1496,6 +1496,52 @@ pub enum ValueToSerializeValueAdapterError {
     },
 }
 
+mod doctests {
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql, skip_name_checks)]
+    /// struct TestUdt {}
+    /// ```
+    fn _test_udt_bad_attributes_skip_name_check_requires_enforce_order() {}
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql, flavor = "enforce_order", skip_name_checks)]
+    /// struct TestUdt {
+    ///     #[scylla(rename = "b")]
+    ///     a: i32,
+    /// }
+    /// ```
+    fn _test_udt_bad_attributes_skip_name_check_conflicts_with_rename() {}
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql)]
+    /// struct TestUdt {
+    ///     #[scylla(rename = "b")]
+    ///     a: i32,
+    ///     b: String,
+    /// }
+    /// ```
+    fn _test_udt_bad_attributes_rename_collision_with_field() {}
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql)]
+    /// struct TestUdt {
+    ///     #[scylla(rename = "c")]
+    ///     a: i32,
+    ///     #[scylla(rename = "c")]
+    ///     b: String,
+    /// }
+    /// ```
+    fn _test_udt_bad_attributes_rename_collision_with_another_rename() {}
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1579,6 +1579,18 @@ mod doctests {
     /// }
     /// ```
     fn _test_udt_unordered_flavour_no_limitations_on_allow_missing() {}
+
+    /// ```
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql)]
+    /// struct TestUdt {
+    ///     a: i32,
+    ///     #[scylla(default_when_null)]
+    ///     b: bool,
+    ///     c: String,
+    /// }
+    /// ```
+    fn _test_udt_default_when_null_is_accepted() {}
 }
 
 #[cfg(test)]

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -2591,7 +2591,7 @@ mod tests {
     }
 
     #[derive(SerializeValue, Debug, PartialEq, Eq, Default)]
-    #[scylla(crate = crate, force_exact_match)]
+    #[scylla(crate = crate, forbid_excess_udt_fields)]
     struct TestStrictUdtWithFieldSorting {
         a: String,
         b: i32,
@@ -2647,7 +2647,7 @@ mod tests {
     }
 
     #[derive(SerializeValue, Debug, PartialEq, Eq, Default)]
-    #[scylla(crate = crate, flavor = "enforce_order", force_exact_match)]
+    #[scylla(crate = crate, flavor = "enforce_order", forbid_excess_udt_fields)]
     struct TestStrictUdtWithEnforcedOrder {
         a: String,
         b: i32,

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1594,7 +1594,7 @@ mod doctests {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::BTreeMap;
 
     use crate::frame::response::result::{ColumnType, CqlValue};
@@ -1654,7 +1654,7 @@ mod tests {
         t.serialize(typ, writer).map(|_| ()).map(|()| ret)
     }
 
-    fn do_serialize<T: SerializeValue>(t: T, typ: &ColumnType) -> Vec<u8> {
+    pub(crate) fn do_serialize<T: SerializeValue>(t: T, typ: &ColumnType) -> Vec<u8> {
         do_serialize_result(t, typ).unwrap()
     }
 

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -1540,6 +1540,45 @@ mod doctests {
     /// }
     /// ```
     fn _test_udt_bad_attributes_rename_collision_with_another_rename() {}
+
+    /// ```compile_fail
+    ///
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql, flavor = "enforce_order", skip_name_checks)]
+    /// struct TestUdt {
+    ///     a: i32,
+    ///     #[scylla(allow_missing)]
+    ///     b: bool,
+    ///     c: String,
+    /// }
+    /// ```
+    fn _test_udt_bad_attributes_name_skip_name_checks_limitations_on_allow_missing() {}
+
+    /// ```
+    ///
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql, flavor = "enforce_order", skip_name_checks)]
+    /// struct TestUdt {
+    ///     a: i32,
+    ///     #[scylla(allow_missing)]
+    ///     b: bool,
+    ///     #[scylla(allow_missing)]
+    ///     c: String,
+    /// }
+    /// ```
+    fn _test_udt_good_attributes_name_skip_name_checks_limitations_on_allow_missing() {}
+
+    /// ```
+    /// #[derive(scylla_macros::SerializeValue)]
+    /// #[scylla(crate = scylla_cql)]
+    /// struct TestUdt {
+    ///     a: i32,
+    ///     #[scylla(allow_missing)]
+    ///     b: bool,
+    ///     c: String,
+    /// }
+    /// ```
+    fn _test_udt_unordered_flavour_no_limitations_on_allow_missing() {}
 }
 
 #[cfg(test)]

--- a/scylla-cql/src/types/types_tests.rs
+++ b/scylla-cql/src/types/types_tests.rs
@@ -1,0 +1,152 @@
+mod derive_macros_integration {
+    mod value {
+        use bytes::Bytes;
+
+        use crate::frame::response::result::ColumnType;
+        use crate::types::deserialize::value::tests::{deserialize, udt_def_with_fields};
+        use crate::types::serialize::value::tests::do_serialize;
+
+        #[test]
+        fn derive_serialize_and_deserialize_value_loose_ordering() {
+            #[derive(
+                scylla_macros::DeserializeValue, scylla_macros::SerializeValue, PartialEq, Eq, Debug,
+            )]
+            #[scylla(crate = "crate")]
+            struct Udt<'a> {
+                a: &'a str,
+                #[scylla(skip)]
+                x: String,
+                #[scylla(allow_missing)]
+                b: Option<i32>,
+                #[scylla(default_when_null)]
+                c: i64,
+            }
+
+            let original_udt = Udt {
+                a: "The quick brown fox",
+                x: String::from("THIS SHOULD NOT BE (DE)SERIALIZED"),
+                b: Some(42),
+                c: 2137,
+            };
+
+            let tests = [
+                // All fields present
+                (
+                    udt_def_with_fields([
+                        ("a", ColumnType::Text),
+                        ("b", ColumnType::Int),
+                        ("c", ColumnType::BigInt),
+                    ]),
+                    Udt {
+                        x: String::new(),
+                        ..original_udt
+                    },
+                ),
+                //
+                // One field missing:
+                // - ignored during serialization,
+                // - default-initialized during deserialization.
+                (
+                    udt_def_with_fields([("a", ColumnType::Text), ("c", ColumnType::BigInt)]),
+                    Udt {
+                        x: String::new(),
+                        b: None,
+                        ..original_udt
+                    },
+                ),
+                //
+                // UDT fields switched - should still work.
+                (
+                    udt_def_with_fields([
+                        ("b", ColumnType::Int),
+                        ("a", ColumnType::Text),
+                        ("c", ColumnType::BigInt),
+                    ]),
+                    Udt {
+                        x: String::new(),
+                        ..original_udt
+                    },
+                ),
+            ];
+            for (typ, expected_udt) in tests {
+                let serialized_udt = Bytes::from(do_serialize(&original_udt, &typ));
+                let deserialized_udt = deserialize::<Udt<'_>>(&typ, &serialized_udt).unwrap();
+
+                assert_eq!(deserialized_udt, expected_udt);
+            }
+        }
+
+        #[test]
+        fn derive_serialize_and_deserialize_value_strict_ordering() {
+            #[derive(
+                scylla_macros::DeserializeValue, scylla_macros::SerializeValue, PartialEq, Eq, Debug,
+            )]
+            #[scylla(crate = "crate", flavor = "enforce_order")]
+            struct Udt<'a> {
+                #[scylla(allow_missing)]
+                #[scylla(default_when_null)]
+                a: &'a str,
+                #[scylla(skip)]
+                x: String,
+                #[scylla(allow_missing)]
+                b: Option<i32>,
+            }
+
+            let original_udt = Udt {
+                a: "The quick brown fox",
+                x: String::from("THIS SHOULD NOT BE (DE)SERIALIZED"),
+                b: Some(42),
+            };
+
+            let tests = [
+                // All fields present
+                (
+                    udt_def_with_fields([("a", ColumnType::Text), ("b", ColumnType::Int)]),
+                    Udt {
+                        x: String::new(),
+                        ..original_udt
+                    },
+                ),
+                //
+                // An excess field at the end of UDT
+                (
+                    udt_def_with_fields([
+                        ("a", ColumnType::Text),
+                        ("b", ColumnType::Int),
+                        ("d", ColumnType::Boolean),
+                    ]),
+                    Udt {
+                        x: String::new(),
+                        ..original_udt
+                    },
+                ),
+                //
+                // Missing non-required fields
+                (
+                    udt_def_with_fields([("a", ColumnType::Text)]),
+                    Udt {
+                        x: String::new(),
+                        b: None,
+                        ..original_udt
+                    },
+                ),
+                //
+                // An excess field at the end of UDT instead of non-required fields
+                (
+                    udt_def_with_fields([("d", ColumnType::Boolean)]),
+                    Udt {
+                        x: String::new(),
+                        a: "",
+                        b: None,
+                    },
+                ),
+            ];
+            for (typ, expected_udt) in tests {
+                let serialized_udt = Bytes::from(do_serialize(&original_udt, &typ));
+                let deserialized_udt = deserialize::<Udt<'_>>(&typ, &serialized_udt).unwrap();
+
+                assert_eq!(deserialized_udt, expected_udt);
+            }
+        }
+    }
+}

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -5,6 +5,8 @@ use proc_macro2::Span;
 use syn::ext::IdentExt;
 use syn::parse_quote;
 
+use crate::Flavor;
+
 use super::{DeserializeCommonFieldAttrs, DeserializeCommonStructAttrs};
 
 #[derive(FromAttributes)]
@@ -13,12 +15,8 @@ struct StructAttrs {
     #[darling(rename = "crate")]
     crate_path: Option<syn::Path>,
 
-    // If true, then the type checking code will require the order of the fields
-    // to be the same in both the Rust struct and the columns. This allows the
-    // deserialization to be slightly faster because looking struct fields up
-    // by name can be avoided, though it is less convenient.
     #[darling(default)]
-    enforce_order: bool,
+    flavor: Flavor,
 
     // If true, then the type checking code won't verify the column names.
     // Columns will be matched to struct fields based solely on the order.
@@ -94,7 +92,7 @@ fn validate_attrs(attrs: &StructAttrs, fields: &[Field]) -> Result<(), darling::
 
     if attrs.skip_name_checks {
         // Skipping name checks is only available in enforce_order mode
-        if !attrs.enforce_order {
+        if attrs.flavor != Flavor::EnforceOrder {
             let error =
                 darling::Error::custom("attribute <skip_name_checks> requires <enforce_order>.");
             errors.push(error);
@@ -153,18 +151,16 @@ type StructDesc = super::StructDescForDeserialize<StructAttrs, Field>;
 
 impl StructDesc {
     fn generate_type_check_method(&self) -> syn::ImplItemFn {
-        if self.attrs.enforce_order {
-            TypeCheckAssumeOrderGenerator(self).generate()
-        } else {
-            TypeCheckUnorderedGenerator(self).generate()
+        match self.attrs.flavor {
+            Flavor::MatchByName => TypeCheckUnorderedGenerator(self).generate(),
+            Flavor::EnforceOrder => TypeCheckAssumeOrderGenerator(self).generate(),
         }
     }
 
     fn generate_deserialize_method(&self) -> syn::ImplItemFn {
-        if self.attrs.enforce_order {
-            DeserializeAssumeOrderGenerator(self).generate()
-        } else {
-            DeserializeUnorderedGenerator(self).generate()
+        match self.attrs.flavor {
+            Flavor::MatchByName => DeserializeUnorderedGenerator(self).generate(),
+            Flavor::EnforceOrder => DeserializeAssumeOrderGenerator(self).generate(),
         }
     }
 }

--- a/scylla-macros/src/lib.rs
+++ b/scylla-macros/src/lib.rs
@@ -1,4 +1,4 @@
-use darling::ToTokens;
+use darling::{FromMeta, ToTokens};
 use proc_macro::TokenStream;
 
 mod from_row;
@@ -6,6 +6,24 @@ mod from_user_type;
 mod into_user_type;
 mod parser;
 mod value_list;
+
+// Flavor of serialization/deserialization macros ({De,S}erialize{Value,Row}).
+#[derive(Copy, Clone, PartialEq, Eq, Default)]
+enum Flavor {
+    #[default]
+    MatchByName,
+    EnforceOrder,
+}
+
+impl FromMeta for Flavor {
+    fn from_string(value: &str) -> darling::Result<Self> {
+        match value {
+            "match_by_name" => Ok(Self::MatchByName),
+            "enforce_order" => Ok(Self::EnforceOrder),
+            _ => Err(darling::Error::unknown_value(value)),
+        }
+    }
+}
 
 mod serialize;
 

--- a/scylla-macros/src/serialize/mod.rs
+++ b/scylla-macros/src/serialize/mod.rs
@@ -1,21 +1,2 @@
-use darling::FromMeta;
-
 pub(crate) mod row;
 pub(crate) mod value;
-
-#[derive(Copy, Clone, PartialEq, Eq, Default)]
-enum Flavor {
-    #[default]
-    MatchByName,
-    EnforceOrder,
-}
-
-impl FromMeta for Flavor {
-    fn from_string(value: &str) -> darling::Result<Self> {
-        match value {
-            "match_by_name" => Ok(Self::MatchByName),
-            "enforce_order" => Ok(Self::EnforceOrder),
-            _ => Err(darling::Error::unknown_value(value)),
-        }
-    }
-}

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::parse_quote;
 
-use super::Flavor;
+use crate::Flavor;
 
 #[derive(FromAttributes)]
 #[darling(attributes(scylla))]

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -16,6 +16,10 @@ struct Attributes {
     #[darling(default)]
     flavor: Flavor,
 
+    // If true, then the type checking code won't verify the column names.
+    // Columns will be matched to struct fields based solely on the order.
+    //
+    // This annotation only works if `enforce_order` flavor is specified.
     #[darling(default)]
     skip_name_checks: bool,
 }
@@ -47,8 +51,12 @@ impl Field {
 #[derive(FromAttributes)]
 #[darling(attributes(scylla))]
 struct FieldAttributes {
+    // If set, then serializes from the column with this particular name
+    // instead of the Rust field name.
     rename: Option<String>,
 
+    // If true, then the field is not serialized at all, but simply ignored.
+    // All other attributes are ignored.
     #[darling(default)]
     skip: bool,
 }

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -72,6 +72,11 @@ struct FieldAttributes {
     #[darling(default)]
     #[darling(rename = "allow_missing")]
     ignore_missing: bool,
+
+    // Used for deserialization only. Ignored in serialization.
+    #[darling(default)]
+    #[darling(rename = "default_when_null")]
+    _default_when_null: bool,
 }
 
 struct Context {

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::parse_quote;
 
-use super::Flavor;
+use crate::Flavor;
 
 #[derive(FromAttributes)]
 #[darling(attributes(scylla))]

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -16,6 +16,10 @@ struct Attributes {
     #[darling(default)]
     flavor: Flavor,
 
+    // If true, then the type checking code won't verify the UDT field names.
+    // UDT fields will be matched to struct fields based solely on the order.
+    //
+    // This annotation only works if `enforce_order` flavor is specified.
     #[darling(default)]
     skip_name_checks: bool,
 
@@ -62,8 +66,12 @@ impl Field {
 #[derive(FromAttributes)]
 #[darling(attributes(scylla))]
 struct FieldAttributes {
+    // If set, then serializes from the UDT field with this particular name
+    // instead of the Rust field name.
     rename: Option<String>,
 
+    // If true, then the field is not serialized at all, but simply ignored.
+    // All other attributes are ignored.
     #[darling(default)]
     skip: bool,
 

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -44,12 +44,12 @@ pub use scylla_cql::macros::IntoUserType;
 /// - serialization will succeed in "match_by_name" flavor (default). Missing
 ///   fields in the middle of UDT will be sent as NULLs, missing fields at the end will not be sent
 ///   at all.
-/// - serialization will succed if suffix of UDT fields is missing. If there are missing fields in the
+/// - serialization will succeed if suffix of UDT fields is missing. If there are missing fields in the
 ///   middle it will fail. Note that if "skip_name_checks" is enabled, and the types happen to match,
 ///   it is possible for serialization to succeed with unexpected result.
 ///
 /// This behavior is the default to support ALTERing UDTs by adding new fields.
-/// You can require exact match of fields using `force_exact_match` attribute.
+/// You can forbid excess fields in the UDT using `forbid_excess_udt_fields` attribute.
 ///
 /// In case of failure, either [`BuiltinTypeCheckError`](crate::serialize::value::BuiltinTypeCheckError)
 /// or [`BuiltinSerializationError`](crate::serialize::value::BuiltinSerializationError)
@@ -125,7 +125,7 @@ pub use scylla_cql::macros::IntoUserType;
 /// struct field names and UDT field names, i.e. it's OK if i-th field has a
 /// different name in Rust and in the UDT. Fields are still being type-checked.
 ///
-/// `#[scylla(force_exact_match)]`
+/// `#[scylla(forbid_excess_udt_fields)]`
 ///
 /// Forces Rust struct to have all the fields present in UDT, otherwise
 /// serialization fails.

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -307,20 +307,26 @@ pub use scylla_cql::macros::SerializeRow;
 /// macro itself, so in those cases the user must provide an alternative path
 /// to either the `scylla` or `scylla-cql` crate.
 ///
-/// `#[scylla(enforce_order)]`
 ///
-/// By default, the generated deserialization code will be insensitive
-/// to the UDT field order - when processing a field, it will look it up
-/// in the Rust struct with the corresponding field and set it. However,
-/// if the UDT field order is known to be the same both in the UDT
-/// and the Rust struct, then the `enforce_order` annotation can be used
-/// so that a more efficient implementation that does not perform lookups
-/// is be generated. The UDT field names will still be checked during the
-/// type check phase.
+/// `#[scylla(flavor = "flavor_name")]`
+///
+/// Allows to choose one of the possible "flavors", i.e. the way how the
+/// generated code will approach deserialization. Possible flavors are:
+///
+/// - `"match_by_name"` (default) - the generated implementation _does not
+///   require_ the fields in the Rust struct to be in the same order as the
+///   fields in the UDT. During deserialization, the implementation will take
+///   care to deserialize the fields in the order which the database expects.
+/// - `"enforce_order"` - the generated implementation _requires_ the fields
+///   in the Rust struct to be in the same order as the fields in the UDT.
+///   If the order is incorrect, type checking/deserialization will fail.
+///   This is a less robust flavor than `"match_by_name"`, but should be
+///   slightly more performant as it doesn't need to perform lookups by name.
+///   The UDT field names will still be checked during the type check phase.
 ///
 /// #[(scylla(skip_name_checks))]
 ///
-/// This attribute only works when used with `enforce_order`.
+/// This attribute only works when used with `flavor = "enforce_order"`.
 ///
 /// If set, the generated implementation will not verify the UDT field names at
 /// all. Because it only works with `enforce_order`, it will deserialize first

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -443,19 +443,25 @@ pub use scylla_macros::DeserializeValue;
 /// macro itself, so in those cases the user must provide an alternative path
 /// to either the `scylla` or `scylla-cql` crate.
 ///
-/// `#[scylla(enforce_order)]`
+/// `#[scylla(flavor = "flavor_name")]`
 ///
-/// By default, the generated deserialization code will be insensitive
-/// to the column order - when processing a column, the corresponding Rust field
-/// will be looked up and the column will be deserialized based on its type.
-/// However, if the column order and the Rust field order is known to be the
-/// same,  then the `enforce_order` annotation can be used so that a more
-/// efficient implementation that does not perform lookups is be generated.
-/// The generated code will still check that the column and field names match.
+/// Allows to choose one of the possible "flavors", i.e. the way how the
+/// generated code will approach deserialization. Possible flavors are:
+///
+/// - `"match_by_name"` (default) - the generated implementation _does not
+///   require_ the fields in the Rust struct to be in the same order as the
+///   columns in the row. During deserialization, the implementation will take
+///   care to deserialize the columns in the order which the database provided.
+/// - `"enforce_order"` - the generated implementation _requires_ the fields
+///   in the Rust struct to be in the same order as the columns in the row.
+///   If the order is incorrect, type checking/deserialization will fail.
+///   This is a less robust flavor than `"match_by_name"`, but should be
+///   slightly more performant as it doesn't need to perform lookups by name.
+///   The generated code will still check that the column and field names match.
 ///
 /// #[(scylla(skip_name_checks))]
 ///
-/// This attribute only works when used with `enforce_order`.
+/// This attribute only works when used with `flavor = "enforce_order"`.
 ///
 /// If set, the generated implementation will not verify the column names at
 /// all. Because it only works with `enforce_order`, it will deserialize first


### PR DESCRIPTION
## Motivation
When deserialization macros were introduced in #1024, their attributes differed in naming and usage from those introduced in #851 for serialization derive macros.

This PR aims to unify attributes between `SerializeValue` and `DeserializeValue`, and between `SerializeRow` and `DeserializeRow`, so that both traits can be derived for a struct without a clash in attribute parsing.

Fixes: #462
FINALLY!

## What's done

1. In `SerializeValue`: `force_exact_match` -> `forbid_excess_udt_fields` (attribute renamed for consistency with `DeserializeValue`);
2. `Flavor` is shared between serialization and deserialization derive macros, and both have the same syntax for choosing the flavor: `flavor = "enforce_order"`;
3. `allow_missing` is supported for `SerializeValue`, as it is in `DeserializeValue`;
4. `default_when_null` is parsed and ignored in `SerializeValue`, as it's a no-op for serialization (it's only useful for deserialization, as it says: _"If I got NULL for a non-Option Rust field, let's fill it with Default::default()"_; currently, it would cause a parse error in `SerializeValue`.
5. Doctests are added (analogous to those for `Deserialize{Value,Row}`) for sanity verification of provided attributes.
6. Tests are added for Ser/De macros integration. Those make sure that those macros don't conflict and their attributes' syntax and behaviour are consistent.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
