### PR TITLE
session: Degenericise `run_request` & unify autohandling of specific responses

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1858,17 +1858,16 @@ impl Session {
     /// On success, this request's result is returned.
     // I tried to make this closures take a reference instead of an Arc but failed
     // maybe once async closures get stabilized this can be fixed
-    async fn run_request<'a, QueryFut, ResT>(
+    async fn run_request<'a, QueryFut>(
         &'a self,
         statement_info: RoutingInfo<'a>,
         statement_config: &'a StatementConfig,
         execution_profile: Arc<ExecutionProfileInner>,
         run_request_once: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
         request_span: &'a RequestSpan,
-    ) -> Result<(RunRequestResult<ResT>, Coordinator), ExecutionError>
+    ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), ExecutionError>
     where
-        QueryFut: Future<Output = Result<ResT, RequestAttemptError>>,
-        ResT: AllowedRunRequestResTType,
+        QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
         let history_listener_and_id: Option<(&'a dyn HistoryListener, history::RequestId)> =
             statement_config
@@ -2029,16 +2028,15 @@ impl Session {
     /// If request fails, retry session is used to perform retries.
     ///
     /// Returns None, if provided plan is empty.
-    async fn run_request_speculative_fiber<'a, QueryFut, ResT>(
+    async fn run_request_speculative_fiber<'a, QueryFut>(
         &'a self,
         request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
         run_request_once: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
         execution_profile: &ExecutionProfileInner,
         mut context: ExecuteRequestContext<'a>,
-    ) -> Option<Result<(RunRequestResult<ResT>, Coordinator), RequestError>>
+    ) -> Option<Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>>
     where
-        QueryFut: Future<Output = Result<ResT, RequestAttemptError>>,
-        ResT: AllowedRunRequestResTType,
+        QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
         let mut last_error: Option<RequestError> = None;
         let mut current_consistency: Consistency = context
@@ -2079,7 +2077,7 @@ impl Session {
 
                 let attempt_id: Option<history::AttemptId> =
                     context.log_attempt_start(connect_address);
-                let request_result: Result<ResT, RequestAttemptError> =
+                let request_result: Result<NonErrorQueryResponse, RequestAttemptError> =
                     run_request_once(connection, current_consistency, execution_profile)
                         .instrument(span.clone())
                         .await;
@@ -2347,21 +2345,6 @@ impl Session {
         &self.default_execution_profile_handle
     }
 }
-
-// run_request, run_request_speculative_fiber, etc have a template type called ResT.
-// There was a bug where ResT was set to QueryResponse, which could
-// be an error response. This was not caught by retry policy which
-// assumed all errors would come from analyzing Result<ResT, ExecutionError>.
-// This trait is a guard to make sure that this mistake doesn't
-// happen again.
-// When using run_request make sure that the ResT type is NOT able
-// to contain any errors.
-// See https://github.com/scylladb/scylla-rust-driver/issues/501
-pub(crate) trait AllowedRunRequestResTType {}
-
-impl AllowedRunRequestResTType for Uuid {}
-impl AllowedRunRequestResTType for QueryResult {}
-impl AllowedRunRequestResTType for NonErrorQueryResponse {}
 
 struct ExecuteRequestContext<'a> {
     is_idempotent: bool,


### PR DESCRIPTION
## What's done

###  De-genericised `Session::run_request(_speculative_fiber)`
    
In the past, those functions needed to be generic over the result type `ResT`, because they actually were instantiated with different result types. Now, they are always instantiated with the same type: `NonErrorQueryResponse`. This means we can de-genericise both those functions for better readability and maintainability.

As a bonus, we can remove the trait `AllowedRunRequestResTType`.

### Special responses are now handled straight in `Session::run_request`

Two special kinds of responses:
- SetKeyspace,
- SchemaChanged,
used to be separately handled in both `query()` and `execute()`. This not only duplicated code, but also made it bug-prone.

This commit moves the handling of these responses to a common place, `Session::run_request()`, which is a meeting point for all* requests.

*not true. `{query,execute}_iter()` are not using it. We however hope that no one would run schema modification statements via the `QueryPager` API. If they do, well - poor they. They will have to handle these responses themselves.



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
