### PR TITLE
errors: final cleanups (restructure ExecutionError and introduce SchemaAgreementError)

### DIFF
--- a/examples/schema_agreement.rs
+++ b/examples/schema_agreement.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use futures::TryStreamExt as _;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::errors::ExecutionError;
+use scylla::errors::SchemaAgreementError;
 use std::env;
 use std::time::Duration;
 
@@ -27,7 +27,9 @@ async fn main() -> Result<()> {
 
     match session.await_schema_agreement().await {
         Ok(_schema_version) => println!("Schema is in agreement in time"),
-        Err(ExecutionError::RequestTimeout(_)) => println!("Schema is NOT in agreement in time"),
+        Err(SchemaAgreementError::Timeout(_)) => {
+            println!("Schema is NOT in agreement in time")
+        }
         Err(err) => bail!(err),
     };
     session

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -988,9 +988,7 @@ impl Session {
         self.handle_set_keyspace_response(&response).await?;
         self.handle_auto_await_schema_agreement(&response).await?;
 
-        let (result, paging_state_response) = response
-            .into_query_result_and_paging_state()
-            .map_err(RequestAttemptError::into_execution_error)?;
+        let (result, paging_state_response) = response.into_query_result_and_paging_state()?;
         span.record_result_fields(&result);
 
         Ok((result, paging_state_response))
@@ -1295,9 +1293,7 @@ impl Session {
         self.handle_set_keyspace_response(&response).await?;
         self.handle_auto_await_schema_agreement(&response).await?;
 
-        let (result, paging_state_response) = response
-            .into_query_result_and_paging_state()
-            .map_err(RequestAttemptError::into_execution_error)?;
+        let (result, paging_state_response) = response.into_query_result_and_paging_state()?;
         span.record_result_fields(&result);
 
         Ok((result, paging_state_response))

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -15,7 +15,7 @@ use crate::cluster::node::{InternalKnownNode, KnownNode, NodeRef};
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::{
     BadQuery, ExecutionError, MetadataError, NewSessionError, PagerExecutionError, PrepareError,
-    ProtocolError, RequestAttemptError, RequestError, TracingError, UseKeyspaceError,
+    RequestAttemptError, RequestError, TracingError, UseKeyspaceError,
 };
 use crate::frame::response::result;
 #[cfg(feature = "ssl")]
@@ -867,7 +867,9 @@ impl Session {
             .await?;
         if !paging_state_response.finished() {
             error!("Unpaged unprepared query returned a non-empty paging state! This is a driver-side or server-side bug.");
-            return Err(ProtocolError::NonfinishedPagingState.into());
+            return Err(ExecutionError::LastAttemptError(
+                RequestAttemptError::NonfinishedPagingState,
+            ));
         }
         Ok(result)
     }
@@ -1173,7 +1175,9 @@ impl Session {
             .await?;
         if !paging_state.finished() {
             error!("Unpaged prepared query returned a non-empty paging state! This is a driver-side or server-side bug.");
-            return Err(ProtocolError::NonfinishedPagingState.into());
+            return Err(ExecutionError::LastAttemptError(
+                RequestAttemptError::NonfinishedPagingState,
+            ));
         }
         Ok(result)
     }

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -69,10 +69,6 @@ pub enum ExecutionError {
     #[error("No connections in the pool: {0}")]
     ConnectionPoolError(#[from] ConnectionPoolError),
 
-    /// Protocol error.
-    #[error("Protocol error: {0}")]
-    ProtocolError(#[from] ProtocolError),
-
     /// Failed to run a request within a provided client timeout.
     #[error(
         "Request execution exceeded a client timeout of {}ms",
@@ -152,16 +148,6 @@ pub enum NewSessionError {
     #[error("'USE KEYSPACE <>' request failed: {0}")]
     UseKeyspaceError(#[from] UseKeyspaceError),
 }
-
-/// A protocol error.
-///
-/// It indicates an inconsistency between CQL protocol
-/// and server's behavior.
-/// In some cases, it could also represent a misuse
-/// of internal driver API - a driver bug.
-#[derive(Error, Debug, Clone)]
-#[non_exhaustive]
-pub enum ProtocolError {}
 
 /// An error that occurred during `USE KEYSPACE <>` request.
 #[derive(Error, Debug, Clone)]

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -1,12 +1,10 @@
 //! This module contains various errors which can be returned by [`Session`](crate::client::session::Session).
 
-use std::{
-    error::Error,
-    io::ErrorKind,
-    net::{AddrParseError, IpAddr, SocketAddr},
-    num::ParseIntError,
-    sync::Arc,
-};
+use std::error::Error;
+use std::io::ErrorKind;
+use std::net::{AddrParseError, IpAddr, SocketAddr};
+use std::num::ParseIntError;
+use std::sync::Arc;
 
 use thiserror::Error;
 

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -161,11 +161,7 @@ pub enum NewSessionError {
 /// of internal driver API - a driver bug.
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
-pub enum ProtocolError {
-    /// Unable extract a partition key based on prepared statement's metadata.
-    #[error("Unable extract a partition key based on prepared statement's metadata")]
-    PartitionKeyExtraction,
-}
+pub enum ProtocolError {}
 
 /// An error that occurred during `USE KEYSPACE <>` request.
 #[derive(Error, Debug, Clone)]
@@ -437,6 +433,10 @@ pub enum TablesMetadataError {
 #[error("Invalid query passed to Session")]
 #[non_exhaustive]
 pub enum BadQuery {
+    /// Unable extract a partition key based on prepared statement's metadata.
+    #[error("Unable extract a partition key based on prepared statement's metadata")]
+    PartitionKeyExtraction,
+
     #[error("Serializing values failed: {0} ")]
     SerializationError(#[from] SerializationError),
 

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -56,14 +56,6 @@ pub enum ExecutionError {
     #[error(transparent)]
     BadQuery(#[from] BadQuery),
 
-    /// Failed to serialize CQL request.
-    #[error("Failed to serialize CQL request: {0}")]
-    CqlRequestSerialization(#[from] CqlRequestSerializationError),
-
-    /// Failed to deserialize frame body extensions.
-    #[error(transparent)]
-    BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
-
     /// Load balancing policy returned an empty plan.
     #[error(
         "Load balancing policy returned an empty plan.\
@@ -72,14 +64,6 @@ pub enum ExecutionError {
         then this is most probably a driver bug!"
     )]
     EmptyPlan,
-
-    /// Received a RESULT server response, but failed to deserialize it.
-    #[error(transparent)]
-    CqlResultParseError(#[from] CqlResultParseError),
-
-    /// Received an ERROR server response, but failed to deserialize it.
-    #[error("Failed to deserialize ERROR response: {0}")]
-    CqlErrorParseError(#[from] CqlErrorParseError),
 
     /// A metadata error occurred during schema agreement.
     #[error("Cluster metadata fetch error occurred during automatic schema agreement: {0}")]
@@ -92,14 +76,6 @@ pub enum ExecutionError {
     /// Protocol error.
     #[error("Protocol error: {0}")]
     ProtocolError(#[from] ProtocolError),
-
-    /// A connection has been broken during query execution.
-    #[error(transparent)]
-    BrokenConnection(#[from] BrokenConnectionError),
-
-    /// Driver was unable to allocate a stream id to execute a query on.
-    #[error("Unable to allocate stream id")]
-    UnableToAllocStreamId,
 
     /// Failed to run a request within a provided client timeout.
     #[error(
@@ -196,23 +172,6 @@ pub enum NewSessionError {
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum ProtocolError {
-    /// Received an unexpected response when RESULT or ERROR was expected.
-    #[error(
-        "Received unexpected response from the server: {0}. Expected RESULT or ERROR response."
-    )]
-    UnexpectedResponse(CqlResponseKind),
-
-    /// Prepared statement id changed after repreparation.
-    #[error(
-        "Prepared statement id changed after repreparation; md5 sum (computed from the query string) should stay the same;\
-        Statement: \"{statement}\"; expected id: {expected_id:?}; reprepared id: {reprepared_id:?}"
-    )]
-    RepreparedIdChanged {
-        statement: String,
-        expected_id: Vec<u8>,
-        reprepared_id: Vec<u8>,
-    },
-
     /// A protocol error appeared during schema version fetch.
     #[error("Schema version fetch protocol error: {0}")]
     SchemaVersionFetch(#[from] SchemaVersionFetchError),
@@ -224,11 +183,6 @@ pub enum ProtocolError {
     /// Unable extract a partition key based on prepared statement's metadata.
     #[error("Unable extract a partition key based on prepared statement's metadata")]
     PartitionKeyExtraction,
-
-    /// Driver tried to reprepare a statement in the batch, but the reprepared
-    /// statement's id is not included in the batch.
-    #[error("Reprepared statement's id does not exist in the batch.")]
-    RepreparedIdMissingInBatch,
 }
 
 /// An error that occurred during `USE KEYSPACE <>` request.

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -39,15 +39,6 @@ use crate::response::query_result::{IntoRowsResultError, SingleRowError};
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum ExecutionError {
-    /// Failed to prepare the statement.
-    /// Applies to unprepared statements with non-empty value parameters.
-    #[error("Failed to prepare the statement: {0}")]
-    PrepareError(#[from] PrepareError),
-
-    /// An error returned by last attempt of request execution.
-    #[error(transparent)]
-    LastAttemptError(#[from] RequestAttemptError),
-
     /// Caller passed an invalid query
     #[error(transparent)]
     BadQuery(#[from] BadQuery),
@@ -61,13 +52,18 @@ pub enum ExecutionError {
     )]
     EmptyPlan,
 
-    /// A metadata error occurred during schema agreement.
-    #[error("Cluster metadata fetch error occurred during automatic schema agreement: {0}")]
-    MetadataError(#[from] MetadataError),
+    /// Failed to prepare the statement.
+    /// Applies to unprepared statements with non-empty value parameters.
+    #[error("Failed to prepare the statement: {0}")]
+    PrepareError(#[from] PrepareError),
 
     /// Selected node's connection pool is in invalid state.
     #[error("No connections in the pool: {0}")]
     ConnectionPoolError(#[from] ConnectionPoolError),
+
+    /// An error returned by last attempt of request execution.
+    #[error(transparent)]
+    LastAttemptError(#[from] RequestAttemptError),
 
     /// Failed to run a request within a provided client timeout.
     #[error(
@@ -83,6 +79,10 @@ pub enum ExecutionError {
     /// Failed to await automatic schema agreement.
     #[error("Failed to await schema agreement: {0}")]
     SchemaAgreementError(#[from] SchemaAgreementError),
+
+    /// A metadata error occurred during schema agreement.
+    #[error("Cluster metadata fetch error occurred during automatic schema agreement: {0}")]
+    MetadataError(#[from] MetadataError),
 }
 
 impl From<SerializationError> for ExecutionError {

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -166,10 +166,6 @@ pub enum ProtocolError {
     #[error("Schema version fetch protocol error: {0}")]
     SchemaVersionFetch(#[from] SchemaVersionFetchError),
 
-    /// A result with nonfinished paging state received for unpaged query.
-    #[error("Unpaged query returned a non-empty paging state! This is a driver-side or server-side bug.")]
-    NonfinishedPagingState,
-
     /// Unable extract a partition key based on prepared statement's metadata.
     #[error("Unable extract a partition key based on prepared statement's metadata")]
     PartitionKeyExtraction,
@@ -849,6 +845,10 @@ pub enum RequestAttemptError {
     /// statement's id is not included in the batch.
     #[error("Reprepared statement's id does not exist in the batch.")]
     RepreparedIdMissingInBatch,
+
+    /// A result with nonfinished paging state received for unpaged query.
+    #[error("Unpaged query returned a non-empty paging state! This is a driver-side or server-side bug.")]
+    NonfinishedPagingState,
 }
 
 impl From<response::error::Error> for RequestAttemptError {

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -1,9 +1,5 @@
 //! This module contains various errors which can be returned by [`Session`](crate::client::session::Session).
 
-// Re-export DbError type and types that it depends on
-// so they can be found in `scylla::errors`.
-pub use scylla_cql::frame::response::error::{DbError, OperationType, WriteType};
-
 use std::{
     error::Error,
     io::ErrorKind,
@@ -12,28 +8,34 @@ use std::{
     sync::Arc,
 };
 
-use scylla_cql::{
-    deserialize::{DeserializationError, TypeCheckError},
-    frame::{
-        frame_errors::{
-            CqlAuthChallengeParseError, CqlAuthSuccessParseError, CqlAuthenticateParseError,
-            CqlErrorParseError, CqlEventParseError, CqlRequestSerializationError,
-            CqlResponseParseError, CqlResultParseError, CqlSupportedParseError,
-            FrameBodyExtensionsParseError, FrameHeaderParseError,
-        },
-        request::CqlRequestKind,
-        response::CqlResponseKind,
-    },
-    serialize::SerializationError,
-};
-
 use thiserror::Error;
 
-use crate::client::pager::NextPageError;
-use crate::{authentication::AuthError, frame::response};
+use crate::frame::response;
 
-use crate::client::pager::NextRowError;
-use crate::response::query_result::{IntoRowsResultError, SingleRowError};
+// Re-export error types from pager module.
+pub use crate::client::pager::{NextPageError, NextRowError};
+
+// Re-export error types from query_result module.
+pub use crate::response::query_result::{
+    FirstRowError, IntoRowsResultError, MaybeFirstRowError, ResultNotRowsError, RowsError,
+    SingleRowError,
+};
+
+// Re-export error type from authentication module.
+pub use crate::authentication::AuthError;
+
+// Re-export error types from scylla-cql.
+pub use scylla_cql::deserialize::{DeserializationError, TypeCheckError};
+pub use scylla_cql::frame::frame_errors::{
+    CqlAuthChallengeParseError, CqlAuthSuccessParseError, CqlAuthenticateParseError,
+    CqlErrorParseError, CqlEventParseError, CqlRequestSerializationError, CqlResponseParseError,
+    CqlResultParseError, CqlSupportedParseError, FrameBodyExtensionsParseError,
+    FrameHeaderParseError,
+};
+pub use scylla_cql::frame::request::CqlRequestKind;
+pub use scylla_cql::frame::response::error::{DbError, OperationType, WriteType};
+pub use scylla_cql::frame::response::CqlResponseKind;
+pub use scylla_cql::serialize::SerializationError;
 
 /// Error that occurred during query execution
 #[derive(Error, Debug, Clone)]

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -821,13 +821,12 @@ impl Connection {
     pub(crate) async fn query_unpaged(
         &self,
         query: impl Into<Query>,
-    ) -> Result<QueryResult, ExecutionError> {
+    ) -> Result<QueryResult, RequestAttemptError> {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         let query: Query = query.into();
 
         self.query_raw_unpaged(&query)
             .await
-            .map_err(ExecutionError::LastAttemptError)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -889,11 +888,10 @@ impl Connection {
         &self,
         prepared: &PreparedStatement,
         values: SerializedValues,
-    ) -> Result<QueryResult, ExecutionError> {
+    ) -> Result<QueryResult, RequestAttemptError> {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.execute_raw_unpaged(prepared, values)
             .await
-            .map_err(ExecutionError::LastAttemptError)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -1048,7 +1046,7 @@ impl Connection {
         &self,
         batch: &Batch,
         values: impl BatchValues,
-    ) -> Result<QueryResult, ExecutionError> {
+    ) -> Result<QueryResult, RequestAttemptError> {
         self.batch_with_consistency(
             batch,
             values,
@@ -1058,7 +1056,6 @@ impl Connection {
             batch.config.serial_consistency.flatten(),
         )
         .await
-        .map_err(ExecutionError::LastAttemptError)
         .and_then(QueryResponse::into_query_result)
     }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -827,7 +827,7 @@ impl Connection {
 
         self.query_raw_unpaged(&query)
             .await
-            .map_err(RequestAttemptError::into_execution_error)
+            .map_err(ExecutionError::LastAttemptError)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -893,7 +893,7 @@ impl Connection {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.execute_raw_unpaged(prepared, values)
             .await
-            .map_err(RequestAttemptError::into_execution_error)
+            .map_err(ExecutionError::LastAttemptError)
             .and_then(QueryResponse::into_query_result)
     }
 
@@ -1058,7 +1058,7 @@ impl Connection {
             batch.config.serial_consistency.flatten(),
         )
         .await
-        .map_err(RequestAttemptError::into_execution_error)
+        .map_err(ExecutionError::LastAttemptError)
         .and_then(QueryResponse::into_query_result)
     }
 

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -2867,7 +2867,8 @@ mod latency_awareness {
                 | RequestAttemptError::BodyExtensionsParseError(_)
                 | RequestAttemptError::RepreparedIdChanged { .. }
                 | RequestAttemptError::RepreparedIdMissingInBatch
-                | RequestAttemptError::UnexpectedResponse(_) => true,
+                | RequestAttemptError::UnexpectedResponse(_)
+                | RequestAttemptError::NonfinishedPagingState => true,
             }
         }
     }

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -117,7 +117,8 @@ fn can_be_ignored<ResT>(result: &Result<ResT, RequestError>) -> bool {
                     | RequestAttemptError::CqlErrorParseError(_)
                     | RequestAttemptError::UnexpectedResponse(_)
                     | RequestAttemptError::RepreparedIdChanged { .. }
-                    | RequestAttemptError::RepreparedIdMissingInBatch => false,
+                    | RequestAttemptError::RepreparedIdMissingInBatch
+                    | RequestAttemptError::NonfinishedPagingState => false,
 
                     // Errors that can be ignored
                     RequestAttemptError::BrokenConnectionError(_)

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -6,7 +6,7 @@ use scylla_cql::frame::response::{NonErrorResponse, Response};
 use tracing::error;
 use uuid::Uuid;
 
-use crate::errors::{ExecutionError, RequestAttemptError};
+use crate::errors::RequestAttemptError;
 use crate::frame::response::{self, result};
 use crate::response::query_result::QueryResult;
 
@@ -43,7 +43,7 @@ impl QueryResponse {
             .into_query_result_and_paging_state()
     }
 
-    pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
+    pub(crate) fn into_query_result(self) -> Result<QueryResult, RequestAttemptError> {
         self.into_non_error_query_response()?.into_query_result()
     }
 }
@@ -84,7 +84,7 @@ impl NonErrorQueryResponse {
         ))
     }
 
-    pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
+    pub(crate) fn into_query_result(self) -> Result<QueryResult, RequestAttemptError> {
         let (result, paging_state) = self.into_query_result_and_paging_state()?;
 
         if !paging_state.finished() {
@@ -92,9 +92,7 @@ impl NonErrorQueryResponse {
                 "Internal driver API misuse or a server bug: nonfinished paging state\
                 would be discarded by `NonErrorQueryResponse::into_query_result`"
             );
-            return Err(ExecutionError::LastAttemptError(
-                RequestAttemptError::NonfinishedPagingState,
-            ));
+            return Err(RequestAttemptError::NonfinishedPagingState);
         }
 
         Ok(result)

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -6,7 +6,7 @@ use scylla_cql::frame::response::{NonErrorResponse, Response};
 use tracing::error;
 use uuid::Uuid;
 
-use crate::errors::{ExecutionError, ProtocolError, RequestAttemptError};
+use crate::errors::{ExecutionError, RequestAttemptError};
 use crate::frame::response::{self, result};
 use crate::response::query_result::QueryResult;
 
@@ -92,7 +92,9 @@ impl NonErrorQueryResponse {
                 "Internal driver API misuse or a server bug: nonfinished paging state\
                 would be discarded by `NonErrorQueryResponse::into_query_result`"
             );
-            return Err(ProtocolError::NonfinishedPagingState.into());
+            return Err(ExecutionError::LastAttemptError(
+                RequestAttemptError::NonfinishedPagingState,
+            ));
         }
 
         Ok(result)

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -44,9 +44,7 @@ impl QueryResponse {
     }
 
     pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
-        self.into_non_error_query_response()
-            .map_err(RequestAttemptError::into_execution_error)?
-            .into_query_result()
+        self.into_non_error_query_response()?.into_query_result()
     }
 }
 
@@ -87,9 +85,7 @@ impl NonErrorQueryResponse {
     }
 
     pub(crate) fn into_query_result(self) -> Result<QueryResult, ExecutionError> {
-        let (result, paging_state) = self
-            .into_query_result_and_paging_state()
-            .map_err(RequestAttemptError::into_execution_error)?;
+        let (result, paging_state) = self.into_query_result_and_paging_state()?;
 
         if !paging_state.finished() {
             error!(

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use super::{PageSize, StatementConfig};
 use crate::client::execution_profile::ExecutionProfileHandle;
-use crate::errors::{BadQuery, ExecutionError, ProtocolError};
+use crate::errors::{BadQuery, ExecutionError};
 use crate::frame::response::result::PreparedMetadata;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::observability::history::HistoryListener;
@@ -498,7 +498,7 @@ impl PartitionKeyError {
     pub fn into_execution_error(self) -> ExecutionError {
         match self {
             PartitionKeyError::PartitionKeyExtraction(_) => {
-                ExecutionError::ProtocolError(ProtocolError::PartitionKeyExtraction)
+                ExecutionError::BadQuery(BadQuery::PartitionKeyExtraction)
             }
             PartitionKeyError::TokenCalculation(TokenCalculationError::ValueTooLong(
                 values_len,

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -229,6 +229,9 @@ impl PerformDDL for Connection {
     async fn ddl(&self, query: impl Into<Query> + Send) -> Result<(), ExecutionError> {
         let mut query = query.into();
         apply_ddl_lbp(&mut query);
-        self.query_unpaged(query).await.map(|_| ())
+        self.query_unpaged(query)
+            .await
+            .map(|_| ())
+            .map_err(ExecutionError::LastAttemptError)
     }
 }

--- a/scylla/tests/integration/batch.rs
+++ b/scylla/tests/integration/batch.rs
@@ -1,6 +1,6 @@
 use scylla::batch::Batch;
 use scylla::batch::BatchType;
-use scylla::errors::ExecutionError;
+use scylla::errors::{ExecutionError, RequestAttemptError};
 use scylla::frame::frame_errors::BatchSerializationError;
 use scylla::frame::frame_errors::CqlRequestSerializationError;
 use scylla::query::Query;
@@ -46,14 +46,14 @@ async fn batch_statements_and_values_mismatch_detected() {
         let err = session.batch(&batch, &((1, 2), ())).await.unwrap_err();
         assert_matches!(
             err,
-            ExecutionError::CqlRequestSerialization(
+            ExecutionError::LastAttemptError(RequestAttemptError::CqlRequestSerialization(
                 CqlRequestSerializationError::BatchSerialization(
                     BatchSerializationError::ValuesAndStatementsLengthMismatch {
                         n_value_lists: 2,
                         n_statements: 3
                     }
                 )
-            )
+            ))
         )
     }
 
@@ -65,14 +65,14 @@ async fn batch_statements_and_values_mismatch_detected() {
             .unwrap_err();
         assert_matches!(
             err,
-            ExecutionError::CqlRequestSerialization(
+            ExecutionError::LastAttemptError(RequestAttemptError::CqlRequestSerialization(
                 CqlRequestSerializationError::BatchSerialization(
                     BatchSerializationError::ValuesAndStatementsLengthMismatch {
                         n_value_lists: 4,
                         n_statements: 3
                     }
                 )
-            )
+            ))
         )
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/519

This PR originated from our offline discussion with @Lorak-mmk .

# Changes

## ProtocolError
We remove this type altogether. We noticed that this error type was a catch-all for sub-errors/variants we did not know where to put otherwise.

## ExecutionError
Before this PR, it would contain a lot of top-level variants without providing some meaningful context for them. Most of the variants came from the `RequestAttemptError::into_execution_error` method.

### Inlining RequestAttemptError
We decided  that it's best to inline `RequestAttemptError`, so users have additional context about how request execution looks like when they match the error. It allows us to remove a lot of variants from ExecutionError and ProtocolError (which is later removed).

## SchemaAgreementError
New error type - returned by public API related to awaiting schema agreement (Session::await/check_schema_agreement).

## BadQuery
Me and @Lorak-mmk agreed that final version (after this PR) of `BadQuery` is just fine. I did not do any changes to this error type, apart from moving one of the ProtocolError variants to it. I remember that @wprzytula did not like the name of this error - any suggestions?

# Potential improvements for the future
## SerializationError appears in two places
1. `BadQuery::SerializationError`
This is an error that appears on standard execution path for `Session::execute` and `Session::batch`, when we serialize the values (before doing the retries etc.)

2. `ExecutionError::LastAttemptError(RequestAttemptError::SerializationError)`
This error is constructed ONLY for `Session::query` with non-empty values. Why do we currently need a SerializationError in RequestAttemptError - i.e. why do we serialize on each attempt? This is because we need to firstly prepare the statement during each attempt - the statement needs to be firstly prepared on the node during current attempt. Only after preparation, have we access to the metadata and are able to serialize the values.

After discussion, we decided to currently leave it as is. This is something to be potentially fixed in the future. The fix requires non-trivial changes to execution logic (which is quite complex). The idea is to prepare the statement only once before the retries - then we can serialize the values and pass the serialized values to the context of each attempt. I think it deserves a separate issue in the repository, since it not only will fix the hierarchy of errors, but will improve the overall performance as well - we won't need to prepare the statement on each attempt (we can send QUERY cql request to the node).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
