### PR TITLE
Add working `Debug` impl for caching session

### DIFF
--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -16,6 +16,7 @@ use scylla_cql::frame::response::result::{PreparedMetadata, ResultMetadata};
 use scylla_cql::types::serialize::batch::BatchValues;
 use scylla_cql::types::serialize::row::SerializeRow;
 use std::collections::hash_map::RandomState;
+use std::fmt;
 use std::hash::BuildHasher;
 use std::sync::Arc;
 
@@ -39,7 +40,6 @@ struct RawPreparedStatementData {
 }
 
 /// Provides auto caching while executing queries
-#[derive(Debug)]
 pub struct GenericCachingSession<DeserializationApi, S = RandomState>
 where
     S: Clone + BuildHasher,
@@ -51,6 +51,20 @@ where
     /// is removed from the cache
     max_capacity: usize,
     cache: DashMap<String, RawPreparedStatementData, S>,
+}
+
+impl<DeserializationApi, S> fmt::Debug for GenericCachingSession<DeserializationApi, S>
+where
+    S: Clone + BuildHasher,
+    DeserializationApi: DeserializationApiKind,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GenericCachingSession")
+            .field("session", &self.session)
+            .field("max_capacity", &self.max_capacity)
+            .field("cache", &self.cache)
+            .finish()
+    }
 }
 
 pub type CachingSession<S = RandomState> = GenericCachingSession<CurrentDeserializationApi, S>;

--- a/scylla/src/transport/caching_session.rs
+++ b/scylla/src/transport/caching_session.rs
@@ -349,6 +349,8 @@ mod tests {
     use crate::transport::partitioner::PartitionerName;
     use crate::transport::session::Session;
     use crate::utils::test_utils::unique_keyspace_name;
+    #[allow(deprecated)]
+    use crate::LegacyCachingSession;
     use crate::{
         batch::{Batch, BatchStatement},
         prepared_statement::PreparedStatement,
@@ -779,5 +781,13 @@ mod tests {
         // one can see which case failed by looking at the full backtrace
         verify_partitioner().await;
         verify_partitioner().await;
+    }
+
+    // NOTE: intentionally no `#[test]`: this is a compile-time test
+    fn _caching_session_impls_debug() {
+        fn assert_debug<T: std::fmt::Debug>() {}
+        assert_debug::<CachingSession>();
+        #[allow(deprecated)]
+        assert_debug::<LegacyCachingSession>();
     }
 }


### PR DESCRIPTION
The previous derived implementation was not actually usable because it had `Debug` bounds on the type parameters. The `RandomState` default value for the `S` argument does not impl `Debug`, so this didn't work.

This commit switches to a manual `Debug` impl that doesn't have these unnecessary bounds.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
