### PR TITLE
session: add missing fields in Debug output for Session

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -96,6 +96,27 @@ impl std::fmt::Debug for Session {
             "auto_await_schema_agreement_timeout",
             &self.schema_agreement_timeout,
         )
+        .field(
+            "schema_agreement_automatic_waiting",
+            &self.schema_agreement_automatic_waiting,
+        )
+        .field(
+            "refresh_metadata_on_auto_schema_agreement",
+            &self.refresh_metadata_on_auto_schema_agreement,
+        )
+        .field("keyspace_name", &self.keyspace_name)
+        .field(
+            "tracing_info_fetch_attempts",
+            &self.tracing_info_fetch_attempts,
+        )
+        .field(
+            "tracing_info_fetch_interval",
+            &self.tracing_info_fetch_interval,
+        )
+        .field(
+            "tracing_info_fetch_consistency",
+            &self.tracing_info_fetch_consistency,
+        )
         .finish()
     }
 }


### PR DESCRIPTION
The `Debug` implementation for `Session` omitted new fields - This patch includes all current `Session` fields

Fixes: #954 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
