### PR TITLE
Address Clippy's lints introduced in Rust 1.87

### DIFF
--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -177,6 +177,7 @@ impl Completer for CqlHelper {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn print_result(result: QueryResult) -> Result<(), IntoRowsResultError> {
     match result.into_rows_result() {
         Ok(rows_result) => {

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -243,7 +243,7 @@ pub(crate) async fn write_frame(
 ) -> Result<(), tokio::io::Error> {
     let compressed_body = compression
         .maybe_compress_body(params.flags, body)
-        .map_err(|e| tokio::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(tokio::io::Error::other)?;
 
     let body = compressed_body.as_deref().unwrap_or(body);
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -301,10 +301,10 @@ pub(crate) async fn resolve_hostname(hostname: &str) -> Result<SocketAddr, io::E
     addrs
         .find_or_last(|addr| matches!(addr, SocketAddr::V4(_)))
         .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Empty address list returned by DNS for {}", hostname),
-            )
+            io::Error::other(format!(
+                "Empty address list returned by DNS for {}",
+                hostname
+            ))
         })
 }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1346,7 +1346,7 @@ impl Connection {
                     std::pin::Pin::new(&mut stream)
                         .connect()
                         .await
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                        .map_err(std::io::Error::other)?;
                     return Ok(spawn_router_and_get_handle(
                         config,
                         stream,

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -145,11 +145,11 @@ impl From<TlsError> for io::Error {
             #[cfg(feature = "openssl-010")]
             TlsError::OpenSsl010(e) => e.into(),
             #[cfg(feature = "rustls-023")]
-            TlsError::InvalidName(e) => io::Error::new(io::ErrorKind::Other, e),
+            TlsError::InvalidName(e) => io::Error::other(e),
             #[cfg(feature = "rustls-023")]
-            TlsError::PemParse(e) => io::Error::new(io::ErrorKind::Other, e),
+            TlsError::PemParse(e) => io::Error::other(e),
             #[cfg(feature = "rustls-023")]
-            TlsError::Rustls023(e) => io::Error::new(io::ErrorKind::Other, e),
+            TlsError::Rustls023(e) => io::Error::other(e),
         }
     }
 }

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -207,6 +207,8 @@ impl QueryResult {
     /// Ok(())
     /// # }
     /// ```
+    // `allow(clippy::result_large_err)` is fine. `QueryRowsResult` is larger than `IntoRowsResultError`.
+    #[allow(clippy::result_large_err)]
     pub fn into_rows_result(self) -> Result<QueryRowsResult, IntoRowsResultError> {
         let Some(raw_metadata_and_rows) = self.raw_metadata_and_rows else {
             return Err(IntoRowsResultError::ResultNotRows(self));

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -248,17 +248,18 @@ pub(crate) mod batch_values {
 
     use super::BatchStatement;
 
-    // Takes an optional reference to the first statement in the batch and
-    // the batch values, and tries to compute the token for the statement.
-    // Returns the (optional) token and batch values. If the function needed
-    // to serialize values for the first statement, the returned batch values
-    // will cache the results of the serialization.
-    //
-    // NOTE: Batch values returned by this function might not type check
-    // the first statement when it is serialized! However, if they don't,
-    // then the first row was already checked by the function. It is assumed
-    // that `statement` holds the first prepared statement of the batch (if
-    // there is one), and that it will be used later to serialize the values.
+    /// Takes an optional reference to the first statement in the batch and
+    /// the batch values, and tries to compute the token for the statement.
+    /// Returns the (optional) token and batch values. If the function needed
+    /// to serialize values for the first statement, the returned batch values
+    /// will cache the results of the serialization.
+    ///
+    /// NOTE: Batch values returned by this function might not type check
+    /// the first statement when it is serialized! However, if they don't,
+    /// then the first row was already checked by the function. It is assumed
+    /// that `statement` holds the first prepared statement of the batch (if
+    /// there is one), and that it will be used later to serialize the values.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn peek_first_token<'bv>(
         values: impl BatchValues + 'bv,
         statement: Option<&BatchStatement>,

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -2,7 +2,6 @@ use scylla_cql::frame::response::error::DbError;
 use tracing::{error, warn};
 
 use crate::client::caching_session::CachingSession;
-use crate::client::execution_profile::ExecutionProfile;
 use crate::client::session::Session;
 use crate::client::session_builder::{GenericSessionBuilder, SessionBuilderKind};
 use crate::cluster::ClusterState;
@@ -214,7 +213,7 @@ fn apply_ddl_lbp(query: &mut Statement) {
     let policy = query
         .get_execution_profile_handle()
         .map(|profile| profile.pointee_to_builder())
-        .unwrap_or(ExecutionProfile::builder())
+        .unwrap_or_default()
         .load_balancing_policy(Arc::new(SchemaQueriesLBP))
         .retry_policy(Arc::new(SchemaQueriesRetryPolicy))
         .build();


### PR DESCRIPTION
New Rust version, new Clippy lints enabled by default. I decided to silence the lints about too large errors. Those are our standard error types, it would not be ergonomical to Box them. In some cases the Ok variant is larger, so it would make no sense to Box errors. If it ever becomes an issue, we can reconsider.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
