### PR TITLE
doctests: correct configuration wrt crate features

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["database", "scylla", "cql", "cassandra"]
 categories = ["database"]
 license = "MIT OR Apache-2.0"
 
+[package.metadata."docs.rs"]
+all-features = true
+
 [dependencies]
 # Important: We use precise version of scylla-macros. This enables
 # us to make breaking changes in the doc(hidden) interfaces that are

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT OR Apache-2.0"
 [lib]
 proc-macro = true
 
+[package.metadata."docs.rs"]
+all-features = true
+
 [dependencies]
 darling = "0.20.10"
 syn = "2.0"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["database", "scylla", "cql", "cassandra"]
 categories = ["database"]
 license = "MIT OR Apache-2.0"
 
+[package.metadata."docs.rs"]
+all-features = true
+
 [features]
 defaults = []
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["database", "scylla", "cql", "cassandra"]
 categories = ["database"]
 license = "MIT OR Apache-2.0"
 
-[package.metadata.docs.rs]
+[package.metadata."docs.rs"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -329,27 +329,33 @@ impl GenericSessionBuilder<DefaultMode> {
     ///
     /// Default is None.
     ///
-    /// # Example
-    /// ```
-    /// # use std::fs;
-    /// # use std::path::PathBuf;
-    /// # use scylla::client::session::Session;
-    /// # use scylla::client::session_builder::SessionBuilder;
-    /// # use openssl::ssl::{SslContextBuilder, SslVerifyMode, SslMethod, SslFiletype};
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let certdir = fs::canonicalize(PathBuf::from("./examples/certs/scylla.crt"))?;
-    /// let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
-    /// context_builder.set_certificate_file(certdir.as_path(), SslFiletype::PEM)?;
-    /// context_builder.set_verify(SslVerifyMode::NONE);
-    ///
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .tls_context(Some(context_builder.build()))
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
+    #[cfg_attr(
+        feature = "openssl-010",
+        doc = r#"
+# Example
+
+```
+    # use std::fs;
+    # use std::path::PathBuf;
+    # use scylla::client::session::Session;
+    # use scylla::client::session_builder::SessionBuilder;
+    # use openssl::ssl::{SslContextBuilder, SslVerifyMode, SslMethod, SslFiletype};
+    # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    let certdir = fs::canonicalize(PathBuf::from("./examples/certs/scylla.crt"))?;
+    let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
+    context_builder.set_certificate_file(certdir.as_path(), SslFiletype::PEM)?;
+    context_builder.set_verify(SslVerifyMode::NONE);
+
+    let session: Session = SessionBuilder::new()
+        .known_node("127.0.0.1:9042")
+        .tls_context(Some(context_builder.build()))
+        .build()
+        .await?;
+    # Ok(())
+    # }
+```
+"#
+    )]
     pub fn tls_context(mut self, tls_context: Option<impl Into<TlsContext>>) -> Self {
         self.config.tls_context = tls_context.map(|t| t.into());
         self

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -335,12 +335,13 @@ impl GenericSessionBuilder<DefaultMode> {
 # Example
 
 ```
-    # use std::fs;
-    # use std::path::PathBuf;
-    # use scylla::client::session::Session;
-    # use scylla::client::session_builder::SessionBuilder;
-    # use openssl::ssl::{SslContextBuilder, SslVerifyMode, SslMethod, SslFiletype};
     # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+    use std::path::PathBuf;
+    use scylla::client::session::Session;
+    use scylla::client::session_builder::SessionBuilder;
+    use openssl::ssl::{SslContextBuilder, SslVerifyMode, SslMethod, SslFiletype};
+
     let certdir = fs::canonicalize(PathBuf::from("./examples/certs/scylla.crt"))?;
     let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
     context_builder.set_certificate_file(certdir.as_path(), SslFiletype::PEM)?;

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -35,7 +35,8 @@ pub enum CloudConfigError {
 
 /// Configuration for creating a session to a serverless cluster.
 /// This can be automatically created if you provide the bundle path
-/// to the [`CloudSessionBuilder`] constructor.
+/// to the [`CloudSessionBuilder`](crate::client::session_builder::CloudSessionBuilder)
+/// constructor.
 #[derive(Debug)]
 pub struct CloudConfig {
     datacenters: HashMap<String, Datacenter>,


### PR DESCRIPTION
This patch fixes the unmet requirements for doctests wrt features:
1. The doctest for `SessionBuilder::tls_context()` is compiled conditionally, only when the required `openssl-010`  feature is turned on;
2. `scylla-macros`, `scylla-cql`, and `scylla-proxy` now have set `all-features` flag for docs.rs, which will make optional entities appear in those crates' respective docs. Before, `#[cfg(feature)]`'d entities would not show up in, e.g., `scylla-cql` crate docs on docs.rs.

Fixes: #1369

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
