### PR TITLE
errors: narrow error types accepted by `HistoryListener`

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -148,7 +148,7 @@ struct PagerWorker<'a, QueryFunc, SpanCreatorFunc> {
     paging_state: PagingState,
 
     history_listener: Option<Arc<dyn HistoryListener>>,
-    current_query_id: Option<history::QueryId>,
+    current_request_id: Option<history::RequestId>,
     current_attempt_id: Option<history::AttemptId>,
 
     parent_span: tracing::Span,
@@ -398,7 +398,7 @@ where
             None => return,
         };
 
-        self.current_query_id = Some(history_listener.log_query_start());
+        self.current_request_id = Some(history_listener.log_query_start());
     }
 
     fn log_query_success(&mut self) {
@@ -407,12 +407,12 @@ where
             None => return,
         };
 
-        let query_id: history::QueryId = match &self.current_query_id {
+        let request_id: history::RequestId = match &self.current_request_id {
             Some(id) => *id,
             None => return,
         };
 
-        history_listener.log_query_success(query_id);
+        history_listener.log_query_success(request_id);
     }
 
     fn log_query_error(&mut self, error: &RequestError) {
@@ -421,12 +421,12 @@ where
             None => return,
         };
 
-        let query_id: history::QueryId = match &self.current_query_id {
+        let request_id: history::RequestId = match &self.current_request_id {
             Some(id) => *id,
             None => return,
         };
 
-        history_listener.log_query_error(query_id, error);
+        history_listener.log_query_error(request_id, error);
     }
 
     fn log_attempt_start(&mut self, node_addr: SocketAddr) {
@@ -435,13 +435,13 @@ where
             None => return,
         };
 
-        let query_id: history::QueryId = match &self.current_query_id {
+        let request_id: history::RequestId = match &self.current_request_id {
             Some(id) => *id,
             None => return,
         };
 
         self.current_attempt_id =
-            Some(history_listener.log_attempt_start(query_id, None, node_addr));
+            Some(history_listener.log_attempt_start(request_id, None, node_addr));
     }
 
     fn log_attempt_success(&mut self) {
@@ -754,7 +754,7 @@ impl QueryPager {
                 metrics,
                 paging_state: PagingState::start(),
                 history_listener: query.config.history_listener.clone(),
-                current_query_id: None,
+                current_request_id: None,
                 current_attempt_id: None,
                 parent_span,
                 span_creator,
@@ -872,7 +872,7 @@ impl QueryPager {
                 metrics: config.metrics,
                 paging_state: PagingState::start(),
                 history_listener: config.prepared.config.history_listener.clone(),
-                current_query_id: None,
+                current_request_id: None,
                 current_attempt_id: None,
                 parent_span,
                 span_creator,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1979,13 +1979,7 @@ where
             Some(timeout) => tokio::time::timeout(timeout, runner)
                 .await
                 .map(|res| res.map_err(RequestError::into_query_error))
-                .unwrap_or_else(|e| {
-                    Err(QueryError::RequestTimeout(format!(
-                        "Request took longer than {}ms: {}",
-                        timeout.as_millis(),
-                        e
-                    )))
-                }),
+                .unwrap_or_else(|_| Err(QueryError::RequestTimeout(timeout))),
             None => runner.await.map_err(RequestError::into_query_error),
         };
 
@@ -2144,8 +2138,8 @@ where
             self.await_schema_agreement_indefinitely(),
         )
         .await
-        .unwrap_or(Err(QueryError::RequestTimeout(
-            "schema agreement not reached in time".to_owned(),
+        .unwrap_or(Err(QueryError::SchemaAgreementTimeout(
+            self.schema_agreement_timeout,
         )))
     }
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1854,7 +1854,7 @@ where
             statement_config
                 .history_listener
                 .as_ref()
-                .map(|hl| (&**hl, hl.log_query_start()));
+                .map(|hl| (&**hl, hl.log_request_start()));
 
         let load_balancer = &execution_profile.load_balancing_policy;
 
@@ -1987,8 +1987,8 @@ where
 
         if let Some((history_listener, request_id)) = history_listener_and_id {
             match &result {
-                Ok(_) => history_listener.log_query_success(request_id),
-                Err(e) => history_listener.log_query_error(request_id, e),
+                Ok(_) => history_listener.log_request_success(request_id),
+                Err(e) => history_listener.log_request_error(request_id, e),
             }
         }
 

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -904,6 +904,13 @@ pub enum RequestError {
     #[error("No connections in the pool: {0}")]
     ConnectionPoolError(#[from] ConnectionPoolError),
 
+    /// Failed to run a request within a provided client timeout.
+    #[error(
+            "Request execution exceeded a client timeout of {}ms",
+            std::time::Duration::as_millis(.0)
+        )]
+    RequestTimeout(std::time::Duration),
+
     /// Failed to execute request.
     #[error(transparent)]
     LastAttemptError(#[from] RequestAttemptError),
@@ -914,6 +921,7 @@ impl RequestError {
         match self {
             RequestError::EmptyPlan => QueryError::EmptyPlan,
             RequestError::ConnectionPoolError(e) => e.into(),
+            RequestError::RequestTimeout(dur) => QueryError::RequestTimeout(dur),
             RequestError::LastAttemptError(e) => e.into_query_error(),
         }
     }

--- a/scylla/src/observability/history.rs
+++ b/scylla/src/observability/history.rs
@@ -400,9 +400,9 @@ impl From<&HistoryCollectorData> for StructuredHistory {
 /// StructuredHistory should be used for printing query history.
 impl Display for StructuredHistory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Queries History:")?;
+        writeln!(f, "Requests History:")?;
         for (i, query) in self.requests.iter().enumerate() {
-            writeln!(f, "=== Query #{} ===", i)?;
+            writeln!(f, "=== Request #{} ===", i)?;
             writeln!(f, "| start_time: {}", query.start_time)?;
             writeln!(f, "| Non-speculative attempts:")?;
             write_fiber_attempts(&query.non_speculative_fiber, f)?;
@@ -416,13 +416,13 @@ impl Display for StructuredHistory {
             writeln!(f, "|")?;
             match &query.result {
                 Some(RequestHistoryResult::Success(succ_time)) => {
-                    writeln!(f, "| Query successful at {}", succ_time)?;
+                    writeln!(f, "| Request successful at {}", succ_time)?;
                 }
                 Some(RequestHistoryResult::Error(err_time, error)) => {
-                    writeln!(f, "| Query failed at {}", err_time)?;
+                    writeln!(f, "| Request failed at {}", err_time)?;
                     writeln!(f, "| Error: {}", error)?;
                 }
-                None => writeln!(f, "| Query still running - no final result yet")?,
+                None => writeln!(f, "| Request still running - no final result yet")?,
             };
             writeln!(f, "=================")?;
         }
@@ -546,7 +546,7 @@ mod tests {
 
         assert!(history.requests.is_empty());
 
-        let displayed = "Queries History:
+        let displayed = "Requests History:
 ";
         assert_eq!(displayed, format!("{}", history));
     }
@@ -567,12 +567,12 @@ mod tests {
             .is_empty());
         assert!(history.requests[0].speculative_fibers.is_empty());
 
-        let displayed = "Queries History:
-=== Query #0 ===
+        let displayed = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 |
-| Query still running - no final result yet
+| Request still running - no final result yet
 =================
 ";
 
@@ -600,15 +600,15 @@ mod tests {
             Some(AttemptResult::Success(_))
         );
 
-        let displayed = "Queries History:
-=== Query #0 ===
+        let displayed = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
 ";
         assert_eq!(displayed, format!("{}", set_one_time(history)));
@@ -645,8 +645,8 @@ mod tests {
         let history: StructuredHistory = history_collector.clone_structured_history();
 
         let displayed =
-"Queries History:
-=== Query #0 ===
+"Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
@@ -661,7 +661,7 @@ mod tests {
 |   Error: Database returned an error: Not enough nodes are alive to satisfy required consistency level (consistency: Quorum, required: 2, alive: 1), Error message: Not enough nodes to satisfy consistency
 |   Retry decision: DontRetry
 |
-| Query failed at 2022-02-22 20:22:22 UTC
+| Request failed at 2022-02-22 20:22:22 UTC
 | Error: Database returned an error: Not enough nodes are alive to satisfy required consistency level (consistency: Quorum, required: 2, alive: 1), Error message: Not enough nodes to satisfy consistency
 =================
 ";
@@ -696,8 +696,8 @@ mod tests {
             .attempts
             .is_empty());
 
-        let displayed = "Queries History:
-=== Query #0 ===
+        let displayed = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 |
@@ -713,7 +713,7 @@ mod tests {
 | > Speculative fiber #2
 | fiber start time: 2022-02-22 20:22:22 UTC
 |
-| Query still running - no final result yet
+| Request still running - no final result yet
 =================
 ";
         assert_eq!(displayed, format!("{}", set_one_time(history)));
@@ -772,8 +772,8 @@ mod tests {
 
         let history: StructuredHistory = history_collector.clone_structured_history();
 
-        let displayed = "Queries History:
-=== Query #0 ===
+        let displayed = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
@@ -819,7 +819,7 @@ mod tests {
 |   request send time: 2022-02-22 20:22:22 UTC
 |   No result yet
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
 ";
         assert_eq!(displayed, format!("{}", set_one_time(history)));
@@ -851,8 +851,8 @@ mod tests {
 
         let history: StructuredHistory = history_collector.clone_structured_history();
 
-        let displayed = "Queries History:
-=== Query #0 ===
+        let displayed = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
@@ -865,16 +865,16 @@ mod tests {
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
-=== Query #1 ===
+=== Request #1 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
 ";
         assert_eq!(displayed, format!("{}", set_one_time(history)));

--- a/scylla/src/observability/history.rs
+++ b/scylla/src/observability/history.rs
@@ -1,4 +1,4 @@
-//! Collecting history of query executions - retries, speculative, etc.
+//! Collecting history of request executions - retries, speculative, etc.
 use std::{
     collections::BTreeMap,
     fmt::{Debug, Display},
@@ -17,7 +17,7 @@ use tracing::warn;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct RequestId(pub usize);
 
-/// Id of a single attempt within a query, a single request sent on some connection.
+/// Id of a single attempt within a request run - a single request sent on some connection.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct AttemptId(pub usize);
 
@@ -33,17 +33,17 @@ pub struct SpeculativeId(pub usize);
 /// `Query`, `PreparedStatement`, etc...\
 /// The listener has to generate unique IDs for new requests, attempts and speculative fibers.
 /// These ids are then used by the caller to identify them.\
-/// It's important to note that even after a query is finished there still might come events related to it.
-/// These events come from speculative futures that didn't notice the query is done already.
+/// It's important to note that even after a request is finished there still might come events related to it.
+/// These events come from speculative futures that didn't notice the request is done already.
 pub trait HistoryListener: Debug + Send + Sync {
-    /// Log that a query has started on query start - right after the call to Session::{query,execute}_*/batch.
-    fn log_query_start(&self) -> RequestId;
+    /// Log that a request has started on request start - right after the call to Session::{query,execute}_*/batch.
+    fn log_request_start(&self) -> RequestId;
 
-    /// Log that query was successful - called right before returning the result from Session::query_*, execute_*, etc.
-    fn log_query_success(&self, request_id: RequestId);
+    /// Log that request was successful - called right before returning the result from Session::query_*, execute_*, etc.
+    fn log_request_success(&self, request_id: RequestId);
 
-    /// Log that query ended with an error - called right before returning the error from Session::query_*, execute_*, etc.
-    fn log_query_error(&self, request_id: RequestId, error: &RequestError);
+    /// Log that request ended with an error - called right before returning the error from Session::query_*, execute_*, etc.
+    fn log_request_error(&self, request_id: RequestId, error: &RequestError);
 
     /// Log that a new speculative fiber has started.
     fn log_new_speculative_fiber(&self, request_id: RequestId) -> SpeculativeId;
@@ -70,7 +70,7 @@ pub trait HistoryListener: Debug + Send + Sync {
 
 pub type TimePoint = DateTime<Utc>;
 
-/// HistoryCollector can be used as HistoryListener to collect all the query history events.
+/// HistoryCollector can be used as HistoryListener to collect all the request history events.
 /// Each event is marked with an UTC timestamp.
 #[derive(Debug, Default)]
 pub struct HistoryCollector {
@@ -87,9 +87,9 @@ pub struct HistoryCollectorData {
 
 #[derive(Debug, Clone)]
 pub enum HistoryEvent {
-    NewQuery(RequestId),
-    QuerySuccess(RequestId),
-    QueryError(RequestId, RequestError),
+    NewRequest(RequestId),
+    RequestSuccess(RequestId),
+    RequestError(RequestId, RequestError),
     NewSpeculativeFiber(SpeculativeId, RequestId),
     NewAttempt(AttemptId, RequestId, Option<SpeculativeId>, SocketAddr),
     AttemptSuccess(AttemptId),
@@ -130,7 +130,7 @@ impl HistoryCollector {
     }
 
     /// Takes the data out of the collector. The collected events are cleared.\
-    /// It's possible that after finishing a query and taking out the events
+    /// It's possible that after finishing a request and taking out the events
     /// new ones will still come - from requests that haven't been cancelled yet.
     pub fn take_collected(&self) -> HistoryCollectorData {
         self.do_with_data(|data| {
@@ -174,24 +174,24 @@ impl HistoryCollector {
 }
 
 impl HistoryListener for HistoryCollector {
-    fn log_query_start(&self) -> RequestId {
+    fn log_request_start(&self) -> RequestId {
         self.do_with_data(|data| {
             let new_request_id: RequestId = data.next_request_id;
             data.next_request_id.0 += 1;
-            data.add_event(HistoryEvent::NewQuery(new_request_id));
+            data.add_event(HistoryEvent::NewRequest(new_request_id));
             new_request_id
         })
     }
 
-    fn log_query_success(&self, request_id: RequestId) {
+    fn log_request_success(&self, request_id: RequestId) {
         self.do_with_data(|data| {
-            data.add_event(HistoryEvent::QuerySuccess(request_id));
+            data.add_event(HistoryEvent::RequestSuccess(request_id));
         })
     }
 
-    fn log_query_error(&self, request_id: RequestId, error: &RequestError) {
+    fn log_request_error(&self, request_id: RequestId, error: &RequestError) {
         self.do_with_data(|data| {
-            data.add_event(HistoryEvent::QueryError(request_id, error.clone()))
+            data.add_event(HistoryEvent::RequestError(request_id, error.clone()))
         })
     }
 
@@ -323,7 +323,7 @@ impl From<&HistoryCollectorData> for StructuredHistory {
                         None => warn!("StructuredHistory - attempt with id {:?} finished with an error but not created", attempt_id)
                     }
                 }
-                HistoryEvent::NewQuery(request_id) => {
+                HistoryEvent::NewRequest(request_id) => {
                     requests.insert(
                         *request_id,
                         RequestHistory {
@@ -337,14 +337,14 @@ impl From<&HistoryCollectorData> for StructuredHistory {
                         },
                     );
                 }
-                HistoryEvent::QuerySuccess(request_id) => {
-                    if let Some(query) = requests.get_mut(request_id) {
-                        query.result = Some(RequestHistoryResult::Success(*event_time));
+                HistoryEvent::RequestSuccess(request_id) => {
+                    if let Some(request) = requests.get_mut(request_id) {
+                        request.result = Some(RequestHistoryResult::Success(*event_time));
                     }
                 }
-                HistoryEvent::QueryError(request_id, error) => {
-                    if let Some(query) = requests.get_mut(request_id) {
-                        query.result =
+                HistoryEvent::RequestError(request_id, error) => {
+                    if let Some(request) = requests.get_mut(request_id) {
+                        request.result =
                             Some(RequestHistoryResult::Error(*event_time, error.clone()));
                     }
                 }
@@ -371,8 +371,8 @@ impl From<&HistoryCollectorData> for StructuredHistory {
                             }
                         }
                         None => {
-                            if let Some(query) = requests.get_mut(request_id) {
-                                query.non_speculative_fiber.attempts.push(attempt);
+                            if let Some(request) = requests.get_mut(request_id) {
+                                request.non_speculative_fiber.attempts.push(attempt);
                             }
                         }
                     }
@@ -384,8 +384,8 @@ impl From<&HistoryCollectorData> for StructuredHistory {
         for (event, _) in &data.events {
             if let HistoryEvent::NewSpeculativeFiber(speculative_id, request_id) = event {
                 if let Some(fiber) = fibers.remove(speculative_id) {
-                    if let Some(query) = requests.get_mut(request_id) {
-                        query.speculative_fibers.push(fiber);
+                    if let Some(request) = requests.get_mut(request_id) {
+                        request.speculative_fibers.push(fiber);
                     }
                 }
             }
@@ -397,16 +397,16 @@ impl From<&HistoryCollectorData> for StructuredHistory {
     }
 }
 
-/// StructuredHistory should be used for printing query history.
+/// StructuredHistory should be used for printing request history.
 impl Display for StructuredHistory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Requests History:")?;
-        for (i, query) in self.requests.iter().enumerate() {
+        for (i, request) in self.requests.iter().enumerate() {
             writeln!(f, "=== Request #{} ===", i)?;
-            writeln!(f, "| start_time: {}", query.start_time)?;
+            writeln!(f, "| start_time: {}", request.start_time)?;
             writeln!(f, "| Non-speculative attempts:")?;
-            write_fiber_attempts(&query.non_speculative_fiber, f)?;
-            for (spec_i, speculative_fiber) in query.speculative_fibers.iter().enumerate() {
+            write_fiber_attempts(&request.non_speculative_fiber, f)?;
+            for (spec_i, speculative_fiber) in request.speculative_fibers.iter().enumerate() {
                 writeln!(f, "|")?;
                 writeln!(f, "|")?;
                 writeln!(f, "| > Speculative fiber #{}", spec_i)?;
@@ -414,7 +414,7 @@ impl Display for StructuredHistory {
                 write_fiber_attempts(speculative_fiber, f)?;
             }
             writeln!(f, "|")?;
-            match &query.result {
+            match &request.result {
                 Some(RequestHistoryResult::Success(succ_time)) => {
                     writeln!(f, "| Request successful at {}", succ_time)?;
                 }
@@ -481,16 +481,16 @@ mod tests {
             Utc,
         );
 
-        for query in &mut history.requests {
-            query.start_time = the_time;
-            match &mut query.result {
+        for request in &mut history.requests {
+            request.start_time = the_time;
+            match &mut request.result {
                 Some(RequestHistoryResult::Success(succ_time)) => *succ_time = the_time,
                 Some(RequestHistoryResult::Error(err_time, _)) => *err_time = the_time,
                 None => {}
             };
 
-            for fiber in std::iter::once(&mut query.non_speculative_fiber)
-                .chain(query.speculative_fibers.iter_mut())
+            for fiber in std::iter::once(&mut request.non_speculative_fiber)
+                .chain(request.speculative_fibers.iter_mut())
             {
                 fiber.start_time = the_time;
                 for attempt in &mut fiber.attempts {
@@ -552,11 +552,11 @@ mod tests {
     }
 
     #[test]
-    fn empty_query() {
+    fn empty_request() {
         setup_tracing();
         let history_collector = HistoryCollector::new();
 
-        let _request_id: RequestId = history_collector.log_query_start();
+        let _request_id: RequestId = history_collector.log_request_start();
 
         let history: StructuredHistory = history_collector.clone_structured_history();
 
@@ -584,11 +584,11 @@ mod tests {
         setup_tracing();
         let history_collector = HistoryCollector::new();
 
-        let request_id: RequestId = history_collector.log_query_start();
+        let request_id: RequestId = history_collector.log_request_start();
         let attempt_id: AttemptId =
             history_collector.log_attempt_start(request_id, None, node1_addr());
         history_collector.log_attempt_success(attempt_id);
-        history_collector.log_query_success(request_id);
+        history_collector.log_request_success(request_id);
 
         let history: StructuredHistory = history_collector.clone_structured_history();
 
@@ -619,7 +619,7 @@ mod tests {
         setup_tracing();
         let history_collector = HistoryCollector::new();
 
-        let request_id: RequestId = history_collector.log_query_start();
+        let request_id: RequestId = history_collector.log_request_start();
 
         let attempt_id: AttemptId =
             history_collector.log_attempt_start(request_id, None, node1_addr());
@@ -637,7 +637,7 @@ mod tests {
             &RetryDecision::DontRetry,
         );
 
-        history_collector.log_query_error(
+        history_collector.log_request_error(
             request_id,
             &RequestError::LastAttemptError(unavailable_error()),
         );
@@ -673,7 +673,7 @@ mod tests {
         setup_tracing();
         let history_collector = HistoryCollector::new();
 
-        let request_id: RequestId = history_collector.log_query_start();
+        let request_id: RequestId = history_collector.log_request_start();
         history_collector.log_new_speculative_fiber(request_id);
         history_collector.log_new_speculative_fiber(request_id);
         history_collector.log_new_speculative_fiber(request_id);
@@ -724,7 +724,7 @@ mod tests {
         setup_tracing();
         let history_collector = HistoryCollector::new();
 
-        let request_id: RequestId = history_collector.log_query_start();
+        let request_id: RequestId = history_collector.log_request_start();
 
         let attempt1: AttemptId =
             history_collector.log_attempt_start(request_id, None, node1_addr());
@@ -768,7 +768,7 @@ mod tests {
             history_collector.log_attempt_start(request_id, Some(speculative4), node2_addr());
 
         history_collector.log_attempt_success(spec2_attempt2);
-        history_collector.log_query_success(request_id);
+        history_collector.log_request_success(request_id);
 
         let history: StructuredHistory = history_collector.clone_structured_history();
 
@@ -830,24 +830,24 @@ mod tests {
         setup_tracing();
         let history_collector = HistoryCollector::new();
 
-        let query1_id: RequestId = history_collector.log_query_start();
-        let query1_attempt1: AttemptId =
-            history_collector.log_attempt_start(query1_id, None, node1_addr());
+        let request1_id: RequestId = history_collector.log_request_start();
+        let request1_attempt1: AttemptId =
+            history_collector.log_attempt_start(request1_id, None, node1_addr());
         history_collector.log_attempt_error(
-            query1_attempt1,
+            request1_attempt1,
             &unexpected_response(CqlResponseKind::Supported),
             &RetryDecision::RetryNextNode(Some(Consistency::Quorum)),
         );
-        let query1_attempt2: AttemptId =
-            history_collector.log_attempt_start(query1_id, None, node2_addr());
-        history_collector.log_attempt_success(query1_attempt2);
-        history_collector.log_query_success(query1_id);
+        let request1_attempt2: AttemptId =
+            history_collector.log_attempt_start(request1_id, None, node2_addr());
+        history_collector.log_attempt_success(request1_attempt2);
+        history_collector.log_request_success(request1_id);
 
-        let query2_id: RequestId = history_collector.log_query_start();
-        let query2_attempt1: AttemptId =
-            history_collector.log_attempt_start(query2_id, None, node1_addr());
-        history_collector.log_attempt_success(query2_attempt1);
-        history_collector.log_query_success(query2_id);
+        let request2_id: RequestId = history_collector.log_request_start();
+        let request2_attempt1: AttemptId =
+            history_collector.log_attempt_start(request2_id, None, node1_addr());
+        history_collector.log_attempt_success(request2_attempt1);
+        history_collector.log_request_success(request2_id);
 
         let history: StructuredHistory = history_collector.clone_structured_history();
 

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -97,6 +97,9 @@ fn can_be_ignored<ResT>(result: &Result<ResT, RequestError>) -> bool {
             // in the future, it should not be ignored.
             RequestError::EmptyPlan => false,
 
+            // Request execution timed out.
+            RequestError::RequestTimeout(_) => false,
+
             // Can try on another node.
             RequestError::ConnectionPoolError { .. } => true,
 

--- a/scylla/tests/integration/history.rs
+++ b/scylla/tests/integration/history.rs
@@ -119,15 +119,15 @@ async fn successful_query_history() {
 
     let history: StructuredHistory = history_collector.clone_structured_history();
 
-    let displayed = "Queries History:
-=== Query #0 ===
+    let displayed = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
 ";
     assert_eq!(
@@ -144,24 +144,24 @@ async fn successful_query_history() {
 
     let history2: StructuredHistory = history_collector.clone_structured_history();
 
-    let displayed2 = "Queries History:
-=== Query #0 ===
+    let displayed2 = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
-=== Query #1 ===
+=== Request #1 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
 ";
     assert_eq!(
@@ -187,8 +187,8 @@ async fn failed_query_history() {
     let history: StructuredHistory = history_collector.clone_structured_history();
 
     let displayed =
-"Queries History:
-=== Query #0 ===
+"Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
@@ -197,7 +197,7 @@ async fn failed_query_history() {
 |   Error: Database returned an error: The submitted query has a syntax error, Error message: Error message from database
 |   Retry decision: DontRetry
 |
-| Query failed at 2022-02-22 20:22:22 UTC
+| Request failed at 2022-02-22 20:22:22 UTC
 | Error: Database returned an error: The submitted query has a syntax error, Error message: Error message from database
 =================
 ";
@@ -251,42 +251,42 @@ async fn iterator_query_history() {
 
     assert!(history.requests.len() >= 4);
 
-    let displayed_prefix = "Queries History:
-=== Query #0 ===
+    let displayed_prefix = "Requests History:
+=== Request #0 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
-=== Query #1 ===
+=== Request #1 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
-=== Query #2 ===
+=== Request #2 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
-=== Query #3 ===
+=== Request #3 ===
 | start_time: 2022-02-22 20:22:22 UTC
 | Non-speculative attempts:
 | - Attempt #0 sent to 127.0.0.1:19042
 |   request send time: 2022-02-22 20:22:22 UTC
 |   Success at 2022-02-22 20:22:22 UTC
 |
-| Query successful at 2022-02-22 20:22:22 UTC
+| Request successful at 2022-02-22 20:22:22 UTC
 =================
 ";
     let displayed_str = format!(


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## New error types and variants

### RequestError (reintroduced)
Error type returned by `run_request_speculative_fiber`. It represents either a definite request failure - last attempt error, connection pool error, or an empty plan error.

### Replaced QueryError::RequestTimeout
This error variant was not good for 2 reasons:
1. it contains stringified error message
2. it was used for both user requests timeouts, and schema agreement timeouts
I decoupled this variant into two separate variants that provide more context.

### RequestError::RequestTimeout
After refactoring the timeout errors in `QueryError`, I added the corresponding variant to `RequestError` (one introduced in this PR) as well.

## HistoryListener
### Narrowed error types passed to log_query_error and log_attempt_error.
`log_query_error` (or rather `log_request_error` after rename) now accepts `RequestError`. `log_attempt_error` now accepts `RequestAttemptError` (representing an error of a single attempt).

### Replaced "query" mentions with "request"
I did the replacement in trait methods, docstrings, tests etc. I tried to break the changes into multiple commits.

## Execution errors summary
Currently, in session layer we can distinguish 3 kind of errors:
- `RequestAttemptError` - a failure of a single attempt of request execution. It is used in public API in `RetrySession::decide_should_retry` and `HistoryListener::log_attempt_error`
- `RequestError` - a definite failure of request execution, after all (speculative) retries etc. In addition to `RequestAttemptError` it contains information about the empty plan and request timeout. It also contains `ConnectionPoolError` variant. This variant is not included in `RequestAttemptError`, because we don't want to log such error in execution history - there is a comment suggesting that (is it still true, though?). `RequestError` is used in public API in `HistoryListener::log_request_error`.
- `QueryError` - a top-level error returned by `Session` methods. It holds some additional information - e.g. about the failure of request preparation - values serialization etc.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
