### PR TITLE
Add information about server application version to metadata

### DIFF
--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -179,7 +179,9 @@ impl Peer {
         }
     }
 
-    pub(crate) fn into_peer_endpoint_and_tokens(self) -> (PeerEndpoint, Vec<Token>) {
+    pub(crate) fn into_peer_endpoint_tokens_and_server_version(
+        self,
+    ) -> (PeerEndpoint, Vec<Token>, Option<String>) {
         (
             PeerEndpoint {
                 host_id: self.host_id,
@@ -188,6 +190,7 @@ impl Peer {
                 rack: self.rack,
             },
             self.tokens,
+            self.server_version,
         )
     }
 }

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -123,6 +123,7 @@ pub(crate) struct Metadata {
 #[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
 pub struct Peer {
     pub host_id: Uuid,
+    pub server_version: Option<String>,
     pub address: NodeAddr,
     pub tokens: Vec<Token>,
     pub datacenter: Option<String>,
@@ -408,6 +409,7 @@ impl Metadata {
                     datacenter: None,
                     rack: None,
                     host_id: Uuid::new_v4(),
+                    server_version: None,
                 }
             })
             .collect();
@@ -746,7 +748,6 @@ impl ControlConnection {
 #[scylla(crate = "scylla_cql")]
 struct NodeInfoRow {
     host_id: Option<Uuid>,
-    #[allow(dead_code)] // TODO: remove later
     #[scylla(rename = "release_version")]
     server_version: Option<String>,
     #[scylla(rename = "rpc_address")]
@@ -850,7 +851,7 @@ impl ControlConnection {
     ) -> Option<Peer> {
         let NodeInfoRow {
             host_id,
-            server_version: _,
+            server_version,
             untranslated_ip_addr,
             datacenter,
             rack,
@@ -903,6 +904,7 @@ impl ControlConnection {
 
         Some(Peer {
             host_id,
+            server_version,
             address: node_addr,
             tokens,
             datacenter,

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -75,6 +75,7 @@ impl Display for NodeAddr {
 #[derive(Debug)]
 pub struct Node {
     pub host_id: Uuid,
+    pub server_version: Option<String>,
     pub address: NodeAddr,
     pub datacenter: Option<String>,
     pub rack: Option<String>,
@@ -92,6 +93,7 @@ impl Node {
     /// Creates a new node which starts connecting in the background.
     pub(crate) fn new(
         peer: PeerEndpoint,
+        server_version: Option<String>,
         pool_config: &PoolConfig,
         keyspace_name: Option<VerifiedKeyspaceName>,
         enabled: bool,
@@ -117,6 +119,7 @@ impl Node {
 
         Node {
             host_id,
+            server_version,
             address,
             datacenter,
             rack,
@@ -133,13 +136,18 @@ impl Node {
     ///
     /// - `node` - previous definition of that node
     /// - `address` - new address to connect to
-    pub(crate) fn inherit_with_ip_changed(node: &Node, endpoint: PeerEndpoint) -> Self {
+    pub(crate) fn inherit_with_ip_changed(
+        node: &Node,
+        endpoint: PeerEndpoint,
+        server_version: Option<String>,
+    ) -> Self {
         let address = endpoint.address;
         if let Some(ref pool) = node.pool {
             pool.update_endpoint(endpoint);
         }
         Self {
             address,
+            server_version,
             down_marker: false.into(),
             datacenter: node.datacenter.clone(),
             rack: node.rack.clone(),
@@ -367,6 +375,7 @@ mod tests {
         ) -> Self {
             Self {
                 host_id: id.unwrap_or(Uuid::new_v4()),
+                server_version: None,
                 address: address.unwrap_or(NodeAddr::Translatable(SocketAddr::from((
                     [255, 255, 255, 255],
                     0,

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -24,6 +24,7 @@ pub struct ClusterState {
     pub(crate) known_peers: HashMap<Uuid, Arc<Node>>, // Invariant: nonempty after Cluster::new()
     pub(crate) keyspaces: HashMap<String, Keyspace>,
     pub(crate) locator: ReplicaLocator,
+    pub(crate) cluster_version: Option<String>,
 }
 
 /// Enables printing [ClusterState] struct in a neat way, skipping the clutter involved by
@@ -201,6 +202,7 @@ impl ClusterState {
             known_peers: new_known_peers,
             keyspaces,
             locator,
+            cluster_version: metadata.cluster_version,
         }
     }
 
@@ -217,6 +219,16 @@ impl ClusterState {
     /// Access details about nodes known to the driver
     pub fn get_nodes_info(&self) -> &[Arc<Node>] {
         self.locator.unique_nodes_in_global_ring()
+    }
+
+    /// Returns the cluster version.
+    ///
+    /// Cluster version is the server application version used by
+    /// the current control connection node (if such information is provided by the server).
+    ///
+    /// To check version of each node, we suggest using [`ClusterState::get_nodes_info()`].
+    pub fn cluster_version(&self) -> Option<&str> {
+        self.cluster_version.as_deref()
     }
 
     /// Compute token of a table partition key

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1444,6 +1444,7 @@ mod tests {
             let info = Metadata {
                 peers,
                 keyspaces: HashMap::new(),
+                cluster_version: None,
             };
 
             ClusterState::new(

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1437,6 +1437,7 @@ mod tests {
                     address: id_to_invalid_addr(*id),
                     tokens: vec![Token::new(*id as i64 * 100)],
                     host_id: Uuid::new_v4(),
+                    server_version: None,
                 })
                 .collect::<Vec<_>>();
 

--- a/scylla/src/policies/load_balancing/plan.rs
+++ b/scylla/src/policies/load_balancing/plan.rs
@@ -229,6 +229,7 @@ mod tests {
             known_peers: Default::default(),
             keyspaces: Default::default(),
             locator,
+            cluster_version: None,
         };
         let routing_info = RoutingInfo::default();
         let plan = Plan::new(&policy, &routing_info, &cluster_state);

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -64,6 +64,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(1),
             tokens: vec![Token::new(50), Token::new(250), Token::new(400)],
             host_id: Uuid::new_v4(),
+            server_version: None,
         },
         Peer {
             // B
@@ -72,6 +73,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(2),
             tokens: vec![Token::new(100), Token::new(600), Token::new(900)],
             host_id: Uuid::new_v4(),
+            server_version: None,
         },
         Peer {
             // C
@@ -80,6 +82,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(3),
             tokens: vec![Token::new(300), Token::new(650), Token::new(700)],
             host_id: Uuid::new_v4(),
+            server_version: None,
         },
         Peer {
             // D
@@ -88,6 +91,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(4),
             tokens: vec![Token::new(350), Token::new(550)],
             host_id: Uuid::new_v4(),
+            server_version: None,
         },
         Peer {
             // E
@@ -96,6 +100,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(5),
             tokens: vec![Token::new(150), Token::new(750)],
             host_id: Uuid::new_v4(),
+            server_version: None,
         },
         Peer {
             // F
@@ -104,6 +109,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(6),
             tokens: vec![Token::new(200), Token::new(450)],
             host_id: Uuid::new_v4(),
+            server_version: None,
         },
         Peer {
             // G
@@ -112,6 +118,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(7),
             tokens: vec![Token::new(500), Token::new(800)],
             host_id: Uuid::new_v4(),
+            server_version: None,
         },
     ];
 

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -168,6 +168,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
     Metadata {
         peers: Vec::from(peers),
         keyspaces,
+        cluster_version: None,
     }
 }
 

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -191,6 +191,7 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
     for peer in &metadata.peers {
         let node = Arc::new(Node::new(
             peer.to_peer_endpoint(),
+            None,
             &pool_config,
             None,
             true,


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1286

This PR adds server application version information to the metadata.

It is exposed in two places:
1. `Node` struct - a server version of specific node (`release_version` from `system.local/system.peers`)
2. `ClusterState` - a cluster version, which is the version of the node currently used for control connection (`release_version` from `system.local`)

I'm not entirely sure about the second place. Maybe it's not really needed. I added some context to the corresponding commit message, so we can discuss this.

I implemented the test which validates the version for Scylla. It's possible, because Scylla currently hardcodes the `release_version` column to `3.0.8` and it does not seem like it's going to be addressed in the near future (the reason is some java-driver compatibility issues).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
