### PR TITLE
Release 0.15

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_matches",
  "async-trait",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1477,7 +1477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 name = "sphinx-docs"
 description = "ScyllaDB Documentation"
-version = "0.14"
+version = "0.15"
 authors = ["ScyllaDB Documentation Contributors"]
 package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
 pygments = "^2.18.0"
-redirects_cli ="^0.1.3"
+redirects_cli = "^0.1.3"
 sphinx-scylladb-theme = "^1.8.1"
 sphinx-sitemap = "^2.6.0"
 sphinx-autobuild = "^2024.4.19"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,14 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ['v0.13.2', 'v0.14.0']
+TAGS = ['v0.14.0', 'v0.15.0']
 BRANCHES = ['main']
 # Set the latest version.
-LATEST_VERSION = 'v0.14.0'
+LATEST_VERSION = 'v0.15.0'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['main']
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ['v0.13.2']
+DEPRECATED_VERSIONS = ['v0.14.0']
 
 # -- General configuration
 

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "0.14"
+scylla = "0.15"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla-macros = { version = "0.6.0", path = "../scylla-macros" }
+scylla-macros = { version = "0.7.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 tokio = { version = "1.34", features = ["io-util", "time"] }

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.70"
 description = "CQL data types and primitives, for interacting with Scylla."

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.70"
 description = "proc macros for scylla async CQL driver"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "0.3.0", path = "../scylla-cql" }
+scylla-cql = { version = "0.4.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -41,7 +41,7 @@ full-serialization = [
 ]
 
 [dependencies]
-scylla-macros = { version = "0.6.0", path = "../scylla-macros" }
+scylla-macros = { version = "0.7.0", path = "../scylla-macros" }
 scylla-cql = { version = "0.3.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
@@ -84,7 +84,7 @@ num-bigint-04 = { package = "num-bigint", version = "0.4" }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4" }
 scylla-proxy = { version = "0.0.3", path = "../scylla-proxy" }
 ntest = "0.9.3"
-criterion = "0.4"                                              # Note: v0.5 needs at least rust 1.70.0
+criterion = "0.4"                                                      # Note: v0.5 needs at least rust 1.70.0
 tokio = { version = "1.34", features = ["test-util"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 assert_matches = "1.5.0"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -42,7 +42,7 @@ full-serialization = [
 
 [dependencies]
 scylla-macros = { version = "0.7.0", path = "../scylla-macros" }
-scylla-cql = { version = "0.3.0", path = "../scylla-cql" }
+scylla-cql = { version = "0.4.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.70"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"


### PR DESCRIPTION
# Proposed release notes:

The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 0.15.0,
an asynchronous CQL driver for Rust, optimized for Scylla, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 2.516k downloads on crates!
- over 583 GitHub stars!

## Changes

Beginning with this release, instead of putting all API-breaking changes into one group, now they are in the proper categories, but labeled as ⚠️ **[API-breaking]**.

### Main changes:

#### New deserialization API

The main change in this release is the deserialization API refactor. Its primary goal was to reduce overhead caused by all rows being eagerly deserialized to type-erased `CqlValue` type, only then being converted to end user types.
Old traits and structs (`FromCqlVal`, `FromRow`, `QueryResult` - renamed to `LegacyQueryResult`, `RowIterator` - renamed to `LegacyRowIterator`, `TypedRowIterator` - renamed to `LegacyTypedRowIterator`) are replaced by new ones (`DeserializeValue`, `DeserializeRow`, new `QueryResult`, `QueryPager`, `TypedRowStream`). There are wrappers and helper implementations provided, designed to aid in gradually migrating to new API - see the migration guide in the book for more information. Old traits and structs will be removed in one of future versions.

New serialization API has a benefit of increased efficiency - now, rows are deserialized straight to the end user type, without any copying and allocations on the way.
Another feature is the ability to deserialize rows to borrowed types (e.g. `&str` or `&[u8]`).
And the result metadata is now deserialized in the borrowed form, saving even more allocations.

The refactor included:
- ⚠️ **[API-breaking]** Parametrized `Deserialize{Value,Row}` with two lifetimes: `'frame` and `'metadata` separately ([#1101](https://github.com/scylladb/scylla-rust-driver/pull/1101)).
- ⚠️ **[API-breaking]** The deserialization refactor was finished ([#1088](https://github.com/scylladb/scylla-rust-driver/pull/1088), [#1107](https://github.com/scylladb/scylla-rust-driver/pull/1107), [#1109](https://github.com/scylladb/scylla-rust-driver/pull/1109), [#1093](https://github.com/scylladb/scylla-rust-driver/pull/1093), [#1057](https://github.com/scylladb/scylla-rust-driver/pull/1057), [#1120](https://github.com/scylladb/scylla-rust-driver/pull/1120), [#1118](https://github.com/scylladb/scylla-rust-driver/pull/1118), [#1122](https://github.com/scylladb/scylla-rust-driver/pull/1122), [#1121](https://github.com/scylladb/scylla-rust-driver/pull/1121)).
- ⚠️ **[API-breaking]** Unified macro attributes' syntax and semantics between serialization and deserialization derive macros ([#1119](https://github.com/scylladb/scylla-rust-driver/pull/1119)).


### Other changes by category:

**New features / enhancements:**
- ⚠️ **[API-breaking]** Made `ResultMetadata` lifetime-generic, which paved a path to deserializing metadata in a borrowed way as an optimisation to save allocations ([#1082](https://github.com/scylladb/scylla-rust-driver/pull/1082)).
- Exported serialization migration macros that accidentally hadn't been exported before ([#1089](https://github.com/scylladb/scylla-rust-driver/pull/1089)).
- Exposed public getters to type-erased errors ([#1087](https://github.com/scylladb/scylla-rust-driver/pull/1087)).
- Trace message is now issued upon successful keepalive ([#1092](https://github.com/scylladb/scylla-rust-driver/pull/1092)).
- Added `SerializeRow` impl for `Box<T: SerializeRow>` ([#1105](https://github.com/scylladb/scylla-rust-driver/pull/1105)).
- Exposed public getters for execution profile configuration ([#1104](https://github.com/scylladb/scylla-rust-driver/pull/1104)).
- Allowed public access to the profile associated with an execution profile handle ([#1112](https://github.com/scylladb/scylla-rust-driver/pull/1112)).

**Bug fixes:**
- ⚠️ **[API-breaking]** Fixed driver's logic that bases on error variants returned from query execution ([#1075](https://github.com/scylladb/scylla-rust-driver/pull/1075)).
- Fixed possible panic in speculative execution ([#1086](https://github.com/scylladb/scylla-rust-driver/pull/1086))
- ⚠️ **[API-breaking]** Disallowed deserializing Counter type to plain `i64` for type safety ([#1106](https://github.com/scylladb/scylla-rust-driver/pull/1106)).
- Fixed logic about ignoring particular error kinds if speculative execution failed ([#1124](https://github.com/scylladb/scylla-rust-driver/pull/1124)).

**API cleanups / better types:**
- ⚠️ **[API-breaking]** Some of our error types were restructured to be more strongly typed (instead of just containing a string) and better reflect the conditions that they appear in. This work will be continued in 0.16. ([#1067](https://github.com/scylladb/scylla-rust-driver/pull/1067), [#1074](https://github.com/scylladb/scylla-rust-driver/pull/1074), [#1054](https://github.com/scylladb/scylla-rust-driver/pull/1054), [#1080](https://github.com/scylladb/scylla-rust-driver/pull/1074), [#1080](https://github.com/scylladb/scylla-rust-driver/pull/1080), [#1117](https://github.com/scylladb/scylla-rust-driver/pull/1117)).
- Removed wildcard re-exports of the serialization framework's entities ([#1090](https://github.com/scylladb/scylla-rust-driver/pull/1090)).
- ⚠️ **[API-breaking]** Made `RetryPolicy` stored behind `Arc` instead of `Box` ([#1103](https://github.com/scylladb/scylla-rust-driver/pull/1103)).

**Internal API cleanups/refactors:**
- Removed paging state parameter from unpaged raw `Connection`'s API ([#1084](https://github.com/scylladb/scylla-rust-driver/pull/1084)).
- ⚠️ **[API-breaking]** Fixed unnameable types in our codebase (by making them exposed, unexposing them or deleting them at all) and enabled the `unnameable_types` clippy lint to prevent having such situation in the future ([#1094](https://github.com/scylladb/scylla-rust-driver/pull/1094)).
- Tiny optimizations and code refactors ([#1108](https://github.com/scylladb/scylla-rust-driver/pull/1108)).


**Documentation:**
- Updated docs theme ([#1081](https://github.com/scylladb/scylla-rust-driver/pull/1081), [#1110](https://github.com/scylladb/scylla-rust-driver/pull/1110)).


**CI / developer tool improvements:**
- clippy was appeased again ([#1072](https://github.com/scylladb/scylla-rust-driver/pull/1072), [#1077](https://github.com/scylladb/scylla-rust-driver/pull/1077), [#1095](https://github.com/scylladb/scylla-rust-driver/pull/1095)).
- Pinned Rust version in `book.yml` CI workflow ([#1096](https://github.com/scylladb/scylla-rust-driver/pull/1096)).

**Others:**
- Rewritten RELEASE.md, so that it now contains up-to-date guide about maintaining and releasing the driver ([#1076](https://github.com/scylladb/scylla-rust-driver/pull/1076)).
- Bumped MSRV to 1.70 ([#1098](https://github.com/scylladb/scylla-rust-driver/pull/1098)).
- Added an example showing Counter UPDATE ([#1100](https://github.com/scylladb/scylla-rust-driver/pull/1100)).


Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

| commits | author            |
|---------|-------------------|
| 154     | Mikołaj Uzarski   |
| 89      | Wojciech Przytuła |
| 45      | Karol Baryła      |
| 26      | Piotr Dulikowski  |
| 3       | David Garcia      |
| 1       | Daniel Boll       |
| 1       | Alex Pozhylenkov  |
