### PR TITLE
Fix improper ip address formatting in CCM integration.

### DIFF
--- a/scylla/tests/ccm_integration/ccm/ip_allocator.rs
+++ b/scylla/tests/ccm_integration/ccm/ip_allocator.rs
@@ -57,7 +57,7 @@ impl NetPrefix {
 
 impl std::fmt::Display for NetPrefix {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.to_str())
     }
 }
 


### PR DESCRIPTION
When passing `NetPrefix` as an argument to `ccm populate` it is
formatted using `.to_string()` method. Result of this is then concatenated
with the node id, and the result is an "ip" that ccm tries to find in
Scylla logs to determine that the node is UP.

`.to_string()` implementation was displaying the whole ip, instead of
it's first 3 octets, resulting in CCM looking for ips like `127.0.1.02`.
Instead the `to_str()` method should be used, that produces ccm-compatible
form of the ip range.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
