### PR TITLE
Refactor `ColumnSpecs` and adjust `PreparedStatement` API

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -646,7 +646,7 @@ impl QueryPager {
     pub fn type_check<'frame, 'metadata, RowT: DeserializeRow<'frame, 'metadata>>(
         &self,
     ) -> Result<(), TypeCheckError> {
-        RowT::type_check(self.column_specs().inner())
+        RowT::type_check(self.column_specs().as_slice())
     }
 
     /// Casts the iterator to a given row type, enabling [Stream]'ed operations

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -955,7 +955,7 @@ impl QueryPager {
 
     /// Returns specification of row columns
     #[inline]
-    pub fn column_specs(&self) -> ColumnSpecs<'_> {
+    pub fn column_specs(&self) -> ColumnSpecs<'_, '_> {
         ColumnSpecs::new(self.current_page.metadata().col_specs())
     }
 

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -18,11 +18,13 @@ pub struct ColumnSpecs<'slice, 'spec> {
 }
 
 impl<'slice, 'spec> ColumnSpecs<'slice, 'spec> {
-    pub(crate) fn new(specs: &'slice [ColumnSpec<'spec>]) -> Self {
+    /// Creates new [`ColumnSpecs`] wrapper from a slice.
+    pub fn new(specs: &'slice [ColumnSpec<'spec>]) -> Self {
         Self { specs }
     }
 
-    pub(crate) fn inner(&self) -> &'slice [ColumnSpec<'spec>] {
+    /// Returns a slice of col specs encompassed by this struct.
+    pub fn as_slice(&self) -> &'slice [ColumnSpec<'spec>] {
         self.specs
     }
 

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -79,16 +79,19 @@ impl<'res> ColumnSpecView<'res> {
 
 /// A view over specification of columns returned by the database.
 #[derive(Debug, Clone, Copy)]
-pub struct ColumnSpecs<'res> {
-    specs: &'res [ColumnSpec<'res>],
+pub struct ColumnSpecs<'slice, 'spec> {
+    specs: &'slice [ColumnSpec<'spec>],
 }
 
-impl<'res> ColumnSpecs<'res> {
-    pub(crate) fn new(specs: &'res [ColumnSpec<'res>]) -> Self {
+impl<'slice, 'spec> ColumnSpecs<'slice, 'spec>
+where
+    'slice: 'spec,
+{
+    pub(crate) fn new(specs: &'slice [ColumnSpec<'spec>]) -> Self {
         Self { specs }
     }
 
-    pub(crate) fn inner(&self) -> &'res [ColumnSpec<'res>] {
+    pub(crate) fn inner(&self) -> &'slice [ColumnSpec<'spec>] {
         self.specs
     }
 
@@ -101,13 +104,13 @@ impl<'res> ColumnSpecs<'res> {
 
     /// Returns specification of k-th column returned from the database.
     #[inline]
-    pub fn get_by_index(&self, k: usize) -> Option<ColumnSpecView<'res>> {
+    pub fn get_by_index(&self, k: usize) -> Option<ColumnSpecView<'spec>> {
         self.specs.get(k).map(ColumnSpecView::new_from_column_spec)
     }
 
     /// Returns specification of the column with given name returned from the database.
     #[inline]
-    pub fn get_by_name(&self, name: &str) -> Option<(usize, ColumnSpecView<'res>)> {
+    pub fn get_by_name(&self, name: &str) -> Option<(usize, ColumnSpecView<'spec>)> {
         self.specs
             .iter()
             .enumerate()
@@ -118,7 +121,7 @@ impl<'res> ColumnSpecs<'res> {
     /// Returns iterator over specification of columns returned from the database,
     /// ordered by column order in the response.
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = ColumnSpecView<'res>> {
+    pub fn iter(&self) -> impl Iterator<Item = ColumnSpecView<'spec>> {
         self.specs.iter().map(ColumnSpecView::new_from_column_spec)
     }
 }
@@ -316,7 +319,7 @@ impl QueryRowsResult {
 
     /// Returns column specifications.
     #[inline]
-    pub fn column_specs(&self) -> ColumnSpecs {
+    pub fn column_specs(&self) -> ColumnSpecs<'_, '_> {
         ColumnSpecs::new(self.raw_rows_with_metadata.metadata().col_specs())
     }
 

--- a/scylla/src/statement/prepared_statement.rs
+++ b/scylla/src/statement/prepared_statement.rs
@@ -19,6 +19,7 @@ use crate::frame::response::result::PreparedMetadata;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::observability::history::HistoryListener;
 use crate::policies::retry::RetryPolicy;
+use crate::response::query_result::ColumnSpecs;
 use crate::routing::partitioner::{Partitioner, PartitionerHasher, PartitionerName};
 use crate::routing::Token;
 
@@ -398,8 +399,8 @@ impl PreparedStatement {
     }
 
     /// Access column specifications of the bind variables of this statement
-    pub fn get_variable_col_specs(&self) -> &[ColumnSpec<'static>] {
-        &self.shared.metadata.col_specs
+    pub fn get_variable_col_specs(&self) -> ColumnSpecs<'_, 'static> {
+        ColumnSpecs::new(&self.shared.metadata.col_specs)
     }
 
     /// Access info about partition key indexes of the bind variables of this statement
@@ -413,8 +414,8 @@ impl PreparedStatement {
     }
 
     /// Access column specifications of the result set returned after the execution of this statement
-    pub fn get_result_set_col_specs(&self) -> &[ColumnSpec<'static>] {
-        self.shared.result_metadata.col_specs()
+    pub fn get_result_set_col_specs(&self) -> ColumnSpecs<'_, 'static> {
+        ColumnSpecs::new(self.shared.result_metadata.col_specs())
     }
 
     /// Get the name of the partitioner used for this statement.

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -17,5 +17,6 @@ mod shards;
 mod silent_prepare_batch;
 mod silent_prepare_query;
 mod skip_metadata_optimization;
+mod statement;
 mod tablets;
 pub(crate) mod utils;

--- a/scylla/tests/integration/statement.rs
+++ b/scylla/tests/integration/statement.rs
@@ -1,0 +1,57 @@
+use scylla::cluster::metadata::{ColumnType, NativeType};
+use scylla::frame::response::result::{ColumnSpec, TableSpec};
+
+use crate::utils::{create_new_session_builder, setup_tracing, unique_keyspace_name, PerformDDL};
+
+#[tokio::test]
+async fn test_prepared_statement_col_specs() {
+    setup_tracing();
+    let session = create_new_session_builder().build().await.unwrap();
+
+    let ks = unique_keyspace_name();
+    session
+        .ddl(format!(
+            "CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = 
+            {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}",
+            ks
+        ))
+        .await
+        .unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
+
+    session
+        .ddl(
+            "CREATE TABLE t (k1 int, k2 varint, c1 timestamp,
+            a tinyint, b text, c smallint, PRIMARY KEY ((k1, k2), c1))",
+        )
+        .await
+        .unwrap();
+
+    let spec = |name: &'static str, typ: ColumnType<'static>| -> ColumnSpec<'_> {
+        ColumnSpec::borrowed(name, typ, TableSpec::borrowed(&ks, "t"))
+    };
+
+    let prepared = session
+        .prepare("SELECT * FROM t WHERE k1 = ? AND k2 = ? AND c1 > ?")
+        .await
+        .unwrap();
+
+    let variable_col_specs = prepared.get_variable_col_specs().as_slice();
+    let expected_variable_col_specs = &[
+        spec("k1", ColumnType::Native(NativeType::Int)),
+        spec("k2", ColumnType::Native(NativeType::Varint)),
+        spec("c1", ColumnType::Native(NativeType::Timestamp)),
+    ];
+    assert_eq!(variable_col_specs, expected_variable_col_specs);
+
+    let result_set_col_specs = prepared.get_result_set_col_specs().as_slice();
+    let expected_result_set_col_specs = &[
+        spec("k1", ColumnType::Native(NativeType::Int)),
+        spec("k2", ColumnType::Native(NativeType::Varint)),
+        spec("c1", ColumnType::Native(NativeType::Timestamp)),
+        spec("a", ColumnType::Native(NativeType::TinyInt)),
+        spec("b", ColumnType::Native(NativeType::Text)),
+        spec("c", ColumnType::Native(NativeType::SmallInt)),
+    ];
+    assert_eq!(result_set_col_specs, expected_result_set_col_specs);
+}


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1132

## Motivation
The motivation is described in the issue - TLDR, there is a return type discrepancy between `PreparedStatement` and `QueryRowsResult/QueryPager` methods.

## What changed:
- refactored `ColumnSpecs` wrapper - adjusted it to two lifetimes so it can be used in `PreparedStatement`'s API
- removed `ColumnSpecView` and `TableSpecView` - these are redundant
- adjusted `PreparedStatement` API to `ColumnSpecs`
- introduced a small integration test case for `PreparedStatement` metadata. The methods used to get col specs (bind markers and result set) were not tested anywhere.

## Why I decided to not remove `ColumnSpecs`?
Originally, I (others as well - based on the discussion in the issue) wanted to remove `ColumnSpecs` wrapper. But then, when I did that and started to adjust the test cases, I noticed that `get_by_name` method is really handy. When having a raw slice, user needs to do multiple chained calls on iterator. I believe that `ColumnSpecs` API is user friendly.

Since I decided to not remove `ColumnSpecs`, I also pubified its constructor and deconstructor (conversion back to slice). My only concern is that if we ever decide to change the structure of `ColumnSpecs`, it may require some API breaking changes. This can be discussed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
