### PR TITLE
errors: pager API errors refactor

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -803,7 +803,9 @@ impl QueryPager {
                 ) {
                 Ok(res) => res.unzip(),
                 Err(err) => {
-                    let (proof, _res) = ProvingSender::from(sender).send(Err(err)).await;
+                    let (proof, _res) = ProvingSender::from(sender)
+                        .send(Err(err.into_query_error()))
+                        .await;
                     return proof;
                 }
             };

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1235,6 +1235,7 @@ where
                 self.metrics.clone(),
             )
             .await
+            .map_err(QueryError::from)
         } else {
             // Making QueryPager::new_for_query work with values is too hard (if even possible)
             // so instead of sending one prepare to a specific connection on each iterator query,
@@ -1249,6 +1250,7 @@ where
                 metrics: self.metrics.clone(),
             })
             .await
+            .map_err(QueryError::from)
         }
     }
 
@@ -1504,6 +1506,7 @@ where
             metrics: self.metrics.clone(),
         })
         .await
+        .map_err(QueryError::from)
     }
 
     async fn do_batch(

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -31,7 +31,7 @@ use crate::policies::host_filter::HostFilter;
 use crate::policies::load_balancing::{self, RoutingInfo};
 use crate::policies::retry::{RequestInfo, RetryDecision, RetrySession};
 use crate::policies::speculative_execution;
-use crate::prepared_statement::PreparedStatement;
+use crate::prepared_statement::{PartitionKeyError, PreparedStatement};
 use crate::query::Query;
 #[allow(deprecated)]
 use crate::response::legacy_query_result::LegacyQueryResult;
@@ -1394,7 +1394,8 @@ where
         let paging_state_ref = &paging_state;
 
         let (partition_key, token) = prepared
-            .extract_partition_key_and_calculate_token(prepared.get_partitioner_name(), values_ref)?
+            .extract_partition_key_and_calculate_token(prepared.get_partitioner_name(), values_ref)
+            .map_err(PartitionKeyError::into_query_error)?
             .unzip();
 
         let execution_profile = prepared

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -847,6 +847,7 @@ async fn query_peers(conn: &Arc<Connection>, connect_port: u16) -> Result<Vec<Pe
             Ok::<_, QueryError>(rows_stream)
         })
         .into_stream()
+        .map(|result| result.map(|stream| stream.map_err(QueryError::from)))
         .try_flatten()
         .and_then(|row_result| future::ok((NodeInfoSource::Peer, row_result)));
 
@@ -864,6 +865,7 @@ async fn query_peers(conn: &Arc<Connection>, connect_port: u16) -> Result<Vec<Pe
             Ok::<_, QueryError>(rows_stream)
         })
         .into_stream()
+        .map(|result| result.map(|stream| stream.map_err(QueryError::from)))
         .try_flatten()
         .and_then(|row_result| future::ok((NodeInfoSource::Local, row_result)));
 
@@ -1007,7 +1009,9 @@ where
             pager.rows_stream::<R>().map_err(convert_typecheck_error)?;
         Ok::<_, QueryError>(stream)
     };
-    fut.into_stream().try_flatten()
+    fut.into_stream()
+        .map(|result| result.map(|stream| stream.map_err(QueryError::from)))
+        .try_flatten()
 }
 
 async fn query_keyspaces(
@@ -1861,6 +1865,7 @@ async fn query_table_partitioners(
             Ok::<_, QueryError>(stream)
         })
         .into_stream()
+        .map(|result| result.map(|stream| stream.map_err(QueryError::from)))
         .try_flatten();
 
     let result = rows

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -982,7 +982,7 @@ where
             let mut query = Query::new(query_str);
             query.set_page_size(METADATA_QUERY_PAGE_SIZE);
 
-            conn.query_iter(query).await
+            conn.query_iter(query).await.map_err(QueryError::from)
         } else {
             let keyspaces = &[keyspaces_to_fetch] as &[&[String]];
             let query_str = format!("{query_str} where keyspace_name in ?");
@@ -995,7 +995,9 @@ where
                 .await
                 .map_err(RequestAttemptError::into_query_error)?;
             let serialized_values = prepared.serialize_values(&keyspaces)?;
-            conn.execute_iter(prepared, serialized_values).await
+            conn.execute_iter(prepared, serialized_values)
+                .await
+                .map_err(QueryError::from)
         }
     }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1,6 +1,6 @@
 use crate::authentication::AuthenticatorProvider;
 use crate::batch::{Batch, BatchStatement};
-use crate::client::pager::QueryPager;
+use crate::client::pager::{NextRowError, QueryPager};
 use crate::client::Compression;
 use crate::client::SelfIdentity;
 #[cfg(feature = "cloud")]
@@ -988,7 +988,7 @@ impl Connection {
     pub(crate) async fn query_iter(
         self: Arc<Self>,
         query: Query,
-    ) -> Result<QueryPager, QueryError> {
+    ) -> Result<QueryPager, NextRowError> {
         let consistency = query
             .config
             .determine_consistency(self.config.default_consistency);
@@ -1004,7 +1004,7 @@ impl Connection {
         self: Arc<Self>,
         prepared_statement: PreparedStatement,
         values: SerializedValues,
-    ) -> Result<QueryPager, QueryError> {
+    ) -> Result<QueryPager, NextRowError> {
         let consistency = prepared_statement
             .config
             .determine_consistency(self.config.default_consistency);

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -217,6 +217,7 @@ pub(crate) mod batch_values {
     use scylla_cql::types::serialize::{RowWriter, SerializationError};
 
     use crate::errors::QueryError;
+    use crate::prepared_statement::PartitionKeyError;
     use crate::routing::Token;
 
     use super::BatchStatement;
@@ -247,7 +248,9 @@ pub(crate) mod batch_values {
                         .map(|o| o.is_some())
                 })?;
                 if did_write {
-                    let token = ps.calculate_token_untyped(&first_values)?;
+                    let token = ps
+                        .calculate_token_untyped(&first_values)
+                        .map_err(PartitionKeyError::into_query_error)?;
                     (token, Some(first_values))
                 } else {
                     (None, None)


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## Motivation
There are three main objectives:
### Purge pager.rs module of QueryError
It's yet another module where usage of `QueryError` was abused. It's taken care of in this PR

### Narrow return error type of `[poll_]next()` methods on iterators/streams
They now return a self-contained `NextRow` error. It's independent of `QueryError`.

### Step forward narrowing error type of metadata related functions
Currently all top-level metadata related functions/methods (e.g. `Session::refresh_metadata`) return `QueryError`. This is because low-level methods use `QueryPager` API under the hood. Before this PR, the pager API would return `QueryError`. In the follow-up PR we will continue on purging the metadata methods of `QueryError`. It will be replaced with an error type designated for these operations - namely `MetadataError`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
