### PR TITLE
Update time docs to reflect new chrono feature flag name

### DIFF
--- a/docs/source/data-types/date.md
+++ b/docs/source/data-types/date.md
@@ -42,7 +42,7 @@ while let Some((date_value,)) = iter.try_next().await? {
 
 ## chrono::NaiveDate
 
-If full range is not required and `chrono` feature is enabled,
+If full range is not required and `chrono-04` feature is enabled,
 [`chrono::NaiveDate`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html) can be used.
 [`chrono::NaiveDate`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html) supports dates from
 -262145-01-01 to 262143-12-31.
@@ -78,7 +78,7 @@ while let Some((date_value,)) = iter.try_next().await? {
 
 ## time::Date
 
-Alternatively, `time` feature can be used to enable support of
+Alternatively, the `time-03` feature can be used to enable support of
 [`time::Date`](https://docs.rs/time/0.3/time/struct.Date.html).
 [`time::Date`](https://docs.rs/time/0.3/time/struct.Date.html)'s value range depends on feature flags, see its
 documentation to get more info.

--- a/docs/source/data-types/time.md
+++ b/docs/source/data-types/time.md
@@ -42,7 +42,7 @@ while let Some((value,)) = iter.try_next().await? {
 
 ## chrono::NaiveTime
 
-If `chrono` feature is enabled, [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html)
+If `chrono-04` feature is enabled, [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html)
 can be used to interact with the database. Although chrono can represent leap seconds, they are not supported.
 Attempts to convert [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html) with leap
 second to `CqlTime` or write it to the database will return an error.

--- a/docs/source/data-types/time.md
+++ b/docs/source/data-types/time.md
@@ -42,7 +42,7 @@ while let Some((value,)) = iter.try_next().await? {
 
 ## chrono::NaiveTime
 
-If `chrono-04` feature is enabled, [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html)
+If the `chrono-04` feature is enabled, [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html)
 can be used to interact with the database. Although chrono can represent leap seconds, they are not supported.
 Attempts to convert [`chrono::NaiveTime`](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html) with leap
 second to `CqlTime` or write it to the database will return an error.
@@ -78,7 +78,7 @@ while let Some((time_value,)) = iter.try_next().await? {
 
 ## time::Time
 
-If `time` feature is enabled, [`time::Time`](https://docs.rs/time/0.3/time/struct.Time.html) can be used to interact
+If the `time-03` feature is enabled, [`time::Time`](https://docs.rs/time/0.3/time/struct.Time.html) can be used to interact
 with the database.
 
 ```rust

--- a/docs/source/data-types/timestamp.md
+++ b/docs/source/data-types/timestamp.md
@@ -43,7 +43,7 @@ while let Some((value,)) = iter.try_next().await? {
 
 ## chrono::DateTime
 
-If full value range is not required, `chrono` feature can be used to enable support of
+If the full value range is not required, the `chrono-04` feature can be used to enable support of
 [`chrono::DateTime`](https://docs.rs/chrono/0.4/chrono/struct.DateTime.html). All values are expected to be converted
 to UTC timezone explicitly, as [timestamp](https://docs.scylladb.com/stable/cql/types.html#timestamps) doesn't store
 timezone information. Any precision finer than 1ms will be lost.
@@ -83,7 +83,7 @@ while let Some((timestamp_value,)) = iter.try_next().await? {
 
 ## time::OffsetDateTime
 
-Alternatively, `time` feature can be used to enable support of
+Alternatively, the `time-03` feature can be used to enable support of
 [`time::OffsetDateTime`](https://docs.rs/time/0.3/time/struct.OffsetDateTime.html). As
 [timestamp](https://docs.scylladb.com/stable/cql/types.html#timestamps) doesn't support timezone information, time will
 be corrected to UTC and timezone info will be erased on write. On read, UTC timestamp is returned. Any precision finer


### PR DESCRIPTION
Changes `chrono` -> `chrono-04` to reflect the new name for the feature flag. This was confusing when I was trying to find the feature flag.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I have provided docstrings for the public items that I want to introduce.
- [X] I have adjusted the documentation in `./docs/source/`.
- [X] I added appropriate `Fixes:` annotations to PR description.
