### PR TITLE
Update `rand` crate 0.8.5 -> 0.9.0

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -651,7 +651,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -921,7 +933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -1266,20 +1278,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1287,18 +1299,19 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
  "rand_core",
 ]
@@ -1338,7 +1351,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.60",
 ]
@@ -2072,7 +2085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "atomic",
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2108,6 +2121,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2362,6 +2384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,7 +2422,16 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.34",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -2399,6 +2439,17 @@ name = "zerocopy-derive"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,7 +28,7 @@ uuid = { version = "1.0", features = ["v1"] }
 tower = "0.4"
 stats_alloc = "0.1"
 clap = { version = "3.2.4", features = ["derive"] }
-rand = "0.8.5"
+rand = "0.9.0"
 env_logger = "0.10"
 
 [[example]]

--- a/examples/custom_load_balancing_policy.rs
+++ b/examples/custom_load_balancing_policy.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rand::thread_rng;
+use rand::rng;
 use rand::Rng;
 use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
@@ -23,7 +23,7 @@ fn with_random_shard(node: NodeRef) -> (NodeRef, Option<Shard>) {
         .sharder()
         .map(|sharder| sharder.nr_shards.get())
         .unwrap_or(1);
-    (node, Some(thread_rng().gen_range(0..nr_shards) as Shard))
+    (node, Some(rng().random_range(0..nr_shards) as Shard))
 }
 
 impl LoadBalancingPolicy for CustomLoadBalancingPolicy {

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -33,7 +33,7 @@ bigdecimal = "0.4"
 num-bigint = "0.3"
 tracing = "0.1.25"
 chrono = { version = "0.4", default-features = false }
-rand = "0.8.5"
+rand = "0.9.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -105,7 +105,7 @@ impl Condition {
                 })
                 .unwrap_or(false),
             Condition::RandomWithProbability(probability) => {
-                rand::thread_rng().gen_bool(*probability)
+                rand::rng().random_bool(*probability)
             }
 
             Condition::TrueForLimitedTimes(times) => {
@@ -592,7 +592,7 @@ impl ResponseForger {
             || example_db_errors::other(2137),
         ];
         RequestReaction::forge_with_error_lazy_delay(
-            Box::new(|| ERRORS[rand::thread_rng().next_u32() as usize % ERRORS.len()]()),
+            Box::new(|| ERRORS[rand::rng().next_u32() as usize % ERRORS.len()]()),
             delay,
         )
     }

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1315,7 +1315,7 @@ mod tests {
     fn random_body() -> Bytes {
         let body_len = (rand::random::<u32>() % 1000) as usize;
         let mut body = BytesMut::zeroed(body_len);
-        rand::thread_rng().fill_bytes(body.as_mut());
+        rand::rng().fill_bytes(body.as_mut());
         body.freeze()
     }
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -58,7 +58,7 @@ tokio = { version = "1.34", features = [
 ] }
 snap = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
-rand = "0.8.3"
+rand = "0.9.0"
 thiserror = "2.0.6"
 itertools = "0.13.0"
 tracing = "0.1.36"
@@ -74,7 +74,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.9.14", optional = true }
 url = { version = "2.3.1", optional = true }
 base64 = { version = "0.22.1", optional = true }
-rand_pcg = "0.3.1"
+rand_pcg = "0.9.0"
 socket2 = { version = "0.5.3", features = ["all"] }
 lazy_static = "1"
 
@@ -88,7 +88,7 @@ criterion = "0.4"                                                      # Note: v
 tokio = { version = "1.34", features = ["test-util"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 assert_matches = "1.5.0"
-rand_chacha = "0.3.1"
+rand_chacha = "0.9.0"
 time = "0.3"
 
 [[bench]]

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -33,8 +33,8 @@ use crate::utils::pretty::{CommaSeparatedDisplayer, DisplayUsingDebug};
 use futures::future::{self, FutureExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::Stream;
-use rand::seq::SliceRandom;
-use rand::{thread_rng, Rng};
+use rand::seq::{IndexedRandom, SliceRandom};
+use rand::{rng, Rng};
 use scylla_macros::DeserializeRow;
 use std::borrow::BorrowMut;
 use std::cell::Cell;
@@ -416,7 +416,7 @@ impl MetadataReader {
 
         let control_connection_endpoint = UntranslatedEndpoint::ContactPoint(
             initial_peers
-                .choose(&mut thread_rng())
+                .choose(&mut rng())
                 .expect("Tried to initialize MetadataReader with empty initial_known_nodes list!")
                 .clone(),
         );
@@ -469,7 +469,7 @@ impl MetadataReader {
         // Therefore, we try to fetch metadata from other known peers, in order.
 
         // shuffle known_peers to iterate through them in random order later
-        self.known_peers.shuffle(&mut thread_rng());
+        self.known_peers.shuffle(&mut rng());
         debug!(
             "Known peers: {}",
             CommaSeparatedDisplayer(self.known_peers.iter().map(DisplayUsingDebug))
@@ -641,7 +641,7 @@ impl MetadataReader {
                 if !self.known_peers.is_empty() {
                     self.control_connection_endpoint = self
                         .known_peers
-                        .choose(&mut thread_rng())
+                        .choose(&mut rng())
                         .expect("known_peers is empty - should be impossible")
                         .clone();
 
@@ -856,7 +856,7 @@ async fn create_peer_from_row(
             // Also, we could implement support for Cassandra's other standard partitioners
             // like RandomPartitioner or ByteOrderedPartitioner.
             trace!("Couldn't parse tokens as 64-bit integers: {}, proceeding with a dummy token. If you're using a partitioner with different token size, consider migrating to murmur3", e);
-            vec![Token::new(rand::thread_rng().gen::<i64>())]
+            vec![Token::new(rand::rng().random::<i64>())]
         }
     };
 

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -284,7 +284,7 @@ impl NodeConnectionPool {
                 sharder,
                 connections,
             } => {
-                let shard: u16 = rand::thread_rng().gen_range(0..sharder.nr_shards.get());
+                let shard: u16 = rand::rng().random_range(0..sharder.nr_shards.get());
                 Self::connection_for_shard_helper(shard, sharder.nr_shards, connections.as_slice())
             }
         })
@@ -308,7 +308,7 @@ impl NodeConnectionPool {
 
         let orig_shard = shard;
         while !shards_to_try.is_empty() {
-            let idx = rand::thread_rng().gen_range(0..shards_to_try.len());
+            let idx = rand::rng().random_range(0..shards_to_try.len());
             let shard = shards_to_try.swap_remove(idx);
 
             if let Some(conn) =
@@ -381,7 +381,7 @@ impl NodeConnectionPool {
         } else if v.len() == 1 {
             Some(v[0].clone())
         } else {
-            let idx = rand::thread_rng().gen_range(0..v.len());
+            let idx = rand::rng().random_range(0..v.len());
             Some(v[idx].clone())
         }
     }

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -11,7 +11,7 @@ use crate::{
     routing::{Shard, Token},
 };
 use itertools::{Either, Itertools};
-use rand::{prelude::SliceRandom, thread_rng, Rng};
+use rand::{prelude::SliceRandom, rng, Rng};
 use rand_pcg::Pcg32;
 use scylla_cql::frame::response::result::TableSpec;
 use scylla_cql::frame::types::SerialConsistency;
@@ -815,7 +815,7 @@ impl DefaultPolicy {
             let mut gen = Pcg32::new(fixed, 0);
             replica_set.choose_filtered(&mut gen, |(node, shard)| predicate(node, *shard))
         } else {
-            replica_set.choose_filtered(&mut thread_rng(), |(node, shard)| predicate(node, *shard))
+            replica_set.choose_filtered(&mut rng(), |(node, shard)| predicate(node, *shard))
         }
     }
 
@@ -853,7 +853,7 @@ impl DefaultPolicy {
         // Create a randomly rotated slice view
         let nodes_len = nodes.len();
         if nodes_len > 0 {
-            let index = rand::thread_rng().gen_range(0..nodes_len); // gen_range() panics when range is empty!
+            let index = rng().random_range(0..nodes_len); // gen_range() panics when range is empty!
             Either::Left(
                 nodes[index..]
                     .iter()
@@ -896,7 +896,7 @@ impl DefaultPolicy {
             let mut gen = Pcg32::new(fixed, 0);
             vec.shuffle(&mut gen);
         } else {
-            vec.shuffle(&mut thread_rng());
+            vec.shuffle(&mut rng());
         }
 
         vec.into_iter()

--- a/scylla/src/policies/load_balancing/plan.rs
+++ b/scylla/src/policies/load_balancing/plan.rs
@@ -1,4 +1,4 @@
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use tracing::error;
 
 use super::{FallbackPlan, LoadBalancingPolicy, NodeRef, RoutingInfo};
@@ -98,7 +98,7 @@ impl<'a> Plan<'a> {
                     .sharder()
                     .map(|sharder| sharder.nr_shards.get())
                     .unwrap_or(1);
-                thread_rng().gen_range(0..nr_shards).into()
+                rng().random_range(0..nr_shards).into()
             }),
         )
     }

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -364,7 +364,7 @@ impl<'a> ReplicaSet<'a> {
     {
         let len = self.len();
         if len > 0 {
-            let index = rng.gen_range(0..len);
+            let index = rng.random_range(0..len);
 
             match &self.inner {
                 ReplicaSetInner::Plain(replicas) => replicas

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -433,7 +433,7 @@ mod tests {
                 partitioner.write(data);
             } else {
                 let pivot = if !data.is_empty() {
-                    randgen.gen_range(0..data.len())
+                    randgen.random_range(0..data.len())
                 } else {
                     0
                 };

--- a/scylla/src/routing/sharding.rs
+++ b/scylla/src/routing/sharding.rs
@@ -66,8 +66,8 @@ impl Sharder {
     /// Randomly choose a source port `p` such that `shard == shard_of_source_port(p)`.
     pub fn draw_source_port_for_shard(&self, shard: Shard) -> u16 {
         assert!(shard < self.nr_shards.get() as u32);
-        rand::thread_rng()
-            .gen_range((49152 + self.nr_shards.get() - 1)..(65535 - self.nr_shards.get() + 1))
+        rand::rng()
+            .random_range((49152 + self.nr_shards.get() - 1)..(65535 - self.nr_shards.get() + 1))
             / self.nr_shards.get()
             * self.nr_shards.get()
             + shard as u16


### PR DESCRIPTION
Also updates the following to align versions and avoid duplicates in transitive dependencies
* `rand_pcg` 0.3.1 -> 0.9.0
* `rand_chacha` 0.3.1 -> 0.9.0

MSRV for all changes is 1.63, so should hopefully be good

I'm currently trying to reduce the number of duplicate dependencies to reduce some bloat in my projects, and `rand` is one of them.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
