### PR TITLE
session: narrow error type of prepare_batch

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -999,7 +999,7 @@ impl Session {
     async fn handle_set_keyspace_response(
         &self,
         response: &NonErrorQueryResponse,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), UseKeyspaceError> {
         if let Some(set_keyspace) = response.as_set_keyspace() {
             debug!(
                 "Detected USE KEYSPACE query, setting session's keyspace to {}",

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1446,7 +1446,7 @@ impl Session {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn prepare_batch(&self, batch: &Batch) -> Result<Batch, ExecutionError> {
+    pub async fn prepare_batch(&self, batch: &Batch) -> Result<Batch, PrepareError> {
         let mut prepared_batch = batch.clone();
 
         try_join_all(
@@ -1458,7 +1458,7 @@ impl Session {
                         let prepared = self.prepare(query.clone()).await?;
                         *statement = BatchStatement::PreparedStatement(prepared);
                     }
-                    Ok::<(), ExecutionError>(())
+                    Ok::<(), PrepareError>(())
                 }),
         )
         .await?;


### PR DESCRIPTION
When introducing `PrepareError`, I missed the public `Session::prepare_batch` method. This PR narrows the return error type of this method to PrepareError. As a bonus, I also narrow the error type of private `Session::handle_set_keyspace_response` method.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
