### PR TITLE
ccm: Make 'opts' parameter of the 'stop' method be optional

### DIFF
--- a/scylla/tests/ccm_integration/ccm/cluster.rs
+++ b/scylla/tests/ccm_integration/ccm/cluster.rs
@@ -174,6 +174,7 @@ impl NodeStartOptions {
 /// Options to stop the node with.
 /// It allows to control the value of `--no-wait` and `--not-gently` ccm options.
 #[allow(dead_code)]
+#[derive(Default)]
 pub(crate) struct NodeStopOptions {
     /// Dont't wait for the node to properly stop.
     no_wait: bool,
@@ -295,7 +296,7 @@ impl Node {
         Ok(())
     }
 
-    pub(crate) async fn stop(&mut self, opts: NodeStopOptions) -> Result<(), Error> {
+    pub(crate) async fn stop(&mut self, opts: Option<NodeStopOptions>) -> Result<(), Error> {
         let mut args: Vec<String> = vec![
             self.opts.name(),
             "stop".to_string(),
@@ -306,7 +307,7 @@ impl Node {
         let NodeStopOptions {
             no_wait,
             not_gently,
-        } = opts;
+        } = opts.unwrap_or_default();
         if no_wait {
             args.push(NodeStopOptions::NO_WAIT.to_string());
         }


### PR DESCRIPTION
It will allow to use the 'stop' method just providing "None" parameter:
```
  ... .stop(None).await;
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
