### PR TITLE
errors: introduce PrepareError

### DIFF
--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -1,7 +1,7 @@
 use crate::batch::{Batch, BatchStatement};
 #[allow(deprecated)]
 use crate::client::pager::LegacyRowIterator;
-use crate::errors::ExecutionError;
+use crate::errors::{ExecutionError, PrepareError};
 use crate::prepared_statement::PreparedStatement;
 use crate::query::Query;
 #[allow(deprecated)]
@@ -276,7 +276,7 @@ where
     pub async fn add_prepared_statement(
         &self,
         query: impl Into<&Query>,
-    ) -> Result<PreparedStatement, ExecutionError> {
+    ) -> Result<PreparedStatement, PrepareError> {
         self.add_prepared_statement_owned(query.into().clone())
             .await
     }
@@ -284,7 +284,7 @@ where
     async fn add_prepared_statement_owned(
         &self,
         query: impl Into<Query>,
-    ) -> Result<PreparedStatement, ExecutionError> {
+    ) -> Result<PreparedStatement, PrepareError> {
         let query = query.into();
 
         if let Some(raw) = self.cache.get(&query.contents) {

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,4 +1,4 @@
-use crate::errors::{BadQuery, ExecutionError};
+use crate::errors::{BadQuery, ConnectionPoolError};
 use crate::network::{Connection, PoolConfig, VerifiedKeyspaceName};
 use crate::policies::host_filter::HostFilter;
 use crate::prepared_statement::TokenCalculationError;
@@ -268,7 +268,7 @@ impl ClusterState {
     /// Returns nonempty iterator of working connections to all shards.
     pub(crate) fn iter_working_connections(
         &self,
-    ) -> Result<impl Iterator<Item = Arc<Connection>> + '_, ExecutionError> {
+    ) -> Result<impl Iterator<Item = Arc<Connection>> + '_, ConnectionPoolError> {
         // The returned iterator is nonempty by nonemptiness invariant of `self.known_peers`.
         assert!(!self.known_peers.is_empty());
         let mut peers_iter = self.known_peers.values();

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -212,12 +212,6 @@ pub enum ProtocolError {
     )]
     UnexpectedResponse(CqlResponseKind),
 
-    /// Prepared statement id mismatch.
-    #[error(
-        "Prepared statement id mismatch between multiple connections - all result ids should be equal."
-    )]
-    PreparedStatementIdsMismatch,
-
     /// Prepared statement id changed after repreparation.
     #[error(
         "Prepared statement id changed after repreparation; md5 sum (computed from the query string) should stay the same;\


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

As noticed by @wprzytula , after renaming `QueryError` to `ExecutionError` it is clear that `Session::prepare` should not return such error. This is why we introduce a `PrepareError` - an error that occurred during statement preparation. It's returned by `Session::prepare` method.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
