### PR TITLE
Latency awareness: don't reinvent the wheel (use existing `Iterator` methods instead)

### DIFF
--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -2807,12 +2807,11 @@ mod latency_awareness {
                 }
             }
 
-            let mut fast_targets = fast_targets.into_iter();
-            let mut penalised_targets = penalised_targets.into_iter();
+            let fast_targets = fast_targets.into_iter();
+            let penalised_targets = penalised_targets.into_iter();
 
-            let skipping_penalised_targets_iterator = std::iter::from_fn(move || {
-                fast_targets.next().or_else(|| penalised_targets.next())
-            });
+            let skipping_penalised_targets_iterator =
+                fast_targets.into_iter().chain(penalised_targets);
 
             Either::Right(skipping_penalised_targets_iterator)
         }


### PR DESCRIPTION
I noticed that the code I wrote in latency awareness module reinvents the wheel, i.e., manually achieves what is available using existing `Iterator` methods.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
