### PR TITLE
Implement coalescing delay configuration

### DIFF
--- a/scylla/src/client/mod.rs
+++ b/scylla/src/client/mod.rs
@@ -30,4 +30,4 @@ pub mod session_builder;
 
 pub use scylla_cql::frame::Compression;
 
-pub use crate::network::PoolSize;
+pub use crate::network::{PoolSize, WriteCoalescingDelay};

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -886,7 +886,9 @@ impl Session {
             event_sender: None,
             default_consistency: Default::default(),
             address_translator,
-            enable_write_coalescing: config.enable_write_coalescing,
+            write_coalescing_delay: config
+                .enable_write_coalescing
+                .then_some(config.write_coalescing_delay),
             keepalive_interval: config.keepalive_interval,
             keepalive_timeout: config.keepalive_timeout,
             tablet_sender: Some(tablet_sender),

--- a/scylla/src/network/mod.rs
+++ b/scylla/src/network/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use connection::{Connection, ConnectionConfig, VerifiedKeyspaceName};
 
 mod connection_pool;
 
+pub use connection::WriteCoalescingDelay;
 pub use connection_pool::PoolSize;
 pub(crate) use connection_pool::{NodeConnectionPool, PoolConfig};
 


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1282

This PR introduces `WriteCoalescingDelay` enum and exposes delay configuration options in `SessionConfig` and `SessionBuilder`. I adjusted the delay implementation details, as well as `test_coalescing` to new variant (`WriteCoalescingDelay::Milliseconds` - represents a non-zero milliseconds delay implemented using tokio::sleep).

## Things to discuss:
- Is `scylla::client::session::WriteCoalescingDelay` a reasonable place to put new enum? I did this, because we already defined `TlsContext` enum here. OTOH, I see that some other configuration types are defined somewhere else and re-exported under `scylla::client::*`. For example, `PoolSize` is defined in `scylla::network::connection_pool`, and re-exported in `scylla::client`.
- Ideally, `enable_write_coalescing`, and new `write_coalescing_delay` options should be merged/unified. Probably as `Option<WriteCoalescingDelay>`. We can't do that currently, as it would break the API. I'll open the corresponding issue once this PR is merged and put it under 2.0 milestone.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
