### PR TITLE
errors: improve `ExecutionError::EmptyPlan` error message

### DIFF
--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -49,10 +49,10 @@ pub enum ExecutionError {
 
     /// Load balancing policy returned an empty plan.
     #[error(
-        "Load balancing policy returned an empty plan.\
-        First thing to investigate should be the logic of custom LBP implementation.\
-        If you think that your LBP implementation is correct, or you make use of `DefaultPolicy`,\
-        then this is most probably a driver bug!"
+        "Load balancing policy returned an empty plan. \
+        If you are using DefaultPolicy, ensure that you have not selected a nonexistent datacenter as preferred. \
+        If you are using a custom LBP implementation, ensure that your LBP implementation is correct. \
+        If neither of the above suggestions is the cause, then this is most likely a driver bug!"
     )]
     EmptyPlan,
 


### PR DESCRIPTION
As noted in #747, before the error refactor the `ExecutionError::EmptyPlan` error message had not been very helpful for users of the `DefaultPolicy`. Even after the error refactor, the message still did not provide hint to check the preferred datacenter when using `DefaultPolicy`. This commit improves the error message to mention this particular possible cause of the error.

Fixes: #747
Closes: #825

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
