### PR TITLE
Allow serialization of "columns" that are not valid rust identifiers

### DIFF
--- a/scylla-cql/src/types/serialize/row.rs
+++ b/scylla-cql/src/types/serialize/row.rs
@@ -1568,6 +1568,23 @@ pub(crate) mod tests {
         assert_eq!(reference, row);
     }
 
+    #[test]
+    fn test_row_serialization_with_not_rust_idents() {
+        #[derive(SerializeRow, Debug)]
+        #[scylla(crate = crate)]
+        struct RowWithTTL {
+            #[scylla(rename = "[ttl]")]
+            ttl: i32,
+        }
+
+        let spec = [col("[ttl]", ColumnType::Int)];
+
+        let reference = do_serialize((42i32,), &spec);
+        let row = do_serialize(RowWithTTL { ttl: 42 }, &spec);
+
+        assert_eq!(reference, row);
+    }
+
     #[derive(SerializeRow, Debug)]
     #[scylla(crate = crate)]
     struct TestRowWithSkippedFields {

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -223,7 +223,7 @@ impl Generator for ColumnSortingGenerator<'_> {
         statements.push(self.ctx.generate_mk_ser_err());
 
         // Generate a "visited" flag for each field
-        let visited_flag_names = rust_field_names
+        let visited_flag_names = rust_field_idents
             .iter()
             .map(|s| syn::Ident::new(&format!("visited_flag_{}", s), Span::call_site()))
             .collect::<Vec<_>>();

--- a/scylla/src/macros.rs
+++ b/scylla/src/macros.rs
@@ -360,7 +360,7 @@ pub use scylla_cql::macros::SerializeRow;
 /// If the value of the field received from DB is null, the field will be
 /// initialized with `Default::default()`.
 ///
-/// `#[scylla(rename = "field_name")`
+/// `#[scylla(rename = "field_name")]`
 ///
 /// By default, the generated implementation will try to match the Rust field
 /// to a UDT field with the same name. This attribute instead allows to match
@@ -475,7 +475,7 @@ pub use scylla_macros::DeserializeValue;
 /// The field will be completely ignored during deserialization and will
 /// be initialized with `Default::default()`.
 ///
-/// `#[scylla(rename = "field_name")`
+/// `#[scylla(rename = "field_name")]`
 ///
 /// By default, the generated implementation will try to match the Rust field
 /// to a column with the same name. This attribute allows to match to a column


### PR DESCRIPTION
## Fixes

When trying to serialize a row that isn't a valid rust identifier, the macro fails to expand due to the invalid rust identifier being used when creating variables for the derived implementation. This PR fixes that such that those variables are driven by the field identifier rather than the column name. 

In particular, this occurs when trying to serialize a dynamic TTL that would be using in a query such as:

```cql
INSERT INTO my_table (/* snip cols */) VALUES((/* snip cols */) USING TTL ?
```

The struct desired for serialization is:
```rust
struct InsertRow {
    #[scylla(rename = "[ttl]"]
    ttl: i32,
    /* snip cols */
}
```

However, in the current version of the driver this fails because it tries to create a variable called `visited_flag_[ttl]` which is not a valid rust identifier. As far as I could tell there is no reason for this variable to be based on the column name rather than the field name so I switched it to be based off the field name since that already has to be a valid identifier. 

I added a test to verify that the serialization works but I didn't add any integration tests to make sure that the TTL insert actually works. I have tested it locally however. 

For context: I am using this dynamic TTL to allow moving of rows to different "buckets" (which drive partitions in my schema). I want the re-bucketing to not affect the existing TTL so I am reading the existing TTL in one query and then applying it to the new row in the new bucket in an insert. 

I also fixed a doc typo that was missing an ending square bracket. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I have provided docstrings for the public items that I want to introduce.
- [X] I have adjusted the documentation in `./docs/source/`.
- [X] I added appropriate `Fixes:` annotations to PR description.
