### PR TITLE
errors: rename `QueryError` to `ExecutionError`

### DIFF
--- a/docs/source/queries/schema-agreement.md
+++ b/docs/source/queries/schema-agreement.md
@@ -27,7 +27,7 @@ let session = SessionBuilder::new()
 
 `Session::await_schema_agreement` returns a `Future` that can be `await`ed as long as schema is not in an agreement.
 However, it won't wait forever; `SessionConfig` defines a timeout that limits the time of waiting. If the timeout elapses,
-the return value is `Err(ExecutionError::RequestTimeout)`, otherwise it is `Ok(schema_version)`.
+the return value is `Err(ExecutionError::SchemaAgreementTimeout)`, otherwise it is `Ok(schema_version)`.
 
 ```rust
 # extern crate scylla;

--- a/docs/source/queries/schema-agreement.md
+++ b/docs/source/queries/schema-agreement.md
@@ -27,7 +27,7 @@ let session = SessionBuilder::new()
 
 `Session::await_schema_agreement` returns a `Future` that can be `await`ed as long as schema is not in an agreement.
 However, it won't wait forever; `SessionConfig` defines a timeout that limits the time of waiting. If the timeout elapses,
-the return value is `Err(QueryError::RequestTimeout)`, otherwise it is `Ok(schema_version)`.
+the return value is `Err(ExecutionError::RequestTimeout)`, otherwise it is `Ok(schema_version)`.
 
 ```rust
 # extern crate scylla;

--- a/docs/source/queries/timeouts.md
+++ b/docs/source/queries/timeouts.md
@@ -1,7 +1,7 @@
 # Query timeouts
 
 Query execution time can be limited by setting a request timeout. If a query does not complete
-in the given time, then `QueryError::RequestTimeout` is returned by the driver immediately,
+in the given time, then `ExecutionError::RequestTimeout` is returned by the driver immediately,
 so that application logic can continue operating, but the query may still be in progress on the server.
 
 As a side note, if one wishes custom server-side timeouts (i.e. actual interruption of query processing),

--- a/examples/schema_agreement.rs
+++ b/examples/schema_agreement.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use futures::TryStreamExt as _;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::errors::QueryError;
+use scylla::errors::ExecutionError;
 use std::env;
 use std::time::Duration;
 
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
 
     match session.await_schema_agreement().await {
         Ok(_schema_version) => println!("Schema is in agreement in time"),
-        Err(QueryError::RequestTimeout(_)) => println!("Schema is NOT in agreement in time"),
+        Err(ExecutionError::RequestTimeout(_)) => println!("Schema is NOT in agreement in time"),
         Err(err) => bail!(err),
     };
     session

--- a/examples/tower.rs
+++ b/examples/tower.rs
@@ -16,7 +16,7 @@ struct SessionService {
 // A trivial service implementation for sending parameterless simple string requests to Scylla.
 impl Service<scylla::query::Query> for SessionService {
     type Response = scylla::response::query_result::QueryResult;
-    type Error = scylla::errors::QueryError;
+    type Error = scylla::errors::ExecutionError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -1,7 +1,7 @@
 use crate::batch::{Batch, BatchStatement};
 #[allow(deprecated)]
 use crate::client::pager::LegacyRowIterator;
-use crate::errors::QueryError;
+use crate::errors::ExecutionError;
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 #[allow(deprecated)]
@@ -116,7 +116,7 @@ where
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
         self.session.execute_unpaged(&prepared, values).await
@@ -128,7 +128,7 @@ where
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<QueryPager, QueryError> {
+    ) -> Result<QueryPager, ExecutionError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
         self.session.execute_iter(prepared, values).await
@@ -141,7 +141,7 @@ where
         query: impl Into<Query>,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(QueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
         self.session
@@ -157,7 +157,7 @@ where
         &self,
         batch: &Batch,
         values: impl BatchValues,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         let all_prepared: bool = batch
             .statements
             .iter()
@@ -188,7 +188,7 @@ where
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<LegacyQueryResult, QueryError> {
+    ) -> Result<LegacyQueryResult, ExecutionError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
         self.session.execute_unpaged(&prepared, values).await
@@ -200,7 +200,7 @@ where
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<LegacyRowIterator, QueryError> {
+    ) -> Result<LegacyRowIterator, ExecutionError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
         self.session.execute_iter(prepared, values).await
@@ -213,7 +213,7 @@ where
         query: impl Into<Query>,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(LegacyQueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(LegacyQueryResult, PagingStateResponse), ExecutionError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
         self.session
@@ -228,7 +228,7 @@ where
         &self,
         batch: &Batch,
         values: impl BatchValues,
-    ) -> Result<LegacyQueryResult, QueryError> {
+    ) -> Result<LegacyQueryResult, ExecutionError> {
         let all_prepared: bool = batch
             .statements
             .iter()
@@ -252,7 +252,7 @@ where
     /// Prepares all statements within the batch and returns a new batch where every
     /// statement is prepared.
     /// Uses the prepared statements cache.
-    pub async fn prepare_batch(&self, batch: &Batch) -> Result<Batch, QueryError> {
+    pub async fn prepare_batch(&self, batch: &Batch) -> Result<Batch, ExecutionError> {
         let mut prepared_batch = batch.clone();
 
         try_join_all(
@@ -264,7 +264,7 @@ where
                         let prepared = self.add_prepared_statement(&*query).await?;
                         *statement = BatchStatement::PreparedStatement(prepared);
                     }
-                    Ok::<(), QueryError>(())
+                    Ok::<(), ExecutionError>(())
                 }),
         )
         .await?;
@@ -276,7 +276,7 @@ where
     pub async fn add_prepared_statement(
         &self,
         query: impl Into<&Query>,
-    ) -> Result<PreparedStatement, QueryError> {
+    ) -> Result<PreparedStatement, ExecutionError> {
         self.add_prepared_statement_owned(query.into().clone())
             .await
     }
@@ -284,7 +284,7 @@ where
     async fn add_prepared_statement_owned(
         &self,
         query: impl Into<Query>,
-    ) -> Result<PreparedStatement, QueryError> {
+    ) -> Result<PreparedStatement, ExecutionError> {
         let query = query.into();
 
         if let Some(raw) = self.cache.get(&query.contents) {

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1183,7 +1183,7 @@ where
 
         let (result, paging_state_response) = response
             .into_query_result_and_paging_state()
-            .map_err(RequestAttemptError::into_query_error)?;
+            .map_err(RequestAttemptError::into_execution_error)?;
         span.record_result_fields(&result);
 
         Ok((result, paging_state_response))
@@ -1319,7 +1319,7 @@ where
         let first_ok: Result<PreparedStatement, RequestAttemptError> =
             results.by_ref().find_or_first(Result::is_ok).unwrap();
         let mut prepared: PreparedStatement =
-            first_ok.map_err(RequestAttemptError::into_query_error)?;
+            first_ok.map_err(RequestAttemptError::into_execution_error)?;
 
         // Validate prepared ids equality
         for statement in results.flatten() {
@@ -1407,7 +1407,7 @@ where
 
         let (partition_key, token) = prepared
             .extract_partition_key_and_calculate_token(prepared.get_partitioner_name(), values_ref)
-            .map_err(PartitionKeyError::into_query_error)?
+            .map_err(PartitionKeyError::into_execution_error)?
             .unzip();
 
         let execution_profile = prepared
@@ -1490,7 +1490,7 @@ where
 
         let (result, paging_state_response) = response
             .into_query_result_and_paging_state()
-            .map_err(RequestAttemptError::into_query_error)?;
+            .map_err(RequestAttemptError::into_execution_error)?;
         span.record_result_fields(&result);
 
         Ok((result, paging_state_response))
@@ -2006,7 +2006,7 @@ where
             }
         }
 
-        result.map_err(RequestError::into_query_error)
+        result.map_err(RequestError::into_execution_error)
     }
 
     /// Executes the closure `run_request_once`, provided the load balancing plan and some information

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -15,7 +15,7 @@ use crate::cluster::node::CloudEndpoint;
 use crate::cluster::node::{InternalKnownNode, KnownNode, NodeRef};
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::{
-    BadQuery, MetadataError, NewSessionError, ProtocolError, QueryError, RequestAttemptError,
+    BadQuery, ExecutionError, MetadataError, NewSessionError, ProtocolError, RequestAttemptError,
     RequestError, TracingProtocolError, UseKeyspaceError,
 };
 use crate::frame::response::result;
@@ -454,7 +454,7 @@ impl GenericSession<CurrentDeserializationApi> {
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         self.do_query_unpaged(&query.into(), values).await
     }
 
@@ -514,7 +514,7 @@ impl GenericSession<CurrentDeserializationApi> {
         query: impl Into<Query>,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(QueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         self.do_query_single_page(&query.into(), values, paging_state)
             .await
     }
@@ -559,7 +559,7 @@ impl GenericSession<CurrentDeserializationApi> {
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<QueryPager, QueryError> {
+    ) -> Result<QueryPager, ExecutionError> {
         self.do_query_iter(query.into(), values).await
     }
 
@@ -610,7 +610,7 @@ impl GenericSession<CurrentDeserializationApi> {
         &self,
         prepared: &PreparedStatement,
         values: impl SerializeRow,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         self.do_execute_unpaged(prepared, values).await
     }
 
@@ -675,7 +675,7 @@ impl GenericSession<CurrentDeserializationApi> {
         prepared: &PreparedStatement,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(QueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         self.do_execute_single_page(prepared, values, paging_state)
             .await
     }
@@ -723,7 +723,7 @@ impl GenericSession<CurrentDeserializationApi> {
         &self,
         prepared: impl Into<PreparedStatement>,
         values: impl SerializeRow,
-    ) -> Result<QueryPager, QueryError> {
+    ) -> Result<QueryPager, ExecutionError> {
         self.do_execute_iter(prepared.into(), values).await
     }
 
@@ -776,7 +776,7 @@ impl GenericSession<CurrentDeserializationApi> {
         &self,
         batch: &Batch,
         values: impl BatchValues,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         self.do_batch(batch, values).await
     }
 
@@ -822,7 +822,7 @@ impl GenericSession<LegacyDeserializationApi> {
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<LegacyQueryResult, QueryError> {
+    ) -> Result<LegacyQueryResult, ExecutionError> {
         Ok(self
             .do_query_unpaged(&query.into(), values)
             .await?
@@ -834,7 +834,7 @@ impl GenericSession<LegacyDeserializationApi> {
         query: impl Into<Query>,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(LegacyQueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(LegacyQueryResult, PagingStateResponse), ExecutionError> {
         let (result, paging_state_response) = self
             .do_query_single_page(&query.into(), values, paging_state)
             .await?;
@@ -845,7 +845,7 @@ impl GenericSession<LegacyDeserializationApi> {
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<LegacyRowIterator, QueryError> {
+    ) -> Result<LegacyRowIterator, ExecutionError> {
         self.do_query_iter(query.into(), values)
             .await
             .map(QueryPager::into_legacy)
@@ -855,7 +855,7 @@ impl GenericSession<LegacyDeserializationApi> {
         &self,
         prepared: &PreparedStatement,
         values: impl SerializeRow,
-    ) -> Result<LegacyQueryResult, QueryError> {
+    ) -> Result<LegacyQueryResult, ExecutionError> {
         Ok(self
             .do_execute_unpaged(prepared, values)
             .await?
@@ -867,7 +867,7 @@ impl GenericSession<LegacyDeserializationApi> {
         prepared: &PreparedStatement,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(LegacyQueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(LegacyQueryResult, PagingStateResponse), ExecutionError> {
         let (result, paging_state_response) = self
             .do_execute_single_page(prepared, values, paging_state)
             .await?;
@@ -878,7 +878,7 @@ impl GenericSession<LegacyDeserializationApi> {
         &self,
         prepared: impl Into<PreparedStatement>,
         values: impl SerializeRow,
-    ) -> Result<LegacyRowIterator, QueryError> {
+    ) -> Result<LegacyRowIterator, ExecutionError> {
         self.do_execute_iter(prepared.into(), values)
             .await
             .map(QueryPager::into_legacy)
@@ -888,7 +888,7 @@ impl GenericSession<LegacyDeserializationApi> {
         &self,
         batch: &Batch,
         values: impl BatchValues,
-    ) -> Result<LegacyQueryResult, QueryError> {
+    ) -> Result<LegacyQueryResult, ExecutionError> {
         Ok(self.do_batch(batch, values).await?.into_legacy_result()?)
     }
 
@@ -1054,7 +1054,7 @@ where
         &self,
         query: &Query,
         values: impl SerializeRow,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         let (result, paging_state_response) = self
             .query(query, values, None, PagingState::start())
             .await?;
@@ -1070,7 +1070,7 @@ where
         query: &Query,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(QueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         self.query(
             query,
             values,
@@ -1097,7 +1097,7 @@ where
         values: impl SerializeRow,
         page_size: Option<PageSize>,
         paging_state: PagingState,
-    ) -> Result<(QueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let execution_profile = query
             .get_execution_profile_handle()
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
@@ -1192,7 +1192,7 @@ where
     async fn handle_set_keyspace_response(
         &self,
         response: &NonErrorQueryResponse,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), ExecutionError> {
         if let Some(set_keyspace) = response.as_set_keyspace() {
             debug!(
                 "Detected USE KEYSPACE query, setting session's keyspace to {}",
@@ -1208,7 +1208,7 @@ where
     async fn handle_auto_await_schema_agreement(
         &self,
         response: &NonErrorQueryResponse,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), ExecutionError> {
         if self.schema_agreement_automatic_waiting {
             if response.as_schema_change().is_some() {
                 self.await_schema_agreement().await?;
@@ -1228,7 +1228,7 @@ where
         &self,
         query: Query,
         values: impl SerializeRow,
-    ) -> Result<QueryPager, QueryError> {
+    ) -> Result<QueryPager, ExecutionError> {
         let execution_profile = query
             .get_execution_profile_handle()
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
@@ -1242,7 +1242,7 @@ where
                 self.metrics.clone(),
             )
             .await
-            .map_err(QueryError::from)
+            .map_err(ExecutionError::from)
         } else {
             // Making QueryPager::new_for_query work with values is too hard (if even possible)
             // so instead of sending one prepare to a specific connection on each iterator query,
@@ -1257,7 +1257,7 @@ where
                 metrics: self.metrics.clone(),
             })
             .await
-            .map_err(QueryError::from)
+            .map_err(ExecutionError::from)
         }
     }
 
@@ -1297,7 +1297,10 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn prepare(&self, query: impl Into<Query>) -> Result<PreparedStatement, QueryError> {
+    pub async fn prepare(
+        &self,
+        query: impl Into<Query>,
+    ) -> Result<PreparedStatement, ExecutionError> {
         let query = query.into();
         let query_ref = &query;
 
@@ -1358,7 +1361,7 @@ where
         &self,
         prepared: &PreparedStatement,
         values: impl SerializeRow,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         let serialized_values = prepared.serialize_values(&values)?;
         let (result, paging_state) = self
             .execute(prepared, &serialized_values, None, PagingState::start())
@@ -1375,7 +1378,7 @@ where
         prepared: &PreparedStatement,
         values: impl SerializeRow,
         paging_state: PagingState,
-    ) -> Result<(QueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let serialized_values = prepared.serialize_values(&values)?;
         let page_size = prepared.get_validated_page_size();
         self.execute(prepared, &serialized_values, Some(page_size), paging_state)
@@ -1398,7 +1401,7 @@ where
         serialized_values: &SerializedValues,
         page_size: Option<PageSize>,
         paging_state: PagingState,
-    ) -> Result<(QueryResult, PagingStateResponse), QueryError> {
+    ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let values_ref = &serialized_values;
         let paging_state_ref = &paging_state;
 
@@ -1497,7 +1500,7 @@ where
         &self,
         prepared: PreparedStatement,
         values: impl SerializeRow,
-    ) -> Result<QueryPager, QueryError> {
+    ) -> Result<QueryPager, ExecutionError> {
         let serialized_values = prepared.serialize_values(&values)?;
 
         let execution_profile = prepared
@@ -1513,21 +1516,21 @@ where
             metrics: self.metrics.clone(),
         })
         .await
-        .map_err(QueryError::from)
+        .map_err(ExecutionError::from)
     }
 
     async fn do_batch(
         &self,
         batch: &Batch,
         values: impl BatchValues,
-    ) -> Result<QueryResult, QueryError> {
+    ) -> Result<QueryResult, ExecutionError> {
         // Shard-awareness behavior for batch will be to pick shard based on first batch statement's shard
         // If users batch statements by shard, they will be rewarded with full shard awareness
 
         // check to ensure that we don't send a batch statement with more than u16::MAX queries
         let batch_statements_length = batch.statements.len();
         if batch_statements_length > u16::MAX as usize {
-            return Err(QueryError::BadQuery(
+            return Err(ExecutionError::BadQuery(
                 BadQuery::TooManyQueriesInBatchStatement(batch_statements_length),
             ));
         }
@@ -1636,7 +1639,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn prepare_batch(&self, batch: &Batch) -> Result<Batch, QueryError> {
+    pub async fn prepare_batch(&self, batch: &Batch) -> Result<Batch, ExecutionError> {
         let mut prepared_batch = batch.clone();
 
         try_join_all(
@@ -1648,7 +1651,7 @@ where
                         let prepared = self.prepare(query.clone()).await?;
                         *statement = BatchStatement::PreparedStatement(prepared);
                     }
-                    Ok::<(), QueryError>(())
+                    Ok::<(), ExecutionError>(())
                 }),
         )
         .await?;
@@ -1739,7 +1742,7 @@ where
     ///
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/tracing/tracing.html)
     /// for more information about query tracing
-    pub async fn get_tracing_info(&self, tracing_id: &Uuid) -> Result<TracingInfo, QueryError> {
+    pub async fn get_tracing_info(&self, tracing_id: &Uuid) -> Result<TracingInfo, ExecutionError> {
         // tracing_info_fetch_attempts is NonZeroU32 so at least one attempt will be made
         for _ in 0..self.tracing_info_fetch_attempts.get() {
             let current_try: Option<TracingInfo> = self
@@ -1777,7 +1780,7 @@ where
         &self,
         tracing_id: &Uuid,
         consistency: Option<Consistency>,
-    ) -> Result<Option<TracingInfo>, QueryError> {
+    ) -> Result<Option<TracingInfo>, ExecutionError> {
         // Query system_traces.sessions for TracingInfo
         let mut traces_session_query =
             Query::new(crate::observability::tracing::TRACES_SESSION_QUERY_STR);
@@ -1856,7 +1859,7 @@ where
         execution_profile: Arc<ExecutionProfileInner>,
         run_request_once: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
         request_span: &'a RequestSpan,
-    ) -> Result<RunRequestResult<ResT>, QueryError>
+    ) -> Result<RunRequestResult<ResT>, ExecutionError>
     where
         QueryFut: Future<Output = Result<ResT, RequestAttemptError>>,
         ResT: AllowedRunRequestResTType,
@@ -2133,7 +2136,7 @@ where
         last_error.map(Result::Err)
     }
 
-    async fn await_schema_agreement_indefinitely(&self) -> Result<Uuid, QueryError> {
+    async fn await_schema_agreement_indefinitely(&self) -> Result<Uuid, ExecutionError> {
         loop {
             tokio::time::sleep(self.schema_agreement_interval).await;
             if let Some(agreed_version) = self.check_schema_agreement().await? {
@@ -2142,18 +2145,18 @@ where
         }
     }
 
-    pub async fn await_schema_agreement(&self) -> Result<Uuid, QueryError> {
+    pub async fn await_schema_agreement(&self) -> Result<Uuid, ExecutionError> {
         timeout(
             self.schema_agreement_timeout,
             self.await_schema_agreement_indefinitely(),
         )
         .await
-        .unwrap_or(Err(QueryError::SchemaAgreementTimeout(
+        .unwrap_or(Err(ExecutionError::SchemaAgreementTimeout(
             self.schema_agreement_timeout,
         )))
     }
 
-    pub async fn check_schema_agreement(&self) -> Result<Option<Uuid>, QueryError> {
+    pub async fn check_schema_agreement(&self) -> Result<Option<Uuid>, ExecutionError> {
         let cluster_data = self.get_cluster_data();
         let connections_iter = cluster_data.iter_working_connections()?;
 
@@ -2175,7 +2178,7 @@ where
 // run_request, run_request_speculative_fiber, etc have a template type called ResT.
 // There was a bug where ResT was set to QueryResponse, which could
 // be an error response. This was not caught by retry policy which
-// assumed all errors would come from analyzing Result<ResT, QueryError>.
+// assumed all errors would come from analyzing Result<ResT, ExecutionError>.
 // This trait is a guard to make sure that this mistake doesn't
 // happen again.
 // When using run_request make sure that the ResT type is NOT able

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,4 +1,4 @@
-use crate::errors::{BadQuery, QueryError};
+use crate::errors::{BadQuery, ExecutionError};
 use crate::network::{Connection, PoolConfig, VerifiedKeyspaceName};
 use crate::policies::host_filter::HostFilter;
 use crate::prepared_statement::TokenCalculationError;
@@ -268,7 +268,7 @@ impl ClusterState {
     /// Returns nonempty iterator of working connections to all shards.
     pub(crate) fn iter_working_connections(
         &self,
-    ) -> Result<impl Iterator<Item = Arc<Connection>> + '_, QueryError> {
+    ) -> Result<impl Iterator<Item = Arc<Connection>> + '_, ExecutionError> {
         // The returned iterator is nonempty by nonemptiness invariant of `self.known_peers`.
         assert!(!self.known_peers.is_empty());
         let mut peers_iter = self.known_peers.values();

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -832,12 +832,12 @@ pub enum RequestError {
 }
 
 impl RequestError {
-    pub fn into_query_error(self) -> ExecutionError {
+    pub fn into_execution_error(self) -> ExecutionError {
         match self {
             RequestError::EmptyPlan => ExecutionError::EmptyPlan,
             RequestError::ConnectionPoolError(e) => e.into(),
             RequestError::RequestTimeout(dur) => ExecutionError::RequestTimeout(dur),
-            RequestError::LastAttemptError(e) => e.into_query_error(),
+            RequestError::LastAttemptError(e) => e.into_execution_error(),
         }
     }
 }
@@ -912,7 +912,7 @@ pub enum RequestAttemptError {
 
 impl RequestAttemptError {
     /// Converts the error to [`ExecutionError`].
-    pub fn into_query_error(self) -> ExecutionError {
+    pub fn into_execution_error(self) -> ExecutionError {
         match self {
             RequestAttemptError::CqlRequestSerialization(e) => e.into(),
             RequestAttemptError::DbError(err, msg) => ExecutionError::DbError(err, msg),
@@ -1070,14 +1070,14 @@ mod tests {
         assert_eq!(db_error_displayed, expected_dberr_msg);
 
         // Test that ExecutionError::DbError::(DbError::Unavailable) is displayed correctly
-        let query_error =
+        let execution_error =
             ExecutionError::DbError(db_error, "a message about unavailable error".to_string());
-        let query_error_displayed: String = format!("{}", query_error);
+        let execution_error_displayed: String = format!("{}", execution_error);
 
         let mut expected_querr_msg = "Database returned an error: ".to_string();
         expected_querr_msg += &expected_dberr_msg;
         expected_querr_msg += ", Error message: a message about unavailable error";
 
-        assert_eq!(query_error_displayed, expected_querr_msg);
+        assert_eq!(execution_error_displayed, expected_querr_msg);
     }
 }

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -1074,10 +1074,10 @@ mod tests {
             ExecutionError::DbError(db_error, "a message about unavailable error".to_string());
         let execution_error_displayed: String = format!("{}", execution_error);
 
-        let mut expected_querr_msg = "Database returned an error: ".to_string();
-        expected_querr_msg += &expected_dberr_msg;
-        expected_querr_msg += ", Error message: a message about unavailable error";
+        let mut expected_execution_err_msg = "Database returned an error: ".to_string();
+        expected_execution_err_msg += &expected_dberr_msg;
+        expected_execution_err_msg += ", Error message: a message about unavailable error";
 
-        assert_eq!(execution_error_displayed, expected_querr_msg);
+        assert_eq!(execution_error_displayed, expected_execution_err_msg);
     }
 }

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -43,7 +43,7 @@ use crate::response::query_result::{IntoRowsResultError, SingleRowError};
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 #[allow(deprecated)]
-pub enum QueryError {
+pub enum ExecutionError {
     /// Database sent a response containing some error with a message
     #[error("Database returned an error: {0}, Error message: {1}")]
     DbError(DbError, String),
@@ -114,8 +114,8 @@ pub enum QueryError {
 
     // TODO: This should not belong here, but it requires changes to error types
     // returned in async iterator API. This should be handled in separate PR.
-    // The reason this needs to be included is that topology.rs makes use of iter API and returns QueryError.
-    // Once iter API is adjusted, we can then adjust errors returned by topology module (e.g. refactor MetadataError and not include it in QueryError).
+    // The reason this needs to be included is that topology.rs makes use of iter API and returns ExecutionError.
+    // Once iter API is adjusted, we can then adjust errors returned by topology module (e.g. refactor MetadataError and not include it in ExecutionError).
     /// An error occurred during async iteration over rows of result.
     #[error("An error occurred during async iteration over rows of result: {0}")]
     NextRowError(#[from] NextRowError),
@@ -132,21 +132,21 @@ pub enum QueryError {
 }
 
 #[allow(deprecated)]
-impl From<SerializeValuesError> for QueryError {
-    fn from(serialized_err: SerializeValuesError) -> QueryError {
-        QueryError::BadQuery(BadQuery::SerializeValuesError(serialized_err))
+impl From<SerializeValuesError> for ExecutionError {
+    fn from(serialized_err: SerializeValuesError) -> ExecutionError {
+        ExecutionError::BadQuery(BadQuery::SerializeValuesError(serialized_err))
     }
 }
 
-impl From<SerializationError> for QueryError {
-    fn from(serialized_err: SerializationError) -> QueryError {
-        QueryError::BadQuery(BadQuery::SerializationError(serialized_err))
+impl From<SerializationError> for ExecutionError {
+    fn from(serialized_err: SerializationError) -> ExecutionError {
+        ExecutionError::BadQuery(BadQuery::SerializationError(serialized_err))
     }
 }
 
-impl From<response::Error> for QueryError {
-    fn from(error: response::Error) -> QueryError {
-        QueryError::DbError(error.error, error.reason)
+impl From<response::Error> for ExecutionError {
+    fn from(error: response::Error) -> ExecutionError {
+        ExecutionError::DbError(error.error, error.reason)
     }
 }
 
@@ -832,11 +832,11 @@ pub enum RequestError {
 }
 
 impl RequestError {
-    pub fn into_query_error(self) -> QueryError {
+    pub fn into_query_error(self) -> ExecutionError {
         match self {
-            RequestError::EmptyPlan => QueryError::EmptyPlan,
+            RequestError::EmptyPlan => ExecutionError::EmptyPlan,
             RequestError::ConnectionPoolError(e) => e.into(),
-            RequestError::RequestTimeout(dur) => QueryError::RequestTimeout(dur),
+            RequestError::RequestTimeout(dur) => ExecutionError::RequestTimeout(dur),
             RequestError::LastAttemptError(e) => e.into_query_error(),
         }
     }
@@ -911,11 +911,11 @@ pub enum RequestAttemptError {
 }
 
 impl RequestAttemptError {
-    /// Converts the error to [`QueryError`].
-    pub fn into_query_error(self) -> QueryError {
+    /// Converts the error to [`ExecutionError`].
+    pub fn into_query_error(self) -> ExecutionError {
         match self {
             RequestAttemptError::CqlRequestSerialization(e) => e.into(),
-            RequestAttemptError::DbError(err, msg) => QueryError::DbError(err, msg),
+            RequestAttemptError::DbError(err, msg) => ExecutionError::DbError(err, msg),
             RequestAttemptError::CqlResultParseError(e) => e.into(),
             RequestAttemptError::CqlErrorParseError(e) => e.into(),
             RequestAttemptError::BrokenConnectionError(e) => e.into(),
@@ -923,7 +923,7 @@ impl RequestAttemptError {
                 ProtocolError::UnexpectedResponse(response).into()
             }
             RequestAttemptError::BodyExtensionsParseError(e) => e.into(),
-            RequestAttemptError::UnableToAllocStreamId => QueryError::UnableToAllocStreamId,
+            RequestAttemptError::UnableToAllocStreamId => ExecutionError::UnableToAllocStreamId,
             RequestAttemptError::RepreparedIdChanged {
                 statement,
                 expected_id,
@@ -1025,7 +1025,7 @@ pub(crate) enum ResponseParseError {
 mod tests {
     use scylla_cql::Consistency;
 
-    use super::{DbError, QueryError, WriteType};
+    use super::{DbError, ExecutionError, WriteType};
 
     #[test]
     fn write_type_from_str() {
@@ -1047,7 +1047,7 @@ mod tests {
         }
     }
 
-    // A test to check that displaying DbError and QueryError::DbError works as expected
+    // A test to check that displaying DbError and ExecutionError::DbError works as expected
     // - displays error description
     // - displays error parameters
     // - displays error message
@@ -1069,9 +1069,9 @@ mod tests {
 
         assert_eq!(db_error_displayed, expected_dberr_msg);
 
-        // Test that QueryError::DbError::(DbError::Unavailable) is displayed correctly
+        // Test that ExecutionError::DbError::(DbError::Unavailable) is displayed correctly
         let query_error =
-            QueryError::DbError(db_error, "a message about unavailable error".to_string());
+            ExecutionError::DbError(db_error, "a message about unavailable error".to_string());
         let query_error_displayed: String = format!("{}", query_error);
 
         let mut expected_querr_msg = "Database returned an error: ".to_string();

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -827,7 +827,7 @@ impl Connection {
 
         self.query_raw_unpaged(&query)
             .await
-            .map_err(RequestAttemptError::into_query_error)
+            .map_err(RequestAttemptError::into_execution_error)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -893,7 +893,7 @@ impl Connection {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.execute_raw_unpaged(prepared, values)
             .await
-            .map_err(RequestAttemptError::into_query_error)
+            .map_err(RequestAttemptError::into_execution_error)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -1056,7 +1056,7 @@ impl Connection {
             batch.config.serial_consistency.flatten(),
         )
         .await
-        .map_err(RequestAttemptError::into_query_error)
+        .map_err(RequestAttemptError::into_execution_error)
         .and_then(QueryResponse::into_query_result)
     }
 

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -45,7 +45,7 @@ impl QueryResponse {
 
     pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
         self.into_non_error_query_response()
-            .map_err(RequestAttemptError::into_query_error)?
+            .map_err(RequestAttemptError::into_execution_error)?
             .into_query_result()
     }
 }
@@ -89,7 +89,7 @@ impl NonErrorQueryResponse {
     pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
         let (result, paging_state) = self
             .into_query_result_and_paging_state()
-            .map_err(RequestAttemptError::into_query_error)?;
+            .map_err(RequestAttemptError::into_execution_error)?;
 
         if !paging_state.finished() {
             error!(

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -6,7 +6,7 @@ use scylla_cql::frame::response::{NonErrorResponse, Response};
 use tracing::error;
 use uuid::Uuid;
 
-use crate::errors::{ProtocolError, QueryError, RequestAttemptError};
+use crate::errors::{ExecutionError, ProtocolError, RequestAttemptError};
 use crate::frame::response::{self, result};
 use crate::response::query_result::QueryResult;
 
@@ -43,7 +43,7 @@ impl QueryResponse {
             .into_query_result_and_paging_state()
     }
 
-    pub(crate) fn into_query_result(self) -> Result<QueryResult, QueryError> {
+    pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
         self.into_non_error_query_response()
             .map_err(RequestAttemptError::into_query_error)?
             .into_query_result()
@@ -86,7 +86,7 @@ impl NonErrorQueryResponse {
         ))
     }
 
-    pub(crate) fn into_query_result(self) -> Result<QueryResult, QueryError> {
+    pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
         let (result, paging_state) = self
             .into_query_result_and_paging_state()
             .map_err(RequestAttemptError::into_query_error)?;

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -250,7 +250,7 @@ pub(crate) mod batch_values {
                 if did_write {
                     let token = ps
                         .calculate_token_untyped(&first_values)
-                        .map_err(PartitionKeyError::into_query_error)?;
+                        .map_err(PartitionKeyError::into_execution_error)?;
                     (token, Some(first_values))
                 } else {
                     (None, None)

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -216,7 +216,7 @@ pub(crate) mod batch_values {
     use scylla_cql::serialize::row::SerializedValues;
     use scylla_cql::serialize::{RowWriter, SerializationError};
 
-    use crate::errors::QueryError;
+    use crate::errors::ExecutionError;
     use crate::prepared_statement::PartitionKeyError;
     use crate::routing::Token;
 
@@ -236,7 +236,7 @@ pub(crate) mod batch_values {
     pub(crate) fn peek_first_token<'bv>(
         values: impl BatchValues + 'bv,
         statement: Option<&BatchStatement>,
-    ) -> Result<(Option<Token>, impl BatchValues + 'bv), QueryError> {
+    ) -> Result<(Option<Token>, impl BatchValues + 'bv), ExecutionError> {
         let mut values_iter = values.batch_values_iter();
         let (token, first_values) = match statement {
             Some(BatchStatement::PreparedStatement(ps)) => {

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use super::{PageSize, StatementConfig};
 use crate::client::execution_profile::ExecutionProfileHandle;
-use crate::errors::{BadQuery, ProtocolError, QueryError};
+use crate::errors::{BadQuery, ExecutionError, ProtocolError};
 use crate::frame::response::result::PreparedMetadata;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::observability::history::HistoryListener;
@@ -494,17 +494,19 @@ pub enum PartitionKeyError {
 }
 
 impl PartitionKeyError {
-    /// Converts the error to [`QueryError`].
-    pub fn into_query_error(self) -> QueryError {
+    /// Converts the error to [`ExecutionError`].
+    pub fn into_query_error(self) -> ExecutionError {
         match self {
             PartitionKeyError::PartitionKeyExtraction(_) => {
-                QueryError::ProtocolError(ProtocolError::PartitionKeyExtraction)
+                ExecutionError::ProtocolError(ProtocolError::PartitionKeyExtraction)
             }
             PartitionKeyError::TokenCalculation(TokenCalculationError::ValueTooLong(
                 values_len,
-            )) => QueryError::BadQuery(BadQuery::ValuesTooLongForKey(values_len, u16::MAX.into())),
+            )) => {
+                ExecutionError::BadQuery(BadQuery::ValuesTooLongForKey(values_len, u16::MAX.into()))
+            }
             PartitionKeyError::Serialization(err) => {
-                QueryError::BadQuery(BadQuery::SerializationError(err))
+                ExecutionError::BadQuery(BadQuery::SerializationError(err))
             }
         }
     }

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -495,7 +495,7 @@ pub enum PartitionKeyError {
 
 impl PartitionKeyError {
     /// Converts the error to [`ExecutionError`].
-    pub fn into_query_error(self) -> ExecutionError {
+    pub fn into_execution_error(self) -> ExecutionError {
         match self {
             PartitionKeyError::PartitionKeyExtraction(_) => {
                 ExecutionError::ProtocolError(ProtocolError::PartitionKeyExtraction)

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -4,7 +4,7 @@ use crate::client::session::Session;
 use crate::client::session_builder::{GenericSessionBuilder, SessionBuilderKind};
 use crate::cluster::ClusterState;
 use crate::cluster::NodeRef;
-use crate::errors::QueryError;
+use crate::errors::ExecutionError;
 use crate::network::Connection;
 use crate::policies::load_balancing::{FallbackPlan, LoadBalancingPolicy, RoutingInfo};
 use crate::query::Query;
@@ -157,12 +157,12 @@ fn apply_ddl_lbp(query: &mut Query) {
 // or something like that.
 #[async_trait::async_trait]
 pub(crate) trait PerformDDL {
-    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), QueryError>;
+    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), ExecutionError>;
 }
 
 #[async_trait::async_trait]
 impl PerformDDL for Session {
-    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), QueryError> {
+    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), ExecutionError> {
         let mut query = query.into();
         apply_ddl_lbp(&mut query);
         self.query_unpaged(query, &[]).await.map(|_| ())
@@ -171,7 +171,7 @@ impl PerformDDL for Session {
 
 #[async_trait::async_trait]
 impl PerformDDL for CachingSession {
-    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), QueryError> {
+    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), ExecutionError> {
         let mut query = query.into();
         apply_ddl_lbp(&mut query);
         self.execute_unpaged(query, &[]).await.map(|_| ())
@@ -180,7 +180,7 @@ impl PerformDDL for CachingSession {
 
 #[async_trait::async_trait]
 impl PerformDDL for Connection {
-    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), QueryError> {
+    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), ExecutionError> {
         let mut query = query.into();
         apply_ddl_lbp(&mut query);
         self.query_unpaged(query).await.map(|_| ())

--- a/scylla/tests/integration/batch.rs
+++ b/scylla/tests/integration/batch.rs
@@ -1,6 +1,6 @@
 use scylla::batch::Batch;
 use scylla::batch::BatchType;
-use scylla::errors::QueryError;
+use scylla::errors::ExecutionError;
 use scylla::frame::frame_errors::BatchSerializationError;
 use scylla::frame::frame_errors::CqlRequestSerializationError;
 use scylla::query::Query;
@@ -46,12 +46,14 @@ async fn batch_statements_and_values_mismatch_detected() {
         let err = session.batch(&batch, &((1, 2), ())).await.unwrap_err();
         assert_matches!(
             err,
-            QueryError::CqlRequestSerialization(CqlRequestSerializationError::BatchSerialization(
-                BatchSerializationError::ValuesAndStatementsLengthMismatch {
-                    n_value_lists: 2,
-                    n_statements: 3
-                }
-            ))
+            ExecutionError::CqlRequestSerialization(
+                CqlRequestSerializationError::BatchSerialization(
+                    BatchSerializationError::ValuesAndStatementsLengthMismatch {
+                        n_value_lists: 2,
+                        n_statements: 3
+                    }
+                )
+            )
         )
     }
 
@@ -63,12 +65,14 @@ async fn batch_statements_and_values_mismatch_detected() {
             .unwrap_err();
         assert_matches!(
             err,
-            QueryError::CqlRequestSerialization(CqlRequestSerializationError::BatchSerialization(
-                BatchSerializationError::ValuesAndStatementsLengthMismatch {
-                    n_value_lists: 4,
-                    n_statements: 3
-                }
-            ))
+            ExecutionError::CqlRequestSerialization(
+                CqlRequestSerializationError::BatchSerialization(
+                    BatchSerializationError::ValuesAndStatementsLengthMismatch {
+                        n_value_lists: 4,
+                        n_statements: 3
+                    }
+                )
+            )
         )
     }
 }

--- a/scylla/tests/integration/tablets.rs
+++ b/scylla/tests/integration/tablets.rs
@@ -21,7 +21,7 @@ use scylla::query::Query;
 use scylla::response::query_result::QueryResult;
 use scylla::serialize::row::SerializeRow;
 
-use scylla::errors::QueryError;
+use scylla::errors::ExecutionError;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, ResponseFrame, ResponseOpcode, ResponseReaction, ResponseRule,
     ShardAwareness, TargetShard, WorkerError,
@@ -188,7 +188,7 @@ async fn send_statement_everywhere(
     cluster: &ClusterState,
     statement: &PreparedStatement,
     values: &dyn SerializeRow,
-) -> Result<Vec<QueryResult>, QueryError> {
+) -> Result<Vec<QueryResult>, ExecutionError> {
     let tasks = cluster.get_nodes_info().iter().flat_map(|node| {
         let shard_count: u16 = node.sharder().unwrap().nr_shards.into();
         (0..shard_count).map(|shard| {
@@ -213,7 +213,7 @@ async fn send_unprepared_query_everywhere(
     session: &Session,
     cluster: &ClusterState,
     query: &Query,
-) -> Result<Vec<QueryResult>, QueryError> {
+) -> Result<Vec<QueryResult>, ExecutionError> {
     let tasks = cluster.get_nodes_info().iter().flat_map(|node| {
         let shard_count: u16 = node.sharder().unwrap().nr_shards.into();
         (0..shard_count).map(|shard| {

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -5,7 +5,7 @@ use scylla::client::session_builder::{GenericSessionBuilder, SessionBuilderKind}
 use scylla::cluster::ClusterState;
 use scylla::cluster::NodeRef;
 use scylla::deserialize::DeserializeValue;
-use scylla::errors::QueryError;
+use scylla::errors::ExecutionError;
 use scylla::policies::load_balancing::{FallbackPlan, LoadBalancingPolicy, RoutingInfo};
 use scylla::query::Query;
 use scylla::routing::Shard;
@@ -222,12 +222,12 @@ fn apply_ddl_lbp(query: &mut Query) {
 // or something like that.
 #[async_trait::async_trait]
 pub(crate) trait PerformDDL {
-    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), QueryError>;
+    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), ExecutionError>;
 }
 
 #[async_trait::async_trait]
 impl PerformDDL for Session {
-    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), QueryError> {
+    async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), ExecutionError> {
         let mut query = query.into();
         apply_ddl_lbp(&mut query);
         self.query_unpaged(query, &[]).await.map(|_| ())


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519
Step forward: https://github.com/scylladb/scylla-rust-driver/issues/713

As the PR titles says, this PR renames the `QueryError` to `ExecutionError`. I also checked the mentions of the QueryError in the docs - last commit adjusts the docs regarding the error returned in case of schema agreement timeout. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
