### PR TITLE
f_errors: remove unused variant from ColumnSpecParseErrorKind

### DIFF
--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -11,7 +11,6 @@ pub use super::request::{
     startup::StartupSerializationError,
 };
 
-use super::response::result::TableSpec;
 use super::response::CqlResponseKind;
 use super::TryFromPrimitiveError;
 use thiserror::Error;
@@ -425,9 +424,6 @@ pub struct ColumnSpecParseError {
 pub enum ColumnSpecParseErrorKind {
     #[error("Invalid table spec: {0}")]
     TableSpecParseError(#[from] TableSpecParseError),
-    // TODO: remove this variant before the next major release.
-    #[error("Table spec differs across columns - got specs: {0:?} and {1:?}")]
-    TableSpecDiffersAcrossColumns(TableSpec<'static>, TableSpec<'static>),
     #[error("Malformed column name: {0}")]
     ColumnNameParseError(#[from] LowLevelDeserializationError),
     #[error("Invalid column type: {0}")]


### PR DESCRIPTION
In #1135 we removed a check for the table spec across different column specs. Since we wanted to release it in a patch release, the corresponding error variant was not removed (not to introduce API breaking changes).

This commit removes the unused variant.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
