### PR TITLE
CI: cassandra workflow: bigger prepared cache

### DIFF
--- a/test/cluster/cassandra/docker-compose.yml
+++ b/test/cluster/cassandra/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       - CASSANDRA_BROADCAST_ADDRESS=172.42.0.2
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
+    # Only needed to set the custom prepared cache size in /etc/cassandra/cassandra.yaml.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "sed -i 's/^prepared_statements_cache_size:.*/prepared_statements_cache_size: 100MiB/' /etc/cassandra/cassandra.yaml && docker-entrypoint.sh"
   cassandra2:
     image: cassandra
     healthcheck:
@@ -38,6 +43,11 @@ services:
       - CASSANDRA_SEEDS=172.42.0.2
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
+    # Only needed to set the custom prepared cache size in /etc/cassandra/cassandra.yaml.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "sed -i 's/^prepared_statements_cache_size:.*/prepared_statements_cache_size: 100MiB/' /etc/cassandra/cassandra.yaml && docker-entrypoint.sh"
     depends_on:
       cassandra1:
         condition: service_healthy
@@ -56,6 +66,11 @@ services:
       - CASSANDRA_SEEDS=172.42.0.2,172.42.0.3
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
+    # Only needed to set the custom prepared cache size in /etc/cassandra/cassandra.yaml.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "sed -i 's/^prepared_statements_cache_size:.*/prepared_statements_cache_size: 100MiB/' /etc/cassandra/cassandra.yaml && docker-entrypoint.sh"
     depends_on:
       cassandra2:
         condition: service_healthy

--- a/test/cluster/cassandra/docker-compose.yml
+++ b/test/cluster/cassandra/docker-compose.yml
@@ -12,10 +12,10 @@ services:
   cassandra1:
     image: cassandra
     healthcheck:
-        test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
-        interval: 5s
-        timeout: 5s
-        retries: 60
+      test: [ "CMD", "cqlsh", "-e", "describe keyspaces" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
     networks:
       public:
         ipv4_address: 172.42.0.2
@@ -26,10 +26,10 @@ services:
   cassandra2:
     image: cassandra
     healthcheck:
-        test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
-        interval: 5s
-        timeout: 5s
-        retries: 60
+      test: [ "CMD", "cqlsh", "-e", "describe keyspaces" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
     networks:
       public:
         ipv4_address: 172.42.0.3
@@ -44,10 +44,10 @@ services:
   cassandra3:
     image: cassandra
     healthcheck:
-        test: ["CMD", "cqlsh", "-e", "describe keyspaces" ]
-        interval: 5s
-        timeout: 5s
-        retries: 60
+      test: [ "CMD", "cqlsh", "-e", "describe keyspaces" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
     networks:
       public:
         ipv4_address: 172.42.0.4


### PR DESCRIPTION
Some tests (notably: `test_coalescing` - #864) exhibit flakiness when run against Cassandra, returning `DbError::Unprepared`. As an attempt to combat the flakiness, the prepared statements cache size is increased in the docker compose script.

The default is `MAX(10MiB, heap_size / 256)`. 100MB is the first guess; let's see if it's enough.

Fixes: #864
_(hopefully)_

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [ ] I added appropriate `Fixes:` annotations to PR description.
