### PR TITLE
Make fields of ConnectionSetupRequestError public

### DIFF
--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -695,9 +695,10 @@ pub enum TranslationError {
 /// It indicates that request needed to initiate a connection failed.
 #[derive(Error, Debug, Clone)]
 #[error("Failed to perform a connection setup request. Request: {request_kind}, reason: {error}")]
+#[non_exhaustive]
 pub struct ConnectionSetupRequestError {
-    request_kind: CqlRequestKind,
-    error: ConnectionSetupRequestErrorKind,
+    pub request_kind: CqlRequestKind,
+    pub error: ConnectionSetupRequestErrorKind,
 }
 
 #[derive(Error, Debug, Clone)]


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.

This seems like an accidental omission. Without these fields being public it is impossible to match on the error type.