### PR TITLE
Remove MissingUserDefinedType from public API

### DIFF
--- a/scylla/src/transport/cluster.rs
+++ b/scylla/src/transport/cluster.rs
@@ -185,6 +185,7 @@ impl Cluster {
             &None,
             host_filter.as_deref(),
             TabletsInfo::new(),
+            &HashMap::new(),
         )
         .await;
         cluster_data.wait_until_all_pools_are_initialized().await;
@@ -278,6 +279,7 @@ impl ClusterData {
         used_keyspace: &Option<VerifiedKeyspaceName>,
         host_filter: Option<&dyn HostFilter>,
         mut tablets: TabletsInfo,
+        old_keyspaces: &HashMap<String, Keyspace>,
     ) -> Self {
         // Create new updated known_peers and ring
         let mut new_known_peers: HashMap<Uuid, Arc<Node>> =
@@ -323,6 +325,26 @@ impl ClusterData {
             }
         }
 
+        let keyspaces: HashMap<String, Keyspace> = metadata
+            .keyspaces
+            .into_iter()
+            .filter_map(|(ks_name, ks)| match ks {
+                Ok(ks) => Some((ks_name, ks)),
+                Err(e) => {
+                    if let Some(old_ks) = old_keyspaces.get(&ks_name) {
+                        warn!("Encountered an error while processing metadata of keyspace \"{ks_name}\": {e}.\
+                               Re-using older version of this keyspace metadata");
+                        Some((ks_name, old_ks.clone()))
+                    } else {
+                        warn!("Encountered an error while processing metadata of keyspace \"{ks_name}\": {e}.\
+                               No previous version of this keyspace metadata found, so it will not be\
+                               present in ClusterData until next refresh.");
+                        None
+                    }
+                }
+            })
+            .collect();
+
         {
             let removed_nodes = {
                 let mut removed_nodes = HashSet::new();
@@ -336,7 +358,7 @@ impl ClusterData {
             };
 
             let table_predicate = |spec: &TableSpec| {
-                if let Some(ks) = metadata.keyspaces.get(spec.ks_name()) {
+                if let Some(ks) = keyspaces.get(spec.ks_name()) {
                     ks.tables.contains_key(spec.table_name())
                 } else {
                     false
@@ -364,7 +386,6 @@ impl ClusterData {
             )
         }
 
-        let keyspaces = metadata.keyspaces;
         let (locator, keyspaces) = tokio::task::spawn_blocking(move || {
             let keyspace_strategies = keyspaces.values().map(|ks| &ks.strategy);
             let locator = ReplicaLocator::new(ring.into_iter(), keyspace_strategies, tablets);
@@ -706,6 +727,7 @@ impl ClusterWorker {
                 &self.used_keyspace,
                 self.host_filter.as_deref(),
                 cluster_data.locator.tablets.clone(),
+                &cluster_data.keyspaces,
             )
             .await,
         );

--- a/scylla/src/transport/load_balancing/default.rs
+++ b/scylla/src/transport/load_balancing/default.rs
@@ -1410,6 +1410,7 @@ mod tests {
                 &None,
                 None,
                 TabletsInfo::new(),
+                &HashMap::new(),
             )
             .await
         }
@@ -1440,6 +1441,7 @@ mod tests {
                 &None,
                 None,
                 TabletsInfo::new(),
+                &HashMap::new(),
             )
             .await
         }
@@ -2489,6 +2491,7 @@ mod tests {
                 Some(&FHostFilter)
             },
             TabletsInfo::new(),
+            &HashMap::new(),
         )
         .await;
 

--- a/scylla/src/transport/locator/mod.rs
+++ b/scylla/src/transport/locator/mod.rs
@@ -857,21 +857,39 @@ mod tests {
         check(
             160,
             None,
-            &metadata.keyspaces.get(KEYSPACE_NTS_RF_3).unwrap().strategy,
+            &metadata
+                .keyspaces
+                .get(KEYSPACE_NTS_RF_3)
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .strategy,
             TABLE_NTS_RF_3,
             vec![F, A, C, D, G, E],
         );
         check(
             160,
             None,
-            &metadata.keyspaces.get(KEYSPACE_NTS_RF_2).unwrap().strategy,
+            &metadata
+                .keyspaces
+                .get(KEYSPACE_NTS_RF_2)
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .strategy,
             TABLE_NTS_RF_2,
             vec![F, A, D, G],
         );
         check(
             160,
             None,
-            &metadata.keyspaces.get(KEYSPACE_SS_RF_2).unwrap().strategy,
+            &metadata
+                .keyspaces
+                .get(KEYSPACE_SS_RF_2)
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .strategy,
             TABLE_SS_RF_2,
             vec![F, A],
         );
@@ -879,21 +897,39 @@ mod tests {
         check(
             160,
             Some("eu"),
-            &metadata.keyspaces.get(KEYSPACE_NTS_RF_3).unwrap().strategy,
+            &metadata
+                .keyspaces
+                .get(KEYSPACE_NTS_RF_3)
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .strategy,
             TABLE_NTS_RF_3,
             vec![A, C, G],
         );
         check(
             160,
             Some("us"),
-            &metadata.keyspaces.get(KEYSPACE_NTS_RF_3).unwrap().strategy,
+            &metadata
+                .keyspaces
+                .get(KEYSPACE_NTS_RF_3)
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .strategy,
             TABLE_NTS_RF_3,
             vec![F, D, E],
         );
         check(
             160,
             Some("eu"),
-            &metadata.keyspaces.get(KEYSPACE_SS_RF_2).unwrap().strategy,
+            &metadata
+                .keyspaces
+                .get(KEYSPACE_SS_RF_2)
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .strategy,
             TABLE_SS_RF_2,
             vec![A],
         );

--- a/scylla/src/transport/locator/precomputed_replicas.rs
+++ b/scylla/src/transport/locator/precomputed_replicas.rs
@@ -231,14 +231,14 @@ mod tests {
         let mut metadata = mock_metadata_for_token_aware_tests();
         metadata.keyspaces = [(
             "SimpleStrategy{rf=2}".into(),
-            Keyspace {
+            Ok(Keyspace {
                 strategy: Strategy::SimpleStrategy {
                     replication_factor: 2,
                 },
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),
-            },
+            }),
         )]
         .iter()
         .cloned()
@@ -251,7 +251,7 @@ mod tests {
             metadata
                 .keyspaces
                 .values()
-                .map(|keyspace| &keyspace.strategy),
+                .map(|keyspace| &keyspace.as_ref().unwrap().strategy),
         );
 
         let check = |token, replication_factor, expected_node_ids| {
@@ -293,7 +293,7 @@ mod tests {
             metadata
                 .keyspaces
                 .values()
-                .map(|keyspace| &keyspace.strategy),
+                .map(|keyspace| &keyspace.as_ref().unwrap().strategy),
         );
 
         let check = |token, dc, replication_factor, expected_node_ids| {

--- a/scylla/src/transport/locator/test.rs
+++ b/scylla/src/transport/locator/test.rs
@@ -120,18 +120,18 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
     let keyspaces = [
         (
             KEYSPACE_SS_RF_2.into(),
-            Keyspace {
+            Ok(Keyspace {
                 strategy: Strategy::SimpleStrategy {
                     replication_factor: 2,
                 },
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),
-            },
+            }),
         ),
         (
             KEYSPACE_NTS_RF_2.into(),
-            Keyspace {
+            Ok(Keyspace {
                 strategy: Strategy::NetworkTopologyStrategy {
                     datacenter_repfactors: [("eu".to_owned(), 2), ("us".to_owned(), 2)]
                         .into_iter()
@@ -140,11 +140,11 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),
-            },
+            }),
         ),
         (
             KEYSPACE_NTS_RF_3.into(),
-            Keyspace {
+            Ok(Keyspace {
                 strategy: Strategy::NetworkTopologyStrategy {
                     datacenter_repfactors: [("eu".to_owned(), 3), ("us".to_owned(), 3)]
                         .into_iter()
@@ -153,7 +153,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),
-            },
+            }),
         ),
     ]
     .iter()
@@ -201,7 +201,10 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
 
 pub(crate) fn create_locator(metadata: &Metadata) -> ReplicaLocator {
     let ring = create_ring(metadata);
-    let strategies = metadata.keyspaces.values().map(|ks| &ks.strategy);
+    let strategies = metadata
+        .keyspaces
+        .values()
+        .map(|ks| &ks.as_ref().unwrap().strategy);
 
     ReplicaLocator::new(ring, strategies, TabletsInfo::new())
 }

--- a/scylla/src/transport/session_test.rs
+++ b/scylla/src/transport/session_test.rs
@@ -1475,7 +1475,7 @@ fn udt_type_c_def(ks: &str) -> Arc<UserDefinedType> {
                     }),
                     Box::new(CqlType::UserDefinedType {
                         frozen: true,
-                        definition: Ok(udt_type_b_def(ks)),
+                        definition: udt_type_b_def(ks),
                     }),
                 ),
             },
@@ -1566,7 +1566,7 @@ async fn test_schema_types_in_metadata() {
         a.type_,
         CqlType::UserDefinedType {
             frozen: true,
-            definition: Ok(udt_type_a_def(&ks)),
+            definition: udt_type_a_def(&ks),
         }
     );
 
@@ -1576,7 +1576,7 @@ async fn test_schema_types_in_metadata() {
         b.type_,
         CqlType::UserDefinedType {
             frozen: false,
-            definition: Ok(udt_type_b_def(&ks)),
+            definition: udt_type_b_def(&ks),
         }
     );
 
@@ -1586,7 +1586,7 @@ async fn test_schema_types_in_metadata() {
         c.type_,
         CqlType::UserDefinedType {
             frozen: true,
-            definition: Ok(udt_type_c_def(&ks))
+            definition: udt_type_c_def(&ks)
         }
     );
 

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -64,7 +64,7 @@ pub(crate) struct MetadataReader {
 /// Describes all metadata retrieved from the cluster
 pub(crate) struct Metadata {
     pub(crate) peers: Vec<Peer>,
-    pub(crate) keyspaces: HashMap<String, Keyspace>,
+    pub(crate) keyspaces: HashMap<String, Result<Keyspace, MissingUserDefinedType>>,
 }
 
 #[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
@@ -274,7 +274,7 @@ pub struct UserDefinedType {
 /// Represents a user defined type whose definition is missing from the metadata.
 #[derive(Clone, Debug, Error)]
 #[error("Missing UDT: {keyspace}, {name}")]
-struct MissingUserDefinedType {
+pub(crate) struct MissingUserDefinedType {
     name: String,
     keyspace: String,
 }
@@ -784,17 +784,6 @@ async fn query_metadata(
     if peers.iter().all(|peer| peer.tokens.is_empty()) {
         return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists).into());
     }
-
-    let keyspaces = keyspaces
-        .into_iter()
-        .filter_map(|(ks_name, ks)| match ks {
-            Ok(ks) => Some((ks_name, ks)),
-            Err(e) => {
-                warn!("Error while processing keyspace \"{ks_name}\": {e}");
-                None
-            }
-        })
-        .collect();
 
     Ok(Metadata { peers, keyspaces })
 }

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -19,6 +19,7 @@ use scylla_cql::types::deserialize::TypeCheckError;
 use scylla_macros::DeserializeRow;
 use std::borrow::BorrowMut;
 use std::cell::Cell;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Formatter;
@@ -204,28 +205,25 @@ impl PreCqlType {
     pub(crate) fn into_cql_type(
         self,
         keyspace_name: &String,
-        udts: &HashMap<String, HashMap<String, Arc<UserDefinedType>>>,
+        keyspace_udts: &HashMap<String, Arc<UserDefinedType>>,
     ) -> CqlType {
         match self {
             PreCqlType::Native(n) => CqlType::Native(n),
             PreCqlType::Collection { frozen, type_ } => CqlType::Collection {
                 frozen,
-                type_: type_.into_collection_type(keyspace_name, udts),
+                type_: type_.into_collection_type(keyspace_name, keyspace_udts),
             },
             PreCqlType::Tuple(t) => CqlType::Tuple(
                 t.into_iter()
-                    .map(|t| t.into_cql_type(keyspace_name, udts))
+                    .map(|t| t.into_cql_type(keyspace_name, keyspace_udts))
                     .collect(),
             ),
             PreCqlType::Vector { type_, dimensions } => CqlType::Vector {
-                type_: Box::new(type_.into_cql_type(keyspace_name, udts)),
+                type_: Box::new(type_.into_cql_type(keyspace_name, keyspace_udts)),
                 dimensions,
             },
             PreCqlType::UserDefinedType { frozen, name } => {
-                let definition = match udts
-                    .get(keyspace_name)
-                    .and_then(|per_keyspace_udts| per_keyspace_udts.get(&name))
-                {
+                let definition = match keyspace_udts.get(&name) {
                     Some(def) => Ok(def.clone()),
                     None => Err(MissingUserDefinedType {
                         name,
@@ -343,18 +341,18 @@ impl PreCollectionType {
     pub(crate) fn into_collection_type(
         self,
         keyspace_name: &String,
-        udts: &HashMap<String, HashMap<String, Arc<UserDefinedType>>>,
+        keyspace_udts: &HashMap<String, Arc<UserDefinedType>>,
     ) -> CollectionType {
         match self {
             PreCollectionType::List(t) => {
-                CollectionType::List(Box::new(t.into_cql_type(keyspace_name, udts)))
+                CollectionType::List(Box::new(t.into_cql_type(keyspace_name, keyspace_udts)))
             }
             PreCollectionType::Map(tk, tv) => CollectionType::Map(
-                Box::new(tk.into_cql_type(keyspace_name, udts)),
-                Box::new(tv.into_cql_type(keyspace_name, udts)),
+                Box::new(tk.into_cql_type(keyspace_name, keyspace_udts)),
+                Box::new(tv.into_cql_type(keyspace_name, keyspace_udts)),
             ),
             PreCollectionType::Set(t) => {
-                CollectionType::Set(Box::new(t.into_cql_type(keyspace_name, udts)))
+                CollectionType::Set(Box::new(t.into_cql_type(keyspace_name, keyspace_udts)))
             }
         }
     }
@@ -1116,22 +1114,25 @@ async fn query_user_defined_types(
             field_types,
         } = udt_row;
 
+        let mut keyspace_entry = match udts.entry(keyspace_name) {
+            Entry::Occupied(e) => e,
+            Entry::Vacant(e) => e.insert_entry(HashMap::new()),
+        };
+
         let mut fields = Vec::with_capacity(field_names.len());
 
         for (field_name, field_type) in field_names.into_iter().zip(field_types.into_iter()) {
-            let cql_type = field_type.into_cql_type(&keyspace_name, &udts);
+            let cql_type = field_type.into_cql_type(keyspace_entry.key(), keyspace_entry.get());
             fields.push((field_name, cql_type));
         }
 
         let udt = Arc::new(UserDefinedType {
             name: type_name.clone(),
-            keyspace: keyspace_name.clone(),
+            keyspace: keyspace_entry.key().clone(),
             field_types: fields,
         });
 
-        udts.entry(keyspace_name)
-            .or_insert_with(HashMap::new)
-            .insert(type_name, udt);
+        keyspace_entry.get_mut().insert(type_name, udt);
     }
 
     Ok(udts)
@@ -1496,6 +1497,8 @@ async fn query_tables_schema(
         }
     );
 
+    let empty_map = HashMap::new();
+
     let mut tables_schema = HashMap::new();
 
     rows.map(|row_result| {
@@ -1505,8 +1508,9 @@ async fn query_tables_schema(
             return Ok::<_, QueryError>(());
         }
 
+        let keyspace_udts = udts.get(&keyspace_name).unwrap_or(&empty_map);
         let pre_cql_type = map_string_to_cql_type(&type_)?;
-        let cql_type = pre_cql_type.into_cql_type(&keyspace_name, udts);
+        let cql_type = pre_cql_type.into_cql_type(&keyspace_name, keyspace_udts);
 
         let kind = ColumnKind::from_str(&kind).map_err(|_| {
             MetadataError::Tables(TablesMetadataError::UnknownColumnKind {

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -1000,9 +1000,10 @@ async fn query_keyspaces(
 
     let (mut all_tables, mut all_views, mut all_user_defined_types) = if fetch_schema {
         let udts = query_user_defined_types(conn, keyspaces_to_fetch).await?;
+        let mut tables_schema = query_tables_schema(conn, keyspaces_to_fetch, &udts).await?;
         (
-            query_tables(conn, keyspaces_to_fetch, &udts).await?,
-            query_views(conn, keyspaces_to_fetch, &udts).await?,
+            query_tables(conn, keyspaces_to_fetch, &mut tables_schema).await?,
+            query_views(conn, keyspaces_to_fetch, &mut tables_schema).await?,
             udts,
         )
     } else {
@@ -1401,7 +1402,7 @@ mod toposort_tests {
 async fn query_tables(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
-    udts: &HashMap<String, HashMap<String, Arc<UserDefinedType>>>,
+    tables: &mut HashMap<(String, String), Table>,
 ) -> Result<HashMap<String, HashMap<String, Table>>, QueryError> {
     let rows = query_filter_keyspace_name::<(String, String)>(
         conn,
@@ -1410,7 +1411,6 @@ async fn query_tables(
         |err| MetadataError::Tables(TablesMetadataError::SchemaTablesInvalidColumnType(err)),
     );
     let mut result = HashMap::new();
-    let mut tables = query_tables_schema(conn, keyspaces_to_fetch, udts).await?;
 
     rows.map(|row_result| {
         let keyspace_and_table_name = row_result?;
@@ -1438,7 +1438,7 @@ async fn query_tables(
 async fn query_views(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
-    udts: &HashMap<String, HashMap<String, Arc<UserDefinedType>>>,
+    tables: &mut HashMap<(String, String), Table>,
 ) -> Result<HashMap<String, HashMap<String, MaterializedView>>, QueryError> {
     let rows = query_filter_keyspace_name::<(String, String, String)>(
         conn,
@@ -1448,7 +1448,6 @@ async fn query_views(
     );
 
     let mut result = HashMap::new();
-    let mut tables = query_tables_schema(conn, keyspaces_to_fetch, udts).await?;
 
     rows.map(|row_result| {
         let (keyspace_name, view_name, base_table_name) = row_result?;

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -19,7 +19,6 @@ use scylla_cql::types::deserialize::TypeCheckError;
 use scylla_macros::DeserializeRow;
 use std::borrow::BorrowMut;
 use std::cell::Cell;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Formatter;
@@ -28,6 +27,7 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
@@ -206,31 +206,37 @@ impl PreCqlType {
         self,
         keyspace_name: &String,
         keyspace_udts: &HashMap<String, Arc<UserDefinedType>>,
-    ) -> CqlType {
+    ) -> Result<CqlType, MissingUserDefinedType> {
         match self {
-            PreCqlType::Native(n) => CqlType::Native(n),
-            PreCqlType::Collection { frozen, type_ } => CqlType::Collection {
-                frozen,
-                type_: type_.into_collection_type(keyspace_name, keyspace_udts),
-            },
-            PreCqlType::Tuple(t) => CqlType::Tuple(
-                t.into_iter()
-                    .map(|t| t.into_cql_type(keyspace_name, keyspace_udts))
-                    .collect(),
-            ),
-            PreCqlType::Vector { type_, dimensions } => CqlType::Vector {
-                type_: Box::new(type_.into_cql_type(keyspace_name, keyspace_udts)),
-                dimensions,
-            },
+            PreCqlType::Native(n) => Ok(CqlType::Native(n)),
+            PreCqlType::Collection { frozen, type_ } => type_
+                .into_collection_type(keyspace_name, keyspace_udts)
+                .map(|inner| CqlType::Collection {
+                    frozen,
+                    type_: inner,
+                }),
+            PreCqlType::Tuple(t) => t
+                .into_iter()
+                .map(|t| t.into_cql_type(keyspace_name, keyspace_udts))
+                .collect::<Result<Vec<CqlType>, MissingUserDefinedType>>()
+                .map(CqlType::Tuple),
+            PreCqlType::Vector { type_, dimensions } => type_
+                .into_cql_type(keyspace_name, keyspace_udts)
+                .map(|inner| CqlType::Vector {
+                    type_: Box::new(inner),
+                    dimensions,
+                }),
             PreCqlType::UserDefinedType { frozen, name } => {
                 let definition = match keyspace_udts.get(&name) {
-                    Some(def) => Ok(def.clone()),
-                    None => Err(MissingUserDefinedType {
-                        name,
-                        keyspace: keyspace_name.clone(),
-                    }),
+                    Some(def) => def.clone(),
+                    None => {
+                        return Err(MissingUserDefinedType {
+                            name,
+                            keyspace: keyspace_name.clone(),
+                        })
+                    }
                 };
-                CqlType::UserDefinedType { frozen, definition }
+                Ok(CqlType::UserDefinedType { frozen, definition })
             }
         }
     }
@@ -253,7 +259,7 @@ pub enum CqlType {
     UserDefinedType {
         frozen: bool,
         // Using Arc here in order not to have many copies of the same definition
-        definition: Result<Arc<UserDefinedType>, MissingUserDefinedType>,
+        definition: Arc<UserDefinedType>,
     },
 }
 
@@ -266,7 +272,8 @@ pub struct UserDefinedType {
 }
 
 /// Represents a user defined type whose definition is missing from the metadata.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Error)]
+#[error("Missing UDT: {keyspace}, {name}")]
 pub struct MissingUserDefinedType {
     pub name: String,
     pub keyspace: String,
@@ -342,18 +349,18 @@ impl PreCollectionType {
         self,
         keyspace_name: &String,
         keyspace_udts: &HashMap<String, Arc<UserDefinedType>>,
-    ) -> CollectionType {
+    ) -> Result<CollectionType, MissingUserDefinedType> {
         match self {
-            PreCollectionType::List(t) => {
-                CollectionType::List(Box::new(t.into_cql_type(keyspace_name, keyspace_udts)))
-            }
-            PreCollectionType::Map(tk, tv) => CollectionType::Map(
-                Box::new(tk.into_cql_type(keyspace_name, keyspace_udts)),
-                Box::new(tv.into_cql_type(keyspace_name, keyspace_udts)),
-            ),
-            PreCollectionType::Set(t) => {
-                CollectionType::Set(Box::new(t.into_cql_type(keyspace_name, keyspace_udts)))
-            }
+            PreCollectionType::List(t) => t
+                .into_cql_type(keyspace_name, keyspace_udts)
+                .map(|inner| CollectionType::List(Box::new(inner))),
+            PreCollectionType::Map(tk, tv) => Ok(CollectionType::Map(
+                Box::new(tk.into_cql_type(keyspace_name, keyspace_udts)?),
+                Box::new(tv.into_cql_type(keyspace_name, keyspace_udts)?),
+            )),
+            PreCollectionType::Set(t) => t
+                .into_cql_type(keyspace_name, keyspace_udts)
+                .map(|inner| CollectionType::Set(Box::new(inner))),
         }
     }
 }
@@ -778,6 +785,17 @@ async fn query_metadata(
         return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists).into());
     }
 
+    let keyspaces = keyspaces
+        .into_iter()
+        .filter_map(|(ks_name, ks)| match ks {
+            Ok(ks) => Some((ks_name, ks)),
+            Err(e) => {
+                warn!("Error while processing keyspace \"{ks_name}\": {e}");
+                None
+            }
+        })
+        .collect();
+
     Ok(Metadata { peers, keyspaces })
 }
 
@@ -986,7 +1004,7 @@ async fn query_keyspaces(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
     fetch_schema: bool,
-) -> Result<HashMap<String, Keyspace>, QueryError> {
+) -> Result<HashMap<String, Result<Keyspace, MissingUserDefinedType>>, QueryError> {
     let rows = query_filter_keyspace_name::<(String, HashMap<String, String>)>(
         conn,
         "select keyspace_name, replication from system_schema.keyspaces",
@@ -1019,11 +1037,20 @@ async fn query_keyspaces(
                 error,
             })
         })?;
-        let tables = all_tables.remove(&keyspace_name).unwrap_or_default();
-        let views = all_views.remove(&keyspace_name).unwrap_or_default();
+        let tables = all_tables
+            .remove(&keyspace_name)
+            .unwrap_or_else(|| Ok(HashMap::new()));
+        let views = all_views
+            .remove(&keyspace_name)
+            .unwrap_or_else(|| Ok(HashMap::new()));
         let user_defined_types = all_user_defined_types
             .remove(&keyspace_name)
-            .unwrap_or_default();
+            .unwrap_or_else(|| Ok(HashMap::new()));
+
+        let (tables, views, user_defined_types) = match (tables, views, user_defined_types) {
+            (Ok(t), Ok(v), Ok(u)) => (t, v, u),
+            (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => return Ok((keyspace_name, Err(e))),
+        };
 
         let keyspace = Keyspace {
             strategy,
@@ -1032,7 +1059,7 @@ async fn query_keyspaces(
             user_defined_types,
         };
 
-        Ok((keyspace_name, keyspace))
+        Ok((keyspace_name, Ok(keyspace)))
     })
     .try_collect()
     .await
@@ -1080,7 +1107,10 @@ impl TryFrom<UdtRow> for UdtRowWithParsedFieldTypes {
 async fn query_user_defined_types(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
-) -> Result<HashMap<String, HashMap<String, Arc<UserDefinedType>>>, QueryError> {
+) -> Result<
+    HashMap<String, Result<HashMap<String, Arc<UserDefinedType>>, MissingUserDefinedType>>,
+    QueryError,
+> {
     let rows = query_filter_keyspace_name::<UdtRow>(
         conn,
         "select keyspace_name, type_name, field_names, field_types from system_schema.types",
@@ -1107,7 +1137,7 @@ async fn query_user_defined_types(
     );
 
     let mut udts = HashMap::new();
-    for udt_row in udt_rows {
+    'udts_loop: for udt_row in udt_rows {
         let UdtRowWithParsedFieldTypes {
             keyspace_name,
             type_name,
@@ -1115,27 +1145,38 @@ async fn query_user_defined_types(
             field_types,
         } = udt_row;
 
-        let mut keyspace_entry = match udts.entry(keyspace_name) {
-            Entry::Occupied(e) => e,
-            Entry::Vacant(e) => e.insert_entry(HashMap::new()),
+        let keyspace_name_clone = keyspace_name.clone();
+
+        let keyspace_udts_result = udts
+            .entry(keyspace_name)
+            .or_insert_with(|| Ok(HashMap::new()));
+
+        // If there was previously an error in this keyspace then it makes no sense to process this UDT.
+        let keyspace_udts = match keyspace_udts_result {
+            Ok(udts) => udts,
+            Err(_) => continue,
         };
 
         let mut fields = Vec::with_capacity(field_names.len());
 
         for (field_name, field_type) in field_names.into_iter().zip(field_types.into_iter()) {
-            let cql_type = field_type.into_cql_type(keyspace_entry.key(), keyspace_entry.get());
-            fields.push((field_name, cql_type));
+            match field_type.into_cql_type(&keyspace_name_clone, keyspace_udts) {
+                Ok(cql_type) => fields.push((field_name, cql_type)),
+                Err(e) => {
+                    *keyspace_udts_result = Err(e);
+                    continue 'udts_loop;
+                }
+            }
         }
 
         let udt = Arc::new(UserDefinedType {
             name: type_name.clone(),
-            keyspace: keyspace_entry.key().clone(),
+            keyspace: keyspace_name_clone,
             field_types: fields,
         });
 
-        keyspace_entry.get_mut().insert(type_name, udt);
+        keyspace_udts.insert(type_name, udt);
     }
-
     Ok(udts)
 }
 
@@ -1402,8 +1443,8 @@ mod toposort_tests {
 async fn query_tables(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
-    tables: &mut HashMap<(String, String), Table>,
-) -> Result<HashMap<String, HashMap<String, Table>>, QueryError> {
+    tables: &mut HashMap<(String, String), Result<Table, MissingUserDefinedType>>,
+) -> Result<HashMap<String, Result<HashMap<String, Table>, MissingUserDefinedType>>, QueryError> {
     let rows = query_filter_keyspace_name::<(String, String)>(
         conn,
         "SELECT keyspace_name, table_name FROM system_schema.tables",
@@ -1415,17 +1456,23 @@ async fn query_tables(
     rows.map(|row_result| {
         let keyspace_and_table_name = row_result?;
 
-        let table = tables.remove(&keyspace_and_table_name).unwrap_or(Table {
+        let table = tables.remove(&keyspace_and_table_name).unwrap_or(Ok(Table {
             columns: HashMap::new(),
             partition_key: vec![],
             clustering_key: vec![],
             partitioner: None,
-        });
+        }));
 
-        result
+        let mut entry = result
             .entry(keyspace_and_table_name.0)
-            .or_insert_with(HashMap::new)
-            .insert(keyspace_and_table_name.1, table);
+            .or_insert_with(|| Ok(HashMap::new()));
+        match (&mut entry, table) {
+            (Ok(tables), Ok(table)) => {
+                let _ = tables.insert(keyspace_and_table_name.1, table);
+            }
+            (Err(_), _) => (),
+            (Ok(_), Err(e)) => *entry = Err(e),
+        };
 
         Ok::<_, QueryError>(())
     })
@@ -1438,8 +1485,11 @@ async fn query_tables(
 async fn query_views(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
-    tables: &mut HashMap<(String, String), Table>,
-) -> Result<HashMap<String, HashMap<String, MaterializedView>>, QueryError> {
+    tables: &mut HashMap<(String, String), Result<Table, MissingUserDefinedType>>,
+) -> Result<
+    HashMap<String, Result<HashMap<String, MaterializedView>, MissingUserDefinedType>>,
+    QueryError,
+> {
     let rows = query_filter_keyspace_name::<(String, String, String)>(
         conn,
         "SELECT keyspace_name, view_name, base_table_name FROM system_schema.views",
@@ -1454,21 +1504,30 @@ async fn query_views(
 
         let keyspace_and_view_name = (keyspace_name, view_name);
 
-        let table = tables.remove(&keyspace_and_view_name).unwrap_or(Table {
-            columns: HashMap::new(),
-            partition_key: vec![],
-            clustering_key: vec![],
-            partitioner: None,
-        });
-        let materialized_view = MaterializedView {
-            view_metadata: table,
-            base_table_name,
-        };
+        let materialized_view = tables
+            .remove(&keyspace_and_view_name)
+            .unwrap_or(Ok(Table {
+                columns: HashMap::new(),
+                partition_key: vec![],
+                clustering_key: vec![],
+                partitioner: None,
+            }))
+            .map(|table| MaterializedView {
+                view_metadata: table,
+                base_table_name,
+            });
 
-        result
+        let mut entry = result
             .entry(keyspace_and_view_name.0)
-            .or_insert_with(HashMap::new)
-            .insert(keyspace_and_view_name.1, materialized_view);
+            .or_insert_with(|| Ok(HashMap::new()));
+
+        match (&mut entry, materialized_view) {
+            (Ok(views), Ok(view)) => {
+                let _ = views.insert(keyspace_and_view_name.1, view);
+            }
+            (Err(_), _) => (),
+            (Ok(_), Err(e)) => *entry = Err(e),
+        };
 
         Ok::<_, QueryError>(())
     })
@@ -1481,8 +1540,8 @@ async fn query_views(
 async fn query_tables_schema(
     conn: &Arc<Connection>,
     keyspaces_to_fetch: &[String],
-    udts: &HashMap<String, HashMap<String, Arc<UserDefinedType>>>,
-) -> Result<HashMap<(String, String), Table>, QueryError> {
+    udts: &HashMap<String, Result<HashMap<String, Arc<UserDefinedType>>, MissingUserDefinedType>>,
+) -> Result<HashMap<(String, String), Result<Table, MissingUserDefinedType>>, QueryError> {
     // Upon migration from thrift to CQL, Cassandra internally creates a surrogate column "value" of
     // type EmptyType for dense tables. This resolves into this CQL type name.
     // This column shouldn't be exposed to the user but is currently exposed in system tables.
@@ -1496,9 +1555,9 @@ async fn query_tables_schema(
         }
     );
 
-    let empty_map = HashMap::new();
+    let empty_ok_map = Ok(HashMap::new());
 
-    let mut tables_schema = HashMap::new();
+    let mut tables_schema: HashMap<_, Result<_, MissingUserDefinedType>> = HashMap::new();
 
     rows.map(|row_result| {
         let (keyspace_name, table_name, column_name, kind, position, type_) = row_result?;
@@ -1507,9 +1566,42 @@ async fn query_tables_schema(
             return Ok::<_, QueryError>(());
         }
 
-        let keyspace_udts = udts.get(&keyspace_name).unwrap_or(&empty_map);
+        let keyspace_udts = match udts.get(&keyspace_name).unwrap_or(&empty_ok_map) {
+            Ok(udts) => udts,
+            Err(e) => {
+                // There are two things we could do here
+                // 1. Not inserting, just returning. In that case the keyspaces containing
+                //    tables that have a column with a broken UDT will not be present in
+                //    the output of this function at all.
+                // 2. Inserting an error (which requires cloning it). In that case,
+                //    keyspace containing a table with broken UDT will have the error
+                //    cloned from this UDT.
+                //
+                // Solution number 1 seems weird because it can be seen as silencing
+                // the error: we have data for a keyspace, but we just don't put
+                // it in the result at all.
+                // Solution 2 is also not perfect because it:
+                // - Returns error for the keyspace even if the broken UDT is not used in any table.
+                // - Doesn't really distinguish between a table using a broken UDT and
+                //   a keyspace just containing some broken UDTs.
+                //
+                // I chose solution 2. Its first problem is not really important because
+                // the caller will error out the entire keyspace anyway. The second problem
+                // is minor enough to ignore. Note that the first issue also applies to
+                // solution 1: but the keyspace won't be present in the result at all,
+                // which is arguably worse.
+                tables_schema.insert((keyspace_name, table_name), Err(e.clone()));
+                return Ok::<_, QueryError>(());
+            }
+        };
         let pre_cql_type = map_string_to_cql_type(&type_)?;
-        let cql_type = pre_cql_type.into_cql_type(&keyspace_name, keyspace_udts);
+        let cql_type = match pre_cql_type.into_cql_type(&keyspace_name, keyspace_udts) {
+            Ok(t) => t,
+            Err(e) => {
+                tables_schema.insert((keyspace_name, table_name), Err(e));
+                return Ok::<_, QueryError>(());
+            }
+        };
 
         let kind = ColumnKind::from_str(&kind).map_err(|_| {
             MetadataError::Tables(TablesMetadataError::UnknownColumnKind {
@@ -1520,11 +1612,17 @@ async fn query_tables_schema(
             })
         })?;
 
-        let entry = tables_schema.entry((keyspace_name, table_name)).or_insert((
-            HashMap::new(), // columns
-            HashMap::new(), // partition key
-            HashMap::new(), // clustering key
-        ));
+        let Ok(entry) = tables_schema
+            .entry((keyspace_name, table_name))
+            .or_insert(Ok((
+                HashMap::new(), // columns
+                HashMap::new(), // partition key
+                HashMap::new(), // clustering key
+            )))
+        else {
+            // This table was previously marked as broken, no way to insert anything.
+            return Ok::<_, QueryError>(());
+        };
 
         if kind == ColumnKind::PartitionKey || kind == ColumnKind::Clustering {
             let key_map = if kind == ColumnKind::PartitionKey {
@@ -1551,9 +1649,16 @@ async fn query_tables_schema(
     let mut all_partitioners = query_table_partitioners(conn).await?;
     let mut result = HashMap::new();
 
-    for ((keyspace_name, table_name), (columns, partition_key_columns, clustering_key_columns)) in
-        tables_schema
-    {
+    for ((keyspace_name, table_name), table_result) in tables_schema {
+        let keyspace_and_table_name = (keyspace_name, table_name);
+
+        let (columns, partition_key_columns, clustering_key_columns) = match table_result {
+            Ok(table) => table,
+            Err(e) => {
+                let _ = result.insert(keyspace_and_table_name, Err(e));
+                continue;
+            }
+        };
         let mut partition_key = vec!["".to_string(); partition_key_columns.len()];
         for (position, column_name) in partition_key_columns {
             partition_key[position as usize] = column_name;
@@ -1564,20 +1669,18 @@ async fn query_tables_schema(
             clustering_key[position as usize] = column_name;
         }
 
-        let keyspace_and_table_name = (keyspace_name, table_name);
-
         let partitioner = all_partitioners
             .remove(&keyspace_and_table_name)
             .unwrap_or_default();
 
         result.insert(
             keyspace_and_table_name,
-            Table {
+            Ok(Table {
                 columns,
                 partition_key,
                 clustering_key,
                 partitioner,
-            },
+            }),
         );
     }
 

--- a/scylla/src/transport/topology.rs
+++ b/scylla/src/transport/topology.rs
@@ -274,9 +274,9 @@ pub struct UserDefinedType {
 /// Represents a user defined type whose definition is missing from the metadata.
 #[derive(Clone, Debug, Error)]
 #[error("Missing UDT: {keyspace}, {name}")]
-pub struct MissingUserDefinedType {
-    pub name: String,
-    pub keyspace: String,
+struct MissingUserDefinedType {
+    name: String,
+    keyspace: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Up until now `CqlType::UserDefinedType` contained a `Result`, with error type `MissingUserDefinedType`.
This error is an edge case that should be quite rare. It could possibly happen if we fetch metadata in the middle of schema change.
Possible scenario:
- We fetch UDTs
- New UDT is added
- New column is added to some table, with the type being this new UDT
- We fetch column types for all tables
- Now we have a column type with unknown UDT.

As this error should be extremely rare, it is okay to handle it a little bit less gracefully.
This simplifies user API (user no longer needs to handle the error) and makes progress towards unifying CqlType and ColumnType.

The new proposed way to handle this error is to drop the fetched metadata for the whole keyspace - re-using older version of it if available - and printing a warning.

As a side-fix, I found that `query_tables_schema` was unnecessarily called twice, so I deduplicated those calls.
`query_tables_schema` is likely the heaviest part of metadata reading, so this fix should lower the cluster load resulting from metadata fetches.

Progresses towards: https://github.com/scylladb/scylla-rust-driver/issues/691

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
