### PR TITLE
session: internal request execution API error types refactor

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -37,7 +37,7 @@ use crate::observability::driver_tracing::RequestSpan;
 use crate::observability::history::{self, HistoryListener};
 use crate::observability::metrics::Metrics;
 use crate::policies::load_balancing::{self, RoutingInfo};
-use crate::policies::retry::{QueryInfo, RetryDecision, RetrySession};
+use crate::policies::retry::{RequestInfo, RetryDecision, RetrySession};
 use crate::response::query_result::ColumnSpecs;
 use crate::response::{NonErrorQueryResponse, QueryResponse};
 use crate::statement::{prepared_statement::PreparedStatement, query::Query};
@@ -223,7 +223,7 @@ where
                 };
 
                 // Use retry policy to decide what to do next
-                let query_info = QueryInfo {
+                let query_info = RequestInfo {
                     error: &request_error,
                     is_idempotent: self.query_is_idempotent,
                     consistency: self.query_consistency,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -329,7 +329,7 @@ where
                 self.log_query_success();
                 self.execution_profile
                     .load_balancing_policy
-                    .on_query_success(&self.statement_info, elapsed, node);
+                    .on_request_success(&self.statement_info, elapsed, node);
 
                 request_span.record_raw_rows_fields(&rows);
 
@@ -362,7 +362,7 @@ where
                 self.metrics.inc_failed_paged_queries();
                 self.execution_profile
                     .load_balancing_policy
-                    .on_query_failure(&self.statement_info, elapsed, node, &err);
+                    .on_request_failure(&self.statement_info, elapsed, node, &err);
                 Err(err.into_query_error())
             }
             Ok(NonErrorQueryResponse {
@@ -383,7 +383,7 @@ where
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
                 self.execution_profile
                     .load_balancing_policy
-                    .on_query_failure(&self.statement_info, elapsed, node, &err);
+                    .on_request_failure(&self.statement_info, elapsed, node, &err);
                 Err(err.into_query_error())
             }
         }

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -206,7 +206,7 @@ where
 
                 let request_error: RequestAttemptError = match queries_result {
                     Ok(proof) => {
-                        trace!(parent: &span, "Query succeeded");
+                        trace!(parent: &span, "Request succeeded");
                         // query_pages returned Ok, so we are guaranteed
                         // that it attempted to send at least one page
                         // through self.sender and we can safely return now.
@@ -216,7 +216,7 @@ where
                         trace!(
                             parent: &span,
                             error = %error,
-                            "Query failed"
+                            "Request failed"
                         );
                         error
                     }

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -359,12 +359,11 @@ where
                 Ok(ControlFlow::Continue(()))
             }
             Err(err) => {
-                let err = err.into_query_error();
                 self.metrics.inc_failed_paged_queries();
                 self.execution_profile
                     .load_balancing_policy
                     .on_query_failure(&self.statement_info, elapsed, node, &err);
-                Err(err)
+                Err(err.into_query_error())
             }
             Ok(NonErrorQueryResponse {
                 response: NonErrorResponse::Result(_),
@@ -381,11 +380,11 @@ where
             Ok(response) => {
                 self.metrics.inc_failed_paged_queries();
                 let err =
-                    ProtocolError::UnexpectedResponse(response.response.to_response_kind()).into();
+                    RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
                 self.execution_profile
                     .load_balancing_policy
                     .on_query_failure(&self.statement_info, elapsed, node, &err);
-                Err(err)
+                Err(err.into_query_error())
             }
         }
     }

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2068,7 +2068,6 @@ where
                         return Some(Ok(RunRequestResult::Completed(response)));
                     }
                     Err(e) => {
-                        let e = e.into_query_error();
                         trace!(
                             parent: &span,
                             last_error = %e,
@@ -2081,7 +2080,7 @@ where
                             node,
                             &e,
                         );
-                        Some(e)
+                        Some(e.into_query_error())
                     }
                 };
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1585,6 +1585,8 @@ where
                                 serial_consistency,
                             )
                             .await
+                            .map_err(UserRequestError::into_query_error)
+                            .and_then(QueryResponse::into_query_result)
                     }
                 },
                 &span,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -28,7 +28,7 @@ use crate::observability::tracing::TracingInfo;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::load_balancing::{self, RoutingInfo};
-use crate::policies::retry::{QueryInfo, RetryDecision, RetrySession};
+use crate::policies::retry::{RequestInfo, RetryDecision, RetrySession};
 use crate::policies::speculative_execution;
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
@@ -2085,7 +2085,7 @@ where
                 };
 
                 // Use retry policy to decide what to do next
-                let query_info = QueryInfo {
+                let query_info = RequestInfo {
                     error: &request_error,
                     is_idempotent: context.is_idempotent,
                     consistency: context

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2060,7 +2060,7 @@ where
                         trace!(parent: &span, "Request succeeded");
                         let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
-                        execution_profile.load_balancing_policy.on_query_success(
+                        execution_profile.load_balancing_policy.on_request_success(
                             context.query_info,
                             elapsed,
                             node,
@@ -2074,7 +2074,7 @@ where
                             "Request failed"
                         );
                         self.metrics.inc_failed_nonpaged_queries();
-                        execution_profile.load_balancing_policy.on_query_failure(
+                        execution_profile.load_balancing_policy.on_request_failure(
                             context.query_info,
                             elapsed,
                             node,

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -9,7 +9,7 @@ use crate::cluster::metadata::{CollectionType, ColumnKind, CqlType, NativeType, 
 use crate::deserialize::DeserializeOwnedValue;
 use crate::errors::{BadKeyspaceName, BadQuery, DbError, QueryError};
 use crate::observability::tracing::TracingInfo;
-use crate::policies::retry::{QueryInfo, RetryDecision, RetryPolicy, RetrySession};
+use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::routing::partitioner::{
@@ -2725,7 +2725,7 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
 
     struct MyRetrySession(Arc<AtomicBool>);
     impl RetrySession for MyRetrySession {
-        fn decide_should_retry(&mut self, _: QueryInfo) -> RetryDecision {
+        fn decide_should_retry(&mut self, _: RequestInfo) -> RetryDecision {
             self.0.store(true, Ordering::Relaxed);
             RetryDecision::IgnoreWriteError
         }

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -19,7 +19,7 @@
 use crate::client::pager::QueryPager;
 use crate::cluster::node::resolve_contact_points;
 use crate::deserialize::DeserializeOwnedRow;
-use crate::errors::{DbError, NewSessionError, QueryError, UserRequestError};
+use crate::errors::{DbError, NewSessionError, QueryError, RequestAttemptError};
 use crate::frame::response::event::Event;
 use crate::network::{Connection, ConnectionConfig, NodeConnectionPool, PoolConfig, PoolSize};
 use crate::policies::host_filter::HostFilter;
@@ -989,7 +989,7 @@ where
             let prepared = conn
                 .prepare(&query)
                 .await
-                .map_err(UserRequestError::into_query_error)?;
+                .map_err(RequestAttemptError::into_query_error)?;
             let serialized_values = prepared.serialize_values(&keyspaces)?;
             conn.execute_iter(prepared, serialized_values).await
         }

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -907,6 +907,8 @@ pub(crate) enum UserRequestError {
         expected_id: Vec<u8>,
         reprepared_id: Vec<u8>,
     },
+    #[error("Reprepared statement's id does not exist in the batch.")]
+    RepreparedIdMissingInBatch,
 }
 
 impl UserRequestError {
@@ -933,6 +935,9 @@ impl UserRequestError {
                 reprepared_id,
             }
             .into(),
+            UserRequestError::RepreparedIdMissingInBatch => {
+                ProtocolError::RepreparedIdMissingInBatch.into()
+            }
         }
     }
 }

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -145,33 +145,6 @@ impl From<tokio::time::error::Elapsed> for QueryError {
     }
 }
 
-impl From<UserRequestError> for QueryError {
-    fn from(value: UserRequestError) -> Self {
-        match value {
-            UserRequestError::CqlRequestSerialization(e) => e.into(),
-            UserRequestError::DbError(err, msg) => QueryError::DbError(err, msg),
-            UserRequestError::CqlResultParseError(e) => e.into(),
-            UserRequestError::CqlErrorParseError(e) => e.into(),
-            UserRequestError::BrokenConnectionError(e) => e.into(),
-            UserRequestError::UnexpectedResponse(response) => {
-                ProtocolError::UnexpectedResponse(response).into()
-            }
-            UserRequestError::BodyExtensionsParseError(e) => e.into(),
-            UserRequestError::UnableToAllocStreamId => QueryError::UnableToAllocStreamId,
-            UserRequestError::RepreparedIdChanged {
-                statement,
-                expected_id,
-                reprepared_id,
-            } => ProtocolError::RepreparedIdChanged {
-                statement,
-                expected_id,
-                reprepared_id,
-            }
-            .into(),
-        }
-    }
-}
-
 impl From<QueryError> for NewSessionError {
     fn from(query_error: QueryError) -> NewSessionError {
         match query_error {
@@ -934,6 +907,34 @@ pub(crate) enum UserRequestError {
         expected_id: Vec<u8>,
         reprepared_id: Vec<u8>,
     },
+}
+
+impl UserRequestError {
+    /// Converts the error to [`QueryError`].
+    pub(crate) fn into_query_error(self) -> QueryError {
+        match self {
+            UserRequestError::CqlRequestSerialization(e) => e.into(),
+            UserRequestError::DbError(err, msg) => QueryError::DbError(err, msg),
+            UserRequestError::CqlResultParseError(e) => e.into(),
+            UserRequestError::CqlErrorParseError(e) => e.into(),
+            UserRequestError::BrokenConnectionError(e) => e.into(),
+            UserRequestError::UnexpectedResponse(response) => {
+                ProtocolError::UnexpectedResponse(response).into()
+            }
+            UserRequestError::BodyExtensionsParseError(e) => e.into(),
+            UserRequestError::UnableToAllocStreamId => QueryError::UnableToAllocStreamId,
+            UserRequestError::RepreparedIdChanged {
+                statement,
+                expected_id,
+                reprepared_id,
+            } => ProtocolError::RepreparedIdChanged {
+                statement,
+                expected_id,
+                reprepared_id,
+            }
+            .into(),
+        }
+    }
 }
 
 impl From<response::error::Error> for UserRequestError {

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -909,6 +909,8 @@ pub(crate) enum UserRequestError {
     },
     #[error("Reprepared statement's id does not exist in the batch.")]
     RepreparedIdMissingInBatch,
+    #[error("Failed to serialize query parameters: {0}")]
+    SerializationError(#[from] SerializationError),
 }
 
 impl UserRequestError {
@@ -938,6 +940,7 @@ impl UserRequestError {
             UserRequestError::RepreparedIdMissingInBatch => {
                 ProtocolError::RepreparedIdMissingInBatch.into()
             }
+            UserRequestError::SerializationError(e) => e.into(),
         }
     }
 }

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -883,27 +883,19 @@ pub enum CqlEventHandlingError {
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum UserRequestError {
+    /// Failed to serialize query parameters. This error occurs, when user executes
+    /// a CQL `QUERY` request with non-empty parameter's value list and the serialization
+    /// of provided values fails during statement preparation.
+    #[error("Failed to serialize query parameters: {0}")]
+    SerializationError(#[from] SerializationError),
+
     /// Failed to serialize CQL request.
     #[error("Failed to serialize CQL request: {0}")]
     CqlRequestSerialization(#[from] CqlRequestSerializationError),
 
-    /// Database sent a response containing some error with a message
-    #[error("Database returned an error: {0}, Error message: {1}")]
-    DbError(DbError, String),
-
-    /// Received a RESULT server response, but failed to deserialize it.
-    #[error(transparent)]
-    CqlResultParseError(#[from] CqlResultParseError),
-
-    /// Received an ERROR server response, but failed to deserialize it.
-    #[error("Failed to deserialize ERROR response: {0}")]
-    CqlErrorParseError(#[from] CqlErrorParseError),
-
-    /// Received an unexpected response from the server.
-    #[error(
-        "Received unexpected response from the server: {0}. Expected RESULT or ERROR response."
-    )]
-    UnexpectedResponse(CqlResponseKind),
+    /// Driver was unable to allocate a stream id to execute a query on.
+    #[error("Unable to allocate stream id")]
+    UnableToAllocStreamId,
 
     /// A connection has been broken during query execution.
     #[error(transparent)]
@@ -913,9 +905,23 @@ pub enum UserRequestError {
     #[error(transparent)]
     BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
 
-    /// Driver was unable to allocate a stream id to execute a query on.
-    #[error("Unable to allocate stream id")]
-    UnableToAllocStreamId,
+    /// Received a RESULT server response, but failed to deserialize it.
+    #[error(transparent)]
+    CqlResultParseError(#[from] CqlResultParseError),
+
+    /// Received an ERROR server response, but failed to deserialize it.
+    #[error("Failed to deserialize ERROR response: {0}")]
+    CqlErrorParseError(#[from] CqlErrorParseError),
+
+    /// Database sent a response containing some error with a message
+    #[error("Database returned an error: {0}, Error message: {1}")]
+    DbError(DbError, String),
+
+    /// Received an unexpected response from the server.
+    #[error(
+        "Received unexpected response from the server: {0}. Expected RESULT or ERROR response."
+    )]
+    UnexpectedResponse(CqlResponseKind),
 
     /// Prepared statement id changed after repreparation.
     #[error(
@@ -932,12 +938,6 @@ pub enum UserRequestError {
     /// statement's id is not included in the batch.
     #[error("Reprepared statement's id does not exist in the batch.")]
     RepreparedIdMissingInBatch,
-
-    /// Failed to serialize query parameters. This error occurs, when user executes
-    /// a CQL `QUERY` request with non-empty parameter's value list and the serialization
-    /// of provided values fails during statement preparation.
-    #[error("Failed to serialize query parameters: {0}")]
-    SerializationError(#[from] SerializationError),
 }
 
 impl UserRequestError {

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -879,7 +879,7 @@ pub enum CqlEventHandlingError {
 ///
 /// requests. The retry decision is made based
 /// on this error.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum RequestAttemptError {
     /// Failed to serialize query parameters. This error occurs, when user executes

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1096,10 +1096,10 @@ impl Connection {
                     _ => Err(err.into()),
                 },
                 Response::Result(_) => Ok(query_response.into_query_result()?),
-                _ => Err(ProtocolError::UnexpectedResponse(
+                _ => Err(UserRequestError::UnexpectedResponse(
                     query_response.response.to_response_kind(),
                 )
-                .into()),
+                .into_query_error()),
             };
         }
     }

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1090,7 +1090,9 @@ impl Connection {
                                 .map_err(UserRequestError::into_query_error)?;
                             continue;
                         } else {
-                            return Err(ProtocolError::RepreparedIdMissingInBatch.into());
+                            return Err(
+                                UserRequestError::RepreparedIdMissingInBatch.into_query_error()
+                            );
                         }
                     }
                     _ => Err(err.into()),

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -559,13 +559,18 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         "DefaultPolicy".to_string()
     }
 
-    fn on_query_success(&self, _routing_info: &RoutingInfo, latency: Duration, node: NodeRef<'_>) {
+    fn on_request_success(
+        &self,
+        _routing_info: &RoutingInfo,
+        latency: Duration,
+        node: NodeRef<'_>,
+    ) {
         if let Some(latency_awareness) = self.latency_awareness.as_ref() {
-            latency_awareness.report_query(node, latency);
+            latency_awareness.report_request(node, latency);
         }
     }
 
-    fn on_query_failure(
+    fn on_request_failure(
         &self,
         _routing_info: &RoutingInfo,
         latency: Duration,
@@ -574,7 +579,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
     ) {
         if let Some(latency_awareness) = self.latency_awareness.as_ref() {
             if LatencyAwareness::reliable_latency_measure(error) {
-                latency_awareness.report_query(node, latency);
+                latency_awareness.report_request(node, latency);
             }
         }
     }
@@ -2808,7 +2813,7 @@ mod latency_awareness {
             Either::Right(skipping_penalised_targets_iterator)
         }
 
-        pub(super) fn report_query(&self, node: &Node, latency: Duration) {
+        pub(super) fn report_request(&self, node: &Node, latency: Duration) {
             let node_avgs_guard = self.node_avgs.read().unwrap();
             if let Some(previous_node_avg) = node_avgs_guard.get(&node.host_id) {
                 // The usual path, the node has been already noticed.

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -6,7 +6,7 @@ use crate::cluster::ClusterState;
 use crate::{
     cluster::metadata::Strategy,
     cluster::node::Node,
-    errors::QueryError,
+    errors::RequestAttemptError,
     routing::locator::ReplicaSet,
     routing::{Shard, Token},
 };
@@ -570,7 +570,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         _routing_info: &RoutingInfo,
         latency: Duration,
         node: NodeRef<'_>,
-        error: &QueryError,
+        error: &RequestAttemptError,
     ) {
         if let Some(latency_awareness) = self.latency_awareness.as_ref() {
             if LatencyAwareness::reliable_latency_measure(error) {
@@ -2554,7 +2554,7 @@ mod latency_awareness {
     use uuid::Uuid;
 
     use crate::cluster::node::Node;
-    use crate::errors::{DbError, QueryError};
+    use crate::errors::{DbError, RequestAttemptError};
     use crate::policies::load_balancing::NodeRef;
     use crate::routing::Shard;
     use std::{
@@ -2839,33 +2839,27 @@ mod latency_awareness {
             }
         }
 
-        pub(crate) fn reliable_latency_measure(error: &QueryError) -> bool {
+        pub(crate) fn reliable_latency_measure(error: &RequestAttemptError) -> bool {
             match error {
                 // "fast" errors, i.e. ones that are returned quickly after the query begins
-                QueryError::BadQuery(_)
-                | QueryError::CqlRequestSerialization(_)
-                | QueryError::BrokenConnection(_)
-                | QueryError::ConnectionPoolError(_)
-                | QueryError::EmptyPlan
-                | QueryError::UnableToAllocStreamId
-                | QueryError::DbError(DbError::IsBootstrapping, _)
-                | QueryError::DbError(DbError::Unavailable { .. }, _)
-                | QueryError::DbError(DbError::Unprepared { .. }, _)
-                | QueryError::DbError(DbError::Overloaded { .. }, _)
-                | QueryError::DbError(DbError::RateLimitReached { .. }, _) => false,
+                RequestAttemptError::CqlRequestSerialization(_)
+                | RequestAttemptError::BrokenConnectionError(_)
+                | RequestAttemptError::UnableToAllocStreamId
+                | RequestAttemptError::DbError(DbError::IsBootstrapping, _)
+                | RequestAttemptError::DbError(DbError::Unavailable { .. }, _)
+                | RequestAttemptError::DbError(DbError::Unprepared { .. }, _)
+                | RequestAttemptError::DbError(DbError::Overloaded { .. }, _)
+                | RequestAttemptError::DbError(DbError::RateLimitReached { .. }, _)
+                | RequestAttemptError::SerializationError(_) => false,
 
                 // "slow" errors, i.e. ones that are returned after considerable time of query being run
-                #[allow(deprecated)]
-                QueryError::DbError(_, _)
-                | QueryError::CqlResultParseError(_)
-                | QueryError::CqlErrorParseError(_)
-                | QueryError::BodyExtensionsParseError(_)
-                | QueryError::MetadataError(_)
-                | QueryError::ProtocolError(_)
-                | QueryError::TimeoutError
-                | QueryError::RequestTimeout(_)
-                | QueryError::NextRowError(_)
-                | QueryError::IntoLegacyQueryResultError(_) => true,
+                RequestAttemptError::DbError(_, _)
+                | RequestAttemptError::CqlResultParseError(_)
+                | RequestAttemptError::CqlErrorParseError(_)
+                | RequestAttemptError::BodyExtensionsParseError(_)
+                | RequestAttemptError::RepreparedIdChanged { .. }
+                | RequestAttemptError::RepreparedIdMissingInBatch
+                | RequestAttemptError::UnexpectedResponse(_) => true,
             }
         }
     }

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::cluster::{ClusterState, NodeRef};
 use crate::{
-    errors::QueryError,
+    errors::RequestAttemptError,
     routing::{Shard, Token},
 };
 use scylla_cql::frame::{response::result::TableSpec, types};
@@ -91,7 +91,7 @@ pub trait LoadBalancingPolicy: Send + Sync + std::fmt::Debug {
         _query: &RoutingInfo,
         _latency: Duration,
         _node: NodeRef<'_>,
-        _error: &QueryError,
+        _error: &RequestAttemptError,
     ) {
     }
 

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -19,8 +19,8 @@ pub use plan::Plan;
 /// Represents info about statement that can be used by load balancing policies.
 #[derive(Default, Clone, Debug)]
 pub struct RoutingInfo<'a> {
-    /// Requested consistency information allows to route queries to the appropriate
-    /// datacenters. E.g. queries with a LOCAL_ONE consistency should be routed to the same
+    /// Requested consistency information allows to route requests to the appropriate
+    /// datacenters. E.g. requests with a LOCAL_ONE consistency should be routed to the same
     /// datacenter.
     pub consistency: types::Consistency,
     pub serial_consistency: Option<types::SerialConsistency>,
@@ -33,62 +33,62 @@ pub struct RoutingInfo<'a> {
 
     /// If, while preparing, we received from the cluster information that the statement is an LWT,
     /// then we can use this information for routing optimisation. Namely, an optimisation
-    /// can be performed: the query should be routed to the replicas in a predefined order
+    /// can be performed: the request should be routed to the replicas in a predefined order
     /// (i. e. always try first to contact replica A, then B if it fails, then C, etc.).
-    /// If false, the query should be routed normally.
+    /// If false, the request should be routed normally.
     /// Note: this a Scylla-specific optimisation. Therefore, the flag will be always false for Cassandra.
     pub is_confirmed_lwt: bool,
 }
 
-/// The fallback list of nodes in the query plan.
+/// The fallback list of nodes in the request plan.
 ///
 /// It is computed on-demand, only if querying the most preferred node fails
 /// (or when speculative execution is triggered).
 pub type FallbackPlan<'a> =
     Box<dyn Iterator<Item = (NodeRef<'a>, Option<Shard>)> + Send + Sync + 'a>;
 
-/// Policy that decides which nodes and shards to contact for each query.
+/// Policy that decides which nodes and shards to contact for each request.
 ///
-/// When a query is prepared to be sent to ScyllaDB/Cassandra, a `LoadBalancingPolicy`
+/// When a request is prepared to be sent to ScyllaDB/Cassandra, a `LoadBalancingPolicy`
 /// implementation constructs a load balancing plan. That plan is a list of
 /// targets (target is a node + an optional shard) to which
-/// the driver will try to send the query. The first elements of the plan are the targets which are
+/// the driver will try to send the request. The first elements of the plan are the targets which are
 /// the best to contact (e.g. they might have the lowest latency).
 ///
-/// Most queries are sent on the first try, so the query execution layer rarely needs to know more
+/// Most requests are sent on the first try, so the request execution layer rarely needs to know more
 /// than one target from plan. To better optimize that case, `LoadBalancingPolicy` has two methods:
-/// `pick` and `fallback`. `pick` returns the first target to contact for a given query, `fallback`
+/// `pick` and `fallback`. `pick` returns the first target to contact for a given request, `fallback`
 /// returns the rest of the load balancing plan.
 ///
 /// `fallback` is called not only if a send to `pick`ed node failed (or when executing
 /// speculatively), but also if `pick` returns `None`.
 ///
-/// Usually the driver needs only the first node from load balancing plan (most queries are send
+/// Usually the driver needs only the first node from load balancing plan (most requests are send
 /// successfully, and there is no need to retry).
 ///
-/// This trait is used to produce an iterator of nodes to contact for a given query.
+/// This trait is used to produce an iterator of nodes to contact for a given request.
 pub trait LoadBalancingPolicy: Send + Sync + std::fmt::Debug {
-    /// Returns the first node to contact for a given query.
+    /// Returns the first node to contact for a given request.
     fn pick<'a>(
         &'a self,
-        query: &'a RoutingInfo,
+        request: &'a RoutingInfo,
         cluster: &'a ClusterState,
     ) -> Option<(NodeRef<'a>, Option<Shard>)>;
 
-    /// Returns all contact-appropriate nodes for a given query.
+    /// Returns all contact-appropriate nodes for a given request.
     fn fallback<'a>(
         &'a self,
-        query: &'a RoutingInfo,
+        request: &'a RoutingInfo,
         cluster: &'a ClusterState,
     ) -> FallbackPlan<'a>;
 
-    /// Invoked each time a query succeeds.
-    fn on_query_success(&self, _query: &RoutingInfo, _latency: Duration, _node: NodeRef<'_>) {}
+    /// Invoked each time a request succeeds.
+    fn on_request_success(&self, _request: &RoutingInfo, _latency: Duration, _node: NodeRef<'_>) {}
 
-    /// Invoked each time a query fails.
-    fn on_query_failure(
+    /// Invoked each time a request fails.
+    fn on_request_failure(
         &self,
-        _query: &RoutingInfo,
+        _request: &RoutingInfo,
         _latency: Duration,
         _node: NodeRef<'_>,
         _error: &RequestAttemptError,

--- a/scylla/src/policies/retry/downgrading_consistency.rs
+++ b/scylla/src/policies/retry/downgrading_consistency.rs
@@ -2,7 +2,7 @@ use scylla_cql::Consistency;
 use tracing::debug;
 
 use super::{QueryInfo, RetryDecision, RetryPolicy, RetrySession};
-use crate::errors::{DbError, QueryError, WriteType};
+use crate::errors::{DbError, RequestAttemptError, WriteType};
 
 /// Downgrading consistency retry policy - retries with lower consistency level if it knows\
 /// that the initial CL is unreachable. Also, it behaves as [DefaultRetryPolicy](crate::policies::retry::DefaultRetryPolicy)
@@ -51,7 +51,7 @@ impl RetrySession for DowngradingConsistencyRetrySession {
         let cl = match query_info.consistency {
             Consistency::Serial | Consistency::LocalSerial => {
                 return match query_info.error {
-                    QueryError::DbError(DbError::Unavailable { .. }, _) => {
+                    RequestAttemptError::DbError(DbError::Unavailable { .. }, _) => {
                         // JAVA-764: if the requested consistency level is serial, it means that the operation failed at
                         // the paxos phase of a LWT.
                         // Retry on the next host, on the assumption that the initial coordinator could be network-isolated.
@@ -88,11 +88,10 @@ impl RetrySession for DowngradingConsistencyRetrySession {
         match query_info.error {
             // Basic errors - there are some problems on this node
             // Retry on a different one if possible
-            QueryError::BrokenConnection(_)
-            | QueryError::ConnectionPoolError(_)
-            | QueryError::DbError(DbError::Overloaded, _)
-            | QueryError::DbError(DbError::ServerError, _)
-            | QueryError::DbError(DbError::TruncateError, _) => {
+            RequestAttemptError::BrokenConnectionError(_)
+            | RequestAttemptError::DbError(DbError::Overloaded, _)
+            | RequestAttemptError::DbError(DbError::ServerError, _)
+            | RequestAttemptError::DbError(DbError::TruncateError, _) => {
                 if query_info.is_idempotent {
                     RetryDecision::RetryNextNode(None)
                 } else {
@@ -101,7 +100,7 @@ impl RetrySession for DowngradingConsistencyRetrySession {
             }
             // Unavailable - the current node believes that not enough nodes
             // are alive to satisfy specified consistency requirements.
-            QueryError::DbError(DbError::Unavailable { alive, .. }, _) => {
+            RequestAttemptError::DbError(DbError::Unavailable { alive, .. }, _) => {
                 if !self.was_retry {
                     self.was_retry = true;
                     max_likely_to_work_cl(*alive, cl)
@@ -110,7 +109,7 @@ impl RetrySession for DowngradingConsistencyRetrySession {
                 }
             }
             // ReadTimeout - coordinator didn't receive enough replies in time.
-            QueryError::DbError(
+            RequestAttemptError::DbError(
                 DbError::ReadTimeout {
                     received,
                     required,
@@ -132,7 +131,7 @@ impl RetrySession for DowngradingConsistencyRetrySession {
                 }
             }
             // Write timeout - coordinator didn't receive enough replies in time.
-            QueryError::DbError(
+            RequestAttemptError::DbError(
                 DbError::WriteTimeout {
                     write_type,
                     received,
@@ -161,9 +160,11 @@ impl RetrySession for DowngradingConsistencyRetrySession {
                 }
             }
             // The node is still bootstrapping it can't execute the query, we should try another one
-            QueryError::DbError(DbError::IsBootstrapping, _) => RetryDecision::RetryNextNode(None),
+            RequestAttemptError::DbError(DbError::IsBootstrapping, _) => {
+                RetryDecision::RetryNextNode(None)
+            }
             // Connection to the contacted node is overloaded, try another one
-            QueryError::UnableToAllocStreamId => RetryDecision::RetryNextNode(None),
+            RequestAttemptError::UnableToAllocStreamId => RetryDecision::RetryNextNode(None),
             // In all other cases propagate the error to the user
             _ => RetryDecision::DontRetry,
         }
@@ -177,8 +178,9 @@ impl RetrySession for DowngradingConsistencyRetrySession {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
+    use scylla_cql::frame::frame_errors::{BatchSerializationError, CqlRequestSerializationError};
 
-    use crate::errors::{BadQuery, BrokenConnectionErrorKind, ConnectionPoolError, ProtocolError};
+    use crate::errors::{BrokenConnectionErrorKind, RequestAttemptError};
     use crate::test_utils::setup_tracing;
 
     use super::*;
@@ -196,7 +198,7 @@ mod tests {
     ];
 
     fn make_query_info_with_cl(
-        error: &QueryError,
+        error: &RequestAttemptError,
         is_idempotent: bool,
         cl: Consistency,
     ) -> QueryInfo<'_> {
@@ -208,7 +210,10 @@ mod tests {
     }
 
     // Asserts that downgrading consistency policy never retries for this Error
-    fn downgrading_consistency_policy_assert_never_retries(error: QueryError, cl: Consistency) {
+    fn downgrading_consistency_policy_assert_never_retries(
+        error: RequestAttemptError,
+        cl: Consistency,
+    ) {
         let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info_with_cl(&error, false, cl)),
@@ -264,28 +269,39 @@ mod tests {
         for &cl in CONSISTENCY_LEVELS {
             for dberror in never_retried_dberrors.clone() {
                 downgrading_consistency_policy_assert_never_retries(
-                    QueryError::DbError(dberror, String::new()),
+                    RequestAttemptError::DbError(dberror, String::new()),
                     cl,
                 );
             }
 
             downgrading_consistency_policy_assert_never_retries(
-                QueryError::BadQuery(BadQuery::Other(
-                    "Length of provided values must be equal to number of batch statements \
-                        (got 1 values, 2 statements)"
-                        .to_owned(),
-                )),
+                RequestAttemptError::RepreparedIdMissingInBatch,
                 cl,
             );
             downgrading_consistency_policy_assert_never_retries(
-                ProtocolError::NonfinishedPagingState.into(),
+                RequestAttemptError::RepreparedIdChanged {
+                    statement: String::new(),
+                    expected_id: vec![],
+                    reprepared_id: vec![],
+                },
+                cl,
+            );
+            downgrading_consistency_policy_assert_never_retries(
+                RequestAttemptError::CqlRequestSerialization(
+                    CqlRequestSerializationError::BatchSerialization(
+                        BatchSerializationError::TooManyStatements(u16::MAX as usize + 1),
+                    ),
+                ),
                 cl,
             );
         }
     }
 
     // Asserts that for this error policy retries on next on idempotent queries only
-    fn downgrading_consistency_policy_assert_idempotent_next(error: QueryError, cl: Consistency) {
+    fn downgrading_consistency_policy_assert_idempotent_next(
+        error: RequestAttemptError,
+        cl: Consistency,
+    ) {
         let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
         assert_eq!(
             policy.decide_should_retry(make_query_info_with_cl(&error, false, cl)),
@@ -318,13 +334,12 @@ mod tests {
     fn downgrading_consistency_idempotent_next_retries() {
         setup_tracing();
         let idempotent_next_errors = vec![
-            QueryError::DbError(DbError::Overloaded, String::new()),
-            QueryError::DbError(DbError::TruncateError, String::new()),
-            QueryError::DbError(DbError::ServerError, String::new()),
-            QueryError::BrokenConnection(
+            RequestAttemptError::DbError(DbError::Overloaded, String::new()),
+            RequestAttemptError::DbError(DbError::TruncateError, String::new()),
+            RequestAttemptError::DbError(DbError::ServerError, String::new()),
+            RequestAttemptError::BrokenConnectionError(
                 BrokenConnectionErrorKind::TooManyOrphanedStreamIds(5).into(),
             ),
-            QueryError::ConnectionPoolError(ConnectionPoolError::Initializing),
         ];
 
         for &cl in CONSISTENCY_LEVELS {
@@ -338,7 +353,7 @@ mod tests {
     #[test]
     fn downgrading_consistency_bootstrapping() {
         setup_tracing();
-        let error = QueryError::DbError(DbError::IsBootstrapping, String::new());
+        let error = RequestAttemptError::DbError(DbError::IsBootstrapping, String::new());
 
         for &cl in CONSISTENCY_LEVELS {
             let mut policy = DowngradingConsistencyRetryPolicy::new().new_session();
@@ -360,7 +375,7 @@ mod tests {
     fn downgrading_consistency_unavailable() {
         setup_tracing();
         let alive = 1;
-        let error = QueryError::DbError(
+        let error = RequestAttemptError::DbError(
             DbError::Unavailable {
                 consistency: Consistency::Two,
                 required: 2,
@@ -399,7 +414,7 @@ mod tests {
     fn downgrading_consistency_read_timeout() {
         setup_tracing();
         // Enough responses and data_present == false - coordinator received only checksums
-        let enough_responses_no_data = QueryError::DbError(
+        let enough_responses_no_data = RequestAttemptError::DbError(
             DbError::ReadTimeout {
                 consistency: Consistency::Two,
                 received: 2,
@@ -450,7 +465,7 @@ mod tests {
         }
         // Enough responses but data_present == true - coordinator probably timed out
         // waiting for read-repair acknowledgement.
-        let enough_responses_with_data = QueryError::DbError(
+        let enough_responses_with_data = RequestAttemptError::DbError(
             DbError::ReadTimeout {
                 consistency: Consistency::Two,
                 received: 2,
@@ -486,7 +501,7 @@ mod tests {
 
         // Not enough responses, data_present == true
         let received = 1;
-        let not_enough_responses_with_data = QueryError::DbError(
+        let not_enough_responses_with_data = RequestAttemptError::DbError(
             DbError::ReadTimeout {
                 consistency: Consistency::Two,
                 received,
@@ -548,7 +563,7 @@ mod tests {
         setup_tracing();
         for (received, required) in (1..=5).zip(2..=6) {
             // WriteType == BatchLog
-            let write_type_batchlog = QueryError::DbError(
+            let write_type_batchlog = RequestAttemptError::DbError(
                 DbError::WriteTimeout {
                     consistency: Consistency::Two,
                     received,
@@ -591,7 +606,7 @@ mod tests {
             }
 
             // WriteType == UnloggedBatch
-            let write_type_unlogged_batch = QueryError::DbError(
+            let write_type_unlogged_batch = RequestAttemptError::DbError(
                 DbError::WriteTimeout {
                     consistency: Consistency::Two,
                     received,
@@ -634,7 +649,7 @@ mod tests {
             }
 
             // WriteType == other
-            let write_type_other = QueryError::DbError(
+            let write_type_other = RequestAttemptError::DbError(
                 DbError::WriteTimeout {
                     consistency: Consistency::Two,
                     received,

--- a/scylla/src/policies/retry/fallthrough.rs
+++ b/scylla/src/policies/retry/fallthrough.rs
@@ -1,4 +1,4 @@
-use super::{QueryInfo, RetryDecision, RetryPolicy, RetrySession};
+use super::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 
 /// Forwards all errors directly to the user, never retries
 #[derive(Debug)]
@@ -24,7 +24,7 @@ impl RetryPolicy for FallthroughRetryPolicy {
 }
 
 impl RetrySession for FallthroughRetrySession {
-    fn decide_should_retry(&mut self, _query_info: QueryInfo) -> RetryDecision {
+    fn decide_should_retry(&mut self, _query_info: RequestInfo) -> RetryDecision {
         RetryDecision::DontRetry
     }
 

--- a/scylla/src/policies/retry/mod.rs
+++ b/scylla/src/policies/retry/mod.rs
@@ -8,4 +8,4 @@ pub use downgrading_consistency::{
     DowngradingConsistencyRetryPolicy, DowngradingConsistencyRetrySession,
 };
 pub use fallthrough::{FallthroughRetryPolicy, FallthroughRetrySession};
-pub use retry_policy::{QueryInfo, RetryDecision, RetryPolicy, RetrySession};
+pub use retry_policy::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};

--- a/scylla/src/policies/retry/retry_policy.rs
+++ b/scylla/src/policies/retry/retry_policy.rs
@@ -2,13 +2,13 @@
 //! To decide when to retry a query the `Session` can use any object which implements
 //! the `RetryPolicy` trait
 
-use crate::errors::QueryError;
+use crate::errors::RequestAttemptError;
 use crate::frame::types::Consistency;
 
 /// Information about a failed query
 pub struct QueryInfo<'a> {
     /// The error with which the query failed
-    pub error: &'a QueryError,
+    pub error: &'a RequestAttemptError,
     /// A query is idempotent if it can be applied multiple times without changing the result of the initial application\
     /// If set to `true` we can be sure that it is idempotent\
     /// If set to `false` it is unknown whether it is idempotent

--- a/scylla/src/policies/retry/retry_policy.rs
+++ b/scylla/src/policies/retry/retry_policy.rs
@@ -1,19 +1,19 @@
-//! Query retries configurations\
-//! To decide when to retry a query the `Session` can use any object which implements
+//! Request retries configurations\
+//! To decide when to retry a request the `Session` can use any object which implements
 //! the `RetryPolicy` trait
 
 use crate::errors::RequestAttemptError;
 use crate::frame::types::Consistency;
 
-/// Information about a failed query
-pub struct QueryInfo<'a> {
-    /// The error with which the query failed
+/// Information about a failed request
+pub struct RequestInfo<'a> {
+    /// The error with which the request failed
     pub error: &'a RequestAttemptError,
-    /// A query is idempotent if it can be applied multiple times without changing the result of the initial application\
+    /// A request is idempotent if it can be applied multiple times without changing the result of the initial application\
     /// If set to `true` we can be sure that it is idempotent\
     /// If set to `false` it is unknown whether it is idempotent
     pub is_idempotent: bool,
-    /// Consistency with which the query failed
+    /// Consistency with which the request failed
     pub consistency: Consistency,
 }
 
@@ -25,18 +25,18 @@ pub enum RetryDecision {
     IgnoreWriteError,
 }
 
-/// Specifies a policy used to decide when to retry a query
+/// Specifies a policy used to decide when to retry a request
 pub trait RetryPolicy: std::fmt::Debug + Send + Sync {
-    /// Called for each new query, starts a session of deciding about retries
+    /// Called for each new request, starts a session of deciding about retries
     fn new_session(&self) -> Box<dyn RetrySession>;
 }
 
-/// Used throughout a single query to decide when to retry it
-/// After this query is finished it is destroyed or reset
+/// Used throughout a single request to decide when to retry it
+/// After this request is finished it is destroyed or reset
 pub trait RetrySession: Send + Sync {
-    /// Called after the query failed - decide what to do next
-    fn decide_should_retry(&mut self, query_info: QueryInfo) -> RetryDecision;
+    /// Called after the request failed - decide what to do next
+    fn decide_should_retry(&mut self, request_info: RequestInfo) -> RetryDecision;
 
-    /// Reset before using for a new query
+    /// Reset before using for a new request
     fn reset(&mut self);
 }

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -44,7 +44,9 @@ impl QueryResponse {
     }
 
     pub(crate) fn into_query_result(self) -> Result<QueryResult, QueryError> {
-        self.into_non_error_query_response()?.into_query_result()
+        self.into_non_error_query_response()
+            .map_err(UserRequestError::into_query_error)?
+            .into_query_result()
     }
 }
 
@@ -85,7 +87,9 @@ impl NonErrorQueryResponse {
     }
 
     pub(crate) fn into_query_result(self) -> Result<QueryResult, QueryError> {
-        let (result, paging_state) = self.into_query_result_and_paging_state()?;
+        let (result, paging_state) = self
+            .into_query_result_and_paging_state()
+            .map_err(UserRequestError::into_query_error)?;
 
         if !paging_state.finished() {
             error!(

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -97,9 +97,9 @@ impl<const NODE: u8> RetryPolicy for BoundToPredefinedNodePolicy<NODE> {
 impl<const NODE: u8> RetrySession for BoundToPredefinedNodePolicy<NODE> {
     fn decide_should_retry(
         &mut self,
-        query_info: scylla::policies::retry::QueryInfo,
+        request_info: scylla::policies::retry::RequestInfo,
     ) -> scylla::policies::retry::RetryDecision {
-        self.report_consistency(query_info.consistency);
+        self.report_consistency(request_info.consistency);
         scylla::policies::retry::RetryDecision::DontRetry
     }
 

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -65,7 +65,7 @@ impl<const NODE: u8> LoadBalancingPolicy for BoundToPredefinedNodePolicy<NODE> {
         Box::new(std::iter::empty())
     }
 
-    fn on_query_success(
+    fn on_request_success(
         &self,
         _query: &RoutingInfo,
         _latency: std::time::Duration,
@@ -73,7 +73,7 @@ impl<const NODE: u8> LoadBalancingPolicy for BoundToPredefinedNodePolicy<NODE> {
     ) {
     }
 
-    fn on_query_failure(
+    fn on_request_failure(
         &self,
         _query: &RoutingInfo,
         _latency: std::time::Duration,

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -78,7 +78,7 @@ impl<const NODE: u8> LoadBalancingPolicy for BoundToPredefinedNodePolicy<NODE> {
         _query: &RoutingInfo,
         _latency: std::time::Duration,
         _node: NodeRef<'_>,
-        _error: &scylla::errors::QueryError,
+        _error: &scylla::errors::RequestAttemptError,
     ) {
     }
 


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## run_request_once closure
To narrow the error return types of some important API functions (e.g. `RS::decide_should_retry` and `LBP::on_query_failure`), the error type of `execute_request_once` (previously known as `do_query`) needs to be adjusted as well. A couple of commits at the beginning of this PR do just that. What we achieve, is that we narrow the return error type of the closure from `QueryError` to `UserRequestError`.

## UserRequestError
This error is renamed to `RequestAttemptError` - as the name suggests, it represents a failure of a single attempt of execution.

## LBP and RetrySession
Both of these traits accept some error and do something based on the error. Before this PR, they would accept a `QueryError`, resulting in matches against variants that could never even be constructed before the call. In this PR, I pub-ified the `RequestAttemptError`, and made `LBP::on_query_failure` and `RetrySession::decide_should_retry` accept it instead of `QueryError`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
