### PR TITLE
Make metrics collection optional/faster

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,8 @@ jobs:
     # Various (de)serialization features.
     - name: Cargo check with all serialization features
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "full-serialization"
+    - name: Cargo check with metrics feature
+      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "metrics"
     - name: Cargo check with secrecy-08 feature
       run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secrecy-08"
     - name: Cargo check with chrono-04 feature

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -822,9 +822,12 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "histogram"
-version = "0.6.9"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+checksum = "58cf6b99a250776d813cdf2f0b478a053a822d078e7a2baf5cb36afc88c41a7c"
+dependencies = [
+ "thiserror 1.0.60",
+]
 
 [[package]]
 name = "home"

--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -1,5 +1,7 @@
 # Driver metrics
 
+This feature is available only under the crate feature `metrics`.
+
 During operation the driver collects various metrics.
 
 They can be accessed at any moment using `Session::get_metrics()`
@@ -11,6 +13,9 @@ They can be accessed at any moment using `Session::get_metrics()`
 * Total number of paged queries
 * Number of errors during paged queries
 * Number of retries
+* Latency histogram statistics (min, max, mean, standard deviation, percentiles)
+* Rates of queries per second in various time frames
+* Number of active connections, and connection and request timeouts
 
 ### Example
 ```rust
@@ -24,11 +29,32 @@ println!("Queries requested: {}", metrics.get_queries_num());
 println!("Iter queries requested: {}", metrics.get_queries_iter_num());
 println!("Errors occurred: {}", metrics.get_errors_num());
 println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
-println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
+println!("Average latency: {}", metrics.get_latency_avg_ms()?);
 println!(
     "99.9 latency percentile: {}",
-    metrics.get_latency_percentile_ms(99.9).unwrap()
+    metrics.get_latency_percentile_ms(99.9)?
 );
+
+let snapshot = metrics.get_snapshot()?;
+println!("Min: {}", snapshot.min);
+println!("Max: {}", snapshot.max);
+println!("Mean: {}", snapshot.mean);
+println!("Standard deviation: {}", snapshot.stddev);
+println!("Median: {}", snapshot.median);
+println!("75th percentile: {}", snapshot.percentile_75);
+println!("95th percentile: {}", snapshot.percentile_95);
+println!("98th percentile: {}", snapshot.percentile_98);
+println!("99th percentile: {}", snapshot.percentile_99);
+println!("99.9th percentile: {}", snapshot.percentile_99_9);
+
+println!("Mean rate: {}", metrics.get_mean_rate());
+println!("One minute rate: {}", metrics.get_one_minute_rate());
+println!("Five minute rate: {}", metrics.get_five_minute_rate());
+println!("Fifteen minute rate: {}", metrics.get_fifteen_minute_rate());
+
+println!("Total connections: {}", metrics.get_total_connections());
+println!("Connection timeouts: {}", metrics.get_connection_timeouts());
+println!("Requests timeouts: {}", metrics.get_request_timeouts());
 # Ok(())
 # }
 ```

--- a/docs/source/speculative-execution/percentile.md
+++ b/docs/source/speculative-execution/percentile.md
@@ -4,6 +4,8 @@ This policy has access to `Metrics` shared with session, and triggers
 speculative execution when the request to the current host is above a
 given percentile.
 
+This policy requires enabling crate feature `"metrics"` to be available.
+
 
 ### Example
 To use this policy in `Session`:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ scylla = { path = "../scylla", features = [
     "num-bigint-03",
     "num-bigint-04",
     "bigdecimal-04",
+    "metrics",
 ] }
 tokio = { version = "1.34", features = ["full"] }
 tracing = { version = "0.1.25", features = ["log"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -94,11 +94,32 @@ async fn main() -> Result<()> {
     println!("Iter queries requested: {}", metrics.get_queries_iter_num());
     println!("Errors occurred: {}", metrics.get_errors_num());
     println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
-    println!("Average latency: {}", metrics.get_latency_avg_ms().unwrap());
+    println!("Average latency: {}", metrics.get_latency_avg_ms()?);
     println!(
         "99.9 latency percentile: {}",
-        metrics.get_latency_percentile_ms(99.9).unwrap()
+        metrics.get_latency_percentile_ms(99.9)?
     );
+
+    let snapshot = metrics.get_snapshot()?;
+    println!("Min: {}", snapshot.min);
+    println!("Max: {}", snapshot.max);
+    println!("Mean: {}", snapshot.mean);
+    println!("Standard deviation: {}", snapshot.stddev);
+    println!("Median: {}", snapshot.median);
+    println!("75th percentile: {}", snapshot.percentile_75);
+    println!("95th percentile: {}", snapshot.percentile_95);
+    println!("98th percentile: {}", snapshot.percentile_98);
+    println!("99th percentile: {}", snapshot.percentile_99);
+    println!("99.9th percentile: {}", snapshot.percentile_99_9);
+
+    println!("Mean rate: {}", metrics.get_mean_rate());
+    println!("One minute rate: {}", metrics.get_one_minute_rate());
+    println!("Five minute rate: {}", metrics.get_five_minute_rate());
+    println!("Fifteen minute rate: {}", metrics.get_fifteen_minute_rate());
+
+    println!("Total connections: {}", metrics.get_total_connections());
+    println!("Connection timeouts: {}", metrics.get_connection_timeouts());
+    println!("Requests timeouts: {}", metrics.get_request_timeouts());
 
     println!("Ok.");
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -39,6 +39,7 @@ full-serialization = [
     "num-bigint-04",
     "bigdecimal-04",
 ]
+metrics = ["dep:histogram"]
 unstable-testing = []
 
 [dependencies]
@@ -47,7 +48,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
-histogram = "0.11.1"
+histogram = { version = "0.11.1", optional = true }
 tokio = { version = "1.34", features = [
     "net",
     "time",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -47,7 +47,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
-histogram = "0.6.9"
+histogram = "0.11.1"
 tokio = { version = "1.34", features = [
     "net",
     "time",

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -24,6 +24,7 @@ use crate::errors::{
 };
 use crate::frame::response::event::Event;
 use crate::network::{Connection, ConnectionConfig, NodeConnectionPool, PoolConfig, PoolSize};
+use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::Token;
 use crate::statement::unprepared::Statement;
@@ -104,6 +105,8 @@ pub(crate) struct MetadataReader {
     // When a control connection breaks, the PoolRefiller of its pool uses the requester
     // to signal ClusterWorker that an immediate metadata refresh is advisable.
     control_connection_repair_requester: broadcast::Sender<()>,
+
+    metrics: Arc<Metrics>,
 }
 
 /// Describes all metadata retrieved from the cluster
@@ -422,6 +425,7 @@ impl MetadataReader {
         keyspaces_to_fetch: Vec<String>,
         fetch_schema: bool,
         host_filter: &Option<Arc<dyn HostFilter>>,
+        metrics: Arc<Metrics>,
     ) -> Result<Self, NewSessionError> {
         let (initial_peers, resolved_hostnames) =
             resolve_contact_points(&initial_known_nodes).await;
@@ -459,6 +463,7 @@ impl MetadataReader {
             control_connection_endpoint.clone(),
             &control_connection_pool_config,
             control_connection_repair_requester.clone(),
+            metrics.clone(),
         );
 
         Ok(MetadataReader {
@@ -474,6 +479,7 @@ impl MetadataReader {
             host_filter: host_filter.clone(),
             initial_known_nodes,
             control_connection_repair_requester,
+            metrics,
         })
     }
 
@@ -575,6 +581,7 @@ impl MetadataReader {
                 self.control_connection_endpoint.clone(),
                 &self.control_connection_pool_config,
                 self.control_connection_repair_requester.clone(),
+                Arc::clone(&self.metrics),
             );
 
             debug!(
@@ -673,6 +680,7 @@ impl MetadataReader {
                         self.control_connection_endpoint.clone(),
                         &self.control_connection_pool_config,
                         self.control_connection_repair_requester.clone(),
+                        Arc::clone(&self.metrics),
                     );
                 }
             }
@@ -683,8 +691,9 @@ impl MetadataReader {
         endpoint: UntranslatedEndpoint,
         pool_config: &PoolConfig,
         refresh_requester: broadcast::Sender<()>,
+        metrics: Arc<Metrics>,
     ) -> NodeConnectionPool {
-        NodeConnectionPool::new(endpoint, pool_config, None, refresh_requester)
+        NodeConnectionPool::new(endpoint, pool_config, None, refresh_requester, metrics)
     }
 }
 

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -24,6 +24,7 @@ use crate::errors::{
 };
 use crate::frame::response::event::Event;
 use crate::network::{Connection, ConnectionConfig, NodeConnectionPool, PoolConfig, PoolSize};
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::Token;
@@ -106,6 +107,7 @@ pub(crate) struct MetadataReader {
     // to signal ClusterWorker that an immediate metadata refresh is advisable.
     control_connection_repair_requester: broadcast::Sender<()>,
 
+    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 }
 
@@ -425,7 +427,7 @@ impl MetadataReader {
         keyspaces_to_fetch: Vec<String>,
         fetch_schema: bool,
         host_filter: &Option<Arc<dyn HostFilter>>,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Result<Self, NewSessionError> {
         let (initial_peers, resolved_hostnames) =
             resolve_contact_points(&initial_known_nodes).await;
@@ -463,6 +465,7 @@ impl MetadataReader {
             control_connection_endpoint.clone(),
             &control_connection_pool_config,
             control_connection_repair_requester.clone(),
+            #[cfg(feature = "metrics")]
             metrics.clone(),
         );
 
@@ -479,6 +482,7 @@ impl MetadataReader {
             host_filter: host_filter.clone(),
             initial_known_nodes,
             control_connection_repair_requester,
+            #[cfg(feature = "metrics")]
             metrics,
         })
     }
@@ -581,6 +585,7 @@ impl MetadataReader {
                 self.control_connection_endpoint.clone(),
                 &self.control_connection_pool_config,
                 self.control_connection_repair_requester.clone(),
+                #[cfg(feature = "metrics")]
                 Arc::clone(&self.metrics),
             );
 
@@ -680,6 +685,7 @@ impl MetadataReader {
                         self.control_connection_endpoint.clone(),
                         &self.control_connection_pool_config,
                         self.control_connection_repair_requester.clone(),
+                        #[cfg(feature = "metrics")]
                         Arc::clone(&self.metrics),
                     );
                 }
@@ -691,9 +697,16 @@ impl MetadataReader {
         endpoint: UntranslatedEndpoint,
         pool_config: &PoolConfig,
         refresh_requester: broadcast::Sender<()>,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> NodeConnectionPool {
-        NodeConnectionPool::new(endpoint, pool_config, None, refresh_requester, metrics)
+        NodeConnectionPool::new(
+            endpoint,
+            pool_config,
+            None,
+            refresh_requester,
+            #[cfg(feature = "metrics")]
+            metrics,
+        )
     }
 }
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -7,6 +7,7 @@ use crate::errors::{ConnectionPoolError, UseKeyspaceError};
 use crate::network::Connection;
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{NodeConnectionPool, PoolConfig};
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 /// Node represents a cluster node along with it's data and connections
 use crate::routing::{Shard, Sharder};
@@ -100,7 +101,7 @@ impl Node {
         pool_config: &PoolConfig,
         keyspace_name: Option<VerifiedKeyspaceName>,
         enabled: bool,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Self {
         let host_id = peer.host_id;
         let address = peer.address;
@@ -115,6 +116,7 @@ impl Node {
                 pool_config,
                 keyspace_name,
                 pool_empty_notifier,
+                #[cfg(feature = "metrics")]
                 metrics,
             )
         });

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -89,13 +89,7 @@ pub struct Node {
 pub type NodeRef<'a> = &'a Arc<Node>;
 
 impl Node {
-    /// Creates new node which starts connecting in the background
-    /// # Arguments
-    ///
-    /// `address` - address to connect to
-    /// `compression` - preferred compression to use
-    /// `datacenter` - optional datacenter name
-    /// `rack` - optional rack name
+    /// Creates a new node which starts connecting in the background.
     pub(crate) fn new(
         peer: PeerEndpoint,
         pool_config: &PoolConfig,

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -7,6 +7,7 @@ use crate::errors::{ConnectionPoolError, UseKeyspaceError};
 use crate::network::Connection;
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{NodeConnectionPool, PoolConfig};
+use crate::observability::metrics::Metrics;
 /// Node represents a cluster node along with it's data and connections
 use crate::routing::{Shard, Sharder};
 
@@ -99,6 +100,7 @@ impl Node {
         pool_config: &PoolConfig,
         keyspace_name: Option<VerifiedKeyspaceName>,
         enabled: bool,
+        metrics: Arc<Metrics>,
     ) -> Self {
         let host_id = peer.host_id;
         let address = peer.address;
@@ -113,6 +115,7 @@ impl Node {
                 pool_config,
                 keyspace_name,
                 pool_empty_notifier,
+                metrics,
             )
         });
 

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,5 +1,6 @@
 use crate::errors::{ClusterStateTokenError, ConnectionPoolError};
 use crate::network::{Connection, PoolConfig, VerifiedKeyspaceName};
+use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::locator::tablets::{RawTablet, Tablet, TabletsInfo};
 use crate::routing::locator::ReplicaLocator;
@@ -56,6 +57,7 @@ impl ClusterState {
 
     /// Creates new ClusterState using information about topology held in `metadata`.
     /// Uses provided `known_peers` hashmap to recycle nodes if possible.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         metadata: Metadata,
         pool_config: &PoolConfig,
@@ -64,6 +66,7 @@ impl ClusterState {
         host_filter: Option<&dyn HostFilter>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
+        metrics: &Arc<Metrics>,
     ) -> Self {
         // Create new updated known_peers and ring
         let mut new_known_peers: HashMap<Uuid, Arc<Node>> =
@@ -98,6 +101,7 @@ impl ClusterState {
                         pool_config,
                         used_keyspace.clone(),
                         is_enabled,
+                        Arc::clone(metrics),
                     ))
                 }
             };

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,5 +1,6 @@
 use crate::errors::{ClusterStateTokenError, ConnectionPoolError};
 use crate::network::{Connection, PoolConfig, VerifiedKeyspaceName};
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::locator::tablets::{RawTablet, Tablet, TabletsInfo};
@@ -66,7 +67,7 @@ impl ClusterState {
         host_filter: Option<&dyn HostFilter>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
-        metrics: &Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: &Arc<Metrics>,
     ) -> Self {
         // Create new updated known_peers and ring
         let mut new_known_peers: HashMap<Uuid, Arc<Node>> =
@@ -101,6 +102,7 @@ impl ClusterState {
                         pool_config,
                         used_keyspace.clone(),
                         is_enabled,
+                        #[cfg(feature = "metrics")]
                         Arc::clone(metrics),
                     ))
                 }

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -2,6 +2,7 @@ use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::frame::response::event::{Event, StatusChangeEvent};
 use crate::network::{PoolConfig, VerifiedKeyspaceName};
+use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::locator::tablets::{RawTablet, TabletsInfo};
 
@@ -79,6 +80,8 @@ struct ClusterWorker {
     // This value determines how frequently the cluster
     // worker will refresh the cluster metadata
     cluster_metadata_refresh_interval: Duration,
+
+    metrics: Arc<Metrics>,
 }
 
 #[derive(Debug)]
@@ -93,6 +96,7 @@ struct UseKeyspaceRequest {
 }
 
 impl Cluster {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         known_nodes: Vec<InternalKnownNode>,
         pool_config: PoolConfig,
@@ -101,6 +105,7 @@ impl Cluster {
         host_filter: Option<Arc<dyn HostFilter>>,
         cluster_metadata_refresh_interval: Duration,
         tablet_receiver: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
+        metrics: Arc<Metrics>,
     ) -> Result<Cluster, NewSessionError> {
         let (refresh_sender, refresh_receiver) = tokio::sync::mpsc::channel(32);
         let (use_keyspace_sender, use_keyspace_receiver) = tokio::sync::mpsc::channel(32);
@@ -116,6 +121,7 @@ impl Cluster {
             keyspaces_to_fetch,
             fetch_schema_metadata,
             &host_filter,
+            Arc::clone(&metrics),
         )
         .await?;
 
@@ -128,6 +134,7 @@ impl Cluster {
             host_filter.as_deref(),
             TabletsInfo::new(),
             &HashMap::new(),
+            &metrics,
         )
         .await;
         cluster_state.wait_until_all_pools_are_initialized().await;
@@ -150,6 +157,8 @@ impl Cluster {
 
             host_filter,
             cluster_metadata_refresh_interval,
+
+            metrics,
         };
 
         let (fut, worker_handle) = worker.work().remote_handle();
@@ -412,6 +421,7 @@ impl ClusterWorker {
                 self.host_filter.as_deref(),
                 cluster_state.locator.tablets.clone(),
                 &cluster_state.keyspaces,
+                &self.metrics,
             )
             .await,
         );

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -2,6 +2,7 @@ use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::frame::response::event::{Event, StatusChangeEvent};
 use crate::network::{PoolConfig, VerifiedKeyspaceName};
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::locator::tablets::{RawTablet, TabletsInfo};
@@ -81,6 +82,7 @@ struct ClusterWorker {
     // worker will refresh the cluster metadata
     cluster_metadata_refresh_interval: Duration,
 
+    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 }
 
@@ -105,7 +107,7 @@ impl Cluster {
         host_filter: Option<Arc<dyn HostFilter>>,
         cluster_metadata_refresh_interval: Duration,
         tablet_receiver: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Result<Cluster, NewSessionError> {
         let (refresh_sender, refresh_receiver) = tokio::sync::mpsc::channel(32);
         let (use_keyspace_sender, use_keyspace_receiver) = tokio::sync::mpsc::channel(32);
@@ -121,6 +123,7 @@ impl Cluster {
             keyspaces_to_fetch,
             fetch_schema_metadata,
             &host_filter,
+            #[cfg(feature = "metrics")]
             Arc::clone(&metrics),
         )
         .await?;
@@ -134,6 +137,7 @@ impl Cluster {
             host_filter.as_deref(),
             TabletsInfo::new(),
             &HashMap::new(),
+            #[cfg(feature = "metrics")]
             &metrics,
         )
         .await;
@@ -158,6 +162,7 @@ impl Cluster {
             host_filter,
             cluster_metadata_refresh_interval,
 
+            #[cfg(feature = "metrics")]
             metrics,
         };
 
@@ -421,6 +426,7 @@ impl ClusterWorker {
                 self.host_filter.as_deref(),
                 cluster_state.locator.tablets.clone(),
                 &cluster_state.keyspaces,
+                #[cfg(feature = "metrics")]
                 &self.metrics,
             )
             .await,

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -10,6 +10,7 @@ use crate::routing::{Shard, ShardCount, Sharder};
 
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
 
+#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 
 use crate::cluster::NodeAddr;
@@ -195,7 +196,7 @@ impl NodeConnectionPool {
         pool_config: &PoolConfig,
         current_keyspace: Option<VerifiedKeyspaceName>,
         pool_empty_notifier: broadcast::Sender<()>,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Self {
         let (use_keyspace_request_sender, use_keyspace_request_receiver) = mpsc::channel(1);
         let pool_updated_notify = Arc::new(Notify::new());
@@ -210,6 +211,7 @@ impl NodeConnectionPool {
             current_keyspace,
             pool_updated_notify.clone(),
             pool_empty_notifier,
+            #[cfg(feature = "metrics")]
             metrics,
         );
 
@@ -489,6 +491,7 @@ struct PoolRefiller {
     // Signaled when the connection pool becomes empty
     pool_empty_notifier: broadcast::Sender<()>,
 
+    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 }
 
@@ -505,7 +508,7 @@ impl PoolRefiller {
         current_keyspace: Option<VerifiedKeyspaceName>,
         pool_updated_notify: Arc<Notify>,
         pool_empty_notifier: broadcast::Sender<()>,
-        metrics: Arc<Metrics>,
+        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Self {
         // At the beginning, we assume the node does not have any shards
         // and assume that the node is a Cassandra node
@@ -535,6 +538,7 @@ impl PoolRefiller {
             pool_updated_notify,
             pool_empty_notifier,
 
+            #[cfg(feature = "metrics")]
             metrics,
         }
     }
@@ -873,6 +877,7 @@ impl PoolRefiller {
         let cfg = self.pool_config.connection_config.clone();
         let mut endpoint = self.endpoint.read().unwrap().clone();
 
+        #[cfg(feature = "metrics")]
         let count_in_metrics = {
             let metrics = Arc::clone(&self.metrics);
             move |connect_result: &Result<_, ConnectionError>| {
@@ -898,6 +903,7 @@ impl PoolRefiller {
                 )
                 .await;
 
+                #[cfg(feature = "metrics")]
                 count_in_metrics(&result);
 
                 OpenedConnectionEvent {
@@ -911,6 +917,7 @@ impl PoolRefiller {
                 let non_shard_aware_endpoint = endpoint;
                 let result = open_connection(&non_shard_aware_endpoint, None, &cfg).await;
 
+                #[cfg(feature = "metrics")]
                 count_in_metrics(&result);
 
                 OpenedConnectionEvent {
@@ -989,6 +996,7 @@ impl PoolRefiller {
             match maybe_idx {
                 Some(idx) => {
                     v.swap_remove(idx);
+                    #[cfg(feature = "metrics")]
                     self.metrics.dec_total_connections();
                     true
                 }

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -209,6 +209,9 @@ pub struct Metrics {
     retries_num: AtomicU64,
     histogram: Arc<AtomicHistogram>,
     meter: Arc<RequestRateMeter>,
+    total_connections: AtomicU64,
+    connection_timeouts: AtomicU64,
+    request_timeouts: AtomicU64,
 }
 
 impl Metrics {
@@ -242,6 +245,28 @@ impl Metrics {
     /// Increments counter measuring how many times a retry policy has decided to retry a query
     pub(crate) fn inc_retries_num(&self) {
         self.retries_num.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Increments counter for active number of connections to the cluster.
+    /// Should be called when opening new connections, once per connection.
+    pub(crate) fn inc_total_connections(&self) {
+        self.total_connections.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Decrements counter for number of active connections to the cluster.
+    /// Should be called when closing the connections, once per connection.
+    pub(crate) fn dec_total_connections(&self) {
+        self.total_connections.fetch_sub(1, ORDER_TYPE);
+    }
+
+    /// Increments counter for timeouts for new connections to the cluster.
+    pub(crate) fn inc_connection_timeouts(&self) {
+        self.connection_timeouts.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Increments counter for client request timeouts.
+    pub(crate) fn inc_request_timeouts(&self) {
+        self.request_timeouts.fetch_add(1, ORDER_TYPE);
     }
 
     /// Saves to histogram latency of completing single query.
@@ -359,6 +384,21 @@ impl Metrics {
         self.meter.fifteen_minute_rate()
     }
 
+    /// Returns total number of active connections
+    pub fn get_total_connections(&self) -> u64 {
+        self.total_connections.load(ORDER_TYPE)
+    }
+
+    /// Returns counter for connection timeouts
+    pub fn get_connection_timeouts(&self) -> u64 {
+        self.connection_timeouts.load(ORDER_TYPE)
+    }
+
+    /// Returns counter for request timeouts
+    pub fn get_request_timeouts(&self) -> u64 {
+        self.request_timeouts.load(ORDER_TYPE)
+    }
+
     // Metric implementations
 
     // histogram crate used to implement Histogram::mean() method. Why did they remove it?
@@ -466,6 +506,9 @@ impl Default for Metrics {
             retries_num: AtomicU64::new(0),
             histogram: Arc::new(AtomicHistogram::new(grouping_power, max_value_power).unwrap()),
             meter: Arc::new(RequestRateMeter::new()),
+            total_connections: AtomicU64::new(0),
+            connection_timeouts: AtomicU64::new(0),
+            request_timeouts: AtomicU64::new(0),
         }
     }
 }
@@ -481,6 +524,9 @@ impl std::fmt::Debug for Metrics {
             .field("retries_num", &self.retries_num)
             .field("histogram", &h)
             .field("meter", &self.meter)
+            .field("total_connections", &self.total_connections)
+            .field("connection_timeouts", &self.connection_timeouts)
+            .field("request_timeouts", &self.request_timeouts)
             .finish()
     }
 }

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -1,46 +1,32 @@
-use histogram::Histogram;
+use histogram::{AtomicHistogram, Histogram};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use thiserror::Error;
 
 const ORDER_TYPE: Ordering = Ordering::Relaxed;
 
-#[derive(Debug)]
-pub struct MetricsError {
-    cause: &'static str,
+/// Error that occured upon a metrics operation.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum MetricsError {
+    #[error("Histogram error: {0}")]
+    HistogramError(#[from] Arc<dyn std::error::Error + Send + Sync>),
+    #[error("Histogram is empty")]
+    Empty,
 }
 
-impl From<&'static str> for MetricsError {
-    fn from(err: &'static str) -> MetricsError {
-        MetricsError { cause: err }
-    }
-}
-
-impl std::fmt::Display for MetricsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "metrics error: {}", self.cause)
-    }
-}
-
-#[derive(Default, Debug)]
 pub struct Metrics {
     errors_num: AtomicU64,
     queries_num: AtomicU64,
     errors_iter_num: AtomicU64,
     queries_iter_num: AtomicU64,
     retries_num: AtomicU64,
-    histogram: Arc<Mutex<Histogram>>,
+    histogram: Arc<AtomicHistogram>,
 }
 
 impl Metrics {
     pub fn new() -> Self {
-        Self {
-            errors_num: AtomicU64::new(0),
-            queries_num: AtomicU64::new(0),
-            errors_iter_num: AtomicU64::new(0),
-            queries_iter_num: AtomicU64::new(0),
-            retries_num: AtomicU64::new(0),
-            histogram: Arc::new(Mutex::new(Histogram::new())),
-        }
+        Metrics::default()
     }
 
     /// Increments counter for errors that occurred in nonpaged queries.
@@ -76,15 +62,16 @@ impl Metrics {
     ///
     /// * `latency` - time in milliseconds that should be logged
     pub(crate) fn log_query_latency(&self, latency: u64) -> Result<(), MetricsError> {
-        let mut histogram_unlocked = self.histogram.lock().unwrap();
-        histogram_unlocked.increment(latency)?;
-        Ok(())
+        if let Err(err) = self.histogram.increment(latency) {
+            Err(MetricsError::HistogramError(Arc::new(err)))
+        } else {
+            Ok(())
+        }
     }
 
     /// Returns average latency in milliseconds
     pub fn get_latency_avg_ms(&self) -> Result<u64, MetricsError> {
-        let histogram_unlocked = self.histogram.lock().unwrap();
-        Ok(histogram_unlocked.mean()?)
+        Self::mean(&self.histogram.load())
     }
 
     /// Returns latency from histogram for a given percentile
@@ -92,8 +79,15 @@ impl Metrics {
     ///
     /// * `percentile` - float value (0.0 - 100.0)
     pub fn get_latency_percentile_ms(&self, percentile: f64) -> Result<u64, MetricsError> {
-        let histogram_unlocked = self.histogram.lock().unwrap();
-        Ok(histogram_unlocked.percentile(percentile)?)
+        let res = self.histogram.load().percentile(percentile);
+
+        match res {
+            Err(err) => Err(MetricsError::HistogramError(Arc::new(err))),
+
+            Ok(None) => Err(MetricsError::Empty),
+
+            Ok(Some(p)) => Ok(p.count()),
+        }
     }
 
     /// Returns counter for errors occurred in nonpaged queries
@@ -119,5 +113,73 @@ impl Metrics {
     /// Returns counter measuring how many times a retry policy has decided to retry a query
     pub fn get_retries_num(&self) -> u64 {
         self.retries_num.load(ORDER_TYPE)
+    }
+
+    // Metric implementations
+
+    // histogram crate used to implement Histogram::mean() method. Why did they remove it?
+    // Answer of brayniac, the maintainer of histogram crate:
+    //
+    // > The histogram has no way of providing a true mean. Do we use the lower or upper end
+    // > of the bucket range while calculating? Somewhere in the middle? It seems more appropriate
+    // > to let the caller decide how they want to deal with this detail. Same when determining
+    // > a percentile, the best we can do is return the Bucket where the percentile falls into its range.
+    // > It may depend on your use-case on what value to report. Previous assumptions of over-reporting
+    // > latencies by using the upper-edge of the bucket might not be appropriate for all use-cases.
+    fn mean(h: &Histogram) -> Result<u64, MetricsError> {
+        // Compute the mean (count each bucket as its interval's center).
+        let mut weighted_sum = 0_u128;
+        let mut count = 0_u128;
+
+        for bucket in h {
+            let mid = ((bucket.start() + bucket.end()) / 2) as u128;
+            weighted_sum += mid * bucket.count() as u128;
+            count += bucket.count() as u128;
+        }
+
+        if count != 0 {
+            Ok((weighted_sum / count) as u64)
+        } else {
+            Err(MetricsError::Empty)
+        }
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        // Configuration:
+        //  - exponent of max value: n = 16
+        //  - inverse exponent of relative error: p = 12,
+        //  - max value: N = 65535,
+        //  - relative error: e = 0.000244,
+        //  - total number of buckets: (n - p + 1) * 2^p = 20480,
+        //  - histogram size: 1.7 MiB.
+        // Reference for calculating these values:
+        //  - https://observablehq.com/@iopsystems/h2histogram
+        let max_value_power = 16;
+        let grouping_power = 12;
+
+        Self {
+            errors_num: AtomicU64::new(0),
+            queries_num: AtomicU64::new(0),
+            errors_iter_num: AtomicU64::new(0),
+            queries_iter_num: AtomicU64::new(0),
+            retries_num: AtomicU64::new(0),
+            histogram: Arc::new(AtomicHistogram::new(grouping_power, max_value_power).unwrap()),
+        }
+    }
+}
+
+impl std::fmt::Debug for Metrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let h = self.histogram.load();
+        f.debug_struct("Metrics")
+            .field("errors_num", &self.errors_num)
+            .field("queries_num", &self.queries_num)
+            .field("errors_iter_num", &self.errors_iter_num)
+            .field("queries_iter_num", &self.queries_iter_num)
+            .field("retries_num", &self.retries_num)
+            .field("histogram", &h)
+            .finish()
     }
 }

--- a/scylla/src/observability/mod.rs
+++ b/scylla/src/observability/mod.rs
@@ -7,5 +7,6 @@
 
 pub(crate) mod driver_tracing;
 pub mod history;
+#[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod tracing;

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1420,6 +1420,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                &Default::default(),
             )
             .await
         }
@@ -1451,6 +1452,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                &Default::default(),
             )
             .await
         }
@@ -2501,6 +2503,7 @@ mod tests {
             },
             TabletsInfo::new(),
             &HashMap::new(),
+            &Default::default(),
         )
         .await;
 

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1420,6 +1420,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                #[cfg(feature = "metrics")]
                 &Default::default(),
             )
             .await
@@ -1452,6 +1453,7 @@ mod tests {
                 None,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                #[cfg(feature = "metrics")]
                 &Default::default(),
             )
             .await
@@ -2503,6 +2505,7 @@ mod tests {
             },
             TabletsInfo::new(),
             &HashMap::new(),
+            #[cfg(feature = "metrics")]
             &Default::default(),
         )
         .await;

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -182,7 +182,13 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
     let mut ring: Vec<(Token, Arc<Node>)> = Vec::new();
 
     for peer in &metadata.peers {
-        let node = Arc::new(Node::new(peer.to_peer_endpoint(), &pool_config, None, true));
+        let node = Arc::new(Node::new(
+            peer.to_peer_endpoint(),
+            &pool_config,
+            None,
+            true,
+            Default::default(),
+        ));
 
         for token in &peer.tokens {
             ring.push((*token, node.clone()));

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -187,6 +187,7 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
             &pool_config,
             None,
             true,
+            #[cfg(feature = "metrics")]
             Default::default(),
         ));
 


### PR DESCRIPTION
This is a touch-up of #1147. Pasting the original cover letter below.
-------

This patch contains:
- Implementation of lock-free histogram with hot and cold bucket pools
- Introduction of crate feature "metrics" to make using them optional
- Functionality to gather latency statistics via histogram snapshots
- Implementation of [rates of queries per second](https://github.com/scylladb/cpp-driver/blob/9d6b05c9d4ebd0a6d7006af4df3e33fcdf956eeb/src/metrics.hpp#L39C1-L252C5) based on cpp-driver implementation.
- Initial implementation of connection metrics (changes required after review)

Fixes: #330

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
