### PR TITLE
feat: add nil() method for CqlTimeuuid

### DIFF
--- a/scylla-cql/src/value.rs
+++ b/scylla-cql/src/value.rs
@@ -42,6 +42,10 @@ pub struct CqlTimeuuid(Uuid);
 
 /// [`Uuid`] delegate methods
 impl CqlTimeuuid {
+    pub fn nil() -> Self {
+        Self(Uuid::nil())
+    }
+
     pub fn as_bytes(&self) -> &[u8; 16] {
         self.0.as_bytes()
     }
@@ -1404,6 +1408,14 @@ mod tests {
         let uuid = CqlTimeuuid::from_str("ffffffff-ffff-ffff-ffff-ffffffffffff").unwrap();
 
         assert_eq!(0xffffffffffffffff, uuid.lsb());
+    }
+
+    #[test]
+    fn timeuuid_nil() {
+        let uuid = CqlTimeuuid::nil();
+
+        assert_eq!(0x0000000000000000, uuid.msb());
+        assert_eq!(0x0000000000000000, uuid.lsb());
     }
 
     #[test]


### PR DESCRIPTION
This patch adds a nil() method for CqlTimeuuid
To directly generate nil values and recude boilerplate code

Fixes https://github.com/scylladb/scylla-rust-driver/issues/930

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
