### PR TITLE
Adjust to MSRV 1.80

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1718,7 +1718,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "histogram",
  "itertools 0.14.0",
- "lazy_static",
  "lz4_flex",
  "ntest",
  "num-bigint 0.3.3",

--- a/scylla-cql/src/deserialize/result.rs
+++ b/scylla-cql/src/deserialize/result.rs
@@ -237,6 +237,7 @@ mod tests {
 
     use bytes::Bytes;
     use std::ops::Deref;
+    use std::sync::LazyLock;
 
     use crate::frame::response::result::{
         ColumnSpec, ColumnType, DeserializedMetadataAndRawRows, NativeType, ResultMetadata,
@@ -285,19 +286,15 @@ mod tests {
         //
         // I: for<'item> LendingIterator<Item<'item> = ColumnIterator<'item>>,
         //
-        // The bug is said to be a lot of effort to fix, so in tests let's just use `lazy_static`
+        // The bug is said to be a lot of effort to fix, so in tests let's just use `LazyLock`
         // to obtain 'static references.
-        //
-        // `std::sync::LazyLock` is stable since 1.80, so once we bump MSRV enough,
-        // we will be able to replace `lazy_static` with `LazyLock`.
 
         static SPECS: &[ColumnSpec<'static>] = &[
             spec("b1", ColumnType::Native(NativeType::Blob)),
             spec("b2", ColumnType::Native(NativeType::Blob)),
         ];
-        lazy_static::lazy_static! {
-            static ref RAW_DATA: Bytes = serialize_cells([Some(CELL1), Some(CELL2), Some(CELL2), Some(CELL1)]);
-        }
+        static RAW_DATA: LazyLock<Bytes> =
+            LazyLock::new(|| serialize_cells([Some(CELL1), Some(CELL2), Some(CELL2), Some(CELL1)]));
         let raw_data = RAW_DATA.deref();
         let specs = SPECS;
 
@@ -339,9 +336,9 @@ mod tests {
             spec("b1", ColumnType::Native(NativeType::Blob)),
             spec("b2", ColumnType::Native(NativeType::Blob)),
         ];
-        lazy_static::lazy_static! {
-            static ref RAW_DATA: Bytes = serialize_cells([Some(CELL1), Some(CELL2)]);
-        }
+        static RAW_DATA: LazyLock<Bytes> =
+            LazyLock::new(|| serialize_cells([Some(CELL1), Some(CELL2)]));
+
         let raw_data = RAW_DATA.deref();
         let specs = SPECS;
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -79,7 +79,6 @@ url = { version = "2.3.1", optional = true }
 base64 = { version = "0.22.1", optional = true }
 rand_pcg = "0.9.0"
 socket2 = { version = "0.5.3", features = ["all"] }
-lazy_static = "1"
 
 [dev-dependencies]
 num-bigint-03 = { package = "num-bigint", version = "0.3" }

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -28,7 +28,6 @@ use tracing::warn;
 mod sealed {
     // This is a sealed trait - its whole purpose is to be unnameable.
     // This means we need to disable the check.
-    #[allow(unknown_lints)] // Rust 1.66 doesn't know this lint
     #[allow(unnameable_types)]
     pub trait Sealed {}
 }

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -83,9 +83,7 @@ impl TlsProvider {
                 };
 
                 cloud_config.make_tls_config_for_scylla_cloud_host(host_id, dc, address)
-                    // inspect_err() is stable since 1.76.
-                    // TODO: use inspect_err once we bump MSRV to at least 1.76.
-                    .map_err(|err| {
+                    .inspect_err(|err| {
                         warn!(
                             "TlsProvider for SNI connection to Scylla Cloud node {{ host_id={:?}, dc={:?} at {} }} could not be set up: {}\n Proceeding with attempting probably nonworking connection",
                             host_id,

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -78,7 +78,6 @@ impl PartitionerHasher for PartitionerHasherAny {
 mod sealed {
     // This is a sealed trait - its whole purpose is to be unnameable.
     // This means we need to disable the check.
-    #[allow(unknown_lints)] // Rust 1.70 doesn't know this lint
     #[allow(unnameable_types)]
     pub trait Sealed {}
 }


### PR DESCRIPTION
After we bumped MSRV to 1.80 in #1144, some code became obsolete. Also, it unlocked using `LazyLock` (forgive me the pun) instead of `lazy_static`. This PR takes advantage of the MSRV bump and adjusts the codebase.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
