### PR TITLE
Displayer for QueryRowsResult

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.34",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -66,16 +66,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anyhow"
-version = "1.0.83"
+name = "ansi-str"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
+dependencies = [
+ "nom",
+ "vte",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "assert_matches"
@@ -85,20 +110,23 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "atomic"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "atty"
@@ -113,48 +141,46 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.4"
+version = "1.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
+checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
 dependencies = [
  "aws-lc-sys",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
+checksum = "6bbe221bbf523b625a4dd8585c7f38166e31167ec2ca98051dbcb4c3b6e825d2"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "paste",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -165,13 +191,13 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9324c8014cd04590682b34f1e9448d38f0674d0f7b2dc553331016ef0e4e9ebc"
+checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -182,7 +208,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.10.5",
@@ -195,7 +221,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.90",
+ "syn 2.0.100",
  "which",
 ]
 
@@ -207,15 +233,27 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
+name = "bytemuck"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -225,9 +263,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"
@@ -237,9 +275,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -263,14 +301,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -372,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -414,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -433,15 +471,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "darling"
@@ -464,7 +502,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -475,7 +513,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -522,6 +560,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,9 +578,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "endian-type"
@@ -554,18 +603,18 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -651,9 +700,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -666,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -676,15 +725,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -693,38 +742,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -758,14 +807,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -800,6 +849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,39 +871,39 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "histogram"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cf6b99a250776d813cdf2f0b478a053a822d078e7a2baf5cb36afc88c41a7c"
+checksum = "95aebe0dec9a429e3207e5e34d97f2a7d1064d5ee6d8ed13ce0a26456de000ae"
 dependencies = [
- "thiserror 1.0.60",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -868,6 +923,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,12 +1048,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -895,23 +1079,29 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.12"
+name = "inline_colorization"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "dc1804bdb6a9784758b200007273a8b84e2b0b0b97a8f1e18e763eceb3e9f98a"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -934,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -949,18 +1139,19 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -970,9 +1161,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -981,14 +1172,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -996,15 +1187,21 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -1018,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lz4_flex"
@@ -1042,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -1063,22 +1260,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1169,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1202,35 +1399,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -1238,7 +1425,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1255,7 +1442,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1283,10 +1470,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.2"
+name = "papergrid"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1302,14 +1502,8 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1319,9 +1513,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1331,15 +1525,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1350,15 +1544,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -1371,25 +1565,28 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.23",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -1419,19 +1616,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.92"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1454,7 +1673,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy 0.8.20",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -1469,12 +1688,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1508,34 +1726,34 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.60",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1549,13 +1767,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1566,15 +1784,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1598,22 +1816,22 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1643,6 +1861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
 name = "rustyline"
 version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,7 +1885,7 @@ dependencies = [
  "scopeguard",
  "smallvec",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
  "utf8parse",
  "winapi",
 ]
@@ -1678,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1714,12 +1938,13 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "histogram",
+ "inline_colorization",
  "itertools 0.14.0",
  "lazy_static",
  "lz4_flex",
  "ntest",
  "num-bigint 0.3.3",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "openssl",
  "rand",
  "rand_chacha",
@@ -1732,7 +1957,8 @@ dependencies = [
  "smallvec",
  "snap",
  "socket2",
- "thiserror 2.0.9",
+ "tabled",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-openssl",
@@ -1758,13 +1984,13 @@ dependencies = [
  "lazy_static",
  "lz4_flex",
  "num-bigint 0.3.3",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "scylla-macros",
  "secrecy",
  "serde",
  "snap",
  "stable_deref_trait",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "uuid",
@@ -1780,7 +2006,7 @@ dependencies = [
  "quote",
  "scylla",
  "scylla-cql",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1797,7 +2023,7 @@ dependencies = [
  "num-bigint 0.3.3",
  "rand",
  "scylla-cql",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1815,31 +2041,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1850,7 +2077,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.8.0",
  "itoa",
  "ryu",
  "serde",
@@ -1892,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "snap"
@@ -1904,9 +2131,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1967,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,7 +2211,32 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1998,48 +2250,48 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.60",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2054,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2068,18 +2320,28 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2093,57 +2355,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "tokio-openssl"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffab79df67727f6acf57f1ff743091873c24c579b1e2ce4d8f53e47ded4d63d"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
 dependencies = [
- "futures-util",
  "openssl",
  "openssl-sys",
  "tokio",
@@ -2151,27 +2396,28 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.8.0",
  "toml_datetime",
  "winnow",
 ]
@@ -2189,21 +2435,21 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2213,20 +2459,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2245,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2272,37 +2518,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2318,9 +2555,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2328,26 +2565,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "atomic",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2357,9 +2606,30 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"
@@ -2388,34 +2658,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2423,28 +2694,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2480,11 +2754,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2499,8 +2773,14 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
@@ -2517,7 +2797,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2537,18 +2826,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2559,9 +2848,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2571,9 +2860,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2583,15 +2872,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2601,9 +2890,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2613,9 +2902,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2625,9 +2914,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2637,15 +2926,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -2656,8 +2945,20 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
@@ -2679,48 +2980,48 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive 0.7.34",
+ "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.20",
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2734,18 +3035,40 @@ dependencies = [
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.100",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]

--- a/docs/source/statements/displaying-results.md
+++ b/docs/source/statements/displaying-results.md
@@ -1,0 +1,124 @@
+# Displaying Query Results
+
+This guide explains how to display query results from the database using the `RowsDisplayer` utility. The `RowsDisplayer` provides a flexible way to format and visualize query results as tables with various customization options, it tries to copy the behavior of the `cqlsh` utility.
+
+## Basic Usage
+
+To display query results, create a `RowsDisplayer` instance and configure its display settings:
+
+```rust
+let result: QueryRowsResult = session
+    .query_unpaged("SELECT * FROM examples_ks.basic1", &[])
+    .await?
+    .into_rows_result()?;
+let displayer = result.rows_displayer();
+println!("{}", displayer);
+```
+
+## Display Settings
+
+### Terminal Width
+
+Control the width of the output table:
+
+```rust
+displayer.set_terminal_width(80);
+```
+
+- Setting width to 0 (default) disables wrapping
+- Table will attempt to wrap at specified width while maintaining readability
+- Columns are adjusted proportionally when wrapping
+
+### Color Output
+
+Enable or disable colored output:
+
+```rust
+displayer.use_color(true);  // Enable colors (default)
+displayer.use_color(false); // Disable colors
+```
+
+When enabled, different data types are displayed in distinct colors:
+- Numbers (integers, decimals, floats): Green
+- Text and strings: Yellow
+- Collections (lists, sets, maps): Blue
+- Errors: Red
+- Binary data: Magenta
+
+### Binary Data Display
+
+Configure how BLOB data is displayed using `ByteDisplaying`:
+
+```rust
+displayer.set_blob_displaying(ByteDisplaying::Hex);  // Default
+displayer.set_blob_displaying(ByteDisplaying::Ascii);
+displayer.set_blob_displaying(ByteDisplaying::Dec);
+```
+
+Options:
+- `Hex`: Display as hexadecimal values (e.g., "0A FF 42")
+- `Ascii`: Display as ASCII characters where possible
+- `Dec`: Display as decimal values (e.g., "213 7 66")
+
+### Number Formatting
+
+#### Integer Display
+
+Control scientific notation for integers:
+
+```rust
+displayer.set_exponent_displaying_integers(true);  // Enable scientific notation
+displayer.set_exponent_displaying_integers(false); // Disable (default)
+```
+
+#### Floating Point Precision
+
+Set the number of decimal places for floating point numbers:
+
+```rust
+displayer.set_floating_point_precision(6);  // Show 6 decimal places (default)
+```
+
+## Example Output
+
+Here's an example of how the output might look with default settings:
+
+```
++----------+-------------+----------------+-------------+
+| id       | name        | values        | created_at  |
++----------+-------------+----------------+-------------+
+| 1        | Example     | [1, 2, 3]     | 2024-01-06 |
+| 2        | Test Data   | [4, 5, 6]     | 2024-01-06 |
++----------+-------------+----------------+-------------+
+```
+
+## Best Practices
+
+1. **Terminal Width**
+   - Set appropriate terminal width for better readability
+   - Consider using terminal width detection if available
+   - Use 0 width for untruncated output
+
+2. **Color Usage**
+   - Enable colors for better type distinction
+   - Disable colors when outputting to files or non-terminal destinations
+   - Consider user accessibility settings
+
+3. **Binary Data**
+   - Choose appropriate blob display format based on data content
+   - Use Hex for general binary data
+   - Use ASCII when data is known to be text
+   - Use Dec for byte-oriented analysis
+
+4. **Number Formatting**
+   - Adjust floating point precision based on data requirements
+   - Enable scientific notation for very large/small numbers
+   - Consider locale-specific formatting needs
+
+## Implementation Details
+
+The displayer uses the following traits internally:
+- `Display` for converting values to strings
+- Custom formatting traits for specific types
+
+Output is generated using Rust's formatting system (`fmt::Display`), ensuring efficient memory usage and proper error handling.

--- a/docs/source/statements/statements.md
+++ b/docs/source/statements/statements.md
@@ -107,5 +107,6 @@ There is a special functionality to enable [USE keyspace](usekeyspace.md).
    schema-agreement
    lwt
    timeouts
+   displaying-results
    timestamp-generators
 ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,6 +20,7 @@ scylla = { path = "../scylla", features = [
     "num-bigint-04",
     "bigdecimal-04",
     "metrics",
+    "result-displayer",
 ] }
 tokio = { version = "1.34", features = ["full"] }
 tracing = { version = "0.1.25", features = ["log"] }
@@ -137,3 +138,8 @@ path = "tls-rustls.rs"
 [[example]]
 name = "execution_profile"
 path = "execution_profile.rs"
+
+
+[[example]]
+name = "displayer"
+path = "displayer.rs"

--- a/examples/displayer.rs
+++ b/examples/displayer.rs
@@ -1,0 +1,341 @@
+use anyhow::Result;
+use scylla::{
+    client::{session::Session, session_builder::SessionBuilder},
+    response::rows_displayer::ByteDisplaying,
+};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    // prepare the session
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+
+    session.query_unpaged("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session
+        .query_unpaged(
+            "CREATE TABLE IF NOT EXISTS examples_ks.basic (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.basic (a, b, c) VALUES (?, ?, ?)",
+            (3, 4, "lorem Ipsum jest tekstem stosowanym jako przykładowy wypełniacz w przemyśle poligraficznym. Został po raz pierwszy użyty w XV w. przez nieznanego drukarza do wypełnienia tekstem próbnej książki. Pięć wieków później zaczął być używany przemyśle elektronicznym,"),
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.basic (a, b, c) VALUES (1, 2, 'abc')",
+            &[],
+        )
+        .await?;
+
+    let prepared = session
+        .prepare("INSERT INTO examples_ks.basic (a, b, c) VALUES (?, 7, ?)")
+        .await?;
+    session
+        .execute_unpaged(&prepared, (42_i32, "I'm prepared!"))
+        .await?;
+    session
+        .execute_unpaged(&prepared, (43_i32, "I'm prepared 2!"))
+        .await?;
+    session
+        .execute_unpaged(&prepared, (44_i32, "I'm prepared 3!"))
+        .await?;
+
+    // example 1 - basic table
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT a, b, c FROM examples_ks.basic", &[])
+        .await?
+        .into_rows_result()?;
+
+    let displayer = result.rows_displayer();
+    println!("\nlong text and special characters:");
+    println!("{}", displayer);
+
+    // example 2 - blob, double, float, time, timestamp
+    session
+    .query_unpaged(
+        "CREATE TABLE IF NOT EXISTS examples_ks.basic4 (a int, b int, c text, d int, timest timestamp, bytes blob, fl float, db double, time1 time, primary key (a, c))",
+        &[],
+    )
+    .await?;
+
+    session
+    .query_unpaged(
+        "INSERT INTO examples_ks.basic4 
+        (a, b, c, d, timest, bytes, fl, db, time1) 
+        VALUES 
+        (1, 10, 'example text', 3, toTimestamp(now()), textAsBlob('sample bytes'), 3.14, 2.718281, '14:30:00');",
+        &[],
+    )
+    .await?;
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT * FROM examples_ks.basic4", &[])
+        .await?
+        .into_rows_result()?;
+
+    let mut displayer = result.rows_displayer();
+    displayer.set_blob_displaying(ByteDisplaying::Ascii);
+    println!("\nblob, double, float, time, timestamp:");
+    println!("{}", displayer);
+
+    // example 3 - date, duration, ip address, timeuuid
+
+    session
+    .query_unpaged(
+        "CREATE TABLE IF NOT EXISTS examples_ks.basic6 (a int, timud timeuuid, date1 date, ipaddr inet, dur duration, primary key (a))",
+        &[],
+    )
+    .await?;
+
+    // insert some data
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.basic6 
+        (a, timud, date1, ipaddr, dur) 
+        VALUES 
+        (1, now(), '2021-01-01', '3.14.15.9', 1h);",
+            &[],
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.basic6 
+        (a, timud, date1, ipaddr, dur) 
+        VALUES
+        (3, NOW(), '2024-01-15', '128.0.0.1', 89h4m48s137ms);", // cqlsh prints this as 89.08003805555556h4.8022833333333335m48.137s137.0ms
+            &[],
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.basic6 
+        (a, timud, date1, ipaddr, dur) 
+        VALUES
+        (4, NOW(), '2024-01-15', '192.168.0.14', 13y2w89h4m48s137ms);",
+            &[],
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.basic6 (a, timud, date1, ipaddr, dur) 
+        VALUES (2, NOW(), '2024-02-20', '2001:0db8:0:0::1428:57ab', 5d2h);",
+            &[],
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.basic6 (a, timud, date1, ipaddr, dur) 
+        VALUES (5, NOW(), '-250000-02-20', '2001:db8::1428:57ab', 1y1mo1w1d1h1m1s700ms);",
+            &[],
+        )
+        .await?;
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT * FROM examples_ks.basic6", &[])
+        .await?
+        .into_rows_result()?;
+
+    let mut displayer = result.rows_displayer();
+    println!("\ndate, duration, ip address, timeuuid:");
+    println!("{}", displayer);
+
+    displayer.set_terminal_width(80);
+    displayer.use_color(false);
+    println!("\nno color, width = 80:");
+    println!("{}", displayer);
+
+    // example 4 - List
+    // Create a table with a list of text
+    session
+    .query_unpaged(
+        "CREATE TABLE IF NOT EXISTS examples_ks.upcoming_calendar ( year int, month int, events list<text>, PRIMARY KEY ( year, month) )",
+        &[],
+    )
+    .await?;
+
+    // Insert some data
+    session
+    .query_unpaged(
+        "INSERT INTO examples_ks.upcoming_calendar(year, month, events) VALUES (2015, 6, ['e1', 'e2', 'e3'])",
+        &[],
+    )
+    .await?;
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT * FROM examples_ks.upcoming_calendar", &[])
+        .await?
+        .into_rows_result()?;
+
+    let displayer = result.rows_displayer();
+    println!("\nList:");
+    println!("{}", displayer);
+
+    // example 5 - map
+    // Create a table with a list of text
+    session
+    .query_unpaged(
+        "CREATE TABLE IF NOT EXISTS examples_ks.cyclist_teams ( id UUID PRIMARY KEY, lastname text, firstname text, teams map<int,text> )",
+        &[],
+    )
+    .await?;
+
+    // Insert some data
+    session
+    .query_unpaged(
+        "INSERT INTO examples_ks.cyclist_teams (id, lastname, firstname, teams) 
+        VALUES (
+        5b6962dd-3f90-4c93-8f61-eabfa4a803e2,
+        'VOS', 
+        'Marianne', 
+        {2015 : 'Rabobank-Liv Woman Cycling Team', 2014 : 'Rabobank-Liv Woman Cycling Team', 2013 : 'Rabobank-Liv Giant', 
+            2012 : 'Rabobank Women Team', 2011 : 'Nederland bloeit' })",
+                &[],
+            )
+    .await?;
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT * FROM examples_ks.cyclist_teams", &[])
+        .await?
+        .into_rows_result()?;
+
+    let displayer = result.rows_displayer();
+    println!("\nMap:");
+    println!("{}", displayer);
+
+    // example 6 - set
+    session
+    .query_unpaged(
+        "CREATE TABLE IF NOT EXISTS examples_ks.cyclist_career_teams ( id UUID PRIMARY KEY, lastname text, teams set<text> );",
+        &[],
+    )
+    .await?;
+
+    // Insert some data
+    session
+    .query_unpaged(
+        "INSERT INTO examples_ks.cyclist_career_teams (id,lastname,teams) 
+        VALUES (5b6962dd-3f90-4c93-8f61-eabfa4a803e2, 'VOS', 
+        { 'Rabobank-Liv Woman Cycling Team','Rabobank-Liv Giant','Rabobank Women Team','Nederland bloeit' } )",
+                &[],
+            )
+    .await?;
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT * FROM examples_ks.cyclist_career_teams", &[])
+        .await?
+        .into_rows_result()?;
+
+    let displayer = result.rows_displayer();
+    println!("\nSet:");
+    println!("{}", displayer);
+
+    // example 7 - user defined type
+    session
+        .query_unpaged(
+            "CREATE TYPE IF NOT EXISTS examples_ks.basic_info (
+        birthday timestamp,
+        nationality text,
+        weight text,
+        height text
+        )",
+            &[],
+        )
+        .await?;
+
+    // make table
+    session
+    .query_unpaged(
+        "CREATE TABLE IF NOT EXISTS examples_ks.cyclist_stats ( id uuid PRIMARY KEY, lastname text, basics FROZEN<basic_info>)",
+        &[],
+    )
+    .await?;
+
+    // Insert some data
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.cyclist_stats (id, lastname, basics) VALUES (
+        e7ae5cf3-d358-4d99-b900-85902fda9bb0, 
+        'FRAME', 
+        { birthday : '1993-06-18', nationality : 'New Zealand', weight : null, height : null }
+        )",
+            &[],
+        )
+        .await?;
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT * FROM examples_ks.cyclist_stats", &[])
+        .await?
+        .into_rows_result()?;
+
+    let displayer = result.rows_displayer();
+    println!("\nUser defined type:");
+    println!("{}", displayer);
+
+    // example 8 - tuples
+
+    // make table
+    session
+    .query_unpaged(
+        "CREATE TABLE IF NOT EXISTS examples_ks.route (race_id int, race_name text, point_id int, lat_long tuple<text, tuple<float,float>>, PRIMARY KEY (race_id, point_id))",
+        &[],
+    )
+    .await?;
+
+    // Insert some data
+    session
+    .query_unpaged(
+        "INSERT INTO examples_ks.route (race_id, race_name, point_id, lat_long) VALUES (500, '47th Tour du Pays de Vaud', 2, ('Champagne', (46.833, 6.65)))",
+                &[],
+            )
+    .await?;
+
+    // fetch the data
+
+    // in real life scenario you should always fetch data in pages for maximum performance
+    let result = session
+        .query_unpaged("SELECT * FROM examples_ks.route", &[])
+        .await?
+        .into_rows_result()?;
+
+    let displayer = result.rows_displayer();
+    println!("\nTuples:");
+    println!("{}", displayer);
+
+    Ok(())
+}

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -41,6 +41,7 @@ full-serialization = [
 ]
 metrics = ["dep:histogram"]
 unstable-testing = []
+result-displayer = ["dep:tabled", "dep:inline_colorization", "dep:num-bigint-04", "dep:bigdecimal-04"]
 
 [dependencies]
 scylla-cql = { version = "1.0.0", path = "../scylla-cql" }
@@ -80,6 +81,10 @@ base64 = { version = "0.22.1", optional = true }
 rand_pcg = "0.9.0"
 socket2 = { version = "0.5.3", features = ["all"] }
 lazy_static = "1"
+tabled =  { version = "0.17.0", features = ["std", "ansi"], optional = true }
+inline_colorization = { version = "0.1.6", optional = true }
+num-bigint-04 = { package = "num-bigint", version = "0.4", optional = true }
+bigdecimal-04 = { package = "bigdecimal", version = "0.4", optional = true }
 
 [dev-dependencies]
 num-bigint-03 = { package = "num-bigint", version = "0.3" }

--- a/scylla/src/response/mod.rs
+++ b/scylla/src/response/mod.rs
@@ -9,6 +9,8 @@
 
 pub mod query_result;
 mod request_response;
+#[cfg(feature = "result-displayer")]
+pub mod rows_displayer;
 
 pub(crate) use request_response::{
     NonErrorAuthResponse, NonErrorQueryResponse, NonErrorStartupResponse, QueryResponse,

--- a/scylla/src/response/rows_displayer.rs
+++ b/scylla/src/response/rows_displayer.rs
@@ -1,0 +1,1191 @@
+use chrono::{Duration, NaiveDate, NaiveTime, TimeZone, Utc};
+use inline_colorization::{color_blue, color_green, color_magenta, color_red, color_yellow};
+use num_bigint_04::BigInt;
+use scylla_cql::deserialize::result::TypedRowIterator;
+use scylla_cql::value::{
+    Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlValue,
+    CqlVarint, Row,
+};
+use std::fmt;
+use tabled::settings::object::Rows;
+use tabled::settings::peaker::Priority;
+use tabled::settings::{Alignment, Width};
+use tabled::{builder::Builder, settings::themes::Colorization, settings::Color, settings::Style};
+use uuid::Uuid;
+
+use super::query_result::QueryRowsResult;
+
+/// A utility struct for displaying rows received from the database in a [`QueryRowsResult`].
+///
+/// This struct provides methods to configure the display settings and format the rows
+/// as a table for easier visualization. It supports various display settings such as
+/// terminal width, color usage, and formatting of different CQL value types.
+///
+/// # Example
+///
+/// ```rust
+/// # use scylla::response::query_result::{QueryResult, QueryRowsResult};
+/// # use scylla::response::rows_displayer::RowsDisplayer;
+/// # fn example(query_result: QueryResult) -> Result<(), Box<dyn std::error::Error>> {
+///     let rows_result = query_result.into_rows_result()?;
+///     let mut displayer = rows_result.rows_displayer();
+///     displayer.set_terminal_width(80);
+///     displayer.use_color(true);
+///     println!("{}", displayer);
+///     # Ok(())
+/// # }
+/// ```
+pub struct RowsDisplayer<'a> {
+    query_result: &'a QueryRowsResult,
+    display_settings: RowsDisplayerSettings,
+}
+
+impl<'a> RowsDisplayer<'a> {
+    /// Creates a new `RowsDisplayer` for the given `QueryRowsResult`.
+    /// The default settings are:
+    /// - terminal width: 0,
+    /// - color usage: true,
+    /// - byte displaying: `ByteDisplaying::Hex`
+    pub fn new(query_result: &'a QueryRowsResult) -> Self {
+        Self {
+            query_result,
+            display_settings: RowsDisplayerSettings::new(),
+        }
+    }
+
+    /// Sets the terminal width for wrapping the table output.
+    /// The table will be wrapped to the given width, if possible.
+    /// If the width is set to 0, the table will not be wrapped.
+    /// The default value is 0.
+    pub fn set_terminal_width(&mut self, terminal_width: usize) {
+        self.display_settings.terminal_width = terminal_width;
+    }
+
+    /// Enables or disables color in the table output.
+    pub fn use_color(&mut self, use_color: bool) {
+        self.display_settings.print_in_color = use_color;
+    }
+
+    /// Sets the byte display format for blobs.
+    /// The default value is `ByteDisplaying::Hex`.
+    /// Possible values are:
+    /// - `ByteDisplaying::Ascii` - display bytes as ASCII characters,
+    /// - `ByteDisplaying::Hex` - display bytes as hexadecimal numbers,
+    /// - `ByteDisplaying::Dec` - display bytes as decimal numbers.
+    pub fn set_blob_displaying(&mut self, byte_displaying: ByteDisplaying) {
+        self.display_settings.byte_displaying = byte_displaying;
+    }
+
+    /// Sets the exponent display for integers.
+    /// If set to true, integers will be displayed in scientific notation.
+    /// The default value is false.
+    pub fn set_exponent_displaying_integers(&mut self, exponent_displaying_integers: bool) {
+        self.display_settings.exponent_displaying_integers = exponent_displaying_integers;
+    }
+
+    /// Sets the exponent display for floats and doubles.
+    pub fn set_floating_point_precision(&mut self, precision: usize) {
+        self.display_settings.double_precision = precision;
+    }
+}
+
+// wrappers for scylla datatypes implementing Display
+fn get_item_wrapper<'a>(
+    item: &'a CqlValue,
+    display_settings: &'a RowsDisplayerSettings,
+) -> Box<dyn StringConvertible<'a> + 'a> {
+    match item {
+        CqlValue::Ascii(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::BigInt(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Blob(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Boolean(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Counter(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Decimal(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Double(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Float(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Int(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Text(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Timestamp(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Uuid(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Inet(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::List(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Map(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Set(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::UserDefinedType {
+            keyspace: _,
+            fields,
+            name: _,
+        } => Box::new(WrapperDisplay {
+            value: fields,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Tuple(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Date(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Duration(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Empty => Box::new(WrapperDisplay {
+            value: &None,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::SmallInt(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::TinyInt(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Varint(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Time(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        CqlValue::Timeuuid(value) => Box::new(WrapperDisplay {
+            value,
+            settings: display_settings,
+            cql_value: item,
+        }),
+        // case not covered by display
+        _ => Box::new(WrapperDisplay {
+            value: &None,
+            settings: display_settings,
+            cql_value: item,
+        }),
+    }
+}
+
+impl fmt::Display for RowsDisplayer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let row_iter: TypedRowIterator<'_, '_, Row> = match self.query_result.rows::<Row>() {
+            Ok(row_iter) => row_iter,
+            Err(_) => return fmt::Result::Err(fmt::Error),
+        };
+
+        // put columns names to the table
+        let column_names = self
+            .query_result
+            .column_specs()
+            .iter()
+            .map(|column_spec| column_spec.name());
+        let mut builder: Builder = Builder::new();
+        builder.push_record(column_names);
+
+        // put rows to the table
+        for row_result in row_iter {
+            let row_result: Row = match row_result {
+                Ok(row_result) => row_result,
+                Err(_) => return fmt::Result::Err(fmt::Error),
+            };
+            let columns: Vec<Option<CqlValue>> = row_result.columns;
+            let mut row_values: Vec<Box<dyn StringConvertible>> = Vec::new();
+            let columns = columns.iter().map(|item| {
+                let item = match item {
+                    Some(item) => item,
+                    None => &CqlValue::Empty,
+                };
+                get_item_wrapper(item, &self.display_settings)
+            });
+            row_values.extend(columns);
+
+            builder.push_record(row_values);
+        }
+
+        // build the table
+        let mut binding = builder.build();
+        let mut table = binding.with(Style::psql()).with(Alignment::right());
+        if self.display_settings.terminal_width != 0 {
+            table = table.with(
+                Width::wrap(self.display_settings.terminal_width).priority(Priority::max(true)),
+            );
+        }
+
+        // align and colorize the table
+        table.modify(Rows::first(), Alignment::left());
+
+        if self.display_settings.print_in_color {
+            table = table.with(Colorization::exact(
+                [Color::FG_MAGENTA | Color::BOLD],
+                tabled::settings::object::Rows::first(),
+            ));
+        }
+
+        write!(f, "{}", table)
+    }
+}
+
+/// Settings for displaying rows in a `RowsDisplayer`.
+///
+/// This struct holds various configuration options for formatting and displaying
+/// rows received from the database. It includes settings for byte display format,
+/// exponent display for floats and integers, precision for doubles, color usage,
+/// and terminal width for wrapping the table output.
+struct RowsDisplayerSettings {
+    byte_displaying: ByteDisplaying,    // for blobs
+    exponent_displaying_floats: bool,   // for floats
+    exponent_displaying_integers: bool, // for integers
+    double_precision: usize,            // for doubles
+    print_in_color: bool,
+    terminal_width: usize,
+    colors: ValueColors,
+}
+
+impl RowsDisplayerSettings {
+    fn new() -> Self {
+        Self {
+            byte_displaying: ByteDisplaying::Hex,
+            exponent_displaying_floats: false,
+            exponent_displaying_integers: false,
+            double_precision: 5,
+            print_in_color: true,
+            terminal_width: 0,
+            colors: ValueColors::default(),
+        }
+    }
+}
+
+impl Default for RowsDisplayerSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ValueColors {
+    text: &'static str,
+    error: &'static str,
+    blob: &'static str,
+    timestamp: &'static str,
+    date: &'static str,
+    time: &'static str,
+    int: &'static str,
+    float: &'static str,
+    decimal: &'static str,
+    inet: &'static str,
+    boolean: &'static str,
+    uuid: &'static str,
+    duration: &'static str,
+    collection: &'static str,
+}
+
+impl Default for ValueColors {
+    fn default() -> Self {
+        Self {
+            text: color_yellow,     // YELLOW
+            error: color_red,       // RED
+            blob: color_magenta,    // DARK_MAGENTA (using regular magenta as closest match)
+            timestamp: color_green, // GREEN
+            date: color_green,      // GREEN
+            time: color_green,      // GREEN
+            int: color_green,       // GREEN
+            float: color_green,     // GREEN
+            decimal: color_green,   // GREEN
+            inet: color_green,      // GREEN
+            boolean: color_green,   // GREEN
+            uuid: color_green,      // GREEN
+            duration: color_green,  // GREEN
+            collection: color_blue, // BLUE
+        }
+    }
+}
+
+// macro for writing colored and bold text
+macro_rules! write_colored {
+    ($f:expr, $enabled:expr, $color:expr, $($arg:tt)*) => {
+        // write bold
+        if $enabled {
+            write!($f, "{}", inline_colorization::style_bold)?;
+            write!($f, "{}", $color)?;
+            write!($f, $($arg)*)?;
+            write!($f, "{}", inline_colorization::color_reset)?;
+            write!($f, "{}", inline_colorization::style_reset)
+        } else {
+            write!($f, $($arg)*)
+        }
+    };
+}
+
+#[derive(PartialEq)]
+pub enum ByteDisplaying {
+    Ascii,
+    Hex,
+    Dec,
+}
+
+// wrappers for scylla datatypes implementing Display
+
+/// A wrapper struct for displaying various Scylla CQL value types with custom formatting settings.
+///
+/// This struct is used to format and display different CQL value types according to the provided
+/// display settings. It supports various formatting options such as color usage, byte display format,
+/// exponent display for floats and integers, and precision for doubles.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the value to be displayed.
+///
+/// # Fields
+///
+/// - `value`: A reference to the value to be displayed.
+/// - `settings`: A reference to the display settings to be used for formatting.
+///
+///
+/// This will print the value `42` formatted according to the provided settings.
+struct WrapperDisplay<'a, T: 'a> {
+    value: &'a T,
+    settings: &'a RowsDisplayerSettings,
+    cql_value: &'a CqlValue,
+}
+
+/// A trait for types that can be converted to a `String`.
+///
+/// Trait bound to ensure From<WrapperDisplay<T>> for String is implemented
+trait StringConvertible<'a>: 'a + fmt::Display {}
+
+// Implement the trait for types that have From<WrapperDisplay<T>> for String
+impl<'a, T> StringConvertible<'a> for WrapperDisplay<'a, T> where WrapperDisplay<'a, T>: fmt::Display
+{}
+
+// generic impl of From ... for String
+impl<'a> From<Box<dyn StringConvertible<'a>>> for String {
+    fn from(wrapper: Box<dyn StringConvertible<'a>>) -> Self {
+        wrapper.to_string()
+    }
+}
+
+impl<'a, T> From<WrapperDisplay<'a, T>> for String
+where
+    T: 'a,
+    WrapperDisplay<'a, T>: fmt::Display,
+{
+    fn from(wrapper: WrapperDisplay<'a, T>) -> Self {
+        format!("{}", wrapper)
+    }
+}
+
+// Actual implementations of Display for scylla datatypes
+
+// none WrapperDisplay
+impl fmt::Display for WrapperDisplay<'_, std::option::Option<CqlValue>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.error,
+            "null"
+        )
+    }
+}
+
+// tiny int
+impl fmt::Display for WrapperDisplay<'_, i8> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.settings.exponent_displaying_floats {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{:e}",
+                self.value
+            )
+        } else {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{}",
+                self.value
+            )
+        }
+    }
+}
+
+// small int
+impl fmt::Display for WrapperDisplay<'_, i16> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.settings.exponent_displaying_floats {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{:e}",
+                self.value
+            )
+        } else {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{}",
+                self.value
+            )
+        }
+    }
+}
+
+// int
+impl fmt::Display for WrapperDisplay<'_, i32> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.settings.exponent_displaying_floats {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{:e}",
+                self.value
+            )
+        } else {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{}",
+                self.value
+            )
+        }
+    }
+}
+
+// bigint
+impl fmt::Display for WrapperDisplay<'_, i64> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.settings.exponent_displaying_floats {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{:e}",
+                self.value
+            )
+        } else {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.int,
+                "{}",
+                self.value
+            )
+        }
+    }
+}
+
+// varint
+impl fmt::Display for WrapperDisplay<'_, CqlVarint> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // create a bigint from bytes
+        let big_int = BigInt::from_signed_bytes_be(self.value.as_signed_bytes_be_slice());
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.int,
+            "{}",
+            big_int
+        )
+    }
+}
+
+// decimal
+impl fmt::Display for WrapperDisplay<'_, CqlDecimal> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (big_decimal, exp) = self.value.as_signed_be_bytes_slice_and_exponent();
+        let big_int = BigInt::from_signed_bytes_be(big_decimal);
+        let big_int = big_int * BigInt::from(10).pow(exp as u32);
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.decimal,
+            "{}",
+            big_int
+        )
+    }
+}
+
+// counter
+impl fmt::Display for WrapperDisplay<'_, Counter> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.int,
+            "{}",
+            self.value.0
+        )
+    }
+}
+
+// float
+impl fmt::Display for WrapperDisplay<'_, f32> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.settings.exponent_displaying_floats {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.float,
+                "{:e}",
+                self.value
+            )
+        } else {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.float,
+                "{}",
+                self.value
+            )
+        }
+    }
+}
+
+// double
+impl fmt::Display for WrapperDisplay<'_, f64> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.settings.exponent_displaying_floats {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.float,
+                "{:e}",
+                self.value
+            )
+        } else {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.float,
+                "{:.digits$}",
+                self.value,
+                digits = self.settings.double_precision
+            )
+        }
+    }
+}
+
+// blob
+impl fmt::Display for WrapperDisplay<'_, Vec<u8>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.settings.byte_displaying == ByteDisplaying::Hex {
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.blob,
+                "0x"
+            )?;
+        }
+        for byte in self.value {
+            match self.settings.byte_displaying {
+                ByteDisplaying::Ascii => {
+                    write_colored!(
+                        f,
+                        self.settings.print_in_color,
+                        self.settings.colors.blob,
+                        "{}",
+                        *byte as char
+                    )?;
+                }
+                ByteDisplaying::Hex => {
+                    write_colored!(
+                        f,
+                        self.settings.print_in_color,
+                        self.settings.colors.blob,
+                        "{:02x}",
+                        byte
+                    )?;
+                }
+                ByteDisplaying::Dec => {
+                    write_colored!(
+                        f,
+                        self.settings.print_in_color,
+                        self.settings.colors.blob,
+                        "{}",
+                        byte
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// string
+impl fmt::Display for WrapperDisplay<'_, String> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.text,
+            "{}",
+            self.value
+        )
+    }
+}
+
+// timestamp
+impl fmt::Display for WrapperDisplay<'_, CqlTimestamp> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // example of formating timestamp 14:30:00.000000000
+        let seconds_from_epoch = self.value.0;
+        let datetime = Utc.timestamp_millis_opt(seconds_from_epoch).single();
+
+        let datetime = match datetime {
+            Some(datetime) => datetime,
+            None => {
+                return write_colored!(
+                    f,
+                    self.settings.print_in_color,
+                    self.settings.colors.error,
+                    "Invalid timestamp: {:?} seconds given",
+                    seconds_from_epoch
+                )
+            }
+        };
+
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.timestamp,
+            "{}.{:06}+0000",
+            datetime.format("%Y-%m-%d %H:%M:%S"),
+            datetime.timestamp_subsec_micros()
+        )
+    }
+}
+
+// time
+impl fmt::Display for WrapperDisplay<'_, CqlTime> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // example of formating time 14:30:00.000000000
+        let nanoseconds = self.value.0;
+        let total_seconds = nanoseconds / 1_000_000_000;
+        let hours = total_seconds / 3600;
+        let minutes = (total_seconds % 3600) / 60;
+        let seconds = total_seconds % 60;
+        let nanos = nanoseconds % 1_000_000_000;
+
+        // Create NaiveTime with the calculated components
+        let time = NaiveTime::from_hms_nano_opt(
+            hours as u32,
+            minutes as u32,
+            seconds as u32,
+            nanos as u32,
+        );
+
+        let time = match time {
+            Some(time) => time,
+            None => {
+                return write_colored!(
+                    f,
+                    self.settings.print_in_color,
+                    self.settings.colors.error,
+                    "Invalid time: {} hours, {} minutes, {} seconds, {} nanoseconds given",
+                    hours,
+                    minutes,
+                    seconds,
+                    nanos
+                )
+            }
+        };
+
+        // Format the time with 9 digits of nanoseconds
+
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.time,
+            "{}",
+            time.format("%H:%M:%S.%9f")
+        )
+    }
+}
+
+// timeuuid
+impl fmt::Display for WrapperDisplay<'_, CqlTimeuuid> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let uuid = self.value.as_bytes();
+
+        write_colored!(f, self.settings.print_in_color, self.settings.colors.uuid,
+            "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            uuid[0], uuid[1], uuid[2], uuid[3],
+            uuid[4], uuid[5],
+            uuid[6], uuid[7],
+            uuid[8], uuid[9],
+            uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15])
+    }
+}
+
+// duration
+impl fmt::Display for WrapperDisplay<'_, CqlDuration> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let if_color = self.settings.print_in_color;
+        let color = self.settings.colors.duration;
+
+        let months = self.value.months;
+        let days = self.value.days;
+        let nanoseconds = self.value.nanoseconds;
+
+        let years = months / 12;
+        let months = months % 12;
+        let weeks = days / 7;
+        let days = days % 7;
+        let hours = nanoseconds / 3_600_000_000_000;
+        let minutes = (nanoseconds % 3_600_000_000_000) / 60_000_000_000;
+        let seconds = (nanoseconds % 60_000_000_000) / 1_000_000_000;
+        let nanoseconds = nanoseconds % 1_000_000_000;
+
+        if years != 0 {
+            write_colored!(f, if_color, color, "{}y", years)?;
+        }
+
+        if months != 0 {
+            write_colored!(f, if_color, color, "{}mo", months)?;
+        }
+
+        if weeks != 0 {
+            write_colored!(f, if_color, color, "{}w", weeks)?;
+        }
+
+        if days != 0 {
+            write_colored!(f, if_color, color, "{}d", days)?;
+        }
+
+        if hours != 0 {
+            write_colored!(f, if_color, color, "{}h", hours)?;
+        }
+
+        if minutes != 0 {
+            write_colored!(f, if_color, color, "{}m", minutes)?;
+        }
+
+        if seconds != 0 {
+            write_colored!(f, if_color, color, "{}s", seconds)?;
+        }
+
+        if nanoseconds != 0 {
+            write_colored!(f, if_color, color, "{}ns", nanoseconds)?;
+        }
+        Ok(())
+    }
+}
+
+// date
+impl fmt::Display for WrapperDisplay<'_, CqlDate> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // example of formating date 2021-12-31
+        // CqlDate is Represented as number of days since -5877641-06-23 i.e. 2^31 days before unix epoch.
+        let magic_constant = 2055453495; // it is number of days from -5877641-06-23 to -250000-01-01
+                                         // around -250000-01-01  is the limit of naive date
+                                         // without this constant we can't convert days to date
+                                         // because from_ymd_opt will return None
+
+        let days = self.value.0 - magic_constant;
+        let base_date = NaiveDate::from_ymd_opt(-250000, 1, 1).unwrap();
+
+        // Add the number of days
+        let target_date = base_date
+            + match Duration::try_days(days as i64) {
+                Some(duration) => duration,
+                None => {
+                    return write_colored!(
+                        f,
+                        self.settings.print_in_color,
+                        self.settings.colors.error,
+                        "Invalid date: {:?} days given",
+                        days
+                    )
+                }
+            };
+
+        // Format the date
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.date,
+            "{}",
+            target_date.format("%Y-%m-%d")
+        )
+    }
+}
+
+// inet
+impl fmt::Display for WrapperDisplay<'_, std::net::IpAddr> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ip = self.value;
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.inet,
+            "{}",
+            ip
+        )
+    }
+}
+
+// boolean
+impl fmt::Display for WrapperDisplay<'_, bool> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.boolean,
+            "{}",
+            self.value
+        )
+    }
+}
+
+// Uuid
+impl fmt::Display for WrapperDisplay<'_, Uuid> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.uuid,
+            "{}",
+            self.value
+        )
+    }
+}
+
+fn display_in_quotes_and_colored<'a>(
+    f: &mut fmt::Formatter<'_>,
+    value: &(dyn StringConvertible<'a> + 'a),
+    settings: &RowsDisplayerSettings,
+) -> fmt::Result {
+    write_colored!(f, settings.print_in_color, settings.colors.text, "'")?;
+    write_colored!(
+        f,
+        settings.print_in_color,
+        settings.colors.text,
+        "{}",
+        value
+    )?;
+    write_colored!(f, settings.print_in_color, settings.colors.text, "'")
+}
+
+// list or set
+impl fmt::Display for WrapperDisplay<'_, Vec<CqlValue>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // choose opening bracket
+        match self.cql_value {
+            CqlValue::List(_) => write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.collection,
+                "["
+            )?,
+            CqlValue::Set(_) => write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.collection,
+                "{{"
+            )?,
+            _ => write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.error,
+                "Invalid type of collection. Expected List or Set",
+            )?,
+        }
+
+        // print elements
+        let mut first_ture = true;
+        let value: &Vec<CqlValue> = self.value;
+        for item in value {
+            let item_wrapper = get_item_wrapper(item, self.settings);
+
+            // write comma
+            if !first_ture {
+                write_colored!(
+                    f,
+                    self.settings.print_in_color,
+                    self.settings.colors.collection,
+                    ", "
+                )?;
+            }
+            first_ture = false;
+
+            // if item is text, display it in colored quotes, otherwise display it as is (e.g. number)
+            // to not confuse with text
+            if matches!(item, CqlValue::Text(_)) {
+                display_in_quotes_and_colored(f, &*item_wrapper, self.settings)?;
+            } else {
+                write!(f, "{}", item_wrapper)?;
+            }
+        }
+
+        // choose closing bracket
+        match self.cql_value {
+            CqlValue::List(_) => write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.collection,
+                "]"
+            )?,
+            CqlValue::Set(_) => write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.collection,
+                "}}"
+            )?,
+            _ => write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.error,
+                "Invalid type of collection. Expected List or Set",
+            )?,
+        }
+        Ok(())
+    }
+}
+
+// map
+impl fmt::Display for WrapperDisplay<'_, Vec<(CqlValue, CqlValue)>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.collection,
+            "{{"
+        )?;
+        let mut first_item = true; // we want to start printing comma after first item
+        let value: &Vec<(CqlValue, CqlValue)> = self.value;
+        for (key, value) in value {
+            let key_wrapper = get_item_wrapper(key, self.settings);
+            let value_wrapper = get_item_wrapper(value, self.settings);
+            if !first_item {
+                write_colored!(
+                    f,
+                    self.settings.print_in_color,
+                    self.settings.colors.collection,
+                    ", "
+                )?;
+            }
+
+            // if key is text, display it in colored quotes
+            if let CqlValue::Text(_key) = key {
+                display_in_quotes_and_colored(f, &*key_wrapper, self.settings)?;
+            } else {
+                write!(f, "{}", key_wrapper)?;
+            }
+
+            // display colon
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.collection,
+                ": "
+            )?;
+
+            // if item is text, display it in colored quotes, otherwise display it as is (e.g. number)
+            // to not confuse with text
+            if let CqlValue::Text(_item) = value {
+                display_in_quotes_and_colored(f, &*value_wrapper, self.settings)?;
+            } else {
+                write!(f, "{}", value_wrapper)?;
+            }
+
+            first_item = false;
+        }
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.collection,
+            "}}"
+        )
+    }
+}
+
+// udts
+impl fmt::Display for WrapperDisplay<'_, Vec<(String, Option<CqlValue>)>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // write opening bracket
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.collection,
+            "{{"
+        )?;
+        let mut first_item = true; // we want to start printing comma after first item
+        let value: &Vec<(String, Option<CqlValue>)> = self.value;
+        for (field_name, field_value) in value {
+            let field_value_wrapper = match field_value {
+                Some(field_value) => get_item_wrapper(field_value, self.settings),
+                None => Box::new(WrapperDisplay {
+                    value: &None,
+                    settings: self.settings,
+                    cql_value: &CqlValue::Empty,
+                }),
+            };
+
+            // write comma
+            if !first_item {
+                write_colored!(
+                    f,
+                    self.settings.print_in_color,
+                    self.settings.colors.collection,
+                    ", "
+                )?;
+            }
+            first_item = false;
+
+            // write field name
+            write_colored!(
+                f,
+                self.settings.print_in_color,
+                self.settings.colors.text,
+                "{}: ",
+                field_name
+            )?;
+
+            // if item is text, display it in colored quotes, otherwise display it as is (e.g. number)
+            // to not confuse with text
+            if let Some(CqlValue::Text(_item)) = field_value {
+                display_in_quotes_and_colored(f, &*field_value_wrapper, self.settings)?;
+            } else {
+                write!(f, "{}", field_value_wrapper)?;
+            }
+        }
+
+        // write closing bracket
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.collection,
+            "}}"
+        )
+    }
+}
+
+// tuple
+impl fmt::Display for WrapperDisplay<'_, Vec<Option<CqlValue>>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.collection,
+            "("
+        )?;
+        let mut first_item = true; // we want to start printing comma after first item
+        let value: &Vec<Option<CqlValue>> = self.value;
+
+        // write items
+        for item in value {
+            let item_wrapper = match item {
+                Some(item) => get_item_wrapper(item, self.settings),
+                None => Box::new(WrapperDisplay {
+                    value: &None,
+                    settings: self.settings,
+                    cql_value: &CqlValue::Empty,
+                }),
+            };
+
+            // write comma
+            if !first_item {
+                write_colored!(
+                    f,
+                    self.settings.print_in_color,
+                    self.settings.colors.collection,
+                    ", "
+                )?;
+            }
+            first_item = false;
+
+            // if item is text, display it in colored quotes, otherwise display it as is (e.g. number)
+            // to not confuse with text
+            if let Some(CqlValue::Text(_item)) = item {
+                display_in_quotes_and_colored(f, &*item_wrapper, self.settings)?;
+            } else {
+                write!(f, "{}", item_wrapper)?;
+            }
+        }
+        // write closing bracket
+        write_colored!(
+            f,
+            self.settings.print_in_color,
+            self.settings.colors.collection,
+            ")"
+        )
+    }
+}


### PR DESCRIPTION
This PR adds Displayer for QueryRowsResult trying to mimic `cqlsh`  way of displaying tables, but there are some differences:
 - I implement the display for the duration type differently, because I think `cqlsh` displays this type in an unclear way,for more details look in the comments.
 -  When displaying collections (`list`, `map`, `set`, `tuple`, `udt`), I use quotes only for `text` as I think putting other types in quotes might be confusing.


Fixes: #999 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
