### PR TITLE
Don't require `Sized` in `SerializeRow` impl for `Box<T>`

### DIFF
--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -159,7 +159,7 @@ impl<T: SerializeValue> SerializeRow for Vec<T> {
     impl_serialize_row_for_slice!();
 }
 
-impl<T: SerializeRow> SerializeRow for Box<T> {
+impl<T: SerializeRow + ?Sized> SerializeRow for Box<T> {
     #[inline]
     fn serialize(
         &self,


### PR DESCRIPTION
6a1ea41e716d4de49376b26894c811f227d81ddc relaxed the implicit `Sized` requirement in the implementation of `SerializeRow` for `&T`. This does the same for `Box<T>` which allows the use of boxed trait objects.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
