### PR TITLE
errors: rename RequestError and make it private

### DIFF
--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -832,8 +832,8 @@ pub enum BrokenConnectionErrorKind {
     KeepaliveTimeout(IpAddr),
 
     /// Driver sent a keepalive request to the database, but request execution failed.
-    #[error("Failed to execute keepalive query: {0}")]
-    KeepaliveQueryError(Arc<dyn Error + Sync + Send>),
+    #[error("Failed to execute keepalive request: {0}")]
+    KeepaliveRequestError(Arc<dyn Error + Sync + Send>),
 
     /// Failed to deserialize response frame header.
     #[error("Failed to deserialize frame: {0}")]

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -833,7 +833,7 @@ pub enum BrokenConnectionErrorKind {
 
     /// Driver sent a keepalive request to the database, but request execution failed.
     #[error("Failed to execute keepalive query: {0}")]
-    KeepaliveQueryError(RequestError),
+    KeepaliveQueryError(Arc<dyn Error + Sync + Send>),
 
     /// Failed to deserialize response frame header.
     #[error("Failed to deserialize frame: {0}")]

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1608,8 +1608,8 @@ impl Connection {
                 .send_request(&Options, None, false)
                 .await
                 .map(|_| ())
-                .map_err(|q_err| {
-                    BrokenConnectionErrorKind::KeepaliveQueryError(Arc::new(q_err)).into()
+                .map_err(|req_err| {
+                    BrokenConnectionErrorKind::KeepaliveRequestError(Arc::new(req_err)).into()
                 })
         }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1608,7 +1608,9 @@ impl Connection {
                 .send_request(&Options, None, false)
                 .await
                 .map(|_| ())
-                .map_err(|q_err| BrokenConnectionErrorKind::KeepaliveQueryError(q_err).into())
+                .map_err(|q_err| {
+                    BrokenConnectionErrorKind::KeepaliveQueryError(Arc::new(q_err)).into()
+                })
         }
 
         if let Some(keepalive_interval) = keepalive_interval {


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## Motivation
Current `RequestError` is a low-level (connection layer) error that represents a failure of ANY CQL request. Before this PR it was public. Why? There was only one place it was used in public API - namely `BrokenConnectionErrorKind::KeepaliveQueryError`. This is a very rare error.

I decided to make this error type `pub(crate)` for multiple reasons:
- As mentioned previously - this is a very rare low-level error kind. I don't think there is a point in exposing it to the user
- Thanks to that, we can rename it to `InternalRequestError` (since it becomes an error used only in driver's internals)
- `RequestError` name is now available :). It can be used for some more meaningful error returned from user-facing API. For example, an error representing a definite request failure that occurs in a session layer after possible retries, speculative execution etc.

I've hidden this type in `BrokenConnectionErrorKind::KeepaliveRequestError` (variant got renamed as well) behind an `Arc`. It's OK to do so, because this specific case is very rare. I think that not providing any additional context (i.e., ignoring the underlying error cause) is a valid alternative solution.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
