### PR TITLE
CQL Vector support

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -529,9 +529,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "endian-type"

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -33,6 +33,7 @@ Database types and their Rust equivalents:
 * `Map` <----> `std::collections::HashMap<K, V>`
 * `Tuple` <----> Rust tuples
 * `UDT (User defined type)` <----> Custom user structs with macros
+* `Vector` <----> `Vec<T>`
 
 
 ```{eval-rst}
@@ -56,5 +57,6 @@ Database types and their Rust equivalents:
    collections
    tuple
    udt
+   vector
 
 ```

--- a/docs/source/data-types/vector.md
+++ b/docs/source/data-types/vector.md
@@ -1,0 +1,26 @@
+## Vector
+`Vector` is represented as `Vec<T>`
+
+```rust
+# extern crate scylla;
+# extern crate futures;
+# use scylla::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use futures::TryStreamExt;
+
+// Insert a vector of ints into the table
+let my_vector: Vec<i32> = vec![1, 2, 3, 4, 5];
+session
+    .query_unpaged("INSERT INTO keyspace.table (a) VALUES(?)", (&my_vector,))
+    .await?;
+
+// Read a list of ints from the table
+let mut stream = session.query_iter("SELECT a FROM keyspace.table", &[])
+    .await?
+    .rows_stream::<(Vec<i32>,)>()?;
+while let Some((vector_value,)) = stream.try_next().await? {
+    println!("{:?}", vector);
+}
+# Ok(())
+# }

--- a/scylla-cql/src/deserialize/frame_slice.rs
+++ b/scylla-cql/src/deserialize/frame_slice.rs
@@ -155,6 +155,35 @@ impl<'frame> FrameSlice<'frame> {
             original_frame: self.original_frame,
         }))
     }
+
+    /// Reads and consumes a fixed number of bytes from the beginning of the frame,
+    /// returning a subslice that encompasses them.
+    ///
+    /// If this slice is empty, returns `Ok(None)`.
+    /// Otherwise, if the slice does not contain enough data, it returns `Err`.
+    /// If the operation fails then the slice remains unchanged.
+    #[inline]
+    pub fn read_n_bytes(
+        &mut self,
+        count: usize,
+    ) -> Result<Option<FrameSlice<'frame>>, LowLevelDeserializationError> {
+        if self.is_empty() {
+            return Ok(None);
+        }
+
+        // We copy the slice reference, not to mutate the FrameSlice in case of an error.
+        let mut slice = self.frame_subslice;
+
+        let cql_bytes = types::read_raw_bytes(count, &mut slice)?;
+
+        // `read_raw_bytes` hasn't failed, so now we must update the FrameSlice.
+        self.frame_subslice = slice;
+
+        Ok(Some(Self {
+            frame_subslice: cql_bytes,
+            original_frame: self.original_frame,
+        }))
+    }
 }
 
 #[cfg(test)]

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -826,18 +826,40 @@ where
     T: DeserializeValue<'frame, 'metadata>,
 {
     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
-        // It makes sense for both Set and List to deserialize to Vec.
-        ListlikeIterator::<'frame, 'metadata, T>::type_check(typ)
-            .map_err(typck_error_replace_rust_name::<Self>)
+        // It makes sense for Set, List and Vector to deserialize to Vec.
+        match typ {
+            ColumnType::Collection {
+                typ: CollectionType::List(_) | CollectionType::Set(_),
+                ..
+            } => ListlikeIterator::<'frame, 'metadata, T>::type_check(typ)
+                .map_err(typck_error_replace_rust_name::<Self>),
+            ColumnType::Vector { .. } => VectorIterator::<'frame, 'metadata, T>::type_check(typ)
+                .map_err(typck_error_replace_rust_name::<Self>),
+            _ => Err(mk_typck_err::<Self>(
+                typ,
+                BuiltinTypeCheckErrorKind::NotDeserializableToVec,
+            )),
+        }
     }
 
     fn deserialize(
         typ: &'metadata ColumnType<'metadata>,
         v: Option<FrameSlice<'frame>>,
     ) -> Result<Self, DeserializationError> {
-        ListlikeIterator::<'frame, 'metadata, T>::deserialize(typ, v)
-            .and_then(|it| it.collect::<Result<_, DeserializationError>>())
-            .map_err(deser_error_replace_rust_name::<Self>)
+        match typ {
+            ColumnType::Collection {
+                typ: CollectionType::List(_) | CollectionType::Set(_),
+                ..
+            } => ListlikeIterator::<'frame, 'metadata, T>::deserialize(typ, v)
+                .and_then(|it| it.collect::<Result<_, DeserializationError>>())
+                .map_err(deser_error_replace_rust_name::<Self>),
+            ColumnType::Vector { .. } => {
+                VectorIterator::<'frame, 'metadata, T>::deserialize(typ, v)
+                    .and_then(|it| it.collect::<Result<_, DeserializationError>>())
+                    .map_err(deser_error_replace_rust_name::<Self>)
+            }
+            _ => unreachable!("Should be prevented by typecheck"),
+        }
     }
 }
 
@@ -899,6 +921,182 @@ where
         ListlikeIterator::<'frame, 'metadata, T>::deserialize(typ, v)
             .and_then(|it| it.collect::<Result<_, DeserializationError>>())
             .map_err(deser_error_replace_rust_name::<Self>)
+    }
+}
+
+/// A deserialization iterator over a CQL vector.
+///
+/// Deserialization of a vector is done in two ways, depending on the element type:
+/// 1. If the element type is of a fixed-length, the iterator reads
+///    a fixed, known number of bytes for each element and deserializes
+///    according to the element type. The element count and element size
+///    are not encoded as the count is known from the vector type
+///    and the size is known from the element type.
+///
+/// 2. If the element type is of a variable-length, the iterator reads an vint
+///    (variable-length integer) for each element, which indicates the number of bytes
+///    to read for that element. Then, the iterator reads the specified number of bytes
+///    and deserializes according to the element type. This, however, is in contradiction
+///    with the CQL protocol, which specifies that the element count is encoded as a 4 byte int!
+///    Alas, Cassandra does not respect the protocol, so ScyllaDB and this driver have to follow.
+///
+/// It would be nice to have a rule to determine if the element type is fixed-length or not,
+/// however, we only have a heuristic. There are a few types that should, for all intents and purposes,
+/// be considered fixed-length, but are not, e.g TinyInt. See ColumnType::type_size() for the list.
+pub struct VectorIterator<'frame, 'metadata, T> {
+    collection_type: &'metadata ColumnType<'metadata>,
+    element_type: &'metadata ColumnType<'metadata>,
+    remaining: usize,
+    element_length: Option<usize>,
+    slice: FrameSlice<'frame>,
+    phantom_data: std::marker::PhantomData<T>,
+}
+
+impl<'frame, 'metadata, T> VectorIterator<'frame, 'metadata, T> {
+    fn new(
+        collection_type: &'metadata ColumnType<'metadata>,
+        element_type: &'metadata ColumnType<'metadata>,
+        count: usize,
+        element_length: Option<usize>,
+        slice: FrameSlice<'frame>,
+    ) -> Self {
+        Self {
+            collection_type,
+            element_type,
+            remaining: count,
+            element_length,
+            slice,
+            phantom_data: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'frame, 'metadata, T> DeserializeValue<'frame, 'metadata>
+    for VectorIterator<'frame, 'metadata, T>
+where
+    T: DeserializeValue<'frame, 'metadata>,
+{
+    fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
+        match typ {
+            ColumnType::Vector { typ: t, .. } => {
+                <T as DeserializeValue<'frame, 'metadata>>::type_check(t).map_err(|err| {
+                    mk_typck_err::<Self>(typ, VectorTypeCheckErrorKind::ElementTypeCheckFailed(err))
+                })?;
+                Ok(())
+            }
+            _ => Err(mk_typck_err::<Self>(
+                typ,
+                VectorTypeCheckErrorKind::NotVector,
+            )),
+        }
+    }
+
+    fn deserialize(
+        typ: &'metadata ColumnType<'metadata>,
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
+        let (element_type, dimensions) = match typ {
+            ColumnType::Vector {
+                typ: element_type,
+                dimensions,
+            } => (element_type, dimensions),
+            _ => {
+                unreachable!("Typecheck should have prevented this scenario!")
+            }
+        };
+
+        let v = ensure_not_null_frame_slice::<Self>(typ, v)?;
+
+        Ok(Self::new(
+            typ,
+            element_type,
+            *dimensions as usize,
+            element_type.type_size(),
+            v,
+        ))
+    }
+}
+
+impl<'frame, 'metadata, T> VectorIterator<'frame, 'metadata, T>
+where
+    T: DeserializeValue<'frame, 'metadata>,
+{
+    fn next_constant_length_elem(
+        &mut self,
+        element_length: usize,
+    ) -> Option<<Self as Iterator>::Item> {
+        self.remaining = self.remaining.checked_sub(1)?;
+        let raw = self.slice.read_n_bytes(element_length).map_err(|err| {
+            mk_deser_err::<Self>(
+                self.collection_type,
+                BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
+            )
+        });
+        Some(raw.and_then(|raw| {
+            T::deserialize(self.element_type, raw).map_err(|err| {
+                mk_deser_err::<Self>(
+                    self.collection_type,
+                    VectorDeserializationErrorKind::ElementDeserializationFailed(err),
+                )
+            })
+        }))
+    }
+
+    fn next_variable_length_elem(&mut self) -> Option<<Self as Iterator>::Item> {
+        self.remaining = self.remaining.checked_sub(1)?;
+        let size = types::unsigned_vint_decode(self.slice.as_slice_mut()).map_err(|err| {
+            mk_deser_err::<Self>(
+                self.collection_type,
+                BuiltinDeserializationErrorKind::RawCqlBytesReadError(
+                    LowLevelDeserializationError::IoError(Arc::new(err)),
+                ),
+            )
+        });
+        let raw = size
+            .and_then(|size| {
+                size.try_into().map_err(|_| {
+                    mk_deser_err::<Self>(
+                        self.collection_type,
+                        BuiltinDeserializationErrorKind::ValueOverflow,
+                    )
+                })
+            })
+            .and_then(|size: usize| {
+                self.slice.read_n_bytes(size).map_err(|err| {
+                    mk_deser_err::<Self>(
+                        self.collection_type,
+                        BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
+                    )
+                })
+            });
+
+        Some(raw.and_then(|raw| {
+            T::deserialize(self.element_type, raw).map_err(|err| {
+                mk_deser_err::<Self>(
+                    self.element_type,
+                    VectorDeserializationErrorKind::ElementDeserializationFailed(err),
+                )
+            })
+        }))
+    }
+}
+
+impl<'frame, 'metadata, T> Iterator for VectorIterator<'frame, 'metadata, T>
+where
+    T: DeserializeValue<'frame, 'metadata>,
+{
+    type Item = Result<T, DeserializationError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.element_length {
+            Some(element_length) => self.next_constant_length_elem(element_length),
+            None => self.next_variable_length_elem(),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
     }
 }
 
@@ -1507,6 +1705,9 @@ pub enum BuiltinTypeCheckErrorKind {
     /// A type check failure specific to a CQL set or list.
     SetOrListError(SetOrListTypeCheckErrorKind),
 
+    /// A type check failure specific to a CQL vector.
+    VectorError(VectorTypeCheckErrorKind),
+
     /// A type check failure specific to a CQL map.
     MapError(MapTypeCheckErrorKind),
 
@@ -1515,12 +1716,22 @@ pub enum BuiltinTypeCheckErrorKind {
 
     /// A type check failure specific to a CQL UDT.
     UdtError(UdtTypeCheckErrorKind),
+
+    /// A type check detected type not deserializable to a vector.
+    NotDeserializableToVec,
 }
 
 impl From<SetOrListTypeCheckErrorKind> for BuiltinTypeCheckErrorKind {
     #[inline]
     fn from(value: SetOrListTypeCheckErrorKind) -> Self {
         BuiltinTypeCheckErrorKind::SetOrListError(value)
+    }
+}
+
+impl From<VectorTypeCheckErrorKind> for BuiltinTypeCheckErrorKind {
+    #[inline]
+    fn from(value: VectorTypeCheckErrorKind) -> Self {
+        BuiltinTypeCheckErrorKind::VectorError(value)
     }
 }
 
@@ -1552,9 +1763,13 @@ impl Display for BuiltinTypeCheckErrorKind {
                 write!(f, "expected one of the CQL types: {expected:?}")
             }
             BuiltinTypeCheckErrorKind::SetOrListError(err) => err.fmt(f),
+            BuiltinTypeCheckErrorKind::VectorError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::MapError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::TupleError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::UdtError(err) => err.fmt(f),
+            BuiltinTypeCheckErrorKind::NotDeserializableToVec => {
+                f.write_str("the CQL type is not deserializable to a vector")
+            }
         }
     }
 }
@@ -1585,6 +1800,20 @@ impl Display for SetOrListTypeCheckErrorKind {
             }
         }
     }
+}
+
+/// Describes why type checking a vector type failed.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum VectorTypeCheckErrorKind {
+    /// The CQL type is not a vector.
+    #[error(
+        "the CQL type the Rust type was attempted to be type checked against was not a vector"
+    )]
+    NotVector,
+    /// Incompatible element types.
+    #[error("the vector element types between the CQL type and the Rust type failed to type check against each other: {0}")]
+    ElementTypeCheckFailed(TypeCheckError),
 }
 
 /// Describes why type checking of a map type failed.
@@ -1833,6 +2062,9 @@ pub enum BuiltinDeserializationErrorKind {
     /// A deserialization failure specific to a CQL set or list.
     SetOrListError(SetOrListDeserializationErrorKind),
 
+    /// A deserialization failure specific to a CQL vector.
+    VectorError(VectorDeserializationErrorKind),
+
     /// A deserialization failure specific to a CQL map.
     MapError(MapDeserializationErrorKind),
 
@@ -1874,6 +2106,7 @@ impl Display for BuiltinDeserializationErrorKind {
                 "the length of read value in bytes ({got}) is not suitable for IP address; expected 4 or 16"
             ),
             BuiltinDeserializationErrorKind::SetOrListError(err) => err.fmt(f),
+            BuiltinDeserializationErrorKind::VectorError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::MapError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::TupleError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::UdtError(err) => err.fmt(f),
@@ -1912,6 +2145,22 @@ impl From<SetOrListDeserializationErrorKind> for BuiltinDeserializationErrorKind
     #[inline]
     fn from(err: SetOrListDeserializationErrorKind) -> Self {
         Self::SetOrListError(err)
+    }
+}
+
+/// Describes why deserialization of a vector type failed.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum VectorDeserializationErrorKind {
+    /// One of the elements of the vector failed to deserialize.
+    #[error("failed to deserialize one of the elements: {0}")]
+    ElementDeserializationFailed(DeserializationError),
+}
+
+impl From<VectorDeserializationErrorKind> for BuiltinDeserializationErrorKind {
+    #[inline]
+    fn from(err: VectorDeserializationErrorKind) -> Self {
+        Self::VectorError(err)
     }
 }
 

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -199,6 +199,308 @@ fn test_deserialize_bytes() {
 }
 
 #[test]
+fn test_deserialize_vector() {
+    // ser/de identity
+
+    // native types
+
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Ascii)),
+            dimensions: 3,
+        },
+        &vec!["ala", "ma", "kota"],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Boolean)),
+            dimensions: 2,
+        },
+        &vec![true, false],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Blob)),
+            dimensions: 2,
+        },
+        &vec![vec![1_u8, 2_u8], vec![3_u8, 4_u8]],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Counter)),
+            dimensions: 2,
+        },
+        &vec![Counter(1234), Counter(5678)],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Date)),
+            dimensions: 2,
+        },
+        &vec![CqlDate(1234), CqlDate(5678)],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Decimal)),
+            dimensions: 2,
+        },
+        &vec![
+            CqlDecimal::from_signed_be_bytes_slice_and_exponent(b"123", 42),
+            CqlDecimal::from_signed_be_bytes_slice_and_exponent(b"123", 42),
+        ],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Double)),
+            dimensions: 2,
+        },
+        &vec![0.1234, 0.5678],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Duration)),
+            dimensions: 2,
+        },
+        &vec![
+            CqlDuration {
+                months: 1,
+                days: 2,
+                nanoseconds: 3,
+            },
+            CqlDuration {
+                months: 1,
+                days: 2,
+                nanoseconds: 3,
+            },
+        ],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Float)),
+            dimensions: 2,
+        },
+        &vec![0.1234_f32, 0.5678_f32],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Int)),
+            dimensions: 2,
+        },
+        &vec![1, 2],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::BigInt)),
+            dimensions: 2,
+        },
+        &vec![1_i64, 2_i64],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Text)),
+            dimensions: 2,
+        },
+        &vec!["ala", "ma"],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Timestamp)),
+            dimensions: 2,
+        },
+        &vec![CqlTimestamp(1234), CqlTimestamp(5678)],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Inet)),
+            dimensions: 2,
+        },
+        &vec![
+            IpAddr::V4(Ipv4Addr::BROADCAST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::SmallInt)),
+            dimensions: 2,
+        },
+        &vec![1_i16, 2_i16],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::TinyInt)),
+            dimensions: 2,
+        },
+        &vec![1_i8, 2_i8],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Time)),
+            dimensions: 2,
+        },
+        &vec![CqlTime(1234), CqlTime(5678)],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Timeuuid)),
+            dimensions: 2,
+        },
+        &vec![CqlTimeuuid::from_u128(123), CqlTimeuuid::from_u128(456)],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Uuid)),
+            dimensions: 2,
+        },
+        &vec![Uuid::from_u128(123), Uuid::from_u128(456)],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Varint)),
+            dimensions: 2,
+        },
+        &vec![
+            CqlVarint::from_signed_bytes_be(vec![1, 2]),
+            CqlVarint::from_signed_bytes_be(vec![3, 4]),
+        ],
+        &mut Bytes::new(),
+    );
+
+    // collection types
+
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Collection {
+                frozen: false,
+                typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
+            }),
+            dimensions: 2,
+        },
+        &vec![vec![1, 2], vec![3, 4]],
+        &mut Bytes::new(),
+    );
+
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Collection {
+                frozen: false,
+                typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Int))),
+            }),
+            dimensions: 2,
+        },
+        &vec![vec![1, 2], vec![3, 4]],
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Collection {
+                frozen: false,
+                typ: CollectionType::Map(
+                    Box::new(ColumnType::Native(NativeType::Int)),
+                    Box::new(ColumnType::Native(NativeType::Int)),
+                ),
+            }),
+            dimensions: 2,
+        },
+        &vec![
+            BTreeMap::from_iter(vec![(1, 2), (3, 4)]),
+            BTreeMap::from_iter(vec![(5, 6), (7, 8)]),
+        ],
+        &mut Bytes::new(),
+    );
+
+    // tuple types
+
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Tuple(vec![
+                ColumnType::Native(NativeType::Int),
+                ColumnType::Native(NativeType::Int),
+            ])),
+            dimensions: 2,
+        },
+        &vec![(1, 2), (3, 4)],
+        &mut Bytes::new(),
+    );
+
+    // nested vector
+
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Vector {
+                typ: Box::new(ColumnType::Native(NativeType::Int)),
+                dimensions: 2,
+            }),
+            dimensions: 2,
+        },
+        &vec![vec![1, 2], vec![3, 4]],
+        &mut Bytes::new(),
+    );
+
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Collection {
+                frozen: false,
+                typ: CollectionType::List(Box::new(ColumnType::Vector {
+                    typ: Box::new(ColumnType::Native(NativeType::Int)),
+                    dimensions: 2,
+                })),
+            }),
+            dimensions: 2,
+        },
+        &vec![vec![vec![1, 2], vec![3, 4]], vec![vec![5, 6], vec![7, 8]]],
+        &mut Bytes::new(),
+    );
+
+    //empty vector
+
+    let vec: Vec<bool> = vec![];
+    assert_ser_de_identity(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Boolean)),
+            dimensions: 0,
+        },
+        &vec,
+        &mut Bytes::new(),
+    );
+
+    // deser_cql_value
+
+    let buf: Vec<u8> = vec![0, 0, 0, 1, 0, 0, 0, 2];
+    let decoded_vec = super::deser_cql_value(
+        &ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(Int)),
+            dimensions: 2,
+        },
+        &mut buf.as_slice(),
+    )
+    .unwrap();
+    assert_eq!(
+        decoded_vec,
+        CqlValue::Vector(vec![CqlValue::Int(1), CqlValue::Int(2)])
+    );
+}
+
+#[test]
 fn test_deserialize_ascii() {
     const ASCII_TEXT: &str = "The quick brown fox jumps over the lazy dog";
 

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -1553,7 +1553,7 @@ fn test_set_or_list_errors() {
             &Bytes::new(),
             Vec<i64>,
             ColumnType::Native(NativeType::Float),
-            BuiltinTypeCheckErrorKind::SetOrListError(SetOrListTypeCheckErrorKind::NotSetOrList)
+            BuiltinTypeCheckErrorKind::NotDeserializableToVec
         );
 
         // Type check of Rust set against CQL list must fail, because it would be lossy.

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -13,6 +13,7 @@ pub use super::request::{
 
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
+use crate::utils::parse::ParseErrorCause;
 use thiserror::Error;
 
 /// An error returned by `parse_response_body_extensions`.
@@ -440,6 +441,8 @@ pub enum CustomTypeParseError {
     UnknownComplexCustomTypeName(String),
     #[error("Unexpected character encountered: {0}, expected: {1}")]
     UnexpectedCharacter(char, char),
+    #[error("Unable to parse an integer: {0}")]
+    IntegerParseError(ParseErrorCause),
     #[error("Unexpected end of input")]
     UnexpectedEndOfInput,
     #[error("Bad hex string: {0}")]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -430,6 +430,26 @@ pub enum ColumnSpecParseErrorKind {
     ColumnTypeParseError(#[from] CqlTypeParseError),
 }
 
+/// An error type returned when deserialization of Custom CQL type name fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum CustomTypeParseError {
+    #[error("Malformed simple custom type name: {0}")]
+    UnknownSimpleCustomTypeName(String),
+    #[error("Malformed complex custom type name: {0}")]
+    UnknownComplexCustomTypeName(String),
+    #[error("Unexpected character encountered: {0}, expected: {1}")]
+    UnexpectedCharacter(char, char),
+    #[error("Unexpected end of input")]
+    UnexpectedEndOfInput,
+    #[error("Bad hex string: {0}")]
+    BadHexString(String),
+    #[error("Bytes {0:?} do not represent a valid UTF-8 string")]
+    InvalidUtf8(Vec<u8>),
+    #[error("Wrong number of parameters {actual}, expected: {expected}")]
+    InvalidParameterCount { actual: usize, expected: usize },
+}
+
 /// An error type returned when deserialization of CQL type name fails.
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]
@@ -452,6 +472,8 @@ pub enum CqlTypeParseError {
     TupleLengthParseError(LowLevelDeserializationError),
     #[error("CQL Type not yet implemented, id: {0}")]
     TypeNotImplemented(u16),
+    #[error("Failed to parse custom CQL type: {0}")]
+    CustomTypeParseError(CustomTypeParseError),
 }
 
 /// A low level deserialization error.

--- a/scylla-cql/src/frame/response/custom_type_parser.rs
+++ b/scylla-cql/src/frame/response/custom_type_parser.rs
@@ -144,6 +144,34 @@ impl<'result> CustomTypeParser<'result> {
         })))
     }
 
+    fn get_vector_parameters(
+        &mut self,
+    ) -> Result<(ColumnType<'result>, u16), CustomTypeParseError> {
+        self.accept_in_place("(")
+            .map_err(|_| CustomTypeParseError::UnexpectedCharacter(self.get_first_char(), '('))?;
+
+        self.skip_blank_and_comma();
+        // This happens when no parameters are provided.
+        // See: https://github.com/scylladb/scylladb/blob/f5125ffa18871ae74c08a4337c599009d5dd48a9/db/marshal/type_parser.cc#L290
+        if self.parser.accept(")").is_ok() {
+            return Err(CustomTypeParseError::InvalidParameterCount {
+                actual: 0,
+                expected: 2,
+            });
+        }
+
+        let typ = self.do_parse()?;
+        self.skip_blank_and_comma();
+        let (len, parser) = self
+            .parser
+            .parse_u16()
+            .map_err(|err| CustomTypeParseError::IntegerParseError(err.get_cause()))?;
+        self.parser = parser;
+        self.accept_in_place(")")
+            .map_err(|_| CustomTypeParseError::UnexpectedCharacter(self.get_first_char(), ')'))?;
+        Ok((typ, len))
+    }
+
     /// Parse a string of hexadecimal representation of bytes into a byte vector.
     fn from_hex(s: &'result str) -> Result<Vec<u8>, CustomTypeParseError> {
         if s.len() % 2 != 0 {
@@ -273,6 +301,13 @@ impl<'result> CustomTypeParser<'result> {
                     });
                 }
                 Ok(ColumnType::Tuple(params))
+            }
+            "VectorType" => {
+                let (typ, len) = self.get_vector_parameters()?;
+                Ok(ColumnType::Vector {
+                    typ: Box::new(typ),
+                    dimensions: len,
+                })
             }
             "UserType" => {
                 let params = self.get_udt_parameters()?;

--- a/scylla-cql/src/frame/response/custom_type_parser.rs
+++ b/scylla-cql/src/frame/response/custom_type_parser.rs
@@ -1,0 +1,326 @@
+use super::result::CollectionType;
+use super::result::NativeType;
+use super::result::{ColumnType, UserDefinedType};
+use crate::frame::frame_errors::CustomTypeParseError;
+use crate::utils::parse::ParseResult;
+use crate::utils::parse::ParserState;
+use itertools::Either;
+use itertools::Itertools as _;
+use std::borrow::Cow;
+use std::char;
+use std::sync::Arc;
+
+// Here the first parameter is a String, as it is converted from a hex byte array,
+// so it will always be owned.
+// The second parameter is read by the parser, it will always be borrowed.
+// The first two parameters are trivially convertible to Cow, which is the type used in the UDT struct,
+// however, a vector of strings would not be trivially convertible, so we put the Cow type here.
+struct UDTParameters<'result> {
+    type_name: String,
+    keyspace: &'result str,
+    field_types: Vec<(Cow<'result, str>, ColumnType<'result>)>,
+}
+
+// This parser is used to parse the type names in the CQL protocol.
+// The logic is based on the ScyllaDB implementation.
+// https://github.com/scylladb/scylladb/blob/f5125ffa18871ae74c08a4337c599009d5dd48a9/db/marshal/type_parser.cc
+
+pub(crate) struct CustomTypeParser<'result> {
+    parser: ParserState<'result>,
+}
+
+impl<'result> CustomTypeParser<'result> {
+    fn new(input: &'result str) -> CustomTypeParser<'result> {
+        Self {
+            parser: ParserState::new(input),
+        }
+    }
+
+    fn get_first_char(&self) -> char {
+        self.parser.s.chars().next().unwrap_or('\0')
+    }
+
+    fn accept_in_place(&mut self, s: &'static str) -> ParseResult<()> {
+        self.parser = self.parser.accept(s)?;
+        Ok(())
+    }
+
+    pub(crate) fn parse(input: &'result str) -> Result<ColumnType<'result>, CustomTypeParseError> {
+        let mut parser = CustomTypeParser::new(input);
+        parser.do_parse()
+    }
+
+    fn is_identifier_char(c: char) -> bool {
+        c.is_alphanumeric() || c == '+' || c == '-' || c == '_' || c == '.' || c == '&'
+    }
+
+    fn read_next_identifier(&mut self) -> &'result str {
+        let (res, parser) = self.parser.take_while(CustomTypeParser::is_identifier_char);
+        self.parser = parser;
+        res
+    }
+
+    fn skip_blank(&mut self) {
+        self.parser = self.parser.skip_white()
+    }
+
+    // This functions skips blank spaces and, optionally, one comma.
+    // This behavior is consistent with the ScyllaDB implementation.
+    // See: https://github.com/scylladb/scylladb/blob/f5125ffa18871ae74c08a4337c599009d5dd48a9/db/marshal/type_parser.cc#L290
+    fn skip_blank_and_comma(&mut self) {
+        self.skip_blank();
+
+        if let Ok(parser) = self.parser.accept(",") {
+            self.parser = parser;
+            self.skip_blank();
+        }
+    }
+
+    fn get_simple_abstract_type(
+        mut name: &'result str,
+    ) -> Result<ColumnType<'result>, CustomTypeParseError> {
+        name = name
+            .strip_prefix("org.apache.cassandra.db.marshal.")
+            .unwrap_or(name);
+
+        let native = match name {
+            "AsciiType" => NativeType::Ascii,
+            "BooleanType" => NativeType::Boolean,
+            "BytesType" => NativeType::Blob,
+            "CounterColumnType" => NativeType::Counter,
+            "DateType" => NativeType::Date,
+            "DecimalType" => NativeType::Decimal,
+            "DoubleType" => NativeType::Double,
+            "DurationType" => NativeType::Duration,
+            "FloatType" => NativeType::Float,
+            "InetAddressType" => NativeType::Inet,
+            "Int32Type" => NativeType::Int,
+            "IntegerType" => NativeType::Varint,
+            "LongType" => NativeType::BigInt,
+            "SimpleDateType" => NativeType::Date,
+            "ShortType" => NativeType::SmallInt,
+            "UTF8Type" => NativeType::Text,
+            "ByteType" => NativeType::TinyInt,
+            "UUIDType" => NativeType::Uuid,
+            "TimeUUIDType" => NativeType::Timeuuid,
+            "SmallIntType" => NativeType::SmallInt,
+            "TinyIntType" => NativeType::TinyInt,
+            "TimeType" => NativeType::Time,
+            "TimestampType" => NativeType::Timestamp,
+            _ => {
+                return Err(CustomTypeParseError::UnknownSimpleCustomTypeName(
+                    name.into(),
+                ))
+            }
+        };
+        Ok(ColumnType::Native(native))
+    }
+
+    fn get_type_parameters(
+        &mut self,
+    ) -> Result<
+        impl Iterator<Item = Result<ColumnType<'result>, CustomTypeParseError>> + '_,
+        CustomTypeParseError,
+    > {
+        if self.parser.is_at_eof() {
+            return Ok(Either::Left(std::iter::empty()));
+        }
+        self.accept_in_place("(")
+            .map_err(|_| CustomTypeParseError::UnexpectedCharacter(self.get_first_char(), '('))?;
+
+        Ok(Either::Right(std::iter::from_fn(|| {
+            self.skip_blank_and_comma();
+            if self.parser.is_at_eof() {
+                return Some(Err(CustomTypeParseError::UnexpectedEndOfInput));
+            }
+            let result = self.parser.accept(")");
+            match result {
+                Ok(parser) => {
+                    self.parser = parser;
+                    None
+                }
+                Err(_) => Some(self.do_parse()),
+            }
+        })))
+    }
+
+    /// Parse a string of hexadecimal representation of bytes into a byte vector.
+    fn from_hex(s: &'result str) -> Result<Vec<u8>, CustomTypeParseError> {
+        if s.len() % 2 != 0 {
+            return Err(CustomTypeParseError::BadHexString(s.to_owned()));
+        }
+        for c in s.chars() {
+            if !c.is_ascii_hexdigit() {
+                return Err(CustomTypeParseError::BadHexString(s.to_owned()));
+            }
+        }
+        let bytes: Vec<_> = s
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|chunk| {
+                // Safety: All characters were checked to be valid ASCII hexdigits,
+                // so two-byte chunks are valid ASCII strings, too.
+                u8::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16)
+            })
+            .collect::<Result<_, _>>()
+            .map_err(|_| CustomTypeParseError::BadHexString(s.to_owned()))?;
+        Ok(bytes)
+    }
+
+    fn get_udt_parameters(&mut self) -> Result<UDTParameters<'result>, CustomTypeParseError> {
+        self.accept_in_place("(")
+            .map_err(|_| CustomTypeParseError::UnexpectedCharacter(self.get_first_char(), '('))?;
+
+        self.skip_blank_and_comma();
+        let keyspace = self.read_next_identifier();
+        self.skip_blank_and_comma();
+        let hex_name = CustomTypeParser::from_hex(self.read_next_identifier())?;
+        let name = String::from_utf8(hex_name)
+            .map_err(|err| CustomTypeParseError::InvalidUtf8(err.into_bytes()))?;
+        let mut fields = Vec::new();
+        loop {
+            self.skip_blank_and_comma();
+            if self.parser.is_at_eof() {
+                return Err(CustomTypeParseError::UnexpectedEndOfInput);
+            }
+            let result = self.parser.accept(")");
+            match result {
+                Ok(parser) => {
+                    self.parser = parser;
+                    return Ok(UDTParameters {
+                        keyspace,
+                        type_name: name,
+                        field_types: fields,
+                    });
+                }
+                Err(_) => {
+                    let field_hex = CustomTypeParser::from_hex(self.read_next_identifier())?;
+                    let field_name = String::from_utf8(field_hex)
+                        .map_err(|err| CustomTypeParseError::InvalidUtf8(err.into_bytes()))?;
+                    self.accept_in_place(":").map_err(|_| {
+                        CustomTypeParseError::UnexpectedCharacter(self.get_first_char(), ':')
+                    })?;
+                    let field_type = self.do_parse()?;
+                    fields.push((Cow::Owned(field_name), field_type));
+                }
+            }
+        }
+    }
+
+    fn get_n_type_parameters<const N: usize>(
+        &mut self,
+    ) -> Result<[Result<ColumnType<'result>, CustomTypeParseError>; N], CustomTypeParseError> {
+        let mut backup = Self {
+            parser: self.parser,
+        };
+
+        self.get_type_parameters()?
+            .collect_array::<N>()
+            .ok_or_else(|| {
+                // unwrap(): get_type_parameters() already worked above, so it will work here as well.
+
+                let actual_parameter_count = backup.get_type_parameters().unwrap().count();
+
+                CustomTypeParseError::InvalidParameterCount {
+                    actual: actual_parameter_count,
+                    expected: N,
+                }
+            })
+    }
+
+    fn get_complex_abstract_type(
+        &mut self,
+        mut name: &'result str,
+    ) -> Result<ColumnType<'result>, CustomTypeParseError> {
+        name = name
+            .strip_prefix("org.apache.cassandra.db.marshal.")
+            .unwrap_or(name);
+
+        match name {
+            "ListType" => {
+                let [element_type_result] = self.get_n_type_parameters::<1>()?;
+                let element_type = element_type_result?;
+                Ok(ColumnType::Collection {
+                    frozen: false,
+                    typ: CollectionType::List(Box::new(element_type)),
+                })
+            }
+            "SetType" => {
+                let [element_type_result] = self.get_n_type_parameters::<1>()?;
+                let element_type = element_type_result?;
+                Ok(ColumnType::Collection {
+                    frozen: false,
+                    typ: CollectionType::Set(Box::new(element_type)),
+                })
+            }
+            "MapType" => {
+                let [key_type_result, value_type_result] = self.get_n_type_parameters::<2>()?;
+                let key_type = key_type_result?;
+                let value_type = value_type_result?;
+                Ok(ColumnType::Collection {
+                    frozen: false,
+                    typ: CollectionType::Map(Box::new(key_type), Box::new(value_type)),
+                })
+            }
+            "TupleType" => {
+                let params = self
+                    .get_type_parameters()?
+                    .collect::<Result<Vec<_>, CustomTypeParseError>>()?;
+                if params.is_empty() {
+                    return Err(CustomTypeParseError::InvalidParameterCount {
+                        actual: 0,
+                        expected: 1,
+                    });
+                }
+                Ok(ColumnType::Tuple(params))
+            }
+            "UserType" => {
+                let params = self.get_udt_parameters()?;
+                Ok(ColumnType::UserDefinedType {
+                    frozen: false,
+                    definition: Arc::new(UserDefinedType {
+                        name: params.type_name.into(),
+                        keyspace: params.keyspace.into(),
+                        field_types: params.field_types,
+                    }),
+                })
+            }
+            name => Err(CustomTypeParseError::UnknownComplexCustomTypeName(
+                name.into(),
+            )),
+        }
+    }
+
+    fn do_parse(&mut self) -> Result<ColumnType<'result>, CustomTypeParseError> {
+        self.skip_blank();
+
+        let mut name = self.read_next_identifier();
+
+        // Not sure why do we return blob, however this code is ripped from ScyllaDB codebase and they do it this way.
+        // See: https://github.com/scylladb/scylladb/commit/f9b83e299e0c8f6bb5b8084afd6eb6c84e5a9b24
+        if name.is_empty() {
+            if !self.parser.is_at_eof() {
+                return Err(CustomTypeParseError::UnknownComplexCustomTypeName(
+                    self.parser.s.into(),
+                ));
+            }
+            return Ok(ColumnType::Native(NativeType::Blob));
+        }
+
+        // Type can be prefixed by a hex number, which is ignored.
+        // See the reasoning here: https://github.com/scylladb/scylladb/commit/85be9f55e8d7692ef4d17458d21049e565ba3680
+        let result = self.parser.accept(":");
+        if let Ok(parser) = result {
+            self.parser = parser;
+            let _ = usize::from_str_radix(name, 16).map_err(|_| CustomTypeParseError::BadHexString);
+            name = self.read_next_identifier();
+        }
+        self.skip_blank();
+        let result = self.parser.accept("(");
+        match result {
+            // Here we do not change the parser state, because we want to keep the state as it was before the accept.
+            Ok(_) => self.get_complex_abstract_type(name),
+            Err(_) => CustomTypeParser::get_simple_abstract_type(name),
+        }
+    }
+}

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -1,4 +1,5 @@
 pub mod authenticate;
+pub mod custom_type_parser;
 pub mod error;
 pub mod event;
 pub mod result;

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1,6 +1,7 @@
 use crate::deserialize::result::{RawRowIterator, TypedRowIterator};
 use crate::deserialize::row::DeserializeRow;
 use crate::deserialize::{FrameSlice, TypeCheckError};
+use crate::frame::frame_errors::CustomTypeParseError;
 use crate::frame::frame_errors::{
     ColumnSpecParseError, ColumnSpecParseErrorKind, CqlResultParseError, CqlTypeParseError,
     LowLevelDeserializationError, PreparedMetadataParseError, PreparedParseError,
@@ -517,6 +518,8 @@ mod self_borrowed_metadata {
 }
 pub use self_borrowed_metadata::SelfBorrowedMetadataContainer;
 
+use super::custom_type_parser::CustomTypeParser;
+
 /// RESULT:Rows response, in partially serialized form.
 ///
 /// Paging state and metadata are deserialized, rows remain serialized.
@@ -604,6 +607,7 @@ pub enum Result {
 fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
     buf: &mut &'frame [u8],
     read_string: fn(&mut &'frame [u8]) -> StdResult<StrT, LowLevelDeserializationError>,
+    read_custom_type: fn(&'frame str) -> StdResult<ColumnType<'result>, CustomTypeParseError>,
 ) -> StdResult<ColumnType<'result>, CqlTypeParseError> {
     use ColumnType::*;
     use NativeType::*;
@@ -611,22 +615,9 @@ fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
         types::read_short(buf).map_err(|err| CqlTypeParseError::TypeIdParseError(err.into()))?;
     Ok(match id {
         0x0000 => {
-            // We use types::read_string instead of read_string argument here on purpose.
-            // Chances are the underlying string is `...DurationType`, in which case
-            // we don't need to allocate it at all. Only for Custom types
-            // (which we don't support anyway) do we need to allocate.
-            // OTOH, the provided `read_string` function deserializes borrowed OR owned string;
-            // here we want to always deserialize borrowed string.
-            let type_str =
+            let type_str: &'frame str =
                 types::read_string(buf).map_err(CqlTypeParseError::CustomTypeNameParseError)?;
-            match type_str {
-                "org.apache.cassandra.db.marshal.DurationType" => Native(Duration),
-                _ => {
-                    return Err(CqlTypeParseError::CustomTypeUnsupported(
-                        type_str.to_owned(),
-                    ))
-                }
-            }
+            read_custom_type(type_str).map_err(CqlTypeParseError::CustomTypeParseError)?
         }
         0x0001 => Native(Ascii),
         0x0002 => Native(BigInt),
@@ -650,18 +641,26 @@ fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
         0x0015 => Native(Duration),
         0x0020 => Collection {
             frozen: false,
-            typ: CollectionType::List(Box::new(deser_type_generic(buf, read_string)?)),
+            typ: CollectionType::List(Box::new(deser_type_generic(
+                buf,
+                read_string,
+                read_custom_type,
+            )?)),
         },
         0x0021 => Collection {
             frozen: false,
             typ: CollectionType::Map(
-                Box::new(deser_type_generic(buf, read_string)?),
-                Box::new(deser_type_generic(buf, read_string)?),
+                Box::new(deser_type_generic(buf, read_string, read_custom_type)?),
+                Box::new(deser_type_generic(buf, read_string, read_custom_type)?),
             ),
         },
         0x0022 => Collection {
             frozen: false,
-            typ: CollectionType::Set(Box::new(deser_type_generic(buf, read_string)?)),
+            typ: CollectionType::Set(Box::new(deser_type_generic(
+                buf,
+                read_string,
+                read_custom_type,
+            )?)),
         },
         0x0030 => {
             let keyspace_name =
@@ -677,7 +676,7 @@ fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
             for _ in 0..fields_size {
                 let field_name =
                     read_string(buf).map_err(CqlTypeParseError::UdtFieldNameParseError)?;
-                let field_type = deser_type_generic(buf, read_string)?;
+                let field_type = deser_type_generic(buf, read_string, read_custom_type)?;
 
                 field_types.push((field_name.into(), field_type));
             }
@@ -697,7 +696,7 @@ fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
                 .into();
             let mut types = Vec::with_capacity(len);
             for _ in 0..len {
-                types.push(deser_type_generic(buf, read_string)?);
+                types.push(deser_type_generic(buf, read_string, read_custom_type)?);
             }
             Tuple(types)
         }
@@ -710,11 +709,15 @@ fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
 fn deser_type_borrowed<'frame>(
     buf: &mut &'frame [u8],
 ) -> StdResult<ColumnType<'frame>, CqlTypeParseError> {
-    deser_type_generic(buf, |buf| types::read_string(buf))
+    deser_type_generic(buf, |buf| types::read_string(buf), CustomTypeParser::parse)
 }
 
 fn deser_type_owned(buf: &mut &[u8]) -> StdResult<ColumnType<'static>, CqlTypeParseError> {
-    deser_type_generic(buf, |buf| types::read_string(buf).map(ToOwned::to_owned))
+    deser_type_generic(
+        buf,
+        |buf| types::read_string(buf).map(ToOwned::to_owned),
+        |type_str| CustomTypeParser::parse(type_str).map(|t| t.into_owned()),
+    )
 }
 
 /// Deserializes a table spec, be it per-column one or a global one,

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -145,7 +145,7 @@ impl<'a> RawValue<'a> {
     }
 }
 
-fn read_raw_bytes<'a>(
+pub(crate) fn read_raw_bytes<'a>(
     count: usize,
     buf: &mut &'a [u8],
 ) -> Result<&'a [u8], LowLevelDeserializationError> {
@@ -632,7 +632,7 @@ fn zig_zag_decode(v: u64) -> i64 {
     ((v >> 1) as i64) ^ -((v & 1) as i64)
 }
 
-fn unsigned_vint_encode(v: u64, buf: &mut Vec<u8>) {
+pub(crate) fn unsigned_vint_encode(v: u64, buf: &mut Vec<u8>) {
     let mut v = v;
     let mut number_of_bytes = (639 - 9 * v.leading_zeros()) >> 6;
     if number_of_bytes <= 1 {
@@ -650,7 +650,7 @@ fn unsigned_vint_encode(v: u64, buf: &mut Vec<u8>) {
     buf.put_uint(v, number_of_bytes as usize)
 }
 
-fn unsigned_vint_decode(buf: &mut &[u8]) -> Result<u64, std::io::Error> {
+pub(crate) fn unsigned_vint_decode(buf: &mut &[u8]) -> Result<u64, std::io::Error> {
     let first_byte = buf.read_u8()?;
     let extra_bytes = first_byte.leading_ones() as usize;
 

--- a/scylla-cql/src/lib.rs
+++ b/scylla-cql/src/lib.rs
@@ -12,6 +12,8 @@ pub mod serialize;
 
 pub mod value;
 
+pub mod utils;
+
 pub use crate::frame::types::Consistency;
 
 #[doc(hidden)]

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -579,6 +579,7 @@ fn serialize_cql_value<'b>(
         }
         CqlValue::Uuid(u) => <_ as SerializeValue>::serialize(&u, typ, writer),
         CqlValue::Varint(v) => <_ as SerializeValue>::serialize(&v, typ, writer),
+        CqlValue::Vector(_) => unimplemented!("Vector serialization is not implemented yet"),
     }
 }
 

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::frame::response::result::{CollectionType, ColumnType, NativeType};
-use crate::frame::types::vint_encode;
+use crate::frame::types::{unsigned_vint_encode, vint_encode};
 use crate::value::{
     Counter, CqlDate, CqlDecimal, CqlDecimalBorrowed, CqlDuration, CqlTime, CqlTimestamp,
     CqlTimeuuid, CqlValue, CqlVarint, CqlVarintBorrowed, MaybeUnset, Unset,
@@ -24,7 +24,7 @@ use crate::value::{
 use crate::value::ValueOverflow;
 
 use super::writers::WrittenCellProof;
-use super::{CellWriter, SerializationError};
+use super::{CellValueBuilder, CellWriter, SerializationError};
 
 /// A type that can be serialized and sent along with a CQL statement.
 ///
@@ -471,13 +471,37 @@ impl<T: SerializeValue> SerializeValue for Vec<T> {
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        serialize_sequence(
-            std::any::type_name::<Self>(),
-            self.len(),
-            self.iter(),
-            typ,
-            writer,
-        )
+        match typ {
+            ColumnType::Collection {
+                typ: CollectionType::List(_) | CollectionType::Set(_),
+                ..
+            } => serialize_sequence(
+                std::any::type_name::<Self>(),
+                self.len(),
+                self.iter(),
+                typ,
+                writer,
+            ),
+
+            ColumnType::Vector {
+                typ: element_type,
+                dimensions,
+            } => serialize_vector(
+                std::any::type_name::<Self>(),
+                self.len(),
+                self.iter(),
+                element_type,
+                *dimensions,
+                typ,
+                writer,
+            ),
+
+            _ => Err(mk_typck_err_named(
+                std::any::type_name::<Self>(),
+                typ,
+                SetOrListTypeCheckErrorKind::NotSetOrList,
+            )),
+        }
     }
 }
 impl<'a, T: SerializeValue + 'a> SerializeValue for &'a [T] {
@@ -486,13 +510,37 @@ impl<'a, T: SerializeValue + 'a> SerializeValue for &'a [T] {
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        serialize_sequence(
-            std::any::type_name::<Self>(),
-            self.len(),
-            self.iter(),
-            typ,
-            writer,
-        )
+        match typ {
+            ColumnType::Collection {
+                typ: CollectionType::List(_) | CollectionType::Set(_),
+                ..
+            } => serialize_sequence(
+                std::any::type_name::<Self>(),
+                self.len(),
+                self.iter(),
+                typ,
+                writer,
+            ),
+
+            ColumnType::Vector {
+                typ: element_type,
+                dimensions,
+            } => serialize_vector(
+                std::any::type_name::<Self>(),
+                self.len(),
+                self.iter(),
+                element_type,
+                *dimensions,
+                typ,
+                writer,
+            ),
+
+            _ => Err(mk_typck_err_named(
+                std::any::type_name::<Self>(),
+                typ,
+                SetOrListTypeCheckErrorKind::NotSetOrList,
+            )),
+        }
     }
 }
 impl SerializeValue for CqlValue {
@@ -579,7 +627,7 @@ fn serialize_cql_value<'b>(
         }
         CqlValue::Uuid(u) => <_ as SerializeValue>::serialize(&u, typ, writer),
         CqlValue::Varint(v) => <_ as SerializeValue>::serialize(&v, typ, writer),
-        CqlValue::Vector(_) => unimplemented!("Vector serialization is not implemented yet"),
+        CqlValue::Vector(v) => <_ as SerializeValue>::serialize(&v, typ, writer),
     }
 }
 
@@ -855,6 +903,101 @@ fn serialize_sequence<'t, 'b, T: SerializeValue + 't>(
         .map_err(|_| mk_ser_err_named(rust_name, typ, BuiltinSerializationErrorKind::SizeOverflow))
 }
 
+fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
+    rust_name: &'static str,
+    element_type: &ColumnType,
+    typ: &ColumnType,
+    builder: &mut CellValueBuilder,
+    element: &'t T,
+) -> Result<(), SerializationError> {
+    T::serialize(
+        element,
+        element_type,
+        builder.make_sub_writer_without_size(),
+    )
+    .map_err(|err| {
+        mk_ser_err_named(
+            rust_name,
+            typ,
+            VectorSerializationErrorKind::ElementSerializationFailed(err),
+        )
+    })?;
+    Ok(())
+}
+
+fn serialize_next_variable_length_elem<'t, T: SerializeValue + 't>(
+    rust_name: &'static str,
+    element_type: &ColumnType,
+    typ: &ColumnType,
+    builder: &mut CellValueBuilder,
+    element: &'t T,
+) -> Result<(), SerializationError> {
+    let mut element_buffer = Vec::new();
+    let inner_writer = CellWriter::new_without_size(&mut element_buffer);
+    T::serialize(element, element_type, inner_writer).map_err(|err| {
+        mk_ser_err_named(
+            rust_name,
+            typ,
+            VectorSerializationErrorKind::ElementSerializationFailed(err),
+        )
+    })?;
+    let mut element_length_buffer = Vec::new();
+    unsigned_vint_encode(
+        element_buffer.len().try_into().unwrap(),
+        &mut element_length_buffer,
+    );
+    builder.append_bytes(element_length_buffer.as_slice());
+    builder.append_bytes(element_buffer.as_slice());
+    Ok(())
+}
+
+fn serialize_vector<'t, 'b, T: SerializeValue + 't>(
+    rust_name: &'static str,
+    len: usize,
+    iter: impl Iterator<Item = &'t T>,
+    element_type: &ColumnType,
+    dimensions: u16,
+    typ: &ColumnType,
+    writer: CellWriter<'b>,
+) -> Result<WrittenCellProof<'b>, SerializationError> {
+    if len != dimensions as usize {
+        return Err(mk_ser_err_named(
+            rust_name,
+            typ,
+            VectorSerializationErrorKind::InvalidNumberOfElements(len, dimensions),
+        ));
+    }
+    let mut builder = writer.into_value_builder();
+    match element_type.type_size() {
+        Some(_) => {
+            for element in iter {
+                serialize_next_constant_length_elem(
+                    rust_name,
+                    element_type,
+                    typ,
+                    &mut builder,
+                    element,
+                )?;
+            }
+        }
+        None => {
+            for element in iter {
+                serialize_next_variable_length_elem(
+                    rust_name,
+                    element_type,
+                    typ,
+                    &mut builder,
+                    element,
+                )?;
+            }
+        }
+    }
+
+    builder
+        .finish()
+        .map_err(|_| mk_ser_err_named(rust_name, typ, BuiltinSerializationErrorKind::SizeOverflow))
+}
+
 fn serialize_mapping<'t, 'b, K: SerializeValue + 't, V: SerializeValue + 't>(
     rust_name: &'static str,
     len: usize,
@@ -1052,6 +1195,9 @@ pub enum BuiltinSerializationErrorKind {
     /// A serialization failure specific to a CQL set or list.
     SetOrListError(SetOrListSerializationErrorKind),
 
+    /// A serialization failure specific to a CQL set or list.
+    VectorError(VectorSerializationErrorKind),
+
     /// A serialization failure specific to a CQL map.
     MapError(MapSerializationErrorKind),
 
@@ -1065,6 +1211,12 @@ pub enum BuiltinSerializationErrorKind {
 impl From<SetOrListSerializationErrorKind> for BuiltinSerializationErrorKind {
     fn from(value: SetOrListSerializationErrorKind) -> Self {
         BuiltinSerializationErrorKind::SetOrListError(value)
+    }
+}
+
+impl From<VectorSerializationErrorKind> for BuiltinSerializationErrorKind {
+    fn from(value: VectorSerializationErrorKind) -> Self {
+        BuiltinSerializationErrorKind::VectorError(value)
     }
 }
 
@@ -1096,6 +1248,7 @@ impl Display for BuiltinSerializationErrorKind {
                 f.write_str("the Rust value is out of range supported by the CQL type")
             }
             BuiltinSerializationErrorKind::SetOrListError(err) => err.fmt(f),
+            BuiltinSerializationErrorKind::VectorError(err) => err.fmt(f),
             BuiltinSerializationErrorKind::MapError(err) => err.fmt(f),
             BuiltinSerializationErrorKind::TupleError(err) => err.fmt(f),
             BuiltinSerializationErrorKind::UdtError(err) => err.fmt(f),
@@ -1155,7 +1308,7 @@ impl Display for MapSerializationErrorKind {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum SetOrListTypeCheckErrorKind {
-    /// The CQL type is neither a set not a list.
+    /// The CQL type is neither a set, nor a list, nor a vector.
     NotSetOrList,
 }
 
@@ -1163,7 +1316,7 @@ impl Display for SetOrListTypeCheckErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SetOrListTypeCheckErrorKind::NotSetOrList => {
-                f.write_str("the CQL type the Rust type was attempted to be type checked against was neither a set or a list")
+                f.write_str("the CQL type the Rust type was attempted to be type checked against was neither a set, nor a list, nor a vector")
             }
         }
     }
@@ -1191,6 +1344,22 @@ impl Display for SetOrListSerializationErrorKind {
             }
         }
     }
+}
+
+/// Describes why serialization of a vector type failed.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum VectorSerializationErrorKind {
+    /// The number of elements in the serialized collection does not match
+    /// the number of vector dimensions
+    #[error(
+        "number of vector elements ({0}) does not match the number of declared dimensions ({1})"
+    )]
+    InvalidNumberOfElements(usize, u16),
+
+    /// One of the elements of the vector failed to serialize.
+    #[error("failed to serialize one of the elements: {0}")]
+    ElementSerializationFailed(SerializationError),
 }
 
 /// Describes why type checking of a tuple failed.

--- a/scylla-cql/src/serialize/writers.rs
+++ b/scylla-cql/src/serialize/writers.rs
@@ -74,6 +74,7 @@ impl<'buf> RowWriter<'buf> {
 /// in nothing being written.
 pub struct CellWriter<'buf> {
     buf: &'buf mut Vec<u8>,
+    write_size: bool,
 }
 
 impl<'buf> CellWriter<'buf> {
@@ -82,7 +83,21 @@ impl<'buf> CellWriter<'buf> {
     /// The newly created row writer will append data to the end of the vec.
     #[inline]
     pub fn new(buf: &'buf mut Vec<u8>) -> Self {
-        Self { buf }
+        Self {
+            buf,
+            write_size: true,
+        }
+    }
+
+    // Creates a new cell writer based on an existing Vec, without writing size.
+    ///
+    /// The newly created row writer will append data to the end of the vec.
+    #[inline]
+    pub fn new_without_size(buf: &'buf mut Vec<u8>) -> Self {
+        Self {
+            buf,
+            write_size: false,
+        }
     }
 
     /// Sets this value to be null, consuming this object.
@@ -110,7 +125,9 @@ impl<'buf> CellWriter<'buf> {
     #[inline]
     pub fn set_value(self, contents: &[u8]) -> Result<WrittenCellProof<'buf>, CellOverflowError> {
         let value_len: i32 = contents.len().try_into().map_err(|_| CellOverflowError)?;
-        self.buf.extend_from_slice(&value_len.to_be_bytes());
+        if self.write_size {
+            self.buf.extend_from_slice(&value_len.to_be_bytes());
+        }
         self.buf.extend_from_slice(contents);
         Ok(WrittenCellProof::new())
     }
@@ -123,7 +140,7 @@ impl<'buf> CellWriter<'buf> {
     /// or UDTs.
     #[inline]
     pub fn into_value_builder(self) -> CellValueBuilder<'buf> {
-        CellValueBuilder::new(self.buf)
+        CellValueBuilder::new(self.buf, self.write_size)
     }
 }
 
@@ -139,20 +156,29 @@ pub struct CellValueBuilder<'buf> {
 
     // Starting position of the value in the buffer.
     starting_pos: usize,
+
+    // Should we write the size of the value?
+    write_size: bool,
 }
 
 impl<'buf> CellValueBuilder<'buf> {
     #[inline]
-    fn new(buf: &'buf mut Vec<u8>) -> Self {
+    fn new(buf: &'buf mut Vec<u8>, write_size: bool) -> Self {
         // "Length" of a [bytes] frame can either be a non-negative i32,
-        // -1 (null) or -1 (not set). Push an invalid value here. It will be
+        // -1 (null) or -2 (not set). Push an invalid value here. It will be
         // overwritten eventually either by set_null, set_unset or Drop.
         // If the CellSerializer is not dropped as it should, this will trigger
         // an error on the DB side and the serialized data
         // won't be misinterpreted.
         let starting_pos = buf.len();
-        buf.extend_from_slice(&(-3i32).to_be_bytes());
-        Self { buf, starting_pos }
+        if write_size {
+            buf.extend_from_slice(&(-3i32).to_be_bytes());
+        }
+        Self {
+            buf,
+            starting_pos,
+            write_size,
+        }
     }
 
     /// Appends raw bytes to this cell.
@@ -168,17 +194,26 @@ impl<'buf> CellValueBuilder<'buf> {
         CellWriter::new(self.buf)
     }
 
+    /// Appends a sub-value to the end of the current contents of the cell
+    /// and returns an object that allows to fill it in, without writing size.
+    #[inline]
+    pub fn make_sub_writer_without_size(&mut self) -> CellWriter<'_> {
+        CellWriter::new_without_size(self.buf)
+    }
+
     /// Finishes serializing the value.
     ///
     /// Fails if the constructed cell size overflows the maximum allowed
     /// CQL cell size (which is i32::MAX).
     #[inline]
     pub fn finish(self) -> Result<WrittenCellProof<'buf>, CellOverflowError> {
-        let value_len: i32 = (self.buf.len() - self.starting_pos - 4)
-            .try_into()
-            .map_err(|_| CellOverflowError)?;
-        self.buf[self.starting_pos..self.starting_pos + 4]
-            .copy_from_slice(&value_len.to_be_bytes());
+        if self.write_size {
+            let value_len: i32 = (self.buf.len() - self.starting_pos - 4)
+                .try_into()
+                .map_err(|_| CellOverflowError)?;
+            self.buf[self.starting_pos..self.starting_pos + 4]
+                .copy_from_slice(&value_len.to_be_bytes());
+        }
         Ok(WrittenCellProof::new())
     }
 }

--- a/scylla-cql/src/utils/mod.rs
+++ b/scylla-cql/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod parse;

--- a/scylla-cql/src/utils/parse.rs
+++ b/scylla-cql/src/utils/parse.rs
@@ -2,29 +2,31 @@ use std::fmt::Display;
 
 /// An error that can occur during parsing.
 #[derive(Copy, Clone)]
-pub(crate) struct ParseError {
-    pub(crate) remaining: usize,
-    pub(crate) cause: ParseErrorCause,
+#[non_exhaustive]
+pub struct ParseError {
+    remaining: usize,
+    cause: ParseErrorCause,
 }
 
 impl ParseError {
     /// Given the original string, returns the 1-based position
     /// of the error in characters.
     /// If an incorrect string was given, the function may return 0.
-    pub(crate) fn calculate_position(&self, original: &str) -> Option<usize> {
+    pub fn calculate_position(&self, original: &str) -> Option<usize> {
         calculate_position(original, self.remaining)
     }
 
     /// Returns the error cause.
-    pub(crate) fn get_cause(&self) -> ParseErrorCause {
+    pub fn get_cause(&self) -> ParseErrorCause {
         self.cause
     }
 }
 
 /// Cause of the parsing error.
 /// Should be lightweight so that it can be quickly discarded.
-#[derive(Copy, Clone)]
-pub(crate) enum ParseErrorCause {
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParseErrorCause {
     Expected(&'static str),
     Other(&'static str),
 }
@@ -38,26 +40,26 @@ impl Display for ParseErrorCause {
     }
 }
 
-pub(crate) type ParseResult<T> = Result<T, ParseError>;
+pub type ParseResult<T> = Result<T, ParseError>;
 
 /// A utility class for building simple recursive-descent parsers.
 ///
 /// Basically, a wrapper over &str with nice methods that help with parsing.
 #[derive(Clone, Copy)]
 #[must_use]
-pub(crate) struct ParserState<'s> {
-    s: &'s str,
+pub struct ParserState<'s> {
+    pub(crate) s: &'s str,
 }
 
 impl<'s> ParserState<'s> {
     /// Creates a new parser from given input string.
-    pub(crate) fn new(s: &'s str) -> Self {
+    pub fn new(s: &'s str) -> Self {
         Self { s }
     }
 
     /// Applies given parsing function until it returns false
     /// and returns the final parser state.
-    pub(crate) fn parse_while(
+    pub fn parse_while(
         self,
         mut parser: impl FnMut(Self) -> ParseResult<(bool, Self)>,
     ) -> ParseResult<Self> {
@@ -74,7 +76,7 @@ impl<'s> ParserState<'s> {
     /// If the input string contains given string at the beginning,
     /// returns a new parser state with given string skipped.
     /// Otherwise, returns an error.
-    pub(crate) fn accept(self, part: &'static str) -> ParseResult<Self> {
+    pub fn accept(self, part: &'static str) -> ParseResult<Self> {
         match self.s.strip_prefix(part) {
             Some(s) => Ok(Self { s }),
             None => Err(self.error(ParseErrorCause::Expected(part))),
@@ -82,7 +84,7 @@ impl<'s> ParserState<'s> {
     }
 
     /// Returns new parser state with whitespace skipped from the beginning.
-    pub(crate) fn skip_white(self) -> Self {
+    pub fn skip_white(self) -> Self {
         let (_, me) = self.take_while(char::is_whitespace);
         me
     }
@@ -93,7 +95,7 @@ impl<'s> ParserState<'s> {
     /// An error is returned if:
     /// * The first character is not a digit
     /// * The integer is larger than u16
-    pub(crate) fn parse_u16(self) -> ParseResult<(u16, Self)> {
+    pub fn parse_u16(self) -> ParseResult<(u16, Self)> {
         let (digits, p) = self.take_while(|c| c.is_ascii_digit());
         if let Ok(value) = digits.parse() {
             Ok((value, p))
@@ -104,24 +106,24 @@ impl<'s> ParserState<'s> {
 
     /// Skips characters from the beginning while they satisfy given predicate
     /// and returns new parser state which
-    pub(crate) fn take_while(self, mut pred: impl FnMut(char) -> bool) -> (&'s str, Self) {
+    pub fn take_while(self, mut pred: impl FnMut(char) -> bool) -> (&'s str, Self) {
         let idx = self.s.find(move |c| !pred(c)).unwrap_or(self.s.len());
         let new = Self { s: &self.s[idx..] };
         (&self.s[..idx], new)
     }
 
     /// Returns the number of remaining bytes to parse.
-    pub(crate) fn get_remaining(self) -> usize {
+    pub fn get_remaining(self) -> usize {
         self.s.len()
     }
 
     /// Returns true if the input string was parsed completely.
-    pub(crate) fn is_at_eof(self) -> bool {
+    pub fn is_at_eof(self) -> bool {
         self.s.is_empty()
     }
 
     /// Returns an error with given cause, associated with given position.
-    pub(crate) fn error(self, cause: ParseErrorCause) -> ParseError {
+    pub fn error(self, cause: ParseErrorCause) -> ParseError {
         ParseError {
             remaining: self.get_remaining(),
             cause,
@@ -131,7 +133,7 @@ impl<'s> ParserState<'s> {
     /// Given the original string, returns the 1-based position
     /// of the error in characters.
     /// If an incorrect string was given, the function may return None.
-    pub(crate) fn calculate_position(self, original: &str) -> Option<usize> {
+    pub fn calculate_position(self, original: &str) -> Option<usize> {
         calculate_position(original, self.get_remaining())
     }
 }

--- a/scylla-cql/src/value.rs
+++ b/scylla-cql/src/value.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::deserialize::value::DeserializeValue;
 use crate::deserialize::value::{
-    mk_deser_err, BuiltinDeserializationErrorKind, MapIterator, UdtIterator,
+    mk_deser_err, BuiltinDeserializationErrorKind, MapIterator, UdtIterator, VectorIterator,
 };
 use crate::deserialize::DeserializationError;
 use crate::deserialize::FrameSlice;
@@ -1324,10 +1324,9 @@ pub fn deser_cql_value(
             CqlValue::Set(s)
         }
         Vector { .. } => {
-            return Err(mk_deser_err::<CqlValue>(
-                typ,
-                BuiltinDeserializationErrorKind::Unsupported,
-            ))
+            let iter = VectorIterator::deserialize(typ, v)?;
+            let v: Vec<CqlValue> = iter.collect::<StdResult<_, _>>()?;
+            CqlValue::Vector(v)
         }
         UserDefinedType {
             definition: udt, ..

--- a/scylla-cql/src/value.rs
+++ b/scylla-cql/src/value.rs
@@ -843,6 +843,7 @@ pub enum CqlValue {
     Tuple(Vec<Option<CqlValue>>),
     Uuid(Uuid),
     Varint(CqlVarint),
+    Vector(Vec<CqlValue>),
 }
 
 impl CqlValue {
@@ -1162,7 +1163,7 @@ impl std::fmt::Display for CqlValue {
                     .fmt(f)?;
                 f.write_str(")")?;
             }
-            CqlValue::List(v) => {
+            CqlValue::List(v) | CqlValue::Vector(v) => {
                 f.write_str("[")?;
                 v.iter().format(",").fmt(f)?;
                 f.write_str("]")?;

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -29,8 +29,8 @@ use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::Token;
 use crate::statement::unprepared::Statement;
-use crate::utils::parse::{ParseErrorCause, ParseResult, ParserState};
 use crate::DeserializeRow;
+use scylla_cql::utils::parse::{ParseErrorCause, ParseResult, ParserState};
 
 use futures::future::{self, FutureExt};
 use futures::stream::{self, StreamExt, TryStreamExt};

--- a/scylla/src/utils/mod.rs
+++ b/scylla/src/utils/mod.rs
@@ -1,4 +1,2 @@
-pub(crate) mod parse;
-
 #[cfg(test)]
 pub(crate) mod test_utils;


### PR DESCRIPTION
This PR adds serialization and deserialization of CQL Vector (as implemented in Cassandra) therefore achieving compatibility with Cassandra's Vector type. It's important to note that Cassandra implements Vector serialization and deserialization in a way that
contradicts the CQL protocol, using [unsigned vint] instead of [int] as the element size encoding for variable type length vectors.

Fixes #1014 

## Pre-review checklist
<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
