### PR TITLE
codewide: rename remnants of cluster data to state

### DIFF
--- a/docs/source/schema/schema.md
+++ b/docs/source/schema/schema.md
@@ -55,8 +55,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Schema metadata will be fetched below
     session.refresh_metadata().await?;
 
-    let cluster_data = &session.get_cluster_data();
-    let keyspaces = &cluster_data.get_keyspace_info();
+    let cluster_state = &session.get_cluster_state();
+    let keyspaces = &cluster_state.get_keyspace_info();
 
     for (keyspace_name, keyspace_info) in keyspaces.iter() {
         println!("Keyspace {}:", keyspace_name);

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
         println!(
             "Token endpoints for query: {:?}",
             session
-                .get_cluster_data()
+                .get_cluster_state()
                 .get_token_endpoints("examples_ks", "compare_tokens", Token::new(t))
                 .iter()
                 .map(|(node, _shard)| node.address)

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -30,10 +30,10 @@ pub struct ClusterState {
 pub(crate) struct ClusterStateNeatDebug<'a>(pub(crate) &'a Arc<ClusterState>);
 impl std::fmt::Debug for ClusterStateNeatDebug<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let cluster_data = &self.0;
+        let cluster_state = &self.0;
 
         f.debug_struct("ClusterState")
-            .field("known_peers", &cluster_data.known_peers)
+            .field("known_peers", &cluster_state.known_peers)
             .field("ring", {
                 struct RingSizePrinter(usize);
                 impl std::fmt::Debug for RingSizePrinter {
@@ -41,9 +41,9 @@ impl std::fmt::Debug for ClusterStateNeatDebug<'_> {
                         write!(f, "<size={}>", self.0)
                     }
                 }
-                &RingSizePrinter(cluster_data.locator.ring().len())
+                &RingSizePrinter(cluster_state.locator.ring().len())
             })
-            .field("keyspaces", &cluster_data.keyspaces.keys())
+            .field("keyspaces", &cluster_state.keyspaces.keys())
             .finish_non_exhaustive()
     }
 }

--- a/scylla/src/policies/load_balancing/plan.rs
+++ b/scylla/src/policies/load_balancing/plan.rs
@@ -225,13 +225,13 @@ mod tests {
             expected_nodes: expected_nodes(),
         };
         let locator = create_locator(&mock_metadata_for_token_aware_tests());
-        let cluster_data = ClusterState {
+        let cluster_state = ClusterState {
             known_peers: Default::default(),
             keyspaces: Default::default(),
             locator,
         };
         let routing_info = RoutingInfo::default();
-        let plan = Plan::new(&policy, &routing_info, &cluster_data);
+        let plan = Plan::new(&policy, &routing_info, &cluster_state);
         assert_eq!(
             Vec::from_iter(plan.map(|(node, shard)| (node.clone(), shard))),
             policy.expected_nodes

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -36,7 +36,7 @@ pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
     // Cassandra doesn't have a concept of features, so first detect
     // if there is the `supported_features` column in system.local
 
-    let meta = session.get_cluster_data();
+    let meta = session.get_cluster_state();
     let system_local = meta
         .keyspaces
         .get("system")

--- a/scylla/tests/integration/tablets.rs
+++ b/scylla/tests/integration/tablets.rs
@@ -44,8 +44,8 @@ struct Tablet {
 }
 
 async fn get_tablets(session: &Session, ks: &str, table: &str) -> Vec<Tablet> {
-    let cluster_data = session.get_cluster_data();
-    let endpoints = cluster_data.get_nodes_info();
+    let cluster_state = session.get_cluster_state();
+    let endpoints = cluster_state.get_nodes_info();
     for endpoint in endpoints.iter() {
         info!(
             "Endpoint id: {}, address: {}",
@@ -453,7 +453,7 @@ async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
             // as such queries cannot be token-aware anyway
             send_unprepared_query_everywhere(
                 &session,
-                session.get_cluster_data().as_ref(),
+                session.get_cluster_state().as_ref(),
                 &Query::new(format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 1, 'abc')")),
             )
             .await
@@ -555,7 +555,7 @@ async fn test_lwt_optimization_works_with_tablets() {
                 );
                 send_statement_everywhere(
                     &session,
-                    session.get_cluster_data().as_ref(),
+                    session.get_cluster_state().as_ref(),
                     &prepared_insert,
                     values,
                 )

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -97,7 +97,7 @@ pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
     // Cassandra doesn't have a concept of features, so first detect
     // if there is the `supported_features` column in system.local
 
-    let meta = session.get_cluster_data();
+    let meta = session.get_cluster_state();
     let system_local = meta
         .get_keyspace_info()
         .get("system")


### PR DESCRIPTION
There were multiple places where `ClusterState` was still referred to as `ClusterData`:
- `Session::get_cluster_data()`,
- `Cluster::get_data()`,
- variable names,
- comments and docstrings.

All were renamed.

Supplements #1163.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
