### PR TITLE
Enforce request coordinator

### DIFF
--- a/docs/source/load-balancing/load-balancing.md
+++ b/docs/source/load-balancing/load-balancing.md
@@ -36,8 +36,12 @@ awareness enabled and latency-awareness disabled.
 
 ## Configuration
 
-Load balancing policies can be configured via execution profiles. In the code
-sample provided, a new execution profile is created using
+Load balancing policies can be configured in three different ways (sorted by descending precedence):
+1. directly on the `Statement`, `PreparedStatement` or `Batch` (`Statement::set_load_balancing_policy()`)
+2. execution profile set on the statement (`Statement::set_execution_profile_handle()`)
+3. default execution profile set on the session (`SessionBuilder::default_execution_profile_handle()`)
+
+ In the code sample provided, a new execution profile is created using
 `ExecutionProfile::builder()`, and the load balancing policy is set to the
 `DefaultPolicy` using `.load_balancing_policy(policy)`.
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -99,6 +99,10 @@ name = "value_list"
 path = "value_list.rs"
 
 [[example]]
+name = "enforce_coordinator"
+path = "enforce_coordinator.rs"
+
+[[example]]
 name = "custom_load_balancing_policy"
 path = "custom_load_balancing_policy.rs"
 

--- a/examples/enforce_coordinator.rs
+++ b/examples/enforce_coordinator.rs
@@ -1,0 +1,94 @@
+//! This example show how to enforce the target the request is sent to.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use anyhow::Result;
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::cluster::Node;
+use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
+use scylla::statement::prepared::PreparedStatement;
+
+/// Executes "SELECT host_id, rpc_address FROM system.local" query with `node` as the enforced target.
+/// Checks whether the result matches the expected values (i.e. ones stored in peers metadata).
+async fn query_system_local_and_verify(
+    session: &Session,
+    node: &Arc<Node>,
+    query_local: &PreparedStatement,
+) {
+    let (actual_host_id, actual_node_ip) = session
+        .execute_unpaged(query_local, ())
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap()
+        .single_row::<(uuid::Uuid, IpAddr)>()
+        .unwrap();
+
+    println!(
+        "queried host_id: {}; queried node_ip: {}",
+        actual_host_id, actual_node_ip
+    );
+    assert_eq!(node.host_id, actual_host_id);
+    assert_eq!(node.address.ip(), actual_node_ip);
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+
+    let state = session.get_cluster_state();
+    let node = state
+        .get_nodes_info()
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("No nodes in metadata!"))?;
+
+    let expected_host_id = node.host_id;
+    let expected_node_ip = node.address.ip();
+
+    let mut query_local = session
+        .prepare("SELECT host_id, rpc_address FROM system.local where key='local'")
+        .await?;
+
+    // Enforce the node using `Arc<Node>`.
+    {
+        let node_identifier = NodeIdentifier::Node(Arc::clone(node));
+        println!("Enforcing target using {:?}...", node_identifier);
+        query_local.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
+            node_identifier,
+            None,
+        )));
+
+        query_system_local_and_verify(&session, node, &query_local).await;
+    }
+
+    // Enforce the node using host_id.
+    {
+        let node_identifier = NodeIdentifier::HostId(expected_host_id);
+        println!("Enforcing target using {:?}...", node_identifier);
+        query_local.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
+            node_identifier,
+            None,
+        )));
+
+        query_system_local_and_verify(&session, node, &query_local).await;
+    }
+
+    // Enforce the node using **untranslated** node address.
+    {
+        let node_identifier =
+            NodeIdentifier::NodeAddress(SocketAddr::new(expected_node_ip, node.address.port()));
+        println!("Enforcing target using {:?}...", node_identifier);
+        query_local.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
+            node_identifier,
+            None,
+        )));
+
+        query_system_local_and_verify(&session, node, &query_local).await;
+    }
+
+    Ok(())
+}

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -141,7 +141,6 @@ struct PagerWorker<'a, QueryFunc, SpanCreatorFunc> {
     query_is_idempotent: bool,
     query_consistency: Consistency,
     retry_session: Box<dyn RetrySession>,
-    execution_profile: Arc<ExecutionProfileInner>,
     #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 
@@ -744,7 +743,6 @@ impl QueryPager {
                 query_consistency: consistency,
                 load_balancing_policy,
                 retry_session,
-                execution_profile,
                 #[cfg(feature = "metrics")]
                 metrics,
                 paging_state: PagingState::start(),
@@ -868,7 +866,6 @@ impl QueryPager {
                 query_consistency: consistency,
                 load_balancing_policy,
                 retry_session,
-                execution_profile: config.execution_profile,
                 #[cfg(feature = "metrics")]
                 metrics: config.metrics,
                 paging_state: PagingState::start(),

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -699,7 +699,11 @@ impl QueryPager {
             ..Default::default()
         };
 
-        let load_balancing_policy = Arc::clone(&execution_profile.load_balancing_policy);
+        let load_balancing_policy = Arc::clone(
+            statement
+                .get_load_balancing_policy()
+                .unwrap_or(&execution_profile.load_balancing_policy),
+        );
 
         let retry_session = statement
             .get_retry_policy()
@@ -777,7 +781,12 @@ impl QueryPager {
 
         let page_size = config.prepared.get_validated_page_size();
 
-        let load_balancing_policy = Arc::clone(&config.execution_profile.load_balancing_policy);
+        let load_balancing_policy = Arc::clone(
+            config
+                .prepared
+                .get_load_balancing_policy()
+                .unwrap_or(&config.execution_profile.load_balancing_policy),
+        );
 
         let retry_session = config
             .prepared

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1874,6 +1874,7 @@ impl Session {
                                 consistency_set_on_statement: statement_config.consistency,
                                 retry_session: retry_policy.new_session(),
                                 history_data,
+                                load_balancing_policy: load_balancer.as_ref(),
                                 query_info: &statement_info,
                                 request_span,
                             },
@@ -1910,6 +1911,7 @@ impl Session {
                             consistency_set_on_statement: statement_config.consistency,
                             retry_session: retry_policy.new_session(),
                             history_data,
+                            load_balancing_policy: load_balancer.as_ref(),
                             query_info: &statement_info,
                             request_span,
                         },
@@ -2007,7 +2009,7 @@ impl Session {
                         #[cfg(feature = "metrics")]
                         let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
-                        execution_profile.load_balancing_policy.on_request_success(
+                        context.load_balancing_policy.on_request_success(
                             context.query_info,
                             elapsed,
                             node,
@@ -2022,7 +2024,7 @@ impl Session {
                         );
                         #[cfg(feature = "metrics")]
                         self.metrics.inc_failed_nonpaged_queries();
-                        execution_profile.load_balancing_policy.on_request_failure(
+                        context.load_balancing_policy.on_request_failure(
                             context.query_info,
                             elapsed,
                             node,
@@ -2135,6 +2137,7 @@ struct ExecuteRequestContext<'a> {
     consistency_set_on_statement: Option<Consistency>,
     retry_session: Box<dyn RetrySession>,
     history_data: Option<HistoryData<'a>>,
+    load_balancing_policy: &'a dyn load_balancing::LoadBalancingPolicy,
     query_info: &'a load_balancing::RoutingInfo<'a>,
     request_span: &'a RequestSpan,
 }

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -13,8 +13,10 @@ use std::time::Duration;
 
 mod default;
 mod plan;
+mod single_target;
 pub use default::{DefaultPolicy, DefaultPolicyBuilder, LatencyAwarenessBuilder};
 pub use plan::Plan;
+pub use single_target::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
 
 /// Represents info about statement that can be used by load balancing policies.
 #[derive(Default, Clone, Debug)]

--- a/scylla/src/policies/load_balancing/single_target.rs
+++ b/scylla/src/policies/load_balancing/single_target.rs
@@ -1,0 +1,92 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::cluster::{ClusterState, Node, NodeRef};
+use crate::routing::Shard;
+
+use super::{LoadBalancingPolicy, RoutingInfo};
+
+/// Node identifier used by [`SingleTargetLoadBalancingPolicy`].
+///
+/// If `NodeIdentifier::Node` is used, it will be returned immediately without
+/// the lookup in the cluster metadata.
+///
+/// If `NodeIdentifier::HostId` or `NodeIdentifier::NodeAddress` is used,
+/// the node will be looked up in the cluster metadata based on its host_id/address.
+///
+/// Note: `NodeIdentifier::NodeAddress` assumes that provided address is **untranslated**.
+/// In other words, it should be the address of form `<rpc_address>:<cql_port>`, where
+/// `<rpc_address>` is the address of the node stored in the system tables, as well as
+/// in the [`Node`] struct.
+#[derive(Debug, Clone)] // <- Cheaply clonable
+#[non_exhaustive]
+pub enum NodeIdentifier {
+    Node(Arc<Node>),
+    HostId(Uuid),
+    NodeAddress(SocketAddr),
+}
+
+/// Load balancing policy that enforces a single target.
+///
+/// It may be useful for queries to node-local system tables.
+#[derive(Debug)]
+pub struct SingleTargetLoadBalancingPolicy {
+    node_identifier: NodeIdentifier,
+    shard: Option<Shard>,
+}
+
+impl SingleTargetLoadBalancingPolicy {
+    /// Creates a new instance of [`SingleTargetLoadBalancingPolicy`].
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        node_identifier: NodeIdentifier,
+        shard: Option<Shard>,
+    ) -> Arc<dyn LoadBalancingPolicy> {
+        Arc::new(Self {
+            node_identifier,
+            shard,
+        })
+    }
+}
+
+impl LoadBalancingPolicy for SingleTargetLoadBalancingPolicy {
+    fn pick<'a>(
+        &'a self,
+        _request: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+    ) -> Option<(NodeRef<'a>, Option<Shard>)> {
+        let node = match &self.node_identifier {
+            NodeIdentifier::Node(node) => Some(node),
+            NodeIdentifier::HostId(host_id) => cluster.known_peers.get(host_id),
+            NodeIdentifier::NodeAddress(addr) => cluster
+                .all_nodes
+                .iter()
+                .find(|node| SocketAddr::new(node.address.ip(), node.address.port()) == *addr),
+        };
+
+        match node {
+            Some(node) => Some((node, self.shard)),
+            None => {
+                tracing::warn!(
+                    "SingleTargetLoadBalancingPolicy failed to find requested node {:?} in cluster metadata.",
+                    self.node_identifier
+                );
+                None
+            }
+        }
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        _request: &'a RoutingInfo,
+        _cluster: &'a ClusterState,
+    ) -> super::FallbackPlan<'a> {
+        Box::new(std::iter::empty())
+    }
+
+    fn name(&self) -> String {
+        "SingleTargetLoadBalancingPolicy".to_string()
+    }
+}

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use crate::client::execution_profile::ExecutionProfileHandle;
 use crate::observability::history::HistoryListener;
+use crate::policies::load_balancing::LoadBalancingPolicy;
 use crate::policies::retry::RetryPolicy;
 use crate::statement::prepared::PreparedStatement;
 use crate::statement::unprepared::Statement;
@@ -132,6 +133,25 @@ impl Batch {
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
         self.config.retry_policy.as_ref()
+    }
+
+    /// Set the load balancing policy for this batch, overriding the one from execution profile if not None.
+    #[inline]
+    pub fn set_load_balancing_policy(
+        &mut self,
+        load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
+    ) {
+        self.config.load_balancing_policy = load_balancing_policy;
+    }
+
+    /// Get the load balancing policy set for the batch.
+    ///
+    /// This method returns the load balancing policy that is **overriden** on this statement.
+    /// In other words, it returns the load balancing policy set using [`Batch::set_load_balancing_policy`].
+    /// This does not take the load balancing policy from the set execution profile into account.
+    #[inline]
+    pub fn get_load_balancing_policy(&self) -> Option<&Arc<dyn LoadBalancingPolicy>> {
+        self.config.load_balancing_policy.as_ref()
     }
 
     /// Sets the listener capable of listening what happens during query execution.

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -130,6 +130,10 @@ impl Batch {
     }
 
     /// Get the retry policy set for the batch.
+    ///
+    /// This method returns the retry policy that is **overriden** on this statement.
+    /// In other words, it returns the retry policy set using [`Batch::set_retry_policy`].
+    /// This does not take the retry policy from the set execution profile into account.
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
         self.config.retry_policy.as_ref()

--- a/scylla/src/statement/mod.rs
+++ b/scylla/src/statement/mod.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 
 use crate::client::execution_profile::ExecutionProfileHandle;
 use crate::observability::history::HistoryListener;
+use crate::policies::load_balancing::LoadBalancingPolicy;
 use crate::policies::retry::RetryPolicy;
 
 pub mod batch;
@@ -38,6 +39,7 @@ pub(crate) struct StatementConfig {
     pub(crate) history_listener: Option<Arc<dyn HistoryListener>>,
 
     pub(crate) execution_profile_handle: Option<ExecutionProfileHandle>,
+    pub(crate) load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
     pub(crate) retry_policy: Option<Arc<dyn RetryPolicy>>,
 }
 

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -431,6 +431,10 @@ impl PreparedStatement {
     }
 
     /// Get the retry policy set for the statement.
+    ///
+    /// This method returns the retry policy that is **overriden** on this statement.
+    /// In other words, it returns the retry policy set using [`PreparedStatement::set_retry_policy`].
+    /// This does not take the retry policy from the set execution profile into account.
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
         self.config.retry_policy.as_ref()

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -18,6 +18,7 @@ use crate::errors::{BadQuery, ExecutionError};
 use crate::frame::response::result::PreparedMetadata;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::observability::history::HistoryListener;
+use crate::policies::load_balancing::LoadBalancingPolicy;
 use crate::policies::retry::RetryPolicy;
 use crate::response::query_result::ColumnSpecs;
 use crate::routing::partitioner::{Partitioner, PartitionerHasher, PartitionerName};
@@ -433,6 +434,25 @@ impl PreparedStatement {
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
         self.config.retry_policy.as_ref()
+    }
+
+    /// Set the load balancing policy for this statement, overriding the one from execution profile if not None.
+    #[inline]
+    pub fn set_load_balancing_policy(
+        &mut self,
+        load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
+    ) {
+        self.config.load_balancing_policy = load_balancing_policy;
+    }
+
+    /// Get the load balancing policy set for the statement.
+    ///
+    /// This method returns the load balancing policy that is **overriden** on this statement.
+    /// In other words, it returns the load balancing policy set using [`PreparedStatement::set_load_balancing_policy`].
+    /// This does not take the load balancing policy from the set execution profile into account.
+    #[inline]
+    pub fn get_load_balancing_policy(&self) -> Option<&Arc<dyn LoadBalancingPolicy>> {
+        self.config.load_balancing_policy.as_ref()
     }
 
     /// Sets the listener capable of listening what happens during query execution.

--- a/scylla/src/statement/unprepared.rs
+++ b/scylla/src/statement/unprepared.rs
@@ -137,6 +137,10 @@ impl Statement {
     }
 
     /// Get the retry policy set for the statement.
+    ///
+    /// This method returns the retry policy that is **overriden** on this statement.
+    /// In other words, it returns the retry policy set using [`Statement::set_retry_policy`].
+    /// This does not take the retry policy from the set execution profile into account.
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
         self.config.retry_policy.as_ref()

--- a/scylla/src/statement/unprepared.rs
+++ b/scylla/src/statement/unprepared.rs
@@ -2,6 +2,7 @@ use super::{PageSize, StatementConfig};
 use crate::client::execution_profile::ExecutionProfileHandle;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::observability::history::HistoryListener;
+use crate::policies::load_balancing::LoadBalancingPolicy;
 use crate::policies::retry::RetryPolicy;
 use std::sync::Arc;
 use std::time::Duration;
@@ -139,6 +140,25 @@ impl Statement {
     #[inline]
     pub fn get_retry_policy(&self) -> Option<&Arc<dyn RetryPolicy>> {
         self.config.retry_policy.as_ref()
+    }
+
+    /// Set the load balancing policy for this statement, overriding the one from execution profile if not None.
+    #[inline]
+    pub fn set_load_balancing_policy(
+        &mut self,
+        load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
+    ) {
+        self.config.load_balancing_policy = load_balancing_policy;
+    }
+
+    /// Get the load balancing policy set for the statement.
+    ///
+    /// This method returns the load balancing policy that is **overriden** on this statement.
+    /// In other words, it returns the load balancing policy set using [`Statement::set_load_balancing_policy`].
+    /// This does not take the load balancing policy from the set execution profile into account.
+    #[inline]
+    pub fn get_load_balancing_policy(&self) -> Option<&Arc<dyn LoadBalancingPolicy>> {
+        self.config.load_balancing_policy.as_ref()
     }
 
     /// Sets the listener capable of listening what happens during statement execution.

--- a/scylla/tests/integration/statement.rs
+++ b/scylla/tests/integration/statement.rs
@@ -1,5 +1,16 @@
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use assert_matches::assert_matches;
+use futures::StreamExt;
+use scylla::client::session::Session;
 use scylla::cluster::metadata::{ColumnType, NativeType};
+use scylla::errors::ExecutionError;
 use scylla::frame::response::result::{ColumnSpec, TableSpec};
+use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
+use scylla::statement::Statement;
+use uuid::Uuid;
 
 use crate::utils::{create_new_session_builder, setup_tracing, unique_keyspace_name, PerformDDL};
 
@@ -54,4 +65,98 @@ async fn test_prepared_statement_col_specs() {
         spec("c", ColumnType::Native(NativeType::SmallInt)),
     ];
     assert_eq!(result_set_col_specs, expected_result_set_col_specs);
+}
+
+#[tokio::test]
+async fn test_enforce_request_coordinator() {
+    setup_tracing();
+    let session = create_new_session_builder().build().await.unwrap();
+
+    async fn query_system_local_and_verify(
+        session: &Session,
+        node_identifier: NodeIdentifier,
+        expected_node_id: Uuid,
+        expected_node_ip: IpAddr,
+    ) {
+        let mut statement =
+            Statement::new("SELECT host_id, rpc_address FROM system.local WHERE key='local'");
+        statement.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
+            node_identifier,
+            None,
+        )));
+
+        // Check query_unpaged
+        let (actual_node_id, actual_node_ip) = session
+            .query_unpaged(statement.clone(), ())
+            .await
+            .unwrap()
+            .into_rows_result()
+            .unwrap()
+            .single_row::<(uuid::Uuid, IpAddr)>()
+            .unwrap();
+        assert_eq!(expected_node_id, actual_node_id);
+        assert_eq!(expected_node_ip, actual_node_ip);
+
+        // Check query_iter
+        let (actual_node_id, actual_node_ip) = session
+            .query_iter(statement, ())
+            .await
+            .unwrap()
+            .rows_stream::<(uuid::Uuid, IpAddr)>()
+            .unwrap()
+            .next()
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(expected_node_id, actual_node_id);
+        assert_eq!(expected_node_ip, actual_node_ip);
+    }
+
+    let cluster_state = session.get_cluster_state();
+    for node in cluster_state.get_nodes_info() {
+        let (node_id, node_address) = (
+            node.host_id,
+            SocketAddr::new(node.address.ip(), node.address.port()),
+        );
+
+        query_system_local_and_verify(
+            &session,
+            NodeIdentifier::Node(Arc::clone(node)),
+            node_id,
+            node_address.ip(),
+        )
+        .await;
+
+        query_system_local_and_verify(
+            &session,
+            NodeIdentifier::HostId(node_id),
+            node_id,
+            node_address.ip(),
+        )
+        .await;
+
+        query_system_local_and_verify(
+            &session,
+            NodeIdentifier::NodeAddress(SocketAddr::new(node_address.ip(), node_address.port())),
+            node_id,
+            node_address.ip(),
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn test_enforce_non_existent_request_coordinator() {
+    setup_tracing();
+    let session = create_new_session_builder().build().await.unwrap();
+
+    let mut statement =
+        Statement::new("SELECT host_id, rpc_address FROM system.local WHERE key='local'");
+    statement.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
+        NodeIdentifier::NodeAddress(SocketAddr::from_str("1.1.1.1:9042").unwrap()),
+        None,
+    )));
+
+    let result = session.query_unpaged(statement, ()).await;
+    assert_matches!(result, Err(ExecutionError::EmptyPlan))
 }


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1031

## SingleTargetLoadBalancingPolicy

This load balancing policy returns a single target in `pick`.  The fallback
always returns empty iterator.

The node is picked based on the `NodeIdentifier` that user can provide
when constructing the policy.
- NodeIdentifier::Node -> just `Arc<Node>` - it's returned unconditionally from pick()
- NodeIdentifier::Address -> lbp does the lookup in the cluster metadata
   and returns a node with the given address  (if found)
- NodeIdentifier::HostId -> same as for the address, but the lookup is
   done by the host id

## StatementConfig

In addition, we expose a utility method on all statements, that allow to overwrite current LBP, and enforce the specific target for the request.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
