### PR TITLE
caching_session: introduce CachingSessionBuilder

### DIFF
--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -253,6 +253,12 @@ pub const DEFAULT_MAX_CAPACITY: usize = 128;
 
 /// [CachingSessionBuilder] is used to create new [CachingSession] instances.
 ///
+/// **NOTE:** The builder specifies a default capacity of the prepared statement cache
+/// that may be too low for use cases running lots of different prepared statements.
+/// If you expect to run a large number of different prepared statements (more than
+/// [DEFAULT_MAX_CAPACITY]), consider increasing the capacity with
+/// [CachingSessionBuilder::max_capacity].
+///
 /// # Example
 ///
 /// ```


### PR DESCRIPTION
We can see that CachingSession requires more config options than there are currently. Not to cause exponential growth of number of constructors, a builder is introduced.
A unit test using proxy comes together, too.

Fixes: #1342

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
