### PR TITLE
integration: direct node connectivity test

### DIFF
--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -19,6 +19,10 @@ use uuid::Uuid;
 use super::metadata::{Keyspace, Metadata, Strategy};
 use super::node::{Node, NodeRef};
 
+/// Represents the state of the cluster, including known nodes, keyspaces, and replica locator.
+///
+/// It is immutable after creation, and is replaced atomically upon a metadata refresh.
+/// Can be accessed through [Session::get_cluster_state()](crate::client::session::Session::get_cluster_state).
 #[derive(Clone)]
 pub struct ClusterState {
     /// All nodes known to be part of the cluster, accessible by their host ID.

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -1,23 +1,18 @@
 use std::sync::Arc;
 
 use crate::utils::{
-    scylla_supports_tablets, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
-    PerformDDL,
+    scylla_supports_tablets, send_statement_everywhere, send_unprepared_query_everywhere,
+    setup_tracing, test_with_3_node_cluster, unique_keyspace_name, PerformDDL,
 };
 
 use futures::future::try_join_all;
 use futures::TryStreamExt;
 use itertools::Itertools;
 use scylla::client::session::Session;
-use scylla::cluster::ClusterState;
 use scylla::cluster::Node;
-use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
-use scylla::response::query_result::QueryResult;
-use scylla::serialize::row::SerializeRow;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::statement::unprepared::Statement;
 
-use scylla::errors::ExecutionError;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, ResponseFrame, ResponseOpcode, ResponseReaction, ResponseRule,
     ShardAwareness, TargetShard, WorkerError,
@@ -152,50 +147,6 @@ fn calculate_key_per_tablet(tablets: &[Tablet], prepared: &PreparedStatement) ->
     value_lists
 }
 
-async fn send_statement_everywhere(
-    session: &Session,
-    cluster: &ClusterState,
-    statement: &PreparedStatement,
-    values: &dyn SerializeRow,
-) -> Result<Vec<QueryResult>, ExecutionError> {
-    let tasks = cluster.get_nodes_info().iter().flat_map(|node| {
-        let shard_count: u16 = node.sharder().unwrap().nr_shards.into();
-        (0..shard_count).map(|shard| {
-            let mut stmt = statement.clone();
-            let values_ref = &values;
-            stmt.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
-                NodeIdentifier::Node(Arc::clone(node)),
-                Some(shard as u32),
-            )));
-
-            async move { session.execute_unpaged(&stmt, values_ref).await }
-        })
-    });
-
-    try_join_all(tasks).await
-}
-
-async fn send_unprepared_query_everywhere(
-    session: &Session,
-    cluster: &ClusterState,
-    query: &Statement,
-) -> Result<Vec<QueryResult>, ExecutionError> {
-    let tasks = cluster.get_nodes_info().iter().flat_map(|node| {
-        let shard_count: u16 = node.sharder().unwrap().nr_shards.into();
-        (0..shard_count).map(|shard| {
-            let mut stmt = query.clone();
-            stmt.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
-                NodeIdentifier::Node(Arc::clone(node)),
-                Some(shard as u32),
-            )));
-
-            async move { session.query_unpaged(stmt, &()).await }
-        })
-    });
-
-    try_join_all(tasks).await
-}
-
 fn frame_has_tablet_feedback(frame: ResponseFrame) -> bool {
     let response =
         scylla_cql::frame::parse_response_body_extensions(frame.params.flags, None, frame.body)
@@ -218,7 +169,7 @@ fn count_tablet_feedbacks(
 async fn prepare_schema(session: &Session, ks: &str, table: &str, tablet_count: usize) {
     session
         .ddl(format!(
-            "CREATE KEYSPACE IF NOT EXISTS {} 
+            "CREATE KEYSPACE IF NOT EXISTS {}
             WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2}}
             AND tablets = {{ 'initial': {} }}",
             ks, tablet_count
@@ -423,7 +374,7 @@ async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
             .unwrap();
 
             let feedbacks: usize = feedback_rxs.iter_mut().map(count_tablet_feedbacks).sum();
-            assert!(feedbacks == 0);
+            assert_eq!(feedbacks, 0);
 
             running_proxy
         },

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use crate::utils::{
-    scylla_supports_tablets, send_statement_everywhere, send_unprepared_query_everywhere,
-    setup_tracing, test_with_3_node_cluster, unique_keyspace_name, PerformDDL,
+    execute_prepared_statement_everywhere, execute_unprepared_statement_everywhere,
+    scylla_supports_tablets, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
+    PerformDDL,
 };
 
 use futures::future::try_join_all;
@@ -365,7 +366,7 @@ async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
 
             // I expect Scylla to not send feedback for unprepared queries,
             // as such queries cannot be token-aware anyway
-            send_unprepared_query_everywhere(
+            execute_unprepared_statement_everywhere(
                 &session,
                 session.get_cluster_state().as_ref(),
                 &Statement::new(format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 1, 'abc')")),
@@ -471,7 +472,7 @@ async fn test_lwt_optimization_works_with_tablets() {
                         .unwrap()
                         .value()
                 );
-                send_statement_everywhere(
+                execute_prepared_statement_everywhere(
                     &session,
                     session.get_cluster_state().as_ref(),
                     &prepared_insert,

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -370,6 +370,7 @@ async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
                 &session,
                 session.get_cluster_state().as_ref(),
                 &Statement::new(format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 1, 'abc')")),
+                &(),
             )
             .await
             .unwrap();

--- a/scylla/tests/integration/session/cluster_reachability.rs
+++ b/scylla/tests/integration/session/cluster_reachability.rs
@@ -1,0 +1,59 @@
+//! These tests check that all nodes are reachable, i.e. they can serve requests.
+
+use scylla::client::session::Session;
+use scylla::serialize::row::SerializeRow;
+
+use crate::utils::{
+    create_new_session_builder, execute_prepared_statement_everywhere, setup_tracing,
+    unique_keyspace_name, PerformDDL as _,
+};
+
+/// Tests that all nodes are reachable and can serve requests.
+#[tokio::test]
+#[ntest::timeout(30000)]
+async fn test_all_nodes_are_reachable_and_serving() {
+    setup_tracing();
+
+    let session = create_new_session_builder().build().await.unwrap();
+
+    let ks = unique_keyspace_name();
+
+    /* Prepare schema */
+    prepare_schema(&session, &ks, "t").await;
+
+    let prepared = session
+        .prepare(format!(
+            "INSERT INTO {}.t (a, b, c) VALUES (?, ?, 'abc')",
+            ks
+        ))
+        .await
+        .unwrap();
+
+    let cluster_state = session.get_cluster_state();
+    execute_prepared_statement_everywhere(
+        &session,
+        &cluster_state,
+        &prepared,
+        &(1, 2) as &dyn SerializeRow,
+    )
+    .await
+    .unwrap();
+}
+
+async fn prepare_schema(session: &Session, ks: &str, table: &str) {
+    session
+        .ddl(format!(
+            "CREATE KEYSPACE IF NOT EXISTS {}
+            WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}",
+            ks
+        ))
+        .await
+        .unwrap();
+    session
+        .ddl(format!(
+            "CREATE TABLE IF NOT EXISTS {}.{} (a int, b int, c text, primary key (a, b))",
+            ks, table
+        ))
+        .await
+        .unwrap();
+}

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -1,4 +1,5 @@
 mod caching_session;
+mod cluster_reachability;
 mod db_errors;
 mod history;
 mod new_session;

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -410,6 +410,7 @@ pub(crate) async fn execute_unprepared_statement_everywhere(
     session: &Session,
     cluster: &ClusterState,
     query: &Statement,
+    values: &dyn SerializeRow,
 ) -> Result<Vec<QueryResult>, ExecutionError> {
     let tasks = cluster.get_nodes_info().iter().flat_map(|node| {
         let shard_count: u16 = node.sharder().unwrap().nr_shards.into();
@@ -420,7 +421,7 @@ pub(crate) async fn execute_unprepared_statement_everywhere(
                 Some(shard as u32),
             )));
 
-            async move { session.query_unpaged(stmt, &()).await }
+            async move { session.query_unpaged(stmt, values).await }
         })
     });
 

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -383,7 +383,7 @@ pub(crate) fn calculate_proxy_host_ids(
     host_ids
 }
 
-pub(crate) async fn send_statement_everywhere(
+pub(crate) async fn execute_prepared_statement_everywhere(
     session: &Session,
     cluster: &ClusterState,
     statement: &PreparedStatement,
@@ -406,7 +406,7 @@ pub(crate) async fn send_statement_everywhere(
     try_join_all(tasks).await
 }
 
-pub(crate) async fn send_unprepared_query_everywhere(
+pub(crate) async fn execute_unprepared_statement_everywhere(
     session: &Session,
     cluster: &ClusterState,
     query: &Statement,


### PR DESCRIPTION
## Problem

I noticed that we lacked a test that requires direct connectivity to all nodes in the cluster in order to pass. Other tests would often succeed even if only one node (the initial contact point) was directly reachable.

The issue has manifested in testing serverless cloud why working on rustls support: tests would pass even with address translation disabled...

### Side note 
An example of a test which has exercised direct connectivity to all nodes is `tablets.rs`, yet it could be enabled only for non-cloud case, as it uses the proxy.

## Solution
I wrote a test that iterates though all targets (pairs `(node, shard)`) and sends a request directly to them (using a load balancing policy that produces singleton query plans).

### Bonus
I extracted and refactored some utils from `tablets.rs` to `utils.rs`, so that they can be used by other tests.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
