### PR TITLE
Implement 'From<Option>' for 'MaybeUnset'

### DIFF
--- a/scylla-cql/src/value.rs
+++ b/scylla-cql/src/value.rs
@@ -33,6 +33,12 @@ pub enum MaybeUnset<V> {
     Set(V),
 }
 
+impl<V> From<Option<V>> for MaybeUnset<V> {
+    fn from(value: Option<V>) -> Self {
+        value.map_or(Self::Unset, MaybeUnset::Set)
+    }
+}
+
 /// Represents timeuuid (uuid V1) value
 ///
 /// This type has custom comparison logic which follows Scylla/Cassandra semantics.


### PR DESCRIPTION
I think it is convenient to simplify conversion from `Option<T>` to `MaybeUnset<T>`, but maybe I'm missing something.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
