### PR TITLE
Mark some policies-related structs as non_exhaustive

### DIFF
--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -18,6 +18,7 @@ pub use plan::Plan;
 
 /// Represents info about statement that can be used by load balancing policies.
 #[derive(Default, Clone, Debug)]
+#[non_exhaustive]
 pub struct RoutingInfo<'a> {
     /// Requested consistency information allows to route requests to the appropriate
     /// datacenters. E.g. requests with a LOCAL_ONE consistency should be routed to the same

--- a/scylla/src/policies/retry/retry_policy.rs
+++ b/scylla/src/policies/retry/retry_policy.rs
@@ -6,6 +6,7 @@ use crate::errors::RequestAttemptError;
 use crate::frame::types::Consistency;
 
 /// Information about a failed request
+#[non_exhaustive]
 pub struct RequestInfo<'a> {
     /// The error with which the request failed
     pub error: &'a RequestAttemptError,

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -12,6 +12,7 @@ use crate::errors::{RequestAttemptError, RequestError};
 use crate::observability::metrics::Metrics;
 
 /// Context is passed as an argument to `SpeculativeExecutionPolicy` methods
+#[non_exhaustive]
 pub struct Context {
     #[cfg(feature = "metrics")]
     pub metrics: Arc<Metrics>,

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -353,6 +353,7 @@ impl OwnedRoutingInfo {
             token,
             table,
             is_confirmed_lwt,
+            ..
         } = info;
         Self {
             consistency,


### PR DESCRIPTION
We missed some structs when adding non_exhaustive.
This PR fixes that - we may want to add more stuff to them.

One example is RequestInfo, we will definitely want to add at least one field to it, see https://github.com/scylladb/scylla-rust-driver/issues/1155

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
