### PR TITLE
crates: allow `clippy::uninlined_format_args`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,6 +4,9 @@ name = "examples"
 publish = false
 version = "0.0.0"
 
+[lints.clippy]
+uninlined_format_args = "allow"
+
 [dev-dependencies]
 anyhow = "1.0.33"
 futures = "0.3.6"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT OR Apache-2.0"
 [package.metadata."docs.rs"]
 all-features = true
 
+[lints.clippy]
+uninlined_format_args = "allow"
+
 [dependencies]
 # Important: We use precise version of scylla-macros. This enables
 # us to make breaking changes in the doc(hidden) interfaces that are

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -15,6 +15,9 @@ proc-macro = true
 [package.metadata."docs.rs"]
 all-features = true
 
+[lints.clippy]
+uninlined_format_args = "allow"
+
 [dependencies]
 darling = "0.20.10"
 syn = "2.0"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT OR Apache-2.0"
 [package.metadata."docs.rs"]
 all-features = true
 
+[lints.clippy]
+uninlined_format_args = "allow"
+
 [features]
 defaults = []
 

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -14,6 +14,9 @@ license = "MIT OR Apache-2.0"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints.clippy]
+uninlined_format_args = "allow"
+
 [features]
 default = []
 openssl-010 = ["dep:tokio-openssl", "dep:openssl"]


### PR DESCRIPTION
Clippy has started to complain about format strings that are not inlined. In order to satisfy clippy's demands, we would have to introduce a lot of changes. At the same time, I don't see any value in avoiding use of format strings that are not inlined.

Thus, to calm clippy down, we allow this lint in all crates.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
