### PR TITLE
docs: move flatten attribute docs to SerializeRow

### DIFF
--- a/scylla-macros/src/lib.rs
+++ b/scylla-macros/src/lib.rs
@@ -151,15 +151,6 @@ mod serialize;
 ///
 /// Don't use the field during serialization.
 ///
-/// `#[scylla(flatten)]`
-///
-/// Inline fields from a field into the parent struct. In other words, use this field's
-/// `SerializeRow` implementation to serialize into possibly multiple columns as part of the parent
-/// struct's serialization process.
-///
-/// Note that the name of this field is ignored and hence the `rename` attribute does not make sense
-/// here and will cause a compilation error.
-///
 #[proc_macro_derive(SerializeValue, attributes(scylla))]
 pub fn serialize_value_derive(tokens_input: TokenStream) -> TokenStream {
     match serialize::value::derive_serialize_value(tokens_input) {
@@ -263,6 +254,15 @@ pub fn serialize_value_derive(tokens_input: TokenStream) -> TokenStream {
 /// `#[scylla(skip)]`
 ///
 /// Don't use the field during serialization.
+///
+/// `#[scylla(flatten)]`
+///
+/// Inline fields from a field into the parent struct. In other words, use this field's
+/// `SerializeRow` implementation to serialize into possibly multiple columns as part of the parent
+/// struct's serialization process.
+///
+/// Note that the name of this field is ignored and hence the `rename` attribute does not make sense
+/// here and will cause a compilation error.
 #[proc_macro_derive(SerializeRow, attributes(scylla))]
 pub fn serialize_row_derive(tokens_input: TokenStream) -> TokenStream {
     match serialize::row::derive_serialize_row(tokens_input) {


### PR DESCRIPTION
## Pre-review checklist

somehow it was commited in the docs for SerializeValue instead

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I have provided docstrings for the public items that I want to introduce.
- [X] I have adjusted the documentation in `./docs/source/`.
- [X] I added appropriate `Fixes:` annotations to PR description.
