### PR TITLE
CachingSession: Allow skipping result metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.zed
 target/
 Cargo.lock
 /book/book

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -299,8 +299,12 @@ impl CachingSessionBuilder<RandomState> {
     /// which can be used to create a new [CachingSession].
     ///
     pub fn new(session: Session) -> Self {
+        Self::new_shared(Arc::new(session))
+    }
+
+    pub fn new_shared(session: Arc<Session>) -> Self {
         Self {
-            session: Arc::new(session),
+            session,
             max_capacity: DEFAULT_MAX_CAPACITY,
             hasher: RandomState::default(),
             use_cached_metadata: false,

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -37,7 +37,7 @@ pub struct CachingSession<S = RandomState>
 where
     S: Clone + BuildHasher,
 {
-    session: Session,
+    session: Arc<Session>,
     /// The prepared statement cache size
     /// If a prepared statement is added while the limit is reached, the oldest prepared statement
     /// is removed from the cache
@@ -65,7 +65,7 @@ where
 {
     pub fn from(session: Session, cache_size: usize) -> Self {
         Self {
-            session,
+            session: Arc::new(session),
             max_capacity: cache_size,
             cache: Default::default(),
             use_cached_metadata: false,
@@ -81,7 +81,7 @@ where
     /// and a [`BuildHasher`], using a customer hasher.
     pub fn with_hasher(session: Session, cache_size: usize, hasher: S) -> Self {
         Self {
-            session,
+            session: Arc::new(session),
             max_capacity: cache_size,
             cache: DashMap::with_hasher(hasher),
             use_cached_metadata: false,
@@ -288,7 +288,7 @@ pub struct CachingSessionBuilder<S = RandomState>
 where
     S: Clone + BuildHasher,
 {
-    session: Session,
+    session: Arc<Session>,
     max_capacity: usize,
     hasher: S,
     use_cached_metadata: bool,
@@ -300,7 +300,7 @@ impl CachingSessionBuilder<RandomState> {
     ///
     pub fn new(session: Session) -> Self {
         Self {
-            session,
+            session: Arc::new(session),
             max_capacity: DEFAULT_MAX_CAPACITY,
             hasher: RandomState::default(),
             use_cached_metadata: false,

--- a/scylla/tests/integration/session/caching_session.rs
+++ b/scylla/tests/integration/session/caching_session.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use scylla::client::caching_session::{CachingSession, CachingSessionBuilder};
+use scylla::client::session_builder::SessionBuilder;
+use scylla_cql::frame::request::Execute;
+use scylla_cql::frame::request::Request;
+use scylla_proxy::Condition;
+use scylla_proxy::ProxyError;
+use scylla_proxy::Reaction;
+use scylla_proxy::RequestFrame;
+use scylla_proxy::RequestOpcode;
+use scylla_proxy::RequestReaction;
+use scylla_proxy::RequestRule;
+use scylla_proxy::WorkerError;
+use tokio::sync::mpsc;
+
+use crate::utils::test_with_3_node_cluster;
+
+#[tokio::test]
+#[cfg_attr(scylla_cloud_tests, ignore)]
+async fn test_caching_session_metadata_cache() {
+    let res = test_with_3_node_cluster(
+        scylla_proxy::ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel();
+            let prepared_request_feedback_rule = RequestRule(
+                Condition::and(
+                    Condition::not(Condition::ConnectionRegisteredAnyEvent),
+                    Condition::RequestOpcode(RequestOpcode::Execute),
+                ),
+                RequestReaction::noop().with_feedback_when_performed(feedback_tx),
+            );
+            for node in running_proxy.running_nodes.iter_mut() {
+                node.change_request_rules(Some(vec![prepared_request_feedback_rule.clone()]));
+            }
+
+            async fn verify_statement_metadata(
+                session: &CachingSession,
+                statement: &str,
+                should_have_metadata: bool,
+                feedback: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
+            ) {
+                let _result = session.execute_unpaged(statement, ()).await.unwrap();
+                let (req_frame, _) = feedback.recv().await.unwrap();
+                let _ = feedback.try_recv().unwrap_err(); // There should be only one frame.
+                let request = req_frame.deserialize().unwrap();
+                let Request::Execute(Execute { parameters, .. }) = request else {
+                    panic!("Unexpected request type");
+                };
+                let has_metadata = !parameters.skip_metadata;
+                assert_eq!(has_metadata, should_have_metadata);
+            }
+
+            const REQUEST: &str = "SELECT * FROM system.local WHERE key = 'local'";
+
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map.clone()))
+                .build()
+                .await
+                .unwrap();
+            let caching_session: CachingSession = CachingSessionBuilder::new(session)
+                .use_cached_result_metadata(false) // Default, set just to be more explicit
+                .build();
+
+            // Skipping metadata was not set, so metadata should be present
+            verify_statement_metadata(&caching_session, REQUEST, true, &mut feedback_rx).await;
+
+            // It should also be present when executing statement already in cache
+            verify_statement_metadata(&caching_session, REQUEST, true, &mut feedback_rx).await;
+
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+            let caching_session: CachingSession = CachingSessionBuilder::new(session)
+                .use_cached_result_metadata(true)
+                .build();
+
+            // Now we set skip_metadata to true, so metadata should not be present for a new query
+            verify_statement_metadata(&caching_session, REQUEST, false, &mut feedback_rx).await;
+
+            // It should also not be present when executing statement already in cache
+            verify_statement_metadata(&caching_session, REQUEST, false, &mut feedback_rx).await;
+
+            // Test also without setting it explicitly, to verify that it is false by default.
+            let caching_session: CachingSession =
+                CachingSessionBuilder::new_shared(Arc::clone(&session)).build();
+
+            // Skipping metadata was not set, so metadata should be present
+            verify_statement_metadata(&caching_session, REQUEST, true, &mut feedback_rx).await;
+
+            // It should also be present when executing statement already in cache
+            verify_statement_metadata(&caching_session, REQUEST, true, &mut feedback_rx).await;
+
+            running_proxy
+        },
+    )
+    .await;
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -1,4 +1,5 @@
 mod authenticate;
+mod caching_session;
 mod history;
 mod new_session;
 mod retries;


### PR DESCRIPTION
As `CachingSession` manages preparation internally, it does not expose its `PreparedStatement`s in any way. Therefore, it's not possible for a user of `CachingSession` to call
`PreparedStatement::set_use_cached_result_metadata` in order to take advantage of that optimisation.

There are use cases when not having possibility to turn the optimisation on may result in significant inefficiency. As an example, the experimental NodeJS-over-Rust driver's API suits `CachingSession`'s API best, but lack of the mentioned optimisation makes the experimental driver fall short compared to the original NodeJS driver (which, most likely, has the optimisation turned on).

New method is added to recently introduced CachingSessionBuilder, allowing user to enable caching result metadata.
Additionally, I added the possibility to share the same Session between multiple CachingSessions.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1178

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
