### PR TITLE
Use cache in CI

### DIFF
--- a/.github/workflows/authenticate_test.yml
+++ b/.github/workflows/authenticate_test.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Start the cluster
       run: docker compose -f test/cluster/docker-compose-passauth.yml up -d

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -32,7 +32,9 @@ jobs:
         # We can't use cache here, or mdbook will complain about multiple candidates for dependency.
         cache: false
     - name: Install mdbook
-      run: cargo install mdbook --no-default-features
+      uses: taiki-e/install-action@v2
+      with:
+        tool: mdbook
     - name: Build the project
       run: cargo build --examples
     - name: Build the book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -26,10 +26,8 @@ jobs:
         options: --health-cmd "cqlsh --debug scylladb" --health-interval 5s --health-retries 10
     steps:
     - uses: actions/checkout@v3
-    # Set to 1.81 because of regression in 1.82: https://github.com/rust-lang/rust/issues/131893
-    # TODO: change back to latest stable after this bug is fixed.
     - name: Update rust toolchain
-      run: rustup default 1.81
+      run: rustup update
     - name: Install mdbook
       run: cargo install mdbook --no-default-features
     - name: Build the project

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -26,8 +26,11 @@ jobs:
         options: --health-cmd "cqlsh --debug scylladb" --health-interval 5s --health-retries 10
     steps:
     - uses: actions/checkout@v3
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        # We can't use cache here, or mdbook will complain about multiple candidates for dependency.
+        cache: false
     - name: Install mdbook
       run: cargo install mdbook --no-default-features
     - name: Build the project

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -24,8 +24,8 @@ jobs:
       run: |
         docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait
       # A separate step for building to separate measuring time of compilation and testing
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run tests on cassandra
       run: |
         CDC='disabled' RUSTFLAGS="--cfg cassandra_tests" RUST_LOG=trace SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --features "full-serialization" -- --skip test_views_in_schema_info --skip test_large_batch_statements

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,12 +29,18 @@ jobs:
       run: cargo fmt --version
     - name: Print clippy version
       run: cargo clippy --version
+
+# Formatting
     - name: Format check
       run: cargo fmt --all -- --check
+
+# Basic clippy checks
     - name: Clippy check
       run: cargo clippy --all-targets
     - name: Clippy check with all features
       run: cargo clippy --all-targets --all-features
+
+# cpp-rust-driver special cfg
     - name: Cargo check with cpp_rust_unstable cfg
       run: RUSTFLAGS="--cfg cpp_rust_unstable" cargo clippy --all-targets --all-features
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,10 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: clippy, rustfmt
     - name: Print rustc version
       run: rustc --version
     - name: Print rustfmt version
@@ -91,8 +93,8 @@ jobs:
       run: |
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
         docker compose -f test/cluster/docker-compose.yml up -d --wait
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Print rustc version
       run: rustc --version
     - name: Run tests
@@ -114,9 +116,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust ${{ env.rust_min }}
-      run: |
-        rustup install ${{ env.rust_min }}
-        rustup override set ${{ env.rust_min }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.rust_min }}
     - name: Print Rust version
       run: rustc --version
     - name: Use MSRV Cargo.lock
@@ -133,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Compile docs
       run: RUSTDOCFLAGS=-Dwarnings cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,39 +41,39 @@ jobs:
 # Features checks.
     # No features.
     - name: Cargo check without features
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features ""
+      run: cargo check --all-targets -p scylla --features ""
 
     # All features.
     - name: Cargo check with all features
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --all-features
+      run: cargo check --all-targets -p scylla --all-features
 
     # Various (de)serialization features.
     - name: Cargo check with all serialization features
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "full-serialization"
+      run: cargo check --all-targets -p scylla --features "full-serialization"
     - name: Cargo check with metrics feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "metrics"
+      run: cargo check --all-targets -p scylla --features "metrics"
     - name: Cargo check with secrecy-08 feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "secrecy-08"
+      run: cargo check --all-targets -p scylla --features "secrecy-08"
     - name: Cargo check with chrono-04 feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "chrono-04"
+      run: cargo check --all-targets -p scylla --features "chrono-04"
     - name: Cargo check with time-03 feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "time-03"
+      run: cargo check --all-targets -p scylla --features "time-03"
     - name: Cargo check with num-bigint-03 feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "num-bigint-03"
+      run: cargo check --all-targets -p scylla --features "num-bigint-03"
     - name: Cargo check with num-bigint-04 feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "num-bigint-04"
+      run: cargo check --all-targets -p scylla --features "num-bigint-04"
     - name: Cargo check with bigdecimal-04 feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "bigdecimal-04"
+      run: cargo check --all-targets -p scylla --features "bigdecimal-04"
 
     # TLS-related feature sets.
     - name: Cargo check with openssl-x feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "openssl-010"
+      run: cargo check --all-targets -p scylla --features "openssl-010"
     - name: Cargo check with rustls-x feature
-      run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "rustls-023"
+      run: cargo check --all-targets -p scylla --features "rustls-023"
     # (openssl-x, rustls-x) is checked in tls.yml.
 
     - name: Build scylla-cql
-      run: cargo build --all-targets --manifest-path "scylla-cql/Cargo.toml" --features "full-serialization"
+      run: cargo build --all-targets -p scylla-cql --features "full-serialization"
     - name: Build
       run: cargo build --all-targets --features "full-serialization"
   tests:
@@ -118,9 +118,9 @@ jobs:
     - name: MSRV cargo check with features
       run: cargo check --all-targets --all-features --locked
     - name: MSRV cargo check without features
-      run: cargo check --all-targets --locked --manifest-path "scylla/Cargo.toml"
+      run: cargo check --all-targets --locked -p scylla
     - name: MSRV cargo check scylla-cql
-      run: cargo check --all-targets --locked --manifest-path "scylla-cql/Cargo.toml"
+      run: cargo check --all-targets --locked -p scylla-cql
 
   # Tests that docstrings generate docs without warnings
   cargo_docs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
 
 # cpp-rust-driver special cfg
     - name: Cargo check with cpp_rust_unstable cfg
-      run: RUSTFLAGS="--cfg cpp_rust_unstable" cargo clippy --all-targets --all-features
+      run: RUSTFLAGS="--cfg cpp_rust_unstable -Dwarnings" cargo clippy --all-targets --all-features
 
 # Features checks.
     # No features.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,6 @@ jobs:
       run: rustc --version
     - name: Run tests
       run: |
-        cargo clean
         RUST_LOG=trace SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --features "full-serialization"
     - name: Stop the cluster
       if: ${{ always() }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,10 @@ jobs:
     - name: Clippy check with all features
       run: cargo clippy --all-targets --all-features
 
+# Verify scylla-cql separately
+    - name: Clippy scylla-cql
+      run: cargo clippy --all-targets -p scylla-cql --features "full-serialization"
+
 # cpp-rust-driver special cfg
     - name: Cargo check with cpp_rust_unstable cfg
       run: RUSTFLAGS="--cfg cpp_rust_unstable" cargo clippy --all-targets --all-features
@@ -78,8 +82,6 @@ jobs:
       run: cargo check --all-targets -p scylla --features "rustls-023"
     # (openssl-x, rustls-x) is checked in tls.yml.
 
-    - name: Build scylla-cql
-      run: cargo build --all-targets -p scylla-cql --features "full-serialization"
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,8 +80,6 @@ jobs:
 
     - name: Build scylla-cql
       run: cargo build --all-targets -p scylla-cql --features "full-serialization"
-    - name: Build
-      run: cargo build --all-targets --features "full-serialization"
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -58,9 +58,9 @@ jobs:
     - name: Setup rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install semver-checks
-      # Official action uses binary releases fetched from GitHub
-      # If this pipeline becomes too slow, we should do this too.
-      run: cargo install cargo-semver-checks --no-default-features --features gix-reqwest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-semver-checks
     - name: Verify the API compatibilty with PR base
       id: semver-pr-check
       run: |
@@ -146,6 +146,8 @@ jobs:
     - name: Setup rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install semver-checks
-      run: cargo install cargo-semver-checks --no-default-features --features gix-reqwest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-semver-checks
     - name: Run semver-checks to see if it agrees with version updates
       run: make semver-version

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -55,8 +55,8 @@ jobs:
     # I don't know any way to do this using checkout action
     - name: Fetch PR base
       run: git fetch origin "$PR_BASE"
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install semver-checks
       # Official action uses binary releases fetched from GitHub
       # If this pipeline becomes too slow, we should do this too.
@@ -143,8 +143,8 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install semver-checks
       run: cargo install cargo-semver-checks --no-default-features --features gix-reqwest
     - name: Run semver-checks to see if it agrees with version updates

--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -32,11 +32,11 @@ jobs:
         run: cargo check
       # Cloud-related feature sets.   
       - name: Cargo check with unstable-cloud and openssl-x features
-        run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "unstable-cloud" --features "openssl-010"
+        run: cargo check --all-targets -p scylla --features "unstable-cloud" --features "openssl-010"
       - name: Cargo check with unstable-cloud and rustls-x features
-        run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "unstable-cloud" --features "rustls-023"
+        run: cargo check --all-targets -p scylla --features "unstable-cloud" --features "rustls-023"
       - name: Cargo check with unstable-cloud, openssl-x and rustls-x features
-        run: cargo check --all-targets --manifest-path "scylla/Cargo.toml" --features "unstable-cloud" --features "openssl-010" --features "rustls-023"
+        run: cargo check --all-targets -p scylla --features "unstable-cloud" --features "openssl-010" --features "rustls-023"
 
       - name: Run cloud-openssl example
         run: cargo run --example cloud-openssl -- $HOME/.ccm/serverless/config_data.yaml

--- a/.github/workflows/serverless.yaml
+++ b/.github/workflows/serverless.yaml
@@ -26,8 +26,8 @@ jobs:
         run: |
           ccm create serverless -i 127.0.1. -n 1 --scylla -v release:6.2
           ccm start  --sni-proxy --sni-port 7777
-      - name: Update rust toolchain
-        run: rustup update
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Check
         run: cargo check
       # Cloud-related feature sets.   

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -22,8 +22,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Update rust toolchain
-      run: rustup update
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Check
       run: cargo check --features "openssl-010" --features "rustls-023"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ check:
 
 .PHONY: check-without-features
 check-without-features:
-	cargo check --manifest-path "scylla/Cargo.toml" --features "" --all-targets
+	cargo check -p scylla --features "" --all-targets
 
 .PHONY: check-all-features
 check-all-features:

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ all: test
 static: fmt-check check check-without-features check-all-features clippy clippy-all-features
 
 .PHONY: ci
-ci: static test build
+ci: static test
 
 .PHONY: dockerized-ci
-dockerized-ci: static dockerized-test build
+dockerized-ci: static dockerized-test
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
This PR performs some CI improvements. The most important one is utilizing caching, with the help of https://github.com/actions-rust-lang/setup-rust-toolchain action.
This should speed up CI, but its unclear how much exactly. I'll try to check that and post some results.

Apart from caching, this PR:
- fixes a bug, where clippy warnings were not rejected during cpp-rust-driver cfg check.
- makes some minor adjustments, like replacing "--manifest-path" with "--package".
- removes redundant build step.
- replaces scylla-cql build with clippy check.
- removes old workaround for a rust bug

Replaces https://github.com/scylladb/scylla-rust-driver/pull/901

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
