### PR TITLE
mark metadata public structs as `non_exhaustive`

### DIFF
--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -183,7 +183,9 @@ impl Peer {
     }
 }
 
+/// Describes a keyspace in the cluster.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Keyspace {
     pub strategy: Strategy,
     /// Empty HashMap may as well mean that the client disabled schema fetching in SessionConfig
@@ -194,7 +196,9 @@ pub struct Keyspace {
     pub user_defined_types: HashMap<String, Arc<UserDefinedType<'static>>>,
 }
 
+/// Describes a table in the cluster.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Table {
     pub columns: HashMap<String, Column>,
     /// Names of the column of partition key.
@@ -207,13 +211,17 @@ pub struct Table {
     pub(crate) pk_column_specs: Vec<ColumnSpec<'static>>,
 }
 
+/// Describes a materialized view in the cluster.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct MaterializedView {
     pub view_metadata: Table,
     pub base_table_name: String,
 }
 
+/// Describes a column of the table.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Column {
     pub typ: ColumnType<'static>,
     pub kind: ColumnKind,
@@ -315,6 +323,7 @@ impl PreCollectionType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ColumnKind {
     Regular,
     Static,
@@ -341,6 +350,7 @@ impl std::str::FromStr for ColumnKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 #[allow(clippy::enum_variant_names)]
 pub enum Strategy {
     SimpleStrategy {

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -152,13 +152,12 @@ impl UntranslatedEndpoint {
 /// Data used to issue connections to a node.
 ///
 /// Fetched from the cluster in Metadata.
-#[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
 #[derive(Clone, Debug)]
-pub struct PeerEndpoint {
-    pub host_id: Uuid,
-    pub address: NodeAddr,
-    pub datacenter: Option<String>,
-    pub rack: Option<String>,
+pub(crate) struct PeerEndpoint {
+    pub(crate) host_id: Uuid,
+    pub(crate) address: NodeAddr,
+    pub(crate) datacenter: Option<String>,
+    pub(crate) rack: Option<String>,
 }
 
 impl Peer {


### PR DESCRIPTION
I decided to introduce getters for (and un-pub the fields of) `Keyspace` and `Table`. I think these are the structs whose current fields may be modified in the future.

Remaining types (`ColumnKind`, `Column`, `MaterializedView` and `Strategy`) are simple enough for me to believe we won't need to modify their current fields/variants in the future. OTOH, we want to be able to introduce new fields/variants in the future - thus I marked them as `non_exhaustive`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
