### PR TITLE
Release 1.2.0

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "assert_matches",
  "bigdecimal",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1723,7 +1723,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-proxy"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "assert_matches",
  "bigdecimal",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "sphinx-docs"
 description = "ScyllaDB Documentation"
-version = "1.1"
+version = "1.2"
 authors = ["ScyllaDB Documentation Contributors"]
 package-mode = false
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,14 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ['v1.0.0', 'v1.1.0']
+TAGS = ['v1.1.0', 'v1.2.0']
 BRANCHES = ['main']
 # Set the latest version.
-LATEST_VERSION = 'v1.1.0'
+LATEST_VERSION = 'v1.2.0'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['main']
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ['v1.0.0']
+DEPRECATED_VERSIONS = ['v1.1.0']
 
 # -- General configuration
 

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "1.1"
+scylla = "1.2"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # Important: We use precise version of scylla-macros. This enables
 # us to make breaking changes in the doc(hidden) interfaces that are
 # used by macros.
-scylla-macros = { version = "=1.1.0", path = "../scylla-macros" }
+scylla-macros = { version = "=1.2.0", path = "../scylla-macros" }
 byteorder = "1.3.4"
 bytes = "1.0.1"
 tokio = { version = "1.40", features = ["io-util", "time"] }

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.70"
 description = "CQL data types and primitives, for interacting with Scylla."

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.81"
 description = "proc macros for scylla async CQL driver"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "1.1.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.2.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-proxy"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 rust-version = "1.81"
 description = "Proxy layer between Scylla driver and cluster that enables testing Scylla drivers' behaviour in unfavourable conditions"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -81,7 +81,7 @@ socket2 = { version = "0.5.3", features = ["all"] }
 num-bigint-03 = { package = "num-bigint", version = "0.3" }
 num-bigint-04 = { package = "num-bigint", version = "0.4" }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4" }
-scylla-proxy = { version = "0.0.3", path = "../scylla-proxy" }
+scylla-proxy = { version = "0.0.4", path = "../scylla-proxy" }
 ntest = "0.9.3"
 criterion = "0.5"
 tokio = { version = "1.34", features = ["test-util"] }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -43,7 +43,7 @@ metrics = ["dep:histogram"]
 unstable-testing = []
 
 [dependencies]
-scylla-cql = { version = "1.1.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.2.0", path = "../scylla-cql" }
 bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.81"
 description = "Async CQL driver for Rust, optimized for Scylla, fully compatible with Apache Cassandra™"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 1.2.0,
an asynchronous CQL driver for Rust, optimized for Scylla, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 3.877k downloads on crates!
- over 633 GitHub stars!

## Changes

**New features / enhancements:**
- Added `flatten` attribute to `SerializeRow` derive macro. The attribute is inspired and analogous to the one found in `serde` [#1144](https://github.com/scylladb/scylla-rust-driver/pull/1144)
- Introduced CQL Vector type full support [#1165](https://github.com/scylladb/scylla-rust-driver/pull/1165).
- Added `nil()` method for `CqlTimeuuid` [#1314](https://github.com/scylladb/scylla-rust-driver/pull/1314).
- Added `MaybeUnset::from_option()` convenience constructor to reduce boilerplate [#1317](https://github.com/scylladb/scylla-rust-driver/pull/1317).
- Exposed coordinator that served the request [#1287](https://github.com/scylladb/scylla-rust-driver/pull/1287).
- Enabled enforcing a coordinator for the request [#1326](https://github.com/scylladb/scylla-rust-driver/pull/1326).
- Derived `Debug` for timestamp generator types [#1341](https://github.com/scylladb/scylla-rust-driver/pull/1341).
- Introduced `CachingSessionBuilder` [#1345](https://github.com/scylladb/scylla-rust-driver/pull/1345).
- Preparation now is done on exactly one shard on each node (instead of all shards), which reduces unnecessary overhead [#1320](https://github.com/scylladb/scylla-rust-driver/pull/1320).
- Fetching schema version when awaiting for schema agreement is now done on one connection per node only (as opposed to all connnections), which reduces unnecessary overhead [#1323](https://github.com/scylladb/scylla-rust-driver/pull/1323).
- `PreparedStatement` is materialized only where needed, avoiding unnecessary allocations [#1329](https://github.com/scylladb/scylla-rust-driver/pull/1329).
- Exposed an option to allow skipping result metadata when executing prepared statements using `CachingSession` [#1340](https://github.com/scylladb/scylla-rust-driver/pull/1340).

**Bug fixes:**
- Fixed a bug that the driver panicked if the shard returned by the `LoadBalancingPolicy` was out of range for the chosen node [#1325](https://github.com/scylladb/scylla-rust-driver/pull/1325).
- Fixed a bug that `Metrics::percentiles()` would return the number of observations in the corresponding bucket instead of the mean value of the bucket [#1327](https://github.com/scylladb/scylla-rust-driver/pull/1327).
- Nodes with all connections broken are now ignored during schema agreement. This fixes the bug that such nodes made schema agreement awaiting fail [#1355](https://github.com/scylladb/scylla-rust-driver/pull/1355).

**Internal API cleanups/refactors:**
- `LatencyAwareness` uses existing `Iterator`'s methods instead of hand-crafted logic [#1330](https://github.com/scylladb/scylla-rust-driver/pull/1330).
- Renamed `PreparedIteratorConfig` to `PreparedPagerConfig`, because it was a remnant of the legacy naming [#1335](https://github.com/scylladb/scylla-rust-driver/pull/1335)
- Removed `Node::is_down()` and related code, as the event-based node status mechanism is error prone and was not used anyway [#1358](https://github.com/scylladb/scylla-rust-driver/pull/1358).

**Documentation:**
- Described `scylla-cql` API's considerations - versioning requirements, guarantees, etc. [#1322](https://github.com/scylladb/scylla-rust-driver/pull/1322).
- Updated dependencies of the docs [#1333](https://github.com/scylladb/scylla-rust-driver/pull/1333).
- Fixed md redirections for multiversion support in the docs [#1334](https://github.com/scylladb/scylla-rust-driver/pull/1334).
- Moved `flatten` attribute docs to `SerializeRow`, as it had been put in a wrong place [#1144](https://github.com/scylladb/scylla-rust-driver/pull/1144).


**CI / developer tool improvements:**
- Proxy now supports negotiated compression [#1246](https://github.com/scylladb/scylla-rust-driver/pull/1246).
- Added test for the UDT case when metadata is present but the value is missing [#1315](https://github.com/scylladb/scylla-rust-driver/pull/1315).
- Fixed warnings in serverless tests [#1316](https://github.com/scylladb/scylla-rust-driver/pull/1316).
- Reorganised integration tests into a clear tree-like structure ([#1350](https://github.com/scylladb/scylla-rust-driver/pull/1350), [#1351](https://github.com/scylladb/scylla-rust-driver/pull/1351)).
- Clippy was appeased again, after new lints were introduced in Rust 1.87 [#1357](https://github.com/scylladb/scylla-rust-driver/pull/1357).
- Improved our use of Clippy: migrated from `allow()` to `expect()`, removed unnecessary lints and enabled of checking public API with Clippy [#1359](https://github.com/scylladb/scylla-rust-driver/pull/1359).

**Others:**
- MSRV was raised to 1.80 [#1319](https://github.com/scylladb/scylla-rust-driver/pull/1319), and then to 1.81 [#1356](https://github.com/scylladb/scylla-rust-driver/pull/1356).

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:
| commits | author            |
|---------|-------------------|
|     108 | Wojciech Przytuła |
|      20 | Mikołaj Uzarski   |
|      19 | Karol Baryła      |
|       8 | Andres Medina     |
|       8 | smoczy123         |
|       4 | Andrés Medina     |
|       2 | David Garcia      |
|       2 | Vartan Babayan    |
|       1 | Dmitry Kropachev  |
