### PR TITLE
Release 1.0.0

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.7.0"
+version = "1.0.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1699,7 +1699,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "0.15.0"
+version = "1.0.0"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ For planned future improvements, see our [Milestones].
 
 We invite you to discuss any issues and ask questions on the [ScyllaDB Forum] and the `#rust-driver` channel on [ScyllaDB Slack].
 
+## Version support
+
+The driver is considered production ready, hence its version is not 0.x.
+We do however acknowledge that the API will surely need some breaking changes in
+the future, which means it is not our goal to stay on 1.x forever - we will
+release new major version in the future.
+
+The API stability guarantee we provide is that we won't release new major
+versions very often.
+In case of 2.0, it won't be released earlier than 9 months after release 1.0.
+For further major versions this duration may be increased.
+
+After new major version is released, the previous major version will still
+receive bugfixes for some time (exact time is yet to be determined), but new
+features will only be developed for the latest major version.
+
 ## Supported Rust Versions
 
 Our driver's minimum supported Rust version (MSRV) is 1.70.0.

--- a/README.md
+++ b/README.md
@@ -71,12 +71,10 @@ For planned future improvements, see our [Milestones].
 We invite you to discuss any issues and ask questions on the [ScyllaDB Forum] and the `#rust-driver` channel on [ScyllaDB Slack].
 
 ## Supported Rust Versions
-Our driver's minimum supported Rust version (MSRV) is 1.70.0. Any changes:
-- Will be announced in release notes.
-- Before 1.0 will only happen in major releases.
-- After 1.0 will also happen in minor, but not patch releases.
 
-Exact MSRV policy after 1.0 is not yet decided.
+Our driver's minimum supported Rust version (MSRV) is 1.70.0.
+Changes to MSRV can only happen in major and minor relases, but not in patch releases.
+We will not bump MSRV to a Rust version that was released less than 6 months ago.
 
 ## Reference Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 This is a client-side driver for [ScyllaDB] written in pure Rust with a fully async API using [Tokio].
 Although optimized for ScyllaDB, the driver is also compatible with [Apache Cassandra®].
 
-**Note: this driver is officially supported but currently available in beta. Bug reports and pull requests are welcome!**
-
 ## Getting Started
 The [documentation book](https://rust-driver.docs.scylladb.com/stable/index.html) is a good place to get started. Another useful resource is the Rust and Scylla [lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University.
 

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "sphinx-docs"
 description = "ScyllaDB Documentation"
-version = "0.15"
+version = "1.0"
 authors = ["ScyllaDB Documentation Contributors"]
 package-mode = false
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,14 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ['v0.14.0', 'v0.15.1']
+TAGS = ['v0.15.1', 'v1.0.0']
 BRANCHES = ['main']
 # Set the latest version.
-LATEST_VERSION = 'v0.15.1'
+LATEST_VERSION = 'v1.0.0'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['main']
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ['v0.14.0']
+DEPRECATED_VERSIONS = ['v0.15.1']
 
 # -- General configuration
 

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "0.15"
+scylla = "1.0"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # Important: We use precise version of scylla-macros. This enables
 # us to make breaking changes in the doc(hidden) interfaces that are
 # used by macros.
-scylla-macros = { version = "=0.7.0", path = "../scylla-macros" }
+scylla-macros = { version = "=1.0.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 tokio = { version = "1.34", features = ["io-util", "time"] }

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+# Important: We use precise version of scylla-macros. This enables
+# us to make breaking changes in the doc(hidden) interfaces that are
+# used by macros.
 scylla-macros = { version = "=0.7.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 description = "CQL data types and primitives, for interacting with Scylla."

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "0.7.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 description = "proc macros for scylla async CQL driver"

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -22,11 +22,6 @@ proc-macro2 = "1.0"
 unnameable_types = "warn"
 unreachable_pub = "warn"
 
-# When bumping major version of scylla / scylla-cql, those dependencies
-# also need to be updated. Fortunately Cargo will yell very loudly if that
-# is not done.
-# When bumping minor versions of scylla / scylla-cql nothing bad will happen
-# if we forget to update versions here.
 [dev-dependencies]
-scylla = { version = "0.15.0", path = "../scylla"}
-scylla-cql = { version = "0.4.0", path = "../scylla-cql"}
+scylla = { path = "../scylla"}
+scylla-cql = { path = "../scylla-cql"}

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "0.4.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.0.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -43,7 +43,7 @@ metrics = ["dep:histogram"]
 unstable-testing = []
 
 [dependencies]
-scylla-cql = { version = "0.4.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.0.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "0.15.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"


### PR DESCRIPTION
This is a PR with changes for release 1.0.0. Its purpose is to make it possible to review the release notes, and changes to README.md.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/968
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/552

## Current release notes


The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 1.0.0,
an asynchronous CQL driver for Rust, optimized for Scylla, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 3.162k downloads on crates!
- over 612 GitHub stars!

## Stabilization

1.0 has a special meaning for Rust crates - it means that the crate is considered "API-stable" - however there is no specific definition of what it means to be "API-stable".
So what does it mean to us, and why did we release this version?
Up until now, we introduced breaking changes whenever we felt we could improve the API this way (sometimes we kept the old API for a bit, and provided a migration guide). This caused the vast majority of our releases to have to bump the major version number - we didn't reach minor version greater than "2" for a few years now. This is not a great situation for our users, because it means it is basically never possible to update the driver without adjusting their codebases.
At the same time we know that we can't (and don't want to) freeze the API forever - there are still many improvements we can make, and the databases (Scylla / Cassandra) are always changing, which sometimes requires breaking changes on our part (an example of this is Tablets feature in Scylla, which required us to change our load balancing APIs). This means we won't stay on 1.x forever.
We decided to stabilize the API by providing a guarantee regarding how long a breaking change won't occur, which will allows users to better allocate time for dealing with breakage. For the 1.0, we won't release 2.0 earlier than 9 months after 1.0 (but we may release it later). Until then we will release minor (1.x) versions. In 1.x versions we may of course introduce new APIs, and [deprecate](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) old ones, but there will be no breaking changes.
Two exceptions that may force us to release major versions quicker are:
- urgent security issues
- changes in Scylla / Cassandra that have to be supported by driver quickly and there is no way to implement them without a major version bump.

After releasing new major version (e.g. 2.0) we will continue to provide bugfixes (but no new features) for the previous major version (e.g. 1.0). The exact duration of such bugfix support will be provided after the new major version is released.

Additionally, 1.0 release signifies that we view the driver as production ready. It has been for a long time now, but the 0.x version number may have been suggesting otherwise to some people, and we don't want to send mixed signals.

## Changes

**New features / enhancements:**

- ⚠️ **[API-breaking]** Support for Rustls as a TLS provider was added. With this change you can connect to Scylla with TLS without having additional system C libraries installed! ([#1254](https://github.com/scylladb/scylla-rust-driver/pull/1254))
- Added Timestamp Generators. This is a user-customizable way of generating client-side timestamps for requests. ([#1128](https://github.com/scylladb/scylla-rust-driver/pull/1128))
- ⚠️ **[API-breaking]** Driver metrics performance was improved. Previously they used `Mutex` internally, causing performance problems because of contention. Now `AtomicHistogram` is used to avoid this problem. Additionally, metrics are now guarded by `metrics` feature, so that the users who don't need them don't have to pay the performance cost and introduce additional dependency. ([#1263](https://github.com/scylladb/scylla-rust-driver/pull/1263))
- Borrowed versions of CqlVarint and CqlDecimal were added. ([#1148](https://github.com/scylladb/scylla-rust-driver/pull/1148))
- ⚠️ **[API-breaking]** In metadata, MissingUserDefinedType is no longer part of `CqlType::UserDefinedType`. Now, in case of this (and some other errors) the metadata fetch for given keyspace will be aborted (and warning printed), returning previous version of this keyspace if possible. ([#1162](https://github.com/scylladb/scylla-rust-driver/pull/1162))
- Metadata fetching now verifies that partition key and clustering key indexes have no holes. Thanks to that the users now have guarantee that column names from `Table::partition_key` and `Table::clustering_key` are present in `Table::columns`. If this is not the case, fetch is failed only for this keyspace, as above. ([#1252](https://github.com/scylladb/scylla-rust-driver/pull/1252))
- ⚠️ **[API-breaking]** `Node::is_down` was made private, instead new method `Node::is_connected` was introduced. The old method has very misleading semantics. The new one tells if there are currently any driver connections opened to given node. ([#1196](https://github.com/scylladb/scylla-rust-driver/pull/1196))
- ⚠️ **[API-breaking]** Added partial `Vector` support. Driver can now correctly fetch metadata of tables with vector columns. Serializing / deserializing vector values will be added after 1.0. ([#1020](https://github.com/scylladb/scylla-rust-driver/pull/1020))
- `Display` was implemented for `CqlValue`. ([#1257](https://github.com/scylladb/scylla-rust-driver/pull/1257))
- ⚠️ **[API-breaking]** `rand` dependency was updated to 0.9.0. This is a breaking change, because a trait from `rand` appears in `ReplicaSet::choose_filtered` method. ([#1255](https://github.com/scylladb/scylla-rust-driver/pull/1255))
- Made all internal queries to `system.local` table use `WHERE key='local'` which should be a minor performance improvement. ([#1245](https://github.com/scylladb/scylla-rust-driver/pull/1245))
- Implemented `Debug` for `MaybeUnset`.  ([#1199](https://github.com/scylladb/scylla-rust-driver/pull/1199))

**Bug fixes:**

- `Debug` implementation on `CachingSession` was not usable due to unsatisfiable bounds. ([#1161](https://github.com/scylladb/scylla-rust-driver/pull/1161))
- ⚠️ **[API-breaking]** Our derive macros were not fully hygienic. This was discovered when migrating the hygiene test to new ser/deser frameworks. Issue was fixed, test was migrated and extended to cover more scenarios. Fixing hygiene required moving some modules in `scylla-cql`, so the change is breaking - but it should not affect users. ([#1176](https://github.com/scylladb/scylla-rust-driver/pull/1176))

**API cleanups / better types:**

- ⚠️ **[API-breaking]** Most of the driver module structure was reworked. Before most of the files were put in the non-descriptive "transport" module. Now our top-level modules are much more clear: `authentication`, `client`, `cluster`, `network`, `observability`, `policies`, `response`, `routing`, `statement`, `utils`. Some structs and method were also renamed as part of this effort. Unfortunately, this is a big change that will require users of our driver to update most of their `use` statements. ([#1163](https://github.com/scylladb/scylla-rust-driver/pull/1163), [#1187](https://github.com/scylladb/scylla-rust-driver/pull/1187))
- ⚠️ **[API-breaking]** `CqlType` was removed, and `ColumnType` is used in its place. To make this possible, `ColumnType` was heavily modified. ([#1166](https://github.com/scylladb/scylla-rust-driver/pull/1166))
- ⚠️ **[API-breaking]** Errors refactor, started a few versions ago, was finished. Credits to @muzarski for this incredible work. ([#1204](https://github.com/scylladb/scylla-rust-driver/pull/1204), [#1200](https://github.com/scylladb/scylla-rust-driver/pull/1200), [#1191](https://github.com/scylladb/scylla-rust-driver/pull/1191), [#1194](https://github.com/scylladb/scylla-rust-driver/pull/1194), [#1193](https://github.com/scylladb/scylla-rust-driver/pull/1193), [#1201](https://github.com/scylladb/scylla-rust-driver/pull/1201), [#1192](https://github.com/scylladb/scylla-rust-driver/pull/1192), [#1185](https://github.com/scylladb/scylla-rust-driver/pull/1185), [#1180](https://github.com/scylladb/scylla-rust-driver/pull/1180), [#1170](https://github.com/scylladb/scylla-rust-driver/pull/1170), [#1181](https://github.com/scylladb/scylla-rust-driver/pull/1181), [#1160](https://github.com/scylladb/scylla-rust-driver/pull/1160), [#1159](https://github.com/scylladb/scylla-rust-driver/pull/1159), [#1157](https://github.com/scylladb/scylla-rust-driver/pull/1157), [#1168](https://github.com/scylladb/scylla-rust-driver/pull/1168))
- ⚠️ **[API-breaking]** Old serialization and deserialization frameworks were fully removed, after being deprecated in previous version of the driver. ([#1184](https://github.com/scylladb/scylla-rust-driver/pull/1184))
- ⚠️ **[API-breaking]** After legacy APIs were removed it became clear that module structure of `scylla-cql` has a lot of problems. Many of them were addressed, which of course is a very breaking change. ([#1198](https://github.com/scylladb/scylla-rust-driver/pull/1198))
- ⚠️ **[API-breaking]** APIs related to TLS were refactored when adding support for Rustls. This will enable us to add further providers in the future without breaking backwards compatibility. ([#1254](https://github.com/scylladb/scylla-rust-driver/pull/1254))
- ⚠️ **[API-breaking]** `Query` was renamed to `Statement`.  ([#1250](https://github.com/scylladb/scylla-rust-driver/pull/1250))
- ⚠️ **[API-breaking]** Removed `SerializedValues` from public API of `scylla` crate. Functions using it were either changed to using `&dyn SerializeRow` or deemed unnecessary and removed from the public API.  Error types of `ClusterState` token calculation APIs were changed as part of this. ([#1252](https://github.com/scylladb/scylla-rust-driver/pull/1252))
- `ColumnSpecView` and `TableSpecView` were removed. `ColumnSpecs` received a second lifetime. `PreparedStatement::get_variable_col_specs` and `PreparedStatement::get_result_set_col_specs` now return `ColumnSpecs` to make it consistent with `QueryRowsResult` and `QueryPager`. ([#1249](https://github.com/scylladb/scylla-rust-driver/pull/1249))
- ⚠️ **[API-breaking]** Low-level partition APIs were made private. `PreparedStatement::get_partitioner_name()` was made `pub`. ([#1222](https://github.com/scylladb/scylla-rust-driver/pull/1222))
- ⚠️ **[API-breaking]** Marked various structures and enums `#[non_exhaustive]` because we may want to add new variants to them in the future. ([#1261](https://github.com/scylladb/scylla-rust-driver/pull/1261), [#1262](https://github.com/scylladb/scylla-rust-driver/pull/1262), [#1257](https://github.com/scylladb/scylla-rust-driver/pull/1257), [#1205](https://github.com/scylladb/scylla-rust-driver/pull/1205), [#1269](https://github.com/scylladb/scylla-rust-driver/pull/1269))
- ⚠️ **[API-breaking]** `RetryPolicy`-related APIs were adjusted to past naming changes in load balancing. ([#1202](https://github.com/scylladb/scylla-rust-driver/pull/1202))
- ⚠️ **[API-breaking]** Derive macro paths were made consistent, so that there is a single place to import a macro from. ([#1260](https://github.com/scylladb/scylla-rust-driver/pull/1260))
- ⚠️ **[API-breaking]** `ClusterState` now has getter and iterator for keyspaces, instead of exposing `HashMap<String, Keyspace>`. ([#1266](https://github.com/scylladb/scylla-rust-driver/pull/1266))
The two changes below are formally API-breaking, but are extremely unlikely to cause any breakage, so we don't mark them as such.
- Unpublished `PeerEndpoint`, because it was not used in any public API. ([#1261](https://github.com/scylladb/scylla-rust-driver/pull/1261))
- Removed `RowSerializationContext::column_by_name` because there is no probable use case that needs it. ([#1252](https://github.com/scylladb/scylla-rust-driver/pull/1252))

**Internal API cleanups/refactors:**

- Internal Session APIs were renamed to make them easier to understand. ([#1156](https://github.com/scylladb/scylla-rust-driver/pull/1156))

**Documentation:**

- Updated documentation theme to 1.8.5. ([#1175](https://github.com/scylladb/scylla-rust-driver/pull/1175), [#1174](https://github.com/scylladb/scylla-rust-driver/pull/1174))
- Documentation terminology was adjusted with regards to using `query` vs `statement` vs `request`. ([#1250](https://github.com/scylladb/scylla-rust-driver/pull/1250))
- Hidden internal testing API from publicly rendered documentation. ([#1262](https://github.com/scylladb/scylla-rust-driver/pull/1262))
- Our logo was not showing up on crates.io due to issues with relative links. ([#1158](https://github.com/scylladb/scylla-rust-driver/pull/1158))
- README and other markdown files were updated in preparation for 1.0 release. ([#1259](https://github.com/scylladb/scylla-rust-driver/pull/1259))
- Doc comments of our derive macros were moved to `scylla-macros` crate. ([#1260](https://github.com/scylladb/scylla-rust-driver/pull/1260))


**CI / developer tool improvements:**

- Tests now retry DDL requests when Scylla returns "group 0 concurrent modification error" to workaround a problem in Scylla. ([#1197](https://github.com/scylladb/scylla-rust-driver/pull/1197), [#1206](https://github.com/scylladb/scylla-rust-driver/pull/1206))
- Addressed Clippy lints enabled in Rust 1.85. ([#1256](https://github.com/scylladb/scylla-rust-driver/pull/1256))
- Various CI fixes, mostly Docker-related. ([#1195](https://github.com/scylladb/scylla-rust-driver/pull/1195), [#1179](https://github.com/scylladb/scylla-rust-driver/pull/1179), [#1173](https://github.com/scylladb/scylla-rust-driver/pull/1173), [#1209](https://github.com/scylladb/scylla-rust-driver/pull/1209), [#1259](https://github.com/scylladb/scylla-rust-driver/pull/1259))

**Others:**

- Various small performance optimizations, mostly related to allocations in logging. ([#1169](https://github.com/scylladb/scylla-rust-driver/pull/1169))


Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

| commits | author            |
|---------|-------------------|
| 194     | Karol Baryła      |
| 149     | Wojciech Przytuła |
| 133     | Mikołaj Uzarski   |
| 9       | Andrés Medina     |
| 8       | Dmitry Kropachev  |
| 6       | smoczy123         |
| 6       | Dawid Pawlik      |
| 3       | Henrik Gustafsson |
| 2       | Joel Höner        |
| 2       | Lucas Kent        |
| 2       | William Shiao     |
| 2       | dependabot[bot]   |
| 1       | Nikodem Gapski    |
| 1       | Stanislav Tkach   |



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
