### PR TITLE
cicd: fix tls tests

### DIFF
--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -18,25 +18,28 @@ jobs:
   tls:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    services:
-      scylladb:
-        image: scylla-tls
-        build: ./test/tls
-        ports:
-          - 9042:9042
-          - 9142:9142
-        options:
-          --health-cmd "cqlsh --debug"
-          --health-interval 5s
-          --health-retries 10
     env:
       working-directory: ./scylla
     steps:
     - uses: actions/checkout@v3
+
     - name: Update rust toolchain
       run: rustup update
+
     - name: Check
       run: cargo check --verbose --features "ssl"
       working-directory: ${{env.working-directory}}
-    - name: Run tls example
-      run: cargo run --example tls
+
+    - name: Start the cluster
+      run: docker compose -f test/tls/docker-compose-tls.yml up -d
+
+    - name: Run tests
+      run: SCYLLA_URI=172.44.0.2 RUST_LOG=trace cargo run --example tls
+
+    - name: Stop the cluster
+      if: ${{ always() }}
+      run: docker compose -f test/tls/docker-compose-tls.yml stop
+
+    - name: Print the cluster logs
+      if: ${{ always() }}
+      run: docker compose -f test/tls/docker-compose-tls.yml logs

--- a/test/tls/docker-compose-tls.yml
+++ b/test/tls/docker-compose-tls.yml
@@ -1,0 +1,28 @@
+networks:
+  public:
+    name: scylla_rust_driver_tls_public
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.44.0.0/24
+
+services:
+  scylla:
+    networks:
+      public:
+        ipv4_address: 172.44.0.2
+    build: .
+    command: |
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 1
+      --memory 512M
+    ports:
+      - "9042:9042"
+      - "9142:9142"
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60


### PR DESCRIPTION
Commit https://github.com/scylladb/scylla-rust-driver/commit/188964e0be36e035ada0b1d12e6af70a832230c6 assumed that `build` is supported by `github actions services`.
Which is not, so, move to `docker-compose` instead of `services`.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
