### PR TITLE
CI: Improve Cassandra startup time

### DIFF
--- a/test/cluster/cassandra/docker-compose.yml
+++ b/test/cluster/cassandra/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - CASSANDRA_BROADCAST_ADDRESS=172.42.0.2
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
+      - JVM_OPTS=-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=5000
   cassandra2:
     image: cassandra
     healthcheck:
@@ -38,6 +39,7 @@ services:
       - CASSANDRA_SEEDS=172.42.0.2
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
+      - JVM_OPTS=-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=5000
     depends_on:
       cassandra1:
         condition: service_healthy
@@ -56,6 +58,7 @@ services:
       - CASSANDRA_SEEDS=172.42.0.2,172.42.0.3
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
+      - JVM_OPTS=-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=5000
     depends_on:
       cassandra2:
         condition: service_healthy


### PR DESCRIPTION
Similarly to Scylla before Raft, Cassandra needs a lot of time to start the cluster. We can reduce this time for non-production clusters with some options, similar to those that were used for testing older versions of Scylla in test.py etc.

The options I used reduce cluster startup time from 3.5 minutes to 45 seconds on my machine.
IIRC it usually also took 3.5 minutes in the CI, so I'm expecting a similar speedup. If it turns out that those options cause some flakiness, we can increase the values or revert the change.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
