### PR TITLE
feat: add MaybeUnset::from_option() to reduce boilerplate

### DIFF
--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -2349,6 +2349,24 @@ fn unset_value() {
         do_serialize(set_i32, &ColumnType::Native(NativeType::Int)),
         vec![0, 0, 0, 4, 0, 0, 0, 32]
     );
+
+    let unset_option_i32: Option<i32> = None;
+    assert_eq!(
+        do_serialize(
+            MaybeUnset::from_option(unset_option_i32),
+            &ColumnType::Native(NativeType::Int)
+        ),
+        &(-2_i32).to_be_bytes()[..]
+    );
+
+    let set_option_i32: Option<i32> = Some(44);
+    assert_eq!(
+        do_serialize(
+            MaybeUnset::from_option(set_option_i32),
+            &ColumnType::Native(NativeType::Int)
+        ),
+        vec![0, 0, 0, 4, 0, 0, 0, 44]
+    );
 }
 
 #[test]

--- a/scylla-cql/src/value.rs
+++ b/scylla-cql/src/value.rs
@@ -33,6 +33,16 @@ pub enum MaybeUnset<V> {
     Set(V),
 }
 
+impl<V> MaybeUnset<V> {
+    #[inline]
+    pub fn from_option(opt: Option<V>) -> Self {
+        match opt {
+            Some(v) => Self::Set(v),
+            None => Self::Unset,
+        }
+    }
+}
+
 /// Represents timeuuid (uuid V1) value
 ///
 /// This type has custom comparison logic which follows Scylla/Cassandra semantics.


### PR DESCRIPTION
This patch adds from_option() method for MaybeUnset enum
It enables easy conversion from Option<T> into MaybeUnset<T>

Fixes: #1003 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
