### PR TITLE
errors: fix leftover mentions of _query_

### DIFF
--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -38,11 +38,11 @@ pub use scylla_cql::frame::response::error::{DbError, OperationType, WriteType};
 pub use scylla_cql::frame::response::CqlResponseKind;
 pub use scylla_cql::serialize::SerializationError;
 
-/// Error that occurred during query execution
+/// Error that occurred during request execution
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum ExecutionError {
-    /// Caller passed an invalid query
+    /// Caller passed an invalid statement.
     #[error(transparent)]
     BadQuery(#[from] BadQuery),
 
@@ -417,24 +417,25 @@ pub enum TablesMetadataError {
     },
 }
 
-/// Error caused by caller creating an invalid query
+/// Error caused by caller creating an invalid statement.
 #[derive(Error, Debug, Clone)]
-#[error("Invalid query passed to Session")]
+#[error("Invalid statement passed to Session")]
 #[non_exhaustive]
 pub enum BadQuery {
     /// Unable extract a partition key based on prepared statement's metadata.
     #[error("Unable extract a partition key based on prepared statement's metadata")]
     PartitionKeyExtraction,
 
+    /// "Serializing values failed.
     #[error("Serializing values failed: {0} ")]
     SerializationError(#[from] SerializationError),
 
-    /// Serialized values are too long to compute partition key
+    /// Serialized values are too long to compute partition key.
     #[error("Serialized values are too long to compute partition key! Length: {0}, Max allowed length: {1}")]
     ValuesTooLongForKey(usize, usize),
 
-    /// Too many queries in the batch statement
-    #[error("Number of Queries in Batch Statement supplied is {0} which has exceeded the max value of 65,535")]
+    /// Too many statements in the batch statement.
+    #[error("Number of statements in Batch Statement supplied is {0} which has exceeded the max value of 65,535")]
     TooManyQueriesInBatchStatement(usize),
 }
 


### PR DESCRIPTION
When we renamed `Query` to `Statement`, we omitted some occurrences. Unfortunately, the error types can no longer be renamed after we released 1.0, so only docstrings are adjusted.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
