### PR TITLE
docs: fix md redirections for multiversion support

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ extensions = [
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = ['.rst']
+source_suffix = ['.rst', '.md']
 autosectionlabel_prefix_document = True
 
 # The master toctree document.


### PR DESCRIPTION
Related issue & explanation https://github.com/scylladb/scylladb/pull/23957

This should allow navigation between versions without being redirected to the main index page:

![image](https://github.com/user-attachments/assets/42995eb4-80d2-4931-9d1c-ba31c18a48f5)

**Note:** This fix will only apply to future versions unless backported. While backporting may not be worth the effort, it's important to be aware that the issue will remain in older versions.