### PR TITLE
CI: Fix warnings in serverless tests

### DIFF
--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2319,7 +2319,7 @@ mod tests {
     ///    Then use query_iter with page_size set to 7 to select all 100 rows.
     /// 3. INSERT query_iter should work and not return any rows.
     #[tokio::test]
-    #[cfg(not(scylla_cloud_tests))]
+    #[cfg_attr(scylla_cloud_tests, ignore)]
     async fn connection_query_iter_test() {
         use crate::client::session_builder::SessionBuilder;
 
@@ -2423,7 +2423,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(not(scylla_cloud_tests))]
+    #[cfg_attr(scylla_cloud_tests, ignore)]
     async fn test_coalescing() {
         use std::num::NonZeroU64;
 
@@ -2639,7 +2639,7 @@ mod tests {
 
     #[tokio::test]
     #[ntest::timeout(20000)]
-    #[cfg(not(scylla_cloud_tests))]
+    #[cfg_attr(scylla_cloud_tests, ignore)]
     async fn connection_is_closed_on_no_response_to_keepalives() {
         use crate::errors::BrokenConnectionErrorKind;
 

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1181,7 +1181,7 @@ mod tests {
     // Port collision should occur
     // If they are not handled this test will most likely fail
     #[tokio::test]
-    #[cfg(not(scylla_cloud_tests))]
+    #[cfg_attr(scylla_cloud_tests, ignore)]
     async fn many_connections() {
         setup_tracing();
         let connections_number = 512;

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -102,7 +102,7 @@ pub(crate) fn create_new_session_builder() -> GenericSessionBuilder<impl Session
 
         #[cfg(scylla_cloud_tests)]
         {
-            use crate::client::session_builder::{CloudMode, CloudSessionBuilder};
+            use crate::client::session_builder::CloudSessionBuilder;
             use std::path::Path;
 
             std::env::var("CLOUD_CONFIG_PATH")

--- a/scylla/tests/integration/consistency.rs
+++ b/scylla/tests/integration/consistency.rs
@@ -251,7 +251,7 @@ async fn check_for_all_consistencies_and_setting_options<
 //  in the CQL request frame.
 #[tokio::test]
 #[ntest::timeout(60000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn consistency_is_correctly_set_in_cql_requests() {
     setup_tracing();
     let res = test_with_3_node_cluster(
@@ -404,7 +404,7 @@ impl LoadBalancingPolicy for RoutingInfoReportingWrapper {
 // in the RoutingInfo that is exposed to the load balancer.
 #[tokio::test]
 #[ntest::timeout(60000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn consistency_is_correctly_set_in_routing_info() {
     setup_tracing();
     let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
@@ -463,7 +463,7 @@ async fn consistency_is_correctly_set_in_routing_info() {
 // Before, Consistency did not contain serial variants, so it used to be impossible.
 #[tokio::test]
 #[ntest::timeout(60000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn consistency_allows_for_paxos_selects() {
     setup_tracing();
     let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());

--- a/scylla/tests/integration/execution_profiles.rs
+++ b/scylla/tests/integration/execution_profiles.rs
@@ -122,7 +122,7 @@ impl<const NODE: u8> SpeculativeExecutionPolicy for BoundToPredefinedNodePolicy<
 
 #[tokio::test]
 #[ntest::timeout(20000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn test_execution_profiles() {
     setup_tracing();
     let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {

--- a/scylla/tests/integration/lwt_optimisation.rs
+++ b/scylla/tests/integration/lwt_optimisation.rs
@@ -17,7 +17,7 @@ use scylla_proxy::{
 
 #[tokio::test]
 #[ntest::timeout(20000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optimally() {
     use scylla::client::session_builder::SessionBuilder;
 

--- a/scylla/tests/integration/metadata_custom_timeouts.rs
+++ b/scylla/tests/integration/metadata_custom_timeouts.rs
@@ -21,7 +21,7 @@ use tracing::info;
 // By default, custom metadata request timeout is set to 2 seconds.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
 
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 #[tokio::test]
 #[ntest::timeout(20000)]
 async fn test_custom_metadata_timeouts() {

--- a/scylla/tests/integration/new_session.rs
+++ b/scylla/tests/integration/new_session.rs
@@ -6,7 +6,7 @@ use assert_matches::assert_matches;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::errors::{ConnectionError, ConnectionPoolError, MetadataError, NewSessionError};
 
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 #[tokio::test]
 async fn proceed_if_only_some_hostnames_are_invalid() {
     setup_tracing();
@@ -27,7 +27,7 @@ async fn proceed_if_only_some_hostnames_are_invalid() {
         .unwrap();
 }
 
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 #[tokio::test]
 async fn all_hostnames_invalid() {
     setup_tracing();

--- a/scylla/tests/integration/retries.rs
+++ b/scylla/tests/integration/retries.rs
@@ -16,7 +16,7 @@ use scylla_proxy::{
 
 #[tokio::test]
 #[ntest::timeout(30000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn speculative_execution_is_fired() {
     setup_tracing();
     const TIMEOUT_PER_REQUEST: Duration = Duration::from_millis(1000);
@@ -98,7 +98,7 @@ async fn speculative_execution_is_fired() {
 
 #[tokio::test]
 #[ntest::timeout(30000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn retries_occur() {
     setup_tracing();
     let res = test_with_3_node_cluster(ShardAwareness::QueryNode, |proxy_uris, translation_map, mut running_proxy| async move {
@@ -168,7 +168,7 @@ async fn retries_occur() {
 // See https://github.com/scylladb/scylla-rust-driver/issues/1085
 #[tokio::test]
 #[ntest::timeout(30000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn speculative_execution_panic_regression_test() {
     use scylla_proxy::RunningProxy;
 

--- a/scylla/tests/integration/self_identity.rs
+++ b/scylla/tests/integration/self_identity.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 
 #[tokio::test]
 #[ntest::timeout(20000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn self_identity_is_set_properly_in_startup_message() {
     setup_tracing();
 

--- a/scylla/tests/integration/shards.rs
+++ b/scylla/tests/integration/shards.rs
@@ -16,7 +16,7 @@ use scylla_proxy::{ProxyError, RequestFrame, WorkerError};
 
 #[tokio::test]
 #[ntest::timeout(30000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn test_consistent_shard_awareness() {
     setup_tracing();
 

--- a/scylla/tests/integration/silent_prepare_query.rs
+++ b/scylla/tests/integration/silent_prepare_query.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 #[tokio::test]
 #[ntest::timeout(30000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn test_prepare_query_with_values() {
     setup_tracing();
     // unprepared query with non empty values should be prepared
@@ -62,7 +62,7 @@ async fn test_prepare_query_with_values() {
 
 #[tokio::test]
 #[ntest::timeout(30000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn test_query_with_no_values() {
     setup_tracing();
     // unprepared query with empty values should not be prepared

--- a/scylla/tests/integration/skip_metadata_optimization.rs
+++ b/scylla/tests/integration/skip_metadata_optimization.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 #[tokio::test]
 #[ntest::timeout(20000)]
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 async fn test_skip_result_metadata() {
     use scylla::client::session::Session;
     use scylla::client::session_builder::SessionBuilder;

--- a/scylla/tests/integration/tablets.rs
+++ b/scylla/tests/integration/tablets.rs
@@ -280,7 +280,7 @@ async fn prepare_schema(session: &Session, ks: &str, table: &str, tablet_count: 
 /// The test first sends 100 queries per tablet and expects to receive tablet info.
 /// After that we know we have all the info. The test sends the statements again
 /// and expects to not receive any tablet info.
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 #[tokio::test]
 #[ntest::timeout(30000)]
 async fn test_default_policy_is_tablet_aware() {
@@ -411,7 +411,7 @@ async fn test_default_policy_is_tablet_aware() {
 ///
 /// The test sends a query to each shard of every node and verifies that no
 /// tablet info was sent in response.
-#[cfg(not(scylla_cloud_tests))]
+#[cfg_attr(scylla_cloud_tests, ignore)]
 #[tokio::test]
 #[ntest::timeout(30000)]
 async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
@@ -482,7 +482,11 @@ async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
 /// recevied requests for a given tablet.
 ///
 /// TODO: Remove #[ignore] once LWTs are supported with tablets.
-#[cfg(not(scylla_cloud_tests))]
+/// Below cfg_attr is commented out because:
+/// - This test should be always ignored for now
+/// - Having both attrs results in warning about `#[ignore]` being unused
+/// - I don't want to fully remove cfg_attr because it will be needed after we remove `#[ignore]`
+// #[cfg_attr(scylla_cloud_tests, ignore)]
 #[tokio::test]
 #[ntest::timeout(30000)]
 #[ignore]

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -176,7 +176,7 @@ pub(crate) fn create_new_session_builder() -> GenericSessionBuilder<impl Session
 
         #[cfg(scylla_cloud_tests)]
         {
-            use scylla::client::session_builder::{CloudMode, CloudSessionBuilder};
+            use scylla::client::session_builder::CloudSessionBuilder;
             use std::path::Path;
 
             std::env::var("CLOUD_CONFIG_PATH")


### PR DESCRIPTION
When serverless tests are executed, some test that are not compatible with serverless are skipped. Skipping was done by cfg-ing them out. This caused some imports to be unused which of course resulted in warnings. Github, in coordination with `setup-rust-toolchain` action, "helpfully" attached info about those warnings in EVERY COMMIT OF EVERY PR in a section "Unchanged files with check annotations" which despite being a "preview" feature has no good way of being disabled.

This commit fixes that by changing `#[cfg(not(scylla_cloud_tests))]` to `#[cfg_attr(scylla_cloud_tests, ignore)]`. This causes those tests to still be compiled, just not executed.

The above uncovered two real warnings about unused imports, which I also fixed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~!I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
