### PR TITLE
Introduce function to deserialize CloudConfig from Read

### DIFF
--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -53,7 +53,7 @@ If you need to share `Session` with different threads / Tokio tasks etc. use `Ar
 
 ## Metadata
 
-The driver refreshes the cluster metadata periodically, which contains information about cluster topology as well as the cluster schema. By default, the driver refreshes the cluster metadata every 60 seconds. 
+The driver refreshes the cluster metadata periodically, which contains information about cluster topology as well as the cluster schema. By default, the driver refreshes the cluster metadata every 60 seconds.
 However, you can set the `cluster_metadata_refresh_interval` to a non-negative value to periodically refresh the cluster metadata. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
 
 ## Scylla Cloud Serverless
@@ -84,10 +84,39 @@ async fn main() -> Result<(), Box<dyn Error>> {
 # }
 ```
 
+It is also possible to load the secure connection bundle from anything
+which implements read:
+
+```rust
+# extern crate scylla;
+# extern crate tokio;
+# fn check_only_compiles() {
+use std::path::Path;
+use std::error::Error;
+use std::fs::File;
+use scylla::client::session_builder::CloudSessionBuilder;
+use scylla::cloud::{CloudConfig, CloudTlsProvider};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut file = File::open("config_data.yaml").unwrap();
+    let config = CloudConfig::from_reader(&mut file, CloudTlsProvider::OpenSsl010).unwrap();
+    let session = CloudSessionBuilder::from_config(config)
+        .build()
+        .await
+        .unwrap();
+
+    Ok(())
+}
+# }
+```
+
 > ***Note***\
-> `CloudSessionBuilder::new()` accepts two parameters. The first is a path to the configuration file.
-> The second parameter is responsible for choosing the underlying TLS provider library.
-> For more information about providers supported currently by the driver, see [TLS](tls.md).
+> `CloudSessionBuilder::new()` and `CloudConfig::from_reader()` accept
+> two parameters. The first is `Read` or path to the configuration
+> file. The second parameter is responsible for choosing the
+> underlying TLS provider library. For more information about
+> providers supported currently by the driver, see [TLS](tls.md).
 
 Note that the bundle file will be provided after the serverless cluster is created. Here is an example of a
 configuration file for a serverless cluster:

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -361,14 +361,10 @@ impl GenericSessionBuilder<DefaultMode> {
 // here, but rather in `impl<K> GenericSessionBuilder<K>` block.
 #[cfg(feature = "unstable-cloud")]
 impl CloudSessionBuilder {
-    /// Creates a new SessionBuilder with default configuration,
-    /// based on provided path to Scylla Cloud Config yaml.
-    pub fn new(
-        cloud_config: impl AsRef<Path>,
-        tls_provider: CloudTlsProvider,
-    ) -> Result<Self, CloudConfigError> {
+    /// Creates a new SessionBuilder with default configuration, based
+    /// on the provided [`CloudConfig`].
+    pub fn from_config(cloud_config: CloudConfig) -> Self {
         let mut config = SessionConfig::new();
-        let cloud_config = CloudConfig::read_from_yaml(cloud_config, tls_provider)?;
         let mut exec_profile_builder = ExecutionProfile::builder();
         if let Some(default_consistency) = cloud_config.get_default_consistency() {
             exec_profile_builder = exec_profile_builder.consistency(default_consistency);
@@ -379,10 +375,20 @@ impl CloudSessionBuilder {
         }
         config.default_execution_profile_handle = exec_profile_builder.build().into_handle();
         config.cloud_config = Some(Arc::new(cloud_config));
-        Ok(CloudSessionBuilder {
+        CloudSessionBuilder {
             config,
             kind: PhantomData,
-        })
+        }
+    }
+
+    /// Creates a new SessionBuilder with default configuration,
+    /// based on provided path to Scylla Cloud Config yaml.
+    pub fn new(
+        cloud_config: impl AsRef<Path>,
+        tls_provider: CloudTlsProvider,
+    ) -> Result<Self, CloudConfigError> {
+        let cloud_config = CloudConfig::read_from_yaml(cloud_config, tls_provider)?;
+        Ok(Self::from_config(cloud_config))
     }
 }
 

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -760,13 +760,20 @@ mod deserialize {
     }
 
     impl super::CloudConfig {
+        pub fn from_reader<R: Read>(
+            mut config_reader: R,
+            tls_provider: CloudTlsProvider,
+        ) -> Result<Self, CloudConfigError> {
+            let config = RawCloudConfig::try_from_reader(&mut config_reader)?;
+            Self::try_from((config, tls_provider))
+        }
+
         pub fn read_from_yaml(
             config_path: impl AsRef<Path>,
             tls_provider: CloudTlsProvider,
         ) -> Result<Self, CloudConfigError> {
-            let mut yaml = File::open(config_path)?;
-            let config = RawCloudConfig::try_from_reader(&mut yaml)?;
-            Self::try_from((config, tls_provider))
+            let yaml = File::open(config_path)?;
+            Self::from_reader(yaml, tls_provider)
         }
     }
 

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -760,6 +760,7 @@ mod deserialize {
     }
 
     impl super::CloudConfig {
+        /// Load cloud configuration data from the provided reader.
         pub fn from_reader<R: Read>(
             mut config_reader: R,
             tls_provider: CloudTlsProvider,
@@ -768,6 +769,7 @@ mod deserialize {
             Self::try_from((config, tls_provider))
         }
 
+        /// Load cloud configuration data from a file.
         pub fn read_from_yaml(
             config_path: impl AsRef<Path>,
             tls_provider: CloudTlsProvider,


### PR DESCRIPTION
In many cases, it may be desirable to store the contents of the cloud configuration YAML outside of the local filesystem. In order to support this, all that should be necessary is to allow for `CloudConfig` to be deserialized from a `Read`, rather than a file located at some path, and to allow for the `CloudSessionBuilder` to be constructed from an existing `CloudConfig`. 

I considered a `CloudSessionBuilder` constructor which accepted a `Read`, but settled on accepting `CloudConfig` instead as this seemed more logical by a small margin. I would ultimately be comfortable with either implementation, depending on maintainer preference.

Draft because I need to address some of the checklist items.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
