### PR TITLE
Fix renaming in serialization

### DIFF
--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -549,7 +549,7 @@ impl SerializeValue for CqlValue {
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        serialize_cql_value(self, typ, writer).map_err(fix_cql_value_name_in_err::<Self>)
+        serialize_cql_value(self, typ, writer).map_err(fix_rust_name_in_err::<Self>)
     }
 }
 
@@ -631,7 +631,7 @@ fn serialize_cql_value<'b>(
     }
 }
 
-fn fix_cql_value_name_in_err<RustT>(mut err: SerializationError) -> SerializationError {
+fn fix_rust_name_in_err<RustT>(mut err: SerializationError) -> SerializationError {
     // The purpose of this function is to change the `rust_name` field
     // in the error to the given one. Most of the time, the `err` given to the
     // function here will be the sole owner of the data, so theoretically
@@ -713,7 +713,7 @@ fn serialize_udt<'b>(
         match fvalue {
             None => writer.set_null(),
             Some(v) => serialize_cql_value(v, ftyp, writer).map_err(|err| {
-                let err = fix_cql_value_name_in_err::<CqlValue>(err);
+                let err = fix_rust_name_in_err::<CqlValue>(err);
                 mk_ser_err::<CqlValue>(
                     typ,
                     UdtSerializationErrorKind::FieldSerializationFailed {
@@ -756,7 +756,7 @@ fn serialize_tuple_like<'t, 'b>(
         match el {
             None => sub.set_null(),
             Some(el) => serialize_cql_value(el, el_typ, sub).map_err(|err| {
-                let err = fix_cql_value_name_in_err::<CqlValue>(err);
+                let err = fix_rust_name_in_err::<CqlValue>(err);
                 mk_ser_err::<CqlValue>(
                     typ,
                     TupleSerializationErrorKind::ElementSerializationFailed { index, err },

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -549,7 +549,7 @@ impl SerializeValue for CqlValue {
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        serialize_cql_value(self, typ, writer).map_err(fix_cql_value_name_in_err)
+        serialize_cql_value(self, typ, writer).map_err(fix_cql_value_name_in_err::<Self>)
     }
 }
 
@@ -631,13 +631,13 @@ fn serialize_cql_value<'b>(
     }
 }
 
-fn fix_cql_value_name_in_err(mut err: SerializationError) -> SerializationError {
+fn fix_cql_value_name_in_err<RustT>(mut err: SerializationError) -> SerializationError {
     // The purpose of this function is to change the `rust_name` field
-    // in the error to CqlValue. Most of the time, the `err` given to the
+    // in the error to the given one. Most of the time, the `err` given to the
     // function here will be the sole owner of the data, so theoretically
     // we could fix this in place.
 
-    let rust_name = std::any::type_name::<CqlValue>();
+    let rust_name = std::any::type_name::<RustT>();
 
     match Arc::get_mut(&mut err.0) {
         Some(err_mut) => {
@@ -713,7 +713,7 @@ fn serialize_udt<'b>(
         match fvalue {
             None => writer.set_null(),
             Some(v) => serialize_cql_value(v, ftyp, writer).map_err(|err| {
-                let err = fix_cql_value_name_in_err(err);
+                let err = fix_cql_value_name_in_err::<CqlValue>(err);
                 mk_ser_err::<CqlValue>(
                     typ,
                     UdtSerializationErrorKind::FieldSerializationFailed {
@@ -756,7 +756,7 @@ fn serialize_tuple_like<'t, 'b>(
         match el {
             None => sub.set_null(),
             Some(el) => serialize_cql_value(el, el_typ, sub).map_err(|err| {
-                let err = fix_cql_value_name_in_err(err);
+                let err = fix_cql_value_name_in_err::<CqlValue>(err);
                 mk_ser_err::<CqlValue>(
                     typ,
                     TupleSerializationErrorKind::ElementSerializationFailed { index, err },

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -384,7 +384,9 @@ impl<V: SerializeValue> SerializeValue for MaybeUnset<V> {
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
         match self {
-            MaybeUnset::Set(v) => v.serialize(typ, writer),
+            MaybeUnset::Set(v) => v
+                .serialize(typ, writer)
+                .map_err(fix_rust_name_in_err::<Self>),
             MaybeUnset::Unset => Ok(writer.set_unset()),
         }
     }

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -223,7 +223,7 @@ impl<V: SerializeValue + secrecy_08::Zeroize> SerializeValue for secrecy_08::Sec
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
         use secrecy_08::ExposeSecret;
-        V::serialize(self.expose_secret(), typ, writer)
+        V::serialize(self.expose_secret(), typ, writer).map_err(fix_rust_name_in_err::<Self>)
     }
 }
 impl SerializeValue for bool {

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -350,7 +350,9 @@ impl<T: SerializeValue> SerializeValue for Option<T> {
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
         match self {
-            Some(v) => v.serialize(typ, writer),
+            Some(v) => v
+                .serialize(typ, writer)
+                .map_err(fix_rust_name_in_err::<Self>),
             None => Ok(writer.set_null()),
         }
     }

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -406,7 +406,7 @@ impl<T: SerializeValue + ?Sized> SerializeValue for Box<T> {
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        T::serialize(&**self, typ, writer)
+        T::serialize(&**self, typ, writer).map_err(fix_rust_name_in_err::<Self>)
     }
 }
 impl<V: SerializeValue, S: BuildHasher + Default> SerializeValue for HashSet<V, S> {

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -397,7 +397,7 @@ impl<T: SerializeValue + ?Sized> SerializeValue for &T {
         typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        T::serialize(*self, typ, writer)
+        T::serialize(*self, typ, writer).map_err(fix_rust_name_in_err::<Self>)
     }
 }
 impl<T: SerializeValue + ?Sized> SerializeValue for Box<T> {

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -131,6 +131,11 @@ fn test_option_errors() {
     verify_simple_error_in_wrapper::<Option<i32>>(Some(123));
 }
 
+#[test]
+fn test_maybe_unset_errors() {
+    verify_simple_error_in_wrapper::<MaybeUnset<i32>>(MaybeUnset::Set(123));
+}
+
 #[cfg(feature = "bigdecimal-04")]
 #[test]
 fn test_native_errors_bigdecimal_04() {

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -136,6 +136,11 @@ fn test_maybe_unset_errors() {
     verify_simple_error_in_wrapper::<MaybeUnset<i32>>(MaybeUnset::Set(123));
 }
 
+#[test]
+fn test_ref_errors() {
+    verify_simple_error_in_wrapper::<&i32>(&123_i32);
+}
+
 #[cfg(feature = "bigdecimal-04")]
 #[test]
 fn test_native_errors_bigdecimal_04() {

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -126,6 +126,11 @@ fn test_secrecy_08_errors() {
     verify_simple_error_in_wrapper::<Secret<i32>>(Secret::new(123));
 }
 
+#[test]
+fn test_option_errors() {
+    verify_simple_error_in_wrapper::<Option<i32>>(Some(123));
+}
+
 #[cfg(feature = "bigdecimal-04")]
 #[test]
 fn test_native_errors_bigdecimal_04() {

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -5,6 +5,7 @@ use crate::serialize::value::{
     SetOrListSerializationErrorKind, SetOrListTypeCheckErrorKind, TupleSerializationErrorKind,
     TupleTypeCheckErrorKind, UdtSerializationErrorKind, UdtTypeCheckErrorKind,
 };
+use crate::serialize::writers::WrittenCellProof;
 use crate::serialize::{CellWriter, SerializationError};
 use crate::value::{
     Counter, CqlDate, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlValue, CqlVarint,
@@ -20,7 +21,30 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
+use thiserror::Error;
 use uuid::Uuid;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct SerializeWithCustomError;
+
+#[derive(Error, Debug)]
+#[error("Custom serialization error")]
+struct CustomSerializationError;
+
+impl SerializeValue for SerializeWithCustomError {
+    fn serialize<'b>(
+        &self,
+        _typ: &ColumnType,
+        _writer: CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, SerializationError> {
+        Err(SerializationError::new(CustomSerializationError))
+    }
+}
+
+#[cfg(feature = "secrecy-08")]
+impl secrecy_08::Zeroize for SerializeWithCustomError {
+    fn zeroize(&mut self) {}
+}
 
 #[test]
 fn test_dyn_serialize_value() {
@@ -119,31 +143,51 @@ fn verify_simple_error_in_wrapper<T: SerializeValue>(v: T) {
     );
 }
 
+fn verify_custom_error_in_wrapper<T: SerializeValue>(v: T) {
+    let err = do_serialize_err::<T>(v, &ColumnType::Native(NativeType::BigInt));
+    err.0
+        .downcast_ref::<CustomSerializationError>()
+        .expect("CustomSerializationError");
+}
+
 #[cfg(feature = "secrecy-08")]
 #[test]
 fn test_secrecy_08_errors() {
     use secrecy_08::Secret;
     verify_simple_error_in_wrapper::<Secret<i32>>(Secret::new(123));
+    verify_custom_error_in_wrapper::<Secret<SerializeWithCustomError>>(Secret::new(
+        SerializeWithCustomError,
+    ));
 }
 
 #[test]
 fn test_option_errors() {
     verify_simple_error_in_wrapper::<Option<i32>>(Some(123));
+    verify_custom_error_in_wrapper::<Option<SerializeWithCustomError>>(Some(
+        SerializeWithCustomError,
+    ));
 }
 
 #[test]
 fn test_maybe_unset_errors() {
     verify_simple_error_in_wrapper::<MaybeUnset<i32>>(MaybeUnset::Set(123));
+    verify_custom_error_in_wrapper::<MaybeUnset<SerializeWithCustomError>>(MaybeUnset::Set(
+        SerializeWithCustomError,
+    ));
 }
 
 #[test]
 fn test_ref_errors() {
     verify_simple_error_in_wrapper::<&i32>(&123_i32);
+    verify_custom_error_in_wrapper::<&SerializeWithCustomError>(&SerializeWithCustomError);
 }
 
 #[test]
 fn test_box_errors() {
     verify_simple_error_in_wrapper::<Box<i32>>(Box::new(123));
+    verify_custom_error_in_wrapper::<Box<SerializeWithCustomError>>(Box::new(
+        SerializeWithCustomError,
+    ));
 }
 
 #[cfg(feature = "bigdecimal-04")]
@@ -217,6 +261,25 @@ fn test_set_or_list_errors() {
             expected: &[ColumnType::Native(NativeType::Int)],
         }
     );
+
+    // Test serialization with custom error
+    let err = do_serialize_err(
+        vec![SerializeWithCustomError],
+        &ColumnType::Collection {
+            frozen: false,
+            typ: CollectionType::Set(Box::new(ColumnType::Native(NativeType::Double))),
+        },
+    );
+    let err = get_ser_err(&err);
+    let BuiltinSerializationErrorKind::SetOrListError(
+        SetOrListSerializationErrorKind::ElementSerializationFailed(err),
+    ) = &err.kind
+    else {
+        panic!("unexpected error kind: {}", err.kind)
+    };
+    err.0
+        .downcast_ref::<CustomSerializationError>()
+        .expect("CustomSerializationError");
 }
 
 #[test]
@@ -288,6 +351,51 @@ fn test_map_errors() {
             expected: &[ColumnType::Native(NativeType::Int)],
         }
     );
+
+    // Test serialization with custom error
+    // Value
+    let err = do_serialize_err(
+        BTreeMap::from([(123_i32, SerializeWithCustomError)]),
+        &ColumnType::Collection {
+            frozen: false,
+            typ: CollectionType::Map(
+                Box::new(ColumnType::Native(NativeType::Int)),
+                Box::new(ColumnType::Native(NativeType::Int)),
+            ),
+        },
+    );
+    let err = get_ser_err(&err);
+    let BuiltinSerializationErrorKind::MapError(
+        MapSerializationErrorKind::ValueSerializationFailed(err),
+    ) = &err.kind
+    else {
+        panic!("unexpected error kind: {}", err.kind)
+    };
+    err.0
+        .downcast_ref::<CustomSerializationError>()
+        .expect("CustomSerializationError");
+
+    // Key
+    let err = do_serialize_err(
+        BTreeMap::from([(SerializeWithCustomError, 123_i32)]),
+        &ColumnType::Collection {
+            frozen: false,
+            typ: CollectionType::Map(
+                Box::new(ColumnType::Native(NativeType::Int)),
+                Box::new(ColumnType::Native(NativeType::Int)),
+            ),
+        },
+    );
+    let err = get_ser_err(&err);
+    let BuiltinSerializationErrorKind::MapError(MapSerializationErrorKind::KeySerializationFailed(
+        err,
+    )) = &err.kind
+    else {
+        panic!("unexpected error kind: {}", err.kind)
+    };
+    err.0
+        .downcast_ref::<CustomSerializationError>()
+        .expect("CustomSerializationError");
 }
 
 #[test]
@@ -342,6 +450,25 @@ fn test_tuple_errors() {
             expected: &[ColumnType::Native(NativeType::Double)],
         }
     );
+
+    // Test serialization with custom error
+    let err = do_serialize_err(
+        (SerializeWithCustomError, SerializeWithCustomError),
+        &ColumnType::Tuple(vec![
+            ColumnType::Native(NativeType::Double),
+            ColumnType::Native(NativeType::Double),
+        ]),
+    );
+    let err = get_ser_err(&err);
+    let BuiltinSerializationErrorKind::TupleError(
+        TupleSerializationErrorKind::ElementSerializationFailed { index: 0, err },
+    ) = &err.kind
+    else {
+        panic!("unexpected error kind: {}", err.kind)
+    };
+    err.0
+        .downcast_ref::<CustomSerializationError>()
+        .expect("CustomSerializationError");
 }
 
 #[test]

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -106,6 +106,26 @@ fn test_native_errors() {
     // a value which is at least 2GB in size.
 }
 
+fn verify_simple_error_in_wrapper<T: SerializeValue>(v: T) {
+    let err = do_serialize_err::<T>(v, &ColumnType::Native(NativeType::Text));
+    let err = get_typeck_err(&err);
+    assert_eq!(err.rust_name, std::any::type_name::<T>());
+    assert_eq!(err.got, ColumnType::Native(NativeType::Text));
+    assert_matches!(
+        err.kind,
+        BuiltinTypeCheckErrorKind::MismatchedType {
+            expected: &[ColumnType::Native(NativeType::Int)]
+        }
+    );
+}
+
+#[cfg(feature = "secrecy-08")]
+#[test]
+fn test_secrecy_08_errors() {
+    use secrecy_08::Secret;
+    verify_simple_error_in_wrapper::<Secret<i32>>(Secret::new(123));
+}
+
 #[cfg(feature = "bigdecimal-04")]
 #[test]
 fn test_native_errors_bigdecimal_04() {

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -141,6 +141,11 @@ fn test_ref_errors() {
     verify_simple_error_in_wrapper::<&i32>(&123_i32);
 }
 
+#[test]
+fn test_box_errors() {
+    verify_simple_error_in_wrapper::<Box<i32>>(Box::new(123));
+}
+
 #[cfg(feature = "bigdecimal-04")]
 #[test]
 fn test_native_errors_bigdecimal_04() {


### PR DESCRIPTION
Until now "rust_name" updating in serialization only happened for `CqlValue`. It means that if someone tried, for example, to serialize `Secrecy<String>`, or `Option<String>`, against `Int` CQL type, the error message would just mention `String` type instead of `Secrecy<String>`, or `Option<String>`.

This PR fixes that for all cases that I could find, and introduces tests for those cases.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
