### PR TITLE
Schema agreement: Fetch schema version from one connection per node only

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2140,6 +2140,10 @@ impl Session {
         last_error.map(Result::Err)
     }
 
+    /// Awaits schema agreement among all reachable nodes.
+    ///
+    /// Issues an agreement check each `Session::schema_agreement_interval`.
+    /// Loops indefinitely until the agreement is reached.
     async fn await_schema_agreement_indefinitely(&self) -> Result<Uuid, SchemaAgreementError> {
         loop {
             tokio::time::sleep(self.schema_agreement_interval).await;
@@ -2149,6 +2153,11 @@ impl Session {
         }
     }
 
+    /// Awaits schema agreement among all reachable nodes.
+    ///
+    /// Issues an agreement check each `Session::schema_agreement_interval`.
+    /// If agreement is not reached in `Session::schema_agreement_timeout`,
+    /// `SchemaAgreementError::Timeout` is returned.
     pub async fn await_schema_agreement(&self) -> Result<Uuid, SchemaAgreementError> {
         timeout(
             self.schema_agreement_timeout,
@@ -2160,6 +2169,9 @@ impl Session {
         )))
     }
 
+    /// Checks if all reachable nodes have the same schema version.
+    ///
+    /// If so, returns that agreed upon version.
     pub async fn check_schema_agreement(&self) -> Result<Option<Uuid>, SchemaAgreementError> {
         let cluster_state = self.get_cluster_state();
         let connections_iter = cluster_state.iter_working_connections_to_shards()?;

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2174,11 +2174,31 @@ impl Session {
     /// If so, returns that agreed upon version.
     pub async fn check_schema_agreement(&self) -> Result<Option<Uuid>, SchemaAgreementError> {
         let cluster_state = self.get_cluster_state();
-        let connections_iter = cluster_state.iter_working_connections_to_shards()?;
+        // The iterator is guaranteed to be nonempty.
+        let per_node_connections = cluster_state.iter_working_connections_per_node()?;
 
-        let handles = connections_iter.map(|c| async move { c.fetch_schema_version().await });
+        // Therefore, this iterator is guaranteed to be nonempty, too.
+        let handles = per_node_connections.map(|connections_to_node| async move {
+            // Iterate over connections to the node. Fail if fetching schema version failed on all connections.
+            // Else, return the first fetched schema version, because all shards have the same schema version.
+            let mut first_err = None;
+            for connection in connections_to_node {
+                match connection.fetch_schema_version().await {
+                    Ok(schema_version) => return Ok(schema_version),
+                    Err(err) => {
+                        if first_err.is_none() {
+                            first_err = Some(err);
+                        }
+                    }
+                }
+            }
+            // The iterator was guaranteed to be nonempty, so there must have been at least one error.
+            Err(first_err.unwrap())
+        });
+        // Hence, this is nonempty, too.
         let versions = try_join_all(handles).await?;
 
+        // Therefore, taking the first element is safe.
         let local_version: Uuid = versions[0];
         let in_agreement = versions.into_iter().all(|v| v == local_version);
         Ok(in_agreement.then_some(local_version))


### PR DESCRIPTION
Bases on: #1320

Start review from `session: document schema agreement API`.

## Problem
Before, `Session` needlessly fetched schema version from all connections to given node, even that all shards of the same node share the same schema version.

## What's done
`Session::check_schema_agreement()` is modified to only fetch schema version from every node once, instead of on all connections to the same node. To this end, it iterates over connections to given node and tries
to fetch schema version. Once it succeeds on any connection to given node, it does not continue on remaining connections.

Notice that this not only decreases load on the cluster that schema agreement checks involve (a performance optimisation), but it also possibly leads to fewer errors returned from `check_schema_agreement()`. This is because now we only require one connection per node to be operational, whereas before shards on all connections must have successfully returned schema version.

### Tests
For tests, similarly, a new proxy feature would be needed. Therefore, no tests yet.

Fixes: #1289

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
