### PR TITLE
Remove is_down and all related code

### DIFF
--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -18,10 +18,7 @@ use std::net::IpAddr;
 use std::{
     hash::{Hash, Hasher},
     net::SocketAddr,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    sync::Arc,
 };
 
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
@@ -81,8 +78,6 @@ pub struct Node {
 
     // If the node is filtered out by the host filter, this will be None
     pool: Option<NodeConnectionPool>,
-
-    down_marker: AtomicBool,
 }
 
 /// A way that Nodes are often passed and accessed in the driver's code.
@@ -121,7 +116,6 @@ impl Node {
             datacenter,
             rack,
             pool,
-            down_marker: false.into(),
         }
     }
 
@@ -140,7 +134,6 @@ impl Node {
         }
         Self {
             address,
-            down_marker: false.into(),
             datacenter: node.datacenter.clone(),
             rack: node.rack.clone(),
             host_id: node.host_id,
@@ -161,16 +154,6 @@ impl Node {
         self.get_pool()?.connection_for_shard(shard)
     }
 
-    /// Is the node down according to CQL events?
-    /// This status is unreliable and should not be used.
-    /// See [Node::is_connected] for a better way of checking node availability.
-    // TODO: When control connection is broken, we should mark
-    // all nodes as being up.
-    #[allow(unused)]
-    pub(crate) fn is_down(&self) -> bool {
-        self.down_marker.load(Ordering::Relaxed)
-    }
-
     /// Returns true if the driver has any open connections in the pool for this
     /// node.
     pub fn is_connected(&self) -> bool {
@@ -185,10 +168,6 @@ impl Node {
     /// no connections will be opened.
     pub fn is_enabled(&self) -> bool {
         self.pool.is_some()
-    }
-
-    pub(crate) fn change_down_marker(&self, is_down: bool) {
-        self.down_marker.store(is_down, Ordering::Relaxed);
     }
 
     pub(crate) async fn use_keyspace(
@@ -378,7 +357,6 @@ mod tests {
                 datacenter,
                 rack,
                 pool: None,
-                down_marker: false.into(),
             }
         }
     }

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1476,12 +1476,11 @@ mod tests {
         info!("Example plan from policy:",);
         for (node, shard) in example_plan {
             info!(
-                "Node port: {}, shard: {}, dc: {:?}, rack: {:?}, down: {:?}",
+                "Node port: {}, shard: {}, dc: {:?}, rack: {:?}",
                 node.address.port(),
                 shard,
                 node.datacenter,
                 node.rack,
-                node.is_down()
             );
         }
 


### PR DESCRIPTION
Events-related node status is not used for anything, and I don't see any possible uses for it in the future. For that reason I don't think we need this code for anything.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
