### PR TITLE
Rustls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The driver supports the following:
 * Batch statements
 * Configurable load balancing policies
 * Driver-side metrics
-* TLS support - install openssl if you want to use it https://docs.rs/openssl/0.10.32/openssl/#automatic
+* TLS support. Supports either [OpenSSL](https://docs.rs/openssl/0.10.32/openssl/#automatic) or rustls
 * Configurable retry policies
 * Authentication support
 * CQL tracing

--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -1,14 +1,15 @@
 # TLS
 
-Driver uses the [`openssl`](https://github.com/sfackler/rust-openssl) crate for TLS functionality.\
-It was chosen because [`rustls`](https://github.com/ctz/rustls) doesn't support certificates for ip addresses
-(see [issue](https://github.com/briansmith/webpki/issues/54)), which is a common use case for Scylla.
+Driver uses either the
+[`openssl`](https://github.com/sfackler/rust-openssl) crate or the
+[`rustls`](https://github.com/rustls/rustls) crate for TLS functionality.
+
+Both of this features are under a their respective feaure flag.
 
 
 ### Enabling feature
-`openssl` is not a pure Rust library so you need enable a feature and install the proper package.
+To enable use of TLS using `openssl`, add in `Cargo.toml`:
 
-To enable the `tls` feature add in `Cargo.toml`:
 ```toml
 scylla = { version = "0.4", features = ["openssl"] }
 openssl = "0.10.32"
@@ -38,9 +39,13 @@ Then install the package with `openssl`:
     ```
 
 ### Using TLS
-To use tls you will have to create an openssl
+To use TLS you will have to a `TlsContext`. For convenience, both an
+openssl
 [`SslContext`](https://docs.rs/openssl/0.10.33/openssl/ssl/struct.SslContext.html)
-and pass it to `SessionBuilder`
+and a rustls
+[`ClientConfig`](https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html)
+can be automatically converted to a `TlsContext` when passing to
+`SessionBuilder`.
 
 For example, if database certificate is in the file `ca.crt`:
 ```rust

--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -10,12 +10,12 @@ It was chosen because [`rustls`](https://github.com/ctz/rustls) doesn't support 
 
 To enable the `tls` feature add in `Cargo.toml`:
 ```toml
-scylla = { version = "0.4", features = ["ssl"] }
+scylla = { version = "0.4", features = ["openssl"] }
 openssl = "0.10.32"
 ```
 
 Then install the package with `openssl`:
-* Debian/Ubuntu: 
+* Debian/Ubuntu:
     ```bash
     apt install libssl-dev pkg-config
     ```
@@ -23,7 +23,7 @@ Then install the package with `openssl`:
     ```bash
     dnf install openssl-devel
     ```
-<!-- 
+<!--
  scylla-rust-driver doesn't build on Alpine, some strange cc linker errors in proc-macro-hack 0_o
  TODO: try building and add the section
 
@@ -38,7 +38,7 @@ Then install the package with `openssl`:
     ```
 
 ### Using TLS
-To use tls you will have to create an openssl 
+To use tls you will have to create an openssl
 [`SslContext`](https://docs.rs/openssl/0.10.33/openssl/ssl/struct.SslContext.html)
 and pass it to `SessionBuilder`
 

--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -59,7 +59,7 @@ context_builder.set_verify(SslVerifyMode::PEER);
 
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9142") // The the port is now 9142
-    .ssl_context(Some(context_builder.build()))
+    .tls_context(Some(context_builder.build()))
     .build()
     .await?;
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,6 +12,7 @@ rustyline = "9"
 rustyline-derive = "0.6"
 scylla = { path = "../scylla", features = [
     "openssl",
+    "rustls",
     "cloud",
     "chrono-04",
     "time-03",
@@ -30,6 +31,7 @@ stats_alloc = "0.1"
 clap = { version = "3.2.4", features = ["derive"] }
 rand = "0.8.5"
 env_logger = "0.10"
+rustls = "0.23"
 
 [[example]]
 name = "auth"
@@ -123,6 +125,9 @@ path = "query_history.rs"
 name = "cloud"
 path = "cloud.rs"
 
+[[example]]
+name = "tls-rustls"
+path = "tls-rustls.rs"
 
 [[example]]
 name = "execution_profile"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ openssl = "0.10.32"
 rustyline = "9"
 rustyline-derive = "0.6"
 scylla = { path = "../scylla", features = [
-    "ssl",
+    "openssl",
     "cloud",
     "chrono-04",
     "time-03",

--- a/examples/tls-rustls.rs
+++ b/examples/tls-rustls.rs
@@ -1,0 +1,102 @@
+use std::{env, sync::Arc};
+
+use anyhow::Result;
+use futures::TryStreamExt as _;
+
+use rustls::pki_types::{pem::PemObject, CertificateDer};
+use scylla::client::{session::Session, session_builder::SessionBuilder};
+
+// How to run scylla instance with TLS:
+//
+// Edit your scylla.yaml file and add paths to certificates
+// ex:
+// client_encryption_options:
+//     enabled: true
+//     certificate: /etc/scylla/db.crt
+//     keyfile: /etc/scylla/db.key
+//
+// If using docker mount your scylla.yaml file and your cert files with option
+// --volume $(pwd)/tls.yaml:/etc/scylla/scylla.yaml
+//
+// If python returns permission error 13 use "Z" flag
+// --volume $(pwd)/tls.yaml:/etc/scylla/scylla.yaml:Z
+//
+// In your Rust program connect to port 9142 if it wasn't changed
+// Create new SslContextBuilder with SslMethod that is used in your connection
+// Set verification mode
+// if SslVerifyMode::PEER with self-signed certificate you have to
+// use set_ca_file method with path to your ca.crt file as an argument
+// if SslVerifyMode::NONE you don't need to use any additional methods
+//
+// Build it and add to scylla-rust-driver's SessionBuilder
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Create connection
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9142".to_string());
+
+    println!("Connecting to {} ...", uri);
+
+    let rustls_ca = CertificateDer::from_pem_file("./test/tls/ca.crt")?;
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.add(rustls_ca)?;
+
+    let session: Session = SessionBuilder::new()
+        .known_node(uri)
+        .tls_context(Some(Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth(),
+        )))
+        .build()
+        .await?;
+
+    session.query_unpaged("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
+
+    session
+        .query_unpaged(
+            "CREATE TABLE IF NOT EXISTS examples_ks.tls (a int, b int, c text, primary key (a, b))",
+            &[],
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.tls (a, b, c) VALUES (?, ?, ?)",
+            (3, 4, "def"),
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "INSERT INTO examples_ks.tls (a, b, c) VALUES (1, 2, 'abc')",
+            &[],
+        )
+        .await?;
+
+    let prepared = session
+        .prepare("INSERT INTO examples_ks.tls (a, b, c) VALUES (?, 7, ?)")
+        .await?;
+    session
+        .execute_unpaged(&prepared, (42_i32, "I'm prepared!"))
+        .await?;
+    session
+        .execute_unpaged(&prepared, (43_i32, "I'm prepared 2!"))
+        .await?;
+    session
+        .execute_unpaged(&prepared, (44_i32, "I'm prepared 3!"))
+        .await?;
+
+    // Rows can be parsed as tuples
+    let mut iter = session
+        .query_iter("SELECT a, b, c FROM examples_ks.tls", &[])
+        .await?
+        .rows_stream::<(i32, i32, String)>()?;
+    while let Some((a, b, c)) = iter.try_next().await? {
+        println!("a, b, c: {}, {}, {}", a, b, c);
+    }
+
+    println!("Ok.");
+
+    Ok(())
+}

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use futures::TryStreamExt as _;
 use scylla::client::session::Session;
+use scylla::client::session::TlsContext;
 use scylla::client::session_builder::SessionBuilder;
 use std::env;
 use std::fs;
@@ -46,7 +47,7 @@ async fn main() -> Result<()> {
 
     let session: Session = SessionBuilder::new()
         .known_node(uri)
-        .ssl_context(Some(context_builder.build()))
+        .tls_context(Some(TlsContext::OpenSsl(context_builder.build())))
         .build()
         .await?;
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -16,9 +16,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-ssl = ["dep:tokio-openssl", "dep:openssl"]
+openssl = ["dep:tokio-openssl", "dep:openssl"]
 cloud = [
-    "ssl",
     "scylla-cql/serde",
     "dep:serde_yaml",
     "dep:serde",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -17,6 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 openssl = ["dep:tokio-openssl", "dep:openssl", "__tls"]
+rustls = ["dep:tokio-rustls", "dep:rustls", "__tls"]
 cloud = [
     "scylla-cql/serde",
     "dep:serde_yaml",
@@ -65,6 +66,8 @@ tracing = "0.1.36"
 chrono = { version = "0.4.32", default-features = false, features = ["clock"] }
 openssl = { version = "0.10.32", optional = true }
 tokio-openssl = { version = "0.6.1", optional = true }
+tokio-rustls = { version = "0.26", optional = true }
+rustls = { version = "*", optional = true } # make sure it doesn't conflict with tokio-rustls
 arc-swap = "1.3.0"
 dashmap = "5.2"
 lz4_flex = { version = "0.11.1" }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-openssl = ["dep:tokio-openssl", "dep:openssl"]
+openssl = ["dep:tokio-openssl", "dep:openssl", "__tls"]
 cloud = [
     "scylla-cql/serde",
     "dep:serde_yaml",
@@ -38,6 +38,7 @@ full-serialization = [
     "num-bigint-04",
     "bigdecimal-04",
 ]
+__tls = []
 
 [dependencies]
 scylla-macros = { version = "0.7.0", path = "../scylla-macros" }

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -19,7 +19,7 @@ use crate::errors::{
     TracingProtocolError,
 };
 use crate::frame::response::result;
-#[cfg(feature = "ssl")]
+#[cfg(feature = "openssl")]
 use crate::network::SslConfig;
 use crate::network::{Connection, ConnectionConfig, PoolConfig, VerifiedKeyspaceName};
 use crate::observability::driver_tracing::RequestSpan;
@@ -45,7 +45,7 @@ use arc_swap::ArcSwapOption;
 use futures::future::join_all;
 use futures::future::try_join_all;
 use itertools::Itertools;
-#[cfg(feature = "ssl")]
+#[cfg(feature = "openssl")]
 use openssl::ssl::SslContext;
 use scylla_cql::frame::response::NonErrorResponse;
 use scylla_cql::serialize::batch::BatchValues;
@@ -167,7 +167,7 @@ pub struct SessionConfig {
     pub keyspace_case_sensitive: bool,
 
     /// Provide our Session with TLS
-    #[cfg(feature = "ssl")]
+    #[cfg(feature = "openssl")]
     pub ssl_context: Option<SslContext>,
 
     pub authenticator: Option<Arc<dyn AuthenticatorProvider>>,
@@ -292,7 +292,7 @@ impl SessionConfig {
                 .into_handle(),
             used_keyspace: None,
             keyspace_case_sensitive: false,
-            #[cfg(feature = "ssl")]
+            #[cfg(feature = "openssl")]
             ssl_context: None,
             authenticator: None,
             connect_timeout: Duration::from_secs(5),

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -148,6 +148,9 @@ where
 pub enum TlsContext {
     #[cfg(feature = "openssl")]
     OpenSsl(openssl::ssl::SslContext),
+    #[cfg(feature = "rustls")]
+    Rustls(Arc<rustls::ClientConfig>),
+}
 
 #[cfg(feature = "openssl")]
 impl From<openssl::ssl::SslContext> for TlsContext {
@@ -155,6 +158,12 @@ impl From<openssl::ssl::SslContext> for TlsContext {
         TlsContext::OpenSsl(value)
     }
 }
+
+#[cfg(feature = "rustls")]
+impl From<Arc<rustls::ClientConfig>> for TlsContext {
+    fn from(value: Arc<rustls::ClientConfig>) -> Self {
+        TlsContext::Rustls(value)
+    }
 }
 
 /// Configuration options for [`Session`].

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -16,7 +16,7 @@ use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::statement::Consistency;
-#[cfg(feature = "ssl")]
+#[cfg(feature = "openssl")]
 use openssl::ssl::SslContext;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
@@ -353,7 +353,7 @@ impl GenericSessionBuilder<DefaultMode> {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "ssl")]
+    #[cfg(feature = "openssl")]
     pub fn ssl_context(mut self, ssl_context: Option<SslContext>) -> Self {
         self.config.ssl_context = ssl_context;
         self

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -9,6 +9,8 @@ use super::session::{
 };
 use super::{Compression, PoolSize, SelfIdentity};
 use crate::authentication::{AuthenticatorProvider, PlainTextAuthenticator};
+#[cfg(feature = "__tls")]
+use crate::client::session::TlsContext;
 #[cfg(feature = "cloud")]
 use crate::cloud::{CloudConfig, CloudConfigError};
 use crate::errors::NewSessionError;
@@ -16,8 +18,6 @@ use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::statement::Consistency;
-#[cfg(feature = "openssl")]
-use openssl::ssl::SslContext;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
@@ -347,15 +347,15 @@ impl GenericSessionBuilder<DefaultMode> {
     ///
     /// let session: Session = SessionBuilder::new()
     ///     .known_node("127.0.0.1:9042")
-    ///     .ssl_context(Some(context_builder.build()))
+    ///     .tls_context(Some(context_builder.build()))
     ///     .build()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "openssl")]
-    pub fn ssl_context(mut self, ssl_context: Option<SslContext>) -> Self {
-        self.config.ssl_context = ssl_context;
+    #[cfg(feature = "__tls")]
+    pub fn tls_context(mut self, tls_context: Option<impl Into<TlsContext>>) -> Self {
+        self.config.tls_context = tls_context.map(|t| t.into());
         self
     }
 }

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -326,10 +326,10 @@ impl GenericSessionBuilder<DefaultMode> {
         self
     }
 
-    /// ssl feature
-    /// Provide SessionBuilder with SslContext from openssl crate that will be
-    /// used to create an ssl connection to the database.
-    /// If set to None SSL connection won't be used.
+    /// TLS feature
+    /// Provide SessionBuilder with TlsContext that will be
+    /// used to create a TLS connection to the database.
+    /// If set to None TLS connection won't be used.
     /// Default is None.
     ///
     /// # Example

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -21,7 +21,7 @@ pub enum CloudConfigError {
     Validation(String),
 
     #[error("Error during key/cert parsing: {0}")]
-    Ssl(#[from] TlsError),
+    Tls(#[from] TlsError),
 }
 
 /// Configuration for creating a session to a serverless cluster.

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -1,11 +1,9 @@
 use std::{collections::HashMap, io};
 
-use openssl::{
-    pkey::{PKey, Private},
-    x509::X509,
-};
 use scylla_cql::{frame::types::SerialConsistency, Consistency};
 use thiserror::Error;
+
+use crate::network::TlsError;
 
 #[non_exhaustive]
 #[derive(Debug, Error)]
@@ -23,7 +21,7 @@ pub enum CloudConfigError {
     Validation(String),
 
     #[error("Error during key/cert parsing: {0}")]
-    Ssl(#[from] openssl::error::ErrorStack),
+    Ssl(#[from] TlsError),
 }
 
 /// Configuration for creating a session to a serverless cluster.
@@ -74,21 +72,25 @@ impl CloudConfig {
 /// to connect to cloud nodes.
 #[derive(Debug)]
 pub(crate) struct AuthInfo {
-    key: PKey<Private>,
-    cert: X509,
+    tls: TlsInfo,
     #[allow(unused)]
     username: Option<String>,
     #[allow(unused)]
     password: Option<String>,
 }
 
-impl AuthInfo {
-    pub(crate) fn get_key(&self) -> &PKey<Private> {
-        &self.key
-    }
+#[derive(Debug)]
+pub(crate) enum TlsInfo {
+    #[cfg(feature = "openssl")]
+    OpenSsl {
+        key: openssl::pkey::PKey<openssl::pkey::Private>,
+        cert: openssl::x509::X509,
+    },
+}
 
-    pub(crate) fn get_cert(&self) -> &X509 {
-        &self.cert
+impl AuthInfo {
+    pub(crate) fn get_tls(&self) -> &TlsInfo {
+        &self.tls
     }
 
     #[allow(unused)]
@@ -102,10 +104,11 @@ impl AuthInfo {
     }
 }
 
-/// Contains cloud datacenter configuration for creating TLS connections to its nodes.  
+/// Contains cloud datacenter configuration for creating TLS connections to its nodes.
 #[derive(Debug)]
 pub(crate) struct Datacenter {
-    certificate_authority: X509,
+    #[cfg(feature = "openssl")]
+    openssl_ca: openssl::x509::X509,
     server: String,
     #[allow(unused)]
     tls_server_name: Option<String>,
@@ -116,8 +119,9 @@ pub(crate) struct Datacenter {
 }
 
 impl Datacenter {
-    pub(crate) fn get_certificate_authority(&self) -> &X509 {
-        &self.certificate_authority
+    #[cfg(feature = "openssl")]
+    pub(crate) fn openssl_ca(&self) -> &openssl::x509::X509 {
+        &self.openssl_ca
     }
 
     pub(crate) fn get_server(&self) -> &str {
@@ -151,12 +155,10 @@ pub(crate) struct Context {
 }
 
 mod deserialize {
-    use super::CloudConfigError;
+    use super::{CloudConfigError, TlsError, TlsInfo};
     use base64::{engine::general_purpose, Engine as _};
     use scylla_cql::{frame::types::SerialConsistency, Consistency};
     use std::{collections::HashMap, fs::File, io::Read, path::Path};
-
-    use openssl::{pkey::PKey, x509::X509};
 
     use serde::Deserialize;
     use tracing::warn;
@@ -417,13 +419,20 @@ mod deserialize {
                 auth_info.clientKeyPath.as_deref(),
             )?;
 
-            let cert = X509::from_pem(&cert_pem[..]).map_err(CloudConfigError::Ssl)?;
+            let tls = {
+                #[cfg(feature = "openssl")]
+                {
+                    let cert =
+                        openssl::x509::X509::from_pem(&cert_pem[..]).map_err(TlsError::from)?;
 
-            let key = PKey::private_key_from_pem(&key_pem[..]).map_err(CloudConfigError::Ssl)?;
+                    let key = openssl::pkey::PKey::private_key_from_pem(&key_pem[..])
+                        .map_err(TlsError::from)?;
+                    TlsInfo::OpenSsl { key, cert }
+                }
+            };
 
             Ok(super::AuthInfo {
-                key,
-                cert,
+                tls,
                 username: auth_info.username,
                 password: auth_info.password,
             })
@@ -517,11 +526,13 @@ mod deserialize {
                 datacenter.certificateAuthorityPath.as_deref(),
             )?;
 
-            let certificate_authority =
-                X509::from_pem(&cert_pem[..]).map_err(CloudConfigError::Ssl)?;
+            #[cfg(feature = "openssl")]
+            let openssl_ca =
+                openssl::x509::X509::from_pem(&cert_pem[..]).map_err(TlsError::from)?;
 
             Ok(super::Datacenter {
-                certificate_authority,
+                #[cfg(feature = "openssl")]
+                openssl_ca,
                 server: datacenter.server,
                 node_domain,
                 insecure_skip_tls_verify: datacenter.insecureSkipTlsVerify.unwrap_or(false),
@@ -551,6 +562,7 @@ mod deserialize {
     #[cfg(test)]
     mod tests {
         use crate::cloud::config::deserialize::Parameters;
+        use crate::cloud::config::TlsInfo;
         use crate::test_utils::setup_tracing;
 
         use super::super::CloudConfig;
@@ -835,8 +847,15 @@ mod deserialize {
 
                 let auth_info = validated_config.auth_infos.get("one").unwrap();
 
+                #[allow(irrefutable_let_patterns)]
+                // in case multiple tls backends are enabled at the same timeg
+                let TlsInfo::OpenSsl { ref cert, .. } = auth_info.tls
+                else {
+                    panic!("openssl TLS info should have been configured")
+                };
+
                 assert_eq!(
-                    auth_info.cert,
+                    *cert,
                     X509::from_pem(
                         &general_purpose::STANDARD
                             .decode(TEST_CA.as_bytes())
@@ -851,7 +870,7 @@ mod deserialize {
 
                 let datacenter = validated_config.datacenters.get("eu-west-1").unwrap();
                 assert_eq!(
-                    datacenter.certificate_authority,
+                    datacenter.openssl_ca,
                     X509::from_pem(
                         &general_purpose::STANDARD
                             .decode(TEST_CA.as_bytes())

--- a/scylla/src/cloud/mod.rs
+++ b/scylla/src/cloud/mod.rs
@@ -10,18 +10,18 @@ use uuid::Uuid;
 use crate::client::session::TlsContext;
 use crate::network::{ConnectionConfig, TlsConfig};
 
-pub(crate) fn set_ssl_config_for_scylla_cloud_host(
+pub(crate) fn set_tls_config_for_scylla_cloud_host(
     host_id: Option<Uuid>,
     dc: Option<&str>,
     proxy_address: SocketAddr,
     connection_config: &mut ConnectionConfig,
 ) -> Result<(), crate::network::TlsError> {
     if connection_config.tls_config.is_some() {
-        // This can only happen if the user builds SessionConfig by hand, as SessionBuilder in cloud mode prevents setting custom SslContext.
+        // This can only happen if the user builds SessionConfig by hand, as SessionBuilder in cloud mode prevents setting custom TlsConfig.
         warn!(
-            "Overriding user-provided SslContext with Scylla Cloud SslContext due \
+            "Overriding user-provided TlsConfig with Scylla Cloud TlsConfig due \
                 to CloudConfig being provided. This is certainly an API misuse - Cloud \
-                may not be combined with user's own SSL config."
+                may not be combined with user's own TLS config."
         )
     }
 
@@ -100,7 +100,7 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
         _ocsp_response: &[u8],
         _now: rustls::pki_types::UnixTime,
     ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        return Ok(rustls::client::danger::ServerCertVerified::assertion());
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
     }
 
     fn verify_tls12_signature(
@@ -109,7 +109,7 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
         _cert: &rustls::pki_types::CertificateDer<'_>,
         _dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        return Ok(rustls::client::danger::HandshakeSignatureValid::assertion());
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
     }
 
     fn verify_tls13_signature(
@@ -118,7 +118,7 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
         _cert: &rustls::pki_types::CertificateDer<'_>,
         _dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        return Ok(rustls::client::danger::HandshakeSignatureValid::assertion());
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {

--- a/scylla/src/cloud/mod.rs
+++ b/scylla/src/cloud/mod.rs
@@ -4,22 +4,19 @@ use std::net::SocketAddr;
 
 pub use config::CloudConfig;
 pub use config::CloudConfigError;
-use openssl::{
-    error::ErrorStack,
-    ssl::{SslContext, SslMethod, SslVerifyMode},
-};
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::network::{ConnectionConfig, SslConfig};
+use crate::client::session::TlsContext;
+use crate::network::{ConnectionConfig, TlsConfig};
 
 pub(crate) fn set_ssl_config_for_scylla_cloud_host(
     host_id: Option<Uuid>,
     dc: Option<&str>,
     proxy_address: SocketAddr,
     connection_config: &mut ConnectionConfig,
-) -> Result<(), ErrorStack> {
-    if connection_config.ssl_config.is_some() {
+) -> Result<(), crate::network::TlsError> {
+    if connection_config.tls_config.is_some() {
         // This can only happen if the user builds SessionConfig by hand, as SessionBuilder in cloud mode prevents setting custom SslContext.
         warn!(
             "Overriding user-provided SslContext with Scylla Cloud SslContext due \
@@ -35,25 +32,29 @@ pub(crate) fn set_ssl_config_for_scylla_cloud_host(
     let datacenter = dc.and_then(|dc| cloud_config.get_datacenters().get(dc));
     if let Some(datacenter) = datacenter {
         let domain_name = datacenter.get_node_domain();
-        let ca = datacenter.get_certificate_authority();
         let auth_info = cloud_config.get_current_auth_info();
-        let key = auth_info.get_key();
-        let cert = auth_info.get_cert();
 
-        let ssl_context = {
-            let mut builder = SslContext::builder(SslMethod::tls())?;
-            builder.set_verify(if datacenter.get_insecure_skip_tls_verify() {
-                SslVerifyMode::NONE
-            } else {
-                SslVerifyMode::PEER
-            });
-            builder.cert_store_mut().add_cert(ca.clone())?;
-            builder.set_certificate(cert)?;
-            builder.set_private_key(key)?;
-            builder.build()
+        let tls_context = match auth_info.get_tls() {
+            #[cfg(feature = "openssl")]
+            config::TlsInfo::OpenSsl { key, cert } => {
+                use openssl::ssl::{SslContext, SslMethod, SslVerifyMode};
+                let mut builder = SslContext::builder(SslMethod::tls())?;
+                builder.set_verify(if datacenter.get_insecure_skip_tls_verify() {
+                    SslVerifyMode::NONE
+                } else {
+                    SslVerifyMode::PEER
+                });
+                let ca = datacenter.openssl_ca();
+                builder.cert_store_mut().add_cert(ca.clone())?;
+                builder.set_certificate(cert)?;
+                builder.set_private_key(key)?;
+                let context = builder.build();
+                TlsContext::OpenSsl(context)
+            }
         };
-        let ssl_config = SslConfig::new_for_sni(ssl_context, domain_name, host_id);
-        connection_config.ssl_config = Some(ssl_config);
+
+        let tls_config = TlsConfig::new_for_sni(tls_context, domain_name, host_id);
+        connection_config.tls_config = Some(tls_config);
     } else {
         warn!("Datacenter {:?} of node {:?} with addr {} not described in cloud config. Proceeding without setting SNI for the node, which will most probably result in nonworking connections,.",
                dc, host_id, proxy_address);

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -82,7 +82,7 @@
 //!     .query_unpaged("SELECT a, b FROM ks.tab", &[])
 //!     .await?
 //!     .into_rows_result()?;
-//!     
+//!
 //! for row in query_rows.rows()? {
 //!     // Parse row as int and text \
 //!     let (int_val, text_val): (i32, &str) = row?;
@@ -260,6 +260,8 @@ pub mod cloud;
 pub mod cluster;
 pub mod errors;
 mod network;
+#[cfg(feature = "__tls")]
+pub use network::TlsError;
 pub mod observability;
 pub mod policies;
 pub mod response;

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1488,7 +1488,10 @@ impl Connection {
                 #[cfg(feature = "openssl")]
                 Tls::OpenSsl(ssl) => {
                     let mut stream = tokio_openssl::SslStream::new(ssl, stream)?;
-                    let _pin = std::pin::Pin::new(&mut stream).connect().await;
+                    std::pin::Pin::new(&mut stream)
+                        .connect()
+                        .await
+                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                     let (task, handle) = Self::router(
                         config,
                         stream,

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1220,8 +1220,8 @@ mod tests {
         let connection_config = ConnectionConfig {
             compression: None,
             tcp_nodelay: true,
-            #[cfg(feature = "openssl")]
-            ssl_config: None,
+            #[cfg(feature = "__tls")]
+            tls_config: None,
             ..Default::default()
         };
 

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1220,7 +1220,7 @@ mod tests {
         let connection_config = ConnectionConfig {
             compression: None,
             tcp_nodelay: true,
-            #[cfg(feature = "ssl")]
+            #[cfg(feature = "openssl")]
             ssl_config: None,
             ..Default::default()
         };

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "cloud")]
-use crate::cloud::set_ssl_config_for_scylla_cloud_host;
+use crate::cloud::set_tls_config_for_scylla_cloud_host;
 use crate::utils::pretty::CommaSeparatedDisplayer;
 
 use super::connection::{
@@ -190,9 +190,9 @@ impl NodeConnectionPool {
                     ..
                 }) => (Some(host_id), address.into_inner(), datacenter.as_deref()),
             };
-            set_ssl_config_for_scylla_cloud_host(host_id, dc, address, &mut pool_config.connection_config)
+            set_tls_config_for_scylla_cloud_host(host_id, dc, address, &mut pool_config.connection_config)
                 .unwrap_or_else(|err| warn!(
-                    "SslContext for SNI connection to Scylla Cloud node {{ host_id={:?}, dc={:?} at {} }} could not be set up: {}\n Proceeding with attempting probably nonworking connection",
+                    "TlsContext for SNI connection to Scylla Cloud node {{ host_id={:?}, dc={:?} at {} }} could not be set up: {}\n Proceeding with attempting probably nonworking connection",
                     host_id,
                     dc,
                     address,

--- a/scylla/src/network/mod.rs
+++ b/scylla/src/network/mod.rs
@@ -5,8 +5,10 @@
 //! - NodeConnectionPool - a manager that keeps a desired number of connections opened to each shard.
 
 mod connection;
-#[cfg(feature = "openssl")]
-pub(crate) use connection::SslConfig;
+#[cfg(feature = "__tls")]
+pub(crate) use connection::TlsConfig;
+#[cfg(feature = "__tls")]
+pub use connection::TlsError;
 pub(crate) use connection::{Connection, ConnectionConfig, VerifiedKeyspaceName};
 
 mod connection_pool;

--- a/scylla/src/network/mod.rs
+++ b/scylla/src/network/mod.rs
@@ -5,7 +5,7 @@
 //! - NodeConnectionPool - a manager that keeps a desired number of connections opened to each shard.
 
 mod connection;
-#[cfg(feature = "ssl")]
+#[cfg(feature = "openssl")]
 pub(crate) use connection::SslConfig;
 pub(crate) use connection::{Connection, ConnectionConfig, VerifiedKeyspaceName};
 


### PR DESCRIPTION
Fixes #293

This is based on the work and discussion on https://github.com/scylladb/scylla-rust-driver/pull/911

Movement on that PR seems to have stalled but it seemed like you all wanted to do this as part of the other breaking changes for v1.0 so I wanted to get this PR into your eyes prior to that. 

Main breaking changes are:
* Renamed `ssl` items that were meant to be generic over the TLS drivers o be `tls` instead as that is more accurate (although I know they are sometimes used interchangeably) (e.g., `ssl_context` to `tls_context`)
* Renamed `ssl` feature flag to be `openssl`
* The `cloud` feature flag no longer auto-enables `openssl`. This is done so users can choose if they want to enable `openssl` and/or `rustls`. We *could* add a check in the code that says that if `cloud` is enabled and there is no tls-related feature flag then hard compile error. It currently will already not compile but the error won't be as nice I think. 

Other caveats:

* For the `cloud` feature, if both `openssl` and `rustls` are enabled, the current code defaults to using `openssl` to keep it slightly more consistent with the old code. I *think* defaulting to `rustls` may provide a slightly better experience since it doesn't require any linking (dynamic nor static) but I wasn't sure what you all would prefer, it's easy enough to change. 

* For non-cloud, if both `openssl` and `rustls` are enabled, the user has a choice at runtime of what `TlsContext` to pass. 
* I do not have a cloud account for scylla so I have not manually tested the cloud changes. 
* The certificates in the test directory use a version that `rustls` does not support so they are not useful for the `rustls` example. I was unable to create new certs from the existing self-signed CA in the test directory because I do not know the passphrase. I have, however, tested that it works using my own certificates in a self-hosted 3-node Scylla instance in AWS that has TLS enabled for client-node communication. 
* The existing tests only test when using `openssl`, we could (and probably should) add tests for the `rustls` feature but that requires making the right certs that `rustls` can use. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I have provided docstrings for the public items that I want to introduce.
- [X] I have adjusted the documentation in `./docs/source/`.
- [X] I added appropriate `Fixes:` annotations to PR description.
