### PR TITLE
cluster/state: Fix missing zero-token nodes in nodes info

### DIFF
--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -21,8 +21,17 @@ use super::node::{Node, NodeRef};
 
 #[derive(Clone)]
 pub struct ClusterState {
+    /// All nodes known to be part of the cluster, accessible by their host ID.
+    /// Often refered to as "topology metadata".
     pub(crate) known_peers: HashMap<Uuid, Arc<Node>>, // Invariant: nonempty after Cluster::new()
+
+    /// All keyspaces in the cluster, accessible by their name.
+    /// Often refered to as "schema metadata".
     pub(crate) keyspaces: HashMap<String, Keyspace>,
+
+    /// The entity which provides a way to find the set of owning nodes (+shards, in case of ScyllaDB)
+    /// for a given (token, replication strategy, table) tuple.
+    /// It relies on both topology and schema metadata.
     pub(crate) locator: ReplicaLocator,
 }
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -313,7 +313,7 @@ impl ClusterWorker {
                             _ => continue, // Don't go to refreshing
                         }
                     } else {
-                        // If server_events_channel was closed, than TopologyReader was dropped,
+                        // If server_events_channel was closed, than MetadataReader was dropped,
                         // so we can probably stop working too
                         return;
                     }
@@ -355,7 +355,7 @@ impl ClusterWorker {
             }
 
             // Perform the refresh
-            debug!("Requesting topology refresh");
+            debug!("Requesting metadata refresh");
             last_refresh_time = Instant::now();
             let refresh_res = self.perform_refresh().await;
 

--- a/scylla/src/policies/load_balancing/plan.rs
+++ b/scylla/src/policies/load_balancing/plan.rs
@@ -227,6 +227,7 @@ mod tests {
         let locator = create_locator(&mock_metadata_for_token_aware_tests());
         let cluster_state = ClusterState {
             known_peers: Default::default(),
+            all_nodes: Default::default(),
             keyspaces: Default::default(),
             locator,
         };


### PR DESCRIPTION
Ref: #1053

## Problem statement
When manually testing the driver against a cluster containing some zero-token nodes, I uncovered a bug: zero-token nodes are missing from `ClusterState::get_nodes_info()` slice, because the slice is borrowed from `ReplicaLocator`, which only contains nodes that have some tokens assigned.

## Ideal Solution
All nodes reside in `ClusterState::known_peers` `HashMap`. Therefore, my preferred solution would be to change the signature of `ClusterState::get_nodes_info()` to return `Iterator` over `Arc<Node>` instead of `&[Arc<Node>]`. This is, unfortunately, not an option for time now - this must wait until 2.0.

## Taken Solution
For now, to fix the bug, `all_nodes` field is added to `ClusterState`. It's just a `Vec<Arc<Node>>` with the same nodes that are present in `ClusterState::known_peers`.


## Bonus
Some leftover references of `topology` were renamed to `metadata` where appropriate. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
