### PR TITLE
Expose request coordinator

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -142,17 +142,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -814,12 +814,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
@@ -835,11 +829,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -953,10 +947,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -985,7 +980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -993,16 +988,6 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.5.0",
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1067,22 +1052,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1206,20 +1191,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1304,9 +1279,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.7",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1511,21 +1486,30 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.5.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.15",
- "libredox",
+ "redox_syscall 0.2.16",
  "thiserror 1.0.60",
 ]
 
@@ -1644,6 +1628,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustyline"
@@ -2111,28 +2101,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2390,23 +2379,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -2415,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2425,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2438,15 +2428,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2482,11 +2475,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "windows-sys 0.52.0",
+ "winapi",
 ]
 
 [[package]]
@@ -2501,7 +2494,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2519,7 +2512,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2539,18 +2541,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2561,9 +2563,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2573,9 +2575,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2585,15 +2587,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2603,9 +2605,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2615,9 +2617,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2627,9 +2629,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2639,9 +2641,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPOSE := docker compose -f test/cluster/docker-compose.yml
 all: test
 
 .PHONY: static
-static: fmt-check check check-without-features check-all-features clippy clippy-all-features
+static: fmt-check check check-without-features check-all-features clippy clippy-all-features clippy-cpp-rust
 
 .PHONY: ci
 ci: static test
@@ -39,6 +39,11 @@ clippy:
 .PHONY: clippy-all-features
 clippy-all-features:
 	RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features
+
+.PHONY: clippy-cpp-rust
+clippy-cpp-rust:
+	RUSTFLAGS="--cfg cpp_rust_unstable -Dwarnings" cargo clippy --all-targets --all-features
+
 
 .PHONY: test
 test: up

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT OR Apache-2.0"
 scylla-macros = { version = "=1.1.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
-tokio = { version = "1.34", features = ["io-util", "time"] }
+tokio = { version = "1.40", features = ["io-util", "time"] }
 secrecy-08 = { package = "secrecy", version = "0.8", optional = true }
 snap = "1.0"
 uuid = "1.0"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -18,7 +18,7 @@ scylla-cql = { version = "1.1.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"
-tokio = { version = "1.34", features = [
+tokio = { version = "1.40", features = [
     "net",
     "time",
     "io-util",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -49,7 +49,7 @@ bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
 histogram = { version = "0.11.1", optional = true }
-tokio = { version = "1.34", features = [
+tokio = { version = "1.40", features = [
     "net",
     "time",
     "io-util",

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -309,11 +309,12 @@ where
         self.metrics.inc_total_paged_queries();
         let query_start = std::time::Instant::now();
 
+        let connect_address = connection.get_connect_address();
         trace!(
-            connection = %connection.get_connect_address(),
+            connection = %connect_address,
             "Sending"
         );
-        self.log_attempt_start(connection.get_connect_address());
+        self.log_attempt_start(connect_address);
 
         let query_response =
             (self.page_query)(connection.clone(), consistency, self.paging_state.clone())

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -417,6 +417,8 @@ pub(crate) enum RunRequestResult<ResT> {
     Completed(ResT),
 }
 
+/// Represents a CQL session, which can be used to communicate
+/// with the database
 impl Session {
     /// Sends a request to the database and receives a response.\
     /// Executes an unprepared CQL statement without paging, i.e. all results are received in a single response.
@@ -803,11 +805,7 @@ impl Session {
     ) -> Result<QueryResult, ExecutionError> {
         self.do_batch(batch, values).await
     }
-}
 
-/// Represents a CQL session, which can be used to communicate
-/// with the database
-impl Session {
     /// Estabilishes a CQL session with the database
     ///
     /// Usually it's easier to use [SessionBuilder](crate::client::session_builder::SessionBuilder)

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2052,13 +2052,14 @@ impl Session {
                 self.metrics.inc_total_nonpaged_queries();
                 let request_start = std::time::Instant::now();
 
+                let connect_address = connection.get_connect_address();
                 trace!(
                     parent: &span,
-                    connection = %connection.get_connect_address(),
+                    connection = %connect_address,
                     "Sending"
                 );
                 let attempt_id: Option<history::AttemptId> =
-                    context.log_attempt_start(connection.get_connect_address());
+                    context.log_attempt_start(connect_address);
                 let request_result: Result<ResT, RequestAttemptError> =
                     run_request_once(connection, current_consistency, execution_profile)
                         .instrument(span.clone())

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -23,7 +23,8 @@ use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::response::query_result::QueryResult;
 use crate::response::{
-    NonErrorAuthResponse, NonErrorStartupResponse, PagingState, QueryResponse, RawPreparedStatement,
+    NonErrorAuthResponse, NonErrorQueryResponse, NonErrorStartupResponse, PagingState,
+    QueryResponse, RawPreparedStatement,
 };
 use crate::routing::locator::tablets::{RawTablet, TabletParsingError};
 use crate::routing::{Shard, ShardAwarePortRange, ShardInfo, Sharder, ShardingError};
@@ -821,7 +822,8 @@ impl Connection {
 
         self.query_raw_unpaged(&statement)
             .await
-            .and_then(QueryResponse::into_query_result)
+            .and_then(QueryResponse::into_non_error_query_response)
+            .and_then(NonErrorQueryResponse::into_query_result)
     }
 
     async fn query_raw_unpaged(

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -23,8 +23,7 @@ use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::response::query_result::QueryResult;
 use crate::response::{
-    NonErrorAuthResponse, NonErrorQueryResponse, NonErrorStartupResponse, PagingState,
-    QueryResponse, RawPreparedStatement,
+    NonErrorAuthResponse, NonErrorStartupResponse, PagingState, QueryResponse, RawPreparedStatement,
 };
 use crate::routing::locator::tablets::{RawTablet, TabletParsingError};
 use crate::routing::{Shard, ShardAwarePortRange, ShardInfo, Sharder, ShardingError};
@@ -822,8 +821,11 @@ impl Connection {
 
         self.query_raw_unpaged(&statement)
             .await
-            .and_then(QueryResponse::into_non_error_query_response)
-            .and_then(NonErrorQueryResponse::into_query_result)
+            .and_then(|response| {
+                response
+                    .into_non_error_query_response()?
+                    .into_query_result_with_unknown_coordinator()
+            })
     }
 
     async fn query_raw_unpaged(

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use rand::Rng;
 use std::convert::TryInto;
 use std::num::NonZeroUsize;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::sync::{Arc, RwLock, Weak};
 use std::time::Duration;
@@ -190,6 +191,16 @@ impl std::fmt::Debug for NodeConnectionPool {
             .finish_non_exhaustive()
     }
 }
+
+// These implementations are a temporary solution to the following problem:
+// `QueryResult` used to implement `(Ref)UnwindSafe`, but then we wanted it to store a reference to `Node`.
+// This, transitively, made it store `NodeConnectionPool`, which did not implement those traits.
+// Thus, they would no longer be auto-implemented for `QueryResult`, breaking the public API.
+// Not to introduce an API breakage in a minor release, we decided to manually hint that `NodeConnectionPool`
+// is indeed unwind-safe. Even if our we are wrong and the hint is misleading, the documentation of those
+// traits, not being `unsafe` traits, considers them merely guidelines, not strong guarantees.
+impl UnwindSafe for NodeConnectionPool {}
+impl RefUnwindSafe for NodeConnectionPool {}
 
 impl NodeConnectionPool {
     pub(crate) fn new(

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -186,6 +186,7 @@ impl std::fmt::Debug for NodeConnectionPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NodeConnectionPool")
             .field("conns", &self.conns)
+            .field("endpoint", &self.endpoint)
             .finish_non_exhaustive()
     }
 }

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -10,6 +10,7 @@ use tracing::{trace_span, Instrument};
 use crate::errors::{RequestAttemptError, RequestError};
 #[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
+use crate::response::Coordinator;
 
 /// Context is passed as an argument to `SpeculativeExecutionPolicy` methods
 #[non_exhaustive]
@@ -144,9 +145,9 @@ pub(crate) async fn execute<QueryFut, ResT>(
     policy: &dyn SpeculativeExecutionPolicy,
     context: &Context,
     query_runner_generator: impl Fn(bool) -> QueryFut,
-) -> Result<ResT, RequestError>
+) -> Result<(ResT, Coordinator), RequestError>
 where
-    QueryFut: Future<Output = Option<Result<ResT, RequestError>>>,
+    QueryFut: Future<Output = Option<Result<(ResT, Coordinator), RequestError>>>,
 {
     let mut retries_remaining = policy.max_retry_count(context);
     let retry_interval = policy.retry_interval(context);

--- a/scylla/src/response/coordinator.rs
+++ b/scylla/src/response/coordinator.rs
@@ -1,0 +1,47 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use crate::{
+    cluster::{Node, NodeRef},
+    network::Connection,
+    routing::Shard,
+};
+
+/// The coordinator of a CQL request, i.e., the node+shard that receives
+/// and processes the request, and hopefully eventually sends a response.
+#[derive(Debug, Clone)]
+pub struct Coordinator {
+    /// Translated address, i.e., one that the connection is opened against.
+    connection_address: SocketAddr,
+    /// The node that served as coordinator.
+    node: Arc<Node>,
+    /// Number of the shard, if applicable (present for ScyllaDB nodes, absent for Cassandra).
+    shard: Option<Shard>,
+}
+
+impl Coordinator {
+    pub(crate) fn new(node: NodeRef, shard: Option<Shard>, connection: &Connection) -> Self {
+        Self {
+            connection_address: connection.get_connect_address(),
+            node: Arc::clone(node),
+            shard,
+        }
+    }
+
+    /// Translated address, i.e., one that the connection is opened against.
+    #[inline]
+    pub fn connection_address(&self) -> SocketAddr {
+        self.connection_address
+    }
+
+    /// The node that served as coordinator of the request.
+    #[inline]
+    pub fn node(&self) -> NodeRef {
+        &self.node
+    }
+
+    /// Number of the shard, if applicable (present for ScyllaDB nodes, absent for Cassandra).
+    #[inline]
+    pub fn shard(&self) -> Option<Shard> {
+        self.shard
+    }
+}

--- a/scylla/src/response/mod.rs
+++ b/scylla/src/response/mod.rs
@@ -7,9 +7,11 @@
 //! - [QueryRowsResult](query_result::QueryRowsResult) - a result of CQL QUERY/EXECUTE/BATCH
 //!   request that contains some rows, which can be deserialized by the user.
 
+mod coordinator;
 pub mod query_result;
 mod request_response;
 
+pub use coordinator::Coordinator;
 pub(crate) use request_response::{
     NonErrorAuthResponse, NonErrorQueryResponse, NonErrorStartupResponse, QueryResponse,
     RawPreparedStatement,

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -88,10 +88,6 @@ impl QueryResult {
 
     // Preferred to implementing Default, because users shouldn't be able to create
     // an empty QueryResult.
-    //
-    // For now unused, but it will be used once Session's API is migrated
-    // to the new QueryResult.
-    #[allow(dead_code)]
     pub(crate) fn mock_empty() -> Self {
         Self {
             raw_metadata_and_rows: None,

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -38,10 +38,6 @@ impl QueryResponse {
             warnings: self.warnings,
         })
     }
-
-    pub(crate) fn into_query_result(self) -> Result<QueryResult, RequestAttemptError> {
-        self.into_non_error_query_response()?.into_query_result()
-    }
 }
 
 impl NonErrorQueryResponse {

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -39,13 +39,6 @@ impl QueryResponse {
         })
     }
 
-    pub(crate) fn into_query_result_and_paging_state(
-        self,
-    ) -> Result<(QueryResult, PagingStateResponse), RequestAttemptError> {
-        self.into_non_error_query_response()?
-            .into_query_result_and_paging_state()
-    }
-
     pub(crate) fn into_query_result(self) -> Result<QueryResult, RequestAttemptError> {
         self.into_non_error_query_response()?.into_query_result()
     }


### PR DESCRIPTION
This is the second approach to #1030.

### `Coordinator`

`Coordinator` is defined as follows:
```rust
/// The coordinator of a CQL request, i.e., the node+shard that receives
/// and processes the request, and hopefully eventually sends a response.
#[derive(Debug, Clone)]
pub struct Coordinator {
    /// Translated address, i.e., one that the connection is opened against.
    connection_address: SocketAddr,
    /// The node that served as coordinator.
    node: Arc<Node>,
    /// Number of the shard, if applicable (present for ScyllaDB nodes, absent for Cassandra).
    shard: Option<Shard>,
}
```

It has `pub` getters for all of its fields.

`Coordinator` is built from `NodeRef` (`untranslated_address` and `host_id`), `Shard` (`shard`), and `Connection` (`connection_address`).

### Use

`Coordinator` is stored in `QueryResult` (as well as `QueryRowsResult`) and `QueryPager` (together with `TypedRowStream`). `QueryPager` exposes an iterator of references to `Coordinator`s, each of which served one page.

### Testing
No tests yet.

Fixes: #1030

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
