### PR TITLE
Remove SerializedValues from public API of `scylla` crate.

### DIFF
--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -507,7 +507,7 @@ impl SerializedValues {
     pub const EMPTY: &'static SerializedValues = &SerializedValues::new();
 
     /// Constructs `SerializedValues` from given [`SerializeRow`] object.
-    pub fn from_serializable<T: SerializeRow>(
+    pub fn from_serializable<T: SerializeRow + ?Sized>(
         ctx: &RowSerializationContext,
         row: &T,
     ) -> Result<Self, SerializationError> {

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -52,13 +52,6 @@ impl<'a> RowSerializationContext<'a> {
     pub fn columns(&self) -> &'a [ColumnSpec] {
         self.columns
     }
-
-    /// Looks up and returns a column/bind marker by name.
-    // TODO: change RowSerializationContext to make this faster
-    #[inline]
-    pub fn column_by_name(&self, target: &str) -> Option<&ColumnSpec> {
-        self.columns.iter().find(|&c| c.name() == target)
-    }
 }
 
 /// Represents a set of values that can be sent along a CQL statement.

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -39,6 +39,7 @@ full-serialization = [
     "num-bigint-04",
     "bigdecimal-04",
 ]
+unstable-testing = []
 
 [dependencies]
 scylla-macros = { version = "0.7.0", path = "../scylla-macros" }
@@ -96,6 +97,7 @@ time = "0.3"
 [[bench]]
 name = "benchmark"
 harness = false
+required-features = ["unstable-testing"]
 
 [lints.rust]
 unnameable_types = "warn"

--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -1,7 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use bytes::BytesMut;
-use scylla::routing::partitioner::{calculate_token_for_partition_key, PartitionerName};
+use scylla::internal_testing::calculate_token_for_partition_key;
+use scylla::routing::partitioner::PartitionerName;
 use scylla_cql::frame::response::result::{ColumnType, NativeType};
 use scylla_cql::frame::types;
 use scylla_cql::serialize::row::SerializedValues;

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -218,9 +218,6 @@ async fn test_prepared_statement() {
         .unwrap();
 
     let values = (17_i32, 16_i32, "I'm prepared!!!");
-    let serialized_values_complex_pk = prepared_complex_pk_statement
-        .serialize_values(&values)
-        .unwrap();
 
     session
         .execute_unpaged(&prepared_statement, &values)
@@ -245,12 +242,9 @@ async fn test_prepared_statement() {
         let prepared_token = Murmur3Partitioner
             .hash_one(&prepared_statement.compute_partition_key(&values).unwrap());
         assert_eq!(token, prepared_token);
-        let mut pk = SerializedValues::new();
-        pk.add_value(&17_i32, &ColumnType::Native(NativeType::Int))
-            .unwrap();
         let cluster_state_token = session
             .get_cluster_state()
-            .compute_token(&ks, "t2", &pk)
+            .compute_token(&ks, "t2", &(values.0,))
             .unwrap();
         assert_eq!(token, cluster_state_token);
     }
@@ -272,7 +266,7 @@ async fn test_prepared_statement() {
         assert_eq!(token, prepared_token);
         let cluster_state_token = session
             .get_cluster_state()
-            .compute_token(&ks, "complex_pk", &serialized_values_complex_pk)
+            .compute_token(&ks, "complex_pk", &values)
             .unwrap();
         assert_eq!(token, cluster_state_token);
     }
@@ -608,7 +602,6 @@ async fn test_token_calculation() {
             s.push('a');
         }
         let values = (&s,);
-        let serialized_values = prepared_statement.serialize_values(&values).unwrap();
         session
             .execute_unpaged(&prepared_statement, &values)
             .await
@@ -631,7 +624,7 @@ async fn test_token_calculation() {
         assert_eq!(token, prepared_token);
         let cluster_state_token = session
             .get_cluster_state()
-            .compute_token(&ks, "t3", &serialized_values)
+            .compute_token(&ks, "t3", &values)
             .unwrap();
         assert_eq!(token, cluster_state_token);
     }

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -197,7 +197,11 @@ pub struct Keyspace {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Table {
     pub columns: HashMap<String, Column>,
+    /// Names of the column of partition key. 
+    /// All of the names are guaranteed to be present in `columns` field.
     pub partition_key: Vec<String>,
+    /// Names of the column of clustering key. 
+    /// All of the names are guaranteed to be present in `columns` field.
     pub clustering_key: Vec<String>,
     pub partitioner: Option<String>,
 }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -198,6 +198,12 @@ impl ClusterState {
     }
 
     /// Compute token of a table partition key
+    ///
+    /// `partition_key` argument contains the values of all partition key
+    /// columns. You can use both unnamed values like a tuple (e.g. `(1, 5, 5)`)
+    /// or named values (e.g. struct that derives `SerializeRow`), as you would
+    /// when executing a request. No additional values are allowed besides values
+    /// for primary key columns.
     pub fn compute_token(
         &self,
         keyspace: &str,
@@ -257,6 +263,12 @@ impl ClusterState {
     }
 
     /// Access to replicas owning a given partition key (similar to `nodetool getendpoints`)
+    ///
+    /// `partition_key` argument contains the values of all partition key
+    /// columns. You can use both unnamed values like a tuple (e.g. `(1, 5, 5)`)
+    /// or named values (e.g. struct that derives `SerializeRow`), as you would
+    /// when executing a request. No additional values are allowed besides values
+    /// for primary key columns.
     pub fn get_endpoints(
         &self,
         keyspace: &str,

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -12,6 +12,7 @@ use crate::frame::response;
 // Re-export error types from pager module.
 pub use crate::client::pager::{NextPageError, NextRowError};
 
+use crate::statement::prepared::TokenCalculationError;
 // Re-export error types from query_result module.
 pub use crate::response::query_result::{
     FirstRowError, IntoRowsResultError, MaybeFirstRowError, ResultNotRowsError, RowsError,
@@ -932,6 +933,23 @@ pub(crate) enum ResponseParseError {
     BodyExtensionsParseError(#[from] FrameBodyExtensionsParseError),
     #[error(transparent)]
     CqlResponseParseError(#[from] CqlResponseParseError),
+}
+
+/// Error returned from [ClusterState](crate::cluster::ClusterState) APIs.
+#[derive(Clone, Debug, Error)]
+#[non_exhaustive]
+pub enum ClusterStateTokenError {
+    /// Failed to calculate token.
+    #[error(transparent)]
+    TokenCalculation(#[from] TokenCalculationError),
+
+    /// Failed to serialize values required to compute partition key.
+    #[error(transparent)]
+    Serialization(#[from] SerializationError),
+
+    /// ClusterState doesn't currently have metadata for the requested table.
+    #[error("Can't find metadata for requested table ({keyspace}.{table}).")]
+    UnknownTable { keyspace: String, table: String },
 }
 
 #[cfg(test)]

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -163,10 +163,6 @@ pub mod serialize {
             BuiltinSerializationError, BuiltinSerializationErrorKind, BuiltinTypeCheckError,
             BuiltinTypeCheckErrorKind,
         };
-
-        // Not part of the old framework, but something that we should
-        // still aim to remove from public API.
-        pub use scylla_cql::serialize::row::{SerializedValues, SerializedValuesIterator};
     }
 
     /// Contains the [SerializeValue][value::SerializeValue] trait and its implementations.

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -257,3 +257,22 @@ pub(crate) mod utils;
 
 #[cfg(test)]
 pub(crate) use utils::test_utils;
+
+#[cfg(feature = "unstable-testing")]
+pub mod internal_testing {
+    use scylla_cql::serialize::row::SerializedValues;
+
+    use crate::routing::partitioner::PartitionerName;
+    use crate::routing::Token;
+    use crate::statement::prepared::TokenCalculationError;
+
+    pub fn calculate_token_for_partition_key(
+        serialized_partition_key_values: &SerializedValues,
+        partitioner: &PartitionerName,
+    ) -> Result<Token, TokenCalculationError> {
+        crate::routing::partitioner::calculate_token_for_partition_key(
+            serialized_partition_key_values,
+            partitioner,
+        )
+    }
+}

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -349,7 +349,7 @@ impl PartitionerHasher for CDCPartitionerHasher {
 ///
 /// NOTE: the provided values must completely constitute partition key
 /// and be in the order defined in CREATE TABLE statement.
-pub fn calculate_token_for_partition_key(
+pub(crate) fn calculate_token_for_partition_key(
     serialized_partition_key_values: &SerializedValues,
     partitioner: &PartitionerName,
 ) -> Result<Token, TokenCalculationError> {


### PR DESCRIPTION
Some APIs on ClusterState still accept SerializedValues instead of `impl SerializeRow` / `&dyn SerializeRow`.
This is a leftover from the old serialization API, and should be changed. Why? Because there is no easy way for the user to create the SerializedValues.
That means that if a user wants to calculate the token / replicas, for some partition key of some table they need to:
- Get the `Table` struct from `ClusterState`
- Create new SerializedValues
- Iterate over `partition_key` field and retrieve relevant `ColumnSpec`s from `columns` field.
- For each column, call `add_value` on the SerializedValues and handle the error
- Pass the result to `compute_token` / `get_endpoints`

This is a lot of unnecessary work.
This PR changes those methods to accepts `&dyn SerializeRow`.

As a small side change I removed `RowSerializationContext::column_by_name`.
Columns need to be serialized in order, so there is no reason to get the column out of order.
This is confirmed by this method being unused.

## Creating RowSerializationContext from Table

See the commit "Table: Add Vec of primary key column specs" for an explanation.
I'm not sure that the approach I've taken is the best one, so I'm open t suggestions in this matter.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1152

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
