### PR TITLE
Add Bound{Statement,Batch}

### DIFF
--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -50,6 +50,52 @@ where
     pub values: Values,
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct BatchV2<'b> {
+    pub statements_and_values: Cow<'b, [u8]>,
+    pub batch_type: BatchType,
+    pub consistency: types::Consistency,
+    pub serial_consistency: Option<types::SerialConsistency>,
+    pub timestamp: Option<i64>,
+    pub statements_len: u16,
+}
+
+impl SerializableRequest for BatchV2<'_> {
+    const OPCODE: RequestOpcode = RequestOpcode::Batch;
+
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
+        // Serializing type of batch
+        buf.put_u8(self.batch_type as u8);
+
+        // Serializing queries
+        types::write_short(self.statements_len, buf);
+        buf.extend_from_slice(&self.statements_and_values);
+
+        // Serializing consistency
+        types::write_consistency(self.consistency, buf);
+
+        // Serializing flags
+        let mut flags = 0;
+        if self.serial_consistency.is_some() {
+            flags |= FLAG_WITH_SERIAL_CONSISTENCY;
+        }
+        if self.timestamp.is_some() {
+            flags |= FLAG_WITH_DEFAULT_TIMESTAMP;
+        }
+
+        buf.put_u8(flags);
+
+        if let Some(serial_consistency) = self.serial_consistency {
+            types::write_serial_consistency(serial_consistency, buf);
+        }
+        if let Some(timestamp) = self.timestamp {
+            types::write_long(timestamp, buf);
+        }
+
+        Ok(())
+    }
+}
+
 /// The type of a batch.
 #[derive(Clone, Copy)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -245,7 +291,7 @@ impl BatchStatement<'_> {
 }
 
 impl BatchStatement<'_> {
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), BatchStatementSerializationError> {
+    pub fn serialize(&self, buf: &mut impl BufMut) -> Result<(), BatchStatementSerializationError> {
         match self {
             Self::Query { text } => {
                 buf.put_u8(0);

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -108,14 +108,12 @@ impl ControlConnection {
                     NextRowError::NextPageError(NextPageError::RequestFailure(attempt_err.into()))
                 })?;
 
-        let serialized_values = prepared.serialize_values(&values).map_err(|ser_err| {
+        let bound = prepared.into_bind(&values).map_err(|ser_err| {
             NextRowError::NextPageError(NextPageError::RequestFailure(
                 RequestError::LastAttemptError(RequestAttemptError::SerializationError(ser_err)),
             ))
         })?;
-        Arc::clone(&self.conn)
-            .execute_iter(prepared, serialized_values)
-            .await
+        Arc::clone(&self.conn).execute_iter(bound).await
     }
 }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1096,7 +1096,7 @@ impl Connection {
             consistency,
             serial_consistency,
             timestamp,
-            statements_len: batch.statements_len,
+            statements_len: batch.statements_len(),
         };
 
         loop {

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -25,6 +25,7 @@ use crate::response::{NonErrorAuthResponse, NonErrorStartupResponse, PagingState
 use crate::routing::locator::tablets::{RawTablet, TabletParsingError};
 use crate::routing::{Shard, ShardAwarePortRange, ShardInfo, Sharder, ShardingError};
 use crate::statement::batch::{Batch, BatchStatement};
+use crate::statement::bound::BoundStatement;
 use crate::statement::prepared::{PreparedStatement, RawPreparedStatement};
 use crate::statement::unprepared::Statement;
 use crate::statement::{Consistency, PageSize};
@@ -886,17 +887,16 @@ impl Connection {
     #[cfg(test)]
     async fn execute_raw_unpaged(
         &self,
-        prepared: &PreparedStatement,
-        values: &SerializedValues,
+        bound: &BoundStatement<'_>,
     ) -> Result<QueryResponse, RequestAttemptError> {
         // This method is used only for driver internal queries, so no need to consult execution profile here.
         self.execute_raw_with_consistency(
-            prepared,
-            values,
-            prepared
+            bound,
+            bound
+                .prepared
                 .config
                 .determine_consistency(self.config.default_consistency),
-            prepared.config.serial_consistency.flatten(),
+            bound.prepared.config.serial_consistency.flatten(),
             None,
             PagingState::start(),
         )
@@ -950,8 +950,7 @@ impl Connection {
 
     pub(crate) async fn execute_raw_with_consistency(
         &self,
-        prepared_statement: &PreparedStatement,
-        values: &SerializedValues,
+        bound: &BoundStatement<'_>,
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,
         page_size: Option<PageSize>,
@@ -963,7 +962,8 @@ impl Connection {
                 .as_ref()
                 .map(|generator| generator.next_timestamp())
         };
-        let timestamp = prepared_statement
+        let timestamp = bound
+            .prepared
             .get_timestamp()
             .or_else(get_timestamp_from_gen);
 
@@ -972,20 +972,19 @@ impl Connection {
         // If the metadata id extension is supported, there is no point in not caching metadata,
         // so we ignore the setting on prepared statement.
         let skip_metadata =
-            prepared_statement.get_use_cached_result_metadata() || has_metadata_extension;
+            bound.prepared.get_use_cached_result_metadata() || has_metadata_extension;
 
-        let cached_metadata =
-            skip_metadata.then(|| prepared_statement.get_current_result_metadata());
+        let cached_metadata = skip_metadata.then(|| bound.prepared.get_current_result_metadata());
 
         let result_id = Self::get_result_id(&cached_metadata, has_metadata_extension);
 
         let execute_frame = execute::ExecuteV2 {
-            id: prepared_statement.get_id().as_ref().into(),
+            id: bound.prepared.get_id().as_ref().into(),
             result_metadata_id: result_id.map(Into::into),
             parameters: query::QueryParameters {
                 consistency,
                 serial_consistency,
-                values: Cow::Borrowed(values),
+                values: Cow::Borrowed(&bound.values),
                 page_size: page_size.map(Into::into),
                 timestamp,
                 skip_metadata,
@@ -997,12 +996,12 @@ impl Connection {
             .send_request(
                 &execute_frame,
                 true,
-                prepared_statement.config.tracing,
+                bound.prepared.config.tracing,
                 cached_metadata.as_ref(),
             )
             .await?;
 
-        if let Some(spec) = prepared_statement.get_table_spec() {
+        if let Some(spec) = bound.prepared.get_table_spec() {
             if let Err(e) = self
                 .update_tablets_from_response(spec, &query_response)
                 .await
@@ -1011,7 +1010,7 @@ impl Connection {
             }
         }
 
-        Self::handle_result_metadata_new_id(prepared_statement, &query_response);
+        Self::handle_result_metadata_new_id(&bound.prepared, &query_response);
 
         match &query_response.response {
             ResponseWithDeserializedMetadata::Error(frame::response::Error {
@@ -1023,11 +1022,11 @@ impl Connection {
                     statement_id
                 );
                 // Repreparation of a statement is needed
-                self.reprepare(prepared_statement.get_statement(), prepared_statement)
+                self.reprepare(bound.prepared.get_statement(), &bound.prepared)
                     .await?;
                 // Metadata may have changed in reprepare, or in some concurrent execution
                 let cached_metadata =
-                    skip_metadata.then(|| prepared_statement.get_current_result_metadata());
+                    skip_metadata.then(|| bound.prepared.get_current_result_metadata());
                 let result_id = Self::get_result_id(&cached_metadata, has_metadata_extension);
                 let new_response = self
                     .send_request(
@@ -1036,12 +1035,12 @@ impl Connection {
                             ..execute_frame
                         },
                         true,
-                        prepared_statement.config.tracing,
+                        bound.prepared.config.tracing,
                         cached_metadata.as_ref(),
                     )
                     .await?;
 
-                if let Some(spec) = prepared_statement.get_table_spec() {
+                if let Some(spec) = bound.prepared.get_table_spec() {
                     if let Err(e) = self.update_tablets_from_response(spec, &new_response).await {
                         tracing::warn!(
                             "Error while parsing tablet info from custom payload: {}",
@@ -1050,7 +1049,7 @@ impl Connection {
                     }
                 }
 
-                Self::handle_result_metadata_new_id(prepared_statement, &new_response);
+                Self::handle_result_metadata_new_id(&bound.prepared, &new_response);
 
                 Ok(new_response)
             }
@@ -1066,23 +1065,17 @@ impl Connection {
     /// Other kinds of responses will result in an error.
     pub(crate) async fn execute_iter(
         self: Arc<Self>,
-        prepared_statement: PreparedStatement,
-        values: SerializedValues,
+        bound: BoundStatement<'static>,
     ) -> Result<QueryPager, NextRowError> {
-        let consistency = prepared_statement
+        let consistency = bound
+            .prepared
             .config
             .determine_consistency(self.config.default_consistency);
-        let serial_consistency = prepared_statement.config.serial_consistency.flatten();
+        let serial_consistency = bound.prepared.config.serial_consistency.flatten();
 
-        QueryPager::new_for_connection_execute_iter(
-            prepared_statement,
-            values,
-            self,
-            consistency,
-            serial_consistency,
-        )
-        .await
-        .map_err(NextRowError::NextPageError)
+        QueryPager::new_for_connection_execute_iter(bound, self, consistency, serial_consistency)
+            .await
+            .map_err(NextRowError::NextPageError)
     }
 
     pub(crate) async fn batch_with_consistency(
@@ -2285,7 +2278,6 @@ mod tests {
         LWT_OPTIMIZATION_META_BIT_MASK_KEY, SCYLLA_LWT_ADD_METADATA_MARK_EXTENSION,
     };
     use scylla_cql::frame::types;
-    use scylla_cql::serialize::row::SerializedValues;
     use scylla_proxy::{
         Condition, Node, Proxy, Reaction, RequestFrame, RequestOpcode, RequestReaction,
         RequestRule, ResponseFrame, ShardAwareness,
@@ -2297,10 +2289,12 @@ mod tests {
     use super::{HostConnectionConfig, open_connection};
     use crate::cluster::metadata::UntranslatedEndpoint;
     use crate::cluster::node::ResolvedContactPoint;
+    use crate::statement::bound::BoundStatement;
     use crate::statement::unprepared::Statement;
     use crate::test_utils::setup_tracing;
     use crate::utils::test_utils::{PerformDDL, resolve_hostname, unique_keyspace_name};
     use futures::{StreamExt, TryStreamExt};
+    use std::borrow::Cow;
     use std::collections::HashMap;
     use std::net::SocketAddr;
     use std::sync::Arc;
@@ -2358,9 +2352,10 @@ mod tests {
         let select_query =
             Statement::new("SELECT p FROM connection_execute_iter_tab").with_page_size(7);
         let prepared_select = connection.prepare(&select_query).await.unwrap();
+        let bound_select = BoundStatement::empty(Cow::Owned(prepared_select));
         let empty_res = connection
             .clone()
-            .execute_iter(prepared_select.clone(), SerializedValues::new())
+            .execute_iter(bound_select.clone())
             .await
             .unwrap()
             .rows_stream::<(i32,)>()
@@ -2378,8 +2373,8 @@ mod tests {
         let mut insert_futures = Vec::new();
         for v in &values {
             let fut = async {
-                let values = prepared.serialize_values(&(*v,)).unwrap();
-                connection.execute_raw_unpaged(&prepared, &values).await
+                let bound = prepared.bind(&(*v,)).unwrap();
+                connection.execute_raw_unpaged(&bound).await
             };
             insert_futures.push(fut);
         }
@@ -2388,7 +2383,7 @@ mod tests {
 
         let mut results: Vec<i32> = connection
             .clone()
-            .execute_iter(prepared_select, SerializedValues::new())
+            .execute_iter(bound_select.clone())
             .await
             .unwrap()
             .rows_stream::<(i32,)>()
@@ -2472,11 +2467,8 @@ mod tests {
                         let conn = conn.clone();
                         async move {
                             let prepared = conn.prepare(&q).await.unwrap();
-                            let values = prepared
-                                .serialize_values(&(j, vec![j as u8; j as usize]))
-                                .unwrap();
-                            let response =
-                                conn.execute_raw_unpaged(&prepared, &values).await.unwrap();
+                            let bound = prepared.bind(&(j, vec![j as u8; j as usize])).unwrap();
+                            let response = conn.execute_raw_unpaged(&bound).await.unwrap();
                             // QueryResponse might contain an error - make sure that there were no errors
                             let _nonerror_response =
                                 response.into_non_error_query_response().unwrap();

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -2,17 +2,30 @@
 //! that can be executed together.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
+use scylla_cql::frame::frame_errors::{
+    BatchSerializationError, BatchStatementSerializationError, CqlRequestSerializationError,
+};
+use scylla_cql::frame::request;
+use scylla_cql::serialize::batch::{BatchValues, BatchValuesIterator};
+use scylla_cql::serialize::row::{RowSerializationContext, SerializedValues};
+use scylla_cql::serialize::{RowWriter, SerializationError};
+
 use crate::client::execution_profile::ExecutionProfileHandle;
+use crate::errors::{BadQuery, ExecutionError, RequestAttemptError};
 use crate::observability::history::HistoryListener;
 use crate::policies::load_balancing::LoadBalancingPolicy;
 use crate::policies::retry::RetryPolicy;
-use crate::statement::prepared::PreparedStatement;
+use crate::routing::Token;
+use crate::statement::prepared::{PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
 
 use super::StatementConfig;
+use super::bound::BoundStatement;
 use super::{Consistency, SerialConsistency};
 pub use crate::frame::request::batch::BatchType;
 
@@ -283,145 +296,187 @@ impl<'a: 'b, 'b> From<&'a BatchStatement>
     }
 }
 
-pub(crate) mod batch_values {
-    use scylla_cql::serialize::batch::BatchValues;
-    use scylla_cql::serialize::batch::BatchValuesIterator;
-    use scylla_cql::serialize::row::RowSerializationContext;
-    use scylla_cql::serialize::row::SerializedValues;
-    use scylla_cql::serialize::{RowWriter, SerializationError};
+/// A batch with all of its statements bound to values
+pub(crate) struct BoundBatch {
+    pub(crate) config: StatementConfig,
+    batch_type: BatchType,
+    pub(crate) buffer: Vec<u8>,
+    pub(crate) prepared: HashMap<Bytes, PreparedStatement>,
+    pub(crate) first_prepared: Option<(PreparedStatement, Token)>,
+    pub(crate) statements_len: u16,
+}
 
-    use crate::errors::ExecutionError;
-    use crate::routing::Token;
-    use crate::statement::prepared::PartitionKeyError;
-
-    use super::BatchStatement;
-
-    /// Takes an optional reference to the first statement in the batch and
-    /// the batch values, and tries to compute the token for the statement.
-    /// Returns the (optional) token and batch values. If the function needed
-    /// to serialize values for the first statement, the returned batch values
-    /// will cache the results of the serialization.
-    ///
-    /// NOTE: Batch values returned by this function might not type check
-    /// the first statement when it is serialized! However, if they don't,
-    /// then the first row was already checked by the function. It is assumed
-    /// that `statement` holds the first prepared statement of the batch (if
-    /// there is one), and that it will be used later to serialize the values.
+impl BoundBatch {
     #[allow(clippy::result_large_err)]
-    pub(crate) fn peek_first_token<'bv, ValuesT: BatchValues + 'bv>(
-        values: ValuesT,
-        statement: Option<&BatchStatement>,
-    ) -> Result<(Option<Token>, impl BatchValues + use<'bv, ValuesT>), ExecutionError> {
-        let mut values_iter = values.batch_values_iter();
-        let (token, first_values) = match statement {
-            Some(BatchStatement::PreparedStatement(ps)) => {
-                let ctx = RowSerializationContext::from_prepared(ps.get_prepared_metadata());
-                let (first_values, did_write) = SerializedValues::from_closure(|writer| {
-                    values_iter
-                        .serialize_next(&ctx, writer)
-                        .transpose()
-                        .map(|o| o.is_some())
-                })?;
-                if did_write {
-                    let token = ps
-                        .calculate_token_untyped(&first_values)
-                        .map_err(PartitionKeyError::into_execution_error)?;
-                    (token, Some(first_values))
-                } else {
-                    (None, None)
-                }
-            }
-            _ => (None, None),
+    pub(crate) fn from_batch(
+        batch: &Batch,
+        values: impl BatchValues,
+    ) -> Result<Self, ExecutionError> {
+        let mut bound_batch = BoundBatch {
+            config: batch.config.clone(),
+            batch_type: batch.batch_type,
+            prepared: HashMap::new(),
+            buffer: vec![],
+            first_prepared: None,
+            statements_len: batch.statements.len().try_into().map_err(|_| {
+                ExecutionError::BadQuery(BadQuery::TooManyQueriesInBatchStatement(
+                    batch.statements.len(),
+                ))
+            })?,
         };
 
-        // Need to do it explicitly, otherwise the next line will complain
-        // that `values_iter` still borrows `values`.
-        std::mem::drop(values_iter);
+        let mut values = values.batch_values_iter();
+        let mut statements = batch.statements.iter().enumerate();
 
-        // Reuse the already serialized first value via `BatchValuesFirstSerialized`.
-        let values = BatchValuesFirstSerialized::new(values, first_values);
-
-        Ok((token, values))
-    }
-
-    struct BatchValuesFirstSerialized<BV> {
-        // Contains the first value of BV in a serialized form.
-        // The first value in the iterator returned from `rest` should be skipped!
-        first: Option<SerializedValues>,
-        rest: BV,
-    }
-
-    impl<BV> BatchValuesFirstSerialized<BV> {
-        fn new(rest: BV, first: Option<SerializedValues>) -> Self {
-            Self { first, rest }
-        }
-    }
-
-    impl<BV> BatchValues for BatchValuesFirstSerialized<BV>
-    where
-        BV: BatchValues,
-    {
-        type BatchValuesIter<'r>
-            = BatchValuesFirstSerializedIterator<'r, BV::BatchValuesIter<'r>>
-        where
-            Self: 'r;
-
-        fn batch_values_iter(&self) -> Self::BatchValuesIter<'_> {
-            BatchValuesFirstSerializedIterator {
-                first: self.first.as_ref(),
-                rest: self.rest.batch_values_iter(),
-            }
-        }
-    }
-
-    struct BatchValuesFirstSerializedIterator<'f, BVI> {
-        first: Option<&'f SerializedValues>,
-        rest: BVI,
-    }
-
-    impl<'f, BVI> BatchValuesIterator<'f> for BatchValuesFirstSerializedIterator<'f, BVI>
-    where
-        BVI: BatchValuesIterator<'f>,
-    {
-        #[inline]
-        fn serialize_next(
-            &mut self,
-            ctx: &RowSerializationContext<'_>,
-            writer: &mut RowWriter,
-        ) -> Option<Result<(), SerializationError>> {
-            match self.first.take() {
-                Some(sr) => {
-                    writer.append_serialize_row(sr);
-                    self.rest.skip_next();
-                    Some(Ok(()))
+        if let Some((idx, statement)) = statements.next() {
+            match statement {
+                BatchStatement::Query(_) => {
+                    bound_batch.serialize_from_batch_statement(statement, idx, |writer| {
+                        let ctx = RowSerializationContext::empty();
+                        values.serialize_next(&ctx, writer).transpose()
+                    })?;
                 }
-                None => self.rest.serialize_next(ctx, writer),
-            }
-        }
+                BatchStatement::PreparedStatement(ps) => {
+                    let values =
+                        bound_batch.serialize_from_batch_statement(statement, idx, |writer| {
+                            let ctx =
+                                RowSerializationContext::from_prepared(ps.get_prepared_metadata());
 
-        #[inline]
-        fn is_empty_next(&mut self) -> Option<bool> {
-            match self.first.take() {
-                Some(s) => {
-                    self.rest.skip_next();
-                    Some(s.is_empty())
+                            let values = SerializedValues::from_closure(|writer| {
+                                values.serialize_next(&ctx, writer).transpose()
+                            })
+                            .map(|(values, opt)| opt.map(|_| values));
+
+                            if let Ok(Some(values)) = &values {
+                                writer.append_serialize_row(values);
+                            }
+
+                            values
+                        })?;
+
+                    let bound = BoundStatement::new_untyped(Cow::Borrowed(ps), values);
+                    let token = bound
+                        .token()
+                        .map_err(PartitionKeyError::into_execution_error)?;
+
+                    let prepared = bound.prepared.into_owned();
+                    bound_batch.first_prepared = token.map(|token| (prepared.clone(), token));
+                    bound_batch
+                        .prepared
+                        .insert(prepared.get_id().to_owned(), prepared);
                 }
-                None => self.rest.is_empty_next(),
             }
         }
 
-        #[inline]
-        fn skip_next(&mut self) -> Option<()> {
-            self.first = None;
-            self.rest.skip_next()
+        for (idx, statement) in statements {
+            bound_batch.serialize_from_batch_statement(statement, idx, |writer| {
+                let ctx = match statement {
+                    BatchStatement::Query(_) => RowSerializationContext::empty(),
+                    BatchStatement::PreparedStatement(ps) => {
+                        RowSerializationContext::from_prepared(ps.get_prepared_metadata())
+                    }
+                };
+                values.serialize_next(&ctx, writer).transpose()
+            })?;
+
+            if let BatchStatement::PreparedStatement(ps) = statement {
+                if !bound_batch.prepared.contains_key(ps.get_id()) {
+                    bound_batch
+                        .prepared
+                        .insert(ps.get_id().to_owned(), ps.clone());
+                }
+            }
         }
 
-        #[inline]
-        fn count(self) -> usize
-        where
-            Self: Sized,
-        {
-            self.rest.count()
+        // At this point, we have all statements serialized. If any values are still left, we have a mismatch.
+        if values.skip_next().is_some() {
+            return Err(ExecutionError::LastAttemptError(
+                RequestAttemptError::CqlRequestSerialization(
+                    CqlRequestSerializationError::BatchSerialization(counts_mismatch_err(
+                        bound_batch.statements_len as usize + 1 /*skipped above*/ + values.count(),
+                        bound_batch.statements_len,
+                    )),
+                ),
+            ));
         }
+
+        Ok(bound_batch)
+    }
+
+    /// Borrows the execution profile handle associated with this batch.
+    pub(crate) fn get_execution_profile_handle(&self) -> Option<&ExecutionProfileHandle> {
+        self.config.execution_profile_handle.as_ref()
+    }
+
+    /// Gets the default timestamp for this batch in microseconds.
+    pub(crate) fn get_timestamp(&self) -> Option<i64> {
+        self.config.timestamp
+    }
+
+    /// Gets type of batch.
+    pub(crate) fn get_type(&self) -> BatchType {
+        self.batch_type
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn serialize_from_batch_statement<T>(
+        &mut self,
+        statement: &BatchStatement,
+        statement_idx: usize,
+        serialize: impl FnOnce(&mut RowWriter<'_>) -> Result<Option<T>, SerializationError>,
+    ) -> Result<T, ExecutionError> {
+        serialize_statement(
+            request::batch::BatchStatement::from(statement),
+            &mut self.buffer,
+            serialize,
+        )
+        .map_err(|error| BatchSerializationError::StatementSerialization {
+            statement_idx,
+            error,
+        })
+        .transpose()
+        .unwrap_or_else(|| Err(counts_mismatch_err(statement_idx, self.statements_len)))
+        .map_err(|e| {
+            ExecutionError::LastAttemptError(RequestAttemptError::CqlRequestSerialization(
+                CqlRequestSerializationError::BatchSerialization(e),
+            ))
+        })
+    }
+}
+
+fn serialize_statement<T>(
+    statement: request::batch::BatchStatement,
+    buffer: &mut Vec<u8>,
+    serialize: impl FnOnce(&mut RowWriter<'_>) -> Result<Option<T>, SerializationError>,
+) -> Result<Option<T>, BatchStatementSerializationError> {
+    statement.serialize(buffer)?;
+
+    // Reserve two bytes for length
+    let length_pos = buffer.len();
+    buffer.extend_from_slice(&[0, 0]);
+
+    // serialize the values
+    let mut writer = RowWriter::new(buffer);
+    let Some(res) =
+        serialize(&mut writer).map_err(BatchStatementSerializationError::ValuesSerialiation)?
+    else {
+        return Ok(None);
+    };
+
+    // Go back and put the length
+    let count: u16 = writer
+        .value_count()
+        .try_into()
+        .map_err(|_| BatchStatementSerializationError::TooManyValues(writer.value_count()))?;
+
+    buffer[length_pos..length_pos + 2].copy_from_slice(&count.to_be_bytes());
+
+    Ok(Some(res))
+}
+
+fn counts_mismatch_err(n_value_lists: usize, n_statements: u16) -> BatchSerializationError {
+    BatchSerializationError::ValuesAndStatementsLengthMismatch {
+        n_value_lists,
+        n_statements: n_statements as usize,
     }
 }

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -12,20 +12,29 @@ use scylla_cql::frame::frame_errors::{
 };
 use scylla_cql::frame::request;
 use scylla_cql::serialize::batch::{BatchValues, BatchValuesIterator};
-use scylla_cql::serialize::row::{RowSerializationContext, SerializedValues};
+use scylla_cql::serialize::row::{RowSerializationContext, SerializeRow, SerializedValues};
 use scylla_cql::serialize::{RowWriter, SerializationError};
+use thiserror::Error;
+use tracing::Instrument;
 
-use crate::client::execution_profile::ExecutionProfileHandle;
+use crate::client::execution_profile::{ExecutionProfileHandle, ExecutionProfileInner};
+use crate::client::session::{RunRequestResult, Session};
 use crate::errors::{BadQuery, ExecutionError, RequestAttemptError};
+use crate::network::Connection;
+use crate::observability::driver_tracing::RequestSpan;
 use crate::observability::history::HistoryListener;
 use crate::policies::load_balancing::LoadBalancingPolicy;
+use crate::policies::load_balancing::RoutingInfo;
 use crate::policies::retry::RetryPolicy;
+use crate::response::query_result::QueryResult;
+use crate::response::{Coordinator, NonErrorQueryResponse, QueryResponse};
 use crate::routing::Token;
 use crate::statement::prepared::{PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
 
 use super::StatementConfig;
 use super::bound::BoundStatement;
+use super::execute::Execute;
 use super::{Consistency, SerialConsistency};
 pub use crate::frame::request::batch::BatchType;
 
@@ -302,8 +311,8 @@ pub struct BoundBatch {
     batch_type: BatchType,
     pub(crate) buffer: Vec<u8>,
     pub(crate) prepared: HashMap<Bytes, PreparedStatement>,
-    pub(crate) first_prepared: Option<(PreparedStatement, Token)>,
-    pub(crate) statements_len: u16,
+    first_prepared: Option<(PreparedStatement, Token)>,
+    statements_len: u16,
 }
 
 impl BoundBatch {
@@ -313,6 +322,20 @@ impl BoundBatch {
             batch_type,
             ..Default::default()
         }
+    }
+
+    /// Appends a new statement to the batch.
+    pub fn append_statement<'p, V: SerializeRow>(
+        &mut self,
+        statement: impl Into<BoundBatchStatement<'p, V>>,
+    ) -> Result<(), BoundBatchStatementError> {
+        let initial_len = self.buffer.len();
+        self.raw_append_statement(statement).inspect_err(|_| {
+            // if we error'd at any point we should put the buffer back to its old length to not
+            // corrupt the buffer in case the user doesn't drop the boundbatch but instead skips and
+            // tries with a successful statement later
+            self.buffer.truncate(initial_len);
+        })
     }
 
     #[allow(clippy::result_large_err)]
@@ -424,6 +447,96 @@ impl BoundBatch {
         self.batch_type
     }
 
+    /// Gets the number of statements that have been added to this batch so far
+    pub fn statements_len(&self) -> u16 {
+        self.statements_len
+    }
+
+    // **IMPORTANT NOTE**: It is OK for this function to append to the buffer even if it errors
+    // because the caller will fix the buffer, HOWEVER, it is *NOT OK* for *ANY* other field in
+    // `self` to be modified if an error occured because the caller will not reset them.
+    fn raw_append_statement<'p, V: SerializeRow>(
+        &mut self,
+        statement: impl Into<BoundBatchStatement<'p, V>>,
+    ) -> Result<(), BoundBatchStatementError> {
+        let mut statement = statement.into();
+        let mut first_prepared = None;
+
+        if self.statements_len == 0 {
+            // save it into a local variable for now in case a latter steps fails
+            first_prepared = match statement {
+                BoundBatchStatement::Bound(ref b) => b
+                    .token()?
+                    .map(|token| (b.prepared.clone().into_owned(), token)),
+                BoundBatchStatement::Prepared(ps, values) => {
+                    let bound = ps
+                        .into_bind(&values)
+                        .map_err(BatchStatementSerializationError::ValuesSerialiation)?;
+                    let first_prepared = bound
+                        .token()?
+                        .map(|token| (bound.prepared.clone().into_owned(), token));
+                    // we already serialized it so to avoid re-serializing it, modify the statement to a
+                    // BoundStatement
+                    statement = BoundBatchStatement::Bound(bound);
+                    first_prepared
+                }
+                BoundBatchStatement::Query(_) => None,
+            };
+        }
+
+        let stmnt = match &statement {
+            BoundBatchStatement::Prepared(ps, _) => request::batch::BatchStatement::Prepared {
+                id: Cow::Borrowed(ps.get_id()),
+            },
+            BoundBatchStatement::Bound(b) => request::batch::BatchStatement::Prepared {
+                id: Cow::Borrowed(b.prepared.get_id()),
+            },
+            BoundBatchStatement::Query(q) => request::batch::BatchStatement::Query {
+                text: Cow::Borrowed(&q.contents),
+            },
+        };
+
+        serialize_statement(stmnt, &mut self.buffer, |writer| match &statement {
+            BoundBatchStatement::Prepared(ps, values) => {
+                let ctx = RowSerializationContext::from_prepared(ps.get_prepared_metadata());
+                values.serialize(&ctx, writer).map(Some)
+            }
+            BoundBatchStatement::Bound(b) => {
+                writer.append_serialize_row(&b.values);
+                Ok(Some(()))
+            }
+            // query has no values
+            BoundBatchStatement::Query(_) => Ok(Some(())),
+        })?;
+
+        let new_statements_len = self
+            .statements_len
+            .checked_add(1)
+            .ok_or(BoundBatchStatementError::TooManyQueriesInBatchStatement)?;
+
+        /*** at this point nothing else should be fallible as we are going to be modifying
+         * fields that do not get reset ***/
+
+        self.statements_len = new_statements_len;
+
+        if let Some(first_prepared) = first_prepared {
+            self.first_prepared = Some(first_prepared);
+        }
+
+        let prepared = match statement {
+            BoundBatchStatement::Prepared(ps, _) => Cow::Owned(ps),
+            BoundBatchStatement::Bound(b) => b.prepared,
+            BoundBatchStatement::Query(_) => return Ok(()),
+        };
+
+        if !self.prepared.contains_key(prepared.get_id()) {
+            self.prepared
+                .insert(prepared.get_id().to_owned(), prepared.into_owned());
+        }
+
+        Ok(())
+    }
+
     #[allow(clippy::result_large_err)]
     fn serialize_from_batch_statement<T>(
         &mut self,
@@ -497,5 +610,131 @@ fn counts_mismatch_err(n_value_lists: usize, n_statements: u16) -> BatchSerializ
     BatchSerializationError::ValuesAndStatementsLengthMismatch {
         n_value_lists,
         n_statements: n_statements as usize,
+    }
+}
+
+/// This enum represents a CQL statement, that can be part of batch and its values
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum BoundBatchStatement<'p, V: SerializeRow> {
+    /// A prepared statement and its not-yet serialized values
+    Prepared(PreparedStatement, V),
+    /// A statement whose values have already been bound (and thus serialized)
+    Bound(BoundStatement<'p>),
+    /// An unprepared statement with no values
+    Query(Statement),
+}
+
+impl<'p> From<BoundStatement<'p>> for BoundBatchStatement<'p, ()> {
+    fn from(b: BoundStatement<'p>) -> Self {
+        BoundBatchStatement::Bound(b)
+    }
+}
+
+impl<V: SerializeRow> From<(PreparedStatement, V)> for BoundBatchStatement<'static, V> {
+    fn from((p, v): (PreparedStatement, V)) -> Self {
+        BoundBatchStatement::Prepared(p, v)
+    }
+}
+
+impl From<Statement> for BoundBatchStatement<'static, ()> {
+    fn from(s: Statement) -> Self {
+        BoundBatchStatement::Query(s)
+    }
+}
+
+impl From<&str> for BoundBatchStatement<'static, ()> {
+    fn from(s: &str) -> Self {
+        BoundBatchStatement::Query(Statement::from(s))
+    }
+}
+
+/// An error type returned when adding a statement to a bounded batch fails
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum BoundBatchStatementError {
+    /// Failed to serialize the batch statement
+    #[error(transparent)]
+    Statement(#[from] BatchStatementSerializationError),
+    /// Failed to serialize statement's bound values.
+    #[error("Failed to calculate partition key")]
+    PartitionKey(#[from] PartitionKeyError),
+    /// Too many statements in the batch statement.
+    #[error("Added statement goes over exceeded max value of 65,535")]
+    TooManyQueriesInBatchStatement,
+}
+
+impl Execute for BoundBatch {
+    async fn execute(&self, session: &Session) -> Result<QueryResult, ExecutionError> {
+        // Shard-awareness behavior for batch will be to pick shard based on first batch statement's shard
+        // If users batch statements by shard, they will be rewarded with full shard awareness
+        let execution_profile = self
+            .get_execution_profile_handle()
+            .unwrap_or_else(|| session.get_default_execution_profile_handle())
+            .access();
+
+        let consistency = self
+            .config
+            .consistency
+            .unwrap_or(execution_profile.consistency);
+
+        let serial_consistency = self
+            .config
+            .serial_consistency
+            .unwrap_or(execution_profile.serial_consistency);
+
+        let (table, token) = self
+            .first_prepared
+            .as_ref()
+            .and_then(|(ps, token)| ps.get_table_spec().map(|table| (table, *token)))
+            .unzip();
+
+        let statement_info = RoutingInfo {
+            consistency,
+            serial_consistency,
+            token,
+            table,
+            is_confirmed_lwt: false,
+        };
+
+        let span = RequestSpan::new_batch();
+
+        let (run_request_result, coordinator): (
+            RunRequestResult<NonErrorQueryResponse>,
+            Coordinator,
+        ) = session
+            .run_request(
+                statement_info,
+                &self.config,
+                execution_profile,
+                |connection: Arc<Connection>,
+                 consistency: Consistency,
+                 execution_profile: &ExecutionProfileInner| {
+                    let serial_consistency = self
+                        .config
+                        .serial_consistency
+                        .unwrap_or(execution_profile.serial_consistency);
+                    async move {
+                        connection
+                            .batch_with_consistency(self, consistency, serial_consistency)
+                            .await
+                            .and_then(QueryResponse::into_non_error_query_response)
+                    }
+                },
+                &span,
+            )
+            .instrument(span.span().clone())
+            .await?;
+
+        let result = match run_request_result {
+            RunRequestResult::IgnoredWriteError => QueryResult::mock_empty(coordinator),
+            RunRequestResult::Completed(non_error_query_response) => {
+                let result = non_error_query_response.into_query_result(coordinator)?;
+                span.record_result_fields(&result);
+                result
+            }
+        };
+
+        Ok(result)
     }
 }

--- a/scylla/src/statement/bound.rs
+++ b/scylla/src/statement/bound.rs
@@ -82,6 +82,14 @@ impl<'p> BoundStatement<'p> {
         Ok(Some((partition_key, token)))
     }
 
+    /// Consumes this bound statement to return one with no borrowed data
+    pub fn into_owned(self) -> BoundStatement<'static> {
+        BoundStatement {
+            prepared: Cow::Owned(self.prepared.into_owned()),
+            values: self.values,
+        }
+    }
+
     /// Calculates the token for the prepared statement and its bound values
     ///
     /// Returns the token that would be computed for executing the provided prepared statement with

--- a/scylla/src/statement/bound.rs
+++ b/scylla/src/statement/bound.rs
@@ -27,16 +27,20 @@ impl<'p> BoundStatement<'p> {
         values: &impl SerializeRow,
     ) -> Result<Self, SerializationError> {
         let values = prepared.serialize_values(values)?;
-        Ok(Self { prepared, values })
+        Ok(Self::new_untyped(prepared, values))
+    }
+
+    pub(crate) fn new_untyped(
+        prepared: Cow<'p, PreparedStatement>,
+        values: SerializedValues,
+    ) -> Self {
+        Self { prepared, values }
     }
 
     #[cfg(test)]
     /// Create a new bound statement with no values to serialize
     pub fn empty(prepared: Cow<'p, PreparedStatement>) -> Self {
-        Self {
-            prepared,
-            values: SerializedValues::new(),
-        }
+        Self::new_untyped(prepared, SerializedValues::new())
     }
 
     /// Determines which values constitute the partition key and puts them in order.

--- a/scylla/src/statement/bound.rs
+++ b/scylla/src/statement/bound.rs
@@ -1,0 +1,73 @@
+//! Defines the [`BoundStatement`] type, which represents a prepared statement whose values have
+//! already been bound (serialized).
+
+use std::borrow::Cow;
+
+use scylla_cql::serialize::{
+    SerializationError,
+    row::{SerializeRow, SerializedValues},
+};
+
+use crate::routing::Token;
+
+use super::prepared::{
+    PartitionKey, PartitionKeyError, PartitionKeyExtractionError, PreparedStatement,
+};
+
+/// Represents a statement that already had all its values bound
+#[derive(Debug, Clone)]
+pub struct BoundStatement<'p> {
+    pub(crate) prepared: Cow<'p, PreparedStatement>,
+    pub(crate) values: SerializedValues,
+}
+
+impl<'p> BoundStatement<'p> {
+    pub(crate) fn new(
+        prepared: Cow<'p, PreparedStatement>,
+        values: &impl SerializeRow,
+    ) -> Result<Self, SerializationError> {
+        let values = prepared.serialize_values(values)?;
+        Ok(Self { prepared, values })
+    }
+
+    #[cfg(test)]
+    /// Create a new bound statement with no values to serialize
+    pub fn empty(prepared: Cow<'p, PreparedStatement>) -> Self {
+        Self {
+            prepared,
+            values: SerializedValues::new(),
+        }
+    }
+
+    /// Determines which values constitute the partition key and puts them in order.
+    ///
+    /// This is a preparation step necessary for calculating token based on a prepared statement.
+    pub(crate) fn pk(&self) -> Result<PartitionKey<'_>, PartitionKeyExtractionError> {
+        PartitionKey::new(self.prepared.get_prepared_metadata(), &self.values)
+    }
+
+    pub(crate) fn pk_and_token(
+        &self,
+    ) -> Result<Option<(PartitionKey<'_>, Token)>, PartitionKeyError> {
+        if !self.prepared.is_token_aware() {
+            return Ok(None);
+        }
+
+        let partition_key = self.pk()?;
+        let token = partition_key.calculate_token(self.prepared.get_partitioner_name())?;
+        Ok(Some((partition_key, token)))
+    }
+
+    /// Calculates the token for the prepared statement and its bound values
+    ///
+    /// Returns the token that would be computed for executing the provided prepared statement with
+    /// the provided values.
+    pub fn token(&self) -> Result<Option<Token>, PartitionKeyError> {
+        self.pk_and_token().map(|p| p.map(|(_, t)| t))
+    }
+
+    /// Returns the prepared statement behind the `BoundStatement`
+    pub fn prepared(&self) -> &PreparedStatement {
+        &self.prepared
+    }
+}

--- a/scylla/src/statement/execute.rs
+++ b/scylla/src/statement/execute.rs
@@ -1,0 +1,77 @@
+//! Defines the [`Execute`] and [`ExecutePageable`] sealed traits which are implemented for types
+//! that can be executed on a given session
+
+use scylla_cql::frame::request::query::{PagingState, PagingStateResponse};
+use tracing::error;
+
+use crate::{
+    client::session::Session,
+    errors::{ExecutionError, RequestAttemptError},
+    response::query_result::QueryResult,
+};
+
+// seals the trait to foreign implementations
+mod private {
+    use scylla_cql::serialize::row::SerializeRow;
+
+    use crate::statement::{Statement, batch::BoundBatch, bound::BoundStatement};
+
+    #[allow(unnameable_types)]
+    pub trait Sealed {}
+
+    impl Sealed for BoundBatch {}
+    impl Sealed for BoundStatement<'_> {}
+    impl<V: SerializeRow> Sealed for (&Statement, V) {}
+}
+
+/// A type that can be executed on a [`Session`] without any additional values
+///
+/// In practice this means that the statement(s) all already had their values bound.
+pub trait Execute: private::Sealed {
+    /// Executes on the session
+    fn execute(
+        &self,
+        session: &Session,
+    ) -> impl std::future::Future<Output = Result<QueryResult, ExecutionError>>;
+}
+
+/// A type that can be executed on a [`Session`], optionally conitnuing froma saved point
+///
+/// We believe that paging is such an important concept that we require users to make a conscious
+/// decision to use paging or not. For that, we expose three different ways to execute pageable
+/// requests:
+///
+/// * `Execute::execute`: unpaged and from the start
+/// * `ExecutePageable::execute_pageable::<true>`: paginating from a saved point
+/// * `ExecutePageable::execute_pageable::<false>`: no pagination from a saved point
+pub trait ExecutePageable {
+    /// Sends a request to the database, optionally continuing from a saved point.
+    ///
+    /// If SINGLE_PAGE is set to true then a single page is returned. If SINGLE_PAGE is set to
+    /// false, then all pages (starting at `paging_state`) are returned
+    fn execute_pageable<const SINGLE_PAGE: bool>(
+        &self,
+        session: &Session,
+        paging_state: PagingState,
+    ) -> impl std::future::Future<Output = Result<(QueryResult, PagingStateResponse), ExecutionError>>;
+}
+
+impl<T: ExecutePageable + private::Sealed> Execute for T {
+    /// Executes the pageable type but getting all pages from the start
+    async fn execute(&self, session: &Session) -> Result<QueryResult, ExecutionError> {
+        let (result, paging_state) = self
+            .execute_pageable::<false>(session, PagingState::start())
+            .await?;
+
+        if !paging_state.finished() {
+            error!(
+                "Unpaged prepared query returned a non-empty paging state! This is a driver-side or server-side bug."
+            );
+            return Err(ExecutionError::LastAttemptError(
+                RequestAttemptError::NonfinishedPagingState,
+            ));
+        }
+
+        Ok(result)
+    }
+}

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -15,6 +15,7 @@ use crate::policies::load_balancing::LoadBalancingPolicy;
 use crate::policies::retry::RetryPolicy;
 
 pub mod batch;
+pub mod bound;
 pub mod prepared;
 pub mod unprepared;
 

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -16,6 +16,7 @@ use crate::policies::retry::RetryPolicy;
 
 pub mod batch;
 pub mod bound;
+pub mod execute;
 pub mod prepared;
 pub mod unprepared;
 

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -10,12 +10,14 @@ use scylla_cql::frame::types::RawValue;
 use scylla_cql::serialize::SerializationError;
 use scylla_cql::serialize::row::{RowSerializationContext, SerializeRow, SerializedValues};
 use smallvec::{SmallVec, smallvec};
+use std::borrow::Cow;
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use uuid::Uuid;
 
+use super::bound::BoundStatement;
 use super::{PageSize, StatementConfig};
 use crate::client::execution_profile::ExecutionProfileHandle;
 use crate::errors::{BadQuery, ExecutionError};
@@ -336,39 +338,14 @@ impl PreparedStatement {
         &self,
         bound_values: &impl SerializeRow,
     ) -> Result<Bytes, PartitionKeyError> {
-        let serialized = self.serialize_values(bound_values)?;
-        let partition_key = self.extract_partition_key(&serialized)?;
+        let bound = self.bind(bound_values)?;
+        let partition_key = bound.pk()?;
         let mut buf = BytesMut::new();
         let mut writer = |chunk: &[u8]| buf.extend_from_slice(chunk);
 
         partition_key.write_encoded_partition_key(&mut writer)?;
 
         Ok(buf.freeze())
-    }
-
-    /// Determines which values constitute the partition key and puts them in order.
-    ///
-    /// This is a preparation step necessary for calculating token based on a prepared statement.
-    pub(crate) fn extract_partition_key<'ps>(
-        &'ps self,
-        bound_values: &'ps SerializedValues,
-    ) -> Result<PartitionKey<'ps>, PartitionKeyExtractionError> {
-        PartitionKey::new(self.get_prepared_metadata(), bound_values)
-    }
-
-    pub(crate) fn extract_partition_key_and_calculate_token<'ps>(
-        &'ps self,
-        partitioner_name: &'ps PartitionerName,
-        serialized_values: &'ps SerializedValues,
-    ) -> Result<Option<(PartitionKey<'ps>, Token)>, PartitionKeyError> {
-        if !self.is_token_aware() {
-            return Ok(None);
-        }
-
-        let partition_key = self.extract_partition_key(serialized_values)?;
-        let token = partition_key.calculate_token(partitioner_name)?;
-
-        Ok(Some((partition_key, token)))
     }
 
     /// Calculates the token for given prepared statement and values.
@@ -382,7 +359,8 @@ impl PreparedStatement {
         &self,
         values: &impl SerializeRow,
     ) -> Result<Option<Token>, PartitionKeyError> {
-        self.calculate_token_untyped(&self.serialize_values(values)?)
+        let bound = self.bind(values)?;
+        bound.token()
     }
 
     // A version of calculate_token which skips serialization and uses SerializedValues directly.
@@ -391,8 +369,14 @@ impl PreparedStatement {
         &self,
         values: &SerializedValues,
     ) -> Result<Option<Token>, PartitionKeyError> {
-        self.extract_partition_key_and_calculate_token(&self.partitioner_name, values)
-            .map(|opt| opt.map(|(_pk, token)| token))
+        if !self.is_token_aware() {
+            return Ok(None);
+        }
+
+        let partition_key = PartitionKey::new(self.get_prepared_metadata(), values)?;
+        let token = partition_key.calculate_token(&self.partitioner_name)?;
+
+        Ok(Some(token))
     }
 
     /// Return keyspace name and table name this statement is operating on.
@@ -648,6 +632,20 @@ impl PreparedStatement {
         self.config.execution_profile_handle.as_ref()
     }
 
+    pub(crate) fn bind(
+        &self,
+        values: &impl SerializeRow,
+    ) -> Result<BoundStatement<'_>, SerializationError> {
+        BoundStatement::new(Cow::Borrowed(self), values)
+    }
+
+    pub(crate) fn into_bind(
+        self,
+        values: &impl SerializeRow,
+    ) -> Result<BoundStatement<'static>, SerializationError> {
+        BoundStatement::new(Cow::Owned(self), values)
+    }
+
     pub(crate) fn serialize_values(
         &self,
         values: &impl SerializeRow,
@@ -755,7 +753,7 @@ pub(crate) struct PartitionKey<'ps> {
 impl<'ps> PartitionKey<'ps> {
     const SMALLVEC_ON_STACK_SIZE: usize = 8;
 
-    fn new(
+    pub(crate) fn new(
         prepared_metadata: &'ps PreparedMetadata,
         bound_values: &'ps SerializedValues,
     ) -> Result<Self, PartitionKeyExtractionError> {

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -363,22 +363,6 @@ impl PreparedStatement {
         bound.token()
     }
 
-    // A version of calculate_token which skips serialization and uses SerializedValues directly.
-    // Not type-safe, so not exposed to users.
-    pub(crate) fn calculate_token_untyped(
-        &self,
-        values: &SerializedValues,
-    ) -> Result<Option<Token>, PartitionKeyError> {
-        if !self.is_token_aware() {
-            return Ok(None);
-        }
-
-        let partition_key = PartitionKey::new(self.get_prepared_metadata(), values)?;
-        let token = partition_key.calculate_token(&self.partitioner_name)?;
-
-        Ok(Some(token))
-    }
-
     /// Return keyspace name and table name this statement is operating on.
     pub fn get_table_spec(&self) -> Option<&TableSpec<'_>> {
         self.get_prepared_metadata()

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -616,14 +616,20 @@ impl PreparedStatement {
         self.config.execution_profile_handle.as_ref()
     }
 
-    pub(crate) fn bind(
+    /// Binds values with a reference to a prepared statement
+    ///
+    /// This method will serialize the values and thus type erase them on return
+    pub fn bind(
         &self,
         values: &impl SerializeRow,
     ) -> Result<BoundStatement<'_>, SerializationError> {
         BoundStatement::new(Cow::Borrowed(self), values)
     }
 
-    pub(crate) fn into_bind(
+    /// Binds values with an owned prepared statement
+    ///
+    /// This method will serialize the values and thus type erase them on return
+    pub fn into_bind(
         self,
         values: &impl SerializeRow,
     ) -> Result<BoundStatement<'static>, SerializationError> {


### PR DESCRIPTION
This PR adds a version of `BoundStatement` and `BoundBatch` to hopefully help inspire your future design of these structs. 

As discussed in: https://github.com/scylladb/scylla-rust-driver/issues/941, you all wish to design these features yourselves (for totally understandable reasons) so this PR is here just to help inspire the future implementation, perhaps discuss decisions/API, or whatever else I may be able to help with. I will likely use this branch in my own work to solve my need for this API temporarily until an official version is up. 

### `BoundStatement`

```rust
pub struct BoundStatement {
    pub(crate) prepared: PreparedStatement,
    pub(crate) values: SerializedValues,
}
```

This is probably the easiest to understand. It is just a `PreparedStatement` with a bound `SerializedValues`. The only *public* way to create this struct is through `PreparedStatement::bind(self, impl: SerializeRow)`, thus making it externally type safe at creation, while internally it erases the type and just keeps the byte buffer (`SerializedValues`). 

This struct is useful to:
* Keep a prepared statement and its values together in a non-generic way by type erasing at the moment of creation.
* Allow users to get the `Token` related to the prepared statement + values combo without needing to double-serialize (once to get the token and then again when executing the statement). 

All existing internal APIs where a `PreparedStatement` and its relevant values where passed in together are rewritten to use `BoundStatement` instead while all external APIs remain the same so as to not introduce breaking changes. 

### `BoundBatch`

```rust
pub struct BoundBatch {
    pub(crate) buffer: Vec<u8>,
    pub(crate) prepared: HashMap<Bytes, PreparedStatement>,
    first_prepared: Option<(PreparedStatement, Token)>,
    pub(crate) statements_len: u16,
    
    /* snip the less relevant fields */
}
```

This is where things begin to get interesting. While a naive implementation of `BoundBatch` that simply keeps a `Vec<PreparedStatement>` could work, that'd take away some of the current niceties of how `Batch` is serialized, namely when serializing a batch and its values it doesn't create a small buffer for each serialized row but instead serializes every statement + value into one joined buffer thus avoiding multiple small allocations. To let this current optimization live-on while still allowing each statement + value to be passed in sequentially the `BoundBatch` instead keeps a single buffer where it serializes each statement + value as they are passed in. When the bound batch is executed this large buffer is copied into the request buffer in one go.  Since we are serializing as we go, we need to keep track a few extra details:

* A map of prepared statements, key'd by its ID: this allows batches to re-prepare its statements when the DB returns with an error about a statement not being prepared but expected it to be
* The first statement and its token: if that statement was prepared, so that the batch can use it for sharding purposes (batch goes to the shard of the first prepared statement) 
* The length of its statements: needed to make sure we haven't reached the limit and so we can serialize the length when making the request. 

This struct is useful to:
* Keep a batch and its values together in a non-generic way by type erasing at the moment of creation.
* More fool-proof in that the number of statements and values never go out-of-sync
* Allows adding a `BoundStatement` to avoid re-serializing values . This is useful because it is common for batches to be more efficient when they are all for the same token. So now a user can make a `BoundStatement`, use it to calculate its token, and based on that decide what `BoundBatch` instance to put the `BoundStatement` into. `BoundBatch` can easily copy the serialized bytes out of `BoundStatement` thus saving CPU resources. 

Note that this implementation of `BoundBatch` allows for unprepared statements to be added *if and only if* there are no values associated for the unprepared statement. This is done to follow the existing logic of `Batch` where any unprepared statement that had values would be prepared prior to doing the request, now we are just making it explicit for the user to do have to prepared it if they want to use `BoundBatch`. The internal implementation of executing a `Batch` has been rewritten to first prepare the statements in the `Batch` (just as it used to do but earlier now) and then create a `BoundBatch`. This allows the logic of executing a batch to be all in one place so that all the existing tests of `Batch` end up testing `BoundBatch` execution as well. 

### `Execute` trait

This is a sealed trait (users of the crate can call its methods but not implement the trait) for types that can be executed on a `Session` without any additional values. For now this is directly implemented only on `BoundBatch`. Existing methods have been rewritten to use this trait but externally nothing has changed other than this trait being usable publicly. (so someone can call `my_bound_batch.execute(&session)`. 

### `ExecutePageable` trait

Another sealed trait for types that be executed on a `Session` but are aware of pagiination. This is implemented directly on `BoundStatement` and `(Statement, impl SerializeValeus)`. Any type that implements `ExecutePageable` will also auto-implement `Execute` with the implementation calling for the pageable methods with no page limit, and no initial paging state. This allows for `BoundStatement` and `(Statement, impl SerializeValeus)` to have the same three ways to be called now: no pagination from the start, no pagination from a saved point, and pagination from a saved point. This is done via a single method that has a const generic but could easily be refactored to two methods instead (that call for the generic method under the hood). 

### Other random notes

Because the `scylla-cql` crate is already in v1.x, and the `Batch` struct in that crate has its definition fully public, I couldn't change it at all so instead I had to create a new `BatchV2` . I left the current implementation of `Batch` (de)serialization and instead made requests with the batch opcode (de)serialize using `BatchV2`. This allows code to compile but it is *technically* perhaps a breaking change in that if a foreign crate relies on `scylla-cql` deserializing to `Batch` instead of the new `BatchV2` then their code will break at runtime. I can't think of a reason why someone would do that but I figured it was worth bringing up anyway. 

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/941

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
