### PR TITLE
Make any query on system.local go with WHERE clause

### DIFF
--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -757,7 +757,7 @@ async fn query_peers(
         .and_then(|row_result| future::ok((NodeInfoSource::Peer, row_result)));
 
     let mut local_query =
-        Query::new("select host_id, rpc_address, data_center, rack, tokens from system.local");
+        Query::new("select host_id, rpc_address, data_center, rack, tokens from system.local WHERE key='local'");
     local_query.set_page_size(METADATA_QUERY_PAGE_SIZE);
     let local_query_stream = conn
         .clone()

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2586,7 +2586,7 @@ mod tests {
         // As everything is normal, these queries should succeed.
         for _ in 0..3 {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            conn.query_unpaged("SELECT host_id FROM system.local")
+            conn.query_unpaged("SELECT host_id FROM system.local WHERE key='local'")
                 .await
                 .unwrap();
         }
@@ -2610,7 +2610,7 @@ mod tests {
 
         // As the router is invalidated, all further queries should immediately
         // return error.
-        conn.query_unpaged("SELECT host_id FROM system.local")
+        conn.query_unpaged("SELECT host_id FROM system.local WHERE key='local'")
             .await
             .unwrap_err();
 

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -54,7 +54,10 @@ pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
     }
 
     let result = session
-        .query_unpaged("SELECT supported_features FROM system.local", ())
+        .query_unpaged(
+            "SELECT supported_features FROM system.local WHERE key='local'",
+            (),
+        )
         .await
         .unwrap()
         .into_rows_result()

--- a/scylla/tests/integration/history.rs
+++ b/scylla/tests/integration/history.rs
@@ -111,7 +111,7 @@ async fn successful_query_history() {
     setup_tracing();
     let session = create_new_session_builder().build().await.unwrap();
 
-    let mut query = Query::new("SELECT * FROM system.local");
+    let mut query = Query::new("SELECT * FROM system.local WHERE key='local'");
     let history_collector = Arc::new(HistoryCollector::new());
     query.set_history_listener(history_collector.clone());
 

--- a/scylla/tests/integration/new_session.rs
+++ b/scylla/tests/integration/new_session.rs
@@ -20,7 +20,7 @@ async fn proceed_if_only_some_hostnames_are_invalid() {
         .await
         .unwrap();
     session
-        .query_unpaged("SELECT host_id FROM system.local", &[])
+        .query_unpaged("SELECT host_id FROM system.local WHERE key='local'", &[])
         .await
         .unwrap();
 }

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -113,7 +113,10 @@ pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
     }
 
     let result = session
-        .query_unpaged("SELECT supported_features FROM system.local", ())
+        .query_unpaged(
+            "SELECT supported_features FROM system.local WHERE key='local'",
+            (),
+        )
         .await
         .unwrap()
         .into_rows_result()

--- a/test/cluster/docker-compose-passauth.yml
+++ b/test/cluster/docker-compose-passauth.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - "9042:9042"
     healthcheck:
-      test: [ "CMD", "cqlsh", "scylla", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla", "-e", "select * from system.local WHERE key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 60

--- a/test/cluster/docker-compose.yml
+++ b/test/cluster/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       --smp 2
       --memory 1G
     healthcheck:
-      test: [ "CMD", "cqlsh", "scylla1", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla1", "-e", "select * from system.local WHERE key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 60
@@ -41,7 +41,7 @@ services:
       --smp 2
       --memory 1G
     healthcheck:
-      test: [ "CMD", "cqlsh", "scylla2", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla2", "-e", "select * from system.local WHERE key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 60
@@ -62,7 +62,7 @@ services:
       --smp 2
       --memory 1G
     healthcheck:
-      test: [ "CMD", "cqlsh", "scylla3", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla3", "-e", "select * from system.local WHERE key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 60

--- a/test/tls/docker-compose-tls.yml
+++ b/test/tls/docker-compose-tls.yml
@@ -22,7 +22,7 @@ services:
       - "9042:9042"
       - "9142:9142"
     healthcheck:
-      test: [ "CMD", "cqlsh", "scylla", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "scylla", "-e", "select * from system.local WHERE key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 60


### PR DESCRIPTION
Full scan requests are slower even if there is only one record.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1244

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
