### PR TITLE
Remove uses of `SerializeValuesError` and deprecate it

### DIFF
--- a/scylla-cql/src/frame/value.rs
+++ b/scylla-cql/src/frame/value.rs
@@ -13,29 +13,8 @@ use super::types::vint_encode;
 use super::types::RawValue;
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[error("Value too big to be sent in a request - max 2GiB allowed")]
-#[deprecated(
-    since = "0.15.1",
-    note = "Legacy serialization API is not type-safe and is going to be removed soon"
-)]
-pub struct ValueTooBig;
-
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[error("Value is too large to fit in the CQL type")]
 pub struct ValueOverflow;
-
-#[allow(deprecated)]
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SerializeValuesError {
-    #[error("Too many values to add, max 65,535 values can be sent in a request")]
-    TooManyValues,
-    #[error("Mixing named and not named values is not allowed")]
-    MixingNamedAndNotNamedValues,
-    #[error(transparent)]
-    ValueTooBig(#[from] ValueTooBig),
-    #[error("Parsing serialized values failed")]
-    ParseError,
-}
 
 /// Represents an unset value
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -682,6 +661,22 @@ mod legacy {
     /// serialize() should write the Value as [bytes] to the provided buffer
     pub trait Value {
         fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig>;
+    }
+
+    #[derive(Debug, Error, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    #[error("Value too big to be sent in a request - max 2GiB allowed")]
+    pub struct ValueTooBig;
+
+    #[derive(Debug, Error, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub enum SerializeValuesError {
+        #[error("Too many values to add, max 65,535 values can be sent in a request")]
+        TooManyValues,
+        #[error("Mixing named and not named values is not allowed")]
+        MixingNamedAndNotNamedValues,
+        #[error(transparent)]
+        ValueTooBig(#[from] ValueTooBig),
+        #[error("Parsing serialized values failed")]
+        ParseError,
     }
 
     /// Keeps a buffer with serialized Values
@@ -1887,5 +1882,6 @@ mod legacy {
 pub use legacy::{
     LegacyBatchValues, LegacyBatchValuesFirstSerialized, LegacyBatchValuesFromIter,
     LegacyBatchValuesIterator, LegacyBatchValuesIteratorFromIterator, LegacySerializedValues,
-    LegacySerializedValuesIterator, SerializedResult, TupleValuesIter, Value, ValueList,
+    LegacySerializedValuesIterator, SerializeValuesError, SerializedResult, TupleValuesIter, Value,
+    ValueList, ValueTooBig,
 };

--- a/scylla-cql/src/types/serialize/mod.rs
+++ b/scylla-cql/src/types/serialize/mod.rs
@@ -32,6 +32,8 @@ pub use writers::{CellValueBuilder, CellWriter, RowWriter};
 ///   a list of named values encoded with the legacy `ValueList` trait is passed
 ///   as an argument to the statement, and rewriting it using the new
 ///   `SerializeRow` interface fails.
+// TODO: remove mentions about legacy errors from the above description when
+// they are removed.
 #[derive(Debug, Clone, Error)]
 #[error("SerializationError: {0}")]
 pub struct SerializationError(Arc<dyn Error + Send + Sync>);

--- a/scylla/src/transport/errors.rs
+++ b/scylla/src/transport/errors.rs
@@ -12,6 +12,7 @@ use std::{
     sync::Arc,
 };
 
+#[allow(deprecated)]
 use scylla_cql::{
     frame::{
         frame_errors::{
@@ -124,6 +125,7 @@ pub enum QueryError {
     IntoLegacyQueryResultError(#[from] IntoLegacyQueryResultError),
 }
 
+#[allow(deprecated)]
 impl From<SerializeValuesError> for QueryError {
     fn from(serialized_err: SerializeValuesError) -> QueryError {
         QueryError::BadQuery(BadQuery::SerializeValuesError(serialized_err))
@@ -573,7 +575,12 @@ pub enum ViewsMetadataError {
 #[non_exhaustive]
 pub enum BadQuery {
     /// Failed to serialize values passed to a query - values too big
+    #[deprecated(
+        since = "0.15.1",
+        note = "Legacy serialization API is not type-safe and is going to be removed soon"
+    )]
     #[error("Serializing values failed: {0} ")]
+    #[allow(deprecated)]
     SerializeValuesError(#[from] SerializeValuesError),
 
     #[error("Serializing values failed: {0} ")]


### PR DESCRIPTION
`SerializeValuesError` is part of the legacy serialization API, so it should be deprecated as well.

Refs: #1139

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
