### PR TITLE
Make metrics collection optional/faster

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,8 @@ jobs:
     # Various (de)serialization features.
     - name: Cargo check with all serialization features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "full-serialization"
+    - name: Cargo check with metrics feature
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "metrics"
     - name: Cargo check with secrecy-08 feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secrecy-08"
     - name: Cargo check with chrono-04 feature

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -822,9 +822,12 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "histogram"
-version = "0.6.9"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+checksum = "58cf6b99a250776d813cdf2f0b478a053a822d078e7a2baf5cb36afc88c41a7c"
+dependencies = [
+ "thiserror 1.0.60",
+]
 
 [[package]]
 name = "home"

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -1,5 +1,7 @@
 # Driver metrics
 
+This feature is available only under the crate feature `metrics`.
+
 During operation the driver collects various metrics.
 
 They can be accessed at any moment using `Session::get_metrics()`
@@ -11,6 +13,9 @@ They can be accessed at any moment using `Session::get_metrics()`
 * Total number of paged queries
 * Number of errors during paged queries
 * Number of retries
+* Latency histogram statistics (min, max, mean, standard deviation, percentiles)
+* Rates of queries per second in various time frames
+* Number of active connections, and connection and request timeouts
 
 ### Example
 ```rust
@@ -24,11 +29,32 @@ println!("Queries requested: {}", metrics.get_queries_num());
 println!("Iter queries requested: {}", metrics.get_queries_iter_num());
 println!("Errors occurred: {}", metrics.get_errors_num());
 println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
-println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
+println!("Average latency: {}", metrics.get_latency_avg_ms()?);
 println!(
     "99.9 latency percentile: {}",
-    metrics.get_latency_percentile_ms(99.9).unwrap()
+    metrics.get_latency_percentile_ms(99.9)?
 );
+
+let snapshot = metrics.get_snapshot()?;
+println!("Min: {}", snapshot.min);
+println!("Max: {}", snapshot.max);
+println!("Mean: {}", snapshot.mean);
+println!("Standard deviation: {}", snapshot.stddev);
+println!("Median: {}", snapshot.median);
+println!("75th percentile: {}", snapshot.percentile_75);
+println!("95th percentile: {}", snapshot.percentile_95);
+println!("98th percentile: {}", snapshot.percentile_98);
+println!("99th percentile: {}", snapshot.percentile_99);
+println!("99.9th percentile: {}", snapshot.percentile_99_9);
+
+println!("Mean rate: {}", metrics.get_mean_rate());
+println!("One minute rate: {}", metrics.get_one_minute_rate());
+println!("Five minute rate: {}", metrics.get_five_minute_rate());
+println!("Fifteen minute rate: {}", metrics.get_fifteen_minute_rate());
+
+println!("Total connections: {}", metrics.get_total_connections());
+println!("Connection timeouts: {}", metrics.get_connection_timeouts());
+println!("Requests timeouts: {}", metrics.get_request_timeouts());
 # Ok(())
 # }
 ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ scylla = { path = "../scylla", features = [
     "num-bigint-03",
     "num-bigint-04",
     "bigdecimal-04",
+    "metrics",
 ] }
 tokio = { version = "1.34", features = ["full"] }
 tracing = { version = "0.1.25", features = ["log"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -94,11 +94,32 @@ async fn main() -> Result<()> {
     println!("Iter queries requested: {}", metrics.get_queries_iter_num());
     println!("Errors occurred: {}", metrics.get_errors_num());
     println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
-    println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
+    println!("Average latency: {}", metrics.get_latency_avg_ms()?);
     println!(
         "99.9 latency percentile: {}",
-        metrics.get_latency_percentile_ms(99.9).unwrap()
+        metrics.get_latency_percentile_ms(99.9)?
     );
+
+    let snapshot = metrics.get_snapshot()?;
+    println!("Min: {}", snapshot.min);
+    println!("Max: {}", snapshot.max);
+    println!("Mean: {}", snapshot.mean);
+    println!("Standard deviation: {}", snapshot.stddev);
+    println!("Median: {}", snapshot.median);
+    println!("75th percentile: {}", snapshot.percentile_75);
+    println!("95th percentile: {}", snapshot.percentile_95);
+    println!("98th percentile: {}", snapshot.percentile_98);
+    println!("99th percentile: {}", snapshot.percentile_99);
+    println!("99.9th percentile: {}", snapshot.percentile_99_9);
+
+    println!("Mean rate: {}", metrics.get_mean_rate());
+    println!("One minute rate: {}", metrics.get_one_minute_rate());
+    println!("Five minute rate: {}", metrics.get_five_minute_rate());
+    println!("Fifteen minute rate: {}", metrics.get_fifteen_minute_rate());
+
+    println!("Total connections: {}", metrics.get_total_connections());
+    println!("Connection timeouts: {}", metrics.get_connection_timeouts());
+    println!("Requests timeouts: {}", metrics.get_request_timeouts());
 
     println!("Ok.");
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -39,6 +39,7 @@ full-serialization = [
     "num-bigint-04",
     "bigdecimal-04",
 ]
+metrics = ["dep:histogram"]
 
 [dependencies]
 scylla-macros = { version = "0.7.0", path = "../scylla-macros" }
@@ -47,7 +48,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
-histogram = "0.11.1"
+histogram = { version = "0.11.1", optional = true }
 tokio = { version = "1.34", features = [
     "net",
     "time",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -47,7 +47,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
-histogram = "0.6.9"
+histogram = "0.11.1"
 tokio = { version = "1.34", features = [
     "net",
     "time",

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -881,6 +881,8 @@ impl Session {
             can_use_shard_aware_port: !config.disallow_shard_aware_port,
         };
 
+        let metrics = Arc::new(Metrics::new());
+
         let cluster = Cluster::new(
             known_nodes,
             pool_config,
@@ -889,6 +891,7 @@ impl Session {
             config.host_filter,
             config.cluster_metadata_refresh_interval,
             tablet_receiver,
+            metrics.clone(),
         )
         .await?;
 
@@ -898,7 +901,7 @@ impl Session {
             cluster,
             default_execution_profile_handle,
             schema_agreement_interval: config.schema_agreement_interval,
-            metrics: Arc::new(Metrics::new()),
+            metrics,
             schema_agreement_timeout: config.schema_agreement_timeout,
             schema_agreement_automatic_waiting: config.schema_agreement_automatic_waiting,
             refresh_metadata_on_auto_schema_agreement: config
@@ -1855,9 +1858,12 @@ impl Session {
             .request_timeout
             .or(execution_profile.request_timeout);
         let result = match effective_timeout {
-            Some(timeout) => tokio::time::timeout(timeout, runner)
-                .await
-                .unwrap_or_else(|_| Err(RequestError::RequestTimeout(timeout))),
+            Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
+                |_: tokio::time::error::Elapsed| {
+                    self.metrics.inc_request_timeouts();
+                    Err(RequestError::RequestTimeout(timeout))
+                },
+            ),
             None => runner.await,
         };
 

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -24,6 +24,7 @@ use crate::errors::{
 };
 use crate::frame::response::event::Event;
 use crate::network::{Connection, ConnectionConfig, NodeConnectionPool, PoolConfig, PoolSize};
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::Token;
@@ -89,6 +90,7 @@ pub(crate) struct MetadataReader {
     // to signal ClusterWorker that an immediate metadata refresh is advisable.
     control_connection_repair_requester: broadcast::Sender<()>,
 
+    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 }
 
@@ -394,7 +396,7 @@ impl MetadataReader {
         keyspaces_to_fetch: Vec<String>,
         fetch_schema: bool,
         host_filter: &Option<Arc<dyn HostFilter>>,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Result<Self, NewSessionError> {
         let (initial_peers, resolved_hostnames) =
             resolve_contact_points(&initial_known_nodes).await;
@@ -432,6 +434,7 @@ impl MetadataReader {
             control_connection_endpoint.clone(),
             &control_connection_pool_config,
             control_connection_repair_requester.clone(),
+            #[cfg(feature = "metrics")]
             metrics.clone(),
         );
 
@@ -448,6 +451,7 @@ impl MetadataReader {
             host_filter: host_filter.clone(),
             initial_known_nodes,
             control_connection_repair_requester,
+            #[cfg(feature = "metrics")]
             metrics,
         })
     }
@@ -550,6 +554,7 @@ impl MetadataReader {
                 self.control_connection_endpoint.clone(),
                 &self.control_connection_pool_config,
                 self.control_connection_repair_requester.clone(),
+                #[cfg(feature = "metrics")]
                 self.metrics.clone(),
             );
 
@@ -649,6 +654,7 @@ impl MetadataReader {
                         self.control_connection_endpoint.clone(),
                         &self.control_connection_pool_config,
                         self.control_connection_repair_requester.clone(),
+                        #[cfg(feature = "metrics")]
                         self.metrics.clone(),
                     );
                 }
@@ -660,9 +666,16 @@ impl MetadataReader {
         endpoint: UntranslatedEndpoint,
         pool_config: &PoolConfig,
         refresh_requester: broadcast::Sender<()>,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> NodeConnectionPool {
-        NodeConnectionPool::new(endpoint, pool_config, None, refresh_requester, metrics)
+        NodeConnectionPool::new(
+            endpoint,
+            pool_config,
+            None,
+            refresh_requester,
+            #[cfg(feature = "metrics")]
+            metrics,
+        )
     }
 }
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -7,6 +7,7 @@ use crate::errors::{ConnectionPoolError, UseKeyspaceError};
 use crate::network::Connection;
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{NodeConnectionPool, PoolConfig};
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 /// Node represents a cluster node along with it's data and connections
 use crate::routing::{Shard, Sharder};
@@ -100,7 +101,7 @@ impl Node {
         pool_config: &PoolConfig,
         keyspace_name: Option<VerifiedKeyspaceName>,
         enabled: bool,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Self {
         let host_id = peer.host_id;
         let address = peer.address;
@@ -115,6 +116,7 @@ impl Node {
                 pool_config,
                 keyspace_name,
                 pool_empty_notifier,
+                #[cfg(feature = "metrics")]
                 metrics,
             )
         });

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -89,13 +89,7 @@ pub struct Node {
 pub type NodeRef<'a> = &'a Arc<Node>;
 
 impl Node {
-    /// Creates new node which starts connecting in the background
-    /// # Arguments
-    ///
-    /// `address` - address to connect to
-    /// `compression` - preferred compression to use
-    /// `datacenter` - optional datacenter name
-    /// `rack` - optional rack name
+    /// Creates a new node which starts connecting in the background.
     pub(crate) fn new(
         peer: PeerEndpoint,
         pool_config: &PoolConfig,

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -7,6 +7,7 @@ use crate::errors::{ConnectionPoolError, UseKeyspaceError};
 use crate::network::Connection;
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{NodeConnectionPool, PoolConfig};
+use crate::observability::metrics::Metrics;
 /// Node represents a cluster node along with it's data and connections
 use crate::routing::{Shard, Sharder};
 
@@ -99,6 +100,7 @@ impl Node {
         pool_config: &PoolConfig,
         keyspace_name: Option<VerifiedKeyspaceName>,
         enabled: bool,
+        metrics: Arc<Metrics>,
     ) -> Self {
         let host_id = peer.host_id;
         let address = peer.address;
@@ -113,6 +115,7 @@ impl Node {
                 pool_config,
                 keyspace_name,
                 pool_empty_notifier,
+                metrics,
             )
         });
 

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,5 +1,6 @@
 use crate::errors::ConnectionPoolError;
 use crate::network::{Connection, PoolConfig, VerifiedKeyspaceName};
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::locator::tablets::{RawTablet, Tablet, TabletsInfo};
@@ -67,7 +68,7 @@ impl ClusterState {
         host_filter: Option<&dyn HostFilter>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
-        metrics: &Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: &Arc<Metrics>,
     ) -> Self {
         // Create new updated known_peers and ring
         let mut new_known_peers: HashMap<Uuid, Arc<Node>> =
@@ -102,6 +103,7 @@ impl ClusterState {
                         pool_config,
                         used_keyspace.clone(),
                         is_enabled,
+                        #[cfg(feature = "metrics")]
                         metrics.clone(),
                     ))
                 }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,5 +1,6 @@
 use crate::errors::ConnectionPoolError;
 use crate::network::{Connection, PoolConfig, VerifiedKeyspaceName};
+use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::locator::tablets::{RawTablet, Tablet, TabletsInfo};
 use crate::routing::locator::ReplicaLocator;
@@ -57,6 +58,7 @@ impl ClusterState {
 
     /// Creates new ClusterState using information about topology held in `metadata`.
     /// Uses provided `known_peers` hashmap to recycle nodes if possible.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         metadata: Metadata,
         pool_config: &PoolConfig,
@@ -65,6 +67,7 @@ impl ClusterState {
         host_filter: Option<&dyn HostFilter>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
+        metrics: &Arc<Metrics>,
     ) -> Self {
         // Create new updated known_peers and ring
         let mut new_known_peers: HashMap<Uuid, Arc<Node>> =
@@ -99,6 +102,7 @@ impl ClusterState {
                         pool_config,
                         used_keyspace.clone(),
                         is_enabled,
+                        metrics.clone(),
                     ))
                 }
             };

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -10,6 +10,8 @@ use crate::routing::{Shard, ShardCount, Sharder};
 
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
 
+use crate::observability::metrics::Metrics;
+
 use crate::cluster::NodeAddr;
 
 use arc_swap::ArcSwap;
@@ -193,6 +195,7 @@ impl NodeConnectionPool {
         pool_config: &PoolConfig,
         current_keyspace: Option<VerifiedKeyspaceName>,
         pool_empty_notifier: broadcast::Sender<()>,
+        metrics: Arc<Metrics>,
     ) -> Self {
         let (use_keyspace_request_sender, use_keyspace_request_receiver) = mpsc::channel(1);
         let pool_updated_notify = Arc::new(Notify::new());
@@ -207,6 +210,7 @@ impl NodeConnectionPool {
             current_keyspace,
             pool_updated_notify.clone(),
             pool_empty_notifier,
+            metrics,
         );
 
         let conns = refiller.get_shared_connections();
@@ -484,6 +488,8 @@ struct PoolRefiller {
 
     // Signaled when the connection pool becomes empty
     pool_empty_notifier: broadcast::Sender<()>,
+
+    metrics: Arc<Metrics>,
 }
 
 #[derive(Debug)]
@@ -499,6 +505,7 @@ impl PoolRefiller {
         current_keyspace: Option<VerifiedKeyspaceName>,
         pool_updated_notify: Arc<Notify>,
         pool_empty_notifier: broadcast::Sender<()>,
+        metrics: Arc<Metrics>,
     ) -> Self {
         // At the beginning, we assume the node does not have any shards
         // and assume that the node is a Cassandra node
@@ -527,6 +534,8 @@ impl PoolRefiller {
 
             pool_updated_notify,
             pool_empty_notifier,
+
+            metrics,
         }
     }
 
@@ -864,6 +873,17 @@ impl PoolRefiller {
         let cfg = self.pool_config.connection_config.clone();
         let mut endpoint = self.endpoint.read().unwrap().clone();
 
+        let count_in_metrics = {
+            let metrics = self.metrics.clone();
+            move |connect_result: &Result<_, ConnectionError>| {
+                if connect_result.is_ok() {
+                    metrics.inc_total_connections();
+                } else if let Err(ConnectionError::ConnectTimeout) = &connect_result {
+                    metrics.inc_connection_timeouts();
+                }
+            }
+        };
+
         let fut = match (self.sharder.clone(), self.shard_aware_port, shard) {
             (Some(sharder), Some(port), Some(shard)) => async move {
                 let shard_aware_endpoint = {
@@ -877,6 +897,9 @@ impl PoolRefiller {
                     &cfg,
                 )
                 .await;
+
+                count_in_metrics(&result);
+
                 OpenedConnectionEvent {
                     result,
                     requested_shard: Some(shard),
@@ -887,6 +910,9 @@ impl PoolRefiller {
             _ => async move {
                 let non_shard_aware_endpoint = endpoint;
                 let result = open_connection(&non_shard_aware_endpoint, None, &cfg).await;
+
+                count_in_metrics(&result);
+
                 OpenedConnectionEvent {
                     result,
                     requested_shard: None,
@@ -963,6 +989,7 @@ impl PoolRefiller {
             match maybe_idx {
                 Some(idx) => {
                     v.swap_remove(idx);
+                    self.metrics.dec_total_connections();
                     true
                 }
                 None => false,

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -1,5 +1,5 @@
 use histogram::{AtomicHistogram, Histogram};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -33,6 +33,173 @@ pub struct Snapshot {
     pub percentile_99_9: u64,
 }
 
+/// The interval in seconds for which the rate is calculated.
+const INTERVAL: u64 = 5;
+
+/// An implementation of an Exponentially Weighted Moving Average (EWMA).
+#[derive(Debug)]
+struct ExponentiallyWeightedMovingAverage {
+    /// Smoothing factor, a value between 0 and 1.
+    alpha: f64,
+    /// Atomic counter to keep track of the number of requests. \
+    /// Indicates the number of requests that have not been accounted for EWMA yet.
+    uncounted: AtomicU64,
+    /// Atomic boolean to check if the EWMA has been initialized.
+    is_initialized: AtomicBool,
+    ///  Atomic value representing the current rate of requests per second. \
+    ///  AtomicU64 is used to store a floating point number as a bit representation.
+    rate: AtomicU64,
+}
+
+impl ExponentiallyWeightedMovingAverage {
+    fn new(alpha: f64) -> Self {
+        Self {
+            alpha,
+            uncounted: AtomicU64::new(0),
+            is_initialized: AtomicBool::new(false),
+            rate: AtomicU64::new(0),
+        }
+    }
+
+    /// Returns the current `rate` as a floating point number.
+    fn rate(&self) -> f64 {
+        f64::from_bits(self.rate.load(Ordering::Acquire))
+    }
+
+    /// Increments the `uncounted` requests counter. \
+    /// Should be called every time a new request is made.
+    fn update(&self) {
+        self.uncounted.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Updates the `rate` based on the current number of requests. \
+    /// Should be called every time the interval has passed.
+    ///
+    /// The rate is updated using the formula: \
+    /// `rate = rate + alpha * (instant_rate - rate)` \
+    /// where `instant_rate` is the number of requests in the last interval.
+    ///
+    /// The first time this function is called, the `rate` is set to the `instant_rate`.
+    ///
+    /// **WARNING: MUST NOT BE CALLED CONCURRENTLY!**
+    fn tick(&self) {
+        let count = self.uncounted.swap(0, ORDER_TYPE);
+        let instant_rate = count as f64 / INTERVAL as f64;
+
+        if self.is_initialized.load(Ordering::Acquire) {
+            let rate = f64::from_bits(self.rate.load(Ordering::Acquire));
+            self.rate.store(
+                f64::to_bits(rate + self.alpha * (instant_rate - rate)),
+                Ordering::Release,
+            );
+        } else {
+            self.rate
+                .store(f64::to_bits(instant_rate), Ordering::Release);
+            self.is_initialized.store(true, Ordering::Release);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RequestRateMeter {
+    one_minute_rate: ExponentiallyWeightedMovingAverage,
+    five_minute_rate: ExponentiallyWeightedMovingAverage,
+    fifteen_minute_rate: ExponentiallyWeightedMovingAverage,
+    count: AtomicU64,
+    start_time: std::time::Instant,
+    last_tick: AtomicU64,
+}
+
+impl RequestRateMeter {
+    fn new() -> Self {
+        let now = std::time::Instant::now();
+        Self {
+            one_minute_rate: ExponentiallyWeightedMovingAverage::new(
+                1.0 - (-(INTERVAL as f64) / 60.0 / 1.0).exp(),
+            ),
+            five_minute_rate: ExponentiallyWeightedMovingAverage::new(
+                1.0 - (-(INTERVAL as f64) / 60.0 / 5.0).exp(),
+            ),
+            fifteen_minute_rate: ExponentiallyWeightedMovingAverage::new(
+                1.0 - (-(INTERVAL as f64) / 60.0 / 15.0).exp(),
+            ),
+            count: AtomicU64::new(0),
+            start_time: now,
+            last_tick: AtomicU64::new(now.elapsed().as_nanos() as u64),
+        }
+    }
+
+    fn mark(&self) {
+        self.tick_if_necessary();
+        self.count.fetch_add(1, ORDER_TYPE);
+        self.one_minute_rate.update();
+        self.five_minute_rate.update();
+        self.fifteen_minute_rate.update();
+    }
+
+    fn one_minute_rate(&self) -> f64 {
+        self.one_minute_rate.rate()
+    }
+
+    fn five_minute_rate(&self) -> f64 {
+        self.five_minute_rate.rate()
+    }
+
+    fn fifteen_minute_rate(&self) -> f64 {
+        self.fifteen_minute_rate.rate()
+    }
+
+    fn mean_rate(&self) -> f64 {
+        let count = self.count();
+        if count == 0 {
+            0.0
+        } else {
+            let elapsed = self.start_time.elapsed().as_secs_f64();
+            count as f64 / elapsed
+        }
+    }
+
+    fn count(&self) -> u64 {
+        self.count.load(ORDER_TYPE)
+    }
+
+    fn tick_if_necessary(&self) {
+        // Multiple threads could read the same `old_tick`...
+        let old_tick = self.last_tick.load(ORDER_TYPE);
+        let new_tick = self.start_time.elapsed().as_nanos() as u64;
+        let elapsed = new_tick - old_tick;
+
+        // _"Problematic"_ `if` - see a comment below.
+        if elapsed > INTERVAL * 1_000_000_000 {
+            let new_interval_start_tick = new_tick - elapsed % (INTERVAL * 1_000_000_000);
+            // But then only one will succeed in the following COMPARE EXCHANGE operation.
+            if self
+                .last_tick
+                .compare_exchange(old_tick, new_interval_start_tick, ORDER_TYPE, ORDER_TYPE)
+                .is_ok()
+            {
+                let required_ticks = elapsed / (INTERVAL * 1_000_000_000);
+                // So only one thread will do the following ticks.
+                // My only concern is that this loop might take so long that another thread
+                // enters the _"problematic"_ `if` and then we have a logical race there.
+                // BUT this is extremely unlikely, because then the loop would have to take
+                // 5 seconds! (INTERVAL * 1e9). So I think we are safe from those races.
+                for _ in 0..required_ticks {
+                    self.one_minute_rate.tick();
+                    self.five_minute_rate.tick();
+                    self.fifteen_minute_rate.tick();
+                }
+            }
+        }
+    }
+}
+
+impl Default for RequestRateMeter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct Metrics {
     errors_num: AtomicU64,
     queries_num: AtomicU64,
@@ -40,6 +207,7 @@ pub struct Metrics {
     queries_iter_num: AtomicU64,
     retries_num: AtomicU64,
     histogram: Arc<AtomicHistogram>,
+    meter: Arc<RequestRateMeter>,
 }
 
 impl Metrics {
@@ -55,6 +223,7 @@ impl Metrics {
     /// Increments counter for nonpaged queries.
     pub(crate) fn inc_total_nonpaged_queries(&self) {
         self.queries_num.fetch_add(1, ORDER_TYPE);
+        self.meter.mark();
     }
 
     /// Increments counter for errors that occurred in paged queries.
@@ -66,6 +235,7 @@ impl Metrics {
     /// If query_iter would return 4 pages then this counter should be incremented 4 times.
     pub(crate) fn inc_total_paged_queries(&self) {
         self.queries_iter_num.fetch_add(1, ORDER_TYPE);
+        self.meter.mark();
     }
 
     /// Increments counter measuring how many times a retry policy has decided to retry a query
@@ -157,6 +327,26 @@ impl Metrics {
     /// Returns counter measuring how many times a retry policy has decided to retry a query
     pub fn get_retries_num(&self) -> u64 {
         self.retries_num.load(ORDER_TYPE)
+    }
+
+    /// Returns mean rate of queries per second
+    pub fn get_mean_rate(&self) -> f64 {
+        self.meter.mean_rate()
+    }
+
+    /// Returns one-minute rate of queries per second
+    pub fn get_one_minute_rate(&self) -> f64 {
+        self.meter.one_minute_rate()
+    }
+
+    /// Returns five-minute rate of queries per second
+    pub fn get_five_minute_rate(&self) -> f64 {
+        self.meter.five_minute_rate()
+    }
+
+    /// Returns fifteen-minute rate of queries per second
+    pub fn get_fifteen_minute_rate(&self) -> f64 {
+        self.meter.fifteen_minute_rate()
     }
 
     // Metric implementations
@@ -253,6 +443,7 @@ impl Default for Metrics {
             queries_iter_num: AtomicU64::new(0),
             retries_num: AtomicU64::new(0),
             histogram: Arc::new(AtomicHistogram::new(grouping_power, max_value_power).unwrap()),
+            meter: Arc::new(RequestRateMeter::new()),
         }
     }
 }
@@ -267,6 +458,7 @@ impl std::fmt::Debug for Metrics {
             .field("queries_iter_num", &self.queries_iter_num)
             .field("retries_num", &self.retries_num)
             .field("histogram", &h)
+            .field("meter", &self.meter)
             .finish()
     }
 }

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -214,7 +214,7 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Metrics::default()
     }
 

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -15,6 +15,24 @@ pub enum MetricsError {
     Empty,
 }
 
+/// Snapshot is a structure that contains histogram statistics such as
+/// min, max, mean, standard deviation, median, and most common percentiles
+/// collected in a certain moment.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct Snapshot {
+    pub min: u64,
+    pub max: u64,
+    pub mean: u64,
+    pub stddev: u64,
+    pub median: u64,
+    pub percentile_75: u64,
+    pub percentile_95: u64,
+    pub percentile_98: u64,
+    pub percentile_99: u64,
+    pub percentile_99_9: u64,
+}
+
 pub struct Metrics {
     errors_num: AtomicU64,
     queries_num: AtomicU64,
@@ -90,6 +108,32 @@ impl Metrics {
         }
     }
 
+    /// Returns snapshot of histogram metrics taken at the moment of calling this function. \
+    /// Available metrics: min, max, mean, std_dev, median,
+    ///                    percentile_75, percentile_95, percentile_98,
+    ///                    percentile_99, and percentile_99_9.
+    pub fn get_snapshot(&self) -> Result<Snapshot, MetricsError> {
+        let h = self.histogram.load();
+
+        let (min, max) = Self::minmax(&h)?;
+
+        let percentile_args = [50.0, 75.0, 95.0, 98.0, 99.0, 99.9];
+        let percentiles = Self::percentiles(&h, &percentile_args)?;
+
+        Ok(Snapshot {
+            min,
+            max,
+            mean: Self::mean(&h)?,
+            stddev: Self::stddev(&h)?,
+            median: percentiles[0],
+            percentile_75: percentiles[1],
+            percentile_95: percentiles[2],
+            percentile_98: percentiles[3],
+            percentile_99: percentiles[4],
+            percentile_99_9: percentiles[5],
+        })
+    }
+
     /// Returns counter for errors occurred in nonpaged queries
     pub fn get_errors_num(&self) -> u64 {
         self.errors_num.load(ORDER_TYPE)
@@ -132,6 +176,58 @@ impl Metrics {
             Ok((weighted_sum / count) as u64)
         } else {
             Err(MetricsError::Empty)
+        }
+    }
+
+    fn percentiles(h: &Histogram, percentiles: &[f64]) -> Result<Vec<u64>, MetricsError> {
+        let res = h.percentiles(percentiles);
+
+        match res {
+            Err(err) => Err(MetricsError::HistogramError(Arc::new(err))),
+
+            Ok(None) => Err(MetricsError::Empty),
+
+            Ok(Some(ps)) => Ok(ps.into_iter().map(|(_, bucket)| bucket.count()).collect()),
+        }
+    }
+
+    fn stddev(h: &Histogram) -> Result<u64, MetricsError> {
+        let total_count = h
+            .into_iter()
+            .map(|bucket| bucket.count() as u128)
+            .sum::<u128>();
+
+        let mean = Self::mean(h)? as u128;
+        let mut variance_sum = 0;
+        for bucket in h {
+            let count = bucket.count() as u128;
+            let mid = ((bucket.start() + bucket.end()) / 2) as u128;
+
+            variance_sum += count * (mid as i128 - mean as i128).pow(2) as u128;
+        }
+        let variance = variance_sum / total_count;
+
+        Ok((variance as f64).sqrt() as u64)
+    }
+
+    fn minmax(h: &Histogram) -> Result<(u64, u64), MetricsError> {
+        let mut min = u64::MAX;
+        let mut max = 0;
+        for bucket in h {
+            if bucket.count() == 0 {
+                continue;
+            }
+            let lower_bound = bucket.start();
+            let upper_bound = bucket.end();
+
+            min = u64::min(min, lower_bound);
+            max = u64::max(max, upper_bound);
+        }
+
+        if min > max {
+            Err(MetricsError::Empty)
+        } else {
+            Ok((min, max))
         }
     }
 }

--- a/scylla/src/observability/mod.rs
+++ b/scylla/src/observability/mod.rs
@@ -7,5 +7,6 @@
 
 pub(crate) mod driver_tracing;
 pub mod history;
+#[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod tracing;

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1420,6 +1420,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                &Default::default(),
             )
             .await
         }
@@ -1451,6 +1452,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                &Default::default(),
             )
             .await
         }
@@ -2501,6 +2503,7 @@ mod tests {
             },
             TabletsInfo::new(),
             &HashMap::new(),
+            &Default::default(),
         )
         .await;
 

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1420,6 +1420,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                #[cfg(feature = "metrics")]
                 &Default::default(),
             )
             .await
@@ -1452,6 +1453,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                #[cfg(feature = "metrics")]
                 &Default::default(),
             )
             .await
@@ -2503,6 +2505,7 @@ mod tests {
             },
             TabletsInfo::new(),
             &HashMap::new(),
+            #[cfg(feature = "metrics")]
             &Default::default(),
         )
         .await;

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -182,7 +182,13 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
     let mut ring: Vec<(Token, Arc<Node>)> = Vec::new();
 
     for peer in &metadata.peers {
-        let node = Arc::new(Node::new(peer.to_peer_endpoint(), &pool_config, None, true));
+        let node = Arc::new(Node::new(
+            peer.to_peer_endpoint(),
+            &pool_config,
+            None,
+            true,
+            Default::default(),
+        ));
 
         for token in &peer.tokens {
             ring.push((*token, node.clone()));

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -187,6 +187,7 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
             &pool_config,
             None,
             true,
+            #[cfg(feature = "metrics")]
             Default::default(),
         ));
 


### PR DESCRIPTION
This patch contains:
- Implementation of lock-free histogram with hot and cold bucket pools
- Introduction of crate feature "metrics" to make using them optional
- Functionality to gather latency statistics via histogram snapshots
- Implementation of [rates of queries per second](https://github.com/scylladb/cpp-driver/blob/9d6b05c9d4ebd0a6d7006af4df3e33fcdf956eeb/src/metrics.hpp#L39C1-L252C5) based on cpp-driver implementation.
- Initial implementation of connection metrics (changes required after review)

Fixes: #330

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
