### PR TITLE
result: mark ColumnType and related enums as non-exhaustive

### DIFF
--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -50,6 +50,7 @@ pub struct TableSpec<'a> {
 /// types those fields will always be set to `false` (even if the DB column
 /// corresponding to given marker / result type is frozen).
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ColumnType<'frame> {
     /// Types that are "simple" (non-recursive).
     Native(NativeType),
@@ -82,6 +83,7 @@ pub enum ColumnType<'frame> {
 
 /// A [ColumnType] variants that are "simple" (non-recursive).
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NativeType {
     Ascii,
     Boolean,
@@ -110,6 +112,7 @@ pub enum NativeType {
 ///
 /// Tuple and vector are not collections because they have predefined size.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CollectionType<'frame> {
     List(Box<ColumnType<'frame>>),
     Map(Box<ColumnType<'frame>>, Box<ColumnType<'frame>>),


### PR DESCRIPTION
This will allow us to introduce support for new column types in the future without breaking the API.

I did not mark `UserDefinedType` as non_exhaustive. It probably won't ever be extended by additional fields.
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
