### PR TITLE
Construct `PreparedStatement` only where needed

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1066,7 +1066,6 @@ impl Session {
                         .serial_consistency
                         .unwrap_or(execution_profile.serial_consistency);
                     // Needed to avoid moving query and values into async move block
-                    let statement_ref = &statement;
                     let values_ref = &values;
                     let paging_state_ref = &paging_state;
                     async move {
@@ -1074,7 +1073,7 @@ impl Session {
                             span_ref.record_request_size(0);
                             connection
                                 .query_raw_with_consistency(
-                                    statement_ref,
+                                    statement,
                                     consistency,
                                     serial_consistency,
                                     page_size,
@@ -1083,7 +1082,7 @@ impl Session {
                                 .await
                                 .and_then(QueryResponse::into_non_error_query_response)
                         } else {
-                            let prepared = connection.prepare(statement_ref).await?;
+                            let prepared = connection.prepare(statement).await?;
                             let serialized = prepared.serialize_values(values_ref)?;
                             span_ref.record_request_size(serialized.buffer_size());
                             connection

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -632,17 +632,18 @@ impl Connection {
         Ok(supported)
     }
 
+    /// Prepares the given statement and returns [PreparedStatement].
     pub(crate) async fn prepare(
         &self,
-        query: &Statement,
+        statement: &Statement,
     ) -> Result<PreparedStatement, RequestAttemptError> {
         let query_response = self
             .send_request(
                 &request::Prepare {
-                    query: &query.contents,
+                    query: &statement.contents,
                 },
                 true,
-                query.config.tracing,
+                statement.config.tracing,
                 None,
             )
             .await?;
@@ -658,9 +659,9 @@ impl Connection {
                     .prepared_flags_contain_lwt_mark(p.prepared_metadata.flags as u32),
                 p.prepared_metadata,
                 Arc::new(p.result_metadata),
-                query.contents.clone(),
-                query.get_validated_page_size(),
-                query.config.clone(),
+                statement.contents.clone(),
+                statement.get_validated_page_size(),
+                statement.config.clone(),
             ),
             _ => {
                 return Err(RequestAttemptError::UnexpectedResponse(

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -692,14 +692,15 @@ impl Connection {
         previous_prepared: &PreparedStatement,
     ) -> Result<(), RequestAttemptError> {
         let reprepare_query: Statement = query.into();
-        let reprepared = self.prepare(&reprepare_query).await?;
+        let prepared_response = self.prepare_raw(&reprepare_query).await?.prepared_response;
+
         // Reprepared statement should keep its id - it's the md5 sum
         // of statement contents
-        if reprepared.get_id() != previous_prepared.get_id() {
+        if prepared_response.id != previous_prepared.get_id() {
             Err(RequestAttemptError::RepreparedIdChanged {
+                reprepared_id: prepared_response.id.into(),
                 statement: reprepare_query.contents,
                 expected_id: previous_prepared.get_id().clone().into(),
-                reprepared_id: reprepared.get_id().clone().into(),
             })
         } else {
             Ok(())

--- a/scylla/src/response/mod.rs
+++ b/scylla/src/response/mod.rs
@@ -12,5 +12,6 @@ mod request_response;
 
 pub(crate) use request_response::{
     NonErrorAuthResponse, NonErrorQueryResponse, NonErrorStartupResponse, QueryResponse,
+    RawPreparedStatement,
 };
 pub use scylla_cql::frame::request::query::{PagingState, PagingStateResponse};

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use scylla_cql::frame::request::query::PagingStateResponse;
@@ -9,6 +10,8 @@ use uuid::Uuid;
 use crate::errors::RequestAttemptError;
 use crate::frame::response::{self, result};
 use crate::response::query_result::QueryResult;
+use crate::statement::prepared::PreparedStatement;
+use crate::statement::Statement;
 
 pub(crate) struct QueryResponse {
     pub(crate) response: Response,
@@ -107,4 +110,60 @@ pub(crate) enum NonErrorStartupResponse {
 pub(crate) enum NonErrorAuthResponse {
     AuthChallenge(response::authenticate::AuthChallenge),
     AuthSuccess(response::authenticate::AuthSuccess),
+}
+
+/// Parts which are needed to construct [PreparedStatement].
+///
+/// Kept separate for performance reasons, because constructing
+/// [PreparedStatement] involves allocations.
+pub(crate) struct RawPreparedStatement<'statement> {
+    pub(crate) statement: &'statement Statement,
+    pub(crate) prepared_response: result::Prepared,
+    pub(crate) is_lwt: bool,
+    pub(crate) tracing_id: Option<Uuid>,
+}
+
+impl<'statement> RawPreparedStatement<'statement> {
+    pub(crate) fn new(
+        statement: &'statement Statement,
+        prepared_response: result::Prepared,
+        is_lwt: bool,
+        tracing_id: Option<Uuid>,
+    ) -> Self {
+        Self {
+            statement,
+            prepared_response,
+            is_lwt,
+            tracing_id,
+        }
+    }
+}
+
+/// Constructs the fully-fledged [PreparedStatement].
+///
+/// This involves allocations.
+impl RawPreparedStatement<'_> {
+    pub(crate) fn into_prepared_statement(self) -> PreparedStatement {
+        let Self {
+            statement,
+            prepared_response,
+            is_lwt,
+            tracing_id,
+        } = self;
+        let mut prepared_statement = PreparedStatement::new(
+            prepared_response.id,
+            is_lwt,
+            prepared_response.prepared_metadata,
+            Arc::new(prepared_response.result_metadata),
+            statement.contents.clone(),
+            statement.get_validated_page_size(),
+            statement.config.clone(),
+        );
+
+        if let Some(tracing_id) = tracing_id {
+            prepared_statement.prepare_tracing_ids.push(tracing_id);
+        }
+
+        prepared_statement
+    }
 }


### PR DESCRIPTION
## Motivation

Constructing `PreparedStatement` involves allocations:
1. `ResultMetadata` must be put onto heap, behind an `Arc`;
2. `StatementConfig` must be cloned along with all `Arc`s inside;
3. Statement string must be cloned.

I noticed that in a number of places we materialise `PreparedStatement` even though it's not used afterwards.

## What's done

### Introduced `RawPreparedStatement`

`RawPreparedStatement` contains everything that is needed to construct the `PreparedStatement`, but avoid all 3 allocations that I listed above. Those allocations are delayed until one calls `into_prepared_statement()`, if materialised `PreparedStatement` is really needed.

### Extracted `Connection::prepare_raw()`

`Connection::prepare_raw()` extracts most of the logic that was put in `Connection::prepare()` before; yet, it returns `RawPreparedStatement`. `Connection::prepare()` is reimplemented as a wrapper over `Connection::prepare_raw()` that calls `RawPreparedStatement::into_prepared_statement()`.

### Actual optimisation

Call sites that used to call `Connection::prepare()` and later ignore the resulting `PreparedStatement` (or at least not require it in a full materialised form) were adjusted to call `Connection::prepare_raw()`.
Those involve:
1. Repreparation logic. Repreparation only needs to make the server reprepare the statement; the returned metadata  etc. are not needed, as the driver already has `PreparedStatement` built during the original preparation.
2. Preparation on many nodes/shards. Only one `PreparedStatement` needs to be materialised; subsequent results of preparation on other nodes/shards can be ignored (or, more precisely, verified, but for this the raw form suffices).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
