### PR TITLE
pager: rename `Prepared(Iterator->Pager)Config`

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -62,7 +62,7 @@ struct ReceivedPage {
     tracing_id: Option<Uuid>,
 }
 
-pub(crate) struct PreparedIteratorConfig {
+pub(crate) struct PreparedPagerConfig {
     pub(crate) prepared: PreparedStatement,
     pub(crate) values: SerializedValues,
     pub(crate) execution_profile: Arc<ExecutionProfileInner>,
@@ -763,7 +763,7 @@ impl QueryPager {
     }
 
     pub(crate) async fn new_for_prepared_statement(
-        config: PreparedIteratorConfig,
+        config: PreparedPagerConfig,
     ) -> Result<Self, NextPageError> {
         let (sender, receiver) = mpsc::channel::<Result<ReceivedPage, NextPageError>>(1);
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2,7 +2,7 @@
 //! It manages all connections to the cluster and allows to execute CQL requests.
 
 use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle, ExecutionProfileInner};
-use super::pager::{PreparedIteratorConfig, QueryPager};
+use super::pager::{PreparedPagerConfig, QueryPager};
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
 #[cfg(feature = "unstable-cloud")]
@@ -1183,7 +1183,7 @@ impl Session {
             // we fully prepare a statement beforehand.
             let prepared = self.prepare(statement).await?;
             let values = prepared.serialize_values(&values)?;
-            QueryPager::new_for_prepared_statement(PreparedIteratorConfig {
+            QueryPager::new_for_prepared_statement(PreparedPagerConfig {
                 prepared,
                 values,
                 execution_profile,
@@ -1442,7 +1442,7 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        QueryPager::new_for_prepared_statement(PreparedIteratorConfig {
+        QueryPager::new_for_prepared_statement(PreparedPagerConfig {
             prepared,
             values: serialized_values,
             execution_profile,


### PR DESCRIPTION
The name was obsolete; it was overlooked when renaming `RowIterator` to `QueryPager` upon deserialization refactor.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
