### PR TITLE
Implement local bind address configuration option

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -905,6 +905,7 @@ impl Session {
         };
 
         let connection_config = ConnectionConfig {
+            local_ip_address: config.local_ip_address,
             compression: config.compression,
             tcp_nodelay: config.tcp_nodelay,
             tcp_keepalive_interval: config.tcp_keepalive_interval,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -47,7 +47,7 @@ use scylla_cql::serialize::batch::BatchValues;
 use scylla_cql::serialize::row::{SerializeRow, SerializedValues};
 use std::borrow::Borrow;
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
@@ -154,6 +154,13 @@ pub struct SessionConfig {
     /// Session will connect to these nodes to retrieve information about other nodes in the cluster.
     /// Each node can be represented as a hostname or an IP address.
     pub known_nodes: Vec<KnownNode>,
+
+    /// A local ip address to bind all driver's TCP sockets to.
+    ///
+    /// By default set to None, which is equivalent to:
+    /// - `INADDR_ANY` for IPv4 ([`Ipv4Addr::UNSPECIFIED`][std::net::Ipv4Addr::UNSPECIFIED])
+    /// - `in6addr_any` for IPv6 ([`Ipv6Addr::UNSPECIFIED`][std::net::Ipv6Addr::UNSPECIFIED])
+    pub local_ip_address: Option<IpAddr>,
 
     /// Preferred compression algorithm to use on connections.
     /// If it's not supported by database server Session will fall back to no compression.
@@ -293,6 +300,7 @@ impl SessionConfig {
     pub fn new() -> Self {
         SessionConfig {
             known_nodes: Vec::new(),
+            local_ip_address: None,
             compression: None,
             tcp_nodelay: true,
             tcp_keepalive_interval: None,

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -419,17 +419,16 @@ impl Connection {
     /// Opens a connection and makes it ready to send/receive CQL frames on it,
     /// but does not yet send any frames (no OPTIONS/STARTUP handshake nor REGISTER requests).
     async fn new(
-        addr: SocketAddr,
+        connect_address: SocketAddr,
         source_port: Option<u16>,
         config: HostConnectionConfig,
     ) -> Result<(Self, ErrorReceiver), ConnectionError> {
-        let stream_connector = match source_port {
-            Some(p) => {
-                tokio::time::timeout(config.connect_timeout, connect_with_source_port(addr, p))
-                    .await
-            }
-            None => tokio::time::timeout(config.connect_timeout, TcpStream::connect(addr)).await,
-        };
+        let stream_connector = tokio::time::timeout(
+            config.connect_timeout,
+            // TODO: provide source ip instead of None (done later in this PR).
+            connect_with_source_ip_and_port(connect_address, None, source_port),
+        )
+        .await;
         let stream = match stream_connector {
             Ok(stream) => stream?,
             Err(_) => {
@@ -461,7 +460,7 @@ impl Connection {
             error_sender,
             orphan_notification_receiver,
             router_handle.clone(),
-            addr.ip(),
+            connect_address.ip(),
         )
         .await?;
 
@@ -469,7 +468,7 @@ impl Connection {
             _worker_handle,
             config,
             features: Default::default(),
-            connect_address: addr,
+            connect_address,
             router_handle,
         };
 
@@ -2034,26 +2033,28 @@ pub(super) async fn open_connection_to_shard_aware_port(
     Err(ConnectionError::NoSourcePortForShard(shard))
 }
 
-async fn connect_with_source_port(
-    addr: SocketAddr,
-    source_port: u16,
+async fn connect_with_source_ip_and_port(
+    connect_address: SocketAddr,
+    source_ip: Option<IpAddr>,
+    source_port: Option<u16>,
 ) -> Result<TcpStream, std::io::Error> {
-    match addr {
+    // Binding to port 0 is equivalent to choosing random ephemeral port.
+    let source_port = source_port.unwrap_or(0);
+
+    match connect_address {
         SocketAddr::V4(_) => {
+            // If source_ip not provided, bind to INADDR_ANY.
+            let source_ipv4 = source_ip.unwrap_or(Ipv4Addr::UNSPECIFIED.into());
             let socket = TcpSocket::new_v4()?;
-            socket.bind(SocketAddr::new(
-                Ipv4Addr::new(0, 0, 0, 0).into(),
-                source_port,
-            ))?;
-            Ok(socket.connect(addr).await?)
+            socket.bind(SocketAddr::new(source_ipv4, source_port))?;
+            Ok(socket.connect(connect_address).await?)
         }
         SocketAddr::V6(_) => {
+            // If source_ip not provided, bind to in6addr_any.
+            let source_ipv6 = source_ip.unwrap_or(Ipv6Addr::UNSPECIFIED.into());
             let socket = TcpSocket::new_v6()?;
-            socket.bind(SocketAddr::new(
-                Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).into(),
-                source_port,
-            ))?;
-            Ok(socket.connect(addr).await?)
+            socket.bind(SocketAddr::new(source_ipv6, source_port))?;
+            Ok(socket.connect(connect_address).await?)
         }
     }
 }

--- a/scylla/tests/integration/new_session.rs
+++ b/scylla/tests/integration/new_session.rs
@@ -1,8 +1,10 @@
-use crate::utils::setup_tracing;
+use std::net::Ipv4Addr;
+
+use crate::utils::{create_new_session_builder, find_local_ip_for_destination, setup_tracing};
 
 use assert_matches::assert_matches;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::errors::NewSessionError;
+use scylla::errors::{ConnectionError, ConnectionPoolError, MetadataError, NewSessionError};
 
 #[cfg(not(scylla_cloud_tests))]
 #[tokio::test]
@@ -35,4 +37,62 @@ async fn all_hostnames_invalid() {
         SessionBuilder::new().known_node(uri).build().await,
         Err(NewSessionError::FailedToResolveAnyHostname(_))
     );
+}
+
+/// This test assumes that there is no interface configured on 1.1.1.1 address.
+/// This should be true for most standard setups.
+/// It is based on https://github.com/scylladb/cpp-rust-driver/blob/v0.3.0/tests/src/integration/tests/test_control_connection.cpp#L203-L216.
+#[tokio::test]
+async fn invalid_local_ip_address() {
+    setup_tracing();
+
+    let session_builder =
+        create_new_session_builder().local_ip_address(Some(Ipv4Addr::new(1, 1, 1, 1)));
+    let session_result = session_builder.build().await;
+
+    match session_result {
+        Err(NewSessionError::MetadataError(MetadataError::ConnectionPoolError(
+            ConnectionPoolError::Broken {
+                last_connection_error: ConnectionError::IoError(err),
+            },
+        ))) => {
+            assert_matches!(err.kind(), std::io::ErrorKind::AddrNotAvailable)
+        }
+        _ => panic!("Expected EADDRNOTAVAIL error"),
+    }
+}
+
+#[tokio::test]
+async fn valid_local_ip_address() {
+    setup_tracing();
+
+    // Create a dummy session to retrieve the address of one of the nodes.
+    // We could obviously use SCYLLA_URI environment variable, but this would work
+    // only for non-cloud cluster in CI.
+    let dummy_session = create_new_session_builder().build().await.unwrap();
+
+    let first_node_ip = dummy_session
+        .get_cluster_state()
+        .get_nodes_info()
+        .first()
+        .unwrap()
+        .address
+        .ip();
+
+    let local_ip_address =
+        find_local_ip_for_destination(first_node_ip).expect("Failed to find local IP");
+
+    tracing::info!(
+        "Found local IP address {} for destination address {}",
+        local_ip_address,
+        first_node_ip,
+    );
+
+    let session_builder = create_new_session_builder().local_ip_address(Some(local_ip_address));
+    let session = session_builder.build().await.unwrap();
+
+    session
+        .query_unpaged("SELECT host_id FROM system.local WHERE key='local'", &[])
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-rust-driver/issues/1027

This PR solves the first part of the issue: implementing local ip address binding logic.

I implemented the tests for this feature as well. 

~Actually, I have a question regarding these:
I defined a test `valid_local_ip_address` which binds the socket to `172.42.0.1`, which should be the address associated with the interface assigned to docker subnet defined in the docker-compose file (for both Scylla and Cassandra). This means that the test will obviously fail if the cluster is accessible via some other interface. For this reason, I introduced `docker_cluster_tests` cfg option and enable it for scylla (non-cloud) and cassandra tests. I wonder if this is a good solution. Maybe introducing the `cfg` option is an overkill, and we can assume that developers run the tests locally against the docker-compose cluster (e.g. by running `make up`)?~ <- Solved


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
