### PR TITLE
Preparation logic integration test

### DIFF
--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -49,7 +49,7 @@ pub enum Condition {
     /// True for predefined number of evaluations, then always false.
     TrueForLimitedTimes(usize),
 
-    // True if any REGISTER was sent on this connection. Useful to filter out control connection messages.
+    /// True if any REGISTER was sent on this connection. Useful to filter out control connection messages.
     ConnectionRegisteredAnyEvent,
 }
 

--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -135,6 +135,34 @@ impl Condition {
     pub fn or(self, c2: Self) -> Self {
         Self::Or(Box::new(self), Box::new(c2))
     }
+
+    /// A convenience function for creating a tree with [Condition::And] variant in nodes.
+    pub fn all(cs: impl IntoIterator<Item = Self>) -> Self {
+        let mut cs = cs.into_iter();
+        match cs.next() {
+            None => Self::True, // The trivial case for the \forall quantifier.
+            Some(mut c) => {
+                for head in cs {
+                    c = head.and(c);
+                }
+                c
+            }
+        }
+    }
+
+    /// A convenience function for creating a tree with [Condition::Or] variant in nodes.
+    pub fn any(cs: impl IntoIterator<Item = Self>) -> Self {
+        let mut cs = cs.into_iter();
+        match cs.next() {
+            None => Self::False, // The trivial case for the \exists quantifier.
+            Some(mut c) => {
+                for head in cs {
+                    c = head.or(c);
+                }
+                c
+            }
+        }
+    }
 }
 
 /// Just a trait to unify API of both [RequestReaction] and [ResponseReaction].

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -907,13 +907,11 @@ mod tests {
             ),
             // QUERY, PREPARE, EXECUTE -> ERROR rule
             RequestRule(
-                Condition::or(
+                Condition::any([
                     Condition::RequestOpcode(RequestOpcode::Query),
-                    Condition::or(
-                        Condition::RequestOpcode(RequestOpcode::Prepare),
-                        Condition::RequestOpcode(RequestOpcode::Execute),
-                    ),
-                ),
+                    Condition::RequestOpcode(RequestOpcode::Prepare),
+                    Condition::RequestOpcode(RequestOpcode::Execute),
+                ]),
                 RequestReaction::forge().server_error(),
             ),
         ];

--- a/scylla/tests/integration/statements/prepared.rs
+++ b/scylla/tests/integration/statements/prepared.rs
@@ -1,6 +1,10 @@
+use assert_matches::assert_matches;
+use itertools::Itertools;
 use scylla::client::session::Session;
 use scylla::cluster::metadata::{ColumnType, NativeType};
+use scylla::errors::{DbError, PrepareError, RequestAttemptError};
 use scylla::frame::response::result::{ColumnSpec, TableSpec};
+use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
 use scylla::response::{PagingState, PagingStateResponse};
 use scylla::routing::partitioner::PartitionerName;
 use scylla::routing::Token;
@@ -9,10 +13,15 @@ use scylla::statement::prepared::PreparedStatement;
 use scylla::statement::Statement;
 use scylla_cql::frame::types;
 use scylla_proxy::{
-    Condition, ProxyError, Reaction, ResponseFrame, ResponseOpcode, ResponseReaction, ResponseRule,
-    ShardAwareness, TargetShard, WorkerError,
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    ResponseFrame, ResponseOpcode, ResponseReaction, ResponseRule, RunningProxy, ShardAwareness,
+    TargetShard, WorkerError,
 };
+use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::{debug, info};
+use uuid::Uuid;
 
 use crate::utils::{
     create_new_session_builder, scylla_supports_tablets, setup_tracing, test_with_3_node_cluster,
@@ -624,6 +633,244 @@ async fn test_skip_result_metadata() {
         running_proxy
     }).await;
 
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Counts number of feedbacks, aggregated per shard.
+/// Unknown shards feedbacks are counted too.
+fn count_per_shard_feedbacks(
+    rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<TargetShard>)>,
+) -> HashMap<Option<TargetShard>, usize> {
+    let per_shard_feedback_counts = std::iter::from_fn(|| rx.try_recv().ok())
+        .map(|(_frame, shard)| shard)
+        .counts();
+
+    debug!(
+        "Got per_shard_feedback_counts: {:#?}",
+        per_shard_feedback_counts
+    );
+
+    per_shard_feedback_counts
+}
+
+/// Asserts that there was exactly one preparation attempt on every node.
+fn assert_preparation_attempted_exactly_once_on_each_node(
+    rxs: &mut [mpsc::UnboundedReceiver<(RequestFrame, Option<TargetShard>)>],
+) {
+    let per_shard_feedbacks_counts = rxs.iter_mut().map(count_per_shard_feedbacks);
+
+    for (node_num, per_shard_feedbacks_count) in per_shard_feedbacks_counts.enumerate() {
+        let preparation_attempts_to_node: usize = per_shard_feedbacks_count.values().sum();
+        assert_eq!(
+            1, preparation_attempts_to_node,
+            "Unexpected number of preparation attempts on node {}: expected 1, got {}",
+            node_num, preparation_attempts_to_node,
+        );
+    }
+}
+
+/// Asserts that there was at least one preparation attempt on every shard.
+fn assert_preparation_attempted_on_all_shards(
+    rxs: &mut [mpsc::UnboundedReceiver<(RequestFrame, Option<TargetShard>)>],
+) {
+    let per_shard_feedbacks_counts = rxs.iter_mut().map(count_per_shard_feedbacks);
+    for (node_num, per_shard_feedbacks_count) in per_shard_feedbacks_counts.enumerate() {
+        if per_shard_feedbacks_count.contains_key(&None) {
+            // We are shard-unaware. This is most likely due to Cassandra being our DB, not ScyllaDB.
+            // In such case, nothing to check here.
+        } else {
+            // We are shard-aware. Then let's make sure that preparation was attempted on all shards.
+            for (shard, preparation_attempts_to_shard) in per_shard_feedbacks_count
+                .into_iter()
+                .filter_map(|(shard, count)| shard.map(|shard| (shard, count)))
+            {
+                assert!(
+                    preparation_attempts_to_shard >= 1,
+                    "Preparation was not attempted on node {}, shard {}",
+                    node_num,
+                    shard
+                );
+            }
+        }
+    }
+}
+
+/// Assumptions:
+/// - Preparation is expected to succeed iff at least one shard sends a successful PREPARED response.
+/// - If preparation succeeds, the statement is executed on all nodes and this way repreparation logic is additionally checked.
+///
+/// Outline:
+/// 1. All nodes enabled -> preparation succeeds.
+/// 2. One or two nodes fully disabled -> preparation succeeds.
+/// 3. All three nodes fully disabled -> preparation fails, and we assert that all shards were attempted.
+/// 4. All three nodes disabled once (simulation of only part of shards broken) -> preparation succeeds,
+///     and we assert that all shards were attempted.
+///
+#[cfg_attr(scylla_cloud_tests, ignore)]
+#[tokio::test]
+#[ntest::timeout(30000)]
+async fn test_preparation_logic() {
+    setup_tracing();
+
+    const STATEMENT: &str = "SELECT host_id FROM system.local WHERE key='local'";
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = scylla::client::session_builder::SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+            let cluster_state = session.get_cluster_state();
+
+            // Prepares a statement and asserts that its execution succeeds on all nodes.
+            let expect_success = || async {
+                let mut prepared = session.prepare(STATEMENT).await.unwrap();
+
+                for node in cluster_state.get_nodes_info() {
+                    prepared.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
+                        NodeIdentifier::Node(Arc::clone(node)),
+                        None,
+                    )));
+                    let res = session
+                        .execute_unpaged(&prepared, ())
+                        .await
+                        .unwrap()
+                        .into_rows_result()
+                        .unwrap();
+                    let (coordinator_host_id,) = res.single_row::<(Uuid,)>().unwrap();
+
+                    // Just a sanity check that we got the expected result.
+                    assert_eq!(coordinator_host_id, node.host_id);
+                    assert_eq!(
+                        coordinator_host_id,
+                        res.request_coordinator().node().host_id
+                    );
+                }
+            };
+            let expect_failure = || async {
+                assert_matches!(
+                    session.prepare(STATEMENT).await,
+                    Err(PrepareError::AllAttemptsFailed {
+                        first_attempt: RequestAttemptError::DbError(DbError::ServerError, _)
+                    })
+                );
+            };
+
+            struct NodeConfig {
+                /// How many times should the node fail preparation until it finally succeeds.
+                prepare_rejections_count: usize,
+            }
+
+            /// Configures proxy so that nodes reject preparation requested number of times, then always succeed.
+            fn configure_proxy<const N: usize>(
+                running_proxy: &mut RunningProxy,
+                node_config: [NodeConfig; N],
+            ) -> [mpsc::UnboundedReceiver<(RequestFrame, Option<TargetShard>)>; N] {
+                let (feedback_txs, feedback_rxs): (Vec<_>, Vec<_>) = (0..N)
+                    .map(|_| mpsc::unbounded_channel::<(RequestFrame, Option<TargetShard>)>())
+                    .unzip();
+
+                running_proxy
+                    .running_nodes
+                    .iter_mut()
+                    .zip(node_config.iter().zip(feedback_txs))
+                    .for_each(|(node, (config, tx))| {
+                        let noncontrol_prepare_condition = || {
+                            Condition::RequestOpcode(RequestOpcode::Prepare)
+                                .and(Condition::not(Condition::ConnectionRegisteredAnyEvent))
+                        };
+                        let accept_rule = || {
+                            RequestRule(
+                                noncontrol_prepare_condition(),
+                                RequestReaction::noop().with_feedback_when_performed(tx.clone()),
+                            )
+                        };
+                        let reject_rule = |rejections| {
+                            RequestRule(
+                                noncontrol_prepare_condition()
+                                    .and(Condition::TrueForLimitedTimes(rejections)),
+                                RequestReaction::forge()
+                                    .server_error()
+                                    .with_feedback_when_performed(tx.clone()),
+                            )
+                        };
+                        let rules = match config.prepare_rejections_count {
+                            0 => vec![accept_rule()],
+                            n => {
+                                vec![reject_rule(n), accept_rule()]
+                            }
+                        };
+
+                        node.change_request_rules(Some(rules));
+                    });
+
+                feedback_rxs.try_into().unwrap()
+            }
+
+            // 1. All nodes enabled -> preparation succeeds, and we assert that each node was attempted preparation only once.
+            {
+                info!("Test case 1: All nodes enabled.");
+                let mut rxs = configure_proxy(
+                    &mut running_proxy,
+                    [0, 0, 0].map(|n| NodeConfig {
+                        prepare_rejections_count: n,
+                    }),
+                );
+                expect_success().await;
+                assert_preparation_attempted_exactly_once_on_each_node(&mut rxs);
+            }
+
+            // 2. One or two nodes fully disabled -> preparation succeeds, and we assert that each node was attempted preparation only once.
+            {
+                info!("Test case 2: Two nodes disabled.");
+                let mut rxs = configure_proxy(
+                    &mut running_proxy,
+                    [usize::MAX, usize::MAX, 0].map(|n| NodeConfig {
+                        prepare_rejections_count: n,
+                    }),
+                );
+                expect_success().await;
+                assert_preparation_attempted_exactly_once_on_each_node(&mut rxs);
+            }
+
+            // 3. All three nodes fully disabled -> preparation fails, and we assert that all shards were attempted.
+            {
+                info!("Test case 3: All nodes disabled.");
+                let mut rxs = configure_proxy(
+                    &mut running_proxy,
+                    [usize::MAX, usize::MAX, usize::MAX].map(|n| NodeConfig {
+                        prepare_rejections_count: n,
+                    }),
+                );
+                expect_failure().await;
+                assert_preparation_attempted_on_all_shards(&mut rxs);
+            }
+
+            // 4. All three nodes disabled once (simulation of only part of shards broken) -> preparation succeeds,
+            //    and we assert that all shards per each node were attempted.
+            {
+                info!("Test case 4: Simulated part of shards disabled on every node.");
+                let mut rxs = configure_proxy(
+                    &mut running_proxy,
+                    [1, 1, 1].map(|n| NodeConfig {
+                        prepare_rejections_count: n,
+                    }),
+                );
+                expect_success().await;
+                assert_preparation_attempted_on_all_shards(&mut rxs);
+            }
+
+            running_proxy
+        },
+    )
+    .await;
     match res {
         Ok(()) => (),
         Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),


### PR DESCRIPTION
### Assumptions:
- Preparation is expected to succeed iff at least one shard sends  a successful PREPARED response.
- If preparation succeeds, the statement is executed on all nodes and this way repreparation logic is additionally checked.

### Outline:
1. All nodes enabled -> preparation succeeds.
2. One or two nodes fully disabled -> preparation succeeds.
3. All three nodes fully disabled -> preparation fails, and we assert that all shards were attempted.
4. All three nodes disabled once (simulation of only part of shards broken) -> preparation succeeds, and we assert that all shards were attempted.

### Bonus
I implemented convenience constructors for `Condition` in proxy: `Condition::any()` and `Condition::all()`.

Fixes: #1348

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
