### PR TITLE
Remove CqlType in favor of ColumnType

### DIFF
--- a/scylla-cql/benches/benchmark.rs
+++ b/scylla-cql/benches/benchmark.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use scylla_cql::frame::request::query::PagingState;
 use scylla_cql::frame::request::SerializableRequest;
-use scylla_cql::frame::response::result::ColumnType;
+use scylla_cql::frame::response::result::{ColumnType, NativeType};
 use scylla_cql::frame::{request::query, Compression, SerializedRequest};
 use scylla_cql::serialize::row::SerializedValues;
 
@@ -28,18 +28,18 @@ fn serialized_request_make_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("LZ4Compression.SerializedRequest");
     let query_args = [
         ("INSERT foo INTO ks.table_name (?)", {
-            values.add_value(&1234, &ColumnType::Int).unwrap();
+            values.add_value(&1234, &ColumnType::Native(NativeType::Int)).unwrap();
             values.clone()
         }),
         ("INSERT foo, bar, baz INTO ks.table_name (?, ?, ?)", {
-            values.add_value(&"a value", &ColumnType::Text).unwrap();
-            values.add_value(&"i am storing a string", &ColumnType::Text).unwrap();
+            values.add_value(&"a value", &ColumnType::Native(NativeType::Text)).unwrap();
+            values.add_value(&"i am storing a string", &ColumnType::Native(NativeType::Text)).unwrap();
             values.clone()
         }),
         (
             "INSERT foo, bar, baz, boop, blah INTO longer_keyspace.a_big_table_name (?, ?, ?, ?, 1000)",
             {
-                values.add_value(&"dc0c8cd7-d954-47c1-8722-a857941c43fb", &ColumnType::Text).unwrap();
+                values.add_value(&"dc0c8cd7-d954-47c1-8722-a857941c43fb", &ColumnType::Native(NativeType::Text)).unwrap();
                 values.clone()
             }
         ),

--- a/scylla-cql/src/deserialize/mod.rs
+++ b/scylla-cql/src/deserialize/mod.rs
@@ -87,7 +87,7 @@
 //! the respective trait for _all_ lifetimes, i.e.:
 //!
 //! ```rust
-//! # use scylla_cql::frame::response::result::ColumnType;
+//! # use scylla_cql::frame::response::result::{NativeType, ColumnType};
 //! # use scylla_cql::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
 //! # use scylla_cql::deserialize::value::DeserializeValue;
 //! use thiserror::Error;
@@ -101,7 +101,7 @@
 //! }
 //! impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for MyVec {
 //!     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
-//!          if let ColumnType::Blob = typ {
+//!          if let ColumnType::Native(NativeType::Blob) = typ {
 //!              return Ok(());
 //!          }
 //!          Err(TypeCheckError::new(MyDeserError::ExpectedBytes))
@@ -128,7 +128,7 @@
 //! For example:
 //!
 //! ```rust
-//! # use scylla_cql::frame::response::result::ColumnType;
+//! # use scylla_cql::frame::response::result::{NativeType, ColumnType};
 //! # use scylla_cql::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
 //! # use scylla_cql::deserialize::value::DeserializeValue;
 //! use thiserror::Error;
@@ -145,7 +145,7 @@
 //!     'frame: 'a,
 //! {
 //!     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
-//!          if let ColumnType::Blob = typ {
+//!          if let ColumnType::Native(NativeType::Blob) = typ {
 //!              return Ok(());
 //!          }
 //!          Err(TypeCheckError::new(MyDeserError::ExpectedBytes))
@@ -179,7 +179,7 @@
 //! Example:
 //!
 //! ```rust
-//! # use scylla_cql::frame::response::result::ColumnType;
+//! # use scylla_cql::frame::response::result::{NativeType, ColumnType};
 //! # use scylla_cql::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
 //! # use scylla_cql::deserialize::value::DeserializeValue;
 //! # use bytes::Bytes;
@@ -194,7 +194,7 @@
 //! }
 //! impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for MyBytes {
 //!     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
-//!          if let ColumnType::Blob = typ {
+//!          if let ColumnType::Native(NativeType::Blob) = typ {
 //!              return Ok(());
 //!          }
 //!          Err(TypeCheckError::new(MyDeserError::ExpectedBytes))

--- a/scylla-cql/src/deserialize/result.rs
+++ b/scylla-cql/src/deserialize/result.rs
@@ -239,7 +239,7 @@ mod tests {
     use std::ops::Deref;
 
     use crate::frame::response::result::{
-        ColumnSpec, ColumnType, DeserializedMetadataAndRawRows, ResultMetadata,
+        ColumnSpec, ColumnType, DeserializedMetadataAndRawRows, NativeType, ResultMetadata,
     };
 
     use super::super::tests::{serialize_cells, spec, CELL1, CELL2};
@@ -291,8 +291,10 @@ mod tests {
         // `std::sync::LazyLock` is stable since 1.80, so once we bump MSRV enough,
         // we will be able to replace `lazy_static` with `LazyLock`.
 
-        static SPECS: &[ColumnSpec<'static>] =
-            &[spec("b1", ColumnType::Blob), spec("b2", ColumnType::Blob)];
+        static SPECS: &[ColumnSpec<'static>] = &[
+            spec("b1", ColumnType::Native(NativeType::Blob)),
+            spec("b2", ColumnType::Native(NativeType::Blob)),
+        ];
         lazy_static::lazy_static! {
             static ref RAW_DATA: Bytes = serialize_cells([Some(CELL1), Some(CELL2), Some(CELL2), Some(CELL1)]);
         }
@@ -333,8 +335,10 @@ mod tests {
 
     #[test]
     fn test_row_iterators_too_few_rows() {
-        static SPECS: &[ColumnSpec<'static>] =
-            &[spec("b1", ColumnType::Blob), spec("b2", ColumnType::Blob)];
+        static SPECS: &[ColumnSpec<'static>] = &[
+            spec("b1", ColumnType::Native(NativeType::Blob)),
+            spec("b2", ColumnType::Native(NativeType::Blob)),
+        ];
         lazy_static::lazy_static! {
             static ref RAW_DATA: Bytes = serialize_cells([Some(CELL1), Some(CELL2)]);
         }
@@ -363,7 +367,10 @@ mod tests {
     #[test]
     fn test_typed_row_iterator_basic_parse() {
         let raw_data = serialize_cells([Some(CELL1), Some(CELL2), Some(CELL2), Some(CELL1)]);
-        let specs = [spec("b1", ColumnType::Blob), spec("b2", ColumnType::Blob)];
+        let specs = [
+            spec("b1", ColumnType::Native(NativeType::Blob)),
+            spec("b2", ColumnType::Native(NativeType::Blob)),
+        ];
         let iter = RawRowIterator::new(2, &specs, FrameSlice::new(&raw_data));
         let mut iter = TypedRowIterator::<'_, '_, (&[u8], Vec<u8>)>::new(iter).unwrap();
 
@@ -381,7 +388,10 @@ mod tests {
     #[test]
     fn test_typed_row_iterator_wrong_type() {
         let raw_data = Bytes::new();
-        let specs = [spec("b1", ColumnType::Blob), spec("b2", ColumnType::Blob)];
+        let specs = [
+            spec("b1", ColumnType::Native(NativeType::Blob)),
+            spec("b2", ColumnType::Native(NativeType::Blob)),
+        ];
         let iter = RawRowIterator::new(0, &specs, FrameSlice::new(&raw_data));
         assert!(TypedRowIterator::<'_, '_, (i32, i64)>::new(iter).is_err());
     }

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -735,11 +735,11 @@ where
         match typ {
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(el_t),
+                typ: CollectionType::List(el_t),
             }
             | ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(el_t),
+                typ: CollectionType::Set(el_t),
             } => <T as DeserializeValue<'frame, 'metadata>>::type_check(el_t).map_err(|err| {
                 mk_typck_err::<Self>(
                     typ,
@@ -762,11 +762,11 @@ where
         let elem_typ = match typ {
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(elem_typ),
+                typ: CollectionType::List(elem_typ),
             }
             | ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(elem_typ),
+                typ: CollectionType::Set(elem_typ),
             } => elem_typ,
             _ => {
                 unreachable!("Typecheck should have prevented this scenario!")
@@ -851,7 +851,7 @@ where
         match typ {
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(el_t),
+                typ: CollectionType::Set(el_t),
             } => <T as DeserializeValue<'frame, 'metadata>>::type_check(el_t)
                 .map_err(typck_error_replace_rust_name::<Self>),
             _ => Err(mk_typck_err::<Self>(
@@ -882,7 +882,7 @@ where
         match typ {
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(el_t),
+                typ: CollectionType::Set(el_t),
             } => <T as DeserializeValue<'frame, 'metadata>>::type_check(el_t)
                 .map_err(typck_error_replace_rust_name::<Self>),
             _ => Err(mk_typck_err::<Self>(
@@ -956,7 +956,7 @@ where
         match typ {
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(k_t, v_t),
+                typ: CollectionType::Map(k_t, v_t),
             } => {
                 <K as DeserializeValue<'frame, 'metadata>>::type_check(k_t).map_err(|err| {
                     mk_typck_err::<Self>(typ, MapTypeCheckErrorKind::KeyTypeCheckFailed(err))
@@ -977,7 +977,7 @@ where
         let (k_typ, v_typ) = match typ {
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(k_t, v_t),
+                typ: CollectionType::Map(k_t, v_t),
             } => (k_t, v_t),
             _ => {
                 unreachable!("Typecheck should have prevented this scenario!")

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -21,7 +21,7 @@ use crate::frame::value::{
 };
 use crate::frame::{frame_errors::LowLevelDeserializationError, value::CqlVarintBorrowed};
 use crate::frame::{
-    response::result::{deser_cql_value, ColumnType, CqlValue},
+    response::result::{deser_cql_value, ColumnType, CqlValue, NativeType},
     value::CqlDecimalBorrowed,
 };
 
@@ -349,7 +349,7 @@ macro_rules! impl_string_type {
 }
 
 fn check_ascii<T>(typ: &ColumnType, s: &[u8]) -> Result<(), DeserializationError> {
-    if matches!(typ, ColumnType::Ascii) && !s.is_ascii() {
+    if matches!(typ, ColumnType::Native(NativeType::Ascii)) && !s.is_ascii() {
         return Err(mk_deser_err::<T>(
             typ,
             BuiltinDeserializationErrorKind::ExpectedAscii,
@@ -1449,11 +1449,11 @@ fn mk_typck_err_named(
 macro_rules! exact_type_check {
     ($typ:ident, $($cql:tt),*) => {
         match $typ {
-            $(ColumnType::$cql)|* => {},
+            $(ColumnType::Native(NativeType::$cql))|* => {},
             _ => return Err(mk_typck_err::<Self>(
                 $typ,
                 BuiltinTypeCheckErrorKind::MismatchedType {
-                    expected: &[$(ColumnType::$cql),*],
+                    expected: &[$(ColumnType::Native(NativeType::$cql)),*],
                 }
             ))
         }

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -734,9 +734,11 @@ where
     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
         match typ {
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(el_t),
             }
             | ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(el_t),
             } => <T as DeserializeValue<'frame, 'metadata>>::type_check(el_t).map_err(|err| {
                 mk_typck_err::<Self>(
@@ -759,9 +761,11 @@ where
     ) -> Result<Self, DeserializationError> {
         let elem_typ = match typ {
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(elem_typ),
             }
             | ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(elem_typ),
             } => elem_typ,
             _ => {
@@ -846,6 +850,7 @@ where
         // Deserializing List straight to BTreeSet would be lossy.
         match typ {
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(el_t),
             } => <T as DeserializeValue<'frame, 'metadata>>::type_check(el_t)
                 .map_err(typck_error_replace_rust_name::<Self>),
@@ -876,6 +881,7 @@ where
         // Deserializing List straight to HashSet would be lossy.
         match typ {
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(el_t),
             } => <T as DeserializeValue<'frame, 'metadata>>::type_check(el_t)
                 .map_err(typck_error_replace_rust_name::<Self>),
@@ -949,6 +955,7 @@ where
     fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
         match typ {
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(k_t, v_t),
             } => {
                 <K as DeserializeValue<'frame, 'metadata>>::type_check(k_t).map_err(|err| {
@@ -969,6 +976,7 @@ where
     ) -> Result<Self, DeserializationError> {
         let (k_typ, v_typ) = match typ {
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(k_t, v_t),
             } => (k_t, v_t),
             _ => {
@@ -1254,7 +1262,9 @@ impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for UdtIterator<'fra
     ) -> Result<Self, DeserializationError> {
         let v = ensure_not_null_frame_slice::<Self>(typ, v)?;
         let (fields, type_name, keyspace) = match typ {
-            ColumnType::UserDefinedType { definition: udt } => (
+            ColumnType::UserDefinedType {
+                definition: udt, ..
+            } => (
                 udt.field_types.as_ref(),
                 udt.name.as_ref(),
                 udt.keyspace.as_ref(),
@@ -1284,6 +1294,7 @@ impl<'frame, 'metadata> Iterator for UdtIterator<'frame, 'metadata> {
             // There were some bytes but they didn't parse as correct field value
             Some(Err(err)) => Err(mk_deser_err::<Self>(
                 &ColumnType::UserDefinedType {
+                    frozen: false,
                     definition: Arc::new(UserDefinedType {
                         name: self.type_name.into(),
                         keyspace: self.keyspace.into(),

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1830,6 +1830,9 @@ pub enum BuiltinDeserializationErrorKind {
 
     /// A deserialization failure specific to a CQL UDT.
     UdtError(UdtDeserializationErrorKind),
+
+    /// Deserialization of this CQL type is not supported by the driver.
+    Unsupported,
 }
 
 impl Display for BuiltinDeserializationErrorKind {
@@ -1863,6 +1866,9 @@ impl Display for BuiltinDeserializationErrorKind {
             BuiltinDeserializationErrorKind::MapError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::TupleError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::UdtError(err) => err.fmt(f),
+            BuiltinDeserializationErrorKind::Unsupported => {
+                f.write_str("deserialization of this CQL type is not supported by the driver")
+            }
         }
     }
 }

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1778,9 +1778,6 @@ pub enum BuiltinDeserializationErrorKind {
     /// Failed to deserialize raw bytes of cql value.
     RawCqlBytesReadError(LowLevelDeserializationError),
 
-    /// Returned on attempt to deserialize a value of custom type.
-    CustomTypeNotSupported(String),
-
     /// Expected non-null value, got null.
     ExpectedNonNull,
 
@@ -1844,7 +1841,6 @@ impl Display for BuiltinDeserializationErrorKind {
             BuiltinDeserializationErrorKind::MapError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::TupleError(err) => err.fmt(f),
             BuiltinDeserializationErrorKind::UdtError(err) => err.fmt(f),
-            BuiltinDeserializationErrorKind::CustomTypeNotSupported(typ) => write!(f, "Support for custom types is not yet implemented: {}", typ),
         }
     }
 }

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -414,6 +414,7 @@ fn test_null_and_empty() {
     );
     assert_ser_de_identity(
         &ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
         },
         &None::<Vec<&str>>,
@@ -468,6 +469,7 @@ fn test_cql_value() {
 
     assert_ser_de_identity(
         &ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text))),
         },
         &CqlValue::Set(vec![CqlValue::Text("Ala ma kota".to_owned())]),
@@ -486,9 +488,11 @@ fn test_list_and_set() {
     let collection = make_bytes(&collection_contents);
 
     let list_typ = ColumnType::Collection {
+        frozen: false,
         type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
     };
     let set_typ = ColumnType::Collection {
+        frozen: false,
         type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
     };
 
@@ -536,9 +540,11 @@ fn test_list_and_set() {
     // when an empty collection is sent to the DB, the DB nullifies the column instead.
     {
         let list_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
         };
         let set_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::BigInt))),
         };
         type CollTyp = i64;
@@ -585,6 +591,7 @@ fn test_map() {
     let collection = make_bytes(&collection_contents);
 
     let typ = ColumnType::Collection {
+        frozen: false,
         type_: CollectionType::Map(
             Box::new(ColumnType::Native(NativeType::Int)),
             Box::new(ColumnType::Native(NativeType::Ascii)),
@@ -627,6 +634,7 @@ fn test_map() {
     // when an empty collection is sent to the DB, the DB nullifies the column instead.
     {
         let map_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::BigInt)),
                 Box::new(ColumnType::Native(NativeType::Ascii)),
@@ -686,6 +694,7 @@ fn test_tuples() {
     assert_ser_de_identity(
         &ColumnType::Tuple(vec![
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Boolean))),
             },
             ColumnType::Native(NativeType::BigInt),
@@ -715,6 +724,7 @@ pub(crate) fn udt_def_with_fields(
     fields: impl IntoIterator<Item = (impl Into<Cow<'static, str>>, ColumnType<'static>)>,
 ) -> ColumnType<'static> {
     ColumnType::UserDefinedType {
+        frozen: false,
         definition: Arc::new(UserDefinedType {
             name: "udt".into(),
             keyspace: "ks".into(),
@@ -1416,6 +1426,7 @@ fn test_set_or_list_errors() {
             &Bytes::new(),
             BTreeSet<i32>,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
             },
             BuiltinTypeCheckErrorKind::SetOrListError(SetOrListTypeCheckErrorKind::NotSet)
@@ -1428,6 +1439,7 @@ fn test_set_or_list_errors() {
             &Bytes::new(),
             Vec<i64>,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
             },
             BuiltinTypeCheckErrorKind::SetOrListError(
@@ -1437,6 +1449,7 @@ fn test_set_or_list_errors() {
 
         let err = deserialize::<Vec<i64>>(
             &ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Varint))),
             },
             &Bytes::new(),
@@ -1447,6 +1460,7 @@ fn test_set_or_list_errors() {
         assert_eq!(
             err.cql_type,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Varint))),
             },
         );
@@ -1469,6 +1483,7 @@ fn test_set_or_list_errors() {
 
     {
         let ser_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
         };
         let v = vec![123_i32];
@@ -1477,6 +1492,7 @@ fn test_set_or_list_errors() {
         {
             let err = deserialize::<Vec<i64>>(
                 &ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
                 &bytes,
@@ -1487,6 +1503,7 @@ fn test_set_or_list_errors() {
             assert_eq!(
                 err.cql_type,
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             );
@@ -1532,6 +1549,7 @@ fn test_map_errors() {
     {
         let err = deserialize::<HashMap<i64, bool>>(
             &ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Varint)),
                     Box::new(ColumnType::Native(NativeType::Boolean)),
@@ -1545,6 +1563,7 @@ fn test_map_errors() {
         assert_eq!(
             err.cql_type,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Varint)),
                     Box::new(ColumnType::Native(NativeType::Boolean))
@@ -1571,6 +1590,7 @@ fn test_map_errors() {
     {
         let err = deserialize::<BTreeMap<i64, &str>>(
             &ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean)),
@@ -1584,6 +1604,7 @@ fn test_map_errors() {
         assert_eq!(
             err.cql_type,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean))
@@ -1613,6 +1634,7 @@ fn test_map_errors() {
     // Key length mismatch
     {
         let ser_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int)),
                 Box::new(ColumnType::Native(NativeType::Boolean)),
@@ -1623,6 +1645,7 @@ fn test_map_errors() {
 
         let err = deserialize::<HashMap<i64, bool>>(
             &ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean)),
@@ -1636,6 +1659,7 @@ fn test_map_errors() {
         assert_eq!(
             err.cql_type,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean))
@@ -1663,6 +1687,7 @@ fn test_map_errors() {
     // Value length mismatch
     {
         let ser_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int)),
                 Box::new(ColumnType::Native(NativeType::Boolean)),
@@ -1673,6 +1698,7 @@ fn test_map_errors() {
 
         let err = deserialize::<HashMap<i32, i16>>(
             &ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Int)),
                     Box::new(ColumnType::Native(NativeType::SmallInt)),
@@ -1686,6 +1712,7 @@ fn test_map_errors() {
         assert_eq!(
             err.cql_type,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Int)),
                     Box::new(ColumnType::Native(NativeType::SmallInt))
@@ -1834,6 +1861,7 @@ fn test_tuple_errors() {
 #[test]
 fn test_null_errors() {
     let ser_typ = ColumnType::Collection {
+        frozen: false,
         type_: CollectionType::Map(
             Box::new(ColumnType::Native(NativeType::Int)),
             Box::new(ColumnType::Native(NativeType::Boolean)),
@@ -1866,6 +1894,7 @@ fn test_udt_errors() {
             // Not UDT
             {
                 let typ = ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::Map(
                         Box::new(ColumnType::Native(NativeType::Ascii)),
                         Box::new(ColumnType::Native(NativeType::Blob)),
@@ -2049,6 +2078,7 @@ fn test_udt_errors() {
             // Not UDT
             {
                 let typ = ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::Map(
                         Box::new(ColumnType::Native(NativeType::Ascii)),
                         Box::new(ColumnType::Native(NativeType::Blob)),
@@ -2277,6 +2307,7 @@ fn metadata_does_not_bound_deserialized_values() {
 
         // list
         let list_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
         };
         let decoded_vec_str_res = deserialize::<Vec<&str>>(&list_typ, &bytes);
@@ -2284,6 +2315,7 @@ fn metadata_does_not_bound_deserialized_values() {
 
         // set
         let set_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
         };
         let decoded_set_str_res = deserialize::<HashSet<&str>>(&set_typ, &bytes);
@@ -2291,6 +2323,7 @@ fn metadata_does_not_bound_deserialized_values() {
 
         // map
         let map_typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Ascii)),
                 Box::new(ColumnType::Native(NativeType::Int)),
@@ -2300,6 +2333,7 @@ fn metadata_does_not_bound_deserialized_values() {
 
         // UDT
         let udt_typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "udt".into(),
                 keyspace: "ks".into(),

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -415,7 +415,7 @@ fn test_null_and_empty() {
     assert_ser_de_identity(
         &ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
+            typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
         },
         &None::<Vec<&str>>,
         &mut Bytes::new(),
@@ -470,7 +470,7 @@ fn test_cql_value() {
     assert_ser_de_identity(
         &ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text))),
+            typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text))),
         },
         &CqlValue::Set(vec![CqlValue::Text("Ala ma kota".to_owned())]),
         &mut Bytes::new(),
@@ -489,11 +489,11 @@ fn test_list_and_set() {
 
     let list_typ = ColumnType::Collection {
         frozen: false,
-        type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
+        typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
     };
     let set_typ = ColumnType::Collection {
         frozen: false,
-        type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
+        typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
     };
 
     // iterator
@@ -541,11 +541,11 @@ fn test_list_and_set() {
     {
         let list_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
         };
         let set_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::BigInt))),
+            typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::BigInt))),
         };
         type CollTyp = i64;
 
@@ -592,7 +592,7 @@ fn test_map() {
 
     let typ = ColumnType::Collection {
         frozen: false,
-        type_: CollectionType::Map(
+        typ: CollectionType::Map(
             Box::new(ColumnType::Native(NativeType::Int)),
             Box::new(ColumnType::Native(NativeType::Ascii)),
         ),
@@ -635,7 +635,7 @@ fn test_map() {
     {
         let map_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::BigInt)),
                 Box::new(ColumnType::Native(NativeType::Ascii)),
             ),
@@ -695,7 +695,7 @@ fn test_tuples() {
         &ColumnType::Tuple(vec![
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Boolean))),
+                typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Boolean))),
             },
             ColumnType::Native(NativeType::BigInt),
             ColumnType::Native(NativeType::Uuid),
@@ -1427,7 +1427,7 @@ fn test_set_or_list_errors() {
             BTreeSet<i32>,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
+                typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
             },
             BuiltinTypeCheckErrorKind::SetOrListError(SetOrListTypeCheckErrorKind::NotSet)
         );
@@ -1440,7 +1440,7 @@ fn test_set_or_list_errors() {
             Vec<i64>,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
+                typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
             },
             BuiltinTypeCheckErrorKind::SetOrListError(
                 SetOrListTypeCheckErrorKind::ElementTypeCheckFailed(_)
@@ -1450,7 +1450,7 @@ fn test_set_or_list_errors() {
         let err = deserialize::<Vec<i64>>(
             &ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Varint))),
+                typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Varint))),
             },
             &Bytes::new(),
         )
@@ -1461,7 +1461,7 @@ fn test_set_or_list_errors() {
             err.cql_type,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Varint))),
+                typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Varint))),
             },
         );
         let BuiltinTypeCheckErrorKind::SetOrListError(
@@ -1484,7 +1484,7 @@ fn test_set_or_list_errors() {
     {
         let ser_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
+            typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
         };
         let v = vec![123_i32];
         let bytes = serialize(&ser_typ, &v);
@@ -1493,7 +1493,7 @@ fn test_set_or_list_errors() {
             let err = deserialize::<Vec<i64>>(
                 &ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
                 &bytes,
             )
@@ -1504,7 +1504,7 @@ fn test_set_or_list_errors() {
                 err.cql_type,
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             );
             let BuiltinDeserializationErrorKind::SetOrListError(
@@ -1550,7 +1550,7 @@ fn test_map_errors() {
         let err = deserialize::<HashMap<i64, bool>>(
             &ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Varint)),
                     Box::new(ColumnType::Native(NativeType::Boolean)),
                 ),
@@ -1564,7 +1564,7 @@ fn test_map_errors() {
             err.cql_type,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Varint)),
                     Box::new(ColumnType::Native(NativeType::Boolean))
                 ),
@@ -1591,7 +1591,7 @@ fn test_map_errors() {
         let err = deserialize::<BTreeMap<i64, &str>>(
             &ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean)),
                 ),
@@ -1605,7 +1605,7 @@ fn test_map_errors() {
             err.cql_type,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean))
                 ),
@@ -1635,7 +1635,7 @@ fn test_map_errors() {
     {
         let ser_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int)),
                 Box::new(ColumnType::Native(NativeType::Boolean)),
             ),
@@ -1646,7 +1646,7 @@ fn test_map_errors() {
         let err = deserialize::<HashMap<i64, bool>>(
             &ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean)),
                 ),
@@ -1660,7 +1660,7 @@ fn test_map_errors() {
             err.cql_type,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::BigInt)),
                     Box::new(ColumnType::Native(NativeType::Boolean))
                 ),
@@ -1688,7 +1688,7 @@ fn test_map_errors() {
     {
         let ser_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int)),
                 Box::new(ColumnType::Native(NativeType::Boolean)),
             ),
@@ -1699,7 +1699,7 @@ fn test_map_errors() {
         let err = deserialize::<HashMap<i32, i16>>(
             &ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Int)),
                     Box::new(ColumnType::Native(NativeType::SmallInt)),
                 ),
@@ -1713,7 +1713,7 @@ fn test_map_errors() {
             err.cql_type,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Int)),
                     Box::new(ColumnType::Native(NativeType::SmallInt))
                 ),
@@ -1862,7 +1862,7 @@ fn test_tuple_errors() {
 fn test_null_errors() {
     let ser_typ = ColumnType::Collection {
         frozen: false,
-        type_: CollectionType::Map(
+        typ: CollectionType::Map(
             Box::new(ColumnType::Native(NativeType::Int)),
             Box::new(ColumnType::Native(NativeType::Boolean)),
         ),
@@ -1895,7 +1895,7 @@ fn test_udt_errors() {
             {
                 let typ = ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::Map(
+                    typ: CollectionType::Map(
                         Box::new(ColumnType::Native(NativeType::Ascii)),
                         Box::new(ColumnType::Native(NativeType::Blob)),
                     ),
@@ -2079,7 +2079,7 @@ fn test_udt_errors() {
             {
                 let typ = ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::Map(
+                    typ: CollectionType::Map(
                         Box::new(ColumnType::Native(NativeType::Ascii)),
                         Box::new(ColumnType::Native(NativeType::Blob)),
                     ),
@@ -2308,7 +2308,7 @@ fn metadata_does_not_bound_deserialized_values() {
         // list
         let list_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
+            typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
         };
         let decoded_vec_str_res = deserialize::<Vec<&str>>(&list_typ, &bytes);
         let decoded_vec_string_res = deserialize::<Vec<String>>(&list_typ, &bytes);
@@ -2316,7 +2316,7 @@ fn metadata_does_not_bound_deserialized_values() {
         // set
         let set_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
+            typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
         };
         let decoded_set_str_res = deserialize::<HashSet<&str>>(&set_typ, &bytes);
         let decoded_set_string_res = deserialize::<HashSet<String>>(&set_typ, &bytes);
@@ -2324,7 +2324,7 @@ fn metadata_does_not_bound_deserialized_values() {
         // map
         let map_typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Ascii)),
                 Box::new(ColumnType::Native(NativeType::Int)),
             ),

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -10,7 +10,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::deserialize::value::{TupleDeserializationErrorKind, TupleTypeCheckErrorKind};
 use crate::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
-use crate::frame::response::result::{ColumnType, CqlValue};
+use crate::frame::response::result::{ColumnType, CqlValue, NativeType};
 use crate::frame::value::{
     Counter, CqlDate, CqlDecimal, CqlDecimalBorrowed, CqlDuration, CqlTime, CqlTimestamp,
     CqlTimeuuid, CqlVarint, CqlVarintBorrowed,
@@ -32,9 +32,12 @@ fn test_deserialize_bytes() {
 
     let bytes = make_bytes(ORIGINAL_BYTES);
 
-    let decoded_slice = deserialize::<&[u8]>(&ColumnType::Blob, &bytes).unwrap();
-    let decoded_vec = deserialize::<Vec<u8>>(&ColumnType::Blob, &bytes).unwrap();
-    let decoded_bytes = deserialize::<Bytes>(&ColumnType::Blob, &bytes).unwrap();
+    let decoded_slice =
+        deserialize::<&[u8]>(&ColumnType::Native(NativeType::Blob), &bytes).unwrap();
+    let decoded_vec =
+        deserialize::<Vec<u8>>(&ColumnType::Native(NativeType::Blob), &bytes).unwrap();
+    let decoded_bytes =
+        deserialize::<Bytes>(&ColumnType::Native(NativeType::Blob), &bytes).unwrap();
 
     assert_eq!(decoded_slice, ORIGINAL_BYTES);
     assert_eq!(decoded_vec, ORIGINAL_BYTES);
@@ -43,10 +46,18 @@ fn test_deserialize_bytes() {
     // ser/de identity
 
     // Nonempty blob
-    assert_ser_de_identity(&ColumnType::Blob, &ORIGINAL_BYTES, &mut Bytes::new());
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Blob),
+        &ORIGINAL_BYTES,
+        &mut Bytes::new(),
+    );
 
     // Empty blob
-    assert_ser_de_identity(&ColumnType::Blob, &(&[] as &[u8]), &mut Bytes::new());
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Blob),
+        &(&[] as &[u8]),
+        &mut Bytes::new(),
+    );
 }
 
 #[test]
@@ -55,7 +66,12 @@ fn test_deserialize_ascii() {
 
     let ascii = make_bytes(ASCII_TEXT.as_bytes());
 
-    for typ in [ColumnType::Ascii, ColumnType::Text].iter() {
+    for typ in [
+        ColumnType::Native(NativeType::Ascii),
+        ColumnType::Native(NativeType::Text),
+    ]
+    .iter()
+    {
         let decoded_str = deserialize::<&str>(typ, &ascii).unwrap();
         let decoded_string = deserialize::<String>(typ, &ascii).unwrap();
 
@@ -81,19 +97,25 @@ fn test_deserialize_text() {
     let unicode = make_bytes(UNICODE_TEXT.as_bytes());
 
     // Should fail because it's not an ASCII string
-    deserialize::<&str>(&ColumnType::Ascii, &unicode).unwrap_err();
-    deserialize::<String>(&ColumnType::Ascii, &unicode).unwrap_err();
+    deserialize::<&str>(&ColumnType::Native(NativeType::Ascii), &unicode).unwrap_err();
+    deserialize::<String>(&ColumnType::Native(NativeType::Ascii), &unicode).unwrap_err();
 
-    let decoded_text_str = deserialize::<&str>(&ColumnType::Text, &unicode).unwrap();
-    let decoded_text_string = deserialize::<String>(&ColumnType::Text, &unicode).unwrap();
+    let decoded_text_str =
+        deserialize::<&str>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
+    let decoded_text_string =
+        deserialize::<String>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
     assert_eq!(decoded_text_str, UNICODE_TEXT);
     assert_eq!(decoded_text_string, UNICODE_TEXT);
 
     // ser/de identity
 
-    assert_ser_de_identity(&ColumnType::Text, &UNICODE_TEXT, &mut Bytes::new());
     assert_ser_de_identity(
-        &ColumnType::Text,
+        &ColumnType::Native(NativeType::Text),
+        &UNICODE_TEXT,
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Text),
         &UNICODE_TEXT.to_owned(),
         &mut Bytes::new(),
     );
@@ -102,100 +124,133 @@ fn test_deserialize_text() {
 #[test]
 fn test_integral() {
     let tinyint = make_bytes(&[0x01]);
-    let decoded_tinyint = deserialize::<i8>(&ColumnType::TinyInt, &tinyint).unwrap();
+    let decoded_tinyint =
+        deserialize::<i8>(&ColumnType::Native(NativeType::TinyInt), &tinyint).unwrap();
     assert_eq!(decoded_tinyint, 0x01);
 
     let smallint = make_bytes(&[0x01, 0x02]);
-    let decoded_smallint = deserialize::<i16>(&ColumnType::SmallInt, &smallint).unwrap();
+    let decoded_smallint =
+        deserialize::<i16>(&ColumnType::Native(NativeType::SmallInt), &smallint).unwrap();
     assert_eq!(decoded_smallint, 0x0102);
 
     let int = make_bytes(&[0x01, 0x02, 0x03, 0x04]);
-    let decoded_int = deserialize::<i32>(&ColumnType::Int, &int).unwrap();
+    let decoded_int = deserialize::<i32>(&ColumnType::Native(NativeType::Int), &int).unwrap();
     assert_eq!(decoded_int, 0x01020304);
 
     let bigint = make_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-    let decoded_bigint = deserialize::<i64>(&ColumnType::BigInt, &bigint).unwrap();
+    let decoded_bigint =
+        deserialize::<i64>(&ColumnType::Native(NativeType::BigInt), &bigint).unwrap();
     assert_eq!(decoded_bigint, 0x0102030405060708);
 
     // ser/de identity
-    assert_ser_de_identity(&ColumnType::TinyInt, &42_i8, &mut Bytes::new());
-    assert_ser_de_identity(&ColumnType::SmallInt, &2137_i16, &mut Bytes::new());
-    assert_ser_de_identity(&ColumnType::Int, &21372137_i32, &mut Bytes::new());
-    assert_ser_de_identity(&ColumnType::BigInt, &0_i64, &mut Bytes::new());
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::TinyInt),
+        &42_i8,
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::SmallInt),
+        &2137_i16,
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Int),
+        &21372137_i32,
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::BigInt),
+        &0_i64,
+        &mut Bytes::new(),
+    );
 }
 
 #[test]
 fn test_bool() {
     for boolean in [true, false] {
         let boolean_bytes = make_bytes(&[boolean as u8]);
-        let decoded_bool = deserialize::<bool>(&ColumnType::Boolean, &boolean_bytes).unwrap();
+        let decoded_bool =
+            deserialize::<bool>(&ColumnType::Native(NativeType::Boolean), &boolean_bytes).unwrap();
         assert_eq!(decoded_bool, boolean);
 
         // ser/de identity
-        assert_ser_de_identity(&ColumnType::Boolean, &boolean, &mut Bytes::new());
+        assert_ser_de_identity(
+            &ColumnType::Native(NativeType::Boolean),
+            &boolean,
+            &mut Bytes::new(),
+        );
     }
 }
 
 #[test]
 fn test_floating_point() {
     let float = make_bytes(&[63, 0, 0, 0]);
-    let decoded_float = deserialize::<f32>(&ColumnType::Float, &float).unwrap();
+    let decoded_float = deserialize::<f32>(&ColumnType::Native(NativeType::Float), &float).unwrap();
     assert_eq!(decoded_float, 0.5);
 
     let double = make_bytes(&[64, 0, 0, 0, 0, 0, 0, 0]);
-    let decoded_double = deserialize::<f64>(&ColumnType::Double, &double).unwrap();
+    let decoded_double =
+        deserialize::<f64>(&ColumnType::Native(NativeType::Double), &double).unwrap();
     assert_eq!(decoded_double, 2.0);
 
     // ser/de identity
-    assert_ser_de_identity(&ColumnType::Float, &21.37_f32, &mut Bytes::new());
-    assert_ser_de_identity(&ColumnType::Double, &2137.2137_f64, &mut Bytes::new());
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Float),
+        &21.37_f32,
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Double),
+        &2137.2137_f64,
+        &mut Bytes::new(),
+    );
 }
 
 #[test]
 fn test_varlen_numbers() {
     // varint
     assert_ser_de_identity(
-        &ColumnType::Varint,
+        &ColumnType::Native(NativeType::Varint),
         &CqlVarint::from_signed_bytes_be_slice(b"Ala ma kota"),
         &mut Bytes::new(),
     );
 
     assert_ser_de_identity(
-        &ColumnType::Varint,
+        &ColumnType::Native(NativeType::Varint),
         &CqlVarintBorrowed::from_signed_bytes_be_slice(b"Ala ma kota"),
         &mut Bytes::new(),
     );
 
     #[cfg(feature = "num-bigint-03")]
     assert_ser_de_identity(
-        &ColumnType::Varint,
+        &ColumnType::Native(NativeType::Varint),
         &num_bigint_03::BigInt::from_signed_bytes_be(b"Kot ma Ale"),
         &mut Bytes::new(),
     );
 
     #[cfg(feature = "num-bigint-04")]
     assert_ser_de_identity(
-        &ColumnType::Varint,
+        &ColumnType::Native(NativeType::Varint),
         &num_bigint_04::BigInt::from_signed_bytes_be(b"Kot ma Ale"),
         &mut Bytes::new(),
     );
 
     // decimal
     assert_ser_de_identity(
-        &ColumnType::Decimal,
+        &ColumnType::Native(NativeType::Decimal),
         &CqlDecimal::from_signed_be_bytes_slice_and_exponent(b"Ala ma kota", 42),
         &mut Bytes::new(),
     );
 
     assert_ser_de_identity(
-        &ColumnType::Decimal,
+        &ColumnType::Native(NativeType::Decimal),
         &CqlDecimalBorrowed::from_signed_be_bytes_slice_and_exponent(b"Ala ma kota", 42),
         &mut Bytes::new(),
     );
 
     #[cfg(feature = "bigdecimal-04")]
     assert_ser_de_identity(
-        &ColumnType::Decimal,
+        &ColumnType::Native(NativeType::Decimal),
         &bigdecimal_04::BigDecimal::new(
             bigdecimal_04::num_bigint::BigInt::from_signed_bytes_be(b"Ala ma kota"),
             42,
@@ -208,7 +263,7 @@ fn test_varlen_numbers() {
 fn test_date_time_types() {
     // duration
     assert_ser_de_identity(
-        &ColumnType::Duration,
+        &ColumnType::Native(NativeType::Duration),
         &CqlDuration {
             months: 21,
             days: 37,
@@ -218,56 +273,64 @@ fn test_date_time_types() {
     );
 
     // date
-    assert_ser_de_identity(&ColumnType::Date, &CqlDate(0xbeaf), &mut Bytes::new());
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Date),
+        &CqlDate(0xbeaf),
+        &mut Bytes::new(),
+    );
 
     #[cfg(feature = "chrono-04")]
     assert_ser_de_identity(
-        &ColumnType::Date,
+        &ColumnType::Native(NativeType::Date),
         &chrono_04::NaiveDate::from_yo_opt(1999, 99).unwrap(),
         &mut Bytes::new(),
     );
 
     #[cfg(feature = "time-03")]
     assert_ser_de_identity(
-        &ColumnType::Date,
+        &ColumnType::Native(NativeType::Date),
         &time_03::Date::from_ordinal_date(1999, 99).unwrap(),
         &mut Bytes::new(),
     );
 
     // time
-    assert_ser_de_identity(&ColumnType::Time, &CqlTime(0xdeed), &mut Bytes::new());
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Time),
+        &CqlTime(0xdeed),
+        &mut Bytes::new(),
+    );
 
     #[cfg(feature = "chrono-04")]
     assert_ser_de_identity(
-        &ColumnType::Time,
+        &ColumnType::Native(NativeType::Time),
         &chrono_04::NaiveTime::from_hms_micro_opt(21, 37, 21, 37).unwrap(),
         &mut Bytes::new(),
     );
 
     #[cfg(feature = "time-03")]
     assert_ser_de_identity(
-        &ColumnType::Time,
+        &ColumnType::Native(NativeType::Time),
         &time_03::Time::from_hms_micro(21, 37, 21, 37).unwrap(),
         &mut Bytes::new(),
     );
 
     // timestamp
     assert_ser_de_identity(
-        &ColumnType::Timestamp,
+        &ColumnType::Native(NativeType::Timestamp),
         &CqlTimestamp(0xceed),
         &mut Bytes::new(),
     );
 
     #[cfg(feature = "chrono-04")]
     assert_ser_de_identity(
-        &ColumnType::Timestamp,
+        &ColumnType::Native(NativeType::Timestamp),
         &chrono_04::DateTime::<chrono_04::Utc>::from_timestamp_millis(0xdead_cafe_deaf).unwrap(),
         &mut Bytes::new(),
     );
 
     #[cfg(feature = "time-03")]
     assert_ser_de_identity(
-        &ColumnType::Timestamp,
+        &ColumnType::Native(NativeType::Timestamp),
         &time_03::OffsetDateTime::from_unix_timestamp(0xdead_cafe).unwrap(),
         &mut Bytes::new(),
     );
@@ -276,13 +339,13 @@ fn test_date_time_types() {
 #[test]
 fn test_inet() {
     assert_ser_de_identity(
-        &ColumnType::Inet,
+        &ColumnType::Native(NativeType::Inet),
         &IpAddr::V4(Ipv4Addr::BROADCAST),
         &mut Bytes::new(),
     );
 
     assert_ser_de_identity(
-        &ColumnType::Inet,
+        &ColumnType::Native(NativeType::Inet),
         &IpAddr::V6(Ipv6Addr::LOCALHOST),
         &mut Bytes::new(),
     );
@@ -291,13 +354,13 @@ fn test_inet() {
 #[test]
 fn test_uuid() {
     assert_ser_de_identity(
-        &ColumnType::Uuid,
+        &ColumnType::Native(NativeType::Uuid),
         &Uuid::from_u128(0xdead_cafe_deaf_feed_beaf_bead),
         &mut Bytes::new(),
     );
 
     assert_ser_de_identity(
-        &ColumnType::Timeuuid,
+        &ColumnType::Native(NativeType::Timeuuid),
         &CqlTimeuuid::from_u128(0xdead_cafe_deaf_feed_beaf_bead),
         &mut Bytes::new(),
     );
@@ -307,34 +370,47 @@ fn test_uuid() {
 fn test_null_and_empty() {
     // non-nullable emptiable deserialization, non-empty value
     let int = make_bytes(&[21, 37, 0, 0]);
-    let decoded_int = deserialize::<MaybeEmpty<i32>>(&ColumnType::Int, &int).unwrap();
+    let decoded_int =
+        deserialize::<MaybeEmpty<i32>>(&ColumnType::Native(NativeType::Int), &int).unwrap();
     assert_eq!(decoded_int, MaybeEmpty::Value((21 << 24) + (37 << 16)));
 
     // non-nullable emptiable deserialization, empty value
     let int = make_bytes(&[]);
-    let decoded_int = deserialize::<MaybeEmpty<i32>>(&ColumnType::Int, &int).unwrap();
+    let decoded_int =
+        deserialize::<MaybeEmpty<i32>>(&ColumnType::Native(NativeType::Int), &int).unwrap();
     assert_eq!(decoded_int, MaybeEmpty::Empty);
 
     // nullable non-emptiable deserialization, non-null value
     let int = make_bytes(&[21, 37, 0, 0]);
-    let decoded_int = deserialize::<Option<i32>>(&ColumnType::Int, &int).unwrap();
+    let decoded_int =
+        deserialize::<Option<i32>>(&ColumnType::Native(NativeType::Int), &int).unwrap();
     assert_eq!(decoded_int, Some((21 << 24) + (37 << 16)));
 
     // nullable non-emptiable deserialization, null value
     let int = make_null();
-    let decoded_int = deserialize::<Option<i32>>(&ColumnType::Int, &int).unwrap();
+    let decoded_int =
+        deserialize::<Option<i32>>(&ColumnType::Native(NativeType::Int), &int).unwrap();
     assert_eq!(decoded_int, None);
 
     // nullable emptiable deserialization, non-null non-empty value
     let int = make_bytes(&[]);
-    let decoded_int = deserialize::<Option<MaybeEmpty<i32>>>(&ColumnType::Int, &int).unwrap();
+    let decoded_int =
+        deserialize::<Option<MaybeEmpty<i32>>>(&ColumnType::Native(NativeType::Int), &int).unwrap();
     assert_eq!(decoded_int, Some(MaybeEmpty::Empty));
 
     // ser/de identity
-    assert_ser_de_identity(&ColumnType::Int, &Some(12321_i32), &mut Bytes::new());
-    assert_ser_de_identity(&ColumnType::Double, &None::<f64>, &mut Bytes::new());
     assert_ser_de_identity(
-        &ColumnType::Set(Box::new(ColumnType::Ascii)),
+        &ColumnType::Native(NativeType::Int),
+        &Some(12321_i32),
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Double),
+        &None::<f64>,
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Set(Box::new(ColumnType::Native(NativeType::Ascii))),
         &None::<Vec<&str>>,
         &mut Bytes::new(),
     );
@@ -343,44 +419,50 @@ fn test_null_and_empty() {
 #[test]
 fn test_maybe_empty() {
     let empty = make_bytes(&[]);
-    let decoded_empty = deserialize::<MaybeEmpty<i8>>(&ColumnType::TinyInt, &empty).unwrap();
+    let decoded_empty =
+        deserialize::<MaybeEmpty<i8>>(&ColumnType::Native(NativeType::TinyInt), &empty).unwrap();
     assert_eq!(decoded_empty, MaybeEmpty::Empty);
 
     let non_empty = make_bytes(&[0x01]);
     let decoded_non_empty =
-        deserialize::<MaybeEmpty<i8>>(&ColumnType::TinyInt, &non_empty).unwrap();
+        deserialize::<MaybeEmpty<i8>>(&ColumnType::Native(NativeType::TinyInt), &non_empty)
+            .unwrap();
     assert_eq!(decoded_non_empty, MaybeEmpty::Value(0x01));
 }
 
 #[test]
 fn test_cql_value() {
     assert_ser_de_identity(
-        &ColumnType::Counter,
+        &ColumnType::Native(NativeType::Counter),
         &CqlValue::Counter(Counter(765)),
         &mut Bytes::new(),
     );
 
     assert_ser_de_identity(
-        &ColumnType::Timestamp,
+        &ColumnType::Native(NativeType::Timestamp),
         &CqlValue::Timestamp(CqlTimestamp(2136)),
         &mut Bytes::new(),
     );
 
-    assert_ser_de_identity(&ColumnType::Boolean, &CqlValue::Empty, &mut Bytes::new());
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Boolean),
+        &CqlValue::Empty,
+        &mut Bytes::new(),
+    );
 
     assert_ser_de_identity(
-        &ColumnType::Text,
+        &ColumnType::Native(NativeType::Text),
         &CqlValue::Text("kremówki".to_owned()),
         &mut Bytes::new(),
     );
     assert_ser_de_identity(
-        &ColumnType::Ascii,
+        &ColumnType::Native(NativeType::Ascii),
         &CqlValue::Ascii("kremowy".to_owned()),
         &mut Bytes::new(),
     );
 
     assert_ser_de_identity(
-        &ColumnType::Set(Box::new(ColumnType::Text)),
+        &ColumnType::Set(Box::new(ColumnType::Native(NativeType::Text))),
         &CqlValue::Set(vec![CqlValue::Text("Ala ma kota".to_owned())]),
         &mut Bytes::new(),
     );
@@ -396,8 +478,8 @@ fn test_list_and_set() {
 
     let collection = make_bytes(&collection_contents);
 
-    let list_typ = ColumnType::List(Box::new(ColumnType::Ascii));
-    let set_typ = ColumnType::Set(Box::new(ColumnType::Ascii));
+    let list_typ = ColumnType::List(Box::new(ColumnType::Native(NativeType::Ascii)));
+    let set_typ = ColumnType::Set(Box::new(ColumnType::Native(NativeType::Ascii)));
 
     // iterator
     let mut iter = deserialize::<ListlikeIterator<&str>>(&list_typ, &collection).unwrap();
@@ -442,8 +524,8 @@ fn test_list_and_set() {
     // Null collections are interpreted as empty collections, to retain convenience:
     // when an empty collection is sent to the DB, the DB nullifies the column instead.
     {
-        let list_typ = ColumnType::List(Box::new(ColumnType::BigInt));
-        let set_typ = ColumnType::Set(Box::new(ColumnType::BigInt));
+        let list_typ = ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt)));
+        let set_typ = ColumnType::Set(Box::new(ColumnType::Native(NativeType::BigInt)));
         type CollTyp = i64;
 
         fn check<'frame, 'metadata, Collection: DeserializeValue<'frame, 'metadata>>(
@@ -487,7 +569,10 @@ fn test_map() {
 
     let collection = make_bytes(&collection_contents);
 
-    let typ = ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::Ascii));
+    let typ = ColumnType::Map(
+        Box::new(ColumnType::Native(NativeType::Int)),
+        Box::new(ColumnType::Native(NativeType::Ascii)),
+    );
 
     // iterator
     let mut iter = deserialize::<MapIterator<i32, &str>>(&typ, &collection).unwrap();
@@ -524,7 +609,10 @@ fn test_map() {
     // Null collections are interpreted as empty collections, to retain convenience:
     // when an empty collection is sent to the DB, the DB nullifies the column instead.
     {
-        let map_typ = ColumnType::Map(Box::new(ColumnType::BigInt), Box::new(ColumnType::Ascii));
+        let map_typ = ColumnType::Map(
+            Box::new(ColumnType::Native(NativeType::BigInt)),
+            Box::new(ColumnType::Native(NativeType::Ascii)),
+        );
         type KeyTyp = i64;
         type ValueTyp<'s> = &'s str;
 
@@ -561,7 +649,11 @@ fn test_tuples() {
 
     let tuple = make_bytes(&tuple_contents);
 
-    let typ = ColumnType::Tuple(vec![ColumnType::Int, ColumnType::Ascii, ColumnType::Uuid]);
+    let typ = ColumnType::Tuple(vec![
+        ColumnType::Native(NativeType::Int),
+        ColumnType::Native(NativeType::Ascii),
+        ColumnType::Native(NativeType::Uuid),
+    ]);
 
     let tup = deserialize::<(i32, &str, Option<Uuid>)>(&typ, &tuple).unwrap();
     assert_eq!(tup, (42, "foo", None));
@@ -574,10 +666,10 @@ fn test_tuples() {
     // nonempty, varied tuple
     assert_ser_de_identity(
         &ColumnType::Tuple(vec![
-            ColumnType::List(Box::new(ColumnType::Boolean)),
-            ColumnType::BigInt,
-            ColumnType::Uuid,
-            ColumnType::Inet,
+            ColumnType::List(Box::new(ColumnType::Native(NativeType::Boolean))),
+            ColumnType::Native(NativeType::BigInt),
+            ColumnType::Native(NativeType::Uuid),
+            ColumnType::Native(NativeType::Inet),
         ]),
         &(
             vec![true, false, true],
@@ -591,7 +683,7 @@ fn test_tuples() {
     // nested tuples
     assert_ser_de_identity(
         &ColumnType::Tuple(vec![ColumnType::Tuple(vec![ColumnType::Tuple(vec![
-            ColumnType::Text,
+            ColumnType::Native(NativeType::Text),
         ])])]),
         &((("",),),),
         &mut Bytes::new(),
@@ -670,9 +762,9 @@ fn test_udt_loose_ordering() {
             .field(&2137_i64.to_be_bytes())
             .finalize();
         let typ = udt_def_with_fields([
-            ("a", ColumnType::Text),
-            ("b", ColumnType::Int),
-            ("c", ColumnType::BigInt),
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+            ("c", ColumnType::Native(NativeType::BigInt)),
         ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
@@ -694,9 +786,9 @@ fn test_udt_loose_ordering() {
             .field("The quick brown fox".as_bytes())
             .finalize();
         let typ = udt_def_with_fields([
-            ("a", ColumnType::Text),
-            ("b", ColumnType::Int),
-            ("c", ColumnType::BigInt),
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+            ("c", ColumnType::Native(NativeType::BigInt)),
         ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
@@ -719,9 +811,9 @@ fn test_udt_loose_ordering() {
             .field(&2137_i64.to_be_bytes())
             .finalize();
         let typ = udt_def_with_fields([
-            ("b", ColumnType::Int),
-            ("a", ColumnType::Text),
-            ("c", ColumnType::BigInt),
+            ("b", ColumnType::Native(NativeType::Int)),
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("c", ColumnType::Native(NativeType::BigInt)),
         ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
@@ -745,10 +837,10 @@ fn test_udt_loose_ordering() {
             .field(&2137_i64.to_be_bytes())
             .finalize();
         let typ = udt_def_with_fields([
-            ("d", ColumnType::TinyInt),
-            ("b", ColumnType::Int),
-            ("a", ColumnType::Text),
-            ("c", ColumnType::BigInt),
+            ("d", ColumnType::Native(NativeType::TinyInt)),
+            ("b", ColumnType::Native(NativeType::Int)),
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("c", ColumnType::Native(NativeType::BigInt)),
         ]);
 
         Udt::type_check(&typ).unwrap();
@@ -769,7 +861,10 @@ fn test_udt_loose_ordering() {
         let udt_bytes = UdtSerializer::new()
             .field("The quick brown fox".as_bytes())
             .finalize();
-        let typ = udt_def_with_fields([("a", ColumnType::Text), ("c", ColumnType::BigInt)]);
+        let typ = udt_def_with_fields([
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("c", ColumnType::Native(NativeType::BigInt)),
+        ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -785,13 +880,13 @@ fn test_udt_loose_ordering() {
 
     // Wrong column type
     {
-        let typ = udt_def_with_fields([("a", ColumnType::Text)]);
+        let typ = udt_def_with_fields([("a", ColumnType::Native(NativeType::Text))]);
         Udt::type_check(&typ).unwrap_err();
     }
 
     // Missing required column
     {
-        let typ = udt_def_with_fields([("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([("b", ColumnType::Native(NativeType::Int))]);
         Udt::type_check(&typ).unwrap_err();
     }
 }
@@ -815,7 +910,10 @@ fn test_udt_strict_ordering() {
             .field("The quick brown fox".as_bytes())
             .field(&42i32.to_be_bytes())
             .finalize();
-        let typ = udt_def_with_fields([("a", ColumnType::Text), ("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+        ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -834,7 +932,10 @@ fn test_udt_strict_ordering() {
         let udt_bytes = UdtSerializer::new()
             .field("The quick brown fox".as_bytes())
             .finalize();
-        let typ = udt_def_with_fields([("a", ColumnType::Text), ("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+        ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -855,9 +956,9 @@ fn test_udt_strict_ordering() {
             .field(&(true as i8).to_be_bytes())
             .finalize();
         let typ = udt_def_with_fields([
-            ("a", ColumnType::Text),
-            ("b", ColumnType::Int),
-            ("d", ColumnType::Boolean),
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+            ("d", ColumnType::Native(NativeType::Boolean)),
         ]);
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -882,9 +983,9 @@ fn test_udt_strict_ordering() {
         }
 
         let typ = udt_def_with_fields([
-            ("a", ColumnType::Text),
-            ("b", ColumnType::Int),
-            ("d", ColumnType::Boolean),
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+            ("d", ColumnType::Native(NativeType::Boolean)),
         ]);
 
         Udt::type_check(&typ).unwrap_err();
@@ -892,26 +993,32 @@ fn test_udt_strict_ordering() {
 
     // UDT fields switched - will not work
     {
-        let typ = udt_def_with_fields([("b", ColumnType::Int), ("a", ColumnType::Text)]);
+        let typ = udt_def_with_fields([
+            ("b", ColumnType::Native(NativeType::Int)),
+            ("a", ColumnType::Native(NativeType::Text)),
+        ]);
         Udt::type_check(&typ).unwrap_err();
     }
 
     // Wrong column type
     {
-        let typ = udt_def_with_fields([("a", ColumnType::Int), ("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([
+            ("a", ColumnType::Native(NativeType::Int)),
+            ("b", ColumnType::Native(NativeType::Int)),
+        ]);
         Udt::type_check(&typ).unwrap_err();
     }
 
     // Missing required column
     {
-        let typ = udt_def_with_fields([("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([("b", ColumnType::Native(NativeType::Int))]);
         Udt::type_check(&typ).unwrap_err();
     }
 
     // Missing non-required column
     {
         let udt_bytes = UdtSerializer::new().field(b"kotmaale").finalize();
-        let typ = udt_def_with_fields([("a", ColumnType::Text)]);
+        let typ = udt_def_with_fields([("a", ColumnType::Native(NativeType::Text))]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -930,7 +1037,10 @@ fn test_udt_strict_ordering() {
             .null_field()
             .field(&42i32.to_be_bytes())
             .finalize();
-        let typ = udt_def_with_fields([("a", ColumnType::Text), ("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+        ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -961,7 +1071,10 @@ fn test_udt_no_name_check() {
             .field("The quick brown fox".as_bytes())
             .field(&42i32.to_be_bytes())
             .finalize();
-        let typ = udt_def_with_fields([("a", ColumnType::Text), ("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+        ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -980,7 +1093,10 @@ fn test_udt_no_name_check() {
             .field("The quick brown fox".as_bytes())
             .field(&42i32.to_be_bytes())
             .finalize();
-        let typ = udt_def_with_fields([("k", ColumnType::Text), ("l", ColumnType::Int)]);
+        let typ = udt_def_with_fields([
+            ("k", ColumnType::Native(NativeType::Text)),
+            ("l", ColumnType::Native(NativeType::Int)),
+        ]);
 
         let udt = deserialize::<Udt<'_>>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -1011,7 +1127,10 @@ fn test_udt_cross_rename_fields() {
             .field("The quick brown fox".as_bytes())
             .field(&42_i32.to_be_bytes())
             .finalize();
-        let typ = udt_def_with_fields([("a", ColumnType::Text), ("b", ColumnType::Int)]);
+        let typ = udt_def_with_fields([
+            ("a", ColumnType::Native(NativeType::Text)),
+            ("b", ColumnType::Native(NativeType::Int)),
+        ]);
 
         let udt = deserialize::<TestUdt>(&typ, &udt_bytes).unwrap();
         assert_eq!(
@@ -1051,7 +1170,10 @@ fn test_custom_type_parser() {
     append_bytes(&mut tuple_contents, &42i32.to_be_bytes());
     let tuple = make_bytes(&tuple_contents);
 
-    let typ = ColumnType::Tuple(vec![ColumnType::Ascii, ColumnType::Int]);
+    let typ = ColumnType::Tuple(vec![
+        ColumnType::Native(NativeType::Ascii),
+        ColumnType::Native(NativeType::Int),
+    ]);
 
     let tup = deserialize::<SwappedPair<i32, &str>>(&typ, &tuple).unwrap();
     assert_eq!(tup, SwappedPair("foo", 42));
@@ -1174,15 +1296,15 @@ fn test_native_errors() {
     // Simple type mismatch
     {
         let v = 123_i32;
-        let bytes = serialize(&ColumnType::Int, &v);
+        let bytes = serialize(&ColumnType::Native(NativeType::Int), &v);
 
         // Incompatible types render type check error.
         assert_type_check_error!(
             &bytes,
             f64,
-            ColumnType::Int,
+            ColumnType::Native(NativeType::Int),
             super::BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::Double],
+                expected: &[ColumnType::Native(NativeType::Double)],
             }
         );
 
@@ -1190,7 +1312,7 @@ fn test_native_errors() {
         assert_deser_error!(
             &bytes,
             f64,
-            ColumnType::Double,
+            ColumnType::Native(NativeType::Double),
             BuiltinDeserializationErrorKind::ByteLengthMismatch {
                 expected: 8,
                 got: 4,
@@ -1201,21 +1323,24 @@ fn test_native_errors() {
         // As these types have the same size, though, and every binary number in [0, 2^32] is a valid
         // value for both of them, this always succeeds.
         {
-            deserialize::<f32>(&ColumnType::Float, &bytes).unwrap();
+            deserialize::<f32>(&ColumnType::Native(NativeType::Float), &bytes).unwrap();
         }
     }
 
     // str (and also Uuid) are interesting because they accept two types.
     {
         let v = "Ala ma kota";
-        let bytes = serialize(&ColumnType::Ascii, &v);
+        let bytes = serialize(&ColumnType::Native(NativeType::Ascii), &v);
 
         assert_type_check_error!(
             &bytes,
             &str,
-            ColumnType::Double,
+            ColumnType::Native(NativeType::Double),
             BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::Ascii, ColumnType::Text],
+                expected: &[
+                    ColumnType::Native(NativeType::Ascii),
+                    ColumnType::Native(NativeType::Text)
+                ],
             }
         );
 
@@ -1224,7 +1349,7 @@ fn test_native_errors() {
         assert_deser_error!(
             &bytes,
             i64,
-            ColumnType::BigInt,
+            ColumnType::Native(NativeType::BigInt),
             BuiltinDeserializationErrorKind::ByteLengthMismatch {
                 expected: 8,
                 got: 11, // str len
@@ -1234,19 +1359,19 @@ fn test_native_errors() {
     {
         // -126 is not a valid ASCII nor UTF-8 byte.
         let v = -126_i8;
-        let bytes = serialize(&ColumnType::TinyInt, &v);
+        let bytes = serialize(&ColumnType::Native(NativeType::TinyInt), &v);
 
         assert_deser_error!(
             &bytes,
             &str,
-            ColumnType::Ascii,
+            ColumnType::Native(NativeType::Ascii),
             BuiltinDeserializationErrorKind::ExpectedAscii
         );
 
         assert_deser_error!(
             &bytes,
             &str,
-            ColumnType::Text,
+            ColumnType::Native(NativeType::Text),
             BuiltinDeserializationErrorKind::InvalidUtf8(_)
         );
     }
@@ -1259,7 +1384,7 @@ fn test_set_or_list_errors() {
         assert_type_check_error!(
             &Bytes::new(),
             Vec<i64>,
-            ColumnType::Float,
+            ColumnType::Native(NativeType::Float),
             BuiltinTypeCheckErrorKind::SetOrListError(SetOrListTypeCheckErrorKind::NotSetOrList)
         );
 
@@ -1267,7 +1392,7 @@ fn test_set_or_list_errors() {
         assert_type_check_error!(
             &Bytes::new(),
             BTreeSet<i32>,
-            ColumnType::List(Box::new(ColumnType::Int)),
+            ColumnType::List(Box::new(ColumnType::Native(NativeType::Int))),
             BuiltinTypeCheckErrorKind::SetOrListError(SetOrListTypeCheckErrorKind::NotSet)
         );
     }
@@ -1277,20 +1402,23 @@ fn test_set_or_list_errors() {
         assert_type_check_error!(
             &Bytes::new(),
             Vec<i64>,
-            ColumnType::List(Box::new(ColumnType::Ascii)),
+            ColumnType::List(Box::new(ColumnType::Native(NativeType::Ascii))),
             BuiltinTypeCheckErrorKind::SetOrListError(
                 SetOrListTypeCheckErrorKind::ElementTypeCheckFailed(_)
             )
         );
 
         let err = deserialize::<Vec<i64>>(
-            &ColumnType::List(Box::new(ColumnType::Varint)),
+            &ColumnType::List(Box::new(ColumnType::Native(NativeType::Varint))),
             &Bytes::new(),
         )
         .unwrap_err();
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<Vec<i64>>());
-        assert_eq!(err.cql_type, ColumnType::List(Box::new(ColumnType::Varint)),);
+        assert_eq!(
+            err.cql_type,
+            ColumnType::List(Box::new(ColumnType::Native(NativeType::Varint))),
+        );
         let BuiltinTypeCheckErrorKind::SetOrListError(
             SetOrListTypeCheckErrorKind::ElementTypeCheckFailed(ref err),
         ) = err.kind
@@ -1299,27 +1427,32 @@ fn test_set_or_list_errors() {
         };
         let err = get_typeck_err_inner(err.0.as_ref());
         assert_eq!(err.rust_name, std::any::type_name::<i64>());
-        assert_eq!(err.cql_type, ColumnType::Varint);
+        assert_eq!(err.cql_type, ColumnType::Native(NativeType::Varint));
         assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::BigInt]
+                expected: &[ColumnType::Native(NativeType::BigInt)]
             }
         );
     }
 
     {
-        let ser_typ = ColumnType::List(Box::new(ColumnType::Int));
+        let ser_typ = ColumnType::List(Box::new(ColumnType::Native(NativeType::Int)));
         let v = vec![123_i32];
         let bytes = serialize(&ser_typ, &v);
 
         {
-            let err =
-                deserialize::<Vec<i64>>(&ColumnType::List(Box::new(ColumnType::BigInt)), &bytes)
-                    .unwrap_err();
+            let err = deserialize::<Vec<i64>>(
+                &ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                &bytes,
+            )
+            .unwrap_err();
             let err = get_deser_err(&err);
             assert_eq!(err.rust_name, std::any::type_name::<Vec<i64>>());
-            assert_eq!(err.cql_type, ColumnType::List(Box::new(ColumnType::BigInt)),);
+            assert_eq!(
+                err.cql_type,
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            );
             let BuiltinDeserializationErrorKind::SetOrListError(
                 SetOrListDeserializationErrorKind::ElementDeserializationFailed(err),
             ) = &err.kind
@@ -1328,7 +1461,7 @@ fn test_set_or_list_errors() {
             };
             let err = get_deser_err(err);
             assert_eq!(err.rust_name, std::any::type_name::<i64>());
-            assert_eq!(err.cql_type, ColumnType::BigInt);
+            assert_eq!(err.cql_type, ColumnType::Native(NativeType::BigInt));
             assert_matches!(
                 err.kind,
                 BuiltinDeserializationErrorKind::ByteLengthMismatch {
@@ -1344,7 +1477,7 @@ fn test_set_or_list_errors() {
 fn test_map_errors() {
     // Not a map
     {
-        let ser_typ = ColumnType::Float;
+        let ser_typ = ColumnType::Native(NativeType::Float);
         let v = 2.12_f32;
         let bytes = serialize(&ser_typ, &v);
 
@@ -1361,7 +1494,10 @@ fn test_map_errors() {
     // Key type mismatch
     {
         let err = deserialize::<HashMap<i64, bool>>(
-            &ColumnType::Map(Box::new(ColumnType::Varint), Box::new(ColumnType::Boolean)),
+            &ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::Varint)),
+                Box::new(ColumnType::Native(NativeType::Boolean)),
+            ),
             &Bytes::new(),
         )
         .unwrap_err();
@@ -1369,7 +1505,10 @@ fn test_map_errors() {
         assert_eq!(err.rust_name, std::any::type_name::<HashMap<i64, bool>>());
         assert_eq!(
             err.cql_type,
-            ColumnType::Map(Box::new(ColumnType::Varint), Box::new(ColumnType::Boolean))
+            ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::Varint)),
+                Box::new(ColumnType::Native(NativeType::Boolean))
+            )
         );
         let BuiltinTypeCheckErrorKind::MapError(MapTypeCheckErrorKind::KeyTypeCheckFailed(ref err)) =
             err.kind
@@ -1378,11 +1517,11 @@ fn test_map_errors() {
         };
         let err = get_typeck_err_inner(err.0.as_ref());
         assert_eq!(err.rust_name, std::any::type_name::<i64>());
-        assert_eq!(err.cql_type, ColumnType::Varint);
+        assert_eq!(err.cql_type, ColumnType::Native(NativeType::Varint));
         assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::BigInt]
+                expected: &[ColumnType::Native(NativeType::BigInt)]
             }
         );
     }
@@ -1390,7 +1529,10 @@ fn test_map_errors() {
     // Value type mismatch
     {
         let err = deserialize::<BTreeMap<i64, &str>>(
-            &ColumnType::Map(Box::new(ColumnType::BigInt), Box::new(ColumnType::Boolean)),
+            &ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::BigInt)),
+                Box::new(ColumnType::Native(NativeType::Boolean)),
+            ),
             &Bytes::new(),
         )
         .unwrap_err();
@@ -1398,7 +1540,10 @@ fn test_map_errors() {
         assert_eq!(err.rust_name, std::any::type_name::<BTreeMap<i64, &str>>());
         assert_eq!(
             err.cql_type,
-            ColumnType::Map(Box::new(ColumnType::BigInt), Box::new(ColumnType::Boolean))
+            ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::BigInt)),
+                Box::new(ColumnType::Native(NativeType::Boolean))
+            )
         );
         let BuiltinTypeCheckErrorKind::MapError(MapTypeCheckErrorKind::ValueTypeCheckFailed(
             ref err,
@@ -1408,23 +1553,32 @@ fn test_map_errors() {
         };
         let err = get_typeck_err_inner(err.0.as_ref());
         assert_eq!(err.rust_name, std::any::type_name::<&str>());
-        assert_eq!(err.cql_type, ColumnType::Boolean);
+        assert_eq!(err.cql_type, ColumnType::Native(NativeType::Boolean));
         assert_matches!(
             err.kind,
             BuiltinTypeCheckErrorKind::MismatchedType {
-                expected: &[ColumnType::Ascii, ColumnType::Text]
+                expected: &[
+                    ColumnType::Native(NativeType::Ascii),
+                    ColumnType::Native(NativeType::Text)
+                ]
             }
         );
     }
 
     // Key length mismatch
     {
-        let ser_typ = ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::Boolean));
+        let ser_typ = ColumnType::Map(
+            Box::new(ColumnType::Native(NativeType::Int)),
+            Box::new(ColumnType::Native(NativeType::Boolean)),
+        );
         let v = HashMap::from([(42, false), (2137, true)]);
         let bytes = serialize(&ser_typ, &v as &dyn SerializeValue);
 
         let err = deserialize::<HashMap<i64, bool>>(
-            &ColumnType::Map(Box::new(ColumnType::BigInt), Box::new(ColumnType::Boolean)),
+            &ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::BigInt)),
+                Box::new(ColumnType::Native(NativeType::Boolean)),
+            ),
             &bytes,
         )
         .unwrap_err();
@@ -1432,7 +1586,10 @@ fn test_map_errors() {
         assert_eq!(err.rust_name, std::any::type_name::<HashMap<i64, bool>>());
         assert_eq!(
             err.cql_type,
-            ColumnType::Map(Box::new(ColumnType::BigInt), Box::new(ColumnType::Boolean))
+            ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::BigInt)),
+                Box::new(ColumnType::Native(NativeType::Boolean))
+            )
         );
         let BuiltinDeserializationErrorKind::MapError(
             MapDeserializationErrorKind::KeyDeserializationFailed(err),
@@ -1442,7 +1599,7 @@ fn test_map_errors() {
         };
         let err = get_deser_err(err);
         assert_eq!(err.rust_name, std::any::type_name::<i64>());
-        assert_eq!(err.cql_type, ColumnType::BigInt);
+        assert_eq!(err.cql_type, ColumnType::Native(NativeType::BigInt));
         assert_matches!(
             err.kind,
             BuiltinDeserializationErrorKind::ByteLengthMismatch {
@@ -1454,12 +1611,18 @@ fn test_map_errors() {
 
     // Value length mismatch
     {
-        let ser_typ = ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::Boolean));
+        let ser_typ = ColumnType::Map(
+            Box::new(ColumnType::Native(NativeType::Int)),
+            Box::new(ColumnType::Native(NativeType::Boolean)),
+        );
         let v = HashMap::from([(42, false), (2137, true)]);
         let bytes = serialize(&ser_typ, &v as &dyn SerializeValue);
 
         let err = deserialize::<HashMap<i32, i16>>(
-            &ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::SmallInt)),
+            &ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::Int)),
+                Box::new(ColumnType::Native(NativeType::SmallInt)),
+            ),
             &bytes,
         )
         .unwrap_err();
@@ -1467,7 +1630,10 @@ fn test_map_errors() {
         assert_eq!(err.rust_name, std::any::type_name::<HashMap<i32, i16>>());
         assert_eq!(
             err.cql_type,
-            ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::SmallInt))
+            ColumnType::Map(
+                Box::new(ColumnType::Native(NativeType::Int)),
+                Box::new(ColumnType::Native(NativeType::SmallInt))
+            )
         );
         let BuiltinDeserializationErrorKind::MapError(
             MapDeserializationErrorKind::ValueDeserializationFailed(err),
@@ -1477,7 +1643,7 @@ fn test_map_errors() {
         };
         let err = get_deser_err(err);
         assert_eq!(err.rust_name, std::any::type_name::<i16>());
-        assert_eq!(err.cql_type, ColumnType::SmallInt);
+        assert_eq!(err.cql_type, ColumnType::Native(NativeType::SmallInt));
         assert_matches!(
             err.kind,
             BuiltinDeserializationErrorKind::ByteLengthMismatch {
@@ -1495,7 +1661,7 @@ fn test_tuple_errors() {
         assert_type_check_error!(
             &Bytes::new(),
             (i64,),
-            ColumnType::BigInt,
+            ColumnType::Native(NativeType::BigInt),
             BuiltinTypeCheckErrorKind::TupleError(TupleTypeCheckErrorKind::NotTuple)
         );
     }
@@ -1514,7 +1680,10 @@ fn test_tuple_errors() {
         assert_type_check_error!(
             &Bytes::new(),
             (f32,),
-            ColumnType::Tuple(vec![ColumnType::Float, ColumnType::Float]),
+            ColumnType::Tuple(vec![
+                ColumnType::Native(NativeType::Float),
+                ColumnType::Native(NativeType::Float)
+            ]),
             BuiltinTypeCheckErrorKind::TupleError(TupleTypeCheckErrorKind::WrongElementCount {
                 rust_type_el_count: 1,
                 cql_type_el_count: 2,
@@ -1526,13 +1695,16 @@ fn test_tuple_errors() {
     {
         {
             let err = deserialize::<(i64,)>(
-                &ColumnType::Tuple(vec![ColumnType::SmallInt]),
+                &ColumnType::Tuple(vec![ColumnType::Native(NativeType::SmallInt)]),
                 &Bytes::new(),
             )
             .unwrap_err();
             let err = get_typeck_err(&err);
             assert_eq!(err.rust_name, std::any::type_name::<(i64,)>());
-            assert_eq!(err.cql_type, ColumnType::Tuple(vec![ColumnType::SmallInt]));
+            assert_eq!(
+                err.cql_type,
+                ColumnType::Tuple(vec![ColumnType::Native(NativeType::SmallInt)])
+            );
             let BuiltinTypeCheckErrorKind::TupleError(
                 TupleTypeCheckErrorKind::FieldTypeCheckFailed { ref err, position },
             ) = err.kind
@@ -1542,24 +1714,30 @@ fn test_tuple_errors() {
             assert_eq!(position, 0);
             let err = get_typeck_err_inner(err.0.as_ref());
             assert_eq!(err.rust_name, std::any::type_name::<i64>());
-            assert_eq!(err.cql_type, ColumnType::SmallInt);
+            assert_eq!(err.cql_type, ColumnType::Native(NativeType::SmallInt));
             assert_matches!(
                 err.kind,
                 BuiltinTypeCheckErrorKind::MismatchedType {
-                    expected: &[ColumnType::BigInt]
+                    expected: &[ColumnType::Native(NativeType::BigInt)]
                 }
             );
         }
     }
 
     {
-        let ser_typ = ColumnType::Tuple(vec![ColumnType::Int, ColumnType::Float]);
+        let ser_typ = ColumnType::Tuple(vec![
+            ColumnType::Native(NativeType::Int),
+            ColumnType::Native(NativeType::Float),
+        ]);
         let v = (123_i32, 123.123_f32);
         let bytes = serialize(&ser_typ, &v);
 
         {
             let err = deserialize::<(i32, f64)>(
-                &ColumnType::Tuple(vec![ColumnType::Int, ColumnType::Double]),
+                &ColumnType::Tuple(vec![
+                    ColumnType::Native(NativeType::Int),
+                    ColumnType::Native(NativeType::Double),
+                ]),
                 &bytes,
             )
             .unwrap_err();
@@ -1567,7 +1745,10 @@ fn test_tuple_errors() {
             assert_eq!(err.rust_name, std::any::type_name::<(i32, f64)>());
             assert_eq!(
                 err.cql_type,
-                ColumnType::Tuple(vec![ColumnType::Int, ColumnType::Double])
+                ColumnType::Tuple(vec![
+                    ColumnType::Native(NativeType::Int),
+                    ColumnType::Native(NativeType::Double)
+                ])
             );
             let BuiltinDeserializationErrorKind::TupleError(
                 TupleDeserializationErrorKind::FieldDeserializationFailed {
@@ -1581,7 +1762,7 @@ fn test_tuple_errors() {
             assert_eq!(index, 1);
             let err = get_deser_err(err);
             assert_eq!(err.rust_name, std::any::type_name::<f64>());
-            assert_eq!(err.cql_type, ColumnType::Double);
+            assert_eq!(err.cql_type, ColumnType::Native(NativeType::Double));
             assert_matches!(
                 err.kind,
                 BuiltinDeserializationErrorKind::ByteLengthMismatch {
@@ -1595,7 +1776,10 @@ fn test_tuple_errors() {
 
 #[test]
 fn test_null_errors() {
-    let ser_typ = ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::Boolean));
+    let ser_typ = ColumnType::Map(
+        Box::new(ColumnType::Native(NativeType::Int)),
+        Box::new(ColumnType::Native(NativeType::Boolean)),
+    );
     let v = HashMap::from([(42, false), (2137, true)]);
     let bytes = serialize(&ser_typ, &v as &dyn SerializeValue);
 
@@ -1622,7 +1806,10 @@ fn test_udt_errors() {
         {
             // Not UDT
             {
-                let typ = ColumnType::Map(Box::new(ColumnType::Ascii), Box::new(ColumnType::Blob));
+                let typ = ColumnType::Map(
+                    Box::new(ColumnType::Native(NativeType::Ascii)),
+                    Box::new(ColumnType::Native(NativeType::Blob)),
+                );
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1635,7 +1822,7 @@ fn test_udt_errors() {
 
             // UDT missing fields
             {
-                let typ = udt_def_with_fields([("c", ColumnType::Boolean)]);
+                let typ = udt_def_with_fields([("c", ColumnType::Native(NativeType::Boolean))]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1654,9 +1841,9 @@ fn test_udt_errors() {
             // excess fields in UDT
             {
                 let typ = udt_def_with_fields([
-                    ("d", ColumnType::Boolean),
-                    ("a", ColumnType::Text),
-                    ("b", ColumnType::Int),
+                    ("d", ColumnType::Native(NativeType::Boolean)),
+                    ("a", ColumnType::Native(NativeType::Text)),
+                    ("b", ColumnType::Native(NativeType::Int)),
                 ]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
@@ -1673,7 +1860,10 @@ fn test_udt_errors() {
 
             // missing UDT field
             {
-                let typ = udt_def_with_fields([("b", ColumnType::Int), ("a", ColumnType::Text)]);
+                let typ = udt_def_with_fields([
+                    ("b", ColumnType::Native(NativeType::Int)),
+                    ("a", ColumnType::Native(NativeType::Text)),
+                ]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1689,7 +1879,10 @@ fn test_udt_errors() {
 
             // UDT fields incompatible types - field type check failed
             {
-                let typ = udt_def_with_fields([("a", ColumnType::Blob), ("b", ColumnType::Int)]);
+                let typ = udt_def_with_fields([
+                    ("a", ColumnType::Native(NativeType::Blob)),
+                    ("b", ColumnType::Native(NativeType::Int)),
+                ]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1706,11 +1899,14 @@ fn test_udt_errors() {
                 assert_eq!(field_name.as_str(), "a");
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<&str>());
-                assert_eq!(err.cql_type, ColumnType::Blob);
+                assert_eq!(err.cql_type, ColumnType::Native(NativeType::Blob));
                 assert_matches!(
                     err.kind,
                     BuiltinTypeCheckErrorKind::MismatchedType {
-                        expected: &[ColumnType::Ascii, ColumnType::Text]
+                        expected: &[
+                            ColumnType::Native(NativeType::Ascii),
+                            ColumnType::Native(NativeType::Text)
+                        ]
                     }
                 );
             }
@@ -1721,9 +1917,9 @@ fn test_udt_errors() {
             // Got null
             {
                 let typ = udt_def_with_fields([
-                    ("c", ColumnType::Boolean),
-                    ("a", ColumnType::Blob),
-                    ("b", ColumnType::Int),
+                    ("c", ColumnType::Native(NativeType::Boolean)),
+                    ("a", ColumnType::Native(NativeType::Blob)),
+                    ("b", ColumnType::Native(NativeType::Int)),
                 ]);
 
                 let err = Udt::deserialize(&typ, None).unwrap_err();
@@ -1735,8 +1931,10 @@ fn test_udt_errors() {
 
             // UDT field deserialization failed
             {
-                let typ =
-                    udt_def_with_fields([("a", ColumnType::Ascii), ("c", ColumnType::Boolean)]);
+                let typ = udt_def_with_fields([
+                    ("a", ColumnType::Native(NativeType::Ascii)),
+                    ("c", ColumnType::Native(NativeType::Boolean)),
+                ]);
 
                 let udt_bytes = UdtSerializer::new()
                     .field("alamakota".as_bytes())
@@ -1760,7 +1958,7 @@ fn test_udt_errors() {
                 assert_eq!(field_name.as_str(), "c");
                 let err = get_deser_err(err);
                 assert_eq!(err.rust_name, std::any::type_name::<bool>());
-                assert_eq!(err.cql_type, ColumnType::Boolean);
+                assert_eq!(err.cql_type, ColumnType::Native(NativeType::Boolean));
                 assert_matches!(
                     err.kind,
                     BuiltinDeserializationErrorKind::ByteLengthMismatch {
@@ -1789,7 +1987,10 @@ fn test_udt_errors() {
         {
             // Not UDT
             {
-                let typ = ColumnType::Map(Box::new(ColumnType::Ascii), Box::new(ColumnType::Blob));
+                let typ = ColumnType::Map(
+                    Box::new(ColumnType::Native(NativeType::Ascii)),
+                    Box::new(ColumnType::Native(NativeType::Blob)),
+                );
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1802,7 +2003,7 @@ fn test_udt_errors() {
 
             // UDT too few fields
             {
-                let typ = udt_def_with_fields([("a", ColumnType::Text)]);
+                let typ = udt_def_with_fields([("a", ColumnType::Native(NativeType::Text))]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1821,9 +2022,9 @@ fn test_udt_errors() {
             // excess fields in UDT
             {
                 let typ = udt_def_with_fields([
-                    ("a", ColumnType::Text),
-                    ("b", ColumnType::Int),
-                    ("d", ColumnType::Boolean),
+                    ("a", ColumnType::Native(NativeType::Text)),
+                    ("b", ColumnType::Native(NativeType::Int)),
+                    ("d", ColumnType::Native(NativeType::Boolean)),
                 ]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
@@ -1840,7 +2041,10 @@ fn test_udt_errors() {
 
             // UDT fields switched - field name mismatch
             {
-                let typ = udt_def_with_fields([("b", ColumnType::Int), ("a", ColumnType::Text)]);
+                let typ = udt_def_with_fields([
+                    ("b", ColumnType::Native(NativeType::Int)),
+                    ("a", ColumnType::Native(NativeType::Text)),
+                ]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1860,7 +2064,10 @@ fn test_udt_errors() {
 
             // UDT fields incompatible types - field type check failed
             {
-                let typ = udt_def_with_fields([("a", ColumnType::Blob), ("b", ColumnType::Int)]);
+                let typ = udt_def_with_fields([
+                    ("a", ColumnType::Native(NativeType::Blob)),
+                    ("b", ColumnType::Native(NativeType::Int)),
+                ]);
                 let err = Udt::type_check(&typ).unwrap_err();
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<Udt>());
@@ -1877,11 +2084,14 @@ fn test_udt_errors() {
                 assert_eq!(field_name.as_str(), "a");
                 let err = get_typeck_err_inner(err.0.as_ref());
                 assert_eq!(err.rust_name, std::any::type_name::<&str>());
-                assert_eq!(err.cql_type, ColumnType::Blob);
+                assert_eq!(err.cql_type, ColumnType::Native(NativeType::Blob));
                 assert_matches!(
                     err.kind,
                     BuiltinTypeCheckErrorKind::MismatchedType {
-                        expected: &[ColumnType::Ascii, ColumnType::Text]
+                        expected: &[
+                            ColumnType::Native(NativeType::Ascii),
+                            ColumnType::Native(NativeType::Text)
+                        ]
                     }
                 );
             }
@@ -1892,9 +2102,9 @@ fn test_udt_errors() {
             // Got null
             {
                 let typ = udt_def_with_fields([
-                    ("a", ColumnType::Text),
-                    ("b", ColumnType::Int),
-                    ("c", ColumnType::Boolean),
+                    ("a", ColumnType::Native(NativeType::Text)),
+                    ("b", ColumnType::Native(NativeType::Int)),
+                    ("c", ColumnType::Native(NativeType::Boolean)),
                 ]);
 
                 let err = Udt::deserialize(&typ, None).unwrap_err();
@@ -1907,9 +2117,9 @@ fn test_udt_errors() {
             // Bad field format
             {
                 let typ = udt_def_with_fields([
-                    ("a", ColumnType::Text),
-                    ("b", ColumnType::Int),
-                    ("c", ColumnType::Boolean),
+                    ("a", ColumnType::Native(NativeType::Text)),
+                    ("b", ColumnType::Native(NativeType::Int)),
+                    ("c", ColumnType::Native(NativeType::Boolean)),
                 ]);
 
                 let udt_bytes = UdtSerializer::new()
@@ -1934,9 +2144,9 @@ fn test_udt_errors() {
             // UDT field deserialization failed
             {
                 let typ = udt_def_with_fields([
-                    ("a", ColumnType::Text),
-                    ("b", ColumnType::Int),
-                    ("c", ColumnType::Boolean),
+                    ("a", ColumnType::Native(NativeType::Text)),
+                    ("b", ColumnType::Native(NativeType::Int)),
+                    ("c", ColumnType::Native(NativeType::Boolean)),
                 ]);
 
                 let udt_bytes = UdtSerializer::new()
@@ -1962,7 +2172,7 @@ fn test_udt_errors() {
                 assert_eq!(field_name.as_str(), "b");
                 let err = get_deser_err(err);
                 assert_eq!(err.rust_name, std::any::type_name::<i32>());
-                assert_eq!(err.cql_type, ColumnType::Int);
+                assert_eq!(err.cql_type, ColumnType::Native(NativeType::Int));
                 assert_matches!(
                     err.kind,
                     BuiltinDeserializationErrorKind::ByteLengthMismatch {
@@ -1995,25 +2205,28 @@ fn metadata_does_not_bound_deserialized_values() {
         // Metadata's lifetime is limited to this scope.
 
         // blob
-        let blob_typ = ColumnType::Blob;
+        let blob_typ = ColumnType::Native(NativeType::Blob);
         let decoded_blob_res = deserialize::<&[u8]>(&blob_typ, &bytes);
 
         // str
-        let str_typ = ColumnType::Ascii;
+        let str_typ = ColumnType::Native(NativeType::Ascii);
         let decoded_str_res = deserialize::<&str>(&str_typ, &bytes);
 
         // list
-        let list_typ = ColumnType::List(Box::new(ColumnType::Ascii));
+        let list_typ = ColumnType::List(Box::new(ColumnType::Native(NativeType::Ascii)));
         let decoded_vec_str_res = deserialize::<Vec<&str>>(&list_typ, &bytes);
         let decoded_vec_string_res = deserialize::<Vec<String>>(&list_typ, &bytes);
 
         // set
-        let set_typ = ColumnType::Set(Box::new(ColumnType::Ascii));
+        let set_typ = ColumnType::Set(Box::new(ColumnType::Native(NativeType::Ascii)));
         let decoded_set_str_res = deserialize::<HashSet<&str>>(&set_typ, &bytes);
         let decoded_set_string_res = deserialize::<HashSet<String>>(&set_typ, &bytes);
 
         // map
-        let map_typ = ColumnType::Map(Box::new(ColumnType::Ascii), Box::new(ColumnType::Int));
+        let map_typ = ColumnType::Map(
+            Box::new(ColumnType::Native(NativeType::Ascii)),
+            Box::new(ColumnType::Native(NativeType::Int)),
+        );
         let decoded_map_str_int_res = deserialize::<HashMap<&str, i32>>(&map_typ, &bytes);
 
         // UDT
@@ -2021,8 +2234,8 @@ fn metadata_does_not_bound_deserialized_values() {
             type_name: "udt".into(),
             keyspace: "ks".into(),
             field_types: vec![
-                ("bytes".into(), ColumnType::Blob),
-                ("text".into(), ColumnType::Text),
+                ("bytes".into(), ColumnType::Native(NativeType::Blob)),
+                ("text".into(), ColumnType::Native(NativeType::Text)),
             ],
         };
         #[derive(DeserializeValue)]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -442,6 +442,8 @@ pub enum CqlTypeParseError {
     TypeIdParseError(LowLevelDeserializationError),
     #[error("Malformed custom type name: {0}")]
     CustomTypeNameParseError(LowLevelDeserializationError),
+    #[error("Unsupported custom type: {0}")]
+    CustomTypeUnsupported(String),
     #[error("Malformed name of UDT keyspace: {0}")]
     UdtKeyspaceNameParseError(LowLevelDeserializationError),
     #[error("Malformed UDT name: {0}")]

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -194,7 +194,7 @@ mod tests {
                 query::{Query, QueryParameters},
                 DeserializableRequest, SerializableRequest,
             },
-            response::result::ColumnType,
+            response::result::{ColumnType, NativeType},
             types::{self, SerialConsistency},
         },
         Consistency,
@@ -215,7 +215,8 @@ mod tests {
             skip_metadata: false,
             values: {
                 let mut vals = SerializedValues::new();
-                vals.add_value(&2137, &ColumnType::Int).unwrap();
+                vals.add_value(&2137, &ColumnType::Native(NativeType::Int))
+                    .unwrap();
                 Cow::Owned(vals)
             },
         };
@@ -243,8 +244,10 @@ mod tests {
             skip_metadata: false,
             values: {
                 let mut vals = SerializedValues::new();
-                vals.add_value(&42, &ColumnType::Int).unwrap();
-                vals.add_value(&2137, &ColumnType::Int).unwrap();
+                vals.add_value(&42, &ColumnType::Native(NativeType::Int))
+                    .unwrap();
+                vals.add_value(&2137, &ColumnType::Native(NativeType::Int))
+                    .unwrap();
                 Cow::Owned(vals)
             },
         };

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -52,6 +52,20 @@ pub struct TableSpec<'a> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ColumnType<'frame> {
     Custom(Cow<'frame, str>),
+    Native(NativeType),
+    List(Box<ColumnType<'frame>>),
+    Map(Box<ColumnType<'frame>>, Box<ColumnType<'frame>>),
+    Set(Box<ColumnType<'frame>>),
+    UserDefinedType {
+        type_name: Cow<'frame, str>,
+        keyspace: Cow<'frame, str>,
+        field_types: Vec<(Cow<'frame, str>, ColumnType<'frame>)>,
+    },
+    Tuple(Vec<ColumnType<'frame>>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NativeType {
     Ascii,
     Boolean,
     Blob,
@@ -66,19 +80,10 @@ pub enum ColumnType<'frame> {
     Text,
     Timestamp,
     Inet,
-    List(Box<ColumnType<'frame>>),
-    Map(Box<ColumnType<'frame>>, Box<ColumnType<'frame>>),
-    Set(Box<ColumnType<'frame>>),
-    UserDefinedType {
-        type_name: Cow<'frame, str>,
-        keyspace: Cow<'frame, str>,
-        field_types: Vec<(Cow<'frame, str>, ColumnType<'frame>)>,
-    },
     SmallInt,
     TinyInt,
     Time,
     Timeuuid,
-    Tuple(Vec<ColumnType<'frame>>),
     Uuid,
     Varint,
 }
@@ -87,20 +92,7 @@ impl ColumnType<'_> {
     pub fn into_owned(self) -> ColumnType<'static> {
         match self {
             ColumnType::Custom(cow) => ColumnType::Custom(cow.into_owned().into()),
-            ColumnType::Ascii => ColumnType::Ascii,
-            ColumnType::Boolean => ColumnType::Boolean,
-            ColumnType::Blob => ColumnType::Blob,
-            ColumnType::Counter => ColumnType::Counter,
-            ColumnType::Date => ColumnType::Date,
-            ColumnType::Decimal => ColumnType::Decimal,
-            ColumnType::Double => ColumnType::Double,
-            ColumnType::Duration => ColumnType::Duration,
-            ColumnType::Float => ColumnType::Float,
-            ColumnType::Int => ColumnType::Int,
-            ColumnType::BigInt => ColumnType::BigInt,
-            ColumnType::Text => ColumnType::Text,
-            ColumnType::Timestamp => ColumnType::Timestamp,
-            ColumnType::Inet => ColumnType::Inet,
+            ColumnType::Native(b) => ColumnType::Native(b),
             ColumnType::List(elem_type) => ColumnType::List(Box::new(elem_type.into_owned())),
             ColumnType::Map(key_type, value_type) => ColumnType::Map(
                 Box::new(key_type.into_owned()),
@@ -119,15 +111,9 @@ impl ColumnType<'_> {
                     .map(|(cow, column_type)| (cow.into_owned().into(), column_type.into_owned()))
                     .collect(),
             },
-            ColumnType::SmallInt => ColumnType::SmallInt,
-            ColumnType::TinyInt => ColumnType::TinyInt,
-            ColumnType::Time => ColumnType::Time,
-            ColumnType::Timeuuid => ColumnType::Timeuuid,
             ColumnType::Tuple(vec) => {
                 ColumnType::Tuple(vec.into_iter().map(ColumnType::into_owned).collect())
             }
-            ColumnType::Uuid => ColumnType::Uuid,
-            ColumnType::Varint => ColumnType::Varint,
         }
     }
 }
@@ -219,8 +205,8 @@ impl ColumnType<'_> {
     pub(crate) fn supports_special_empty_value(&self) -> bool {
         #[allow(clippy::match_like_matches_macro)]
         match self {
-            ColumnType::Counter
-            | ColumnType::Duration
+            ColumnType::Native(NativeType::Counter)
+            | ColumnType::Native(NativeType::Duration)
             | ColumnType::List(_)
             | ColumnType::Map(_, _)
             | ColumnType::Set(_)
@@ -860,6 +846,7 @@ fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
     read_string: fn(&mut &'frame [u8]) -> StdResult<StrT, LowLevelDeserializationError>,
 ) -> StdResult<ColumnType<'result>, CqlTypeParseError> {
     use ColumnType::*;
+    use NativeType::*;
     let id =
         types::read_short(buf).map_err(|err| CqlTypeParseError::TypeIdParseError(err.into()))?;
     Ok(match id {
@@ -873,30 +860,30 @@ fn deser_type_generic<'frame, 'result, StrT: Into<Cow<'result, str>>>(
             let type_str =
                 types::read_string(buf).map_err(CqlTypeParseError::CustomTypeNameParseError)?;
             match type_str {
-                "org.apache.cassandra.db.marshal.DurationType" => Duration,
+                "org.apache.cassandra.db.marshal.DurationType" => Native(Duration),
                 _ => Custom(type_str.to_owned().into()),
             }
         }
-        0x0001 => Ascii,
-        0x0002 => BigInt,
-        0x0003 => Blob,
-        0x0004 => Boolean,
-        0x0005 => Counter,
-        0x0006 => Decimal,
-        0x0007 => Double,
-        0x0008 => Float,
-        0x0009 => Int,
-        0x000B => Timestamp,
-        0x000C => Uuid,
-        0x000D => Text,
-        0x000E => Varint,
-        0x000F => Timeuuid,
-        0x0010 => Inet,
-        0x0011 => Date,
-        0x0012 => Time,
-        0x0013 => SmallInt,
-        0x0014 => TinyInt,
-        0x0015 => Duration,
+        0x0001 => Native(Ascii),
+        0x0002 => Native(BigInt),
+        0x0003 => Native(Blob),
+        0x0004 => Native(Boolean),
+        0x0005 => Native(Counter),
+        0x0006 => Native(Decimal),
+        0x0007 => Native(Double),
+        0x0008 => Native(Float),
+        0x0009 => Native(Int),
+        0x000B => Native(Timestamp),
+        0x000C => Native(Uuid),
+        0x000D => Native(Text),
+        0x000E => Native(Varint),
+        0x000F => Native(Timeuuid),
+        0x0010 => Native(Inet),
+        0x0011 => Native(Date),
+        0x0012 => Native(Time),
+        0x0013 => Native(SmallInt),
+        0x0014 => Native(TinyInt),
+        0x0015 => Native(Duration),
         0x0020 => List(Box::new(deser_type_generic(buf, read_string)?)),
         0x0021 => Map(
             Box::new(deser_type_generic(buf, read_string)?),
@@ -1253,10 +1240,11 @@ pub fn deser_cql_value(
     buf: &mut &[u8],
 ) -> StdResult<CqlValue, DeserializationError> {
     use ColumnType::*;
+    use NativeType::*;
 
     if buf.is_empty() {
         match typ {
-            Ascii | Blob | Text => {
+            Native(Ascii) | Native(Blob) | Native(Text) => {
                 // can't be empty
             }
             _ => return Ok(CqlValue::Empty),
@@ -1275,83 +1263,83 @@ pub fn deser_cql_value(
                 BuiltinDeserializationErrorKind::CustomTypeNotSupported(type_str.to_string()),
             ))
         }
-        Ascii => {
+        Native(Ascii) => {
             let s = String::deserialize(typ, v)?;
             CqlValue::Ascii(s)
         }
-        Boolean => {
+        Native(Boolean) => {
             let b = bool::deserialize(typ, v)?;
             CqlValue::Boolean(b)
         }
-        Blob => {
+        Native(Blob) => {
             let b = Vec::<u8>::deserialize(typ, v)?;
             CqlValue::Blob(b)
         }
-        Date => {
+        Native(Date) => {
             let d = CqlDate::deserialize(typ, v)?;
             CqlValue::Date(d)
         }
-        Counter => {
+        Native(Counter) => {
             let c = crate::frame::response::result::Counter::deserialize(typ, v)?;
             CqlValue::Counter(c)
         }
-        Decimal => {
+        Native(Decimal) => {
             let d = CqlDecimal::deserialize(typ, v)?;
             CqlValue::Decimal(d)
         }
-        Double => {
+        Native(Double) => {
             let d = f64::deserialize(typ, v)?;
             CqlValue::Double(d)
         }
-        Float => {
+        Native(Float) => {
             let f = f32::deserialize(typ, v)?;
             CqlValue::Float(f)
         }
-        Int => {
+        Native(Int) => {
             let i = i32::deserialize(typ, v)?;
             CqlValue::Int(i)
         }
-        SmallInt => {
+        Native(SmallInt) => {
             let si = i16::deserialize(typ, v)?;
             CqlValue::SmallInt(si)
         }
-        TinyInt => {
+        Native(TinyInt) => {
             let ti = i8::deserialize(typ, v)?;
             CqlValue::TinyInt(ti)
         }
-        BigInt => {
+        Native(BigInt) => {
             let bi = i64::deserialize(typ, v)?;
             CqlValue::BigInt(bi)
         }
-        Text => {
+        Native(Text) => {
             let s = String::deserialize(typ, v)?;
             CqlValue::Text(s)
         }
-        Timestamp => {
+        Native(Timestamp) => {
             let t = CqlTimestamp::deserialize(typ, v)?;
             CqlValue::Timestamp(t)
         }
-        Time => {
+        Native(Time) => {
             let t = CqlTime::deserialize(typ, v)?;
             CqlValue::Time(t)
         }
-        Timeuuid => {
+        Native(Timeuuid) => {
             let t = CqlTimeuuid::deserialize(typ, v)?;
             CqlValue::Timeuuid(t)
         }
-        Duration => {
+        Native(Duration) => {
             let d = CqlDuration::deserialize(typ, v)?;
             CqlValue::Duration(d)
         }
-        Inet => {
+        Native(Inet) => {
             let i = IpAddr::deserialize(typ, v)?;
             CqlValue::Inet(i)
         }
-        Uuid => {
+        Native(Uuid) => {
             let uuid = uuid::Uuid::deserialize(typ, v)?;
             CqlValue::Uuid(uuid)
         }
-        Varint => {
+        Native(Varint) => {
             let vi = CqlVarint::deserialize(typ, v)?;
             CqlValue::Varint(vi)
         }
@@ -1498,28 +1486,29 @@ mod test_utils {
 
     impl ColumnType<'_> {
         fn id(&self) -> u16 {
+            use NativeType::*;
             match self {
                 Self::Custom(_) => 0x0000,
-                Self::Ascii => 0x0001,
-                Self::BigInt => 0x0002,
-                Self::Blob => 0x0003,
-                Self::Boolean => 0x0004,
-                Self::Counter => 0x0005,
-                Self::Decimal => 0x0006,
-                Self::Double => 0x0007,
-                Self::Float => 0x0008,
-                Self::Int => 0x0009,
-                Self::Timestamp => 0x000B,
-                Self::Uuid => 0x000C,
-                Self::Text => 0x000D,
-                Self::Varint => 0x000E,
-                Self::Timeuuid => 0x000F,
-                Self::Inet => 0x0010,
-                Self::Date => 0x0011,
-                Self::Time => 0x0012,
-                Self::SmallInt => 0x0013,
-                Self::TinyInt => 0x0014,
-                Self::Duration => 0x0015,
+                Self::Native(Ascii) => 0x0001,
+                Self::Native(BigInt) => 0x0002,
+                Self::Native(Blob) => 0x0003,
+                Self::Native(Boolean) => 0x0004,
+                Self::Native(Counter) => 0x0005,
+                Self::Native(Decimal) => 0x0006,
+                Self::Native(Double) => 0x0007,
+                Self::Native(Float) => 0x0008,
+                Self::Native(Int) => 0x0009,
+                Self::Native(Timestamp) => 0x000B,
+                Self::Native(Uuid) => 0x000C,
+                Self::Native(Text) => 0x000D,
+                Self::Native(Varint) => 0x000E,
+                Self::Native(Timeuuid) => 0x000F,
+                Self::Native(Inet) => 0x0010,
+                Self::Native(Date) => 0x0011,
+                Self::Native(Time) => 0x0012,
+                Self::Native(SmallInt) => 0x0013,
+                Self::Native(TinyInt) => 0x0014,
+                Self::Native(Duration) => 0x0015,
                 Self::List(_) => 0x0020,
                 Self::Map(_, _) => 0x0021,
                 Self::Set(_) => 0x0022,
@@ -1539,26 +1528,7 @@ mod test_utils {
                 }
 
                 // Simple types
-                ColumnType::Ascii
-                | ColumnType::Boolean
-                | ColumnType::Blob
-                | ColumnType::Counter
-                | ColumnType::Date
-                | ColumnType::Decimal
-                | ColumnType::Double
-                | ColumnType::Duration
-                | ColumnType::Float
-                | ColumnType::Int
-                | ColumnType::BigInt
-                | ColumnType::Text
-                | ColumnType::Timestamp
-                | ColumnType::Inet
-                | ColumnType::SmallInt
-                | ColumnType::TinyInt
-                | ColumnType::Time
-                | ColumnType::Timeuuid
-                | ColumnType::Uuid
-                | ColumnType::Varint => (),
+                ColumnType::Native(_) => (),
 
                 ColumnType::List(elem_type) | ColumnType::Set(elem_type) => {
                     elem_type.serialize(buf)?;
@@ -1698,6 +1668,7 @@ mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use super::NativeType::{self, *};
     use crate as scylla;
     use crate::frame::value::{Counter, CqlDate, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid};
     use scylla::frame::response::result::{ColumnType, CqlValue};
@@ -1708,8 +1679,9 @@ mod tests {
     fn test_deserialize_text_types() {
         let buf: Vec<u8> = vec![0x41];
         let int_slice = &mut &buf[..];
-        let ascii_serialized = super::deser_cql_value(&ColumnType::Ascii, int_slice).unwrap();
-        let text_serialized = super::deser_cql_value(&ColumnType::Text, int_slice).unwrap();
+        let ascii_serialized =
+            super::deser_cql_value(&ColumnType::Native(Ascii), int_slice).unwrap();
+        let text_serialized = super::deser_cql_value(&ColumnType::Native(Text), int_slice).unwrap();
         assert_eq!(ascii_serialized, CqlValue::Ascii("A".to_string()));
         assert_eq!(text_serialized, CqlValue::Text("A".to_string()));
     }
@@ -1720,18 +1692,18 @@ mod tests {
 
         let uuid_buf: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
         let uuid_slice = &mut &uuid_buf[..];
-        let uuid_serialize = super::deser_cql_value(&ColumnType::Uuid, uuid_slice).unwrap();
+        let uuid_serialize = super::deser_cql_value(&ColumnType::Native(Uuid), uuid_slice).unwrap();
         assert_eq!(uuid_serialize, CqlValue::Uuid(my_uuid));
 
         let my_timeuuid = CqlTimeuuid::from_str("00000000000000000000000000000001").unwrap();
         let time_uuid_serialize =
-            super::deser_cql_value(&ColumnType::Timeuuid, uuid_slice).unwrap();
+            super::deser_cql_value(&ColumnType::Native(Timeuuid), uuid_slice).unwrap();
         assert_eq!(time_uuid_serialize, CqlValue::Timeuuid(my_timeuuid));
 
         let my_ip = "::1".parse().unwrap();
         let ip_buf: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
         let ip_slice = &mut &ip_buf[..];
-        let ip_serialize = super::deser_cql_value(&ColumnType::Inet, ip_slice).unwrap();
+        let ip_serialize = super::deser_cql_value(&ColumnType::Native(Inet), ip_slice).unwrap();
         assert_eq!(ip_serialize, CqlValue::Inet(my_ip));
 
         let max_ip = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff".parse().unwrap();
@@ -1739,7 +1711,8 @@ mod tests {
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         ];
         let max_ip_slice = &mut &max_ip_buf[..];
-        let max_ip_serialize = super::deser_cql_value(&ColumnType::Inet, max_ip_slice).unwrap();
+        let max_ip_serialize =
+            super::deser_cql_value(&ColumnType::Native(Inet), max_ip_slice).unwrap();
         assert_eq!(max_ip_serialize, CqlValue::Inet(max_ip));
     }
 
@@ -1750,12 +1723,14 @@ mod tests {
 
         let float_buf: Vec<u8> = vec![63, 0, 0, 0];
         let float_slice = &mut &float_buf[..];
-        let float_serialize = super::deser_cql_value(&ColumnType::Float, float_slice).unwrap();
+        let float_serialize =
+            super::deser_cql_value(&ColumnType::Native(Float), float_slice).unwrap();
         assert_eq!(float_serialize, CqlValue::Float(float));
 
         let double_buf: Vec<u8> = vec![64, 0, 0, 0, 0, 0, 0, 0];
         let double_slice = &mut &double_buf[..];
-        let double_serialize = super::deser_cql_value(&ColumnType::Double, double_slice).unwrap();
+        let double_serialize =
+            super::deser_cql_value(&ColumnType::Native(Double), double_slice).unwrap();
         assert_eq!(double_serialize, CqlValue::Double(double));
     }
 
@@ -1825,7 +1800,8 @@ mod tests {
         let tests = varint_test_cases_from_spec();
 
         for t in tests.iter() {
-            let value = super::deser_cql_value(&ColumnType::Varint, &mut &*t.encoding).unwrap();
+            let value =
+                super::deser_cql_value(&ColumnType::Native(Varint), &mut &*t.encoding).unwrap();
             assert_eq!(CqlValue::Varint(t.value.to_bigint().unwrap().into()), value);
         }
     }
@@ -1838,7 +1814,8 @@ mod tests {
         let tests = varint_test_cases_from_spec();
 
         for t in tests.iter() {
-            let value = super::deser_cql_value(&ColumnType::Varint, &mut &*t.encoding).unwrap();
+            let value =
+                super::deser_cql_value(&ColumnType::Native(Varint), &mut &*t.encoding).unwrap();
             assert_eq!(CqlValue::Varint(t.value.to_bigint().unwrap().into()), value);
         }
     }
@@ -1872,7 +1849,8 @@ mod tests {
         ];
 
         for t in tests.iter() {
-            let value = super::deser_cql_value(&ColumnType::Decimal, &mut &*t.encoding).unwrap();
+            let value =
+                super::deser_cql_value(&ColumnType::Native(Decimal), &mut &*t.encoding).unwrap();
             assert_eq!(
                 CqlValue::Decimal(t.value.clone().try_into().unwrap()),
                 value
@@ -1885,7 +1863,8 @@ mod tests {
         let counter: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 1, 0];
         let counter_slice = &mut &counter[..];
         let counter_serialize =
-            super::deser_cql_value(&ColumnType::Counter, counter_slice).unwrap();
+            super::deser_cql_value(&ColumnType::Native(NativeType::Counter), counter_slice)
+                .unwrap();
         assert_eq!(counter_serialize, CqlValue::Counter(Counter(256)));
     }
 
@@ -1893,7 +1872,7 @@ mod tests {
     fn test_deserialize_blob() {
         let blob: Vec<u8> = vec![0, 1, 2, 3];
         let blob_slice = &mut &blob[..];
-        let blob_serialize = super::deser_cql_value(&ColumnType::Blob, blob_slice).unwrap();
+        let blob_serialize = super::deser_cql_value(&ColumnType::Native(Blob), blob_slice).unwrap();
         assert_eq!(blob_serialize, CqlValue::Blob(blob));
     }
 
@@ -1901,12 +1880,14 @@ mod tests {
     fn test_deserialize_bool() {
         let bool_buf: Vec<u8> = vec![0x00];
         let bool_slice = &mut &bool_buf[..];
-        let bool_serialize = super::deser_cql_value(&ColumnType::Boolean, bool_slice).unwrap();
+        let bool_serialize =
+            super::deser_cql_value(&ColumnType::Native(Boolean), bool_slice).unwrap();
         assert_eq!(bool_serialize, CqlValue::Boolean(false));
 
         let bool_buf: Vec<u8> = vec![0x01];
         let bool_slice = &mut &bool_buf[..];
-        let bool_serialize = super::deser_cql_value(&ColumnType::Boolean, bool_slice).unwrap();
+        let bool_serialize =
+            super::deser_cql_value(&ColumnType::Native(Boolean), bool_slice).unwrap();
         assert_eq!(bool_serialize, CqlValue::Boolean(true));
     }
 
@@ -1914,24 +1895,25 @@ mod tests {
     fn test_deserialize_int_types() {
         let int_buf: Vec<u8> = vec![0, 0, 0, 4];
         let int_slice = &mut &int_buf[..];
-        let int_serialized = super::deser_cql_value(&ColumnType::Int, int_slice).unwrap();
+        let int_serialized = super::deser_cql_value(&ColumnType::Native(Int), int_slice).unwrap();
         assert_eq!(int_serialized, CqlValue::Int(4));
 
         let smallint_buf: Vec<u8> = vec![0, 4];
         let smallint_slice = &mut &smallint_buf[..];
         let smallint_serialized =
-            super::deser_cql_value(&ColumnType::SmallInt, smallint_slice).unwrap();
+            super::deser_cql_value(&ColumnType::Native(SmallInt), smallint_slice).unwrap();
         assert_eq!(smallint_serialized, CqlValue::SmallInt(4));
 
         let tinyint_buf: Vec<u8> = vec![4];
         let tinyint_slice = &mut &tinyint_buf[..];
         let tinyint_serialized =
-            super::deser_cql_value(&ColumnType::TinyInt, tinyint_slice).unwrap();
+            super::deser_cql_value(&ColumnType::Native(TinyInt), tinyint_slice).unwrap();
         assert_eq!(tinyint_serialized, CqlValue::TinyInt(4));
 
         let bigint_buf: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 4];
         let bigint_slice = &mut &bigint_buf[..];
-        let bigint_serialized = super::deser_cql_value(&ColumnType::BigInt, bigint_slice).unwrap();
+        let bigint_serialized =
+            super::deser_cql_value(&ColumnType::Native(BigInt), bigint_slice).unwrap();
         assert_eq!(bigint_serialized, CqlValue::BigInt(4));
     }
 
@@ -2023,34 +2005,38 @@ mod tests {
         // Date is correctly parsed from a 4 byte array
         let four_bytes: [u8; 4] = [12, 23, 34, 45];
         let date: CqlValue =
-            super::deser_cql_value(&ColumnType::Date, &mut four_bytes.as_ref()).unwrap();
+            super::deser_cql_value(&ColumnType::Native(Date), &mut four_bytes.as_ref()).unwrap();
         assert_eq!(
             date,
             CqlValue::Date(CqlDate(u32::from_be_bytes(four_bytes)))
         );
 
         // Date is parsed as u32 not i32, u32::MAX is u32::MAX
-        let date: CqlValue =
-            super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
-                .unwrap();
+        let date: CqlValue = super::deser_cql_value(
+            &ColumnType::Native(Date),
+            &mut u32::MAX.to_be_bytes().as_ref(),
+        )
+        .unwrap();
         assert_eq!(date, CqlValue::Date(CqlDate(u32::MAX)));
 
         // Trying to parse a 0, 3 or 5 byte array fails
-        super::deser_cql_value(&ColumnType::Date, &mut [].as_ref()).unwrap();
-        super::deser_cql_value(&ColumnType::Date, &mut [1, 2, 3].as_ref()).unwrap_err();
-        super::deser_cql_value(&ColumnType::Date, &mut [1, 2, 3, 4, 5].as_ref()).unwrap_err();
+        super::deser_cql_value(&ColumnType::Native(Date), &mut [].as_ref()).unwrap();
+        super::deser_cql_value(&ColumnType::Native(Date), &mut [1, 2, 3].as_ref()).unwrap_err();
+        super::deser_cql_value(&ColumnType::Native(Date), &mut [1, 2, 3, 4, 5].as_ref())
+            .unwrap_err();
 
         // Deserialize unix epoch
         let unix_epoch_bytes = 2_u32.pow(31).to_be_bytes();
 
         let date =
-            super::deser_cql_value(&ColumnType::Date, &mut unix_epoch_bytes.as_ref()).unwrap();
+            super::deser_cql_value(&ColumnType::Native(Date), &mut unix_epoch_bytes.as_ref())
+                .unwrap();
         assert_eq!(date.as_cql_date(), Some(CqlDate(1 << 31)));
 
         // 2^31 - 30 when converted to NaiveDate is 1969-12-02
         let before_epoch = CqlDate((1 << 31) - 30);
         let date: CqlValue = super::deser_cql_value(
-            &ColumnType::Date,
+            &ColumnType::Native(Date),
             &mut ((1_u32 << 31) - 30).to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2060,7 +2046,7 @@ mod tests {
         // 2^31 + 30 when converted to NaiveDate is 1970-01-31
         let after_epoch = CqlDate((1 << 31) + 30);
         let date = super::deser_cql_value(
-            &ColumnType::Date,
+            &ColumnType::Native(Date),
             &mut ((1_u32 << 31) + 30).to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2069,14 +2055,20 @@ mod tests {
 
         // Min date
         let min_date = CqlDate(u32::MIN);
-        let date = super::deser_cql_value(&ColumnType::Date, &mut u32::MIN.to_be_bytes().as_ref())
-            .unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Native(Date),
+            &mut u32::MIN.to_be_bytes().as_ref(),
+        )
+        .unwrap();
         assert_eq!(date.as_cql_date(), Some(min_date));
 
         // Max date
         let max_date = CqlDate(u32::MAX);
-        let date = super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
-            .unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Native(Date),
+            &mut u32::MAX.to_be_bytes().as_ref(),
+        )
+        .unwrap();
         assert_eq!(date.as_cql_date(), Some(max_date));
     }
 
@@ -2087,16 +2079,18 @@ mod tests {
 
         // 2^31 when converted to NaiveDate is 1970-01-01
         let unix_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-        let date =
-            super::deser_cql_value(&ColumnType::Date, &mut (1u32 << 31).to_be_bytes().as_ref())
-                .unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Native(Date),
+            &mut (1u32 << 31).to_be_bytes().as_ref(),
+        )
+        .unwrap();
 
         assert_eq!(date.as_naive_date_04(), Some(unix_epoch));
 
         // 2^31 - 30 when converted to NaiveDate is 1969-12-02
         let before_epoch = NaiveDate::from_ymd_opt(1969, 12, 2).unwrap();
         let date = super::deser_cql_value(
-            &ColumnType::Date,
+            &ColumnType::Native(Date),
             &mut ((1u32 << 31) - 30).to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2106,7 +2100,7 @@ mod tests {
         // 2^31 + 30 when converted to NaiveDate is 1970-01-31
         let after_epoch = NaiveDate::from_ymd_opt(1970, 1, 31).unwrap();
         let date = super::deser_cql_value(
-            &ColumnType::Date,
+            &ColumnType::Native(Date),
             &mut ((1u32 << 31) + 30).to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2115,16 +2109,19 @@ mod tests {
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Date, &mut 0_u32.to_be_bytes().as_ref())
+            super::deser_cql_value(&ColumnType::Native(Date), &mut 0_u32.to_be_bytes().as_ref())
                 .unwrap()
                 .as_naive_date_04(),
             None
         );
 
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
-                .unwrap()
-                .as_naive_date_04(),
+            super::deser_cql_value(
+                &ColumnType::Native(Date),
+                &mut u32::MAX.to_be_bytes().as_ref()
+            )
+            .unwrap()
+            .as_naive_date_04(),
             None
         );
     }
@@ -2137,16 +2134,18 @@ mod tests {
 
         // 2^31 when converted to time_03::Date is 1970-01-01
         let unix_epoch = Date::from_calendar_date(1970, January, 1).unwrap();
-        let date =
-            super::deser_cql_value(&ColumnType::Date, &mut (1u32 << 31).to_be_bytes().as_ref())
-                .unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Native(Date),
+            &mut (1u32 << 31).to_be_bytes().as_ref(),
+        )
+        .unwrap();
 
         assert_eq!(date.as_date_03(), Some(unix_epoch));
 
         // 2^31 - 30 when converted to time_03::Date is 1969-12-02
         let before_epoch = Date::from_calendar_date(1969, December, 2).unwrap();
         let date = super::deser_cql_value(
-            &ColumnType::Date,
+            &ColumnType::Native(Date),
             &mut ((1u32 << 31) - 30).to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2156,7 +2155,7 @@ mod tests {
         // 2^31 + 30 when converted to time_03::Date is 1970-01-31
         let after_epoch = Date::from_calendar_date(1970, January, 31).unwrap();
         let date = super::deser_cql_value(
-            &ColumnType::Date,
+            &ColumnType::Native(Date),
             &mut ((1u32 << 31) + 30).to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2165,16 +2164,19 @@ mod tests {
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Date, &mut 0_u32.to_be_bytes().as_ref())
+            super::deser_cql_value(&ColumnType::Native(Date), &mut 0_u32.to_be_bytes().as_ref())
                 .unwrap()
                 .as_date_03(),
             None
         );
 
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Date, &mut u32::MAX.to_be_bytes().as_ref())
-                .unwrap()
-                .as_date_03(),
+            super::deser_cql_value(
+                &ColumnType::Native(Date),
+                &mut u32::MAX.to_be_bytes().as_ref()
+            )
+            .unwrap()
+            .as_date_03(),
             None
         );
     }
@@ -2191,7 +2193,7 @@ mod tests {
         for test_val in [0, 1, 18463, max_time].iter() {
             let bytes: [u8; 8] = test_val.to_be_bytes();
             let cql_value: CqlValue =
-                super::deser_cql_value(&ColumnType::Time, &mut &bytes[..]).unwrap();
+                super::deser_cql_value(&ColumnType::Native(Time), &mut &bytes[..]).unwrap();
             assert_eq!(cql_value, CqlValue::Time(CqlTime(*test_val)));
         }
 
@@ -2199,7 +2201,7 @@ mod tests {
         // Values bigger than 86399999999999 cause an error
         for test_val in [-1, i64::MIN, max_time + 1, i64::MAX].iter() {
             let bytes: [u8; 8] = test_val.to_be_bytes();
-            super::deser_cql_value(&ColumnType::Time, &mut &bytes[..]).unwrap_err();
+            super::deser_cql_value(&ColumnType::Native(Time), &mut &bytes[..]).unwrap_err();
         }
     }
 
@@ -2210,8 +2212,11 @@ mod tests {
 
         // 0 when converted to NaiveTime is 0:0:0.0
         let midnight = NaiveTime::from_hms_nano_opt(0, 0, 0, 0).unwrap();
-        let time =
-            super::deser_cql_value(&ColumnType::Time, &mut (0i64).to_be_bytes().as_ref()).unwrap();
+        let time = super::deser_cql_value(
+            &ColumnType::Native(Time),
+            &mut (0i64).to_be_bytes().as_ref(),
+        )
+        .unwrap();
 
         assert_eq!(time.as_naive_time_04(), Some(midnight));
 
@@ -2219,7 +2224,7 @@ mod tests {
         let (h, m, s, n) = (10, 10, 30, 500_000_001);
         let midnight = NaiveTime::from_hms_nano_opt(h, m, s, n).unwrap();
         let time = super::deser_cql_value(
-            &ColumnType::Time,
+            &ColumnType::Native(Time),
             &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
                 .to_be_bytes()
                 .as_ref(),
@@ -2232,7 +2237,7 @@ mod tests {
         let (h, m, s, n) = (23, 59, 59, 999_999_999);
         let midnight = NaiveTime::from_hms_nano_opt(h, m, s, n).unwrap();
         let time = super::deser_cql_value(
-            &ColumnType::Time,
+            &ColumnType::Native(Time),
             &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
                 .to_be_bytes()
                 .as_ref(),
@@ -2249,8 +2254,11 @@ mod tests {
 
         // 0 when converted to NaiveTime is 0:0:0.0
         let midnight = Time::from_hms_nano(0, 0, 0, 0).unwrap();
-        let time =
-            super::deser_cql_value(&ColumnType::Time, &mut (0i64).to_be_bytes().as_ref()).unwrap();
+        let time = super::deser_cql_value(
+            &ColumnType::Native(Time),
+            &mut (0i64).to_be_bytes().as_ref(),
+        )
+        .unwrap();
 
         assert_eq!(time.as_time_03(), Some(midnight));
 
@@ -2258,7 +2266,7 @@ mod tests {
         let (h, m, s, n) = (10, 10, 30, 500_000_001);
         let midnight = Time::from_hms_nano(h, m, s, n).unwrap();
         let time = super::deser_cql_value(
-            &ColumnType::Time,
+            &ColumnType::Native(Time),
             &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
                 .to_be_bytes()
                 .as_ref(),
@@ -2271,7 +2279,7 @@ mod tests {
         let (h, m, s, n) = (23, 59, 59, 999_999_999);
         let midnight = Time::from_hms_nano(h, m, s, n).unwrap();
         let time = super::deser_cql_value(
-            &ColumnType::Time,
+            &ColumnType::Native(Time),
             &mut ((h as i64 * 3600 + m as i64 * 60 + s as i64) * 1_000_000_000 + n as i64)
                 .to_be_bytes()
                 .as_ref(),
@@ -2289,7 +2297,7 @@ mod tests {
         for test_val in &[0, -1, 1, 74568745, -4584658, i64::MIN, i64::MAX] {
             let bytes: [u8; 8] = test_val.to_be_bytes();
             let cql_value: CqlValue =
-                super::deser_cql_value(&ColumnType::Timestamp, &mut &bytes[..]).unwrap();
+                super::deser_cql_value(&ColumnType::Native(Timestamp), &mut &bytes[..]).unwrap();
             assert_eq!(cql_value, CqlValue::Timestamp(CqlTimestamp(*test_val)));
         }
     }
@@ -2301,8 +2309,11 @@ mod tests {
 
         // 0 when converted to DateTime is 1970-01-01 0:00:00.00
         let unix_epoch = DateTime::from_timestamp(0, 0).unwrap();
-        let date = super::deser_cql_value(&ColumnType::Timestamp, &mut 0i64.to_be_bytes().as_ref())
-            .unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Native(Timestamp),
+            &mut 0i64.to_be_bytes().as_ref(),
+        )
+        .unwrap();
 
         assert_eq!(date.as_datetime_04(), Some(unix_epoch));
 
@@ -2314,7 +2325,7 @@ mod tests {
         )
         .and_utc();
         let date = super::deser_cql_value(
-            &ColumnType::Timestamp,
+            &ColumnType::Native(Timestamp),
             &mut timestamp.to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2329,7 +2340,7 @@ mod tests {
         )
         .and_utc();
         let date = super::deser_cql_value(
-            &ColumnType::Timestamp,
+            &ColumnType::Native(Timestamp),
             &mut timestamp.to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2338,16 +2349,22 @@ mod tests {
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MIN.to_be_bytes().as_ref())
-                .unwrap()
-                .as_datetime_04(),
+            super::deser_cql_value(
+                &ColumnType::Native(Timestamp),
+                &mut i64::MIN.to_be_bytes().as_ref()
+            )
+            .unwrap()
+            .as_datetime_04(),
             None
         );
 
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MAX.to_be_bytes().as_ref())
-                .unwrap()
-                .as_datetime_04(),
+            super::deser_cql_value(
+                &ColumnType::Native(Timestamp),
+                &mut i64::MAX.to_be_bytes().as_ref()
+            )
+            .unwrap()
+            .as_datetime_04(),
             None
         );
     }
@@ -2359,8 +2376,11 @@ mod tests {
 
         // 0 when converted to OffsetDateTime is 1970-01-01 0:00:00.00
         let unix_epoch = OffsetDateTime::from_unix_timestamp(0).unwrap();
-        let date = super::deser_cql_value(&ColumnType::Timestamp, &mut 0i64.to_be_bytes().as_ref())
-            .unwrap();
+        let date = super::deser_cql_value(
+            &ColumnType::Native(Timestamp),
+            &mut 0i64.to_be_bytes().as_ref(),
+        )
+        .unwrap();
 
         assert_eq!(date.as_offset_date_time_03(), Some(unix_epoch));
 
@@ -2372,7 +2392,7 @@ mod tests {
         )
         .assume_utc();
         let date = super::deser_cql_value(
-            &ColumnType::Timestamp,
+            &ColumnType::Native(Timestamp),
             &mut timestamp.to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2387,7 +2407,7 @@ mod tests {
         )
         .assume_utc();
         let date = super::deser_cql_value(
-            &ColumnType::Timestamp,
+            &ColumnType::Native(Timestamp),
             &mut timestamp.to_be_bytes().as_ref(),
         )
         .unwrap();
@@ -2396,16 +2416,22 @@ mod tests {
 
         // 0 and u32::MAX are out of NaiveDate range, fails with an error, not panics
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MIN.to_be_bytes().as_ref())
-                .unwrap()
-                .as_offset_date_time_03(),
+            super::deser_cql_value(
+                &ColumnType::Native(Timestamp),
+                &mut i64::MIN.to_be_bytes().as_ref()
+            )
+            .unwrap()
+            .as_offset_date_time_03(),
             None
         );
 
         assert_eq!(
-            super::deser_cql_value(&ColumnType::Timestamp, &mut i64::MAX.to_be_bytes().as_ref())
-                .unwrap()
-                .as_offset_date_time_03(),
+            super::deser_cql_value(
+                &ColumnType::Native(Timestamp),
+                &mut i64::MAX.to_be_bytes().as_ref()
+            )
+            .unwrap()
+            .as_offset_date_time_03(),
             None
         );
     }
@@ -2426,7 +2452,7 @@ mod tests {
     fn test_duration_deserialize() {
         let bytes = [0xc, 0x12, 0xe2, 0x8c, 0x39, 0xd2];
         let cql_value: CqlValue =
-            super::deser_cql_value(&ColumnType::Duration, &mut &bytes[..]).unwrap();
+            super::deser_cql_value(&ColumnType::Native(Duration), &mut &bytes[..]).unwrap();
         assert_eq!(
             cql_value,
             CqlValue::Duration(CqlDuration {
@@ -2440,25 +2466,34 @@ mod tests {
     #[test]
     fn test_deserialize_empty_payload() {
         for (test_type, res_cql) in [
-            (ColumnType::Ascii, CqlValue::Ascii("".to_owned())),
-            (ColumnType::Boolean, CqlValue::Empty),
-            (ColumnType::Blob, CqlValue::Blob(vec![])),
-            (ColumnType::Counter, CqlValue::Empty),
-            (ColumnType::Date, CqlValue::Empty),
-            (ColumnType::Decimal, CqlValue::Empty),
-            (ColumnType::Double, CqlValue::Empty),
-            (ColumnType::Float, CqlValue::Empty),
-            (ColumnType::Int, CqlValue::Empty),
-            (ColumnType::BigInt, CqlValue::Empty),
-            (ColumnType::Text, CqlValue::Text("".to_owned())),
-            (ColumnType::Timestamp, CqlValue::Empty),
-            (ColumnType::Inet, CqlValue::Empty),
-            (ColumnType::List(Box::new(ColumnType::Int)), CqlValue::Empty),
+            (ColumnType::Native(Ascii), CqlValue::Ascii("".to_owned())),
+            (ColumnType::Native(Boolean), CqlValue::Empty),
+            (ColumnType::Native(Blob), CqlValue::Blob(vec![])),
+            (ColumnType::Native(NativeType::Counter), CqlValue::Empty),
+            (ColumnType::Native(Date), CqlValue::Empty),
+            (ColumnType::Native(Decimal), CqlValue::Empty),
+            (ColumnType::Native(Double), CqlValue::Empty),
+            (ColumnType::Native(Float), CqlValue::Empty),
+            (ColumnType::Native(Int), CqlValue::Empty),
+            (ColumnType::Native(BigInt), CqlValue::Empty),
+            (ColumnType::Native(Text), CqlValue::Text("".to_owned())),
+            (ColumnType::Native(Timestamp), CqlValue::Empty),
+            (ColumnType::Native(Inet), CqlValue::Empty),
             (
-                ColumnType::Map(Box::new(ColumnType::Int), Box::new(ColumnType::Int)),
+                ColumnType::List(Box::new(ColumnType::Native(Int))),
                 CqlValue::Empty,
             ),
-            (ColumnType::Set(Box::new(ColumnType::Int)), CqlValue::Empty),
+            (
+                ColumnType::Map(
+                    Box::new(ColumnType::Native(Int)),
+                    Box::new(ColumnType::Native(Int)),
+                ),
+                CqlValue::Empty,
+            ),
+            (
+                ColumnType::Set(Box::new(ColumnType::Native(Int))),
+                CqlValue::Empty,
+            ),
             (
                 ColumnType::UserDefinedType {
                     type_name: "".into(),
@@ -2467,13 +2502,13 @@ mod tests {
                 },
                 CqlValue::Empty,
             ),
-            (ColumnType::SmallInt, CqlValue::Empty),
-            (ColumnType::TinyInt, CqlValue::Empty),
-            (ColumnType::Time, CqlValue::Empty),
-            (ColumnType::Timeuuid, CqlValue::Empty),
+            (ColumnType::Native(SmallInt), CqlValue::Empty),
+            (ColumnType::Native(TinyInt), CqlValue::Empty),
+            (ColumnType::Native(Time), CqlValue::Empty),
+            (ColumnType::Native(Timeuuid), CqlValue::Empty),
             (ColumnType::Tuple(vec![]), CqlValue::Empty),
-            (ColumnType::Uuid, CqlValue::Empty),
-            (ColumnType::Varint, CqlValue::Empty),
+            (ColumnType::Native(Uuid), CqlValue::Empty),
+            (ColumnType::Native(Varint), CqlValue::Empty),
         ] {
             let cql_value: CqlValue = super::deser_cql_value(&test_type, &mut &[][..]).unwrap();
 
@@ -2507,7 +2542,8 @@ mod tests {
 
         for (uuid_str, uuid_bytes) in &tests {
             let cql_val: CqlValue =
-                super::deser_cql_value(&ColumnType::Timeuuid, &mut &uuid_bytes[..]).unwrap();
+                super::deser_cql_value(&ColumnType::Native(Timeuuid), &mut &uuid_bytes[..])
+                    .unwrap();
 
             match cql_val {
                 CqlValue::Timeuuid(uuid) => {

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -169,7 +169,7 @@ pub enum CqlValue {
     Set(Vec<CqlValue>),
     UserDefinedType {
         keyspace: String,
-        type_name: String,
+        name: String,
         /// Order of `fields` vector must match the order of fields as defined in the UDT. The
         /// driver does not check it by itself, so incorrect data will be written if the order is
         /// wrong.
@@ -1404,7 +1404,7 @@ pub fn deser_cql_value(
 
             CqlValue::UserDefinedType {
                 keyspace: udt.keyspace.clone().into_owned(),
-                type_name: udt.name.clone().into_owned(),
+                name: udt.name.clone().into_owned(),
                 fields,
             }
         }
@@ -2015,7 +2015,7 @@ mod tests {
 
         let cql: CqlValue = CqlValue::UserDefinedType {
             keyspace: "".to_string(),
-            type_name: "".to_string(),
+            name: "".to_string(),
             fields: my_fields,
         };
 

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -57,7 +57,7 @@ pub enum ColumnType<'frame> {
         typ: CollectionType<'frame>,
     },
     Vector {
-        type_: Box<ColumnType<'frame>>,
+        typ: Box<ColumnType<'frame>>,
         dimensions: u16,
     },
     UserDefinedType {
@@ -114,8 +114,11 @@ impl ColumnType<'_> {
                 frozen,
                 typ: t.into_owned(),
             },
-            ColumnType::Vector { type_, dimensions } => ColumnType::Vector {
-                type_: Box::new(type_.into_owned()),
+            ColumnType::Vector {
+                typ: type_,
+                dimensions,
+            } => ColumnType::Vector {
+                typ: Box::new(type_.into_owned()),
                 dimensions,
             },
             ColumnType::UserDefinedType {

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1,7 +1,7 @@
 // TODO: remove this once deprecated items are deleted.
 #![allow(deprecated)]
 
-use crate::frame::response::result::NativeType;
+use crate::frame::response::result::{CollectionType, NativeType};
 use crate::frame::value::{CqlTimeuuid, CqlVarint};
 use crate::frame::{response::result::CqlValue, types::RawValue, value::LegacyBatchValuesIterator};
 use crate::serialize::batch::{BatchValues, BatchValuesIterator, LegacyBatchValuesAdapter};
@@ -694,7 +694,9 @@ fn vec_set_serialization() {
     assert_eq!(
         serialized(
             m,
-            ColumnType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            ColumnType::Collection {
+                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            }
         ),
         vec![
             0, 0, 0, 25, // 25 bytes
@@ -712,7 +714,9 @@ fn slice_set_serialization() {
     assert_eq!(
         serialized(
             m.as_ref(),
-            ColumnType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            ColumnType::Collection {
+                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            }
         ),
         vec![
             0, 0, 0, 25, // 25 bytes
@@ -750,7 +754,9 @@ fn hashset_serialization() {
     assert_eq!(
         serialized(
             m,
-            ColumnType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            ColumnType::Collection {
+                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            }
         ),
         vec![
             0, 0, 0, 25, // 25 bytes
@@ -769,10 +775,12 @@ fn hashmap_serialization() {
     assert_eq!(
         serialized(
             m,
-            ColumnType::Map(
-                Box::new(ColumnType::Native(NativeType::Text)),
-                Box::new(ColumnType::Native(NativeType::Int))
-            )
+            ColumnType::Collection {
+                type_: CollectionType::Map(
+                    Box::new(ColumnType::Native(NativeType::Text)),
+                    Box::new(ColumnType::Native(NativeType::Int))
+                )
+            }
         ),
         vec![
             0, 0, 0, 49, // 49 bytes
@@ -793,7 +801,9 @@ fn btreeset_serialization() {
     assert_eq!(
         serialized(
             m,
-            ColumnType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            ColumnType::Collection {
+                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+            }
         ),
         vec![
             0, 0, 0, 25, // 25 bytes
@@ -811,10 +821,12 @@ fn btreemap_serialization() {
     assert_eq!(
         serialized(
             m,
-            ColumnType::Map(
-                Box::new(ColumnType::Native(NativeType::Text)),
-                Box::new(ColumnType::Native(NativeType::Int))
-            )
+            ColumnType::Collection {
+                type_: CollectionType::Map(
+                    Box::new(ColumnType::Native(NativeType::Text)),
+                    Box::new(ColumnType::Native(NativeType::Int))
+                )
+            }
         ),
         vec![
             0, 0, 0, 49, // 49 bytes

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -697,7 +697,7 @@ fn vec_set_serialization() {
             m,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+                typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
         vec![
@@ -718,7 +718,7 @@ fn slice_set_serialization() {
             m.as_ref(),
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+                typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
         vec![
@@ -759,7 +759,7 @@ fn hashset_serialization() {
             m,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+                typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
         vec![
@@ -781,7 +781,7 @@ fn hashmap_serialization() {
             m,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Text)),
                     Box::new(ColumnType::Native(NativeType::Int))
                 )
@@ -808,7 +808,7 @@ fn btreeset_serialization() {
             m,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
+                typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
         vec![
@@ -829,7 +829,7 @@ fn btreemap_serialization() {
             m,
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Text)),
                     Box::new(ColumnType::Native(NativeType::Int))
                 )

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -696,6 +696,7 @@ fn vec_set_serialization() {
         serialized(
             m,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
@@ -716,6 +717,7 @@ fn slice_set_serialization() {
         serialized(
             m.as_ref(),
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
@@ -756,6 +758,7 @@ fn hashset_serialization() {
         serialized(
             m,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
@@ -777,6 +780,7 @@ fn hashmap_serialization() {
         serialized(
             m,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Text)),
                     Box::new(ColumnType::Native(NativeType::Int))
@@ -803,6 +807,7 @@ fn btreeset_serialization() {
         serialized(
             m,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text)))
             }
         ),
@@ -823,6 +828,7 @@ fn btreemap_serialization() {
         serialized(
             m,
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::Map(
                     Box::new(ColumnType::Native(NativeType::Text)),
                     Box::new(ColumnType::Native(NativeType::Int))
@@ -863,6 +869,7 @@ fn cqlvalue_serialization() {
         ],
     };
     let typ = ColumnType::UserDefinedType {
+        frozen: false,
         definition: Arc::new(UserDefinedType {
             name: "t".into(),
             keyspace: "ks".into(),

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -856,7 +856,7 @@ fn cqlvalue_serialization() {
     // UDTs
     let udt = CqlValue::UserDefinedType {
         keyspace: "ks".to_string(),
-        type_name: "t".to_string(),
+        name: "t".to_string(),
         fields: vec![
             ("foo".to_string(), Some(CqlValue::Int(123))),
             ("bar".to_string(), None),
@@ -886,7 +886,7 @@ fn cqlvalue_serialization() {
     // the fields
     let udt = CqlValue::UserDefinedType {
         keyspace: "ks".to_string(),
-        type_name: "t".to_string(),
+        name: "t".to_string(),
         fields: vec![
             ("bar".to_string(), None),
             ("foo".to_string(), Some(CqlValue::Int(123))),

--- a/scylla-cql/src/frame/value_tests.rs
+++ b/scylla-cql/src/frame/value_tests.rs
@@ -1,7 +1,7 @@
 // TODO: remove this once deprecated items are deleted.
 #![allow(deprecated)]
 
-use crate::frame::response::result::{CollectionType, NativeType};
+use crate::frame::response::result::{CollectionType, NativeType, UserDefinedType};
 use crate::frame::value::{CqlTimeuuid, CqlVarint};
 use crate::frame::{response::result::CqlValue, types::RawValue, value::LegacyBatchValuesIterator};
 use crate::serialize::batch::{BatchValues, BatchValuesIterator, LegacyBatchValuesAdapter};
@@ -22,6 +22,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
+use std::sync::Arc;
 use std::{borrow::Cow, convert::TryInto};
 use uuid::Uuid;
 
@@ -862,12 +863,14 @@ fn cqlvalue_serialization() {
         ],
     };
     let typ = ColumnType::UserDefinedType {
-        type_name: "t".into(),
-        keyspace: "ks".into(),
-        field_types: vec![
-            ("foo".into(), ColumnType::Native(NativeType::Int)),
-            ("bar".into(), ColumnType::Native(NativeType::Text)),
-        ],
+        definition: Arc::new(UserDefinedType {
+            name: "t".into(),
+            keyspace: "ks".into(),
+            field_types: vec![
+                ("foo".into(), ColumnType::Native(NativeType::Int)),
+                ("bar".into(), ColumnType::Native(NativeType::Text)),
+            ],
+        }),
     };
 
     assert_eq!(

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -954,7 +954,7 @@ pub(crate) mod tests {
     use std::borrow::Cow;
     use std::collections::BTreeMap;
 
-    use crate::frame::response::result::{ColumnSpec, ColumnType, TableSpec};
+    use crate::frame::response::result::{ColumnSpec, ColumnType, NativeType, TableSpec};
     use crate::frame::types::RawValue;
     #[allow(deprecated)]
     use crate::frame::value::{LegacySerializedValues, MaybeUnset, SerializedResult, ValueList};
@@ -992,10 +992,10 @@ pub(crate) mod tests {
         let mut new_data_writer = RowWriter::new(&mut new_data);
         let ctx = RowSerializationContext {
             columns: &[
-                col_spec("a", ColumnType::Int),
-                col_spec("b", ColumnType::Text),
-                col_spec("c", ColumnType::BigInt),
-                col_spec("b", ColumnType::Ascii),
+                col_spec("a", ColumnType::Native(NativeType::Int)),
+                col_spec("b", ColumnType::Native(NativeType::Text)),
+                col_spec("c", ColumnType::Native(NativeType::BigInt)),
+                col_spec("b", ColumnType::Native(NativeType::Ascii)),
             ],
         };
         <_ as SerializeRow>::serialize(&row, &ctx, &mut new_data_writer).unwrap();
@@ -1030,10 +1030,10 @@ pub(crate) mod tests {
         let mut unsorted_row_data_writer = RowWriter::new(&mut unsorted_row_data);
         let ctx = RowSerializationContext {
             columns: &[
-                col_spec("a", ColumnType::Int),
-                col_spec("b", ColumnType::Text),
-                col_spec("c", ColumnType::BigInt),
-                col_spec("d", ColumnType::Ascii),
+                col_spec("a", ColumnType::Native(NativeType::Int)),
+                col_spec("b", ColumnType::Native(NativeType::Text)),
+                col_spec("c", ColumnType::Native(NativeType::BigInt)),
+                col_spec("d", ColumnType::Native(NativeType::Ascii)),
             ],
         };
         <_ as SerializeRow>::serialize(&unsorted_row, &ctx, &mut unsorted_row_data_writer).unwrap();
@@ -1053,10 +1053,10 @@ pub(crate) mod tests {
         );
         let ctx = RowSerializationContext {
             columns: &[
-                col_spec("a", ColumnType::Int),
-                col_spec("b", ColumnType::Text),
-                col_spec("c", ColumnType::BigInt),
-                col_spec("d", ColumnType::Ascii),
+                col_spec("a", ColumnType::Native(NativeType::Int)),
+                col_spec("b", ColumnType::Native(NativeType::Text)),
+                col_spec("c", ColumnType::Native(NativeType::BigInt)),
+                col_spec("d", ColumnType::Native(NativeType::Ascii)),
             ],
         };
 
@@ -1109,8 +1109,8 @@ pub(crate) mod tests {
         }
 
         let columns = &[
-            col_spec("a", ColumnType::Int),
-            col_spec("b", ColumnType::Int),
+            col_spec("a", ColumnType::Native(NativeType::Int)),
+            col_spec("b", ColumnType::Native(NativeType::Int)),
         ];
         let buf = do_serialize(ValueListAdapter(Foo), columns);
         let expected = vec![
@@ -1139,7 +1139,7 @@ pub(crate) mod tests {
         // Unit
         #[allow(clippy::let_unit_value)] // The let binding below is intentional
         let v = ();
-        let spec = [col("a", ColumnType::Text)];
+        let spec = [col("a", ColumnType::Native(NativeType::Text))];
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<()>());
@@ -1154,7 +1154,10 @@ pub(crate) mod tests {
         // Non-unit tuple
         // Count mismatch
         let v = ("Ala ma kota",);
-        let spec = [col("a", ColumnType::Text), col("b", ColumnType::Text)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Text)),
+        ];
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<(&str,)>());
@@ -1168,7 +1171,10 @@ pub(crate) mod tests {
 
         // Serialization of one of the element fails
         let v = ("Ala ma kota", 123_i32);
-        let spec = [col("a", ColumnType::Text), col("b", ColumnType::Text)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Text)),
+        ];
         let err = do_serialize_err(v, &spec);
         let err = get_ser_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<(&str, i32)>());
@@ -1184,7 +1190,10 @@ pub(crate) mod tests {
         // Non-unit tuple
         // Count mismatch
         let v = vec!["Ala ma kota"];
-        let spec = [col("a", ColumnType::Text), col("b", ColumnType::Text)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Text)),
+        ];
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<Vec<&str>>());
@@ -1198,7 +1207,10 @@ pub(crate) mod tests {
 
         // Serialization of one of the element fails
         let v = vec!["Ala ma kota", "Kot ma pchły"];
-        let spec = [col("a", ColumnType::Text), col("b", ColumnType::Int)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+        ];
         let err = do_serialize_err(v, &spec);
         let err = get_ser_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<Vec<&str>>());
@@ -1213,7 +1225,10 @@ pub(crate) mod tests {
     fn test_map_errors() {
         // Missing value for a bind marker
         let v: BTreeMap<_, _> = vec![("a", 123_i32)].into_iter().collect();
-        let spec = [col("a", ColumnType::Int), col("b", ColumnType::Text)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Int)),
+            col("b", ColumnType::Native(NativeType::Text)),
+        ];
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<BTreeMap<&str, i32>>());
@@ -1224,7 +1239,7 @@ pub(crate) mod tests {
 
         // Additional value, not present in the query
         let v: BTreeMap<_, _> = vec![("a", 123_i32), ("b", 456_i32)].into_iter().collect();
-        let spec = [col("a", ColumnType::Int)];
+        let spec = [col("a", ColumnType::Native(NativeType::Int))];
         let err = do_serialize_err(v, &spec);
         let err = get_typeck_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<BTreeMap<&str, i32>>());
@@ -1235,7 +1250,10 @@ pub(crate) mod tests {
 
         // Serialization of one of the element fails
         let v: BTreeMap<_, _> = vec![("a", 123_i32), ("b", 456_i32)].into_iter().collect();
-        let spec = [col("a", ColumnType::Int), col("b", ColumnType::Text)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Int)),
+            col("b", ColumnType::Native(NativeType::Text)),
+        ];
         let err = do_serialize_err(v, &spec);
         let err = get_ser_err(&err);
         assert_eq!(err.rust_name, std::any::type_name::<BTreeMap<&str, i32>>());
@@ -1265,9 +1283,12 @@ pub(crate) mod tests {
     #[test]
     fn test_row_serialization_with_column_sorting_correct_order() {
         let spec = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
-            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+            col(
+                "c",
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            ),
         ];
 
         let reference = do_serialize(("Ala ma kota", 42i32, vec![1i64, 2i64, 3i64]), &spec);
@@ -1287,9 +1308,12 @@ pub(crate) mod tests {
     fn test_row_serialization_with_column_sorting_incorrect_order() {
         // The order of two last columns is swapped
         let spec = [
-            col("a", ColumnType::Text),
-            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
-            col("b", ColumnType::Int),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col(
+                "c",
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            ),
+            col("b", ColumnType::Native(NativeType::Int)),
         ];
 
         let reference = do_serialize(("Ala ma kota", vec![1i64, 2i64, 3i64], 42i32), &spec);
@@ -1312,8 +1336,8 @@ pub(crate) mod tests {
         let mut row_writer = RowWriter::new(&mut data);
 
         let spec_without_c = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
             // Missing column c
         ];
 
@@ -1328,11 +1352,14 @@ pub(crate) mod tests {
         );
 
         let spec_duplicate_column = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
-            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+            col(
+                "c",
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            ),
             // Unexpected last column
-            col("d", ColumnType::Counter),
+            col("d", ColumnType::Native(NativeType::Counter)),
         ];
 
         let ctx = RowSerializationContext {
@@ -1343,9 +1370,9 @@ pub(crate) mod tests {
         assert_matches!(err.kind, BuiltinTypeCheckErrorKind::NoColumnWithName { .. });
 
         let spec_wrong_type = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
-            col("c", ColumnType::TinyInt), // Wrong type
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+            col("c", ColumnType::Native(NativeType::TinyInt)), // Wrong type
         ];
 
         let ctx = RowSerializationContext {
@@ -1370,7 +1397,10 @@ pub(crate) mod tests {
     fn test_row_serialization_with_generics() {
         // A minimal smoke test just to test that it works.
         fn check_with_type<T: SerializeValue + Copy>(typ: ColumnType<'static>, t: T) {
-            let spec = [col("a", ColumnType::Text), col("b", typ)];
+            let spec = [
+                col("a", ColumnType::Native(NativeType::Text)),
+                col("b", typ),
+            ];
             let reference = do_serialize(("Ala ma kota", t), &spec);
             let row = do_serialize(
                 TestRowWithGenerics {
@@ -1382,8 +1412,8 @@ pub(crate) mod tests {
             assert_eq!(reference, row);
         }
 
-        check_with_type(ColumnType::Int, 123_i32);
-        check_with_type(ColumnType::Double, 123_f64);
+        check_with_type(ColumnType::Native(NativeType::Int), 123_i32);
+        check_with_type(ColumnType::Native(NativeType::Double), 123_f64);
     }
 
     #[derive(SerializeRow, Debug, PartialEq, Eq, Default)]
@@ -1397,9 +1427,12 @@ pub(crate) mod tests {
     #[test]
     fn test_row_serialization_with_enforced_order_correct_order() {
         let spec = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
-            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+            col(
+                "c",
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            ),
         ];
 
         let reference = do_serialize(("Ala ma kota", 42i32, vec![1i64, 2i64, 3i64]), &spec);
@@ -1423,9 +1456,12 @@ pub(crate) mod tests {
 
         // The order of two last columns is swapped
         let spec = [
-            col("a", ColumnType::Text),
-            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
-            col("b", ColumnType::Int),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col(
+                "c",
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            ),
+            col("b", ColumnType::Native(NativeType::Int)),
         ];
         let ctx = RowSerializationContext { columns: &spec };
         let err = <_ as SerializeRow>::serialize(&row, &ctx, &mut writer).unwrap_err();
@@ -1436,8 +1472,8 @@ pub(crate) mod tests {
         );
 
         let spec_without_c = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
             // Missing column c
         ];
 
@@ -1452,11 +1488,14 @@ pub(crate) mod tests {
         );
 
         let spec_duplicate_column = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
-            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+            col(
+                "c",
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            ),
             // Unexpected last column
-            col("d", ColumnType::Counter),
+            col("d", ColumnType::Native(NativeType::Counter)),
         ];
 
         let ctx = RowSerializationContext {
@@ -1467,9 +1506,9 @@ pub(crate) mod tests {
         assert_matches!(err.kind, BuiltinTypeCheckErrorKind::NoColumnWithName { .. });
 
         let spec_wrong_type = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
-            col("c", ColumnType::TinyInt), // Wrong type
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+            col("c", ColumnType::Native(NativeType::TinyInt)), // Wrong type
         ];
 
         let ctx = RowSerializationContext {
@@ -1495,8 +1534,12 @@ pub(crate) mod tests {
     #[test]
     fn test_serialized_values_content() {
         let mut values = SerializedValues::new();
-        values.add_value(&1234i32, &ColumnType::Int).unwrap();
-        values.add_value(&"abcdefg", &ColumnType::Ascii).unwrap();
+        values
+            .add_value(&1234i32, &ColumnType::Native(NativeType::Int))
+            .unwrap();
+        values
+            .add_value(&"abcdefg", &ColumnType::Native(NativeType::Ascii))
+            .unwrap();
         let mut buf = Vec::new();
         values.write_to_request(&mut buf);
         assert_eq!(
@@ -1514,8 +1557,12 @@ pub(crate) mod tests {
     #[test]
     fn test_serialized_values_iter() {
         let mut values = SerializedValues::new();
-        values.add_value(&1234i32, &ColumnType::Int).unwrap();
-        values.add_value(&"abcdefg", &ColumnType::Ascii).unwrap();
+        values
+            .add_value(&1234i32, &ColumnType::Native(NativeType::Int))
+            .unwrap();
+        values
+            .add_value(&"abcdefg", &ColumnType::Native(NativeType::Ascii))
+            .unwrap();
 
         let mut iter = values.iter();
         assert_eq!(iter.next(), Some(RawValue::Value(&[0, 0, 4, 210])));
@@ -1531,13 +1578,13 @@ pub(crate) mod tests {
         let mut values = SerializedValues::new();
         for _ in 0..65535 {
             values
-                .add_value(&123456789i64, &ColumnType::BigInt)
+                .add_value(&123456789i64, &ColumnType::Native(NativeType::BigInt))
                 .unwrap();
         }
 
         // Adding this value should fail, we reached max capacity
         values
-            .add_value(&123456789i64, &ColumnType::BigInt)
+            .add_value(&123456789i64, &ColumnType::Native(NativeType::BigInt))
             .unwrap_err();
 
         assert_eq!(values.iter().count(), 65535);
@@ -1564,7 +1611,10 @@ pub(crate) mod tests {
 
     #[test]
     fn test_row_serialization_with_column_rename() {
-        let spec = [col("x", ColumnType::Int), col("a", ColumnType::Text)];
+        let spec = [
+            col("x", ColumnType::Native(NativeType::Int)),
+            col("a", ColumnType::Native(NativeType::Text)),
+        ];
 
         let reference = do_serialize((42i32, "Ala ma kota"), &spec);
         let row = do_serialize(
@@ -1580,7 +1630,10 @@ pub(crate) mod tests {
 
     #[test]
     fn test_row_serialization_with_column_rename_and_enforce_order() {
-        let spec = [col("a", ColumnType::Text), col("x", ColumnType::Int)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("x", ColumnType::Native(NativeType::Int)),
+        ];
 
         let reference = do_serialize(("Ala ma kota", 42i32), &spec);
         let row = do_serialize(
@@ -1603,7 +1656,10 @@ pub(crate) mod tests {
 
     #[test]
     fn test_row_serialization_with_skipped_name_checks() {
-        let spec = [col("a", ColumnType::Text), col("x", ColumnType::Int)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("x", ColumnType::Native(NativeType::Int)),
+        ];
 
         let reference = do_serialize(("Ala ma kota", 42i32), &spec);
         let row = do_serialize(
@@ -1626,7 +1682,7 @@ pub(crate) mod tests {
             ttl: i32,
         }
 
-        let spec = [col("[ttl]", ColumnType::Int)];
+        let spec = [col("[ttl]", ColumnType::Native(NativeType::Int))];
 
         let reference = do_serialize((42i32,), &spec);
         let row = do_serialize(RowWithTTL { ttl: 42 }, &spec);
@@ -1648,9 +1704,12 @@ pub(crate) mod tests {
     #[test]
     fn test_row_serialization_with_skipped_field() {
         let spec = [
-            col("a", ColumnType::Text),
-            col("b", ColumnType::Int),
-            col("c", ColumnType::List(Box::new(ColumnType::BigInt))),
+            col("a", ColumnType::Native(NativeType::Text)),
+            col("b", ColumnType::Native(NativeType::Int)),
+            col(
+                "c",
+                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+            ),
         ];
 
         let reference = do_serialize(
@@ -1676,7 +1735,10 @@ pub(crate) mod tests {
 
     #[test]
     fn test_row_serialization_with_boxed_tuple() {
-        let spec = [col("a", ColumnType::Int), col("b", ColumnType::Int)];
+        let spec = [
+            col("a", ColumnType::Native(NativeType::Int)),
+            col("b", ColumnType::Native(NativeType::Int)),
+        ];
 
         let reference = do_serialize((42i32, 42i32), &spec);
         let row = do_serialize(Box::new((42i32, 42i32)), &spec);

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -1291,7 +1291,7 @@ pub(crate) mod tests {
                 "c",
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
         ];
@@ -1318,7 +1318,7 @@ pub(crate) mod tests {
                 "c",
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
             col("b", ColumnType::Native(NativeType::Int)),
@@ -1366,7 +1366,7 @@ pub(crate) mod tests {
                 "c",
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
             // Unexpected last column
@@ -1444,7 +1444,7 @@ pub(crate) mod tests {
                 "c",
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
         ];
@@ -1475,7 +1475,7 @@ pub(crate) mod tests {
                 "c",
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
             col("b", ColumnType::Native(NativeType::Int)),
@@ -1511,7 +1511,7 @@ pub(crate) mod tests {
                 "c",
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
             // Unexpected last column
@@ -1730,7 +1730,7 @@ pub(crate) mod tests {
                 "c",
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
         ];

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -1290,6 +1290,7 @@ pub(crate) mod tests {
             col(
                 "c",
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
@@ -1316,6 +1317,7 @@ pub(crate) mod tests {
             col(
                 "c",
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
@@ -1363,6 +1365,7 @@ pub(crate) mod tests {
             col(
                 "c",
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
@@ -1440,6 +1443,7 @@ pub(crate) mod tests {
             col(
                 "c",
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
@@ -1470,6 +1474,7 @@ pub(crate) mod tests {
             col(
                 "c",
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
@@ -1505,6 +1510,7 @@ pub(crate) mod tests {
             col(
                 "c",
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),
@@ -1723,6 +1729,7 @@ pub(crate) mod tests {
             col(
                 "c",
                 ColumnType::Collection {
+                    frozen: false,
                     type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
                 },
             ),

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -954,7 +954,9 @@ pub(crate) mod tests {
     use std::borrow::Cow;
     use std::collections::BTreeMap;
 
-    use crate::frame::response::result::{ColumnSpec, ColumnType, NativeType, TableSpec};
+    use crate::frame::response::result::{
+        CollectionType, ColumnSpec, ColumnType, NativeType, TableSpec,
+    };
     use crate::frame::types::RawValue;
     #[allow(deprecated)]
     use crate::frame::value::{LegacySerializedValues, MaybeUnset, SerializedResult, ValueList};
@@ -1287,7 +1289,9 @@ pub(crate) mod tests {
             col("b", ColumnType::Native(NativeType::Int)),
             col(
                 "c",
-                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                ColumnType::Collection {
+                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                },
             ),
         ];
 
@@ -1311,7 +1315,9 @@ pub(crate) mod tests {
             col("a", ColumnType::Native(NativeType::Text)),
             col(
                 "c",
-                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                ColumnType::Collection {
+                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                },
             ),
             col("b", ColumnType::Native(NativeType::Int)),
         ];
@@ -1356,7 +1362,9 @@ pub(crate) mod tests {
             col("b", ColumnType::Native(NativeType::Int)),
             col(
                 "c",
-                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                ColumnType::Collection {
+                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                },
             ),
             // Unexpected last column
             col("d", ColumnType::Native(NativeType::Counter)),
@@ -1431,7 +1439,9 @@ pub(crate) mod tests {
             col("b", ColumnType::Native(NativeType::Int)),
             col(
                 "c",
-                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                ColumnType::Collection {
+                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                },
             ),
         ];
 
@@ -1459,7 +1469,9 @@ pub(crate) mod tests {
             col("a", ColumnType::Native(NativeType::Text)),
             col(
                 "c",
-                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                ColumnType::Collection {
+                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                },
             ),
             col("b", ColumnType::Native(NativeType::Int)),
         ];
@@ -1492,7 +1504,9 @@ pub(crate) mod tests {
             col("b", ColumnType::Native(NativeType::Int)),
             col(
                 "c",
-                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                ColumnType::Collection {
+                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                },
             ),
             // Unexpected last column
             col("d", ColumnType::Native(NativeType::Counter)),
@@ -1708,7 +1722,9 @@ pub(crate) mod tests {
             col("b", ColumnType::Native(NativeType::Int)),
             col(
                 "c",
-                ColumnType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                ColumnType::Collection {
+                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::BigInt))),
+                },
             ),
         ];
 

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -814,11 +814,11 @@ fn serialize_sequence<'t, 'b, T: SerializeValue + 't>(
     let elt = match typ {
         ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::List(elt),
+            typ: CollectionType::List(elt),
         }
         | ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Set(elt),
+            typ: CollectionType::Set(elt),
         } => elt,
         _ => {
             return Err(mk_typck_err_named(
@@ -865,7 +865,7 @@ fn serialize_mapping<'t, 'b, K: SerializeValue + 't, V: SerializeValue + 't>(
     let (ktyp, vtyp) = match typ {
         ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Map(k, v),
+            typ: CollectionType::Map(k, v),
         } => (k, v),
         _ => {
             return Err(mk_typck_err_named(
@@ -1820,7 +1820,7 @@ pub(crate) mod tests {
         let v = &[Unset; 1 << 33] as &[Unset];
         let typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
+            typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
         };
         let err = do_serialize_err(v, &typ);
         let err = get_ser_err(&err);
@@ -1837,7 +1837,7 @@ pub(crate) mod tests {
         let v = vec![123_i32];
         let typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Double))),
+            typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Double))),
         };
         let err = do_serialize_err(v, &typ);
         let err = get_ser_err(&err);
@@ -1878,7 +1878,7 @@ pub(crate) mod tests {
         let v = BTreeMap::from([(123_i32, 456_i32)]);
         let typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Double)),
                 Box::new(ColumnType::Native(NativeType::Int)),
             ),
@@ -1905,7 +1905,7 @@ pub(crate) mod tests {
         let v = BTreeMap::from([(123_i32, 456_i32)]);
         let typ = ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int)),
                 Box::new(ColumnType::Native(NativeType::Double)),
             ),
@@ -2229,7 +2229,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2287,7 +2287,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2348,7 +2348,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2369,7 +2369,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2428,7 +2428,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2589,7 +2589,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2648,7 +2648,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2669,7 +2669,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2714,7 +2714,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2937,7 +2937,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -2971,7 +2971,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -3015,7 +3015,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },
@@ -3064,7 +3064,7 @@ pub(crate) mod tests {
                         "c".into(),
                         ColumnType::Collection {
                             frozen: false,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
                         },

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -511,12 +511,6 @@ fn serialize_cql_value<'b>(
     typ: &ColumnType,
     writer: CellWriter<'b>,
 ) -> Result<WrittenCellProof<'b>, SerializationError> {
-    if let ColumnType::Custom(_) = typ {
-        return Err(mk_typck_err::<CqlValue>(
-            typ,
-            BuiltinTypeCheckErrorKind::CustomTypeUnsupported,
-        ));
-    }
     match value {
         CqlValue::Ascii(a) => <_ as SerializeValue>::serialize(&a, typ, writer),
         CqlValue::Boolean(b) => <_ as SerializeValue>::serialize(&b, typ, writer),
@@ -1146,10 +1140,6 @@ pub enum BuiltinTypeCheckErrorKind {
 
     /// A type check failure specific to a CQL UDT.
     UdtError(UdtTypeCheckErrorKind),
-
-    /// Custom CQL type - unsupported
-    // TODO: Should we actually support it? Counters used to be implemented like that.
-    CustomTypeUnsupported,
 }
 
 impl From<SetOrListTypeCheckErrorKind> for BuiltinTypeCheckErrorKind {
@@ -1189,9 +1179,6 @@ impl Display for BuiltinTypeCheckErrorKind {
             BuiltinTypeCheckErrorKind::MapError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::TupleError(err) => err.fmt(f),
             BuiltinTypeCheckErrorKind::UdtError(err) => err.fmt(f),
-            BuiltinTypeCheckErrorKind::CustomTypeUnsupported => {
-                f.write_str("custom CQL types are unsupported")
-            }
         }
     }
 }

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -633,9 +633,9 @@ fn serialize_udt<'b>(
     writer: CellWriter<'b>,
 ) -> Result<WrittenCellProof<'b>, SerializationError> {
     let (dst_type_name, dst_keyspace, field_types) = match typ {
-        ColumnType::UserDefinedType { definition: udt } => {
-            (&udt.name, &udt.keyspace, &udt.field_types)
-        }
+        ColumnType::UserDefinedType {
+            definition: udt, ..
+        } => (&udt.name, &udt.keyspace, &udt.field_types),
         _ => return Err(mk_typck_err::<CqlValue>(typ, UdtTypeCheckErrorKind::NotUdt)),
     };
 
@@ -813,9 +813,11 @@ fn serialize_sequence<'t, 'b, T: SerializeValue + 't>(
 ) -> Result<WrittenCellProof<'b>, SerializationError> {
     let elt = match typ {
         ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::List(elt),
         }
         | ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Set(elt),
         } => elt,
         _ => {
@@ -862,6 +864,7 @@ fn serialize_mapping<'t, 'b, K: SerializeValue + 't, V: SerializeValue + 't>(
 ) -> Result<WrittenCellProof<'b>, SerializationError> {
     let (ktyp, vtyp) = match typ {
         ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Map(k, v),
         } => (k, v),
         _ => {
@@ -1816,6 +1819,7 @@ pub(crate) mod tests {
         // Such an array is also created instantaneously.
         let v = &[Unset; 1 << 33] as &[Unset];
         let typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
         };
         let err = do_serialize_err(v, &typ);
@@ -1832,6 +1836,7 @@ pub(crate) mod tests {
         // Error during serialization of an element
         let v = vec![123_i32];
         let typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Double))),
         };
         let err = do_serialize_err(v, &typ);
@@ -1872,6 +1877,7 @@ pub(crate) mod tests {
         // Error during serialization of a key
         let v = BTreeMap::from([(123_i32, 456_i32)]);
         let typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Double)),
                 Box::new(ColumnType::Native(NativeType::Int)),
@@ -1898,6 +1904,7 @@ pub(crate) mod tests {
         // Error during serialization of a value
         let v = BTreeMap::from([(123_i32, 456_i32)]);
         let typ = ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int)),
                 Box::new(ColumnType::Native(NativeType::Double)),
@@ -2088,6 +2095,7 @@ pub(crate) mod tests {
             ],
         };
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "udt2".into(),
                 keyspace: "ks".into(),
@@ -2123,6 +2131,7 @@ pub(crate) mod tests {
             ],
         };
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "udt".into(),
                 keyspace: "ks".into(),
@@ -2159,6 +2168,7 @@ pub(crate) mod tests {
             ],
         };
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "udt".into(),
                 keyspace: "ks".into(),
@@ -2208,6 +2218,7 @@ pub(crate) mod tests {
     #[test]
     fn test_udt_serialization_with_field_sorting_correct_order() {
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2217,6 +2228,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2263,6 +2275,7 @@ pub(crate) mod tests {
     #[test]
     fn test_udt_serialization_with_field_sorting_incorrect_order() {
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2273,6 +2286,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2323,6 +2337,7 @@ pub(crate) mod tests {
         let udt = TestUdtWithFieldSorting::default();
 
         let typ_normal = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2332,6 +2347,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2342,6 +2358,7 @@ pub(crate) mod tests {
         };
 
         let typ_unexpected_field = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2351,6 +2368,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2395,6 +2413,7 @@ pub(crate) mod tests {
         let udt3 = TestUdtWithFieldSorting3::default();
 
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2408,6 +2427,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2441,6 +2461,7 @@ pub(crate) mod tests {
         );
 
         let typ_without_c = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2464,6 +2485,7 @@ pub(crate) mod tests {
         );
 
         let typ_wrong_type = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2499,6 +2521,7 @@ pub(crate) mod tests {
         // A minimal smoke test just to test that it works.
         fn check_with_type<T: SerializeValue>(typ: ColumnType, t: T, cql_t: CqlValue) {
             let typ = ColumnType::UserDefinedType {
+                frozen: false,
                 definition: Arc::new(UserDefinedType {
                     name: "typ".into(),
                     keyspace: "ks".into(),
@@ -2555,6 +2578,7 @@ pub(crate) mod tests {
     #[test]
     fn test_udt_serialization_with_enforced_order_correct_order() {
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2564,6 +2588,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2612,6 +2637,7 @@ pub(crate) mod tests {
         let udt = TestUdtWithEnforcedOrder::default();
 
         let typ_normal = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2621,6 +2647,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2631,6 +2658,7 @@ pub(crate) mod tests {
         };
 
         let typ_unexpected_field = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2640,6 +2668,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2673,6 +2702,7 @@ pub(crate) mod tests {
         );
 
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2683,6 +2713,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2701,6 +2732,7 @@ pub(crate) mod tests {
         );
 
         let typ_without_c = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2724,6 +2756,7 @@ pub(crate) mod tests {
         );
 
         let typ_unexpected_field = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2769,6 +2802,7 @@ pub(crate) mod tests {
     #[test]
     fn test_udt_serialization_with_field_rename() {
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2803,6 +2837,7 @@ pub(crate) mod tests {
     #[test]
     fn test_udt_serialization_with_field_rename_and_enforce_order() {
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2845,6 +2880,7 @@ pub(crate) mod tests {
     #[test]
     fn test_udt_serialization_with_skipped_name_checks() {
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2890,6 +2926,7 @@ pub(crate) mod tests {
         let mut data = Vec::new();
 
         let typ_unexpected_field = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2899,6 +2936,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2920,6 +2958,7 @@ pub(crate) mod tests {
         );
 
         let typ_unexpected_field_middle = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2931,6 +2970,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -2964,6 +3004,7 @@ pub(crate) mod tests {
         let mut data = Vec::new();
 
         let typ_unexpected_field = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -2973,6 +3014,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -3011,6 +3053,7 @@ pub(crate) mod tests {
     #[test]
     fn test_row_serialization_with_skipped_field() {
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),
@@ -3020,6 +3063,7 @@ pub(crate) mod tests {
                     (
                         "c".into(),
                         ColumnType::Collection {
+                            frozen: false,
                             type_: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::BigInt,
                             ))),
@@ -3060,6 +3104,7 @@ pub(crate) mod tests {
         }
 
         let typ = ColumnType::UserDefinedType {
+            frozen: false,
             definition: Arc::new(UserDefinedType {
                 name: "typ".into(),
                 keyspace: "ks".into(),

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -546,7 +546,7 @@ fn serialize_cql_value<'b>(
         CqlValue::Set(s) => <_ as SerializeValue>::serialize(&s, typ, writer),
         CqlValue::UserDefinedType {
             keyspace,
-            type_name,
+            name: type_name,
             fields,
         } => serialize_udt(typ, keyspace, type_name, fields, writer),
         CqlValue::SmallInt(s) => <_ as SerializeValue>::serialize(&s, typ, writer),
@@ -2061,7 +2061,7 @@ pub(crate) mod tests {
         // Not a UDT
         let v = CqlValue::UserDefinedType {
             keyspace: "ks".to_string(),
-            type_name: "udt".to_string(),
+            name: "udt".to_string(),
             fields: vec![
                 ("a".to_string(), Some(CqlValue::Int(123_i32))),
                 ("b".to_string(), Some(CqlValue::Int(456_i32))),
@@ -2080,7 +2080,7 @@ pub(crate) mod tests {
         // Wrong type name
         let v = CqlValue::UserDefinedType {
             keyspace: "ks".to_string(),
-            type_name: "udt".to_string(),
+            name: "udt".to_string(),
             fields: vec![
                 ("a".to_string(), Some(CqlValue::Int(123_i32))),
                 ("b".to_string(), Some(CqlValue::Int(456_i32))),
@@ -2115,7 +2115,7 @@ pub(crate) mod tests {
         // Some fields are missing from the CQL type
         let v = CqlValue::UserDefinedType {
             keyspace: "ks".to_string(),
-            type_name: "udt".to_string(),
+            name: "udt".to_string(),
             fields: vec![
                 ("a".to_string(), Some(CqlValue::Int(123_i32))),
                 ("b".to_string(), Some(CqlValue::Int(456_i32))),
@@ -2151,7 +2151,7 @@ pub(crate) mod tests {
         // Error during serialization of one of the fields
         let v = CqlValue::UserDefinedType {
             keyspace: "ks".to_string(),
-            type_name: "udt".to_string(),
+            name: "udt".to_string(),
             fields: vec![
                 ("a".to_string(), Some(CqlValue::Int(123_i32))),
                 ("b".to_string(), Some(CqlValue::Int(456_i32))),
@@ -2229,7 +2229,7 @@ pub(crate) mod tests {
         let reference = do_serialize(
             CqlValue::UserDefinedType {
                 keyspace: "ks".to_string(),
-                type_name: "typ".to_string(),
+                name: "typ".to_string(),
                 fields: vec![
                     (
                         "a".to_string(),
@@ -2285,7 +2285,7 @@ pub(crate) mod tests {
         let reference = do_serialize(
             CqlValue::UserDefinedType {
                 keyspace: "ks".to_string(),
-                type_name: "typ".to_string(),
+                name: "typ".to_string(),
                 fields: vec![
                     // FIXME: UDTs in CqlValue should also honor the order
                     // For now, it's swapped here as well
@@ -2511,7 +2511,7 @@ pub(crate) mod tests {
             let reference = do_serialize(
                 CqlValue::UserDefinedType {
                     keyspace: "ks".to_string(),
-                    type_name: "typ".to_string(),
+                    name: "typ".to_string(),
                     fields: vec![
                         (
                             "a".to_string(),
@@ -2576,7 +2576,7 @@ pub(crate) mod tests {
         let reference = do_serialize(
             CqlValue::UserDefinedType {
                 keyspace: "ks".to_string(),
-                type_name: "typ".to_string(),
+                name: "typ".to_string(),
                 fields: vec![
                     (
                         "a".to_string(),

--- a/scylla-cql/src/types_tests.rs
+++ b/scylla-cql/src/types_tests.rs
@@ -3,7 +3,7 @@ mod derive_macros_integration {
         use bytes::Bytes;
 
         use crate::deserialize::value::tests::{deserialize, udt_def_with_fields};
-        use crate::frame::response::result::ColumnType;
+        use crate::frame::response::result::{ColumnType, NativeType};
         use crate::serialize::value::tests::do_serialize;
 
         #[test]
@@ -33,9 +33,9 @@ mod derive_macros_integration {
                 // All fields present
                 (
                     udt_def_with_fields([
-                        ("a", ColumnType::Text),
-                        ("b", ColumnType::Int),
-                        ("c", ColumnType::BigInt),
+                        ("a", ColumnType::Native(NativeType::Text)),
+                        ("b", ColumnType::Native(NativeType::Int)),
+                        ("c", ColumnType::Native(NativeType::BigInt)),
                     ]),
                     Udt {
                         x: String::new(),
@@ -47,7 +47,10 @@ mod derive_macros_integration {
                 // - ignored during serialization,
                 // - default-initialized during deserialization.
                 (
-                    udt_def_with_fields([("a", ColumnType::Text), ("c", ColumnType::BigInt)]),
+                    udt_def_with_fields([
+                        ("a", ColumnType::Native(NativeType::Text)),
+                        ("c", ColumnType::Native(NativeType::BigInt)),
+                    ]),
                     Udt {
                         x: String::new(),
                         b: None,
@@ -58,9 +61,9 @@ mod derive_macros_integration {
                 // UDT fields switched - should still work.
                 (
                     udt_def_with_fields([
-                        ("b", ColumnType::Int),
-                        ("a", ColumnType::Text),
-                        ("c", ColumnType::BigInt),
+                        ("b", ColumnType::Native(NativeType::Int)),
+                        ("a", ColumnType::Native(NativeType::Text)),
+                        ("c", ColumnType::Native(NativeType::BigInt)),
                     ]),
                     Udt {
                         x: String::new(),
@@ -101,7 +104,10 @@ mod derive_macros_integration {
             let tests = [
                 // All fields present
                 (
-                    udt_def_with_fields([("a", ColumnType::Text), ("b", ColumnType::Int)]),
+                    udt_def_with_fields([
+                        ("a", ColumnType::Native(NativeType::Text)),
+                        ("b", ColumnType::Native(NativeType::Int)),
+                    ]),
                     Udt {
                         x: String::new(),
                         ..original_udt
@@ -111,9 +117,9 @@ mod derive_macros_integration {
                 // An excess field at the end of UDT
                 (
                     udt_def_with_fields([
-                        ("a", ColumnType::Text),
-                        ("b", ColumnType::Int),
-                        ("d", ColumnType::Boolean),
+                        ("a", ColumnType::Native(NativeType::Text)),
+                        ("b", ColumnType::Native(NativeType::Int)),
+                        ("d", ColumnType::Native(NativeType::Boolean)),
                     ]),
                     Udt {
                         x: String::new(),
@@ -123,7 +129,7 @@ mod derive_macros_integration {
                 //
                 // Missing non-required fields
                 (
-                    udt_def_with_fields([("a", ColumnType::Text)]),
+                    udt_def_with_fields([("a", ColumnType::Native(NativeType::Text))]),
                     Udt {
                         x: String::new(),
                         b: None,
@@ -133,7 +139,7 @@ mod derive_macros_integration {
                 //
                 // An excess field at the end of UDT instead of non-required fields
                 (
-                    udt_def_with_fields([("d", ColumnType::Boolean)]),
+                    udt_def_with_fields([("d", ColumnType::Native(NativeType::Boolean))]),
                     Udt {
                         x: String::new(),
                         a: "",
@@ -155,7 +161,7 @@ mod derive_macros_integration {
 
         use crate::deserialize::row::tests::deserialize;
         use crate::deserialize::tests::spec;
-        use crate::frame::response::result::ColumnType;
+        use crate::frame::response::result::{ColumnType, NativeType};
         use crate::serialize::row::tests::do_serialize;
 
         #[test]
@@ -183,9 +189,9 @@ mod derive_macros_integration {
                 // All columns present
                 (
                     &[
-                        spec("a", ColumnType::Text),
-                        spec("b", ColumnType::Int),
-                        spec("c", ColumnType::BigInt),
+                        spec("a", ColumnType::Native(NativeType::Text)),
+                        spec("b", ColumnType::Native(NativeType::Int)),
+                        spec("c", ColumnType::Native(NativeType::BigInt)),
                     ][..],
                     MyRow {
                         x: String::new(),
@@ -196,9 +202,9 @@ mod derive_macros_integration {
                 // Columns switched - should still work.
                 (
                     &[
-                        spec("b", ColumnType::Int),
-                        spec("a", ColumnType::Text),
-                        spec("c", ColumnType::BigInt),
+                        spec("b", ColumnType::Native(NativeType::Int)),
+                        spec("a", ColumnType::Native(NativeType::Text)),
+                        spec("c", ColumnType::Native(NativeType::BigInt)),
                     ],
                     MyRow {
                         x: String::new(),
@@ -236,7 +242,10 @@ mod derive_macros_integration {
             let tests = [
                 // All columns present
                 (
-                    &[spec("a", ColumnType::Text), spec("b", ColumnType::Int)][..],
+                    &[
+                        spec("a", ColumnType::Native(NativeType::Text)),
+                        spec("b", ColumnType::Native(NativeType::Int)),
+                    ][..],
                     MyRow {
                         x: String::new(),
                         ..original_row

--- a/scylla-macros/src/deserialize/value.rs
+++ b/scylla-macros/src/deserialize/value.rs
@@ -194,7 +194,7 @@ impl StructDesc {
         let macro_internal = &self.struct_attrs().macro_internal_path();
         parse_quote!(
             match #typ_expr {
-                #macro_internal::ColumnType::UserDefinedType { field_types, .. } => field_types,
+                #macro_internal::ColumnType::UserDefinedType { definition, .. } => &definition.field_types,
                 other => return ::std::result::Result::Err(
                     #macro_internal::mk_value_typck_err::<Self>(
                         &other,

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -207,8 +207,8 @@ impl Context {
 
         parse_quote! {
             let (type_name, keyspace, field_types) = match typ {
-                #crate_path::ColumnType::UserDefinedType { type_name, keyspace, field_types, .. } => {
-                    (type_name, keyspace, field_types)
+                #crate_path::ColumnType::UserDefinedType { definition: udt, .. } => {
+                    (&udt.name, &udt.keyspace, &udt.field_types)
                 }
                 _ => return ::std::result::Result::Err(mk_typck_err(#err)),
             };

--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -2,7 +2,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use bytes::BytesMut;
 use scylla::routing::partitioner::{calculate_token_for_partition_key, Murmur3Partitioner};
-use scylla_cql::frame::{response::result::ColumnType, types};
+use scylla_cql::frame::response::result::{ColumnType, NativeType};
+use scylla_cql::frame::types;
 use scylla_cql::serialize::row::SerializedValues;
 
 fn types_benchmark(c: &mut Criterion) {
@@ -40,45 +41,45 @@ fn types_benchmark(c: &mut Criterion) {
 fn calculate_token_bench(c: &mut Criterion) {
     let mut serialized_simple_pk = SerializedValues::new();
     serialized_simple_pk
-        .add_value(&"I'm prepared!!!", &ColumnType::Text)
+        .add_value(&"I'm prepared!!!", &ColumnType::Native(NativeType::Text))
         .unwrap();
 
     let mut serialized_simple_pk_long_column = SerializedValues::new();
     serialized_simple_pk_long_column
-        .add_value(&17_i32, &ColumnType::Int)
+        .add_value(&17_i32, &ColumnType::Native(NativeType::Int))
         .unwrap();
     serialized_simple_pk_long_column
-        .add_value(&16_i32, &ColumnType::Int)
+        .add_value(&16_i32, &ColumnType::Native(NativeType::Int))
         .unwrap();
     serialized_simple_pk_long_column
         .add_value(
             &String::from_iter(std::iter::repeat('.').take(2000)),
-            &ColumnType::Text,
+            &ColumnType::Native(NativeType::Text),
         )
         .unwrap();
 
     let mut serialized_complex_pk = SerializedValues::new();
     serialized_complex_pk
-        .add_value(&17_i32, &ColumnType::Int)
+        .add_value(&17_i32, &ColumnType::Native(NativeType::Int))
         .unwrap();
     serialized_complex_pk
-        .add_value(&16_i32, &ColumnType::Int)
+        .add_value(&16_i32, &ColumnType::Native(NativeType::Int))
         .unwrap();
     serialized_complex_pk
-        .add_value(&"I'm prepared!!!", &ColumnType::Text)
+        .add_value(&"I'm prepared!!!", &ColumnType::Native(NativeType::Text))
         .unwrap();
 
     let mut serialized_values_long_column = SerializedValues::new();
     serialized_values_long_column
-        .add_value(&17_i32, &ColumnType::Int)
+        .add_value(&17_i32, &ColumnType::Native(NativeType::Int))
         .unwrap();
     serialized_values_long_column
-        .add_value(&16_i32, &ColumnType::Int)
+        .add_value(&16_i32, &ColumnType::Native(NativeType::Int))
         .unwrap();
     serialized_values_long_column
         .add_value(
             &String::from_iter(std::iter::repeat('.').take(2000)),
-            &ColumnType::Text,
+            &ColumnType::Native(NativeType::Text),
         )
         .unwrap();
 

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -1653,7 +1653,7 @@ async fn test_schema_types_in_metadata() {
     let a = &table_a_columns["a"];
 
     assert_eq!(
-        a.type_,
+        a.typ,
         ColumnType::UserDefinedType {
             frozen: true,
             definition: udt_type_a_def(&ks),
@@ -1663,7 +1663,7 @@ async fn test_schema_types_in_metadata() {
     let b = &table_a_columns["b"];
 
     assert_eq!(
-        b.type_,
+        b.typ,
         ColumnType::UserDefinedType {
             frozen: false,
             definition: udt_type_b_def(&ks),
@@ -1673,7 +1673,7 @@ async fn test_schema_types_in_metadata() {
     let c = &table_a_columns["c"];
 
     assert_eq!(
-        c.type_,
+        c.typ,
         ColumnType::UserDefinedType {
             frozen: true,
             definition: udt_type_c_def(&ks)
@@ -1683,7 +1683,7 @@ async fn test_schema_types_in_metadata() {
     let d = &table_a_columns["d"];
 
     assert_eq!(
-        d.type_,
+        d.typ,
         ColumnType::Collection {
             typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Text)),
@@ -1699,7 +1699,7 @@ async fn test_schema_types_in_metadata() {
     let e = &table_a_columns["e"];
 
     assert_eq!(
-        e.type_,
+        e.typ,
         ColumnType::Tuple(vec![
             ColumnType::Native(NativeType::Int),
             ColumnType::Native(NativeType::Text)
@@ -1710,12 +1710,12 @@ async fn test_schema_types_in_metadata() {
 
     let a = &table_b_columns["a"];
 
-    assert_eq!(a.type_, ColumnType::Native(NativeType::Text));
+    assert_eq!(a.typ, ColumnType::Native(NativeType::Text));
 
     let b = &table_b_columns["b"];
 
     assert_eq!(
-        b.type_,
+        b.typ,
         ColumnType::Collection {
             typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int),),
@@ -3242,14 +3242,14 @@ async fn test_vector_type_metadata() {
     let metadata = session.get_cluster_data();
     let columns = &metadata.keyspaces[&ks].tables["t"].columns;
     assert_eq!(
-        columns["b"].type_,
+        columns["b"].typ,
         ColumnType::Vector {
             typ: Box::new(ColumnType::Native(NativeType::Int)),
             dimensions: 4,
         },
     );
     assert_eq!(
-        columns["c"].type_,
+        columns["c"].typ,
         ColumnType::Vector {
             typ: Box::new(ColumnType::Native(NativeType::Text)),
             dimensions: 2,

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -1504,10 +1504,10 @@ fn udt_type_a_def(ks: &str) -> Arc<UserDefinedType<'_>> {
                 "a".into(),
                 ColumnType::Collection {
                     frozen: false,
-                    type_: CollectionType::Map(
+                    typ: CollectionType::Map(
                         Box::new(ColumnType::Collection {
                             frozen: true,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::Int,
                             ))),
                         }),
@@ -1519,16 +1519,16 @@ fn udt_type_a_def(ks: &str) -> Arc<UserDefinedType<'_>> {
                 "b".into(),
                 ColumnType::Collection {
                     frozen: true,
-                    type_: CollectionType::Map(
+                    typ: CollectionType::Map(
                         Box::new(ColumnType::Collection {
                             frozen: true,
-                            type_: CollectionType::List(Box::new(ColumnType::Native(
+                            typ: CollectionType::List(Box::new(ColumnType::Native(
                                 NativeType::Int,
                             ))),
                         }),
                         Box::new(ColumnType::Collection {
                             frozen: true,
-                            type_: CollectionType::Set(Box::new(ColumnType::Native(
+                            typ: CollectionType::Set(Box::new(ColumnType::Native(
                                 NativeType::Text,
                             ))),
                         }),
@@ -1558,10 +1558,10 @@ fn udt_type_c_def(ks: &str) -> Arc<UserDefinedType<'_>> {
             "a".into(),
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::Map(
+                typ: CollectionType::Map(
                     Box::new(ColumnType::Collection {
                         frozen: true,
-                        type_: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text))),
+                        typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Text))),
                     }),
                     Box::new(ColumnType::UserDefinedType {
                         frozen: true,
@@ -1685,10 +1685,10 @@ async fn test_schema_types_in_metadata() {
     assert_eq!(
         d.type_,
         ColumnType::Collection {
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Text)),
                 Box::new(ColumnType::Collection {
-                    type_: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
+                    typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
                     frozen: true
                 })
             ),
@@ -1717,7 +1717,7 @@ async fn test_schema_types_in_metadata() {
     assert_eq!(
         b.type_,
         ColumnType::Collection {
-            type_: CollectionType::Map(
+            typ: CollectionType::Map(
                 Box::new(ColumnType::Native(NativeType::Int),),
                 Box::new(ColumnType::Native(NativeType::Int),)
             ),

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -3244,14 +3244,14 @@ async fn test_vector_type_metadata() {
     assert_eq!(
         columns["b"].type_,
         ColumnType::Vector {
-            type_: Box::new(ColumnType::Native(NativeType::Int)),
+            typ: Box::new(ColumnType::Native(NativeType::Int)),
             dimensions: 4,
         },
     );
     assert_eq!(
         columns["c"].type_,
         ColumnType::Vector {
-            type_: Box::new(ColumnType::Native(NativeType::Text)),
+            typ: Box::new(ColumnType::Native(NativeType::Text)),
             dimensions: 2,
         },
     );

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -237,10 +237,7 @@ impl PreColumnType {
             PreColumnType::Native(n) => Ok(ColumnType::Native(n)),
             PreColumnType::Collection { frozen, type_ } => type_
                 .into_collection_type(keyspace_name, keyspace_udts)
-                .map(|inner| ColumnType::Collection {
-                    frozen,
-                    type_: inner,
-                }),
+                .map(|inner| ColumnType::Collection { frozen, typ: inner }),
             PreColumnType::Tuple(t) => t
                 .into_iter()
                 .map(|t| t.into_cql_type(keyspace_name, keyspace_udts))

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -349,7 +349,7 @@ pub enum Strategy {
 
 #[derive(Clone, Debug)]
 struct InvalidCqlType {
-    type_: String,
+    typ: String,
     position: usize,
     reason: String,
 }
@@ -363,7 +363,7 @@ impl fmt::Display for InvalidCqlType {
 impl From<InvalidCqlType> for QueryError {
     fn from(e: InvalidCqlType) -> Self {
         ProtocolError::InvalidCqlType {
-            typ: e.type_,
+            typ: e.typ,
             position: e.position,
             reason: e.reason,
         }
@@ -1626,12 +1626,12 @@ async fn query_tables_schema(
 fn map_string_to_cql_type(type_: &str) -> Result<PreColumnType, InvalidCqlType> {
     match parse_cql_type(ParserState::new(type_)) {
         Err(err) => Err(InvalidCqlType {
-            type_: type_.to_string(),
+            typ: type_.to_string(),
             position: err.calculate_position(type_).unwrap_or(0),
             reason: err.get_cause().to_string(),
         }),
         Ok((_, p)) if !p.is_at_eof() => Err(InvalidCqlType {
-            type_: type_.to_string(),
+            typ: type_.to_string(),
             position: p.calculate_position(type_).unwrap_or(0),
             reason: "leftover characters".to_string(),
         }),

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -214,9 +214,7 @@ enum PreCqlType {
     Tuple(Vec<PreCqlType>),
     Vector {
         type_: Box<PreCqlType>,
-        /// matches the datatype used by the java driver:
-        /// <https://github.com/apache/cassandra-java-driver/blob/85bb4065098b887d2dda26eb14423ce4fc687045/core/src/main/java/com/datastax/oss/driver/api/core/type/DataTypes.java#L77>
-        dimensions: i32,
+        dimensions: u16,
     },
     UserDefinedType {
         frozen: bool,
@@ -275,9 +273,7 @@ pub enum CqlType {
     Tuple(Vec<CqlType>),
     Vector {
         type_: Box<CqlType>,
-        /// matches the datatype used by the java driver:
-        /// <https://github.com/apache/cassandra-java-driver/blob/85bb4065098b887d2dda26eb14423ce4fc687045/core/src/main/java/com/datastax/oss/driver/api/core/type/DataTypes.java#L77>
-        dimensions: i32,
+        dimensions: u16,
     },
     UserDefinedType {
         frozen: bool,
@@ -1790,7 +1786,7 @@ fn parse_cql_type(p: ParserState<'_>) -> ParseResult<(PreCqlType, ParserState<'_
         let p = p.skip_white();
         let p = p.accept(",")?;
         let p = p.skip_white();
-        let (size, p) = p.parse_i32()?;
+        let (size, p) = p.parse_u16()?;
         let p = p.skip_white();
         let p = p.accept(">")?;
 

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -246,7 +246,7 @@ impl PreColumnType {
             PreColumnType::Vector { type_, dimensions } => type_
                 .into_cql_type(keyspace_name, keyspace_udts)
                 .map(|inner| ColumnType::Vector {
-                    type_: Box::new(inner),
+                    typ: Box::new(inner),
                     dimensions,
                 }),
             PreColumnType::UserDefinedType { frozen, name } => {

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -1623,16 +1623,16 @@ async fn query_tables_schema(
     Ok(result)
 }
 
-fn map_string_to_cql_type(type_: &str) -> Result<PreColumnType, InvalidCqlType> {
-    match parse_cql_type(ParserState::new(type_)) {
+fn map_string_to_cql_type(typ: &str) -> Result<PreColumnType, InvalidCqlType> {
+    match parse_cql_type(ParserState::new(typ)) {
         Err(err) => Err(InvalidCqlType {
-            typ: type_.to_string(),
-            position: err.calculate_position(type_).unwrap_or(0),
+            typ: typ.to_string(),
+            position: err.calculate_position(typ).unwrap_or(0),
             reason: err.get_cause().to_string(),
         }),
         Ok((_, p)) if !p.is_at_eof() => Err(InvalidCqlType {
-            typ: type_.to_string(),
-            position: p.calculate_position(type_).unwrap_or(0),
+            typ: typ.to_string(),
+            position: p.calculate_position(typ).unwrap_or(0),
             reason: "leftover characters".to_string(),
         }),
         Ok((typ, _)) => Ok(typ),
@@ -1764,8 +1764,8 @@ fn parse_user_defined_type(p: ParserState) -> ParseResult<(&str, ParserState)> {
     Ok((tok, p))
 }
 
-fn freeze_type(type_: PreColumnType) -> PreColumnType {
-    match type_ {
+fn freeze_type(typ: PreColumnType) -> PreColumnType {
+    match typ {
         PreColumnType::Collection { typ: type_, .. } => PreColumnType::Collection {
             frozen: true,
             typ: type_,

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -205,7 +205,7 @@ pub struct MaterializedView {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Column {
-    pub type_: ColumnType<'static>,
+    pub typ: ColumnType<'static>,
     pub kind: ColumnKind,
 }
 
@@ -1569,7 +1569,7 @@ async fn query_tables_schema(
         entry.0.insert(
             column_name,
             Column {
-                type_: cql_type,
+                typ: cql_type,
                 kind,
             },
         );

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -322,40 +322,6 @@ pub enum NativeType {
     Varint,
 }
 
-/// [NativeType] parse error
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NativeTypeFromStrError;
-
-impl std::str::FromStr for NativeType {
-    type Err = NativeTypeFromStrError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ascii" => Ok(Self::Ascii),
-            "boolean" => Ok(Self::Boolean),
-            "blob" => Ok(Self::Blob),
-            "counter" => Ok(Self::Counter),
-            "date" => Ok(Self::Date),
-            "decimal" => Ok(Self::Decimal),
-            "double" => Ok(Self::Double),
-            "duration" => Ok(Self::Duration),
-            "float" => Ok(Self::Float),
-            "int" => Ok(Self::Int),
-            "bigint" => Ok(Self::BigInt),
-            "text" => Ok(Self::Text),
-            "timestamp" => Ok(Self::Timestamp),
-            "inet" => Ok(Self::Inet),
-            "smallint" => Ok(Self::SmallInt),
-            "tinyint" => Ok(Self::TinyInt),
-            "time" => Ok(Self::Time),
-            "timeuuid" => Ok(Self::Timeuuid),
-            "uuid" => Ok(Self::Uuid),
-            "varint" => Ok(Self::Varint),
-            _ => Err(NativeTypeFromStrError),
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum PreCollectionType {
     List(Box<PreCqlType>),
@@ -1811,8 +1777,29 @@ fn parse_cql_type(p: ParserState<'_>) -> ParseResult<(PreCqlType, ParserState<'_
 
 fn parse_native_type(p: ParserState) -> ParseResult<(NativeType, ParserState)> {
     let (tok, p) = p.take_while(|c| c.is_alphanumeric() || c == '_');
-    let typ = NativeType::from_str(tok)
-        .map_err(|_| p.error(ParseErrorCause::Other("invalid native type")))?;
+    let typ = match tok {
+        "ascii" => NativeType::Ascii,
+        "boolean" => NativeType::Boolean,
+        "blob" => NativeType::Blob,
+        "counter" => NativeType::Counter,
+        "date" => NativeType::Date,
+        "decimal" => NativeType::Decimal,
+        "double" => NativeType::Double,
+        "duration" => NativeType::Duration,
+        "float" => NativeType::Float,
+        "int" => NativeType::Int,
+        "bigint" => NativeType::BigInt,
+        "text" => NativeType::Text,
+        "timestamp" => NativeType::Timestamp,
+        "inet" => NativeType::Inet,
+        "smallint" => NativeType::SmallInt,
+        "tinyint" => NativeType::TinyInt,
+        "time" => NativeType::Time,
+        "timeuuid" => NativeType::Timeuuid,
+        "uuid" => NativeType::Uuid,
+        "varint" => NativeType::Varint,
+        _ => return Err(p.error(ParseErrorCause::Other("invalid native type"))),
+    };
     Ok((typ, p))
 }
 

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -124,7 +124,7 @@ pub mod frame {
 
             pub(crate) use scylla_cql::frame::response::result::*;
             pub use scylla_cql::frame::response::result::{
-                ColumnSpec, ColumnType, CqlValue, PartitionKeyIndex, Row, TableSpec,
+                ColumnSpec, ColumnType, CqlValue, NativeType, PartitionKeyIndex, Row, TableSpec,
             };
         }
     }

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -124,7 +124,8 @@ pub mod frame {
 
             pub(crate) use scylla_cql::frame::response::result::*;
             pub use scylla_cql::frame::response::result::{
-                ColumnSpec, ColumnType, CqlValue, NativeType, PartitionKeyIndex, Row, TableSpec,
+                CollectionType, ColumnSpec, ColumnType, CqlValue, NativeType, PartitionKeyIndex,
+                Row, TableSpec,
             };
         }
     }

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -125,7 +125,7 @@ pub mod frame {
             pub(crate) use scylla_cql::frame::response::result::*;
             pub use scylla_cql::frame::response::result::{
                 CollectionType, ColumnSpec, ColumnType, CqlValue, NativeType, PartitionKeyIndex,
-                Row, TableSpec,
+                Row, TableSpec, UserDefinedType,
             };
         }
     }

--- a/scylla/src/response/legacy_query_result.rs
+++ b/scylla/src/response/legacy_query_result.rs
@@ -367,6 +367,7 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
+    use result::NativeType;
     use scylla_cql::frame::response::result::{ColumnType, ResultMetadata, TableSpec};
 
     // Returns specified number of rows, each one containing one int32 value.
@@ -397,7 +398,8 @@ mod tests {
     fn make_test_metadata() -> ResultMetadata<'static> {
         let table_spec = TableSpec::borrowed("some_keyspace", "some_table");
 
-        let column_spec = ColumnSpec::borrowed("column0", ColumnType::Int, table_spec);
+        let column_spec =
+            ColumnSpec::borrowed("column0", ColumnType::Native(NativeType::Int), table_spec);
 
         ResultMetadata::new_for_test(1, vec![column_spec])
     }

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -526,6 +526,7 @@ mod tests {
     use assert_matches::assert_matches;
     use bytes::{Bytes, BytesMut};
     use itertools::Itertools as _;
+    use scylla_cql::frame::response::result::NativeType;
     use scylla_cql::frame::response::result::ResultMetadata;
     use scylla_cql::frame::types;
 
@@ -538,9 +539,9 @@ mod tests {
             ColumnSpec::owned(
                 format!("col_{}", k),
                 match k % 3 {
-                    0 => ColumnType::Ascii,
-                    1 => ColumnType::Boolean,
-                    2 => ColumnType::Float,
+                    0 => ColumnType::Native(NativeType::Ascii),
+                    1 => ColumnType::Native(NativeType::Boolean),
+                    2 => ColumnType::Native(NativeType::Float),
                     _ => unreachable!(),
                 },
                 TABLE_SPEC,
@@ -569,9 +570,9 @@ mod tests {
             static BOOLEAN: &[u8] = &(true as i8).to_be_bytes();
             static FLOAT: &[u8] = &12341_i32.to_be_bytes();
             let cells = metadata.col_specs().iter().map(|spec| match spec.typ() {
-                ColumnType::Ascii => STRING,
-                ColumnType::Boolean => BOOLEAN,
-                ColumnType::Float => FLOAT,
+                ColumnType::Native(NativeType::Ascii) => STRING,
+                ColumnType::Native(NativeType::Boolean) => BOOLEAN,
+                ColumnType::Native(NativeType::Float) => FLOAT,
                 _ => unreachable!(),
             });
             let bytes = serialize_cells(cells.map(Some));

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use scylla_cql::deserialize::value::ListlikeIterator;
 use scylla_cql::deserialize::{DeserializationError, DeserializeValue, FrameSlice, TypeCheckError};
-use scylla_cql::frame::response::result::{ColumnType, TableSpec};
+use scylla_cql::frame::response::result::{ColumnType, NativeType, TableSpec};
 use thiserror::Error;
 use tracing::warn;
 use uuid::Uuid;
@@ -44,11 +44,11 @@ type RawTabletPayload<'frame, 'metadata> =
 
 lazy_static! {
     static ref RAW_TABLETS_CQL_TYPE: ColumnType<'static> = ColumnType::Tuple(vec![
-        ColumnType::BigInt,
-        ColumnType::BigInt,
+        ColumnType::Native(NativeType::BigInt),
+        ColumnType::Native(NativeType::BigInt),
         ColumnType::List(Box::new(ColumnType::Tuple(vec![
-            ColumnType::Uuid,
-            ColumnType::Int,
+            ColumnType::Native(NativeType::Uuid),
+            ColumnType::Native(NativeType::Int),
         ]))),
     ]);
 }
@@ -606,7 +606,7 @@ mod tests {
     use std::sync::Arc;
 
     use bytes::Bytes;
-    use scylla_cql::frame::response::result::{ColumnType, CqlValue, TableSpec};
+    use scylla_cql::frame::response::result::{ColumnType, CqlValue, NativeType, TableSpec};
     use scylla_cql::serialize::value::SerializeValue;
     use scylla_cql::serialize::CellWriter;
     use tracing::debug;
@@ -655,11 +655,11 @@ mod tests {
             Some(CqlValue::List(vec![])),
         ]);
         let col_type = ColumnType::Tuple(vec![
-            ColumnType::Ascii,
-            ColumnType::BigInt,
+            ColumnType::Native(NativeType::Ascii),
+            ColumnType::Native(NativeType::BigInt),
             ColumnType::List(Box::new(ColumnType::Tuple(vec![
-                ColumnType::Uuid,
-                ColumnType::Int,
+                ColumnType::Native(NativeType::Uuid),
+                ColumnType::Native(NativeType::Int),
             ]))),
         ]);
 

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -48,7 +48,7 @@ lazy_static! {
         ColumnType::Native(NativeType::BigInt),
         ColumnType::Collection {
             frozen: false,
-            type_: CollectionType::List(Box::new(ColumnType::Tuple(vec![
+            typ: CollectionType::List(Box::new(ColumnType::Tuple(vec![
                 ColumnType::Native(NativeType::Uuid),
                 ColumnType::Native(NativeType::Int),
             ])))
@@ -664,7 +664,7 @@ mod tests {
             ColumnType::Native(NativeType::BigInt),
             ColumnType::Collection {
                 frozen: false,
-                type_: CollectionType::List(Box::new(ColumnType::Tuple(vec![
+                typ: CollectionType::List(Box::new(ColumnType::Tuple(vec![
                     ColumnType::Native(NativeType::Uuid),
                     ColumnType::Native(NativeType::Int),
                 ]))),

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -47,6 +47,7 @@ lazy_static! {
         ColumnType::Native(NativeType::BigInt),
         ColumnType::Native(NativeType::BigInt),
         ColumnType::Collection {
+            frozen: false,
             type_: CollectionType::List(Box::new(ColumnType::Tuple(vec![
                 ColumnType::Native(NativeType::Uuid),
                 ColumnType::Native(NativeType::Int),
@@ -662,6 +663,7 @@ mod tests {
             ColumnType::Native(NativeType::Ascii),
             ColumnType::Native(NativeType::BigInt),
             ColumnType::Collection {
+                frozen: false,
                 type_: CollectionType::List(Box::new(ColumnType::Tuple(vec![
                     ColumnType::Native(NativeType::Uuid),
                     ColumnType::Native(NativeType::Int),

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -601,7 +601,7 @@ impl<'ps> PartitionKey<'ps> {
 #[cfg(test)]
 mod tests {
     use scylla_cql::frame::response::result::{
-        ColumnSpec, ColumnType, PartitionKeyIndex, PreparedMetadata, TableSpec,
+        ColumnSpec, ColumnType, NativeType, PartitionKeyIndex, PreparedMetadata, TableSpec,
     };
     use scylla_cql::serialize::row::SerializedValues;
 
@@ -639,21 +639,29 @@ mod tests {
         setup_tracing();
         let meta = make_meta(
             [
-                ColumnType::TinyInt,
-                ColumnType::SmallInt,
-                ColumnType::Int,
-                ColumnType::BigInt,
-                ColumnType::Blob,
+                ColumnType::Native(NativeType::TinyInt),
+                ColumnType::Native(NativeType::SmallInt),
+                ColumnType::Native(NativeType::Int),
+                ColumnType::Native(NativeType::BigInt),
+                ColumnType::Native(NativeType::Blob),
             ],
             [4, 0, 3],
         );
         let mut values = SerializedValues::new();
-        values.add_value(&67i8, &ColumnType::TinyInt).unwrap();
-        values.add_value(&42i16, &ColumnType::SmallInt).unwrap();
-        values.add_value(&23i32, &ColumnType::Int).unwrap();
-        values.add_value(&89i64, &ColumnType::BigInt).unwrap();
         values
-            .add_value(&[1u8, 2, 3, 4, 5], &ColumnType::Blob)
+            .add_value(&67i8, &ColumnType::Native(NativeType::TinyInt))
+            .unwrap();
+        values
+            .add_value(&42i16, &ColumnType::Native(NativeType::SmallInt))
+            .unwrap();
+        values
+            .add_value(&23i32, &ColumnType::Native(NativeType::Int))
+            .unwrap();
+        values
+            .add_value(&89i64, &ColumnType::Native(NativeType::BigInt))
+            .unwrap();
+        values
+            .add_value(&[1u8, 2, 3, 4, 5], &ColumnType::Native(NativeType::Blob))
             .unwrap();
 
         let pk = PartitionKey::new(&meta, &values).unwrap();

--- a/scylla/src/utils/parse.rs
+++ b/scylla/src/utils/parse.rs
@@ -87,18 +87,18 @@ impl<'s> ParserState<'s> {
         me
     }
 
-    /// Parses a sequence of digits and '-' as an integer.
-    /// Consumes characters until it finds a character that is not a digit or '-'.
+    /// Parses a sequence of digits as an integer.
+    /// Consumes characters until it finds a character that is not a digit.
     ///
     /// An error is returned if:
-    /// * The first character is not a digit or '-'
-    /// * The integer is larger than i32
-    pub(crate) fn parse_i32(self) -> ParseResult<(i32, Self)> {
-        let (digits, p) = self.take_while(|c| c.is_ascii_digit() || c == '-');
+    /// * The first character is not a digit
+    /// * The integer is larger than u16
+    pub(crate) fn parse_u16(self) -> ParseResult<(u16, Self)> {
+        let (digits, p) = self.take_while(|c| c.is_ascii_digit());
         if let Ok(value) = digits.parse() {
             Ok((value, p))
         } else {
-            Err(p.error(ParseErrorCause::Other("Expected 32-bit signed integer")))
+            Err(p.error(ParseErrorCause::Other("Expected 16-bit unsigned integer")))
         }
     }
 

--- a/scylla/src/utils/pretty.rs
+++ b/scylla/src/utils/pretty.rs
@@ -137,7 +137,7 @@ where
             }
             CqlValue::UserDefinedType {
                 keyspace: _,
-                type_name: _,
+                name: _,
                 fields,
             } => {
                 f.write_str("{")?;
@@ -354,7 +354,7 @@ mod tests {
                 "{}",
                 CqlValueDisplayer(CqlValue::UserDefinedType {
                     keyspace: "ks".to_owned(),
-                    type_name: "typ".to_owned(),
+                    name: "typ".to_owned(),
                     fields,
                 })
             ),

--- a/scylla/tests/integration/cql_value.rs
+++ b/scylla/tests/integration/cql_value.rs
@@ -29,7 +29,7 @@ async fn test_cqlvalue_udt() {
 
     let udt_cql_value = CqlValue::UserDefinedType {
         keyspace: ks,
-        type_name: "cqlvalue_udt_type".to_string(),
+        name: "cqlvalue_udt_type".to_string(),
         fields: vec![
             ("int_val".to_string(), Some(CqlValue::Int(42))),
             ("text_val".to_string(), Some(CqlValue::Text("hi".into()))),

--- a/scylla/tests/integration/hygiene.rs
+++ b/scylla/tests/integration/hygiene.rs
@@ -125,7 +125,7 @@ macro_rules! test_crate {
             let test_struct = TestStruct { a: 16 };
             let value_with_same_layout: CqlValue = CqlValue::UserDefinedType {
                 keyspace: "some_ks".to_string(),
-                type_name: "some_type".to_string(),
+                name: "some_type".to_string(),
                 fields: vec![("a".to_string(), Some(CqlValue::Int(16)))],
             };
             let udt_type = ColumnType::UserDefinedType {

--- a/scylla/tests/integration/hygiene.rs
+++ b/scylla/tests/integration/hygiene.rs
@@ -129,6 +129,7 @@ macro_rules! test_crate {
                 fields: vec![("a".to_string(), Some(CqlValue::Int(16)))],
             };
             let udt_type = ColumnType::UserDefinedType {
+                frozen: false,
                 definition: Arc::new(UserDefinedType {
                     name: "some_type".into(),
                     keyspace: "some_ks".into(),

--- a/scylla/tests/integration/hygiene.rs
+++ b/scylla/tests/integration/hygiene.rs
@@ -47,6 +47,7 @@ macro_rules! test_crate {
             use _scylla::deserialize::FrameSlice;
             use _scylla::frame::response::result::ColumnSpec;
             use _scylla::frame::response::result::ColumnType;
+            use _scylla::frame::response::result::NativeType;
             use _scylla::frame::response::result::TableSpec;
             use _scylla::serialize::row::RowSerializationContext;
             use _scylla::serialize::row::SerializeRow;
@@ -58,7 +59,7 @@ macro_rules! test_crate {
             let tuple_with_same_layout: (i32,) = (16,);
             let column_types = &[ColumnSpec::borrowed(
                 "a",
-                ColumnType::Int,
+                ColumnType::Native(NativeType::Int),
                 TableSpec::borrowed("ks", "table"),
             )];
             let ctx = RowSerializationContext::from_specs(column_types);
@@ -114,7 +115,7 @@ macro_rules! test_crate {
             use ::tracing::info;
             use _scylla::deserialize::DeserializeValue;
             use _scylla::deserialize::FrameSlice;
-            use _scylla::frame::response::result::{ColumnType, CqlValue};
+            use _scylla::frame::response::result::{ColumnType, NativeType, CqlValue};
             use _scylla::serialize::value::SerializeValue;
             use _scylla::serialize::writers::CellWriter;
 
@@ -129,7 +130,7 @@ macro_rules! test_crate {
             let udt_type = ColumnType::UserDefinedType {
                 type_name: "some_type".into(),
                 keyspace: "some_ks".into(),
-                field_types: vec![("a".into(), ColumnType::Int)],
+                field_types: vec![("a".into(), ColumnType::Native(NativeType::Int))],
             };
 
             let mut buf_struct = Vec::<u8>::new();

--- a/scylla/tests/integration/hygiene.rs
+++ b/scylla/tests/integration/hygiene.rs
@@ -172,6 +172,14 @@ macro_rules! test_crate {
             }
         }
 
+        // The purpose of this test is to verify that the important types are
+        // correctly re-exported in `scylla` crate.
+        #[test]
+        fn test_types_imports() {
+            #[allow(unused_imports)]
+            use _scylla::frame::response::result::{CollectionType, ColumnType, NativeType, CqlValue, UserDefinedType};
+        }
+
         // Test attributes for value struct with name flavor
         #[derive(
             _scylla::macros::DeserializeValue, _scylla::macros::SerializeValue, PartialEq, Debug,

--- a/scylla/tests/integration/hygiene.rs
+++ b/scylla/tests/integration/hygiene.rs
@@ -110,12 +110,13 @@ macro_rules! test_crate {
             use ::std::convert::Into;
             use ::std::option::Option::Some;
             use ::std::string::ToString;
+            use ::std::sync::Arc;
             use ::std::vec;
             use ::std::vec::Vec;
             use ::tracing::info;
             use _scylla::deserialize::DeserializeValue;
             use _scylla::deserialize::FrameSlice;
-            use _scylla::frame::response::result::{ColumnType, NativeType, CqlValue};
+            use _scylla::frame::response::result::{ColumnType, NativeType, CqlValue, UserDefinedType};
             use _scylla::serialize::value::SerializeValue;
             use _scylla::serialize::writers::CellWriter;
 
@@ -128,9 +129,11 @@ macro_rules! test_crate {
                 fields: vec![("a".to_string(), Some(CqlValue::Int(16)))],
             };
             let udt_type = ColumnType::UserDefinedType {
-                type_name: "some_type".into(),
-                keyspace: "some_ks".into(),
-                field_types: vec![("a".into(), ColumnType::Native(NativeType::Int))],
+                definition: Arc::new(UserDefinedType {
+                    name: "some_type".into(),
+                    keyspace: "some_ks".into(),
+                    field_types: vec![("a".into(), ColumnType::Native(NativeType::Int))],
+                })
             };
 
             let mut buf_struct = Vec::<u8>::new();


### PR DESCRIPTION
This PR removes `CqlType` (used in schema metadata) and replaces its usages with `ColumnType` (used in statement metadata).
Initially those two structures were quite different, so most of the commits are done to make them mostly identical, which made the unification possible.

## Layout 

CqlType was split into subtypes (native type, collection type, tuple, UDT) as defined by https://cassandra.apache.org/doc/stable/cassandra/cql/types.html
ColumnType was fully inlined - it had a variant for each possible type.

I decided to change ColumnType in this regard to follow CqlType, because CqlType's approach seems to be much more elegant.

## Frozen flag

CqlType contained frozen flag, because the schema contains information about whether the collection/UDT is frozen or not.
ColumnType did not contain such flag, because this information is not present in result metadata / arguments metadata.

There wasn't any real choice - we have to store the frozen flag to accurately represent the schema metadata.
For types used in statements, this flag is simply always set to false.

## UDT shared ownership

ColumnType stored the UDT data inline, this is how the variant looked:
```rust
    UserDefinedType {
        type_name: Cow<'frame, str>,
        keyspace: Cow<'frame, str>,
        field_types: Vec<(Cow<'frame, str>, ColumnType<'frame>)>,
    },
```

CqlType stored it in a separate struct, which was held under Arc:
```rust
/// Definition of a user-defined type
    UserDefinedType {
        frozen: bool,
        // Using Arc here in order not to have many copies of the same definition
        definition: Arc<UserDefinedType>,
    },
...

#[derive(Clone, Debug, PartialEq, Eq)]
pub struct UserDefinedType {
    pub name: String,
    pub keyspace: String,
    pub field_types: Vec<(String, CqlType)>,
}

```

This is because it may be stored in a few places:
- `Keyspace::user_defined_types`
- As a field in another UDT
- As a column in the table
- As a column in the view

This requires either cloning, or shared ownership.

## Custom type

ColumnType had a variant for Custom type, because it is defined by the protocol.
However, this type is rarely used, and we don't really have any working support for it, so I decided to remove it.

## Minor changes

I decided to change the size type of Vector to u16. It frees any users of this struct from dealing with negative numbers (which are disallowed by the protocol, and make no sense here).

Fixes https://github.com/scylladb/scylla-rust-driver/issues/691

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~ - Nothing to adjust
- [x] I added appropriate `Fixes:` annotations to PR description.
