### PR TITLE
refiller: Remove unnecessary clone

### DIFF
--- a/scylla/src/transport/connection_pool.rs
+++ b/scylla/src/transport/connection_pool.rs
@@ -576,7 +576,7 @@ impl PoolRefiller {
                 req = use_keyspace_request_receiver.recv() => {
                     if let Some(req) = req {
                         debug!("[{}] Requested keyspace change: {}", self.endpoint_description(), req.keyspace_name.as_str());
-                        self.use_keyspace(&req.keyspace_name, req.response_sender);
+                        self.use_keyspace(req.keyspace_name, req.response_sender);
                     } else {
                         // The keyspace request channel is dropped.
                         // This means that the corresponding pool is dropped.
@@ -1077,13 +1077,12 @@ impl PoolRefiller {
     // have their keyspace set.
     fn use_keyspace(
         &mut self,
-        keyspace_name: &VerifiedKeyspaceName,
+        keyspace_name: VerifiedKeyspaceName,
         response_sender: tokio::sync::oneshot::Sender<Result<(), QueryError>>,
     ) {
         self.current_keyspace = Some(keyspace_name.clone());
 
         let mut conns = self.conns.clone();
-        let keyspace_name = keyspace_name.clone();
         let address = self.endpoint.read().unwrap().address();
         let connect_timeout = self.pool_config.connection_config.connect_timeout;
 


### PR DESCRIPTION
PoolRefiller::use_keyspace took keyspace_name by ref even though it actually needs the ownership, so it had to clone it. Taking by value removes this clone.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
