### PR TITLE
errors: Narrow return error type of Session::[query/execute]_iter

### DIFF
--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -1,5 +1,5 @@
 use crate::batch::{Batch, BatchStatement};
-use crate::errors::{ExecutionError, PrepareError};
+use crate::errors::{ExecutionError, PagerExecutionError, PrepareError};
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 use crate::response::query_result::QueryResult;
@@ -108,7 +108,7 @@ where
         &self,
         query: impl Into<Query>,
         values: impl SerializeRow,
-    ) -> Result<QueryPager, ExecutionError> {
+    ) -> Result<QueryPager, PagerExecutionError> {
         let query = query.into();
         let prepared = self.add_prepared_statement_owned(query).await?;
         self.session.execute_iter(prepared, values).await

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -111,14 +111,6 @@ pub enum ExecutionError {
     /// 'USE KEYSPACE <>' request failed.
     #[error("'USE KEYSPACE <>' request failed: {0}")]
     UseKeyspaceError(#[from] UseKeyspaceError),
-
-    // TODO: This should not belong here, but it requires changes to error types
-    // returned in async iterator API. This should be handled in separate PR.
-    // The reason this needs to be included is that topology.rs makes use of iter API and returns ExecutionError.
-    // Once iter API is adjusted, we can then adjust errors returned by topology module (e.g. refactor MetadataError and not include it in ExecutionError).
-    /// An error occurred during async iteration over rows of result.
-    #[error("Failed to fetch next page of the result: {0}")]
-    NextPageError(#[from] NextPageError),
 }
 
 impl From<SerializationError> for ExecutionError {

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -152,6 +152,23 @@ pub enum PrepareError {
     PreparedStatementIdsMismatch,
 }
 
+/// An error that occurred during construction of [`QueryPager`][crate::client::pager::QueryPager].
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum PagerExecutionError {
+    /// Failed to prepare the statement.
+    #[error("Failed to prepare the statement to be used by the pager: {0}")]
+    PrepareError(#[from] PrepareError),
+
+    /// Failed to serialize statement parameters.
+    #[error("Failed to serialize statement parameters: {0}")]
+    SerializationError(#[from] SerializationError),
+
+    /// Failed to fetch the first page of the result.
+    #[error("Failed to fetch the first page of the result: {0}")]
+    NextPageError(#[from] NextPageError),
+}
+
 /// Error that occurred during session creation
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -29,6 +29,7 @@ use scylla_cql::{
 
 use thiserror::Error;
 
+use crate::client::pager::NextPageError;
 use crate::{authentication::AuthError, frame::response};
 
 use crate::client::pager::NextRowError;
@@ -116,8 +117,8 @@ pub enum ExecutionError {
     // The reason this needs to be included is that topology.rs makes use of iter API and returns ExecutionError.
     // Once iter API is adjusted, we can then adjust errors returned by topology module (e.g. refactor MetadataError and not include it in ExecutionError).
     /// An error occurred during async iteration over rows of result.
-    #[error("An error occurred during async iteration over rows of result: {0}")]
-    NextRowError(#[from] NextRowError),
+    #[error("Failed to fetch next page of the result: {0}")]
+    NextPageError(#[from] NextPageError),
 }
 
 impl From<SerializationError> for ExecutionError {

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1017,6 +1017,7 @@ impl Connection {
 
         QueryPager::new_for_connection_query_iter(query, self, consistency, serial_consistency)
             .await
+            .map_err(NextRowError::NextPageError)
     }
 
     /// Executes a prepared statements and fetches its results over multiple pages, using
@@ -1039,6 +1040,7 @@ impl Connection {
             serial_consistency,
         )
         .await
+        .map_err(NextRowError::NextPageError)
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

## Motivation

`NextPageError` and `NextRowError` were introduced specifically for `QueryPager` API. Currently (before this PR), the top-level Session methods `[execute/query]_iter()` return a `ExecutionError`. This is why `NextRowError` variant is present in `ExecutionError`. To remove that, we can narrow the return error type of these methods.

There is one subtle thing to pay attention to (and potentially discuss). `query_iter` method potentially prepares the statement (if values are not empty). `Session::prepare` currently returns a `ExecutionError`. This is why newly introduced `PagerExecutionError` now depends on `ExecutionError.` The question is whether we should narrow the return error type of `Session::prepare` to some new error type (`PrepareError`), or leave it as is.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
