### PR TITLE
statements: expose API to unset (serial) consistency

### DIFF
--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -18,21 +18,21 @@ use crate::statement::Statement;
 pub(super) struct ControlConnection {
     conn: Arc<Connection>,
     /// The custom server-side timeout set for requests executed on the control connection.
-    overriden_serverside_timeout: Option<Duration>,
+    overridden_serverside_timeout: Option<Duration>,
 }
 
 impl ControlConnection {
     pub(super) fn new(conn: Arc<Connection>) -> Self {
         Self {
             conn,
-            overriden_serverside_timeout: None,
+            overridden_serverside_timeout: None,
         }
     }
 
     /// Sets the custom server-side timeout set for requests executed on the control connection.
-    pub(super) fn override_serverside_timeout(self, overriden_timeout: Option<Duration>) -> Self {
+    pub(super) fn override_serverside_timeout(self, overridden_timeout: Option<Duration>) -> Self {
         Self {
-            overriden_serverside_timeout: overriden_timeout,
+            overridden_serverside_timeout: overridden_timeout,
             ..self
         }
     }
@@ -49,7 +49,7 @@ impl ControlConnection {
     /// Appends the custom server-side timeout to the statement string, if such custom timeout
     /// is provided and we are connected to ScyllaDB (since custom timeouts is ScyllaDB-only feature).
     fn maybe_append_timeout_override(&self, statement: &mut Statement) {
-        if let Some(timeout) = self.overriden_serverside_timeout {
+        if let Some(timeout) = self.overridden_serverside_timeout {
             if self.is_to_scylladb() {
                 // SAFETY: io::fmt::Write impl for String is infallible.
                 write!(

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -67,6 +67,13 @@ impl Batch {
         self.config.consistency = Some(c);
     }
 
+    /// Unsets the consistency overridden on this batch.
+    /// This means that consistency will be derived from the execution profile
+    /// (per-batch or, if absent, the default one).
+    pub fn unset_consistency(&mut self) {
+        self.config.consistency = None;
+    }
+
     /// Gets the consistency to be used when executing this batch if it is filled.
     /// If this is empty, the default_consistency of the session will be used.
     pub fn get_consistency(&self) -> Option<Consistency> {
@@ -77,6 +84,13 @@ impl Batch {
     /// (Ignored unless the batch is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
         self.config.serial_consistency = Some(sc);
+    }
+
+    /// Unsets the serial consistency overridden on this batch.
+    /// This means that serial consistency will be derived from the execution profile
+    /// (per-batch or, if absent, the default one).
+    pub fn unset_serial_consistency(&mut self) {
+        self.config.serial_consistency = None;
     }
 
     /// Gets the serial consistency to be used when executing this batch.

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -145,7 +145,7 @@ impl Batch {
 
     /// Get the retry policy set for the batch.
     ///
-    /// This method returns the retry policy that is **overriden** on this statement.
+    /// This method returns the retry policy that is **overridden** on this statement.
     /// In other words, it returns the retry policy set using [`Batch::set_retry_policy`].
     /// This does not take the retry policy from the set execution profile into account.
     #[inline]
@@ -164,7 +164,7 @@ impl Batch {
 
     /// Get the load balancing policy set for the batch.
     ///
-    /// This method returns the load balancing policy that is **overriden** on this statement.
+    /// This method returns the load balancing policy that is **overridden** on this statement.
     /// In other words, it returns the load balancing policy set using [`Batch::set_load_balancing_policy`].
     /// This does not take the load balancing policy from the set execution profile into account.
     #[inline]

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -298,6 +298,13 @@ impl PreparedStatement {
         self.config.consistency = Some(c);
     }
 
+    /// Unsets the consistency overridden on this statement.
+    /// This means that consistency will be derived from the execution profile
+    /// (per-statement or, if absent, the default one).
+    pub fn unset_consistency(&mut self) {
+        self.config.consistency = None;
+    }
+
     /// Gets the consistency to be used when executing this prepared statement if it is filled.
     /// If this is empty, the default_consistency of the session will be used.
     pub fn get_consistency(&self) -> Option<Consistency> {
@@ -308,6 +315,13 @@ impl PreparedStatement {
     /// (Ignored unless the statement is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
         self.config.serial_consistency = Some(sc);
+    }
+
+    /// Unsets the serial consistency overridden on this statement.
+    /// This means that serial consistency will be derived from the execution profile
+    /// (per-statement or, if absent, the default one).
+    pub fn unset_serial_consistency(&mut self) {
+        self.config.serial_consistency = None;
     }
 
     /// Gets the serial consistency to be used when executing this statement.

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -446,7 +446,7 @@ impl PreparedStatement {
 
     /// Get the retry policy set for the statement.
     ///
-    /// This method returns the retry policy that is **overriden** on this statement.
+    /// This method returns the retry policy that is **overridden** on this statement.
     /// In other words, it returns the retry policy set using [`PreparedStatement::set_retry_policy`].
     /// This does not take the retry policy from the set execution profile into account.
     #[inline]
@@ -465,7 +465,7 @@ impl PreparedStatement {
 
     /// Get the load balancing policy set for the statement.
     ///
-    /// This method returns the load balancing policy that is **overriden** on this statement.
+    /// This method returns the load balancing policy that is **overridden** on this statement.
     /// In other words, it returns the load balancing policy set using [`PreparedStatement::set_load_balancing_policy`].
     /// This does not take the load balancing policy from the set execution profile into account.
     #[inline]

--- a/scylla/src/statement/unprepared.rs
+++ b/scylla/src/statement/unprepared.rs
@@ -152,7 +152,7 @@ impl Statement {
 
     /// Get the retry policy set for the statement.
     ///
-    /// This method returns the retry policy that is **overriden** on this statement.
+    /// This method returns the retry policy that is **overridden** on this statement.
     /// In other words, it returns the retry policy set using [`Statement::set_retry_policy`].
     /// This does not take the retry policy from the set execution profile into account.
     #[inline]
@@ -171,7 +171,7 @@ impl Statement {
 
     /// Get the load balancing policy set for the statement.
     ///
-    /// This method returns the load balancing policy that is **overriden** on this statement.
+    /// This method returns the load balancing policy that is **overridden** on this statement.
     /// In other words, it returns the load balancing policy set using [`Statement::set_load_balancing_policy`].
     /// This does not take the load balancing policy from the set execution profile into account.
     #[inline]

--- a/scylla/src/statement/unprepared.rs
+++ b/scylla/src/statement/unprepared.rs
@@ -60,6 +60,13 @@ impl Statement {
         self.config.consistency = Some(c);
     }
 
+    /// Unsets the consistency overridden on this statement.
+    /// This means that consistency will be derived from the execution profile
+    /// (per-statement or, if absent, the default one).
+    pub fn unset_consistency(&mut self) {
+        self.config.consistency = None;
+    }
+
     /// Gets the consistency to be used when executing this statement if it is filled.
     /// If this is empty, the default_consistency of the session will be used.
     pub fn get_consistency(&self) -> Option<Consistency> {
@@ -70,6 +77,13 @@ impl Statement {
     /// (Ignored unless the statement is an LWT)
     pub fn set_serial_consistency(&mut self, sc: Option<SerialConsistency>) {
         self.config.serial_consistency = Some(sc);
+    }
+
+    /// Unsets the serial consistency overridden on this statement.
+    /// This means that serial consistency will be derived from the execution profile
+    /// (per-statement or, if absent, the default one).
+    pub fn unset_serial_consistency(&mut self) {
+        self.config.serial_consistency = None;
     }
 
     /// Gets the serial consistency to be used when executing this statement.


### PR DESCRIPTION
This is required by the CPP Rust Driver, and also useful for Rust Driver direct users. See #1384 for details.

Bonus: fixed codewide typo "overriden" -> "overridden".

Fixes: #1384

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
