### PR TITLE
`partitioner`: Change visibility of  `Partitioner`-related items

### DIFF
--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use bytes::BytesMut;
-use scylla::routing::partitioner::{calculate_token_for_partition_key, Murmur3Partitioner};
+use scylla::routing::partitioner::{calculate_token_for_partition_key, PartitionerName};
 use scylla_cql::frame::response::result::{ColumnType, NativeType};
 use scylla_cql::frame::types;
 use scylla_cql::serialize::row::SerializedValues;
@@ -84,7 +84,9 @@ fn calculate_token_bench(c: &mut Criterion) {
         .unwrap();
 
     c.bench_function("calculate_token_from_partition_key simple pk", |b| {
-        b.iter(|| calculate_token_for_partition_key(&serialized_simple_pk, &Murmur3Partitioner))
+        b.iter(|| {
+            calculate_token_for_partition_key(&serialized_simple_pk, &PartitionerName::Murmur3)
+        })
     });
 
     c.bench_function(
@@ -93,14 +95,16 @@ fn calculate_token_bench(c: &mut Criterion) {
             b.iter(|| {
                 calculate_token_for_partition_key(
                     &serialized_simple_pk_long_column,
-                    &Murmur3Partitioner,
+                    &PartitionerName::Murmur3,
                 )
             })
         },
     );
 
     c.bench_function("calculate_token_from_partition_key complex pk", |b| {
-        b.iter(|| calculate_token_for_partition_key(&serialized_complex_pk, &Murmur3Partitioner))
+        b.iter(|| {
+            calculate_token_for_partition_key(&serialized_complex_pk, &PartitionerName::Murmur3)
+        })
     });
 
     c.bench_function(
@@ -109,7 +113,7 @@ fn calculate_token_bench(c: &mut Criterion) {
             b.iter(|| {
                 calculate_token_for_partition_key(
                     &serialized_values_long_column,
-                    &Murmur3Partitioner,
+                    &PartitionerName::Murmur3,
                 )
             })
         },

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -3044,7 +3044,7 @@ async fn test_manual_primary_key_computation() {
 
         let token_by_hand = calculate_token_for_partition_key(
             serialized_pk_values_in_pk_order,
-            &Murmur3Partitioner,
+            &PartitionerName::Murmur3,
         )
         .unwrap();
         println!(

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -16,8 +16,9 @@ use std::num::Wrapping;
 use crate::{prepared_statement::TokenCalculationError, routing::Token};
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Clone, PartialEq, Debug, Default)]
-pub(crate) enum PartitionerName {
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[non_exhaustive]
+pub enum PartitionerName {
     #[default]
     Murmur3,
     CDC,
@@ -48,8 +49,9 @@ impl Partitioner for PartitionerName {
     }
 }
 
+// TODO: make this back `pub(crate)` in this PR.
 #[allow(clippy::upper_case_acronyms)]
-pub(crate) enum PartitionerHasherAny {
+pub enum PartitionerHasherAny {
     Murmur3(Murmur3PartitionerHasher),
     CDC(CDCPartitionerHasher),
 }

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -49,9 +49,8 @@ impl Partitioner for PartitionerName {
     }
 }
 
-// TODO: make this back `pub(crate)` in this PR.
 #[allow(clippy::upper_case_acronyms)]
-pub enum PartitionerHasherAny {
+pub(crate) enum PartitionerHasherAny {
     Murmur3(Murmur3PartitionerHasher),
     CDC(CDCPartitionerHasher),
 }
@@ -77,11 +76,12 @@ impl PartitionerHasher for PartitionerHasherAny {
 /// The Partitioners' design is based on std::hash design: `Partitioner`
 /// corresponds to `HasherBuilder`, and `PartitionerHasher` to `Hasher`.
 /// See their documentation for more details.
-pub trait Partitioner {
+pub(crate) trait Partitioner {
     type Hasher: PartitionerHasher;
 
     fn build_hasher(&self) -> Self::Hasher;
 
+    #[allow(unused)] // Currently, no public API uses this.
     fn hash_one(&self, data: &[u8]) -> Token {
         let mut hasher = self.build_hasher();
         hasher.write(data);
@@ -94,12 +94,12 @@ pub trait Partitioner {
 /// Instances of this trait are created by a `Partitioner` and are stateful.
 /// At any point, one can call `finish()` and a `Token` will be computed
 /// based on values that has been fed so far.
-pub trait PartitionerHasher {
+pub(crate) trait PartitionerHasher {
     fn write(&mut self, pk_part: &[u8]);
     fn finish(&self) -> Token;
 }
 
-pub struct Murmur3Partitioner;
+pub(crate) struct Murmur3Partitioner;
 
 impl Partitioner for Murmur3Partitioner {
     type Hasher = Murmur3PartitionerHasher;
@@ -114,7 +114,7 @@ impl Partitioner for Murmur3Partitioner {
     }
 }
 
-pub struct Murmur3PartitionerHasher {
+pub(crate) struct Murmur3PartitionerHasher {
     total_len: usize,
     buf: [u8; Self::BUF_CAPACITY],
     h1: Wrapping<i64>,
@@ -280,9 +280,9 @@ enum CDCPartitionerHasherState {
     Computed(Token),
 }
 
-pub struct CDCPartitioner;
+pub(crate) struct CDCPartitioner;
 
-pub struct CDCPartitionerHasher {
+pub(crate) struct CDCPartitionerHasher {
     state: CDCPartitionerHasherState,
 }
 

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -348,9 +348,9 @@ impl PartitionerHasher for CDCPartitionerHasher {
 ///
 /// NOTE: the provided values must completely constitute partition key
 /// and be in the order defined in CREATE TABLE statement.
-pub fn calculate_token_for_partition_key<P: Partitioner>(
+pub fn calculate_token_for_partition_key(
     serialized_partition_key_values: &SerializedValues,
-    partitioner: &P,
+    partitioner: &PartitionerName,
 ) -> Result<Token, TokenCalculationError> {
     let mut partitioner_hasher = partitioner.build_hasher();
 

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -418,7 +418,7 @@ impl PreparedStatement {
     }
 
     /// Get the name of the partitioner used for this statement.
-    pub(crate) fn get_partitioner_name(&self) -> &PartitionerName {
+    pub fn get_partitioner_name(&self) -> &PartitionerName {
         &self.partitioner_name
     }
 


### PR DESCRIPTION
# Motivation

We want to extract `session_test.rs` to integration tests directory - out of `scylla` crate.

Tests in `session_test.rs` call `get_partitioner_name()` to assert some things. We must therefore expose `get_partitioner_name().

# What's done
1. `PartitionerName` and `PreparedStatement::get_partitioner_name()` are made `pub`.
2. `PartitionerName` gets missing `Eq` impl and `#[non_exhaustive]` attribute.
3. `calculate_token_for_partition_key()` now accepts `PartitionerName` instead of `impl Partitioner`.
4. `Partitioner(Hasher)` traits and their impls are un`pub`bed.

## Bonus
Implemented `Debug` for `QueryPager` and `TypedRowStream`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
