### PR TITLE
errors: refactor errors on USE KEYSPACE execution path and clean up NewSessionError

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -16,7 +16,7 @@ use crate::cluster::node::{InternalKnownNode, KnownNode, NodeRef};
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::{
     BadQuery, MetadataError, NewSessionError, ProtocolError, QueryError, RequestAttemptError,
-    RequestError, TracingProtocolError,
+    RequestError, TracingProtocolError, UseKeyspaceError,
 };
 use crate::frame::response::result;
 #[cfg(feature = "ssl")]
@@ -1697,7 +1697,7 @@ where
         &self,
         keyspace_name: impl Into<String>,
         case_sensitive: bool,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), UseKeyspaceError> {
         let keyspace_name = keyspace_name.into();
         self.keyspace_name
             .store(Some(Arc::new(keyspace_name.clone())));

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -3,7 +3,7 @@ use tokio::net::lookup_host;
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::errors::{ConnectionPoolError, QueryError};
+use crate::errors::{ConnectionPoolError, UseKeyspaceError};
 use crate::network::Connection;
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{NodeConnectionPool, PoolConfig};
@@ -180,7 +180,7 @@ impl Node {
     pub(crate) async fn use_keyspace(
         &self,
         keyspace_name: VerifiedKeyspaceName,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), UseKeyspaceError> {
         if let Some(pool) = &self.pool {
             pool.use_keyspace(keyspace_name).await?;
         }

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -164,91 +164,13 @@ pub enum NewSessionError {
     #[error("Empty known nodes list")]
     EmptyKnownNodesList,
 
-    /// Database sent a response containing some error with a message
-    #[error("Database returned an error: {0}, Error message: {1}")]
-    DbError(DbError, String),
-
-    /// Caller passed an invalid query
-    #[error(transparent)]
-    BadQuery(#[from] BadQuery),
-
-    /// Failed to serialize CQL request.
-    #[error("Failed to serialize CQL request: {0}")]
-    CqlRequestSerialization(#[from] CqlRequestSerializationError),
-
-    /// Load balancing policy returned an empty plan.
-    #[error(
-        "Load balancing policy returned an empty plan.\
-        First thing to investigate should be the logic of custom LBP implementation.\
-        If you think that your LBP implementation is correct, or you make use of `DefaultPolicy`,\
-        then this is most probably a driver bug!"
-    )]
-    EmptyPlan,
-
-    /// Failed to deserialize frame body extensions.
-    #[error(transparent)]
-    BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
-
     /// Failed to perform initial cluster metadata fetch.
     #[error("Failed to perform initial cluster metadata fetch: {0}")]
     MetadataError(#[from] MetadataError),
 
-    /// Received a RESULT server response, but failed to deserialize it.
-    #[error(transparent)]
-    CqlResultParseError(#[from] CqlResultParseError),
-
-    /// Received an ERROR server response, but failed to deserialize it.
-    #[error("Failed to deserialize ERROR response: {0}")]
-    CqlErrorParseError(#[from] CqlErrorParseError),
-
-    /// Selected node's connection pool is in invalid state.
-    #[error("No connections in the pool: {0}")]
-    ConnectionPoolError(#[from] ConnectionPoolError),
-
-    /// Protocol error.
-    #[error("Protocol error: {0}")]
-    ProtocolError(#[from] ProtocolError),
-
-    /// A connection has been broken during query execution.
-    #[error(transparent)]
-    BrokenConnection(#[from] BrokenConnectionError),
-
-    /// Driver was unable to allocate a stream id to execute a query on.
-    #[error("Unable to allocate stream id")]
-    UnableToAllocStreamId,
-
-    /// Failed to run a request within a provided client timeout.
-    #[error(
-        "Request execution exceeded a client timeout of {}ms",
-        std::time::Duration::as_millis(.0)
-    )]
-    RequestTimeout(std::time::Duration),
-
-    /// Schema agreement timed out.
-    #[error("Schema agreement exceeded {}ms", std::time::Duration::as_millis(.0))]
-    SchemaAgreementTimeout(std::time::Duration),
-
-    // TODO: This should not belong here, but it requires changes to error types
-    // returned in async iterator API. This should be handled in separate PR.
-    // The reason this needs to be included is that topology.rs makes use of iter API and returns QueryError.
-    // Once iter API is adjusted, we can then adjust errors returned by topology module (e.g. refactor MetadataError and not include it in QueryError).
-    /// An error occurred during async iteration over rows of result.
-    #[error("An error occurred during async iteration over rows of result: {0}")]
-    NextRowError(#[from] NextRowError),
-
     /// 'USE KEYSPACE <>' request failed.
     #[error("'USE KEYSPACE <>' request failed: {0}")]
     UseKeyspaceError(#[from] UseKeyspaceError),
-
-    /// Failed to convert [`QueryResult`][crate::response::query_result::QueryResult]
-    /// into [`LegacyQueryResult`][crate::response::legacy_query_result::LegacyQueryResult].
-    #[deprecated(
-        since = "0.15.1",
-        note = "Legacy deserialization API is inefficient and is going to be removed soon"
-    )]
-    #[allow(deprecated)]
-    #[error("Failed to convert `QueryResult` into `LegacyQueryResult`: {0}")]
-    IntoLegacyQueryResultError(#[from] IntoLegacyQueryResultError),
 }
 
 /// A protocol error.

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -89,10 +89,6 @@ pub enum QueryError {
     #[error("Protocol error: {0}")]
     ProtocolError(#[from] ProtocolError),
 
-    /// Timeout error has occurred, function didn't complete in time.
-    #[error("Timeout Error")]
-    TimeoutError,
-
     /// A connection has been broken during query execution.
     #[error(transparent)]
     BrokenConnection(#[from] BrokenConnectionError),
@@ -161,7 +157,6 @@ impl From<QueryError> for NewSessionError {
             QueryError::MetadataError(e) => NewSessionError::MetadataError(e),
             QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
             QueryError::ProtocolError(e) => NewSessionError::ProtocolError(e),
-            QueryError::TimeoutError => NewSessionError::TimeoutError,
             QueryError::BrokenConnection(e) => NewSessionError::BrokenConnection(e),
             QueryError::UnableToAllocStreamId => NewSessionError::UnableToAllocStreamId,
             QueryError::RequestTimeout(dur) => NewSessionError::RequestTimeout(dur),
@@ -240,10 +235,6 @@ pub enum NewSessionError {
     /// Protocol error.
     #[error("Protocol error: {0}")]
     ProtocolError(#[from] ProtocolError),
-
-    /// Timeout error has occurred, couldn't connect to node in time.
-    #[error("Timeout Error")]
-    TimeoutError,
 
     /// A connection has been broken during query execution.
     #[error(transparent)]

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -176,12 +176,6 @@ impl From<QueryError> for NewSessionError {
     }
 }
 
-impl From<BadKeyspaceName> for QueryError {
-    fn from(keyspace_err: BadKeyspaceName) -> QueryError {
-        QueryError::BadQuery(BadQuery::BadKeyspaceName(keyspace_err))
-    }
-}
-
 impl From<response::Error> for QueryError {
     fn from(error: response::Error) -> QueryError {
         QueryError::DbError(error.error, error.reason)
@@ -610,10 +604,6 @@ pub enum BadQuery {
     /// Serialized values are too long to compute partition key
     #[error("Serialized values are too long to compute partition key! Length: {0}, Max allowed length: {1}")]
     ValuesTooLongForKey(usize, usize),
-
-    /// Passed invalid keyspace name to use
-    #[error("Passed invalid keyspace name to use: {0}")]
-    BadKeyspaceName(#[from] BadKeyspaceName),
 
     /// Too many queries in the batch statement
     #[error("Number of Queries in Batch Statement supplied is {0} which has exceeded the max value of 65,535")]

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -144,33 +144,6 @@ impl From<SerializationError> for QueryError {
     }
 }
 
-impl From<QueryError> for NewSessionError {
-    fn from(query_error: QueryError) -> NewSessionError {
-        match query_error {
-            QueryError::DbError(e, msg) => NewSessionError::DbError(e, msg),
-            QueryError::BadQuery(e) => NewSessionError::BadQuery(e),
-            QueryError::CqlRequestSerialization(e) => NewSessionError::CqlRequestSerialization(e),
-            QueryError::CqlResultParseError(e) => NewSessionError::CqlResultParseError(e),
-            QueryError::CqlErrorParseError(e) => NewSessionError::CqlErrorParseError(e),
-            QueryError::BodyExtensionsParseError(e) => NewSessionError::BodyExtensionsParseError(e),
-            QueryError::EmptyPlan => NewSessionError::EmptyPlan,
-            QueryError::MetadataError(e) => NewSessionError::MetadataError(e),
-            QueryError::ConnectionPoolError(e) => NewSessionError::ConnectionPoolError(e),
-            QueryError::ProtocolError(e) => NewSessionError::ProtocolError(e),
-            QueryError::BrokenConnection(e) => NewSessionError::BrokenConnection(e),
-            QueryError::UnableToAllocStreamId => NewSessionError::UnableToAllocStreamId,
-            QueryError::RequestTimeout(dur) => NewSessionError::RequestTimeout(dur),
-            QueryError::SchemaAgreementTimeout(dur) => NewSessionError::SchemaAgreementTimeout(dur),
-            QueryError::UseKeyspaceError(e) => NewSessionError::UseKeyspaceError(e),
-            #[allow(deprecated)]
-            QueryError::IntoLegacyQueryResultError(e) => {
-                NewSessionError::IntoLegacyQueryResultError(e)
-            }
-            QueryError::NextRowError(e) => NewSessionError::NextRowError(e),
-        }
-    }
-}
-
 impl From<response::Error> for QueryError {
     fn from(error: response::Error) -> QueryError {
         QueryError::DbError(error.error, error.reason)


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## Motivation
`NewSessionError` has a lot of variants that can't even be constructed. This is all because of `From<QueryError> for NewSessionError` implementation. The only remaining execution path where we make use of this conversion is USE KEYSPACE request execution. (Previously, there was also `MetadataReader::read_metadata` that returned `QueryError`, but this was addressed in previous PR).

This is why we narrow the return error types in USE KEYSPACE execution path - from `QueryError` to new `UseKeyspaceError`.

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
