### PR TITLE
Clippy overhaul

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
     }
 
     // Or as custom structs that derive DeserializeRow
-    #[allow(unused)]
+    #[expect(unused)]
     #[derive(Debug, DeserializeRow)]
     struct RowData {
         a: i32,

--- a/scylla-cql/src/deserialize/frame_slice.rs
+++ b/scylla-cql/src/deserialize/frame_slice.rs
@@ -121,6 +121,9 @@ impl<'frame> FrameSlice<'frame> {
     /// Returns a new Bytes object which is a subslice of the original Bytes
     /// frame slice object.
     #[inline]
+    // Check triggers because `self` is `Copy`, so `to_` should take it by value.
+    // TODO(2.0): Take self by value.
+    #[expect(clippy::wrong_self_convention)]
     pub fn to_bytes(&self) -> Bytes {
         if self.original_frame.is_empty() {
             // For the borrowed, deficient version of FrameSlice - the one created with

--- a/scylla-cql/src/deserialize/result.rs
+++ b/scylla-cql/src/deserialize/result.rs
@@ -175,7 +175,7 @@ impl RawRowLendingIterator {
     /// The column iterator must be consumed before the rows iterator can
     /// continue.
     #[inline]
-    #[allow(clippy::should_implement_trait)] // https://github.com/rust-lang/rust-clippy/issues/5004
+    #[expect(clippy::should_implement_trait)] // https://github.com/rust-lang/rust-clippy/issues/5004
     pub fn next(&mut self) -> Option<Result<ColumnIterator, DeserializationError>> {
         self.remaining = self.remaining.checked_sub(1)?;
 

--- a/scylla-cql/src/deserialize/result.rs
+++ b/scylla-cql/src/deserialize/result.rs
@@ -256,9 +256,6 @@ mod tests {
         fn lend_next(&mut self) -> Option<Result<Self::Item<'_>, DeserializationError>>;
     }
 
-    // Disable the lint, if there is more than one lifetime included.
-    // Can be removed once https://github.com/rust-lang/rust-clippy/issues/12495 is fixed.
-    #[allow(clippy::needless_lifetimes)]
     impl<'frame, 'metadata> LendingIterator for RawRowIterator<'frame, 'metadata> {
         type Item<'borrow>
             = ColumnIterator<'borrow, 'borrow>

--- a/scylla-cql/src/deserialize/row_tests.rs
+++ b/scylla-cql/src/deserialize/row_tests.rs
@@ -84,12 +84,10 @@ fn test_deserialization_as_column_iterator() {
 // Do not remove. It's not used in tests but we keep it here to check that
 // we properly ignore warnings about unused variables, unnecessary `mut`s
 // etc. that usually pop up when generating code for empty structs.
-#[allow(unused)]
 #[derive(DeserializeRow)]
 #[scylla(crate = crate)]
 struct TestUdtWithNoFieldsUnordered {}
 
-#[allow(unused)]
 #[derive(DeserializeRow)]
 #[scylla(crate = crate, flavor = "enforce_order")]
 struct TestUdtWithNoFieldsOrdered {}

--- a/scylla-cql/src/deserialize/row_tests.rs
+++ b/scylla-cql/src/deserialize/row_tests.rs
@@ -932,9 +932,9 @@ fn metadata_does_not_bound_deserialized_rows() {
         #[derive(DeserializeRow)]
         #[scylla(crate=crate)]
         struct MyRow<'frame> {
-            #[allow(dead_code)]
+            #[expect(dead_code)]
             bytes: &'frame [u8],
-            #[allow(dead_code)]
+            #[expect(dead_code)]
             text: &'frame str,
         }
         let decoded_custom_struct_res = deserialize::<MyRow>(row_typ, &bytes);

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -2167,6 +2167,9 @@ impl From<VectorDeserializationErrorKind> for BuiltinDeserializationErrorKind {
 /// Describes why deserialization of a map type failed.
 #[derive(Debug)]
 #[non_exhaustive]
+// Check triggers because all variants end with "DeserializationFailed".
+// TODO(2.0): Remove the "DeserializationFailed" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum MapDeserializationErrorKind {
     /// Failed to deserialize map's length.
     LengthDeserializationFailed(DeserializationError),

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -1200,12 +1200,10 @@ impl UdtSerializer {
 // Do not remove. It's not used in tests but we keep it here to check that
 // we properly ignore warnings about unused variables, unnecessary `mut`s
 // etc. that usually pop up when generating code for empty structs.
-#[allow(unused)]
 #[derive(scylla_macros::DeserializeValue)]
 #[scylla(crate = crate)]
 struct TestUdtWithNoFieldsUnordered {}
 
-#[allow(unused)]
 #[derive(scylla_macros::DeserializeValue)]
 #[scylla(crate = crate, flavor = "enforce_order")]
 struct TestUdtWithNoFieldsOrdered {}

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -42,7 +42,7 @@ fn test_custom_cassandra_type_parser() {
             dimensions: 5,
         },
     ),
-    (  "636f6c756d6e:org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)", 
+    (  "636f6c756d6e:org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)",
         ColumnType::Collection {
             frozen: false,
             typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
@@ -2781,9 +2781,9 @@ fn metadata_does_not_bound_deserialized_values() {
         #[derive(DeserializeValue)]
         #[scylla(crate=crate)]
         struct Udt<'frame> {
-            #[allow(dead_code)]
+            #[expect(dead_code)]
             bytes: &'frame [u8],
-            #[allow(dead_code)]
+            #[expect(dead_code)]
             text: &'frame str,
         }
         let decoded_udt_res = deserialize::<Udt>(&udt_typ, &bytes);

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -130,6 +130,9 @@ pub enum CqlRequestSerializationError {
 /// server response fails.
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]
+// Check triggers because all variants begin with "Cql".
+// TODO(2.0): Remove the "Cql" prefix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum CqlResponseParseError {
     #[error("Failed to deserialize ERROR response: {0}")]
     CqlErrorParseError(#[from] CqlErrorParseError),
@@ -313,6 +316,9 @@ pub enum PreparedParseError {
 /// - paging state response
 #[non_exhaustive]
 #[derive(Debug, Error, Clone)]
+// Check triggers because all variants end with "ParseError".
+// TODO(2.0): Remove the "ParseError" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum RawRowsAndPagingStateResponseParseError {
     /// Failed to parse metadata flags.
     #[error("Malformed metadata flags: {0}")]
@@ -331,6 +337,9 @@ pub enum RawRowsAndPagingStateResponseParseError {
 /// of statement's prepared metadata failed.
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]
+// Check triggers because all variants end with "ParseError".
+// TODO(2.0): Remove the "ParseError" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum PreparedMetadataParseError {
     /// Failed to parse metadata flags.
     #[error("Malformed metadata flags: {0}")]
@@ -375,6 +384,9 @@ pub enum ResultMetadataAndRowsCountParseError {
 /// of result metadata failed.
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]
+// Check triggers because all variants end with "ParseError".
+// TODO(2.0): Remove the "ParseError" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum ResultMetadataParseError {
     /// Failed to parse metadata flags.
     #[error("Malformed metadata flags: {0}")]
@@ -422,6 +434,9 @@ pub struct ColumnSpecParseError {
 /// of a column specification.
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]
+// Check triggers because all variants end with "ParseError".
+// TODO(2.0): Remove the "ParseError" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum ColumnSpecParseErrorKind {
     #[error("Invalid table spec: {0}")]
     TableSpecParseError(#[from] TableSpecParseError),

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -31,8 +31,11 @@ pub mod flag {
     pub const WARNING: u8 = 0x08;
 }
 
-// All of the Authenticators supported by Scylla
+/// All of the Authenticators supported by Scylla
 #[derive(Debug, PartialEq, Eq, Clone)]
+// Check triggers because all variants end with "Authenticator".
+// TODO(2.0): Remove the "Authenticator" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum Authenticator {
     AllowAllAuthenticator,
     PasswordAuthenticator,

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -226,9 +226,6 @@ impl BatchStatement<'_> {
     }
 }
 
-// Disable the lint, if there is more than one lifetime included.
-// Can be removed once https://github.com/rust-lang/rust-clippy/issues/12495 is fixed.
-#[allow(clippy::needless_lifetimes)]
 impl<'s, 'b> From<&'s BatchStatement<'b>> for BatchStatement<'s> {
     fn from(value: &'s BatchStatement) -> Self {
         match value {

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -162,7 +162,7 @@ impl Request<'_> {
             Request::Query(q) => Some(q.parameters.consistency),
             Request::Execute(e) => Some(e.parameters.consistency),
             Request::Batch(b) => Some(b.consistency),
-            #[allow(unreachable_patterns)] // until other opcodes are supported
+            #[expect(unreachable_patterns)] // until other opcodes are supported
             _ => None,
         }
     }
@@ -173,7 +173,7 @@ impl Request<'_> {
             Request::Query(q) => Some(q.parameters.serial_consistency),
             Request::Execute(e) => Some(e.parameters.serial_consistency),
             Request::Batch(b) => Some(b.serial_consistency),
-            #[allow(unreachable_patterns)] // until other opcodes are supported
+            #[expect(unreachable_patterns)] // until other opcodes are supported
             _ => None,
         }
     }

--- a/scylla-cql/src/frame/response/event.rs
+++ b/scylla-cql/src/frame/response/event.rs
@@ -6,6 +6,9 @@ use crate::frame::types;
 use std::net::SocketAddr;
 
 #[derive(Debug)]
+// Check triggers because all variants end with "Change".
+// TODO(2.0): Remove the "Change" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum Event {
     TopologyChange(TopologyChangeEvent),
     StatusChange(StatusChangeEvent),
@@ -25,6 +28,9 @@ pub enum StatusChangeEvent {
 }
 
 #[derive(Debug)]
+// Check triggers because all variants end with "Change".
+// TODO(2.0): Remove the "Change" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum SchemaChangeEvent {
     KeyspaceChange {
         change_type: SchemaChangeType,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -260,7 +260,7 @@ impl ColumnType<'_> {
     // Scylla's set of types supported for empty values as it's smaller;
     // with Cassandra, some rejects will just have to be rejected on the db side.
     pub(crate) fn supports_special_empty_value(&self) -> bool {
-        #[allow(clippy::match_like_matches_macro)]
+        #[expect(clippy::match_like_matches_macro)]
         match self {
             ColumnType::Native(NativeType::Counter)
             | ColumnType::Native(NativeType::Duration)

--- a/scylla-cql/src/frame/server_event_type.rs
+++ b/scylla-cql/src/frame/server_event_type.rs
@@ -3,6 +3,9 @@ use std::str::FromStr;
 
 use super::frame_errors::CqlEventParseError;
 
+// Check triggers because all variants end with "Change".
+// TODO(2.0): Remove the "Change" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum EventType {
     TopologyChange,
     StatusChange,

--- a/scylla-cql/src/serialize/batch_tests.rs
+++ b/scylla-cql/src/serialize/batch_tests.rs
@@ -320,7 +320,6 @@ fn tuple_batch_values() {
 }
 
 #[test]
-#[allow(clippy::needless_borrow)]
 fn ref_batch_values() {
     let batch_values: &[&[i8]] = &[&[1, 2], &[2, 3, 4, 5], &[6]];
     let cols = &[
@@ -338,7 +337,6 @@ fn ref_batch_values() {
 }
 
 #[test]
-#[allow(clippy::needless_borrow)]
 fn check_ref_tuple() {
     fn assert_has_batch_values<BV: BatchValues>(bv: BV, cols: &[&[ColumnSpec]]) {
         let mut iter = make_batch_value_iter(&bv);

--- a/scylla-cql/src/serialize/row_tests.rs
+++ b/scylla-cql/src/serialize/row_tests.rs
@@ -94,7 +94,6 @@ fn test_dyn_serialize_row() {
 #[test]
 fn test_tuple_errors() {
     // Unit
-    #[allow(clippy::let_unit_value)] // The let binding below is intentional
     let v = ();
     let spec = [col("a", ColumnType::Native(NativeType::Text))];
     let err = do_serialize_err(v, &spec);
@@ -224,7 +223,6 @@ fn test_map_errors() {
 // Do not remove. It's not used in tests but we keep it here to check that
 // we properly ignore warnings about unused variables, unnecessary `mut`s
 // etc. that usually pop up when generating code for empty structs.
-#[allow(unused)]
 #[derive(SerializeRow)]
 #[scylla(crate = crate)]
 struct TestRowWithNoColumns {}

--- a/scylla-cql/src/serialize/row_tests.rs
+++ b/scylla-cql/src/serialize/row_tests.rs
@@ -669,7 +669,7 @@ struct TestRowWithSkippedFields {
     a: String,
     b: i32,
     #[scylla(skip)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     skipped: Vec<String>,
     c: Vec<i64>,
 }

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -522,7 +522,7 @@ fn test_cql_value_udt_errors() {
 // Do not remove. It's not used in tests but we keep it here to check that
 // we properly ignore warnings about unused variables, unnecessary `mut`s
 // etc. that usually pop up when generating code for empty structs.
-#[allow(unused)]
+#[expect(unused)]
 #[derive(SerializeValue)]
 #[scylla(crate = crate)]
 struct TestUdtWithNoFields {}
@@ -1162,7 +1162,7 @@ fn test_udt_serialization_with_field_rename_and_enforce_order() {
     assert_eq!(reference, udt);
 }
 
-#[allow(unused)]
+#[expect(unused)]
 #[derive(SerializeValue, Debug)]
 #[scylla(crate = crate, flavor = "enforce_order", skip_name_checks)]
 struct TestUdtWithSkippedNameChecks {
@@ -1329,7 +1329,7 @@ struct TestUdtWithSkippedFields {
     a: String,
     b: i32,
     #[scylla(skip)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     skipped: Vec<String>,
     c: Vec<i64>,
 }

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -322,7 +322,6 @@ impl DeserializeAssumeOrderGenerator<'_> {
 
         parse_quote! {
             fn deserialize(
-                #[allow(unused_mut)]
                 mut row: #macro_internal::ColumnIterator<#frame_lifetime, #metadata_lifetime>,
             ) -> ::std::result::Result<Self, #macro_internal::DeserializationError> {
                 ::std::result::Result::Ok(Self {
@@ -576,8 +575,7 @@ impl DeserializeUnorderedGenerator<'_> {
 
         parse_quote! {
             fn deserialize(
-                #[allow(unused_mut)]
-                mut row: #macro_internal::ColumnIterator<#frame_lifetime, #metadata_lifetime>,
+                row: #macro_internal::ColumnIterator<#frame_lifetime, #metadata_lifetime>,
             ) -> ::std::result::Result<Self, #macro_internal::DeserializationError> {
 
                 // Generate fields that will serve as temporary storage

--- a/scylla-macros/src/deserialize/value.rs
+++ b/scylla-macros/src/deserialize/value.rs
@@ -536,8 +536,7 @@ impl DeserializeAssumeOrderGenerator<'_> {
         let field_idents = fields.iter().map(|f| f.ident.as_ref().unwrap());
         let field_finalizers = fields.iter().map(|f| self.generate_finalize_field(f));
 
-        #[allow(unused_mut)]
-        let mut iterator_type: syn::Type =
+        let iterator_type: syn::Type =
             parse_quote!(#macro_internal::UdtIterator<#frame_lifetime, #metadata_lifetime>);
 
         parse_quote! {

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -396,7 +396,7 @@ impl Generator for ColumnSortingGenerator<'_> {
                 #partial_struct
                 #partial_serialize
 
-                #[allow(non_local_definitions)]
+                #[expect(non_local_definitions)]
                 #serialize_by_name
 
                 #crate_path::ser::row::ByName::<Self>::serialize(#crate_path::ser::row::ByName(self), ctx, writer)
@@ -447,7 +447,7 @@ impl Generator for ColumnOrderedGenerator<'_> {
                 ctx: &#crate_path::RowSerializationContext,
                 writer: &mut #crate_path::RowWriter<'_scylla_ser_row_writer_buffer>,
             ) -> ::std::result::Result<(), #crate_path::SerializationError> {
-                #[allow(non_local_definitions)]
+                #[expect(non_local_definitions)]
                 impl #impl_generics #crate_path::SerializeRowInOrder for #struct_name #ty_generics #where_clause {
                     fn serialize_in_order(
                         &self,

--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -121,7 +121,7 @@ impl Condition {
     }
 
     /// A convenience function for creating [Condition::Not] variant.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(clippy::should_implement_trait)]
     pub fn not(c: Self) -> Self {
         Condition::Not(Box::new(c))
     }

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1228,7 +1228,7 @@ impl ProxyWorker {
         .await;
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn request_processor(
         self,
         mut requests_rx: mpsc::UnboundedReceiver<RequestFrame>,
@@ -1350,7 +1350,7 @@ impl ProxyWorker {
         .await;
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn response_processor(
         self,
         mut responses_rx: mpsc::UnboundedReceiver<ResponseFrame>,

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -28,7 +28,7 @@ use tracing::warn;
 mod sealed {
     // This is a sealed trait - its whole purpose is to be unnameable.
     // This means we need to disable the check.
-    #[allow(unnameable_types)]
+    #[expect(unnameable_types)]
     pub trait Sealed {}
 }
 pub trait SessionBuilderKind: sealed::Sealed + Clone {}

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -264,12 +264,12 @@ impl AuthInfo {
         &self.tls
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn get_username(&self) -> Option<&str> {
         self.username.as_deref()
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn get_password(&self) -> Option<&str> {
         self.password.as_deref()
     }
@@ -291,7 +291,7 @@ impl Datacenter {
         &self.server
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn get_tls_server_name(&self) -> Option<&str> {
         self.tls_server_name.as_deref()
     }
@@ -304,7 +304,7 @@ impl Datacenter {
         self.insecure_skip_tls_verify
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn get_proxy_url(&self) -> Option<&str> {
         self.proxy_url.as_deref()
     }
@@ -367,7 +367,7 @@ mod deserialize {
     const NODE_DOMAIN_MAX_LENGTH: usize = 255 - 32 - 4 - 1;
 
     #[derive(Deserialize)]
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     struct RawCloudConfig {
         // Kind is a string value representing the REST resource this object represents.
         // Servers may infer this from the endpoint the client submits requests to.
@@ -398,7 +398,7 @@ mod deserialize {
         parameters: Option<Parameters>,
     }
 
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     #[derive(Deserialize)]
     struct AuthInfo {
         // ClientCertificateData contains PEM-encoded data from a client cert file for TLS. Overrides ClientCertificatePath.
@@ -425,7 +425,7 @@ mod deserialize {
         password: Option<String>,
     }
 
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     #[derive(Deserialize)]
     struct Datacenter {
         // CertificateAuthorityPath is the path to a cert file for the certificate authority.
@@ -462,7 +462,7 @@ mod deserialize {
         proxyUrl: Option<String>,
     }
 
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     #[derive(Deserialize)]
     struct Context {
         // DatacenterName is the name of the datacenter for this context.
@@ -472,7 +472,7 @@ mod deserialize {
         authInfoName: String,
     }
 
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     #[derive(Deserialize, Debug)]
     struct Parameters {
         // DefaultConsistency is the default consistency level used for user queries.

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -168,9 +168,7 @@ pub enum CloudTlsProvider {
 #[derive(Debug)]
 pub(crate) struct AuthInfo {
     tls: TlsInfo,
-    #[allow(unused)]
     username: Option<String>,
-    #[allow(unused)]
     password: Option<String>,
 }
 
@@ -282,11 +280,9 @@ impl AuthInfo {
 pub(crate) struct Datacenter {
     ca_cert: TlsCert,
     server: String,
-    #[allow(unused)]
     tls_server_name: Option<String>,
     node_domain: String,
     insecure_skip_tls_verify: bool,
-    #[allow(unused)]
     proxy_url: Option<String>,
 }
 

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -359,6 +359,9 @@ impl std::str::FromStr for ColumnKind {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
+// Check triggers because all variants end with "Strategy".
+// TODO(2.0): Remove the "Strategy" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum Strategy {
     SimpleStrategy {
         replication_factor: usize,

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -420,7 +420,7 @@ impl Metadata {
 
 impl MetadataReader {
     /// Creates new MetadataReader, which connects to initially_known_peers in the background
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) async fn new(
         initial_known_nodes: Vec<InternalKnownNode>,
         control_connection_repair_requester: broadcast::Sender<()>,
@@ -1663,7 +1663,7 @@ impl ControlConnection {
         'tables_loop: for ((keyspace_name, table_name), table_result) in tables_schema {
             let keyspace_and_table_name = (keyspace_name, table_name);
 
-            #[allow(clippy::type_complexity)]
+            #[expect(clippy::type_complexity)]
             let (columns, partition_key_columns, clustering_key_columns): (
                 HashMap<String, Column>,
                 Vec<(i32, String)>,

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -359,7 +359,6 @@ impl std::str::FromStr for ColumnKind {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-#[allow(clippy::enum_variant_names)]
 pub enum Strategy {
     SimpleStrategy {
         replication_factor: usize,

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -260,7 +260,7 @@ pub(crate) struct CloudEndpoint {
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedContactPoint {
     pub(crate) address: SocketAddr,
-    #[cfg_attr(not(feature = "unstable-cloud"), allow(unused))]
+    #[cfg_attr(not(feature = "unstable-cloud"), expect(unused))]
     pub(crate) datacenter: Option<String>,
 }
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -97,7 +97,7 @@ struct UseKeyspaceRequest {
 }
 
 impl Cluster {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) async fn new(
         known_nodes: Vec<InternalKnownNode>,
         pool_config: PoolConfig,

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -116,6 +116,9 @@ pub enum PrepareError {
 /// An error that occurred during construction of [`QueryPager`][crate::client::pager::QueryPager].
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
+// Check triggers because all variants end with "Error".
+// TODO(2.0): Remove the "Error" postfix from variants.
+#[expect(clippy::enum_variant_names)]
 pub enum PagerExecutionError {
     /// Failed to prepare the statement.
     #[error("Failed to prepare the statement to be used by the pager: {0}")]

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -299,9 +299,7 @@ impl ConnectionConfig {
     /// Customizes the config for a specific endpoint.
     pub(crate) fn to_host_connection_config(
         &self,
-        // Currently, this is only used for cloud; but it makes abstract sense to pass endpoint here
-        // also for non-cloud cases, so let's just allow(unused).
-        #[allow(unused)] endpoint: &UntranslatedEndpoint,
+        endpoint: &UntranslatedEndpoint,
     ) -> HostConnectionConfig {
         let tls_config = self
             .tls_provider

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -184,8 +184,6 @@ impl TlsConfig {
 
     /// Produces a new Tls object that is able to wrap a TCP stream.
     pub(crate) fn new_tls(&self) -> Result<Tls, TlsError> {
-        // To silence warnings when TlsContext is an empty enum (tls features are disabled).
-        #[allow(unreachable_code)]
         match self.context {
             #[cfg(feature = "openssl-010")]
             TlsContext::OpenSsl010(ref context) => {

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -50,7 +50,7 @@ impl NodeLocationPreference {
         }
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     fn rack(&self) -> Option<&str> {
         match self {
             Self::Any | Self::Datacenter(_) => None,
@@ -108,7 +108,7 @@ enum PickedReplica<'a> {
 /// to be a better metric showing how (over)loaded a target node/shard is.
 /// For now, however, we don't have an implementation of the
 /// in-flight-requests-aware policy.
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct DefaultPolicy {
     /// Preferences regarding node location. One of: rack and DC, DC, or no preference.
     preferences: NodeLocationPreference,

--- a/scylla/src/policies/load_balancing/single_target.rs
+++ b/scylla/src/policies/load_balancing/single_target.rs
@@ -39,7 +39,7 @@ pub struct SingleTargetLoadBalancingPolicy {
 
 impl SingleTargetLoadBalancingPolicy {
     /// Creates a new instance of [`SingleTargetLoadBalancingPolicy`].
-    #[allow(clippy::new_ret_no_self)]
+    #[expect(clippy::new_ret_no_self)]
     pub fn new(
         node_identifier: NodeIdentifier,
         shard: Option<Shard>,

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -31,7 +31,7 @@ impl<'slice, 'spec> ColumnSpecs<'slice, 'spec> {
     }
 
     /// Returns number of columns.
-    #[allow(clippy::len_without_is_empty)]
+    #[expect(clippy::len_without_is_empty)]
     #[inline]
     pub fn len(&self) -> usize {
         self.specs.len()

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -18,7 +18,7 @@ pub(crate) struct QueryResponse {
     pub(crate) response: Response,
     pub(crate) tracing_id: Option<Uuid>,
     pub(crate) warnings: Vec<String>,
-    #[allow(dead_code)] // This is not exposed to user (yet?)
+    // This is not exposed to user (yet?)
     pub(crate) custom_payload: Option<HashMap<String, Bytes>>,
 }
 

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -729,7 +729,7 @@ impl<'a> Iterator for ReplicasOrderedNTSIterator<'a> {
                 // Clippy can't check that in Eq and Hash impls we don't actually use any field with interior mutability
                 // (in Node only `down_marker` is such, being an AtomicBool).
                 // https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type
-                #[allow(clippy::mutable_key_type)]
+                #[expect(clippy::mutable_key_type)]
                 let mut all_replicas: HashSet<&'a Arc<Node>> = HashSet::new();
                 for (datacenter, repfactor) in datacenter_repfactors.iter() {
                     all_replicas.extend(

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -230,7 +230,7 @@ impl Tablet {
     // make much sense to do so, looking at the caller of this function.
     // Tablet returned in `Err` variant is used as if no error appeared.
     // The only difference is that we use node ids to emit some debug logs.
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub(crate) fn from_raw_tablet(
         raw_tablet: RawTablet,
         replica_translator: impl Fn(Uuid) -> Option<Arc<Node>>,
@@ -520,7 +520,7 @@ impl TabletsInfo {
             .add_tablet(tablet)
     }
 
-    #[allow(clippy::doc_overindented_list_items)]
+    #[expect(clippy::doc_overindented_list_items)]
     /// This method is supposed to be called when topology is updated.
     /// It goes through tablet info and adjusts it to topology changes, to prevent
     /// a situation where local tablet info and a real one are permanently different.

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -490,9 +490,6 @@ impl TabletsInfo {
             table_spec: &'a TableSpec<'a>,
         }
 
-        // Disable the lint, if there is more than one lifetime included.
-        // Can be removed once https://github.com/rust-lang/rust-clippy/issues/12495 is fixed.
-        #[allow(clippy::needless_lifetimes)]
         impl<'key, 'query> hashbrown::Equivalent<TableSpec<'key>> for TableSpecQueryKey<'query> {
             fn equivalent(&self, key: &TableSpec<'key>) -> bool {
                 self.table_spec == key

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -16,7 +16,6 @@ use std::num::Wrapping;
 use crate::routing::Token;
 use crate::statement::prepared::TokenCalculationError;
 
-#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 #[non_exhaustive]
 pub enum PartitionerName {
@@ -51,7 +50,6 @@ impl Partitioner for PartitionerName {
     }
 }
 
-#[allow(clippy::upper_case_acronyms)]
 #[non_exhaustive]
 pub enum PartitionerHasherAny {
     Murmur3(Murmur3PartitionerHasher),
@@ -92,7 +90,7 @@ pub trait Partitioner: sealed::Sealed {
 
     fn build_hasher(&self) -> Self::Hasher;
 
-    #[allow(unused)] // Currently, no public API uses this.
+    // Currently, no public API uses this.
     fn hash_one(&self, data: &[u8]) -> Token {
         let mut hasher = self.build_hasher();
         hasher.write(data);

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -76,7 +76,7 @@ impl PartitionerHasher for PartitionerHasherAny {
 mod sealed {
     // This is a sealed trait - its whole purpose is to be unnameable.
     // This means we need to disable the check.
-    #[allow(unnameable_types)]
+    #[expect(unnameable_types)]
     pub trait Sealed {}
 }
 

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -21,6 +21,11 @@ use crate::statement::prepared::TokenCalculationError;
 pub enum PartitionerName {
     #[default]
     Murmur3,
+    // Check triggers, because according to guidelines acronyms should be counted
+    // as one word and written in UpperCamelCase. In this case the variant should
+    // be Cdc.
+    // TODO(2.0): Rename variant to Cdc.
+    #[expect(clippy::upper_case_acronyms)]
     CDC,
 }
 
@@ -53,6 +58,12 @@ impl Partitioner for PartitionerName {
 #[non_exhaustive]
 pub enum PartitionerHasherAny {
     Murmur3(Murmur3PartitionerHasher),
+    // Check triggers, because according to guidelines acronyms should be counted
+    // as one word and written in UpperCamelCase. In this case the variant should
+    // be Cdc.
+    // TODO(2.0): Rename variant to Cdc.
+    // TODO(2.0): Rename CDCPartitionerHasher to CdcPartitionerHasher
+    #[expect(clippy::upper_case_acronyms)]
     CDC(CDCPartitionerHasher),
 }
 

--- a/scylla/src/routing/sharding.rs
+++ b/scylla/src/routing/sharding.rs
@@ -265,7 +265,7 @@ mod tests {
         assert_eq!(range, ShardAwarePortRange::EPHEMERAL_PORT_RANGE);
 
         // Test invalid range (empty)
-        #[allow(clippy::reversed_empty_ranges)]
+        #[expect(clippy::reversed_empty_ranges)]
         {
             assert!(ShardAwarePortRange::new(49152..=49151).is_err());
         }

--- a/scylla/tests/integration/load_balancing/lwt_optimisation.rs
+++ b/scylla/tests/integration/load_balancing/lwt_optimisation.rs
@@ -110,7 +110,7 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
             assert!(num_queried == 1);
         }
 
-        #[allow(unused)]
+        #[expect(unused)]
         fn who_was_queried(rxs: &mut Rxs) {
             for (i, rx) in rxs.iter_mut().enumerate() {
                 if rx.try_recv().is_ok() {

--- a/scylla/tests/integration/load_balancing/mod.rs
+++ b/scylla/tests/integration/load_balancing/mod.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod load_balancing;
 mod lwt_optimisation;
 mod shards;

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -4,5 +4,5 @@ mod history;
 mod new_session;
 mod retries;
 mod self_identity;
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod session;

--- a/scylla/tests/integration/session/session.rs
+++ b/scylla/tests/integration/session/session.rs
@@ -584,7 +584,7 @@ async fn test_token_calculation() {
     session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
     session.use_keyspace(ks.as_str(), true).await.unwrap();
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn assert_tokens_equal(
         session: &Session,
         prepared: &PreparedStatement,

--- a/scylla/tests/integration/statements/batch/mod.rs
+++ b/scylla/tests/integration/statements/batch/mod.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod batch;
 mod large_batch_statements;
 mod silent_prepare_batch;

--- a/scylla/tests/integration/statements/consistency.rs
+++ b/scylla/tests/integration/statements/consistency.rs
@@ -337,11 +337,11 @@ pub(crate) struct OwnedRoutingInfo {
     consistency: Consistency,
     serial_consistency: Option<SerialConsistency>,
 
-    #[allow(unused)]
+    #[expect(unused)]
     table: Option<TableSpec<'static>>,
-    #[allow(unused)]
+    #[expect(unused)]
     token: Option<Token>,
-    #[allow(unused)]
+    #[expect(unused)]
     is_confirmed_lwt: bool,
 }
 


### PR DESCRIPTION
This PR improves our usage of Clippy in several ways:
- Wherever possible `allow(...)` is replaced with `expect(...)` so that we know if the lint stops triggering.
- Unnecessary lints are removed
- Enabled checking of public API with Clippy. It is disabled by default (which is an absurd default imo), so it did not trigger name checks for several of our public API items.

I removed 2 mut specifiers in macros - they were unnecessary.
From one place in macros I removed `allow(unused_mut)` , despite this mut being unused for structs with 0 fields.
It looks like such lints are not triggered for code generated by macros (anymore),

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
