### PR TITLE
value: `Cql[Varint/Decimal]Borrowed`

### DIFF
--- a/docs/source/data-types/decimal.md
+++ b/docs/source/data-types/decimal.md
@@ -3,7 +3,7 @@
 
 ## value::CqlDecimal
 
-Without any feature flags, the user can interact with `decimal` type by making use of `value::CqlDecimal` which is a very simple wrapper representing the value as signed binary number in big-endian order with a 32-bit scale.
+Without any feature flags, the user can interact with `decimal` type by making use of `value::CqlDecimal` or `value::CqlDecimalBorrowed` which are very simple wrappers representing the value as signed binary number in big-endian order with a 32-bit scale.
 
 ```rust
 # extern crate scylla;

--- a/docs/source/data-types/varint.md
+++ b/docs/source/data-types/varint.md
@@ -7,8 +7,7 @@ To make use of `num_bigint::BigInt` type, user should enable one of the availabl
 
 ## value::CqlVarint
 
-Without any feature flags, the user can interact with `Varint` type by making use of `value::CqlVarint` which
-is a very simple wrapper representing the value as signed binary number in big-endian order.
+Without any feature flags, the user can interact with `Varint` type by making use of `value::CqlVarint` or `value::CqlVarintBorrowed` which are very simple wrappers representing the value as signed binary number in big-endian order.
 
 ## Example
 

--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -303,6 +303,32 @@ impl CqlVarint {
     }
 }
 
+/// Compares two [`CqlVarint`] values after normalization.
+///
+/// # Example
+///
+/// ```rust
+/// # use scylla_cql::frame::value::CqlVarint;
+/// let non_normalized_bytes = vec![0x00, 0x01];
+/// let normalized_bytes = vec![0x01];
+/// assert_eq!(
+///     CqlVarint::from_signed_bytes_be(non_normalized_bytes),
+///     CqlVarint::from_signed_bytes_be(normalized_bytes)
+/// );
+/// ```
+impl PartialEq for CqlVarint {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_normalized_slice() == other.as_normalized_slice()
+    }
+}
+
+/// Computes the hash of normalized [`CqlVarint`].
+impl std::hash::Hash for CqlVarint {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_normalized_slice().hash(state)
+    }
+}
+
 #[cfg(feature = "num-bigint-03")]
 impl From<num_bigint_03::BigInt> for CqlVarint {
     fn from(value: num_bigint_03::BigInt) -> Self {
@@ -328,32 +354,6 @@ impl From<num_bigint_04::BigInt> for CqlVarint {
 impl From<CqlVarint> for num_bigint_04::BigInt {
     fn from(val: CqlVarint) -> Self {
         num_bigint_04::BigInt::from_signed_bytes_be(&val.0)
-    }
-}
-
-/// Compares two [`CqlVarint`] values after normalization.
-///
-/// # Example
-///
-/// ```rust
-/// # use scylla_cql::frame::value::CqlVarint;
-/// let non_normalized_bytes = vec![0x00, 0x01];
-/// let normalized_bytes = vec![0x01];
-/// assert_eq!(
-///     CqlVarint::from_signed_bytes_be(non_normalized_bytes),
-///     CqlVarint::from_signed_bytes_be(normalized_bytes)
-/// );
-/// ```
-impl PartialEq for CqlVarint {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_normalized_slice() == other.as_normalized_slice()
-    }
-}
-
-/// Computes the hash of normalized [`CqlVarint`].
-impl std::hash::Hash for CqlVarint {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_normalized_slice().hash(state)
     }
 }
 

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -15,12 +15,15 @@ use std::fmt::Display;
 use thiserror::Error;
 
 use super::{make_error_replace_rust_name, DeserializationError, FrameSlice, TypeCheckError};
-use crate::frame::response::result::{deser_cql_value, ColumnType, CqlValue};
 use crate::frame::types;
 use crate::frame::value::{
     Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
 };
 use crate::frame::{frame_errors::LowLevelDeserializationError, value::CqlVarintBorrowed};
+use crate::frame::{
+    response::result::{deser_cql_value, ColumnType, CqlValue},
+    value::CqlDecimalBorrowed,
+};
 
 /// A type that can be deserialized from a column value inside a row that was
 /// returned from a query.
@@ -267,6 +270,24 @@ impl_emptiable_strict_type!(
             val, scale,
         ))
     }
+);
+
+impl_emptiable_strict_type!(
+    CqlDecimalBorrowed<'b>,
+    Decimal,
+    |typ: &'metadata ColumnType<'metadata>, v: Option<FrameSlice<'frame>>| {
+        let mut val = ensure_not_null_slice::<Self>(typ, v)?;
+        let scale = types::read_int(&mut val).map_err(|err| {
+            mk_deser_err::<Self>(
+                typ,
+                BuiltinDeserializationErrorKind::BadDecimalScale(err.into()),
+            )
+        })?;
+        Ok(CqlDecimalBorrowed::from_signed_be_bytes_slice_and_exponent(
+            val, scale,
+        ))
+    },
+    'b
 );
 
 #[cfg(feature = "bigdecimal-04")]

--- a/scylla-cql/src/types/deserialize/value.rs
+++ b/scylla-cql/src/types/deserialize/value.rs
@@ -15,12 +15,12 @@ use std::fmt::Display;
 use thiserror::Error;
 
 use super::{make_error_replace_rust_name, DeserializationError, FrameSlice, TypeCheckError};
-use crate::frame::frame_errors::LowLevelDeserializationError;
 use crate::frame::response::result::{deser_cql_value, ColumnType, CqlValue};
 use crate::frame::types;
 use crate::frame::value::{
     Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
 };
+use crate::frame::{frame_errors::LowLevelDeserializationError, value::CqlVarintBorrowed};
 
 /// A type that can be deserialized from a column value inside a row that was
 /// returned from a query.
@@ -220,6 +220,16 @@ impl_emptiable_strict_type!(
         let val = ensure_not_null_slice::<Self>(typ, v)?;
         Ok(CqlVarint::from_signed_bytes_be_slice(val))
     }
+);
+
+impl_emptiable_strict_type!(
+    CqlVarintBorrowed<'b>,
+    Varint,
+    |typ: &'metadata ColumnType<'metadata>, v: Option<FrameSlice<'frame>>| {
+        let val = ensure_not_null_slice::<Self>(typ, v)?;
+        Ok(CqlVarintBorrowed::from_signed_bytes_be_slice(val))
+    },
+    'b
 );
 
 #[cfg(feature = "num-bigint-03")]

--- a/scylla-cql/src/types/deserialize/value_tests.rs
+++ b/scylla-cql/src/types/deserialize/value_tests.rs
@@ -11,6 +11,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use crate::frame::response::result::{ColumnType, CqlValue};
 use crate::frame::value::{
     Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
+    CqlVarintBorrowed,
 };
 use crate::types::deserialize::value::{TupleDeserializationErrorKind, TupleTypeCheckErrorKind};
 use crate::types::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
@@ -156,6 +157,12 @@ fn test_varlen_numbers() {
     assert_ser_de_identity(
         &ColumnType::Varint,
         &CqlVarint::from_signed_bytes_be_slice(b"Ala ma kota"),
+        &mut Bytes::new(),
+    );
+
+    assert_ser_de_identity(
+        &ColumnType::Varint,
+        &CqlVarintBorrowed::from_signed_bytes_be_slice(b"Ala ma kota"),
         &mut Bytes::new(),
     );
 

--- a/scylla-cql/src/types/deserialize/value_tests.rs
+++ b/scylla-cql/src/types/deserialize/value_tests.rs
@@ -10,8 +10,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::frame::response::result::{ColumnType, CqlValue};
 use crate::frame::value::{
-    Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
-    CqlVarintBorrowed,
+    Counter, CqlDate, CqlDecimal, CqlDecimalBorrowed, CqlDuration, CqlTime, CqlTimestamp,
+    CqlTimeuuid, CqlVarint, CqlVarintBorrowed,
 };
 use crate::types::deserialize::value::{TupleDeserializationErrorKind, TupleTypeCheckErrorKind};
 use crate::types::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
@@ -184,6 +184,12 @@ fn test_varlen_numbers() {
     assert_ser_de_identity(
         &ColumnType::Decimal,
         &CqlDecimal::from_signed_be_bytes_slice_and_exponent(b"Ala ma kota", 42),
+        &mut Bytes::new(),
+    );
+
+    assert_ser_de_identity(
+        &ColumnType::Decimal,
+        &CqlDecimalBorrowed::from_signed_be_bytes_slice_and_exponent(b"Ala ma kota", 42),
         &mut Bytes::new(),
     );
 

--- a/scylla-cql/src/types/serialize/value.rs
+++ b/scylla-cql/src/types/serialize/value.rs
@@ -16,8 +16,8 @@ use uuid::Uuid;
 use crate::frame::response::result::{ColumnType, CqlValue};
 use crate::frame::types::vint_encode;
 use crate::frame::value::{
-    Counter, CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlVarint,
-    CqlVarintBorrowed, MaybeUnset, Unset, Value,
+    Counter, CqlDate, CqlDecimal, CqlDecimalBorrowed, CqlDuration, CqlTime, CqlTimestamp,
+    CqlTimeuuid, CqlVarint, CqlVarintBorrowed, MaybeUnset, Unset, Value,
 };
 
 #[cfg(feature = "chrono-04")]
@@ -113,6 +113,18 @@ impl SerializeValue for i64 {
     });
 }
 impl SerializeValue for CqlDecimal {
+    impl_serialize_via_writer!(|me, typ, writer| {
+        exact_type_check!(typ, Decimal);
+        let mut builder = writer.into_value_builder();
+        let (bytes, scale) = me.as_signed_be_bytes_slice_and_exponent();
+        builder.append_bytes(&scale.to_be_bytes());
+        builder.append_bytes(bytes);
+        builder
+            .finish()
+            .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
+    });
+}
+impl SerializeValue for CqlDecimalBorrowed<'_> {
     impl_serialize_via_writer!(|me, typ, writer| {
         exact_type_check!(typ, Decimal);
         let mut builder = writer.into_value_builder();


### PR DESCRIPTION

This PR introduces borrowed versions of CqlDecimal and CqlVarint. It implements SerializeValue and DeserializeValue for new types.

There is a use case for this in cpp-rust-driver - we need to set the pointer user provided, so it points to the underlying data. After lazy-deserialization refactor in cpp-rust-driver, CqlDecimal is not useful anymore. If we deserialize to CqlDecimal, it owns the bytes and is a stack variable - thus, we cannot set the pointer to its underlying data (it will be freed after function call).

Questions for reviewers:
- Should I put it under #[cfg(cpp_rust_unstable]? I think it may be useful for other users as well.
- I only implemente `From<Cql[Varint/Decimal]Borrowed> for Big[Int/Decimal]`. I didn't implement conversions in other direction, since new types borrow bytes (and From consumes). Do you think it's ok to make an exception here, and implement `From<&Big[Int/Decimal]>` (from reference)?


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
