### PR TITLE
rows_result: implement into_inner behind `cpp_rust_unstable` cfg

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,8 @@ jobs:
       run: cargo clippy --verbose --all-targets
     - name: Clippy check with all features
       run: cargo clippy --verbose --all-targets --all-features
+    - name: Cargo check with cpp_rust_unstable cfg
+      run: RUSTFLAGS="--cfg cpp_rust_unstable" cargo clippy --verbose --all-targets --all-features
     - name: Cargo check without features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features ""
     - name: Cargo check with all serialization features

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -98,4 +98,8 @@ harness = false
 [lints.rust]
 unnameable_types = "warn"
 unreachable_pub = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(scylla_cloud_tests)', 'cfg(cassandra_tests)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(scylla_cloud_tests)',
+    'cfg(cassandra_tests)',
+    'cfg(cpp_rust_unstable)',
+] }

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -118,6 +118,9 @@ pub mod frame {
         pub(crate) use scylla_cql::frame::response::*;
 
         pub mod result {
+            #[cfg(cpp_rust_unstable)]
+            pub use scylla_cql::frame::response::result::DeserializedMetadataAndRawRows;
+
             pub(crate) use scylla_cql::frame::response::result::*;
             pub use scylla_cql::frame::response::result::{
                 ColumnSpec, ColumnType, CqlValue, PartitionKeyIndex, Row, TableSpec,

--- a/scylla/src/transport/query_result.rs
+++ b/scylla/src/transport/query_result.rs
@@ -433,6 +433,17 @@ impl QueryRowsResult {
             Err(RowsError::TypeCheckFailed(err)) => Err(SingleRowError::TypeCheckFailed(err)),
         }
     }
+
+    #[cfg(cpp_rust_unstable)]
+    pub fn into_inner(self) -> (DeserializedMetadataAndRawRows, Option<Uuid>, Vec<String>) {
+        let Self {
+            raw_rows_with_metadata,
+            tracing_id,
+            warnings,
+        } = self;
+
+        (raw_rows_with_metadata, tracing_id, warnings)
+    }
 }
 
 /// An error returned by [`QueryResult::into_rows_result`]


### PR DESCRIPTION
This is convenience introduced only for cpp-rust-driver purposes.

We will use DeserializedMetadataAndRawRows directly to implement lazy deserialization in cpp-rust-driver

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
