### PR TITLE
Shard aware port range

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -912,6 +912,7 @@ impl Session {
 
         let connection_config = ConnectionConfig {
             local_ip_address: config.local_ip_address,
+            shard_aware_local_port_range: config.shard_aware_local_port_range,
             compression: config.compression,
             tcp_nodelay: config.tcp_nodelay,
             tcp_keepalive_interval: config.tcp_keepalive_interval,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -32,7 +32,7 @@ use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::response::query_result::{MaybeFirstRowError, QueryResult, RowsError};
 use crate::response::{NonErrorQueryResponse, PagingState, PagingStateResponse, QueryResponse};
 use crate::routing::partitioner::PartitionerName;
-use crate::routing::Shard;
+use crate::routing::{Shard, ShardAwarePortRange};
 use crate::statement::batch::batch_values;
 use crate::statement::batch::{Batch, BatchStatement};
 use crate::statement::prepared::{PartitionKeyError, PreparedStatement};
@@ -161,6 +161,11 @@ pub struct SessionConfig {
     /// - `INADDR_ANY` for IPv4 ([`Ipv4Addr::UNSPECIFIED`][std::net::Ipv4Addr::UNSPECIFIED])
     /// - `in6addr_any` for IPv6 ([`Ipv6Addr::UNSPECIFIED`][std::net::Ipv6Addr::UNSPECIFIED])
     pub local_ip_address: Option<IpAddr>,
+
+    /// Specifies the local port range used for shard-aware connections.
+    ///
+    /// By default set to [`ShardAwarePortRange::EPHEMERAL_PORT_RANGE`].
+    pub shard_aware_local_port_range: ShardAwarePortRange,
 
     /// Preferred compression algorithm to use on connections.
     /// If it's not supported by database server Session will fall back to no compression.
@@ -301,6 +306,7 @@ impl SessionConfig {
         SessionConfig {
             known_nodes: Vec::new(),
             local_ip_address: None,
+            shard_aware_local_port_range: ShardAwarePortRange::EPHEMERAL_PORT_RANGE,
             compression: None,
             tcp_nodelay: true,
             tcp_keepalive_interval: None,

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -13,6 +13,7 @@ use crate::errors::NewSessionError;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::timestamp_generator::TimestampGenerator;
+use crate::routing::ShardAwarePortRange;
 use crate::statement::Consistency;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
@@ -417,6 +418,35 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// ```
     pub fn local_ip_address(mut self, local_ip_address: Option<impl Into<IpAddr>>) -> Self {
         self.config.local_ip_address = local_ip_address.map(Into::into);
+        self
+    }
+
+    /// Specifies the local port range used for shard-aware connections.
+    ///
+    /// A possible use case is when you want to have multiple [`Session`] objects and do not want
+    /// them to compete for the ports within the same range. It is then advised to assign
+    /// mutually non-overlapping port ranges to each session object.
+    ///
+    /// By default this option is set to [`ShardAwarePortRange::EPHEMERAL_PORT_RANGE`].
+    ///
+    /// For details, see [`ShardAwarePortRange`] documentation.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// # use scylla::routing::ShardAwarePortRange;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .shard_aware_local_port_range(ShardAwarePortRange::new(49200..=50000)?)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn shard_aware_local_port_range(mut self, port_range: ShardAwarePortRange) -> Self {
+        self.config.shard_aware_local_port_range = port_range;
         self
     }
 

--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -13,7 +13,7 @@ pub mod locator;
 pub mod partitioner;
 mod sharding;
 
-pub use sharding::{Shard, ShardCount, Sharder};
+pub use sharding::{InvalidShardAwarePortRange, Shard, ShardAwarePortRange, ShardCount, Sharder};
 pub(crate) use sharding::{ShardInfo, ShardingError};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1027

This PR introduces configuration option for shard-aware local port range.

Since not all ranges are valid (e.g. empty one, or one including reserved ports i.e. ports < 1024), I introduced a simple wrapper called `ShardAwarePortRange` which validates provided range in constructor.

Currently, `Sharder` is `pub`, so are its fields, and its methods responsible for computing local ports. This is why, I couldn't modify the sharder in any of the following ways:
- adding `ShardAwarePortRange` field to the `Sharder`
- providing `ShardAwarePortRange` parameter to `Sharder` methods

This is why, I introduced separate set of methods which additionally accept the port range. Current public methods are using new methods by providing a default range (ephemeral port range `[49152, 65535]`).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
