### PR TITLE
errors: metadata errors refactor

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -15,8 +15,8 @@ use crate::cluster::node::CloudEndpoint;
 use crate::cluster::node::{InternalKnownNode, KnownNode, NodeRef};
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::{
-    BadQuery, NewSessionError, ProtocolError, QueryError, RequestAttemptError, RequestError,
-    TracingProtocolError,
+    BadQuery, MetadataError, NewSessionError, ProtocolError, QueryError, RequestAttemptError,
+    RequestError, TracingProtocolError,
 };
 use crate::frame::response::result;
 #[cfg(feature = "ssl")]
@@ -1717,7 +1717,7 @@ where
     ///
     /// Normally this is not needed,
     /// the driver should automatically detect all metadata changes in the cluster
-    pub async fn refresh_metadata(&self) -> Result<(), QueryError> {
+    pub async fn refresh_metadata(&self) -> Result<(), MetadataError> {
         self.cluster.refresh_metadata().await
     }
 

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -590,7 +590,7 @@ impl MetadataReader {
             }
         }
 
-        res
+        res.map_err(QueryError::MetadataError)
     }
 
     fn update_known_peers(&mut self, metadata: &Metadata) {
@@ -684,7 +684,7 @@ async fn query_metadata(
     connect_port: u16,
     keyspace_to_fetch: &[String],
     fetch_schema: bool,
-) -> Result<Metadata, QueryError> {
+) -> Result<Metadata, MetadataError> {
     let peers_query = query_peers(conn, connect_port);
     let keyspaces_query = query_keyspaces(conn, keyspace_to_fetch, fetch_schema);
 
@@ -692,12 +692,12 @@ async fn query_metadata(
 
     // There must be at least one peer
     if peers.is_empty() {
-        return Err(MetadataError::Peers(PeersMetadataError::EmptyPeers).into());
+        return Err(MetadataError::Peers(PeersMetadataError::EmptyPeers));
     }
 
     // At least one peer has to have some tokens
     if peers.iter().all(|peer| peer.tokens.is_empty()) {
-        return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists).into());
+        return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists));
     }
 
     Ok(Metadata { peers, keyspaces })

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -1,5 +1,5 @@
 use crate::client::session::TABLET_CHANNEL_SIZE;
-use crate::errors::{NewSessionError, QueryError};
+use crate::errors::{MetadataError, NewSessionError, QueryError};
 use crate::frame::response::event::{Event, StatusChangeEvent};
 use crate::network::{PoolConfig, VerifiedKeyspaceName};
 use crate::policies::host_filter::HostFilter;
@@ -95,7 +95,7 @@ struct ClusterWorker {
 
 #[derive(Debug)]
 struct RefreshRequest {
-    response_chan: tokio::sync::oneshot::Sender<Result<(), QueryError>>,
+    response_chan: tokio::sync::oneshot::Sender<Result<(), MetadataError>>,
 }
 
 #[derive(Debug)]
@@ -182,7 +182,7 @@ impl Cluster {
         self.data.load_full()
     }
 
-    pub(crate) async fn refresh_metadata(&self) -> Result<(), QueryError> {
+    pub(crate) async fn refresh_metadata(&self) -> Result<(), MetadataError> {
         let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
 
         self.refresh_channel
@@ -401,7 +401,7 @@ impl ClusterWorker {
         use_keyspace_result(use_keyspace_results.into_iter())
     }
 
-    async fn perform_refresh(&mut self) -> Result<(), QueryError> {
+    async fn perform_refresh(&mut self) -> Result<(), MetadataError> {
         // Read latest Metadata
         let metadata = self.metadata_reader.read_metadata(false).await?;
         let cluster_data: Arc<ClusterState> = self.cluster_data.load_full();

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -422,6 +422,10 @@ pub enum TracingProtocolError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum MetadataError {
+    /// Control connection pool error.
+    #[error("Control connection pool error: {0}")]
+    ConnectionPoolError(#[from] ConnectionPoolError),
+
     /// Failed to fetch metadata.
     #[error("transparent")]
     FetchError(#[from] MetadataFetchError),

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -328,14 +328,6 @@ pub enum ProtocolError {
     #[error("Unpaged query returned a non-empty paging state! This is a driver-side or server-side bug.")]
     NonfinishedPagingState,
 
-    /// Failed to parse CQL type.
-    #[error("Failed to parse a CQL type '{typ}', at position {position}: {reason}")]
-    InvalidCqlType {
-        typ: String,
-        position: usize,
-        reason: String,
-    },
-
     /// Unable extract a partition key based on prepared statement's metadata.
     #[error("Unable extract a partition key based on prepared statement's metadata")]
     PartitionKeyExtraction,
@@ -554,6 +546,17 @@ pub enum UdtMetadataError {
     #[error("system_schema.types has invalid column type: {0}")]
     SchemaTypesInvalidColumnType(TypeCheckError),
 
+    /// Failed to parse CQL type returned from system_schema.types query.
+    #[error(
+        "Failed to parse a CQL type returned from system_schema.types query. \
+        Type '{typ}', at position {position}: {reason}"
+    )]
+    InvalidCqlType {
+        typ: String,
+        position: usize,
+        reason: String,
+    },
+
     /// Circular UDT dependency detected.
     #[error("Detected circular dependency between user defined types - toposort is impossible!")]
     CircularTypeDependency,
@@ -570,6 +573,17 @@ pub enum TablesMetadataError {
     /// system_schema.columns has invalid column type.
     #[error("system_schema.columns has invalid column type: {0}")]
     SchemaColumnsInvalidColumnType(TypeCheckError),
+
+    /// Failed to parse CQL type returned from system_schema.columns query.
+    #[error(
+        "Failed to parse a CQL type returned from system_schema.columns query. \
+        Type '{typ}', at position {position}: {reason}"
+    )]
+    InvalidCqlType {
+        typ: String,
+        position: usize,
+        reason: String,
+    },
 
     /// Unknown column kind.
     #[error("Unknown column kind '{column_kind}' for {keyspace_name}.{table_name}.{column_name}")]

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -445,10 +445,6 @@ pub enum MetadataError {
     /// Bad tables metadata.
     #[error("Bad tables metadata: {0}")]
     Tables(#[from] TablesMetadataError),
-
-    /// Bad views metadata.
-    #[error("Bad views metadata: {0}")]
-    Views(#[from] ViewsMetadataError),
 }
 
 /// An error occurred during metadata fetch.
@@ -487,14 +483,6 @@ pub enum MetadataFetchErrorKind {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum PeersMetadataError {
-    /// system.peers has invalid column type.
-    #[error("system.peers has invalid column type: {0}")]
-    SystemPeersInvalidColumnType(TypeCheckError),
-
-    /// system.local has invalid column type.
-    #[error("system.local has invalid column type: {0}")]
-    SystemLocalInvalidColumnType(TypeCheckError),
-
     /// Empty peers list returned during peers metadata fetch.
     #[error("Peers list is empty")]
     EmptyPeers,
@@ -508,10 +496,6 @@ pub enum PeersMetadataError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum KeyspacesMetadataError {
-    /// system_schema.keyspaces has invalid column type.
-    #[error("system_schema.keyspaces has invalid column type: {0}")]
-    SchemaKeyspacesInvalidColumnType(TypeCheckError),
-
     /// Bad keyspace replication strategy.
     #[error("Bad keyspace <{keyspace}> replication strategy: {error}")]
     Strategy {
@@ -546,10 +530,6 @@ pub enum KeyspaceStrategyError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum UdtMetadataError {
-    /// system_schema.types has invalid column type.
-    #[error("system_schema.types has invalid column type: {0}")]
-    SchemaTypesInvalidColumnType(TypeCheckError),
-
     /// Failed to parse CQL type returned from system_schema.types query.
     #[error(
         "Failed to parse a CQL type returned from system_schema.types query. \
@@ -570,14 +550,6 @@ pub enum UdtMetadataError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum TablesMetadataError {
-    /// system_schema.tables has invalid column type.
-    #[error("system_schema.tables has invalid column type: {0}")]
-    SchemaTablesInvalidColumnType(TypeCheckError),
-
-    /// system_schema.columns has invalid column type.
-    #[error("system_schema.columns has invalid column type: {0}")]
-    SchemaColumnsInvalidColumnType(TypeCheckError),
-
     /// Failed to parse CQL type returned from system_schema.columns query.
     #[error(
         "Failed to parse a CQL type returned from system_schema.columns query. \
@@ -597,15 +569,6 @@ pub enum TablesMetadataError {
         column_name: String,
         column_kind: String,
     },
-}
-
-/// An error that occurred during views metadata fetch.
-#[derive(Error, Debug, Clone)]
-#[non_exhaustive]
-pub enum ViewsMetadataError {
-    /// system_schema.views has invalid column type.
-    #[error("system_schema.views has invalid column type: {0}")]
-    SchemaViewsInvalidColumnType(TypeCheckError),
 }
 
 /// Error caused by caller creating an invalid query


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## Motivation

The goal of this PR is to purge `metadata.rs` of `QueryError`, and replace it with `MetadataError`. Thanks to that metadata related functions are now independent of `QueryError`.

I tried to split this PR into commits, so each commit handles one function/method from metadata module. New error variants are introduced where necessary.

When it comes to public API - after this PR `Session::refresh_metadata()` will now return `MetadataError`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
