### PR TITLE
Backport #1224 to main

### DIFF
--- a/scylla/src/client/mod.rs
+++ b/scylla/src/client/mod.rs
@@ -28,9 +28,6 @@ pub mod session;
 
 pub mod session_builder;
 
-#[cfg(test)]
-mod session_test;
-
 pub use scylla_cql::frame::Compression;
 
 pub use crate::network::PoolSize;

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -239,8 +239,10 @@ async fn test_prepared_statement() {
             .single_row::<(i64,)>()
             .unwrap();
         let token = Token::new(value);
-        let prepared_token = Murmur3Partitioner
-            .hash_one(&prepared_statement.compute_partition_key(&values).unwrap());
+        let prepared_token = prepared_statement
+            .calculate_token(&values)
+            .unwrap()
+            .unwrap();
         assert_eq!(token, prepared_token);
         let cluster_state_token = session
             .get_cluster_state()
@@ -258,11 +260,10 @@ async fn test_prepared_statement() {
             .single_row::<(i64,)>()
             .unwrap();
         let token = Token::new(value);
-        let prepared_token = Murmur3Partitioner.hash_one(
-            &prepared_complex_pk_statement
-                .compute_partition_key(&values)
-                .unwrap(),
-        );
+        let prepared_token = prepared_complex_pk_statement
+            .calculate_token(&values)
+            .unwrap()
+            .unwrap();
         assert_eq!(token, prepared_token);
         let cluster_state_token = session
             .get_cluster_state()

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -1026,7 +1026,7 @@ async fn test_tracing_query(session: &Session, ks: String) {
 
     // A query with tracing enabled has a tracing uuid in result
     let mut traced_query: Statement = Statement::new(format!("SELECT * FROM {}.tab", ks));
-    traced_query.config.tracing = true;
+    traced_query.set_tracing(true);
 
     let traced_query_result: QueryResult = session.query_unpaged(traced_query, &[]).await.unwrap();
     assert!(traced_query_result.tracing_id().is_some());
@@ -1055,7 +1055,7 @@ async fn test_tracing_execute(session: &Session, ks: String) {
         .await
         .unwrap();
 
-    traced_prepared.config.tracing = true;
+    traced_prepared.set_tracing(true);
 
     let traced_prepared_result: QueryResult = session
         .execute_unpaged(&traced_prepared, &[])
@@ -1078,7 +1078,7 @@ async fn test_tracing_prepare(session: &Session, ks: String) {
 
     // Preparing a statement with tracing enabled has tracing uuids in result
     let mut to_prepare_traced = Statement::new(format!("SELECT * FROM {}.tab", ks));
-    to_prepare_traced.config.tracing = true;
+    to_prepare_traced.set_tracing(true);
 
     let traced_prepared = session.prepare(to_prepare_traced).await.unwrap();
     assert!(!traced_prepared.prepare_tracing_ids.is_empty());
@@ -1092,7 +1092,7 @@ async fn test_tracing_prepare(session: &Session, ks: String) {
 async fn test_get_tracing_info(session: &Session, ks: String) {
     // A query with tracing enabled has a tracing uuid in result
     let mut traced_query: Statement = Statement::new(format!("SELECT * FROM {}.tab", ks));
-    traced_query.config.tracing = true;
+    traced_query.set_tracing(true);
 
     let traced_query_result: QueryResult = session.query_unpaged(traced_query, &[]).await.unwrap();
     let tracing_id: Uuid = traced_query_result.tracing_id().unwrap();
@@ -1115,7 +1115,7 @@ async fn test_tracing_query_iter(session: &Session, ks: String) {
 
     // A query with tracing enabled has a tracing ids in result
     let mut traced_query: Statement = Statement::new(format!("SELECT * FROM {}.tab", ks));
-    traced_query.config.tracing = true;
+    traced_query.set_tracing(true);
 
     let traced_query_pager = session.query_iter(traced_query, &[]).await.unwrap();
 
@@ -1145,7 +1145,7 @@ async fn test_tracing_execute_iter(session: &Session, ks: String) {
         .prepare(format!("SELECT * FROM {}.tab", ks))
         .await
         .unwrap();
-    traced_prepared.config.tracing = true;
+    traced_prepared.set_tracing(true);
 
     let traced_query_pager = session.execute_iter(traced_prepared, &[]).await.unwrap();
 
@@ -1168,7 +1168,7 @@ async fn test_tracing_batch(session: &Session, ks: String) {
     // Batch with tracing enabled has a tracing uuid in result
     let mut traced_batch: Batch = Default::default();
     traced_batch.append_statement(&format!("INSERT INTO {}.tab (a) VALUES('a')", ks)[..]);
-    traced_batch.config.tracing = true;
+    traced_batch.set_tracing(true);
 
     let traced_batch_result: QueryResult = session.batch(&traced_batch, ((),)).await.unwrap();
     assert!(traced_batch_result.tracing_id().is_some());
@@ -1179,7 +1179,7 @@ async fn test_tracing_batch(session: &Session, ks: String) {
 async fn assert_in_tracing_table(session: &Session, tracing_uuid: Uuid) {
     let mut traces_query =
         Statement::new("SELECT * FROM system_traces.sessions WHERE session_id = ?");
-    traces_query.config.consistency = Some(Consistency::One);
+    traces_query.set_consistency(Consistency::One);
 
     // Tracing info might not be immediately available
     // If rows are empty perform 8 retries with a 32ms wait in between

--- a/scylla/src/client/session_test.rs
+++ b/scylla/src/client/session_test.rs
@@ -2769,28 +2769,28 @@ async fn test_keyspaces_to_fetch() {
     session_default.await_schema_agreement().await.unwrap();
     assert!(session_default
         .get_cluster_state()
-        .keyspaces
-        .contains_key(&ks1));
+        .get_keyspace(&ks1)
+        .is_some());
     assert!(session_default
         .get_cluster_state()
-        .keyspaces
-        .contains_key(&ks2));
+        .get_keyspace(&ks2)
+        .is_some());
 
     let session1 = create_new_session_builder()
         .keyspaces_to_fetch([&ks1])
         .build()
         .await
         .unwrap();
-    assert!(session1.get_cluster_state().keyspaces.contains_key(&ks1));
-    assert!(!session1.get_cluster_state().keyspaces.contains_key(&ks2));
+    assert!(session1.get_cluster_state().get_keyspace(&ks1).is_some());
+    assert!(session1.get_cluster_state().get_keyspace(&ks2).is_none());
 
     let session_all = create_new_session_builder()
         .keyspaces_to_fetch([] as [String; 0])
         .build()
         .await
         .unwrap();
-    assert!(session_all.get_cluster_state().keyspaces.contains_key(&ks1));
-    assert!(session_all.get_cluster_state().keyspaces.contains_key(&ks2));
+    assert!(session_all.get_cluster_state().get_keyspace(&ks1).is_some());
+    assert!(session_all.get_cluster_state().get_keyspace(&ks2).is_some());
 }
 
 // Reproduces the problem with execute_iter mentioned in #608.
@@ -3195,7 +3195,7 @@ async fn test_vector_type_metadata() {
 
     session.refresh_metadata().await.unwrap();
     let metadata = session.get_cluster_state();
-    let columns = &metadata.keyspaces[&ks].tables["t"].columns;
+    let columns = &metadata.get_keyspace(&ks).unwrap().tables["t"].columns;
     assert_eq!(
         columns["b"].typ,
         ColumnType::Vector {

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -216,15 +216,6 @@ pub mod deserialize {
     }
 
     // Shorthands for better readability.
-    #[cfg_attr(not(test), allow(unused))]
-    pub(crate) trait DeserializeOwnedValue:
-        for<'frame, 'metadata> value::DeserializeValue<'frame, 'metadata>
-    {
-    }
-    impl<T> DeserializeOwnedValue for T where
-        T: for<'frame, 'metadata> value::DeserializeValue<'frame, 'metadata>
-    {
-    }
     pub(crate) trait DeserializeOwnedRow:
         for<'frame, 'metadata> row::DeserializeRow<'frame, 'metadata>
     {

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -14,6 +14,7 @@ mod metadata_custom_timeouts;
 mod new_session;
 mod retries;
 mod self_identity;
+mod session;
 mod shards;
 mod silent_prepare_batch;
 mod silent_prepare_query;

--- a/scylla/tests/integration/session.rs
+++ b/scylla/tests/integration/session.rs
@@ -1,4 +1,8 @@
-use crate as scylla;
+use crate::utils::{
+    create_new_session_builder, scylla_supports_tablets, setup_tracing, supports_feature,
+    unique_keyspace_name, DeserializeOwnedValue, PerformDDL,
+};
+
 use scylla::client::caching_session::CachingSession;
 use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
@@ -7,7 +11,6 @@ use scylla::cluster::metadata::Strategy::NetworkTopologyStrategy;
 use scylla::cluster::metadata::{
     CollectionType, ColumnKind, ColumnType, NativeType, UserDefinedType,
 };
-use scylla::deserialize::DeserializeOwnedValue;
 use scylla::errors::OperationType;
 use scylla::errors::{
     BadKeyspaceName, DbError, ExecutionError, RequestAttemptError, UseKeyspaceError,
@@ -25,10 +28,6 @@ use scylla::statement::batch::{Batch, BatchStatement, BatchType};
 use scylla::statement::prepared::PreparedStatement;
 use scylla::statement::unprepared::Statement;
 use scylla::statement::Consistency;
-use scylla::utils::test_utils::{
-    create_new_session_builder, scylla_supports_tablets, setup_tracing, supports_feature,
-    unique_keyspace_name, PerformDDL,
-};
 use scylla::value::Counter;
 use scylla::value::{CqlVarint, Row};
 
@@ -337,7 +336,6 @@ async fn test_prepared_statement() {
     // Check that SerializeRow and DeserializeRow macros work
     {
         #[derive(scylla::SerializeRow, scylla::DeserializeRow, PartialEq, Debug, Clone)]
-        #[scylla(crate = crate)]
         struct ComplexPk {
             a: i32,
             b: i32,

--- a/scylla/tests/integration/session.rs
+++ b/scylla/tests/integration/session.rs
@@ -3163,7 +3163,7 @@ async fn test_deserialize_empty_collections() {
     assert!(map.is_empty());
 }
 
-#[cfg(cassandra_tests)]
+#[cfg_attr(not(cassandra_tests), ignore)]
 #[tokio::test]
 async fn test_vector_type_metadata() {
     setup_tracing();
@@ -3200,7 +3200,7 @@ async fn test_vector_type_metadata() {
     );
 }
 
-#[cfg(cassandra_tests)]
+#[cfg_attr(not(cassandra_tests), ignore)]
 #[tokio::test]
 async fn test_vector_type_unprepared() {
     setup_tracing();
@@ -3232,7 +3232,7 @@ async fn test_vector_type_unprepared() {
     // TODO: Implement and test SELECT statements and bind values (`?`)
 }
 
-#[cfg(cassandra_tests)]
+#[cfg_attr(not(cassandra_tests), ignore)]
 #[tokio::test]
 async fn test_vector_type_prepared() {
     setup_tracing();

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -1,4 +1,5 @@
 use futures::Future;
+use scylla::client::caching_session::CachingSession;
 use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
 use scylla::client::session_builder::{GenericSessionBuilder, SessionBuilderKind};
@@ -282,5 +283,14 @@ impl PerformDDL for Session {
         let mut query = query.into();
         apply_ddl_lbp(&mut query);
         self.query_unpaged(query, &[]).await.map(|_| ())
+    }
+}
+
+#[async_trait::async_trait]
+impl PerformDDL for CachingSession {
+    async fn ddl(&self, query: impl Into<Statement> + Send) -> Result<(), ExecutionError> {
+        let mut query = query.into();
+        apply_ddl_lbp(&mut query);
+        self.execute_unpaged(query, &[]).await.map(|_| ())
     }
 }


### PR DESCRIPTION
This is the first backport of hackathon stuff to main. It backports PR made by @sylwiaszunejko that moves (part of) session_test.rs to integration tests.
Ref: https://github.com/scylladb/scylla-rust-driver/issues/1271

I edited the original PR a bit, because now it is possible to actually move all the tests, which I did.
I also extracted commits that changed the code, so that the actual move only changes the imports in the moved file.
- First commit moves to using `.get_keyspace()` instead of keyspaces field. This is a new change, not present in the original PR.
- Second uses setters for consistency and tracing. It was already done by Sylwia, I just extracted it to a separate commit
- Third commit removes uses of recently un-pubed partitioner API from test_prepared_statement. This is a new change - in the orignal PR test_prepared_statement was not moved to integration.
- Fourth commit merges two of the tests to avoid calling `calculate_token_for_partition_key`
- Fifth commit reorganizes imports , in order to minimize the changes in the sixth commit
- Sixth commit moves the test into integration.
- Seventh commit changes `cfg(cassandra_tests)` to `#[cfg_attr(not(cassandra_tests), ignore)]`

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
