### PR TITLE
Proxy: compresssion support

### DIFF
--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -22,12 +22,12 @@ use response::ResponseOpcode;
 
 const HEADER_SIZE: usize = 9;
 
-mod flag {
+pub mod flag {
     //! Frame flags
-    pub(crate) const COMPRESSION: u8 = 0x01;
-    pub(crate) const TRACING: u8 = 0x02;
-    pub(crate) const CUSTOM_PAYLOAD: u8 = 0x04;
-    pub(crate) const WARNING: u8 = 0x08;
+    pub const COMPRESSION: u8 = 0x01;
+    pub const TRACING: u8 = 0x02;
+    pub const CUSTOM_PAYLOAD: u8 = 0x04;
+    pub const WARNING: u8 = 0x08;
 }
 
 // All of the Authenticators supported by Scylla
@@ -240,7 +240,7 @@ pub fn parse_response_body_extensions(
     })
 }
 
-fn compress_append(
+pub fn compress_append(
     uncomp_body: &[u8],
     compression: Compression,
     out: &mut Vec<u8>,
@@ -266,7 +266,7 @@ fn compress_append(
     }
 }
 
-fn decompress(
+pub fn decompress(
     mut comp_body: &[u8],
     compression: Compression,
 ) -> Result<Vec<u8>, FrameBodyExtensionsParseError> {

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -14,6 +14,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 use uuid::Uuid;
 
 use std::fmt::Display;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{collections::HashMap, convert::TryFrom};
 
@@ -54,6 +55,27 @@ impl Compression {
         match self {
             Compression::Lz4 => "lz4",
             Compression::Snappy => "snappy",
+        }
+    }
+}
+
+/// Unknown compression.
+#[derive(Error, Debug, Clone)]
+#[error("Unknown compression: {name}")]
+pub struct CompressionFromStrError {
+    name: String,
+}
+
+impl FromStr for Compression {
+    type Err = CompressionFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lz4" => Ok(Self::Lz4),
+            "snappy" => Ok(Self::Snappy),
+            other => Err(Self::Err {
+                name: other.to_owned(),
+            }),
         }
     }
 }

--- a/scylla-cql/src/frame/request/startup.rs
+++ b/scylla-cql/src/frame/request/startup.rs
@@ -9,6 +9,8 @@ use crate::{
     frame::types,
 };
 
+use super::DeserializableRequest;
+
 pub struct Startup<'a> {
     pub options: HashMap<Cow<'a, str>, Cow<'a, str>>,
 }
@@ -30,4 +32,16 @@ pub enum StartupSerializationError {
     /// Failed to serialize startup options.
     #[error("Malformed startup options: {0}")]
     OptionsSerialization(TryFromIntError),
+}
+
+impl DeserializableRequest for Startup<'_> {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, super::RequestDeserializationError> {
+        // Note: this is inefficient, but it's only used for tests and it's not common
+        // to deserialize STARTUP frames anyway.
+        let options = types::read_string_map(buf)?
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        Ok(Self { options })
+    }
 }

--- a/scylla-proxy/src/errors.rs
+++ b/scylla-proxy/src/errors.rs
@@ -4,6 +4,12 @@ use scylla_cql::frame::frame_errors::{FrameHeaderParseError, LowLevelDeserializa
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+pub enum ReadFrameError {
+    #[error("Failed to read frame header: {0}")]
+    Header(#[from] FrameHeaderParseError),
+}
+
+#[derive(Debug, Error)]
 pub enum DoorkeeperError {
     #[error("Listen on {0} failed with {1}")]
     Listen(SocketAddr, std::io::Error),
@@ -20,7 +26,7 @@ pub enum DoorkeeperError {
     #[error("Could not send Options frame for obtaining shards number: {0}")]
     ObtainingShardNumber(std::io::Error),
     #[error("Could not send read Supported frame for obtaining shards number: {0}")]
-    ObtainingShardNumberFrame(FrameHeaderParseError),
+    ObtainingShardNumberFrame(ReadFrameError),
     #[error("Could not read Supported options: {0}")]
     ObtainingShardNumberParseOptions(LowLevelDeserializationError),
     #[error("ShardInfo parameters missing")]

--- a/scylla-proxy/src/errors.rs
+++ b/scylla-proxy/src/errors.rs
@@ -1,12 +1,16 @@
 use std::net::SocketAddr;
 
-use scylla_cql::frame::frame_errors::{FrameHeaderParseError, LowLevelDeserializationError};
+use scylla_cql::frame::frame_errors::{
+    FrameBodyExtensionsParseError, FrameHeaderParseError, LowLevelDeserializationError,
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ReadFrameError {
     #[error("Failed to read frame header: {0}")]
     Header(#[from] FrameHeaderParseError),
+    #[error("Failed to decompress frame: {0}")]
+    Compression(#[from] FrameBodyExtensionsParseError),
 }
 
 #[derive(Debug, Error)]

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -321,7 +321,9 @@ pub(crate) async fn read_frame(
         }
     }
 
-    Ok((frame_params, opcode, body.into_inner().into()))
+    let body = compression.maybe_decompress_body(flags, body.into_inner().into())?;
+
+    Ok((frame_params, opcode, body))
 }
 
 pub(crate) async fn read_request_frame(

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -62,12 +62,14 @@ impl RequestFrame {
     pub(crate) async fn write(
         &self,
         writer: &mut (impl AsyncWrite + Unpin),
+        compression: &CompressionReader,
     ) -> Result<(), tokio::io::Error> {
         write_frame(
             self.params,
             FrameOpcode::Request(self.opcode),
             &self.body,
             writer,
+            compression,
         )
         .await
     }
@@ -136,12 +138,14 @@ impl ResponseFrame {
     pub(crate) async fn write(
         &self,
         writer: &mut (impl AsyncWrite + Unpin),
+        compression: &CompressionReader,
     ) -> Result<(), tokio::io::Error> {
         write_frame(
             self.params,
             FrameOpcode::Response(self.opcode),
             &self.body,
             writer,
+            compression,
         )
         .await
     }
@@ -235,6 +239,7 @@ pub(crate) async fn write_frame(
     opcode: FrameOpcode,
     body: &[u8],
     writer: &mut (impl AsyncWrite + Unpin),
+    compression: &CompressionReader,
 ) -> Result<(), tokio::io::Error> {
     let mut header = [0; HEADER_SIZE];
 

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -22,13 +22,13 @@ pub struct FrameParams {
 }
 
 impl FrameParams {
-    pub fn for_request(&self) -> FrameParams {
+    pub const fn for_request(&self) -> FrameParams {
         Self {
             version: self.version & 0x7F,
             ..*self
         }
     }
-    pub fn for_response(&self) -> FrameParams {
+    pub const fn for_response(&self) -> FrameParams {
         Self {
             version: 0x80 | (self.version & 0x7F),
             ..*self

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -48,7 +48,7 @@ pub(crate) enum FrameOpcode {
     Response(ResponseOpcode),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RequestFrame {
     pub params: FrameParams,
     pub opcode: RequestOpcode,
@@ -73,7 +73,7 @@ impl RequestFrame {
         Request::deserialize(&mut &self.body[..], self.opcode)
     }
 }
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResponseFrame {
     pub params: FrameParams,
     pub opcode: ResponseOpcode,

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -56,7 +56,7 @@ pub struct RequestFrame {
 }
 
 impl RequestFrame {
-    pub async fn write(
+    pub(crate) async fn write(
         &self,
         writer: &mut (impl AsyncWrite + Unpin),
     ) -> Result<(), tokio::io::Error> {

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -241,6 +241,12 @@ pub(crate) async fn write_frame(
     writer: &mut (impl AsyncWrite + Unpin),
     compression: &CompressionReader,
 ) -> Result<(), tokio::io::Error> {
+    let compressed_body = compression
+        .maybe_compress_body(params.flags, body)
+        .map_err(|e| tokio::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    let body = compressed_body.as_deref().unwrap_or(body);
+
     let mut header = [0; HEADER_SIZE];
 
     header[0] = params.version;

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -230,7 +230,7 @@ fn serialize_error_specific_fields(
 pub(crate) async fn write_frame(
     params: FrameParams,
     opcode: FrameOpcode,
-    body: &Bytes,
+    body: &[u8],
     writer: &mut (impl AsyncWrite + Unpin),
 ) -> Result<(), tokio::io::Error> {
     let mut header = [0; HEADER_SIZE];

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -2008,7 +2008,7 @@ mod tests {
         let node1_real_addr = next_local_address_with_port(9876);
         let node1_proxy_addr = next_local_address_with_port(9876);
 
-        let delay = Duration::from_millis(30);
+        let delay = Duration::from_millis(60);
 
         let proxy = Proxy::new([Node::new(
             node1_real_addr,

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -946,10 +946,10 @@ impl ProxyWorker {
                             })?;
 
                     debug!(
-                        "Intercepted Cluster ({}) -> Driver ({}) ({}) frame. opcode: {:?}.",
+                        "Intercepted Cluster ({}) ({}) -> Driver ({}) frame. opcode: {:?}.",
                         real_addr,
-                        driver_addr,
                         DisplayableShard(shard),
+                        driver_addr,
                         &frame.opcode
                     );
 
@@ -988,10 +988,10 @@ impl ProxyWorker {
                     };
 
                     debug!(
-                        "Sending Proxy ({}) -> Driver ({}) ({}) frame. opcode: {:?}.",
+                        "Sending Proxy ({}) ({}) -> Driver ({}) frame. opcode: {:?}.",
                         proxy_addr,
-                        driver_addr,
                         DisplayableShard(shard),
+                        driver_addr,
                         &response.opcode
                     );
                     if response.write(&mut write_half).await.is_err() {

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1294,6 +1294,7 @@ pub fn get_exclusive_local_address() -> IpAddr {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::ReadFrameError;
     use crate::frame::{read_frame, read_request_frame, FrameType};
     use crate::{
         setup_tracing, Condition, Reaction as _, RequestReaction, ResponseOpcode, ResponseReaction,
@@ -1302,7 +1303,6 @@ mod tests {
     use bytes::{BufMut, BytesMut};
     use futures::future::{join, join3};
     use rand::RngCore;
-    use scylla_cql::frame::frame_errors::FrameHeaderParseError;
     use scylla_cql::frame::types::write_string_multimap;
     use std::collections::HashMap;
     use std::mem;
@@ -1721,7 +1721,7 @@ mod tests {
             params: FrameParams,
             opcode: FrameOpcode,
             body: &Bytes,
-        ) -> Result<RequestFrame, FrameHeaderParseError> {
+        ) -> Result<RequestFrame, ReadFrameError> {
             let (send_res, recv_res) = join(
                 write_frame(params, opcode, &body.clone(), driver),
                 read_request_frame(node),
@@ -1836,7 +1836,7 @@ mod tests {
             params: FrameParams,
             opcode: FrameOpcode,
             body: &Bytes,
-        ) -> Result<RequestFrame, FrameHeaderParseError> {
+        ) -> Result<RequestFrame, ReadFrameError> {
             let (send_res, recv_res) = join(
                 write_frame(params, opcode, &body.clone(), driver),
                 read_request_frame(node),

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -2404,7 +2404,7 @@ mod tests {
             write_frame(
                 params,
                 FrameOpcode::Request(req_opcode),
-                &(body_base.to_string() + "|request|").into(),
+                (body_base.to_string() + "|request|").as_bytes(),
                 client_socket_ref,
             )
             .await
@@ -2418,7 +2418,7 @@ mod tests {
             write_frame(
                 params.for_response(),
                 FrameOpcode::Response(resp_opcode),
-                &(body_base.to_string() + "|response|").into(),
+                (body_base.to_string() + "|response|").as_bytes(),
                 server_socket_ref,
             )
             .await

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1595,7 +1595,7 @@ mod tests {
         let mock_node_listener = TcpListener::bind(node1_real_addr).await.unwrap();
 
         let params1 = FrameParams {
-            flags: 3,
+            flags: 2,
             version: 0x42,
             stream: 42,
         };
@@ -2141,7 +2141,7 @@ mod tests {
         let running_proxy = proxy.run().await.unwrap();
 
         let params1 = FrameParams {
-            flags: 3,
+            flags: 2,
             version: 0x42,
             stream: 42,
         };


### PR DESCRIPTION
# Motivation

During hackathon, there emerged a need to test compressed communication through proxy. However, proxy did not yet support compression.

# What's done

## `scylla-cql` compression utilities

### Exposed some `scylla-cql` compression utilities
These are now used by the proxy.

### New impls
- `impl FromStr for Compression`
- `impl DeserializableRequest for Startup`

The impls are used by the proxy to read the negotiated compression from STARTUP frame.

## Minor proxy fixes / features

### `impl (Partial)Eq for {Request,Response}Frame`
It's convenient to be able to compare the whole frame at once.

### Fixed some debug prints
Before, they printed the shard number next to the driver, not the node, which was confusing.

### Stopped abusing `COMPRESSED` frame flag in tests randomly
    
Some tests just set random CQL flags and assert that they are simply passed through the proxy. It used to work, but as now we make the proxy clever enough to interpret at least one of them, namely the compression flag, we needed to stop abusing it blindly.

### Combat timing-based flakiness
    
The test `proxy_processes_requests_concurrently` showed to be flaky on my machine. As its timeout there was arbitrarily tight, I increased it.

## Compression abstractions

`CompressionReader` and `CompressionWriter` work in tandem to propagate the compression that the driver negociated with the node (in STARTUP frame) across the proxy connection workers.

- `CompressionWriter` is used by the `request_processor` to set the compression globally for the whole bunch of proxy workers for that connection once a STARTUP message is intercepted.
- `CompressionReader` is used by all workers that perform ser/de (`{sender_to,receiver_from}_{driver,cluster}`) to (de)compress frames as they come. **Proxy always stores the frames and feeds them into feedback channels in the decompressed form, so that it is for example possible to use `Condition`s based on uncompressed body contents.**

##  Unit test for compression mechanisms in the proxy
    
Outline of the test:
1. "driver" sends an, uncompressed, e.g., QUERY frame, feedback returns its uncompressed body, and "node" receives the uncompressed frame.
2. "node" responds with an uncompressed RESULT frame, feedback returns its uncompressed body, and "driver" receives the uncompressed frame.
3. "driver" sends an uncompressed STARTUP frame, feedback returns its uncompressed body, and "node" receives the uncompressed frame.
4. "driver" sends a compressed, e.g., QUERY frame, feedback returns its uncompressed body, and "node" receives the compressed frame.
5. "node" responds with a compressed RESULT frame, feedback returns its uncompressed body, and "driver" receives the compressed frame.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
