### PR TITLE
rust: appease compiler, formatter and linter from toolchain 1.83

### DIFF
--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -196,7 +196,10 @@ fn print_result(result: QueryResult) -> Result<(), IntoRowsResultError> {
             }
             Ok(())
         }
-        Err(IntoRowsResultError::ResultNotRows(_)) => Ok(println!("OK")),
+        Err(IntoRowsResultError::ResultNotRows(_)) => {
+            println!("OK");
+            Ok(())
+        }
         Err(e) => Err(e),
     }
 }

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -228,6 +228,9 @@ impl BatchStatement<'_> {
     }
 }
 
+// Disable the lint, if there is more than one lifetime included.
+// Can be removed once https://github.com/rust-lang/rust-clippy/issues/12495 is fixed.
+#[allow(clippy::needless_lifetimes)]
 impl<'s, 'b> From<&'s BatchStatement<'b>> for BatchStatement<'s> {
     fn from(value: &'s BatchStatement) -> Self {
         match value {

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -36,7 +36,7 @@ impl SerializableRequest for Execute<'_> {
     }
 }
 
-impl<'e> DeserializableRequest for Execute<'e> {
+impl DeserializableRequest for Execute<'_> {
     fn deserialize(buf: &mut &[u8]) -> Result<Self, RequestDeserializationError> {
         let id = types::read_short_bytes(buf)?.to_vec().into();
         let parameters = QueryParameters::deserialize(buf)?;

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -140,7 +140,7 @@ pub enum Request<'r> {
     Batch(Batch<'r, BatchStatement<'r>, Vec<SerializedValues>>),
 }
 
-impl<'r> Request<'r> {
+impl Request<'_> {
     pub fn deserialize(
         buf: &mut &[u8],
         opcode: RequestOpcode,

--- a/scylla-cql/src/frame/request/prepare.rs
+++ b/scylla-cql/src/frame/request/prepare.rs
@@ -13,7 +13,7 @@ pub struct Prepare<'a> {
     pub query: &'a str,
 }
 
-impl<'a> SerializableRequest for Prepare<'a> {
+impl SerializableRequest for Prepare<'_> {
     const OPCODE: RequestOpcode = RequestOpcode::Prepare;
 
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -49,7 +49,7 @@ impl SerializableRequest for Query<'_> {
     }
 }
 
-impl<'q> DeserializableRequest for Query<'q> {
+impl DeserializableRequest for Query<'_> {
     fn deserialize(buf: &mut &[u8]) -> Result<Self, RequestDeserializationError> {
         let contents = Cow::Owned(types::read_long_string(buf)?.to_owned());
         let parameters = QueryParameters::deserialize(buf)?;
@@ -146,7 +146,7 @@ impl QueryParameters<'_> {
     }
 }
 
-impl<'q> QueryParameters<'q> {
+impl QueryParameters<'_> {
     pub fn deserialize(buf: &mut &[u8]) -> Result<Self, RequestDeserializationError> {
         let consistency = types::read_consistency(buf)?;
 

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -83,7 +83,7 @@ pub enum ColumnType<'frame> {
     Varint,
 }
 
-impl<'frame> ColumnType<'frame> {
+impl ColumnType<'_> {
     pub fn into_owned(self) -> ColumnType<'static> {
         match self {
             ColumnType::Custom(cow) => ColumnType::Custom(cow.into_owned().into()),

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -1662,7 +1662,10 @@ where
     IT: Iterator<Item = &'a VL> + Clone,
     VL: ValueList + 'a,
 {
-    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<IT> where Self: 'r;
+    type LegacyBatchValuesIter<'r>
+        = LegacyBatchValuesIteratorFromIterator<IT>
+    where
+        Self: 'r;
     fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         self.it.clone().into()
     }
@@ -1670,7 +1673,10 @@ where
 
 // Implement BatchValues for slices of ValueList types
 impl<T: ValueList> LegacyBatchValues for [T] {
-    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+    type LegacyBatchValuesIter<'r>
+        = LegacyBatchValuesIteratorFromIterator<std::slice::Iter<'r, T>>
+    where
+        Self: 'r;
     fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         self.iter().into()
     }
@@ -1678,7 +1684,10 @@ impl<T: ValueList> LegacyBatchValues for [T] {
 
 // Implement BatchValues for Vec<ValueList>
 impl<T: ValueList> LegacyBatchValues for Vec<T> {
-    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+    type LegacyBatchValuesIter<'r>
+        = LegacyBatchValuesIteratorFromIterator<std::slice::Iter<'r, T>>
+    where
+        Self: 'r;
     fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         LegacyBatchValues::batch_values_iter(self.as_slice())
     }
@@ -1687,7 +1696,10 @@ impl<T: ValueList> LegacyBatchValues for Vec<T> {
 // Here is an example implementation for (T0, )
 // Further variants are done using a macro
 impl<T0: ValueList> LegacyBatchValues for (T0,) {
-    type LegacyBatchValuesIter<'r> = LegacyBatchValuesIteratorFromIterator<std::iter::Once<&'r T0>> where Self: 'r;
+    type LegacyBatchValuesIter<'r>
+        = LegacyBatchValuesIteratorFromIterator<std::iter::Once<&'r T0>>
+    where
+        Self: 'r;
     fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         std::iter::once(&self.0).into()
     }
@@ -1776,7 +1788,10 @@ impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T
 
 // Every &impl BatchValues should also implement BatchValues
 impl<'a, T: LegacyBatchValues + ?Sized> LegacyBatchValues for &'a T {
-    type LegacyBatchValuesIter<'r> = <T as LegacyBatchValues>::LegacyBatchValuesIter<'r> where Self: 'r;
+    type LegacyBatchValuesIter<'r>
+        = <T as LegacyBatchValues>::LegacyBatchValuesIter<'r>
+    where
+        Self: 'r;
     fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         <T as LegacyBatchValues>::batch_values_iter(*self)
     }
@@ -1806,8 +1821,10 @@ impl<'f, T: LegacyBatchValues> LegacyBatchValuesFirstSerialized<'f, T> {
 }
 
 impl<'f, BV: LegacyBatchValues> LegacyBatchValues for LegacyBatchValuesFirstSerialized<'f, BV> {
-    type LegacyBatchValuesIter<'r> =
-        LegacyBatchValuesFirstSerialized<'f, <BV as LegacyBatchValues>::LegacyBatchValuesIter<'r>> where Self: 'r;
+    type LegacyBatchValuesIter<'r>
+        = LegacyBatchValuesFirstSerialized<'f, <BV as LegacyBatchValues>::LegacyBatchValuesIter<'r>>
+    where
+        Self: 'r;
     fn batch_values_iter(&self) -> Self::LegacyBatchValuesIter<'_> {
         LegacyBatchValuesFirstSerialized {
             first: self.first,

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -1609,7 +1609,7 @@ impl ValueList for LegacySerializedValues {
     }
 }
 
-impl<'b> ValueList for Cow<'b, LegacySerializedValues> {
+impl ValueList for Cow<'_, LegacySerializedValues> {
     fn serialized(&self) -> SerializedResult<'_> {
         Ok(Cow::Borrowed(self.as_ref()))
     }
@@ -1787,7 +1787,7 @@ impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T
                              0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15; 16);
 
 // Every &impl BatchValues should also implement BatchValues
-impl<'a, T: LegacyBatchValues + ?Sized> LegacyBatchValues for &'a T {
+impl<T: LegacyBatchValues + ?Sized> LegacyBatchValues for &T {
     type LegacyBatchValuesIter<'r>
         = <T as LegacyBatchValues>::LegacyBatchValuesIter<'r>
     where

--- a/scylla-cql/src/types/deserialize/result.rs
+++ b/scylla-cql/src/types/deserialize/result.rs
@@ -255,6 +255,9 @@ mod tests {
         fn lend_next(&mut self) -> Option<Result<Self::Item<'_>, DeserializationError>>;
     }
 
+    // Disable the lint, if there is more than one lifetime included.
+    // Can be removed once https://github.com/rust-lang/rust-clippy/issues/12495 is fixed.
+    #[allow(clippy::needless_lifetimes)]
     impl<'frame, 'metadata> LendingIterator for RawRowIterator<'frame, 'metadata> {
         type Item<'borrow>
             = ColumnIterator<'borrow, 'borrow>

--- a/scylla-cql/src/types/deserialize/result.rs
+++ b/scylla-cql/src/types/deserialize/result.rs
@@ -256,7 +256,8 @@ mod tests {
     }
 
     impl<'frame, 'metadata> LendingIterator for RawRowIterator<'frame, 'metadata> {
-        type Item<'borrow> = ColumnIterator<'borrow, 'borrow>
+        type Item<'borrow>
+            = ColumnIterator<'borrow, 'borrow>
         where
             Self: 'borrow;
 

--- a/scylla-cql/src/types/serialize/batch.rs
+++ b/scylla-cql/src/types/serialize/batch.rs
@@ -314,7 +314,7 @@ impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T
                              0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15; 16);
 
 // Every &impl BatchValues should also implement BatchValues
-impl<'a, T: BatchValues + ?Sized> BatchValues for &'a T {
+impl<T: BatchValues + ?Sized> BatchValues for &T {
     type BatchValuesIter<'r>
         = <T as BatchValues>::BatchValuesIter<'r>
     where

--- a/scylla-cql/src/types/serialize/batch.rs
+++ b/scylla-cql/src/types/serialize/batch.rs
@@ -166,7 +166,10 @@ where
     IT: Iterator<Item = &'sr SR> + Clone,
     SR: SerializeRow + 'sr,
 {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<IT> where Self: 'r;
+    type BatchValuesIter<'r>
+        = BatchValuesIteratorFromIterator<IT>
+    where
+        Self: 'r;
 
     #[inline]
     fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
@@ -176,7 +179,10 @@ where
 
 // Implement BatchValues for slices of SerializeRow types
 impl<T: SerializeRow> BatchValues for [T] {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+    type BatchValuesIter<'r>
+        = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>>
+    where
+        Self: 'r;
 
     #[inline]
     fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
@@ -186,7 +192,10 @@ impl<T: SerializeRow> BatchValues for [T] {
 
 // Implement BatchValues for Vec<SerializeRow>
 impl<T: SerializeRow> BatchValues for Vec<T> {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>> where Self: 'r;
+    type BatchValuesIter<'r>
+        = BatchValuesIteratorFromIterator<std::slice::Iter<'r, T>>
+    where
+        Self: 'r;
 
     #[inline]
     fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
@@ -197,7 +206,10 @@ impl<T: SerializeRow> BatchValues for Vec<T> {
 // Here is an example implementation for (T0, )
 // Further variants are done using a macro
 impl<T0: SerializeRow> BatchValues for (T0,) {
-    type BatchValuesIter<'r> = BatchValuesIteratorFromIterator<std::iter::Once<&'r T0>> where Self: 'r;
+    type BatchValuesIter<'r>
+        = BatchValuesIteratorFromIterator<std::iter::Once<&'r T0>>
+    where
+        Self: 'r;
 
     #[inline]
     fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
@@ -303,7 +315,10 @@ impl_batch_values_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T
 
 // Every &impl BatchValues should also implement BatchValues
 impl<'a, T: BatchValues + ?Sized> BatchValues for &'a T {
-    type BatchValuesIter<'r> = <T as BatchValues>::BatchValuesIter<'r> where Self: 'r;
+    type BatchValuesIter<'r>
+        = <T as BatchValues>::BatchValuesIter<'r>
+    where
+        Self: 'r;
 
     #[inline]
     fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
@@ -323,7 +338,8 @@ impl<T> BatchValues for LegacyBatchValuesAdapter<T>
 where
     T: LegacyBatchValues,
 {
-    type BatchValuesIter<'r> = LegacyBatchValuesIteratorAdapter<T::LegacyBatchValuesIter<'r>>
+    type BatchValuesIter<'r>
+        = LegacyBatchValuesIteratorAdapter<T::LegacyBatchValuesIter<'r>>
     where
         Self: 'r;
 

--- a/scylla-cql/src/types/serialize/raw_batch.rs
+++ b/scylla-cql/src/types/serialize/raw_batch.rs
@@ -62,7 +62,8 @@ pub trait RawBatchValuesIterator<'a> {
 
 // An implementation used by `scylla-proxy`
 impl RawBatchValues for Vec<SerializedValues> {
-    type RawBatchValuesIter<'r> = std::slice::Iter<'r, SerializedValues>
+    type RawBatchValuesIter<'r>
+        = std::slice::Iter<'r, SerializedValues>
     where
         Self: 'r;
 
@@ -117,7 +118,8 @@ where
     BV: BatchValues,
     CTX: Iterator<Item = RowSerializationContext<'ctx>> + Clone,
 {
-    type RawBatchValuesIter<'r> = RawBatchValuesIteratorAdapter<BV::BatchValuesIter<'r>, CTX>
+    type RawBatchValuesIter<'r>
+        = RawBatchValuesIteratorAdapter<BV::BatchValuesIter<'r>, CTX>
     where
         Self: 'r;
 

--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -286,7 +286,7 @@ impl SerializeRow for LegacySerializedValues {
     fallback_impl_contents!();
 }
 
-impl<'b> SerializeRow for Cow<'b, LegacySerializedValues> {
+impl SerializeRow for Cow<'_, LegacySerializedValues> {
     fallback_impl_contents!();
 }
 

--- a/scylla-cql/src/types/serialize/writers.rs
+++ b/scylla-cql/src/types/serialize/writers.rs
@@ -204,7 +204,7 @@ pub struct WrittenCellProof<'buf> {
     _phantom: std::marker::PhantomData<*mut &'buf ()>,
 }
 
-impl<'buf> WrittenCellProof<'buf> {
+impl WrittenCellProof<'_> {
     /// A shorthand for creating the proof.
     ///
     /// Do not make it public! It's important that only the row writer defined

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -167,7 +167,7 @@ impl StructDesc {
 
 struct TypeCheckAssumeOrderGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
+impl TypeCheckAssumeOrderGenerator<'_> {
     fn generate_name_verification(
         &self,
         field_index: usize, //  These two indices can be different because of `skip` attribute
@@ -267,7 +267,7 @@ impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
 
 struct DeserializeAssumeOrderGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
+impl DeserializeAssumeOrderGenerator<'_> {
     fn generate_finalize_field(&self, field_index: usize, field: &Field) -> syn::Expr {
         if field.skip {
             // Skipped fields are initialized with Default::default()
@@ -335,7 +335,7 @@ impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
 
 struct TypeCheckUnorderedGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> TypeCheckUnorderedGenerator<'sd> {
+impl TypeCheckUnorderedGenerator<'_> {
     // An identifier for a bool variable that represents whether given
     // field was already visited during type check
     fn visited_flag_variable(field: &Field) -> syn::Ident {
@@ -480,7 +480,7 @@ impl<'sd> TypeCheckUnorderedGenerator<'sd> {
 
 struct DeserializeUnorderedGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> DeserializeUnorderedGenerator<'sd> {
+impl DeserializeUnorderedGenerator<'_> {
     // An identifier for a variable that is meant to store the parsed variable
     // before being ultimately moved to the struct on deserialize
     fn deserialize_field_variable(field: &Field) -> syn::Ident {

--- a/scylla-macros/src/deserialize/value.rs
+++ b/scylla-macros/src/deserialize/value.rs
@@ -222,7 +222,7 @@ impl StructDesc {
 
 struct TypeCheckAssumeOrderGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
+impl TypeCheckAssumeOrderGenerator<'_> {
     // Generates name and type validation for given Rust struct's field.
     fn generate_field_validation(&self, rust_field_idx: usize, field: &Field) -> syn::Expr {
         let macro_internal = self.0.struct_attrs().macro_internal_path();
@@ -398,7 +398,7 @@ impl<'sd> TypeCheckAssumeOrderGenerator<'sd> {
 
 struct DeserializeAssumeOrderGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
+impl DeserializeAssumeOrderGenerator<'_> {
     fn generate_finalize_field(&self, field: &Field) -> syn::Expr {
         if field.skip {
             // Skipped fields are initialized with Default::default()
@@ -566,7 +566,7 @@ impl<'sd> DeserializeAssumeOrderGenerator<'sd> {
 
 struct TypeCheckUnorderedGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> TypeCheckUnorderedGenerator<'sd> {
+impl TypeCheckUnorderedGenerator<'_> {
     // An identifier for a bool variable that represents whether given
     // field was already visited during type check
     fn visited_flag_variable(field: &Field) -> syn::Ident {
@@ -730,7 +730,7 @@ impl<'sd> TypeCheckUnorderedGenerator<'sd> {
 
 struct DeserializeUnorderedGenerator<'sd>(&'sd StructDesc);
 
-impl<'sd> DeserializeUnorderedGenerator<'sd> {
+impl DeserializeUnorderedGenerator<'_> {
     /// An identifier for a variable that is meant to store the parsed variable
     /// before being ultimately moved to the struct on deserialize.
     fn deserialize_field_variable(field: &Field) -> syn::Ident {

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -194,7 +194,7 @@ struct ColumnSortingGenerator<'a> {
     ctx: &'a Context,
 }
 
-impl<'a> Generator for ColumnSortingGenerator<'a> {
+impl Generator for ColumnSortingGenerator<'_> {
     fn generate_serialize(&self) -> syn::TraitItemFn {
         // Need to:
         // - Check that all required columns are there and no more
@@ -317,7 +317,7 @@ struct ColumnOrderedGenerator<'a> {
     ctx: &'a Context,
 }
 
-impl<'a> Generator for ColumnOrderedGenerator<'a> {
+impl Generator for ColumnOrderedGenerator<'_> {
     fn generate_serialize(&self) -> syn::TraitItemFn {
         let mut statements: Vec<syn::Stmt> = Vec::new();
 

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -256,7 +256,7 @@ struct FieldSortingGenerator<'a> {
     ctx: &'a Context,
 }
 
-impl<'a> Generator for FieldSortingGenerator<'a> {
+impl Generator for FieldSortingGenerator<'_> {
     fn generate_serialize(&self) -> syn::TraitItemFn {
         // Need to:
         // - Check that all required fields are there and no more
@@ -449,7 +449,7 @@ struct FieldOrderedGenerator<'a> {
     ctx: &'a Context,
 }
 
-impl<'a> Generator for FieldOrderedGenerator<'a> {
+impl Generator for FieldOrderedGenerator<'_> {
     fn generate_serialize(&self) -> syn::TraitItemFn {
         let mut statements: Vec<syn::Stmt> = Vec::new();
 

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -283,9 +283,10 @@ pub(crate) mod batch_values {
     where
         BV: BatchValues,
     {
-        type BatchValuesIter<'r> = BatchValuesFirstSerializedIterator<'r, BV::BatchValuesIter<'r>>
-    where
-        Self: 'r;
+        type BatchValuesIter<'r>
+            = BatchValuesFirstSerializedIterator<'r, BV::BatchValuesIter<'r>>
+        where
+            Self: 'r;
 
         fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
             BatchValuesFirstSerializedIterator {

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -224,7 +224,7 @@ impl PreparedStatement {
     pub(crate) fn extract_partition_key<'ps>(
         &'ps self,
         bound_values: &'ps SerializedValues,
-    ) -> Result<PartitionKey, PartitionKeyExtractionError> {
+    ) -> Result<PartitionKey<'ps>, PartitionKeyExtractionError> {
         PartitionKey::new(self.get_prepared_metadata(), bound_values)
     }
 

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -519,7 +519,7 @@ pub(crate) struct PartitionKey<'ps> {
     pk_values: SmallVec<[Option<PartitionKeyValue<'ps>>; PartitionKey::SMALLVEC_ON_STACK_SIZE]>,
 }
 
-impl<'ps, 'spec: 'ps> PartitionKey<'ps> {
+impl<'ps> PartitionKey<'ps> {
     const SMALLVEC_ON_STACK_SIZE: usize = 8;
 
     fn new(

--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -62,7 +62,7 @@ pub(crate) struct Cluster {
 /// Enables printing [Cluster] struct in a neat way, by skipping the rather useless
 /// print of channels state and printing [ClusterData] neatly.
 pub(crate) struct ClusterNeatDebug<'a>(pub(crate) &'a Cluster);
-impl<'a> std::fmt::Debug for ClusterNeatDebug<'a> {
+impl std::fmt::Debug for ClusterNeatDebug<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let cluster = self.0;
         f.debug_struct("Cluster")
@@ -81,7 +81,7 @@ pub struct ClusterData {
 /// Enables printing [ClusterData] struct in a neat way, skipping the clutter involved by
 /// [ClusterData::ring] being large and [Self::keyspaces] debug print being very verbose by default.
 pub(crate) struct ClusterDataNeatDebug<'a>(pub(crate) &'a Arc<ClusterData>);
-impl<'a> std::fmt::Debug for ClusterDataNeatDebug<'a> {
+impl std::fmt::Debug for ClusterDataNeatDebug<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let cluster_data = &self.0;
 

--- a/scylla/src/transport/connection.rs
+++ b/scylla/src/transport/connection.rs
@@ -193,7 +193,7 @@ impl<'a> OrphanhoodNotifier<'a> {
     }
 }
 
-impl<'a> Drop for OrphanhoodNotifier<'a> {
+impl Drop for OrphanhoodNotifier<'_> {
     fn drop(&mut self) {
         if self.enabled {
             let _ = self.notification_sender.send(self.request_id);

--- a/scylla/src/transport/legacy_query_result.rs
+++ b/scylla/src/transport/legacy_query_result.rs
@@ -175,7 +175,7 @@ impl LegacyQueryResult {
 
     /// Returns a column specification for a column with given name, or None if not found
     #[inline]
-    pub fn get_column_spec<'a>(&'a self, name: &str) -> Option<(usize, &'a ColumnSpec<'_>)> {
+    pub fn get_column_spec<'a>(&'a self, name: &str) -> Option<(usize, &'a ColumnSpec<'a>)> {
         self.col_specs()
             .iter()
             .enumerate()

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -707,7 +707,7 @@ impl DefaultPolicy {
         cluster: &'a ClusterData,
         statement_type: StatementType,
         table_spec: &TableSpec,
-    ) -> Option<PickedReplica> {
+    ) -> Option<PickedReplica<'a>> {
         match statement_type {
             StatementType::Lwt => {
                 self.pick_first_replica(ts, replica_location, predicate, cluster, table_spec)
@@ -744,7 +744,7 @@ impl DefaultPolicy {
         predicate: impl Fn(NodeRef<'a>, Shard) -> bool + 'a,
         cluster: &'a ClusterData,
         table_spec: &TableSpec,
-    ) -> Option<PickedReplica> {
+    ) -> Option<PickedReplica<'a>> {
         match replica_location {
             NodeLocationCriteria::Any => {
                 // ReplicaSet returned by ReplicaLocator for this case:
@@ -819,11 +819,11 @@ impl DefaultPolicy {
         &'a self,
         ts: &TokenWithStrategy<'a>,
         replica_location: NodeLocationCriteria<'a>,
-        predicate: impl Fn(NodeRef<'_>, Shard) -> bool + 'a,
+        predicate: impl Fn(NodeRef<'a>, Shard) -> bool + 'a,
         cluster: &'a ClusterData,
         statement_type: StatementType,
         table_spec: &TableSpec,
-    ) -> impl Iterator<Item = (NodeRef<'_>, Shard)> {
+    ) -> impl Iterator<Item = (NodeRef<'a>, Shard)> {
         let order = match statement_type {
             StatementType::Lwt => ReplicaOrder::Deterministic,
             StatementType::NonLwt => ReplicaOrder::Arbitrary,
@@ -862,7 +862,7 @@ impl DefaultPolicy {
         &'a self,
         nodes: &'a [Arc<Node>],
         predicate: impl Fn(NodeRef<'a>) -> bool,
-    ) -> Option<NodeRef<'_>> {
+    ) -> Option<NodeRef<'a>> {
         // Select the first node that matches the predicate
         Self::randomly_rotated_nodes(nodes).find(|&node| predicate(node))
     }
@@ -873,7 +873,7 @@ impl DefaultPolicy {
         &'a self,
         nodes: &'a [Arc<Node>],
         predicate: impl Fn(NodeRef<'a>) -> bool,
-    ) -> impl Iterator<Item = NodeRef<'_>> {
+    ) -> impl Iterator<Item = NodeRef<'a>> {
         Self::randomly_rotated_nodes(nodes).filter(move |node| predicate(node))
     }
 

--- a/scylla/src/transport/load_balancing/plan.rs
+++ b/scylla/src/transport/load_balancing/plan.rs
@@ -65,7 +65,6 @@ enum PlanState<'a> {
 ///     }
 /// }
 /// ```
-
 pub struct Plan<'a> {
     policy: &'a dyn LoadBalancingPolicy,
     routing_info: &'a RoutingInfo<'a>,

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -99,14 +99,14 @@ impl ReplicaLocator {
             } else {
                 tablets.replicas_for_token(token)
             };
-            return ReplicaSet {
+            ReplicaSet {
                 inner: ReplicaSetInner::PlainSharded(replicas.unwrap_or(
                     // The table is a tablet table, but we don't have information for given token.
                     // Let's just return empty set in this case.
                     &[],
                 )),
                 token,
-            };
+            }
         } else {
             match strategy {
                 Strategy::SimpleStrategy { replication_factor } => {

--- a/scylla/src/transport/locator/replicas.rs
+++ b/scylla/src/transport/locator/replicas.rs
@@ -48,7 +48,7 @@ impl<'a> From<&'a [Arc<Node>]> for ReplicasArray<'a> {
     }
 }
 
-impl<'a> Index<usize> for ReplicasArray<'a> {
+impl Index<usize> for ReplicasArray<'_> {
     type Output = Arc<Node>;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/scylla/src/transport/locator/tablets.rs
+++ b/scylla/src/transport/locator/tablets.rs
@@ -577,7 +577,6 @@ impl TabletsInfo {
     /// * Removing the keyspace and recreating it immediately without tablets. This seems so absurd
     ///     that we most likely don't need to worry about it, but I'm putting it here as a potential problem
     ///     for completeness.
-
     pub(crate) fn perform_maintenance(
         &mut self,
         table_predicate: &impl Fn(&TableSpec) -> bool,

--- a/scylla/src/transport/locator/tablets.rs
+++ b/scylla/src/transport/locator/tablets.rs
@@ -490,6 +490,9 @@ impl TabletsInfo {
             table_spec: &'a TableSpec<'a>,
         }
 
+        // Disable the lint, if there is more than one lifetime included.
+        // Can be removed once https://github.com/rust-lang/rust-clippy/issues/12495 is fixed.
+        #[allow(clippy::needless_lifetimes)]
         impl<'key, 'query> hashbrown::Equivalent<TableSpec<'key>> for TableSpecQueryKey<'query> {
             fn equivalent(&self, key: &TableSpec<'key>) -> bool {
                 self.table_spec == key

--- a/scylla/src/transport/session.rs
+++ b/scylla/src/transport/session.rs
@@ -2272,7 +2272,7 @@ struct HistoryData<'a> {
     speculative_id: Option<history::SpeculativeId>,
 }
 
-impl<'a> ExecuteQueryContext<'a> {
+impl ExecuteQueryContext<'_> {
     fn log_attempt_start(&self, node_addr: SocketAddr) -> Option<history::AttemptId> {
         self.history_data.as_ref().map(|hd| {
             hd.listener
@@ -2423,7 +2423,7 @@ impl RequestSpan {
 
     pub(crate) fn record_replicas<'a>(&'a self, replicas: &'a [(impl Borrow<Arc<Node>>, Shard)]) {
         struct ReplicaIps<'a, N>(&'a [(N, Shard)]);
-        impl<'a, N> Display for ReplicaIps<'a, N>
+        impl<N> Display for ReplicaIps<'_, N>
         where
             N: Borrow<Arc<Node>>,
         {

--- a/scylla/src/utils/pretty.rs
+++ b/scylla/src/utils/pretty.rs
@@ -9,7 +9,7 @@ use std::fmt::{Display, LowerHex, UpperHex};
 
 pub(crate) struct HexBytes<'a>(pub(crate) &'a [u8]);
 
-impl<'a> LowerHex for HexBytes<'a> {
+impl LowerHex for HexBytes<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for b in self.0 {
             write!(f, "{:02x}", b)?;
@@ -18,7 +18,7 @@ impl<'a> LowerHex for HexBytes<'a> {
     }
 }
 
-impl<'a> UpperHex for HexBytes<'a> {
+impl UpperHex for HexBytes<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for b in self.0 {
             write!(f, "{:02X}", b)?;
@@ -154,7 +154,7 @@ where
 
 pub(crate) struct CqlStringLiteralDisplayer<'a>(&'a str);
 
-impl<'a> Display for CqlStringLiteralDisplayer<'a> {
+impl Display for CqlStringLiteralDisplayer<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // CQL string literals use single quotes. The only character that
         // needs escaping is singular quote, and escaping is done by repeating


### PR DESCRIPTION
This PR fixes CI, by fixing the:
- formatting errors - some changes to `cargo fmt` were introduced in 1.83
- compiler warnings - these are regarding elision of lifetimes that are already declared
- clippy lints



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
