### PR TITLE
session: Prepare on one shard per node only

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1246,7 +1246,7 @@ impl Session {
         statement: &Statement,
     ) -> Result<PreparedStatement, PrepareError> {
         let cluster_state = self.get_cluster_state();
-        let connections_iter = cluster_state.iter_working_connections()?;
+        let connections_iter = cluster_state.iter_working_connections_to_shards()?;
 
         // Prepare statements on all connections concurrently
         let handles = connections_iter.map(|c| async move { c.prepare_raw(statement).await });
@@ -2108,7 +2108,7 @@ impl Session {
 
     pub async fn check_schema_agreement(&self) -> Result<Option<Uuid>, SchemaAgreementError> {
         let cluster_state = self.get_cluster_state();
-        let connections_iter = cluster_state.iter_working_connections()?;
+        let connections_iter = cluster_state.iter_working_connections_to_shards()?;
 
         let handles = connections_iter.map(|c| async move { c.fetch_schema_version().await });
         let versions = try_join_all(handles).await?;

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1181,7 +1181,7 @@ impl Session {
             // Making QueryPager::new_for_query work with values is too hard (if even possible)
             // so instead of sending one prepare to a specific connection on each iterator query,
             // we fully prepare a statement beforehand.
-            let prepared = self.prepare(statement).await?;
+            let prepared = self.prepare_nongeneric(statement).await?;
             let values = prepared.serialize_values(&values)?;
             QueryPager::new_for_prepared_statement(PreparedPagerConfig {
                 prepared,
@@ -1237,6 +1237,14 @@ impl Session {
         statement: impl Into<Statement>,
     ) -> Result<PreparedStatement, PrepareError> {
         let statement = statement.into();
+        self.prepare_nongeneric(statement).await
+    }
+
+    // Introduced to avoid monomorphisation of this large function.
+    async fn prepare_nongeneric(
+        &self,
+        statement: Statement,
+    ) -> Result<PreparedStatement, PrepareError> {
         let statement_ref = &statement;
 
         let cluster_state = self.get_cluster_state();
@@ -1583,7 +1591,7 @@ impl Session {
                 .iter_mut()
                 .map(|statement| async move {
                     if let BatchStatement::Query(query) = statement {
-                        let prepared = self.prepare(query.clone()).await?;
+                        let prepared = self.prepare_nongeneric(query.clone()).await?;
                         *statement = BatchStatement::PreparedStatement(prepared);
                     }
                     Ok::<(), PrepareError>(())

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1274,7 +1274,7 @@ impl Session {
         }
 
         prepared.set_partitioner_name(
-            self.extract_partitioner_name(&prepared, &self.cluster.get_state())
+            Self::extract_partitioner_name(&prepared, &self.cluster.get_state())
                 .and_then(PartitionerName::from_str)
                 .unwrap_or_default(),
         );
@@ -1283,7 +1283,6 @@ impl Session {
     }
 
     fn extract_partitioner_name<'a>(
-        &self,
         prepared: &PreparedStatement,
         cluster_state: &'a ClusterState,
     ) -> Option<&'a str> {

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1246,7 +1246,7 @@ impl Session {
         statement: &Statement,
     ) -> Result<PreparedStatement, PrepareError> {
         let cluster_state = self.get_cluster_state();
-        let connections_iter = cluster_state.iter_working_connections_to_shards()?;
+        let connections_iter = cluster_state.iter_working_connections_to_nodes()?;
 
         // Prepare statements on all connections concurrently
         let handles = connections_iter.map(|c| async move { c.prepare_raw(statement).await });
@@ -1255,7 +1255,7 @@ impl Session {
         // If at least one prepare was successful, `prepare()` returns Ok.
         // Find the first result that is Ok, or Err if all failed.
 
-        // Safety: there is at least one node in the cluster, and `Cluster::iter_working_connections()`
+        // Safety: there is at least one node in the cluster, and `Cluster::iter_working_connections_to_nodes()`
         // returns either an error or an iterator with at least one connection, so there will be at least one result.
         let first_ok: Result<RawPreparedStatement, RequestAttemptError> =
             results.by_ref().find_or_first(Result::is_ok).unwrap();

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1285,6 +1285,12 @@ impl Session {
         // Validate prepared ids equality.
         for another_raw_prepared in raw_prepared_statements_results_iter.flatten() {
             if prepared.get_id() != &another_raw_prepared.prepared_response.id {
+                tracing::error!(
+                    "Got differing ids upon statement preparation: statement \"{}\", id1: {:?}, id2: {:?}",
+                    prepared.get_statement(),
+                    prepared.get_id(),
+                    another_raw_prepared.prepared_response.id
+                );
                 return Err(PrepareError::PreparedStatementIdsMismatch);
             }
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1199,6 +1199,9 @@ impl Session {
     /// Prepares a statement on the server side and returns a prepared statement,
     /// which can later be used to perform more efficient requests.
     ///
+    /// The statement is prepared on all nodes. This function finishes once all nodes respond
+    /// with either success or an error.
+    ///
     /// Prepared statements are much faster than unprepared statements:
     /// * Database doesn't need to parse the statement string upon each execution (only once)
     /// * They are properly load balanced using token aware routing

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1279,6 +1279,12 @@ impl Session {
     /// Returns:
     /// - `Ok(PreparedStatement)`, if preparation succeeded on at least one connection;
     /// - `Err(PrepareError)`, if no connection is working or preparation failed on all attempted connections.
+    // TODO: There are no timeouts here. So, just one stuck node freezes the driver here, potentially indefinitely long.
+    // Also, what the driver requires to get from the cluster is the prepared statement metadata.
+    // It suffices that it gets only one copy of it, just from one success response. Therefore, it's a possible
+    // optimisation that the function only waits for one preparation to finish successfully, and then it returns.
+    // For it to be done, other preparations must continue in the background, on a separate tokio task.
+    // Describing issue: #1332.
     async fn prepare_on_all(
         statement: &Statement,
         cluster_state: &ClusterState,

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -207,6 +207,10 @@ impl Node {
         self.get_pool()?.get_working_connections()
     }
 
+    pub(crate) fn get_random_connection(&self) -> Result<Arc<Connection>, ConnectionPoolError> {
+        self.get_pool()?.random_connection()
+    }
+
     pub(crate) async fn wait_until_pool_initialized(&self) {
         if let Some(pool) = &self.pool {
             pool.wait_until_initialized().await;

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -319,7 +319,7 @@ impl ClusterState {
     }
 
     /// Returns nonempty iterator of working connections to all shards.
-    pub(crate) fn iter_working_connections(
+    pub(crate) fn iter_working_connections_to_shards(
         &self,
     ) -> Result<impl Iterator<Item = Arc<Connection>> + '_, ConnectionPoolError> {
         // The returned iterator is nonempty by nonemptiness invariant of `self.known_peers`.

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -324,22 +324,35 @@ impl ClusterState {
     ) -> Result<impl Iterator<Item = Arc<Connection>> + '_, ConnectionPoolError> {
         // The returned iterator is nonempty by nonemptiness invariant of `self.known_peers`.
         assert!(!self.known_peers.is_empty());
-        let mut peers_iter = self.known_peers.values();
+        let nodes_iter = self.known_peers.values();
+        let mut connection_pool_per_node_iter =
+            nodes_iter.map(|node| node.get_working_connections());
 
         // First we try to find the first working pool of connections.
         // If none is found, return error.
-        let first_working_pool = peers_iter
-            .by_ref()
-            .map(|node| node.get_working_connections())
-            .find_or_first(Result::is_ok)
-            .expect("impossible: known_peers was asserted to be nonempty")?;
+        let first_working_pool_or_error: Result<Vec<Arc<Connection>>, ConnectionPoolError> =
+            connection_pool_per_node_iter
+                .by_ref()
+                .find_or_first(Result::is_ok)
+                .expect("impossible: known_peers was asserted to be nonempty");
 
-        let remaining_pools_iter = peers_iter
-            .map(|node| node.get_working_connections())
-            .flatten_ok()
-            .flatten();
+        // We have:
+        // 1. either consumed the whole iterator without success and got the first error,
+        //    in which case we propagate it;
+        // 2. or found the first working pool of connections.
+        let first_working_pool: Vec<Arc<Connection>> = first_working_pool_or_error?;
 
-        Ok(first_working_pool.into_iter().chain(remaining_pools_iter))
+        // We retrieve connection pools for remaining nodes (those that are left in the iterator
+        // once the first working pool has been found).
+        let remaining_pools_iter = connection_pool_per_node_iter;
+        // Pools are flattened, so now we have `impl Iterator<Item = Result<Arc<Connection>, ConnectionPoolError>>`.
+        let remaining_connections_iter = remaining_pools_iter.flatten_ok();
+        // Errors (non-working pools) are filtered out.
+        let remaining_working_connections_iter = remaining_connections_iter.filter_map(Result::ok);
+
+        Ok(first_working_pool
+            .into_iter()
+            .chain(remaining_working_connections_iter))
         // By an invariant `self.known_peers` is nonempty, so the returned iterator
         // is nonempty, too.
     }


### PR DESCRIPTION
## Overview

This PR comes with two main enhancements / optimisations:
1. **Prepare on every node, not on every shard.** This corresponds to #1290.
2. ~~**Wait only for one prepare attempt to succeed, not for all prepare attempts.** This is inspired by cpp-driver's logic.~~ (dropped)

Below, I describe both changes in detail.

## Prepare on every node, not on every shard

Just as other drivers do, now the Rust driver also prepares statements on a single connection to every node, not on a single connection to every shard. This brings performance benefits for both driver and cluster, as it lowers the overhead of handling duplicated prepare requests on both sides.

### Problem: unlucky random choice
As mentioned in https://github.com/scylladb/scylla-rust-driver/issues/1290#issuecomment-2740175939, we might be unlucky enough to end up with all randomly chosen connections being non-working. For example, the targeted shards might be overloaded.

### Solution
Fallback logic is introduced. Once we fail to prepare the statement on any node though the randomly chosen connections, the preparation is re-attempted **on all connections** (which is essentially how it used to work before this PR).

## ~~Wait only for one prepare attempt to succeed~~ (dropped)
~~Having taken a look at cpp-driver's handling of statement preparation, I noticed that the cpp-driver waits only for the first preparation to succeed. Preparation on all remaining nodes is done in the background, which decreases latency of the prepare operation from the driver user's PoV. To understand why, consider a node that is stuck/overloaded/temporarily unavailable. If we wait for prepare responses from all nodes, we are limited by the slowest response. This is not what ScyllaDB is designed for - it should be available and fast even if some nodes happen to be unavailable or overloaded.~~

~~I decided to implement this behaviour in the Rust driver. This is achieved by spawning a tokio worker task which prepares the statement on all nodes. It feeds all results, successes or failures, into a channel and this way signals the parent task. The parent task finishes early once it receives a successful response (a deserialized `PreparedStatement`). Meanwhile, the worker task keeps handling the remaining preparations in the background.~~

~~The change brings two main benefits:~~
    ~~1. reduces driver's latency upon statement preparation;~~
    ~~2. prevents the situation when one stuck node freezes the driver upon
       preparation - **there are no preparation timeouts!** (sic!).~~


## Tests

TODO. Waiting for #1246 to be merged. Then I'll add a new feature to the proxy to be aware of which shard was targeted by the intercepted frame. With that feature available, I'll write tests.

Fixes: #1290
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
