### PR TITLE
Fix Clippy lints introduced in Clippy 0.1.85

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1796,9 +1796,8 @@ impl Session {
         let result = match effective_timeout {
             Some(timeout) => tokio::time::timeout(timeout, runner)
                 .await
-                .map(|res| res.map_err(RequestError::from))
                 .unwrap_or_else(|_| Err(RequestError::RequestTimeout(timeout))),
-            None => runner.await.map_err(RequestError::from),
+            None => runner.await,
         };
 
         if let Some((history_listener, request_id)) = history_listener_and_id {


### PR DESCRIPTION
Clippy 0.1.85 (introduced in Rust 1.85.0) adds or updates a few lints, causing builds to fail.

In particular the changes to the `clippy::useless_conversion` lint from https://github.com/rust-lang/rust-clippy/pull/13756
and `clippy::precedence` lint changed https://github.com/rust-lang/rust-clippy/pull/13743 are causing issues.

The precedence fix changes things that could impact functionality, so tests were added. I have not run any benchmarks, but https://godbolt.org/z/j78fETzbT seems to indicate better codegen with the new code.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
