### PR TITLE
README: Use absolute link for image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/monster+rust.png" height="150" align="right">
+<img src="https://github.com/scylladb/scylla-rust-driver/raw/main/assets/monster+rust.png" height="150" align="right">
 
 # ScyllaDB Rust Driver
 


### PR DESCRIPTION
crates.io doesn't handle relative links well, so currently our logo is not visible on crates.io :(
![image](https://github.com/user-attachments/assets/7b796287-238d-425a-91b6-ca56da873081)

Relevant crates.io issue: https://github.com/rust-lang/crates.io/issues/9939

This PR changes the link to be absolute so that we are not bitten by this again.
It is a bit sad to do this, because now you need internet to render the README locally, and it just feels a bit wrong
to refer to the outside file instead of the file in the same filetree, but I don't see any better option for now.

OTOH if we ever decide to change the logo, the new one will be automatically visible in any place that uses absolute link, which is a plus.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
