### PR TITLE
Implement (derive) Debug for MaybeUnset

### DIFF
--- a/scylla-cql/src/value.rs
+++ b/scylla-cql/src/value.rs
@@ -26,7 +26,7 @@ pub struct Unset;
 pub struct Counter(pub i64);
 
 /// Enum providing a way to represent a value that might be unset
-#[derive(Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum MaybeUnset<V> {
     #[default]
     Unset,


### PR DESCRIPTION
In our project we have multiple structures that derive `SerializeRow` and we often want to print them, but as `MaybeUnset` doesn't implement `Debug` we are forced to manually implement it.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
