### PR TITLE
errors: rename and extract TracingError

### DIFF
--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -211,10 +211,6 @@ pub enum ProtocolError {
     #[error("Unable extract a partition key based on prepared statement's metadata")]
     PartitionKeyExtraction,
 
-    /// A protocol error occurred during tracing info fetch.
-    #[error("Tracing info fetch protocol error: {0}")]
-    Tracing(#[from] TracingProtocolError),
-
     /// Driver tried to reprepare a statement in the batch, but the reprepared
     /// statement's id is not included in the batch.
     #[error("Reprepared statement's id does not exist in the batch.")]
@@ -261,10 +257,16 @@ pub enum SchemaVersionFetchError {
     SingleRowError(SingleRowError),
 }
 
-/// A protocol error that occurred during tracing info fetch.
+/// An error that occurred during tracing info fetch.
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
-pub enum TracingProtocolError {
+pub enum TracingError {
+    /// Failed to execute query to either "system_traces.sessions" or "system_traces.events".
+    #[error(
+        "Failed to execute queries to \"system_traces.sessions\" or \"system_traces.events\" system tables: {0}"
+    )]
+    ExecutionError(#[from] ExecutionError),
+
     /// Failed to convert result of system_traces.session query to rows result.
     #[error("Failed to convert result of system_traces.session query to rows result")]
     TracesSessionIntoRowsResultError(IntoRowsResultError),


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/519

It was previously called `TracingProtocolError` and was contained in ExecutionError::ProtocolError.

Since we now have a big picture of errors hierarchy, it's much clearer that `TracingError` should be a separate error type returned by tracing methods. ExecutionError should NOT depend on it.

This PR renames TracingProtocolError to TracingError, and changes the return type of Session::get_tracing_info(). New variant is introduced to `TracingError` - it contains an `ExecutionError`, which makes sense since we try to execute queries to system tracing tables.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
