### PR TITLE
Add the ability to serialize/deserialize `Arc<str>` and `Box<str>`

### DIFF
--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -16,7 +16,7 @@ Database types and their Rust equivalents:
 * `BigInt` <----> `i64`
 * `Float` <----> `f32`
 * `Double` <----> `f64`
-* `Ascii`, `Text`, `Varchar` <----> `&str`, `String`
+* `Ascii`, `Text`, `Varchar` <----> `&str`, `String`, `Box<str>`, `Arc<str>`
 * `Counter` <----> `value::Counter`
 * `Blob` <----> `Vec<u8>`
 * `Inet` <----> `std::net::IpAddr`

--- a/docs/source/data-types/text.md
+++ b/docs/source/data-types/text.md
@@ -8,6 +8,7 @@
 # use std::error::Error;
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use futures::TryStreamExt;
+use std::sync::Arc;
 
 // Insert some text into the table as a &str
 let to_insert_str: &str = "abcdef";

--- a/docs/source/data-types/text.md
+++ b/docs/source/data-types/text.md
@@ -21,10 +21,22 @@ session
     .query_unpaged("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert_string,))
     .await?;
 
+// Insert some text into the table as a Box<str>
+let to_insert_box_str: Box<str> = "abcdef".into();
+session
+    .query_unpaged("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert_box_str,))
+    .await?;
+
+// Insert some text into the table as a Arc<str>
+let to_insert_arc_str: Arc<str> = "abcdef".into();
+session
+    .query_unpaged("INSERT INTO keyspace.table (a) VALUES(?)", (to_insert_arc_str,))
+    .await?;
+
 // Read ascii/text/varchar from the table
 let mut iter = session.query_iter("SELECT a FROM keyspace.table", &[])
     .await?
-    .rows_stream::<(String,)>()?;
+    .rows_stream::<(String,)>()?; // or: Box<str>, Arc<str>
 while let Some((text_value,)) = iter.try_next().await? {
     println!("{}", text_value);
 }

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -383,6 +383,28 @@ impl_string_type!(
         Ok(s.to_string())
     }
 );
+impl_string_type!(
+    Box<str>,
+    |typ: &'metadata ColumnType<'metadata>, v: Option<FrameSlice<'frame>>| {
+        let val = ensure_not_null_slice::<Self>(typ, v)?;
+        check_ascii::<Box<str>>(typ, val)?;
+        let s = std::str::from_utf8(val).map_err(|err| {
+            mk_deser_err::<Self>(typ, BuiltinDeserializationErrorKind::InvalidUtf8(err))
+        })?;
+        Ok(s.into())
+    }
+);
+impl_string_type!(
+    Arc<str>,
+    |typ: &'metadata ColumnType<'metadata>, v: Option<FrameSlice<'frame>>| {
+        let val = ensure_not_null_slice::<Self>(typ, v)?;
+        check_ascii::<Arc<str>>(typ, val)?;
+        let s = std::str::from_utf8(val).map_err(|err| {
+            mk_deser_err::<Self>(typ, BuiltinDeserializationErrorKind::InvalidUtf8(err))
+        })?;
+        Ok(s.into())
+    }
+);
 
 // TODO: Consider support for deserialization of string::String<Bytes>
 

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -96,11 +96,7 @@ fn test_deserialize_ascii() {
         // Nonempty string
         assert_ser_de_identity(typ, &ASCII_TEXT, &mut Bytes::new());
         assert_ser_de_identity(typ, &ASCII_TEXT.to_owned(), &mut Bytes::new());
-        assert_ser_de_identity(
-            typ,
-            &ASCII_TEXT.to_owned().into_boxed_str(),
-            &mut Bytes::new(),
-        );
+        assert_ser_de_identity(typ, &Box::from(ASCII_TEXT), &mut Bytes::new());
         assert_ser_de_identity(typ, &Arc::from(ASCII_TEXT), &mut Bytes::new());
     }
 }
@@ -121,9 +117,12 @@ fn test_deserialize_text() {
         deserialize::<String>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
     let decoded_text_boxed_str =
         deserialize::<Box<str>>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
+    let decoded_text_arc_str =
+        deserialize::<Arc<str>>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
     assert_eq!(decoded_text_str, UNICODE_TEXT);
     assert_eq!(decoded_text_string, UNICODE_TEXT);
     assert_eq!(decoded_text_boxed_str.as_ref(), UNICODE_TEXT);
+    assert_eq!(decoded_text_arc_str.as_ref(), UNICODE_TEXT);
 
     // ser/de identity
 
@@ -139,7 +138,12 @@ fn test_deserialize_text() {
     );
     assert_ser_de_identity(
         &ColumnType::Native(NativeType::Text),
-        &UNICODE_TEXT.to_owned().into_boxed_str(),
+        &Box::from(UNICODE_TEXT),
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Text),
+        &Arc::from(UNICODE_TEXT),
         &mut Bytes::new(),
     );
 }

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -77,19 +77,31 @@ fn test_deserialize_ascii() {
     {
         let decoded_str = deserialize::<&str>(typ, &ascii).unwrap();
         let decoded_string = deserialize::<String>(typ, &ascii).unwrap();
+        let decoded_boxed_str = deserialize::<Box<str>>(typ, &ascii).unwrap();
+        let decoded_arc_str = deserialize::<Arc<str>>(typ, &ascii).unwrap();
 
         assert_eq!(decoded_str, ASCII_TEXT);
         assert_eq!(decoded_string, ASCII_TEXT);
+        assert_eq!(decoded_boxed_str.as_ref(), ASCII_TEXT);
+        assert_eq!(decoded_arc_str.as_ref(), ASCII_TEXT);
 
         // ser/de identity
 
         // Empty string
         assert_ser_de_identity(typ, &"", &mut Bytes::new());
         assert_ser_de_identity(typ, &"".to_owned(), &mut Bytes::new());
+        assert_ser_de_identity(typ, &"".to_owned().into_boxed_str(), &mut Bytes::new());
+        assert_ser_de_identity(typ, &Arc::from(""), &mut Bytes::new());
 
         // Nonempty string
         assert_ser_de_identity(typ, &ASCII_TEXT, &mut Bytes::new());
         assert_ser_de_identity(typ, &ASCII_TEXT.to_owned(), &mut Bytes::new());
+        assert_ser_de_identity(
+            typ,
+            &ASCII_TEXT.to_owned().into_boxed_str(),
+            &mut Bytes::new(),
+        );
+        assert_ser_de_identity(typ, &Arc::from(ASCII_TEXT), &mut Bytes::new());
     }
 }
 
@@ -107,8 +119,11 @@ fn test_deserialize_text() {
         deserialize::<&str>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
     let decoded_text_string =
         deserialize::<String>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
+    let decoded_text_boxed_str =
+        deserialize::<Box<str>>(&ColumnType::Native(NativeType::Text), &unicode).unwrap();
     assert_eq!(decoded_text_str, UNICODE_TEXT);
     assert_eq!(decoded_text_string, UNICODE_TEXT);
+    assert_eq!(decoded_text_boxed_str.as_ref(), UNICODE_TEXT);
 
     // ser/de identity
 
@@ -120,6 +135,11 @@ fn test_deserialize_text() {
     assert_ser_de_identity(
         &ColumnType::Native(NativeType::Text),
         &UNICODE_TEXT.to_owned(),
+        &mut Bytes::new(),
+    );
+    assert_ser_de_identity(
+        &ColumnType::Native(NativeType::Text),
+        &UNICODE_TEXT.to_owned().into_boxed_str(),
         &mut Bytes::new(),
     );
 }

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -343,6 +343,22 @@ impl SerializeValue for String {
             .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
     });
 }
+impl SerializeValue for Box<str> {
+    impl_serialize_via_writer!(|me, typ, writer| {
+        exact_type_check!(typ, Ascii, Text);
+        writer
+            .set_value(me.as_bytes())
+            .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
+    });
+}
+impl SerializeValue for Arc<str> {
+    impl_serialize_via_writer!(|me, typ, writer| {
+        exact_type_check!(typ, Ascii, Text);
+        writer
+            .set_value(me.as_bytes())
+            .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
+    });
+}
 impl<T: SerializeValue> SerializeValue for Option<T> {
     fn serialize<'b>(
         &self,

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -1636,6 +1636,24 @@ fn text_serialization() {
 }
 
 #[test]
+fn box_str_serialization() {
+    let val: Box<str> = "abc".into();
+    assert_eq!(
+        do_serialize(val, &ColumnType::Native(NativeType::Text)),
+        vec![0, 0, 0, 3, 97, 98, 99]
+    );
+}
+
+#[test]
+fn arc_str_serialization() {
+    let val: Arc<str> = "abc".into();
+    assert_eq!(
+        do_serialize(val, &ColumnType::Native(NativeType::Text)),
+        vec![0, 0, 0, 3, 97, 98, 99]
+    );
+}
+
+#[test]
 fn u8_array_serialization() {
     let val = [1u8; 4];
     assert_eq!(

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -1633,19 +1633,11 @@ fn text_serialization() {
         do_serialize("abc".to_string(), &ColumnType::Native(NativeType::Ascii)),
         vec![0, 0, 0, 3, 97, 98, 99]
     );
-}
-
-#[test]
-fn box_str_serialization() {
     let val: Box<str> = "abc".into();
     assert_eq!(
         do_serialize(val, &ColumnType::Native(NativeType::Text)),
         vec![0, 0, 0, 3, 97, 98, 99]
     );
-}
-
-#[test]
-fn arc_str_serialization() {
     let val: Arc<str> = "abc".into();
     assert_eq!(
         do_serialize(val, &ColumnType::Native(NativeType::Text)),


### PR DESCRIPTION
# Description
This PR add the ability to automatically derive `SerializeValue` and `DeserializeValue` on structs that contain `Box<str>` and `Arc<str>`, enabling particular patterns to reduce memory footprint.

Along with the implementation I have added tests where I thought it made sense. Everything seems to work but I had troubles with the Makefile and wasn't able to bring up the 3-node cluster, so please double check (`cargo t -p scylla-cql` passed every test anyway). 

Thanks!

## Pre-review checklist
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.


Fixes: #1336 