### PR TITLE
errors: adjust ShardingError

### DIFF
--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -13,8 +13,8 @@ pub mod locator;
 pub mod partitioner;
 mod sharding;
 
-pub(crate) use sharding::ShardInfo;
-pub use sharding::{Shard, ShardCount, Sharder, ShardingError};
+pub use sharding::{Shard, ShardCount, Sharder};
+pub(crate) use sharding::{ShardInfo, ShardingError};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 

--- a/scylla/src/routing/sharding.rs
+++ b/scylla/src/routing/sharding.rs
@@ -96,7 +96,7 @@ impl Sharder {
 }
 
 #[derive(Clone, Error, Debug)]
-pub enum ShardingError {
+pub(crate) enum ShardingError {
     /// This indicates that we are most likely connected to a Cassandra cluster.
     /// Unless, there is some serious bug in Scylla.
     #[error("Server did not provide any sharding information")]


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/pull/1170

The only breaking change in this PR is unpubbing `ShardingError`. Remaining commits adjust the internal usages of this error - for example logging in case parsing of sharding info fails.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
