### PR TITLE
Fix clippy::uninlined_format_args

### DIFF
--- a/examples/allocations.rs
+++ b/examples/allocations.rs
@@ -126,7 +126,7 @@ async fn measure(
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    println!("{:?}", args);
+    println!("{args:?}");
 
     println!("Connecting to {} ...", args.node);
 

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -5,7 +5,7 @@ use scylla::client::session_builder::SessionBuilder;
 async fn main() -> Result<()> {
     let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} with cassandra superuser ...", uri);
+    println!("Connecting to {uri} with cassandra superuser ...");
 
     let session = SessionBuilder::new()
         .known_node(uri)

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,7 +11,7 @@ use std::env;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(i32, i32, String)>()?;
     while let Some((a, b, c)) = iter.try_next().await? {
-        println!("a, b, c: {}, {}, {}", a, b, c);
+        println!("a, b, c: {a}, {b}, {c}");
     }
 
     // Or as custom structs that derive DeserializeRow
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<RowData>()?;
     while let Some(row_data) = iter.try_next().await? {
-        println!("row_data: {:?}", row_data);
+        println!("row_data: {row_data:?}");
     }
 
     // Or simply as untyped rows
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
         let a = row.columns[0].as_ref().unwrap().as_int().unwrap();
         let b = row.columns[1].as_ref().unwrap().as_int().unwrap();
         let c = row.columns[2].as_ref().unwrap().as_text().unwrap();
-        println!("a, b, c: {}, {}, {}", a, b, c);
+        println!("a, b, c: {a}, {b}, {c}");
     }
 
     let metrics = session.get_metrics();

--- a/examples/compare-tokens.rs
+++ b/examples/compare-tokens.rs
@@ -9,7 +9,7 @@ use std::env;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
             .into_rows_result()?
             .single_row::<(i64,)>()?;
         assert_eq!(t, qt);
-        println!("token for {}: {}", pk, t);
+        println!("token for {pk}: {t}");
     }
 
     println!("Ok.");

--- a/examples/cql-time-types.rs
+++ b/examples/cql-time-types.rs
@@ -14,7 +14,7 @@ use std::env;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
             Err(_) => continue, // We might read a date that does not fit in NaiveDate, skip it
         };
 
-        println!("Parsed a date into chrono::NaiveDate: {:?}", read_date);
+        println!("Parsed a date into chrono::NaiveDate: {read_date:?}");
     }
 
     // Alternatively, you can enable 'time' feature and use `time::Date` to represent date. `time::Date` only allows
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
             Err(_) => continue, // We might read a date that does not fit in time::Date, skip it
         };
 
-        println!("Parsed a date into time::Date: {:?}", read_date);
+        println!("Parsed a date into time::Date: {read_date:?}");
     }
 
     // Dates outside this range must be represented in the raw form - an u32 describing days since -5877641-06-23
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
             _ => panic!("oh no"),
         };
 
-        println!("Read a date as raw days: {}", read_days);
+        println!("Read a date as raw days: {read_days}");
     }
 
     // Time
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(NaiveTime,)>()?;
     while let Some((read_time,)) = iter.try_next().await? {
-        println!("Parsed a time into chrono::NaiveTime: {:?}", read_time);
+        println!("Parsed a time into chrono::NaiveTime: {read_time:?}");
     }
 
     // time::Time
@@ -141,7 +141,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(time::Time,)>()?;
     while let Some((read_time,)) = iter.try_next().await? {
-        println!("Parsed a time into time::Time: {:?}", read_time);
+        println!("Parsed a time into time::Time: {read_time:?}");
     }
 
     // CqlTime
@@ -156,7 +156,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(CqlTime,)>()?;
     while let Some((read_time,)) = iter.try_next().await? {
-        println!("Read a time as raw nanos: {:?}", read_time);
+        println!("Read a time as raw nanos: {read_time:?}");
     }
 
     // Timestamp
@@ -187,10 +187,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(DateTime<Utc>,)>()?;
     while let Some((read_time,)) = iter.try_next().await? {
-        println!(
-            "Parsed a timestamp into chrono::DateTime<chrono::Utc>: {:?}",
-            read_time
-        );
+        println!("Parsed a timestamp into chrono::DateTime<chrono::Utc>: {read_time:?}");
     }
 
     // time::OffsetDateTime
@@ -208,10 +205,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(time::OffsetDateTime,)>()?;
     while let Some((read_time,)) = iter.try_next().await? {
-        println!(
-            "Parsed a timestamp into time::OffsetDateTime: {:?}",
-            read_time
-        );
+        println!("Parsed a timestamp into time::OffsetDateTime: {read_time:?}");
     }
 
     // CqlTimestamp
@@ -229,7 +223,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(CqlTimestamp,)>()?;
     while let Some((read_time,)) = iter.try_next().await? {
-        println!("Read a timestamp as raw millis: {:?}", read_time);
+        println!("Read a timestamp as raw millis: {read_time:?}");
     }
 
     Ok(())

--- a/examples/cqlsh-rs.rs
+++ b/examples/cqlsh-rs.rs
@@ -164,7 +164,7 @@ impl Completer for CqlHelper {
                     if keyword.starts_with(prefix) {
                         matches.push(Pair {
                             display: keyword.to_string(),
-                            replacement: format!("{} ", keyword),
+                            replacement: format!("{keyword} "),
                         })
                     }
                 }
@@ -189,7 +189,7 @@ fn print_result(result: QueryResult) -> Result<(), IntoRowsResultError> {
                         " {:16}",
                         match column {
                             None => "null".to_owned(),
-                            Some(value) => format!("{:?}", value),
+                            Some(value) => format!("{value:?}"),
                         }
                     );
                 }
@@ -209,7 +209,7 @@ fn print_result(result: QueryResult) -> Result<(), IntoRowsResultError> {
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new()
         .known_node(uri)
@@ -233,13 +233,13 @@ async fn main() -> Result<()> {
                 rl.add_history_entry(line.as_str())?;
                 let maybe_res = session.query_unpaged(line, &[]).await;
                 match maybe_res {
-                    Err(err) => println!("Error: {}", err),
+                    Err(err) => println!("Error: {err}"),
                     Ok(res) => print_result(res)?,
                 }
             }
             Err(ReadlineError::Interrupted) => continue,
             Err(ReadlineError::Eof) => break,
-            Err(err) => println!("Error: {}", err),
+            Err(err) => println!("Error: {err}"),
         }
     }
     Ok(())

--- a/examples/custom_deserialization.rs
+++ b/examples/custom_deserialization.rs
@@ -9,7 +9,7 @@ use std::env;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 

--- a/examples/enforce_coordinator.rs
+++ b/examples/enforce_coordinator.rs
@@ -30,10 +30,7 @@ async fn query_system_local_and_verify(
 
     // "Actual" host_id and node_ip are the ones returned by the query, i.e. the ones stored in system.local.
     let (actual_host_id, actual_node_ip) = result.single_row::<(uuid::Uuid, IpAddr)>().unwrap();
-    println!(
-        "queried host_id: {}; queried node_ip: {}",
-        actual_host_id, actual_node_ip
-    );
+    println!("queried host_id: {actual_host_id}; queried node_ip: {actual_node_ip}");
 
     assert_eq!(enforced_node.host_id, actual_host_id);
     assert_eq!(enforced_node.address.ip(), actual_node_ip);
@@ -67,7 +64,7 @@ async fn main() -> Result<()> {
     // Enforce the node using `Arc<Node>`.
     {
         let node_identifier = NodeIdentifier::Node(Arc::clone(node));
-        println!("Enforcing target using {:?}...", node_identifier);
+        println!("Enforcing target using {node_identifier:?}...");
         query_local.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
             node_identifier,
             None,
@@ -79,7 +76,7 @@ async fn main() -> Result<()> {
     // Enforce the node using host_id.
     {
         let node_identifier = NodeIdentifier::HostId(expected_host_id);
-        println!("Enforcing target using {:?}...", node_identifier);
+        println!("Enforcing target using {node_identifier:?}...");
         query_local.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
             node_identifier,
             None,
@@ -92,7 +89,7 @@ async fn main() -> Result<()> {
     {
         let node_identifier =
             NodeIdentifier::NodeAddress(SocketAddr::new(expected_node_ip, node.address.port()));
-        println!("Enforcing target using {:?}...", node_identifier);
+        println!("Enforcing target using {node_identifier:?}...");
         query_local.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
             node_identifier,
             None,

--- a/examples/execution_profile.rs
+++ b/examples/execution_profile.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let profile1 = ExecutionProfile::builder()
         .consistency(Consistency::LocalQuorum)

--- a/examples/get_by_name.rs
+++ b/examples/get_by_name.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 

--- a/examples/parallel-prepared.rs
+++ b/examples/parallel-prepared.rs
@@ -10,7 +10,7 @@ use tokio::sync::Semaphore;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
     let session = Arc::new(session);
@@ -29,14 +29,14 @@ async fn main() -> Result<()> {
             .prepare("INSERT INTO examples_ks.parallel_prepared (a, b, c) VALUES (?, ?, 'abc')")
             .await?,
     );
-    println!("Prepared statement: {:#?}", prepared);
+    println!("Prepared statement: {prepared:#?}");
 
     let parallelism = 256;
     let sem = Arc::new(Semaphore::new(parallelism));
 
     for i in 0..100_000usize {
         if i % 1000 == 0 {
-            println!("{}", i);
+            println!("{i}");
         }
         let session = session.clone();
         let prepared = prepared.clone();

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -10,7 +10,7 @@ use tokio::sync::Semaphore;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
     let session = Arc::new(session);
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     for i in 0..100_000usize {
         if i % 1000 == 0 {
-            println!("{}", i);
+            println!("{i}");
         }
         let session = session.clone();
         let permit = sem.clone().acquire_owned().await;

--- a/examples/query_history.rs
+++ b/examples/query_history.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
@@ -37,13 +37,13 @@ async fn main() -> Result<()> {
 
     // Access the collected history and print it
     let structured_history: StructuredHistory = history_listener.clone_structured_history();
-    println!("Query history: {}", structured_history);
+    println!("Query history: {structured_history}");
 
     // A single history collector can contain histories of multiple queries.
     // To clear a collector create a new one and set it again.
     let _second_execution = session.query_unpaged(query, ()).await;
     let structured_history: StructuredHistory = history_listener.clone_structured_history();
-    println!("Two queries history: {}", structured_history);
+    println!("Two queries history: {structured_history}");
 
     // The same works for other types of queries, e.g iterators
     for i in 0..32 {

--- a/examples/schema_agreement.rs
+++ b/examples/schema_agreement.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
     // Create connection
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new()
         .known_node(uri)
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
 
     let schema_version = session.await_schema_agreement().await?;
 
-    println!("Schema version: {}", schema_version);
+    println!("Schema version: {schema_version}");
 
     session.query_unpaged("CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}", &[]).await?;
 
@@ -74,13 +74,13 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(i32, i32, String)>()?;
     while let Some((a, b, c)) = iter.try_next().await? {
-        println!("a, b, c: {}, {}, {}", a, b, c);
+        println!("a, b, c: {a}, {b}, {c}");
     }
 
     println!("Ok.");
 
     let schema_version = session.await_schema_agreement().await?;
-    println!("Schema version: {}", schema_version);
+    println!("Schema version: {schema_version}");
 
     Ok(())
 }

--- a/examples/select-paging.rs
+++ b/examples/select-paging.rs
@@ -11,7 +11,7 @@ use std::ops::ControlFlow;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
 
     while let Some(next_row_res) = rows_stream.next().await {
         let (a, b, c) = next_row_res?;
-        println!("a, b, c: {}, {}, {}", a, b, c);
+        println!("a, b, c: {a}, {b}, {c}");
     }
 
     let paged_query =

--- a/examples/speculative-execution.rs
+++ b/examples/speculative-execution.rs
@@ -9,7 +9,7 @@ use std::{env, sync::Arc};
 #[tokio::main]
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let speculative = PercentileSpeculativeExecutionPolicy {
         max_retry_count: 2,

--- a/examples/tls-openssl.rs
+++ b/examples/tls-openssl.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     // Create connection
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9142".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
     let ca_dir = fs::canonicalize(PathBuf::from("./test/tls/ca.crt"))?;
@@ -93,7 +93,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(i32, i32, String)>()?;
     while let Some((a, b, c)) = iter.try_next().await? {
-        println!("a, b, c: {}, {}, {}", a, b, c);
+        println!("a, b, c: {a}, {b}, {c}");
     }
 
     println!("Ok.");

--- a/examples/tls-rustls.rs
+++ b/examples/tls-rustls.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     // Create connection
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9142".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let rustls_ca = CertificateDer::from_pem_file("./test/tls/ca.crt")?;
     let mut root_store = rustls::RootCertStore::empty();
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(i32, i32, String)>()?;
     while let Some((a, b, c)) = iter.try_next().await? {
-        println!("a, b, c: {}, {}, {}", a, b, c);
+        println!("a, b, c: {a}, {b}, {c}");
     }
 
     println!("Ok.");

--- a/examples/tower.rs
+++ b/examples/tower.rs
@@ -33,7 +33,7 @@ impl Service<scylla::statement::unprepared::Statement> for SessionService {
 async fn main() -> anyhow::Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
     let mut session: SessionService = SessionService {
         session: Arc::new(SessionBuilder::new().known_node(uri).build().await?),
     };

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
     let session: Session = SessionBuilder::new()
         .known_node(uri.as_str())
         .build()
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
 
     // prepared.prepare_tracing_id contains tracing ids of all prepare requests
     let prepare_ids: &Vec<Uuid> = &prepared.prepare_tracing_ids;
-    println!("Prepare tracing ids: {:?}\n", prepare_ids);
+    println!("Prepare tracing ids: {prepare_ids:?}\n");
 
     // EXECUTE
     // To trace execution of a prepared statement tracing must be enabled for it

--- a/examples/user-defined-type.rs
+++ b/examples/user-defined-type.rs
@@ -9,7 +9,7 @@ use std::env;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await?;
 
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
         .await?
         .rows_stream::<(MyType,)>()?;
     while let Some((my_val,)) = iter.try_next().await? {
-        println!("{:?}", my_val);
+        println!("{my_val:?}");
     }
 
     println!("Ok.");

--- a/examples/value_list.rs
+++ b/examples/value_list.rs
@@ -8,7 +8,7 @@ use std::env;
 async fn main() -> Result<()> {
     let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
 
-    println!("Connecting to {} ...", uri);
+    println!("Connecting to {uri} ...");
 
     let session: Session = SessionBuilder::new().known_node(uri).build().await.unwrap();
 
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
         .rows_stream::<(i32, String)>()?;
 
     let rows = iter.collect::<Vec<_>>().await;
-    println!("Q: {:?}", rows);
+    println!("Q: {rows:?}");
 
     Ok(())
 }

--- a/scylla-cql/src/deserialize/row.rs
+++ b/scylla-cql/src/deserialize/row.rs
@@ -367,16 +367,13 @@ impl Display for BuiltinTypeCheckErrorKind {
             BuiltinTypeCheckErrorKind::ColumnWithUnknownName { column_name, column_index } => {
                 write!(
                     f,
-                    "the CQL row contains a column {} at column index {}, but the corresponding field is not found in the Rust type",
-                    column_name,
-                    column_index,
+                    "the CQL row contains a column {column_name} at column index {column_index}, but the corresponding field is not found in the Rust type",
                 )
             }
             BuiltinTypeCheckErrorKind::ValuesMissingForColumns { column_names } => {
                 write!(
                     f,
-                    "values for columns {:?} are missing from the DB data but are required by the Rust type",
-                    column_names
+                    "values for columns {column_names:?} are missing from the DB data but are required by the Rust type"
                 )
             },
             BuiltinTypeCheckErrorKind::ColumnNameMismatch {
@@ -385,11 +382,7 @@ impl Display for BuiltinTypeCheckErrorKind {
                 db_column_name
             } => write!(
                 f,
-                "expected column with name {} at column index {}, but the Rust field name at corresponding field index {} is {}",
-                db_column_name,
-                column_index,
-                field_index,
-                rust_column_name,
+                "expected column with name {db_column_name} at column index {column_index}, but the Rust field name at corresponding field index {field_index} is {rust_column_name}",
             ),
             BuiltinTypeCheckErrorKind::ColumnTypeCheckFailed {
                 column_index,
@@ -401,9 +394,7 @@ impl Display for BuiltinTypeCheckErrorKind {
             ),
             BuiltinTypeCheckErrorKind::DuplicatedColumn { column_name, column_index } => write!(
                 f,
-                "column {} occurs more than once in DB metadata; second occurrence is at column index {}",
-                column_name,
-                column_index,
+                "column {column_name} occurs more than once in DB metadata; second occurrence is at column index {column_index}",
             ),
         }
     }

--- a/scylla-cql/src/deserialize/row_tests.rs
+++ b/scylla-cql/src/deserialize/row_tests.rs
@@ -296,7 +296,7 @@ pub(crate) fn get_typck_err_inner<'a>(
 ) -> &'a BuiltinTypeCheckError {
     match err.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinTypeCheckError: {:?}", err),
+        None => panic!("not a BuiltinTypeCheckError: {err:?}"),
     }
 }
 
@@ -309,7 +309,7 @@ fn get_typck_err(err: &DeserializationError) -> &BuiltinTypeCheckError {
 fn get_deser_err(err: &DeserializationError) -> &BuiltinDeserializationError {
     match err.0.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinDeserializationError: {:?}", err),
+        None => panic!("not a BuiltinDeserializationError: {err:?}"),
     }
 }
 

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1878,7 +1878,7 @@ impl Display for SetOrListTypeCheckErrorKind {
                 f.write_str("the CQL type the Rust type was attempted to be type checked against was not a set")
             }
             SetOrListTypeCheckErrorKind::ElementTypeCheckFailed(err) => {
-                write!(f, "the set or list element types between the CQL type and the Rust type failed to type check against each other: {}", err)
+                write!(f, "the set or list element types between the CQL type and the Rust type failed to type check against each other: {err}")
             }
         }
     }
@@ -1917,10 +1917,10 @@ impl Display for MapTypeCheckErrorKind {
                 f.write_str("the CQL type the Rust type was attempted to be type checked against was neither a map")
             }
             MapTypeCheckErrorKind::KeyTypeCheckFailed(err) => {
-                write!(f, "the map key types between the CQL type and the Rust type failed to type check against each other: {}", err)
+                write!(f, "the map key types between the CQL type and the Rust type failed to type check against each other: {err}")
             },
             MapTypeCheckErrorKind::ValueTypeCheckFailed(err) => {
-                write!(f, "the map value types between the CQL type and the Rust type failed to type check against each other: {}", err)
+                write!(f, "the map value types between the CQL type and the Rust type failed to type check against each other: {err}")
             },
         }
     }
@@ -1969,9 +1969,7 @@ impl Display for TupleTypeCheckErrorKind {
 
             TupleTypeCheckErrorKind::FieldTypeCheckFailed { position, err } => write!(
                 f,
-                "the CQL type and the Rust type of the tuple field {} failed to type check against each other: {}",
-                position,
-                err
+                "the CQL type and the Rust type of the tuple field {position} failed to type check against each other: {err}"
             )
         }
     }
@@ -2047,25 +2045,19 @@ impl Display for UdtTypeCheckErrorKind {
             ),
             UdtTypeCheckErrorKind::ExcessFieldInUdt { db_field_name } => write!(
                 f,
-                "UDT contains an excess field {}, which does not correspond to any Rust struct's field.",
-                db_field_name
+                "UDT contains an excess field {db_field_name}, which does not correspond to any Rust struct's field."
             ),
             UdtTypeCheckErrorKind::DuplicatedField { field_name } => write!(
                 f,
-                "field {} occurs more than once in CQL UDT type",
-                field_name
+                "field {field_name} occurs more than once in CQL UDT type"
             ),
             UdtTypeCheckErrorKind::TooFewFields { required_fields, present_fields } => write!(
                 f,
-                "fewer fields present in the UDT than required by the Rust type: UDT has {:?}, Rust type requires {:?}",
-                present_fields,
-                required_fields,
+                "fewer fields present in the UDT than required by the Rust type: UDT has {present_fields:?}, Rust type requires {required_fields:?}",
             ),
             UdtTypeCheckErrorKind::FieldTypeCheckFailed { field_name, err } => write!(
                 f,
-                "the UDT field {} types between the CQL type and the Rust type failed to type check against each other: {}",
-                field_name,
-                err
+                "the UDT field {field_name} types between the CQL type and the Rust type failed to type check against each other: {err}"
             ),
         }
     }
@@ -2163,16 +2155,15 @@ pub enum BuiltinDeserializationErrorKind {
 impl Display for BuiltinDeserializationErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BuiltinDeserializationErrorKind::BadDate { date_field, err } => write!(f, "malformed {} during 'date' deserialization: {}", date_field, err),
-            BuiltinDeserializationErrorKind::BadDecimalScale(err) => write!(f, "malformed decimal's scale: {}", err),
-            BuiltinDeserializationErrorKind::RawCqlBytesReadError(err) => write!(f, "failed to read raw cql value bytes: {}", err),
+            BuiltinDeserializationErrorKind::BadDate { date_field, err } => write!(f, "malformed {date_field} during 'date' deserialization: {err}"),
+            BuiltinDeserializationErrorKind::BadDecimalScale(err) => write!(f, "malformed decimal's scale: {err}"),
+            BuiltinDeserializationErrorKind::RawCqlBytesReadError(err) => write!(f, "failed to read raw cql value bytes: {err}"),
             BuiltinDeserializationErrorKind::ExpectedNonNull => {
                 f.write_str("expected a non-null value, got null")
             }
             BuiltinDeserializationErrorKind::ByteLengthMismatch { expected, got } => write!(
                 f,
-                "the CQL type requires {} bytes, but got {}",
-                expected, got,
+                "the CQL type requires {expected} bytes, but got {got}",
             ),
             BuiltinDeserializationErrorKind::ExpectedAscii => {
                 f.write_str("expected a valid ASCII string")
@@ -2214,10 +2205,10 @@ impl Display for SetOrListDeserializationErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SetOrListDeserializationErrorKind::LengthDeserializationFailed(err) => {
-                write!(f, "failed to deserialize set or list's length: {}", err)
+                write!(f, "failed to deserialize set or list's length: {err}")
             }
             SetOrListDeserializationErrorKind::ElementDeserializationFailed(err) => {
-                write!(f, "failed to deserialize one of the elements: {}", err)
+                write!(f, "failed to deserialize one of the elements: {err}")
             }
         }
     }
@@ -2267,13 +2258,13 @@ impl Display for MapDeserializationErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MapDeserializationErrorKind::LengthDeserializationFailed(err) => {
-                write!(f, "failed to deserialize map's length: {}", err)
+                write!(f, "failed to deserialize map's length: {err}")
             }
             MapDeserializationErrorKind::KeyDeserializationFailed(err) => {
-                write!(f, "failed to deserialize one of the keys: {}", err)
+                write!(f, "failed to deserialize one of the keys: {err}")
             }
             MapDeserializationErrorKind::ValueDeserializationFailed(err) => {
-                write!(f, "failed to deserialize one of the values: {}", err)
+                write!(f, "failed to deserialize one of the values: {err}")
             }
         }
     }

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -1753,7 +1753,7 @@ pub(crate) fn get_typeck_err_inner<'a>(
 ) -> &'a BuiltinTypeCheckError {
     match err.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinTypeCheckError: {:?}", err),
+        None => panic!("not a BuiltinTypeCheckError: {err:?}"),
     }
 }
 
@@ -1766,7 +1766,7 @@ pub(crate) fn get_typeck_err(err: &DeserializationError) -> &BuiltinTypeCheckErr
 pub(crate) fn get_deser_err(err: &DeserializationError) -> &BuiltinDeserializationError {
     match err.0.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinDeserializationError: {:?}", err),
+        None => panic!("not a BuiltinDeserializationError: {err:?}"),
     }
 }
 

--- a/scylla-cql/src/frame/protocol_features.rs
+++ b/scylla-cql/src/frame/protocol_features.rs
@@ -59,7 +59,7 @@ impl ProtocolFeatures {
         if let Some(mask) = self.lwt_optimization_meta_bit_mask {
             options.insert(
                 Cow::Borrowed(SCYLLA_LWT_ADD_METADATA_MARK_EXTENSION),
-                Cow::Owned(format!("{}={}", LWT_OPTIMIZATION_META_BIT_MASK_KEY, mask)),
+                Cow::Owned(format!("{LWT_OPTIMIZATION_META_BIT_MASK_KEY}={mask}")),
             );
         }
 

--- a/scylla-cql/src/frame/response/error.rs
+++ b/scylla-cql/src/frame/response/error.rs
@@ -464,7 +464,7 @@ pub enum WriteType {
 
 impl std::fmt::Display for WriteType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/scylla-cql/src/frame/server_event_type.rs
+++ b/scylla-cql/src/frame/server_event_type.rs
@@ -20,7 +20,7 @@ impl fmt::Display for EventType {
             Self::SchemaChange => "SCHEMA_CHANGE",
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -118,13 +118,13 @@ impl TryFrom<Consistency> for SerialConsistency {
 
 impl std::fmt::Display for Consistency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
 impl std::fmt::Display for SerialConsistency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -568,7 +568,7 @@ fn type_consistency() {
 
     // Check that the error message contains information about the invalid value
     let err_str = format!("{}", c_result.unwrap_err());
-    assert!(err_str.contains(&format!("{}", c)));
+    assert!(err_str.contains(&format!("{c}")));
 }
 
 pub fn read_inet(buf: &mut &[u8]) -> Result<SocketAddr, LowLevelDeserializationError> {

--- a/scylla-cql/src/pretty.rs
+++ b/scylla-cql/src/pretty.rs
@@ -5,7 +5,7 @@ pub(crate) struct HexBytes<'a>(pub(crate) &'a [u8]);
 impl LowerHex for HexBytes<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for b in self.0 {
-            write!(f, "{:02x}", b)?;
+            write!(f, "{b:02x}")?;
         }
         Ok(())
     }
@@ -14,7 +14,7 @@ impl LowerHex for HexBytes<'_> {
 impl UpperHex for HexBytes<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for b in self.0 {
-            write!(f, "{:02X}", b)?;
+            write!(f, "{b:02X}")?;
         }
         Ok(())
     }
@@ -63,7 +63,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.0 {
             None => write!(f, "null")?,
-            Some(v) => write!(f, "{}", v)?,
+            Some(v) => write!(f, "{v}")?,
         }
         Ok(())
     }

--- a/scylla-cql/src/serialize/row_tests.rs
+++ b/scylla-cql/src/serialize/row_tests.rs
@@ -47,14 +47,14 @@ fn col<'a>(name: impl Into<Cow<'a, str>>, typ: ColumnType<'a>) -> ColumnSpec<'a>
 fn get_typeck_err(err: &SerializationError) -> &BuiltinTypeCheckError {
     match err.0.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinTypeCheckError: {}", err),
+        None => panic!("not a BuiltinTypeCheckError: {err}"),
     }
 }
 
 fn get_ser_err(err: &SerializationError) -> &BuiltinSerializationError {
     match err.0.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinSerializationError: {}", err),
+        None => panic!("not a BuiltinSerializationError: {err}"),
     }
 }
 

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -1308,10 +1308,10 @@ impl Display for MapSerializationErrorKind {
                 f.write_str("the map contains too many elements to fit in CQL representation")
             }
             MapSerializationErrorKind::KeySerializationFailed(err) => {
-                write!(f, "failed to serialize one of the keys: {}", err)
+                write!(f, "failed to serialize one of the keys: {err}")
             }
             MapSerializationErrorKind::ValueSerializationFailed(err) => {
-                write!(f, "failed to serialize one of the values: {}", err)
+                write!(f, "failed to serialize one of the values: {err}")
             }
         }
     }

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -83,14 +83,14 @@ fn do_serialize_err<T: SerializeValue>(t: T, typ: &ColumnType) -> SerializationE
 fn get_typeck_err(err: &SerializationError) -> &BuiltinTypeCheckError {
     match err.0.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinTypeCheckError: {}", err),
+        None => panic!("not a BuiltinTypeCheckError: {err}"),
     }
 }
 
 pub(crate) fn get_ser_err(err: &SerializationError) -> &BuiltinSerializationError {
     match err.0.downcast_ref() {
         Some(err) => err,
-        None => panic!("not a BuiltinSerializationError: {}", err),
+        None => panic!("not a BuiltinSerializationError: {err}"),
     }
 }
 

--- a/scylla-cql/src/utils/parse.rs
+++ b/scylla-cql/src/utils/parse.rs
@@ -34,7 +34,7 @@ pub enum ParseErrorCause {
 impl Display for ParseErrorCause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParseErrorCause::Expected(e) => write!(f, "expected {:?}", e),
+            ParseErrorCause::Expected(e) => write!(f, "expected {e:?}"),
             ParseErrorCause::Other(e) => f.write_str(e),
         }
     }

--- a/scylla-cql/src/value.rs
+++ b/scylla-cql/src/value.rs
@@ -1128,14 +1128,14 @@ impl std::fmt::Display for CqlValue {
                     HexBytes(bytes)
                 )?
             }
-            CqlValue::Float(fl) => write!(f, "{}", fl)?,
-            CqlValue::Double(d) => write!(f, "{}", d)?,
-            CqlValue::Boolean(b) => write!(f, "{}", b)?,
-            CqlValue::Int(i) => write!(f, "{}", i)?,
-            CqlValue::BigInt(bi) => write!(f, "{}", bi)?,
-            CqlValue::Inet(i) => write!(f, "'{}'", i)?,
-            CqlValue::SmallInt(si) => write!(f, "{}", si)?,
-            CqlValue::TinyInt(ti) => write!(f, "{}", ti)?,
+            CqlValue::Float(fl) => write!(f, "{fl}")?,
+            CqlValue::Double(d) => write!(f, "{d}")?,
+            CqlValue::Boolean(b) => write!(f, "{b}")?,
+            CqlValue::Int(i) => write!(f, "{i}")?,
+            CqlValue::BigInt(bi) => write!(f, "{bi}")?,
+            CqlValue::Inet(i) => write!(f, "'{i}'")?,
+            CqlValue::SmallInt(si) => write!(f, "{si}")?,
+            CqlValue::TinyInt(ti) => write!(f, "{ti}")?,
             CqlValue::Varint(vi) => write!(
                 f,
                 "blobAsVarint(0x{:x})",
@@ -1146,7 +1146,7 @@ impl std::fmt::Display for CqlValue {
                 // TODO: chrono::NaiveDate does not handle the whole range
                 // supported by the `date` datatype
                 match d.try_to_chrono_04_naive_date() {
-                    Ok(d) => write!(f, "'{}'", d)?,
+                    Ok(d) => write!(f, "'{d}'")?,
                     Err(_) => f.write_str("<date out of representable range>")?,
                 }
             }
@@ -1165,8 +1165,8 @@ impl std::fmt::Display for CqlValue {
                 Ok(d) => write!(f, "{}", d.format("'%Y-%m-%d %H:%M:%S%.3f%z'"))?,
                 Err(_) => f.write_str("<timestamp out of representable range>")?,
             },
-            CqlValue::Timeuuid(t) => write!(f, "{}", t)?,
-            CqlValue::Uuid(u) => write!(f, "{}", u)?,
+            CqlValue::Timeuuid(t) => write!(f, "{t}")?,
+            CqlValue::Uuid(u) => write!(f, "{u}")?,
 
             // Compound types
             CqlValue::Tuple(t) => {

--- a/scylla-macros/src/parser.rs
+++ b/scylla-macros/src/parser.rs
@@ -5,12 +5,8 @@ pub(crate) fn parse_named_fields<'a>(
     input: &'a DeriveInput,
     current_derive: &str,
 ) -> Result<&'a FieldsNamed, syn::Error> {
-    let create_err_msg = || {
-        format!(
-            "derive({}) works only for structs with named fields",
-            current_derive
-        )
-    };
+    let create_err_msg =
+        || format!("derive({current_derive}) works only for structs with named fields");
 
     match &input.data {
         Data::Struct(data) => match &data.fields {

--- a/scylla-macros/src/serialize/row.rs
+++ b/scylla-macros/src/serialize/row.rs
@@ -214,7 +214,7 @@ impl Generator for ColumnSortingGenerator<'_> {
         let struct_name = &self.ctx.struct_name;
         // 1. Defining a partial struct
         let partial_struct_name = syn::Ident::new(
-            &format!("_{}ScyllaSerPartial", struct_name),
+            &format!("_{struct_name}ScyllaSerPartial"),
             struct_name.span(),
         );
         let mut partial_generics = self.ctx.generics.clone();

--- a/scylla-macros/src/serialize/value.rs
+++ b/scylla-macros/src/serialize/value.rs
@@ -328,7 +328,7 @@ impl Generator for FieldSortingGenerator<'_> {
         );
 
         fn make_visited_flag_ident(field_name: &syn::Ident) -> syn::Ident {
-            syn::Ident::new(&format!("visited_flag_{}", field_name), field_name.span())
+            syn::Ident::new(&format!("visited_flag_{field_name}"), field_name.span())
         }
 
         // Generate a "visited" flag for each field

--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -410,7 +410,7 @@ impl RequestReaction {
             error.clone(),
             None,
         )
-        .unwrap_or_else(|_| panic!("Invalid DbError provided: {:#?}", error));
+        .unwrap_or_else(|_| panic!("Invalid DbError provided: {error:#?}"));
 
         RequestReaction {
             to_addressee: None,

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -200,7 +200,7 @@ struct DisplayableRealAddrOption(Option<SocketAddr>);
 impl Display for DisplayableRealAddrOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(addr) = self.0 {
-            write!(f, "{}", addr)
+            write!(f, "{addr}")
         } else {
             write!(f, "<dry mode>")
         }
@@ -212,7 +212,7 @@ struct DisplayableShard(Option<TargetShard>);
 impl Display for DisplayableShard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(shard) = self.0 {
-            write!(f, "shard {}", shard)
+            write!(f, "shard {shard}")
         } else {
             write!(f, "unknown shard")
         }
@@ -455,8 +455,7 @@ impl RunningProxy {
     pub async fn finish(mut self) -> Result<(), ProxyError> {
         self.terminate_signaler.send(()).map_err(|err| {
             ProxyError::AwaitFinishFailure(format!(
-                "Send error in terminate_signaler: {} (bug!)",
-                err
+                "Send error in terminate_signaler: {err} (bug!)"
             ))
         })?;
         info!("Sent finish signal to proxy workers.");
@@ -1725,7 +1724,7 @@ mod tests {
                     let socket = TcpSocket::new_v4().unwrap();
                     socket
                         .bind(mock_driver_addr)
-                        .unwrap_or_else(|_| panic!("driver_addr failed: {}", mock_driver_addr));
+                        .unwrap_or_else(|_| panic!("driver_addr failed: {mock_driver_addr}"));
                     driver_addr_tx.send(socket.local_addr().unwrap()).unwrap();
                     socket.connect(node1_proxy_addr).await.unwrap()
                 };

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -462,8 +462,7 @@ mod tests {
 
         session
             .ddl(format!(
-                "CREATE TABLE IF NOT EXISTS {}.test_table (a int primary key, b int)",
-                ks
+                "CREATE TABLE IF NOT EXISTS {ks}.test_table (a int primary key, b int)"
             ))
             .await
             .expect("Could not create table");
@@ -615,8 +614,7 @@ mod tests {
         for expected_row in expected_rows.iter() {
             if !selected_rows.contains(expected_row) {
                 panic!(
-                    "Expected {:?} to contain row: {:?}, but they didn't",
-                    selected_rows, expected_row
+                    "Expected {selected_rows:?} to contain row: {expected_row:?}, but they didn't"
                 );
             }
         }

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -505,15 +505,13 @@ mod deserialize {
                 .and_then(|mut f| f.read_to_end(&mut buf))
                 .map_err(|_| {
                     CloudConfigError::Validation(format!(
-                        "Cannot read file at given {} {}.",
-                        path_name, path,
+                        "Cannot read file at given {path_name} {path}.",
                     ))
                 })?;
             buf
         } else {
             return Err(CloudConfigError::Validation(format!(
-                "Either {} or {} has to be provided for authInfo.",
-                data_name, path_name,
+                "Either {data_name} or {path_name} has to be provided for authInfo.",
             )));
         };
         Ok(pem.into_boxed_slice())

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -386,7 +386,7 @@ struct InvalidCqlType {
 
 impl fmt::Display for InvalidCqlType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -299,10 +299,7 @@ pub(crate) async fn resolve_hostname(hostname: &str) -> Result<SocketAddr, io::E
     addrs
         .find_or_last(|addr| matches!(addr, SocketAddr::V4(_)))
         .ok_or_else(|| {
-            io::Error::other(format!(
-                "Empty address list returned by DNS for {}",
-                hostname
-            ))
+            io::Error::other(format!("Empty address list returned by DNS for {hostname}"))
         })
 }
 

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -1003,7 +1003,7 @@ mod tests {
             alive: 2,
         };
 
-        let db_error_displayed: String = format!("{}", db_error);
+        let db_error_displayed: String = format!("{db_error}");
 
         let mut expected_dberr_msg =
             "Not enough nodes are alive to satisfy required consistency level ".to_string();
@@ -1016,7 +1016,7 @@ mod tests {
             db_error,
             "a message about unavailable error".to_string(),
         ));
-        let execution_error_displayed: String = format!("{}", execution_error);
+        let execution_error_displayed: String = format!("{execution_error}");
 
         let mut expected_execution_err_msg = "Database returned an error: ".to_string();
         expected_execution_err_msg += &expected_dberr_msg;

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2496,7 +2496,7 @@ mod tests {
         setup_tracing();
         const MASK: &str = "2137";
 
-        let lwt_optimisation_entry = format!("{}={}", LWT_OPTIMIZATION_META_BIT_MASK_KEY, MASK);
+        let lwt_optimisation_entry = format!("{LWT_OPTIMIZATION_META_BIT_MASK_KEY}={MASK}");
 
         let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
 

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -116,8 +116,8 @@ impl std::fmt::Debug for MaybePoolConnections {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MaybePoolConnections::Initializing => write!(f, "Initializing"),
-            MaybePoolConnections::Broken(err) => write!(f, "Broken({:?})", err),
-            MaybePoolConnections::Ready(conns) => write!(f, "{:?}", conns),
+            MaybePoolConnections::Broken(err) => write!(f, "Broken({err:?})"),
+            MaybePoolConnections::Ready(conns) => write!(f, "{conns:?}"),
         }
     }
 }

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -175,7 +175,7 @@ impl TlsConfig {
             context,
             #[cfg(feature = "unstable-cloud")]
             sni: Some(if let Some(host_id) = host_id {
-                format!("{}.{}", host_id, domain_name)
+                format!("{host_id}.{domain_name}")
             } else {
                 domain_name.into()
             }),

--- a/scylla/src/observability/history.rs
+++ b/scylla/src/observability/history.rs
@@ -402,25 +402,25 @@ impl Display for StructuredHistory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Requests History:")?;
         for (i, request) in self.requests.iter().enumerate() {
-            writeln!(f, "=== Request #{} ===", i)?;
+            writeln!(f, "=== Request #{i} ===")?;
             writeln!(f, "| start_time: {}", request.start_time)?;
             writeln!(f, "| Non-speculative attempts:")?;
             write_fiber_attempts(&request.non_speculative_fiber, f)?;
             for (spec_i, speculative_fiber) in request.speculative_fibers.iter().enumerate() {
                 writeln!(f, "|")?;
                 writeln!(f, "|")?;
-                writeln!(f, "| > Speculative fiber #{}", spec_i)?;
+                writeln!(f, "| > Speculative fiber #{spec_i}")?;
                 writeln!(f, "| fiber start time: {}", speculative_fiber.start_time)?;
                 write_fiber_attempts(speculative_fiber, f)?;
             }
             writeln!(f, "|")?;
             match &request.result {
                 Some(RequestHistoryResult::Success(succ_time)) => {
-                    writeln!(f, "| Request successful at {}", succ_time)?;
+                    writeln!(f, "| Request successful at {succ_time}")?;
                 }
                 Some(RequestHistoryResult::Error(err_time, error)) => {
-                    writeln!(f, "| Request failed at {}", err_time)?;
-                    writeln!(f, "| Error: {}", error)?;
+                    writeln!(f, "| Request failed at {err_time}")?;
+                    writeln!(f, "| Error: {error}")?;
                 }
                 None => writeln!(f, "| Request still running - no final result yet")?,
             };
@@ -438,11 +438,11 @@ fn write_fiber_attempts(fiber: &FiberHistory, f: &mut std::fmt::Formatter<'_>) -
         writeln!(f, "| - Attempt #{} sent to {}", i, attempt.node_addr)?;
         writeln!(f, "|   request send time: {}", attempt.send_time)?;
         match &attempt.result {
-            Some(AttemptResult::Success(time)) => writeln!(f, "|   Success at {}", time)?,
+            Some(AttemptResult::Success(time)) => writeln!(f, "|   Success at {time}")?,
             Some(AttemptResult::Error(time, err, retry_decision)) => {
-                writeln!(f, "|   Error at {}", time)?;
-                writeln!(f, "|   Error: {}", err)?;
-                writeln!(f, "|   Retry decision: {:?}", retry_decision)?;
+                writeln!(f, "|   Error at {time}")?;
+                writeln!(f, "|   Error: {err}")?;
+                writeln!(f, "|   Retry decision: {retry_decision:?}")?;
             }
             None => writeln!(f, "|   No result yet")?,
         };
@@ -548,7 +548,7 @@ mod tests {
 
         let displayed = "Requests History:
 ";
-        assert_eq!(displayed, format!("{}", history));
+        assert_eq!(displayed, format!("{history}"));
     }
 
     #[test]

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1315,8 +1315,7 @@ mod tests {
                             if gots.len() > 1 && s.len() > 1 {
                                 assert!(
                                     sets.len() > 1,
-                                    "Group {:?} is expected to be nondeterministic, but it appears to be deterministic",
-                                    expected
+                                    "Group {expected:?} is expected to be nondeterministic, but it appears to be deterministic"
                                 );
                             }
                         }
@@ -1330,8 +1329,7 @@ mod tests {
                             assert_eq!(
                                 sets.len(),
                                 1,
-                                "Group {:?} is expected to be deterministic, but it appears to be nondeterministic",
-                                expected
+                                "Group {expected:?} is expected to be deterministic, but it appears to be nondeterministic"
                             );
                         }
                     }
@@ -3185,7 +3183,7 @@ mod latency_awareness {
                         .unwrap();
                     let mut node_latency =
                         node_latencies.entry(host_id).or_default().write().unwrap();
-                    println!("Set latency: node {}, latency {:?}.", id, average);
+                    println!("Set latency: node {id}, latency {average:?}.");
                     *node_latency = average;
                 }
                 println!("Set node latency stats.")

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -495,7 +495,7 @@ mod tests {
     fn column_spec_infinite_iter() -> impl Iterator<Item = ColumnSpec<'static>> {
         (0..).map(|k| {
             ColumnSpec::owned(
-                format!("col_{}", k),
+                format!("col_{k}"),
                 match k % 3 {
                     0 => ColumnType::Native(NativeType::Ascii),
                     1 => ColumnType::Native(NativeType::Boolean),

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -645,7 +645,7 @@ mod tests {
         let col_specs: Vec<_> = cols
             .into_iter()
             .enumerate()
-            .map(|(i, typ)| ColumnSpec::owned(format!("col_{}", i), typ, table_spec.clone()))
+            .map(|(i, typ)| ColumnSpec::owned(format!("col_{i}"), typ, table_spec.clone()))
             .collect();
         let mut pk_indexes = idx
             .into_iter()

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -32,7 +32,7 @@ pub(crate) fn unique_keyspace_name() -> String {
             .as_secs(),
         cnt
     );
-    println!("Unique name: {}", name);
+    println!("Unique name: {name}");
     name
 }
 

--- a/scylla/tests/integration/ccm/authenticate.rs
+++ b/scylla/tests/integration/ccm/authenticate.rs
@@ -59,7 +59,7 @@ async fn authenticate_superuser_cluster_one_node() {
             .unwrap();
         let ks = unique_keyspace_name();
 
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
         session.use_keyspace(ks, false).await.unwrap();
         session.ddl("DROP TABLE IF EXISTS t;").await.unwrap();
 
@@ -123,7 +123,7 @@ async fn custom_authentication_cluster_one_node() {
             .unwrap();
         let ks = unique_keyspace_name();
 
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
         session.use_keyspace(ks, false).await.unwrap();
         session.ddl("DROP TABLE IF EXISTS t;").await.unwrap();
 

--- a/scylla/tests/integration/ccm/lib/cli_wrapper/cluster.rs
+++ b/scylla/tests/integration/ccm/lib/cli_wrapper/cluster.rs
@@ -179,10 +179,10 @@ impl ClusterStart<'_> {
     fn get_ccm_env(&self) -> HashMap<String, String> {
         let mut value = String::new();
         if let Some(smp) = self.scylla_smp {
-            write!(value, "--smp={} ", smp).unwrap();
+            write!(value, "--smp={smp} ").unwrap();
         }
         if let Some(mem_megabytes) = self.scylla_mem_megabytes {
-            write!(value, "--memory={}M ", mem_megabytes).unwrap();
+            write!(value, "--memory={mem_megabytes}M ").unwrap();
         }
 
         let mut env = HashMap::new();

--- a/scylla/tests/integration/ccm/lib/cli_wrapper/node.rs
+++ b/scylla/tests/integration/ccm/lib/cli_wrapper/node.rs
@@ -62,10 +62,10 @@ impl NodeStart<'_> {
     fn get_ccm_env(&self) -> HashMap<String, String> {
         let mut value = String::new();
         if let Some(smp) = self.scylla_smp {
-            write!(value, "--smp={} ", smp).unwrap();
+            write!(value, "--smp={smp} ").unwrap();
         }
         if let Some(mem_megabytes) = self.scylla_mem_megabytes {
-            write!(value, "--memory={}M ", mem_megabytes).unwrap();
+            write!(value, "--memory={mem_megabytes}M ").unwrap();
         }
 
         let mut env = HashMap::new();

--- a/scylla/tests/integration/ccm/lib/cluster.rs
+++ b/scylla/tests/integration/ccm/lib/cluster.rs
@@ -159,21 +159,20 @@ impl Cluster {
                     );
                 }
             }
-            Err(err) => {
-                match err.kind() {
-                    std::io::ErrorKind::NotFound => {
-                        tokio::fs::create_dir_all(config_dir_path).await.with_context(
-                        || format! {"failed to create root directory {:?}", config_dir_path},
-                    )?;
-                    }
-                    _ => {
-                        return Err(Error::from(err).context(format!(
-                            "failed to create root directory {:?}",
-                            config_dir_path
-                        )));
-                    }
+            Err(err) => match err.kind() {
+                std::io::ErrorKind::NotFound => {
+                    tokio::fs::create_dir_all(config_dir_path)
+                        .await
+                        .with_context(
+                            || format! {"failed to create root directory {config_dir_path:?}"},
+                        )?;
                 }
-            }
+                _ => {
+                    return Err(Error::from(err).context(format!(
+                        "failed to create root directory {config_dir_path:?}"
+                    )));
+                }
+            },
         }
 
         let lcmd = Arc::new(LoggedCmd::new());
@@ -305,7 +304,7 @@ impl Cluster {
             datacenter_id,
             ..NodeOptions::from_cluster_opts(&self.opts)
         };
-        let datacenter_name = format!("dc{}", datacenter_id);
+        let datacenter_name = format!("dc{datacenter_id}");
         self.ccm_cmd
             .cluster_add_node(self.opts.db_type, node_options.name())
             .dc(datacenter_name)

--- a/scylla/tests/integration/ccm/lib/logged_cmd.rs
+++ b/scylla/tests/integration/ccm/lib/logged_cmd.rs
@@ -84,7 +84,7 @@ impl LoggedCmd {
                     format!("exited[{}]", run_id),
                     e
                 );
-                Err(Error::from(e).context(format!("Command `{}` failed", command_with_args,)))
+                Err(Error::from(e).context(format!("Command `{command_with_args}` failed",)))
             }
         }
     }
@@ -285,9 +285,9 @@ mod tests {
     impl tracing::field::Visit for PrintlnVisitor {
         fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
             if self.log_message.is_empty() {
-                write!(self.log_message, "{:?}", value).unwrap();
+                write!(self.log_message, "{value:?}").unwrap();
             } else {
-                write!(self.log_message, ", {}: {:?}", field, value).unwrap();
+                write!(self.log_message, ", {field}: {value:?}").unwrap();
             }
         }
     }

--- a/scylla/tests/integration/load_balancing/lwt_optimisation.rs
+++ b/scylla/tests/integration/load_balancing/lwt_optimisation.rs
@@ -72,7 +72,7 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
 
         // Create schema
         let ks = unique_keyspace_name();
-        let mut create_ks = format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks);
+        let mut create_ks = format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}");
         if scylla_supports_tablets(&session).await {
             create_ks += " and TABLETS = { 'enabled': false}";
         }
@@ -114,7 +114,7 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
         fn who_was_queried(rxs: &mut Rxs) {
             for (i, rx) in rxs.iter_mut().enumerate() {
                 if rx.try_recv().is_ok() {
-                    println!("{} was queried.", i);
+                    println!("{i} was queried.");
                     return;
                 }
             }

--- a/scylla/tests/integration/load_balancing/shards.rs
+++ b/scylla/tests/integration/load_balancing/shards.rs
@@ -44,7 +44,7 @@ async fn test_consistent_shard_awareness() {
         let ks = unique_keyspace_name();
 
         /* Prepare schema */
-        let mut create_ks = format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks);
+        let mut create_ks = format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}");
         if scylla_supports_tablets(&session).await {
             create_ks += " and TABLETS = { 'enabled': false}";
         }
@@ -52,14 +52,13 @@ async fn test_consistent_shard_awareness() {
         session
             .ddl(
                 format!(
-                    "CREATE TABLE IF NOT EXISTS {}.t (a int, b int, c text, primary key (a, b))",
-                    ks
+                    "CREATE TABLE IF NOT EXISTS {ks}.t (a int, b int, c text, primary key (a, b))"
                 ),
             )
             .await
             .unwrap();
 
-        let prepared = session.prepare(format!("INSERT INTO {}.t (a, b, c) VALUES (?, ?, 'abc')", ks)).await.unwrap();
+        let prepared = session.prepare(format!("INSERT INTO {ks}.t (a, b, c) VALUES (?, ?, 'abc')")).await.unwrap();
 
         let value_lists = [
             (4, 2),

--- a/scylla/tests/integration/load_balancing/simple_strategy.rs
+++ b/scylla/tests/integration/load_balancing/simple_strategy.rs
@@ -10,24 +10,22 @@ async fn simple_strategy_test() {
 
     session
         .ddl(format!(
-            "CREATE KEYSPACE {} WITH REPLICATION = \
-                {{'class': 'SimpleStrategy', 'replication_factor': 1}}",
-            ks
+            "CREATE KEYSPACE {ks} WITH REPLICATION = \
+                {{'class': 'SimpleStrategy', 'replication_factor': 1}}"
         ))
         .await
         .unwrap();
 
     session
         .ddl(format!(
-            "CREATE TABLE {}.tab (p int, c int, r int, PRIMARY KEY (p, c, r))",
-            ks
+            "CREATE TABLE {ks}.tab (p int, c int, r int, PRIMARY KEY (p, c, r))"
         ))
         .await
         .unwrap();
 
     session
         .query_unpaged(
-            format!("INSERT INTO {}.tab (p, c, r) VALUES (1, 2, 3)", ks),
+            format!("INSERT INTO {ks}.tab (p, c, r) VALUES (1, 2, 3)"),
             (),
         )
         .await
@@ -35,21 +33,21 @@ async fn simple_strategy_test() {
 
     session
         .query_unpaged(
-            format!("INSERT INTO {}.tab (p, c, r) VALUES (?, ?, ?)", ks),
+            format!("INSERT INTO {ks}.tab (p, c, r) VALUES (?, ?, ?)"),
             (4, 5, 6),
         )
         .await
         .unwrap();
 
     let prepared = session
-        .prepare(format!("INSERT INTO {}.tab (p, c, r) VALUES (?, ?, ?)", ks))
+        .prepare(format!("INSERT INTO {ks}.tab (p, c, r) VALUES (?, ?, ?)"))
         .await
         .unwrap();
 
     session.execute_unpaged(&prepared, (7, 8, 9)).await.unwrap();
 
     let mut rows: Vec<(i32, i32, i32)> = session
-        .query_unpaged(format!("SELECT p, c, r FROM {}.tab", ks), ())
+        .query_unpaged(format!("SELECT p, c, r FROM {ks}.tab"), ())
         .await
         .unwrap()
         .into_rows_result()

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -170,17 +170,15 @@ fn count_tablet_feedbacks(
 async fn prepare_schema(session: &Session, ks: &str, table: &str, tablet_count: usize) {
     session
         .ddl(format!(
-            "CREATE KEYSPACE IF NOT EXISTS {}
+            "CREATE KEYSPACE IF NOT EXISTS {ks}
             WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2}}
-            AND tablets = {{ 'initial': {} }}",
-            ks, tablet_count
+            AND tablets = {{ 'initial': {tablet_count} }}"
         ))
         .await
         .unwrap();
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.{} (a int, b int, c text, primary key (a, b))",
-            ks, table
+            "CREATE TABLE IF NOT EXISTS {ks}.{table} (a int, b int, c text, primary key (a, b))"
         ))
         .await
         .unwrap();
@@ -225,10 +223,7 @@ async fn test_default_policy_is_tablet_aware() {
             let tablets = get_tablets(&session, &ks, "t").await;
 
             let prepared = session
-                .prepare(format!(
-                    "INSERT INTO {}.t (a, b, c) VALUES (?, ?, 'abc')",
-                    ks
-                ))
+                .prepare(format!("INSERT INTO {ks}.t (a, b, c) VALUES (?, ?, 'abc')"))
                 .await
                 .unwrap();
 
@@ -433,17 +428,13 @@ async fn test_lwt_optimization_works_with_tablets() {
             let tablets = get_tablets(&session, &ks, "t").await;
 
             let prepared_insert = session
-                .prepare(format!(
-                    "INSERT INTO {}.t (a, b, c) VALUES (?, ?, null)",
-                    ks
-                ))
+                .prepare(format!("INSERT INTO {ks}.t (a, b, c) VALUES (?, ?, null)"))
                 .await
                 .unwrap();
 
             let prepared_lwt_update = session
                 .prepare(format!(
-                    "UPDATE {}.t SET c = ? WHERE a = ? and b = ? IF c != null",
-                    ks
+                    "UPDATE {ks}.t SET c = ? WHERE a = ? and b = ? IF c != null"
                 ))
                 .await
                 .unwrap();

--- a/scylla/tests/integration/load_balancing/token_awareness.rs
+++ b/scylla/tests/integration/load_balancing/token_awareness.rs
@@ -22,14 +22,13 @@ async fn test_token_awareness() {
     session.ddl(create_ks).await.unwrap();
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.t (a text primary key)",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.t (a text primary key)"
         ))
         .await
         .unwrap();
 
     let mut prepared_statement = session
-        .prepare(format!("INSERT INTO {}.t (a) VALUES (?)", ks))
+        .prepare(format!("INSERT INTO {ks}.t (a) VALUES (?)"))
         .await
         .unwrap();
     prepared_statement.set_tracing(true);

--- a/scylla/tests/integration/macros/complex_pk.rs
+++ b/scylla/tests/integration/macros/complex_pk.rs
@@ -8,7 +8,7 @@ async fn test_macros_complex_pk() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session.use_keyspace(ks, true).await.unwrap();
     session
         .ddl("CREATE TABLE IF NOT EXISTS complex_pk (a int, b int, c text, d int, e int, primary key ((a,b,c),d))")

--- a/scylla/tests/integration/metadata/configuration.rs
+++ b/scylla/tests/integration/metadata/configuration.rs
@@ -221,7 +221,7 @@ async fn test_refresh_metadata_after_schema_agreement() {
     let session = create_new_session_builder().build().await.unwrap();
 
     let ks = unique_keyspace_name();
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session.use_keyspace(ks.clone(), false).await.unwrap();
 
     session
@@ -259,12 +259,12 @@ async fn test_turning_off_schema_fetching() {
     let ks = unique_keyspace_name();
 
     session
-        .ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+        .ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("USE {}", ks), &[])
+        .query_unpaged(format!("USE {ks}"), &[])
         .await
         .unwrap();
 
@@ -332,7 +332,7 @@ async fn test_keyspaces_to_fetch() {
     let session_default = create_new_session_builder().build().await.unwrap();
     for ks in [&ks1, &ks2] {
         session_default
-            .ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+            .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
             .await
             .unwrap();
     }

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -96,12 +96,12 @@ async fn test_schema_types_in_metadata() {
     let ks = unique_keyspace_name();
 
     session
-        .ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+        .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("USE {}", ks), &[])
+        .query_unpaged(format!("USE {ks}"), &[])
         .await
         .unwrap();
 
@@ -249,12 +249,12 @@ async fn test_user_defined_types_in_metadata() {
     let ks = unique_keyspace_name();
 
     session
-        .ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+        .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("USE {}", ks), &[])
+        .query_unpaged(format!("USE {ks}"), &[])
         .await
         .unwrap();
 
@@ -309,12 +309,12 @@ async fn test_column_kinds_in_metadata() {
     let ks = unique_keyspace_name();
 
     session
-        .ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+        .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("USE {}", ks), &[])
+        .query_unpaged(format!("USE {ks}"), &[])
         .await
         .unwrap();
 
@@ -354,12 +354,12 @@ async fn test_primary_key_ordering_in_metadata() {
     let ks = unique_keyspace_name();
 
     session
-        .ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+        .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("USE {}", ks), &[])
+        .query_unpaged(format!("USE {ks}"), &[])
         .await
         .unwrap();
 
@@ -412,7 +412,7 @@ async fn test_table_partitioner_in_metadata() {
     session.ddl(create_ks).await.unwrap();
 
     session
-        .query_unpaged(format!("USE {}", ks), &[])
+        .query_unpaged(format!("USE {ks}"), &[])
         .await
         .unwrap();
 
@@ -445,7 +445,7 @@ async fn test_views_in_schema_info() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    let mut create_ks = format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks);
+    let mut create_ks = format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}");
     // Materialized views + tablets are not supported in Scylla 2025.1.
     if scylla_supports_tablets(&session).await {
         create_ks += " and TABLETS = { 'enabled': false}";

--- a/scylla/tests/integration/session/cluster_reachability.rs
+++ b/scylla/tests/integration/session/cluster_reachability.rs
@@ -22,10 +22,7 @@ async fn test_all_nodes_are_reachable_and_serving() {
     prepare_schema(&session, &ks, "t").await;
 
     let prepared = session
-        .prepare(format!(
-            "INSERT INTO {}.t (a, b, c) VALUES (?, ?, 'abc')",
-            ks
-        ))
+        .prepare(format!("INSERT INTO {ks}.t (a, b, c) VALUES (?, ?, 'abc')"))
         .await
         .unwrap();
 
@@ -43,16 +40,14 @@ async fn test_all_nodes_are_reachable_and_serving() {
 async fn prepare_schema(session: &Session, ks: &str, table: &str) {
     session
         .ddl(format!(
-            "CREATE KEYSPACE IF NOT EXISTS {}
-            WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}",
-            ks
+            "CREATE KEYSPACE IF NOT EXISTS {ks}
+            WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
         ))
         .await
         .unwrap();
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.{} (a int, b int, c text, primary key (a, b))",
-            ks, table
+            "CREATE TABLE IF NOT EXISTS {ks}.{table} (a int, b int, c text, primary key (a, b))"
         ))
         .await
         .unwrap();

--- a/scylla/tests/integration/session/db_errors.rs
+++ b/scylla/tests/integration/session/db_errors.rs
@@ -21,9 +21,9 @@ async fn test_db_errors() {
     ));
 
     // AlreadyExists when creating a keyspace for the second time
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
 
-    let create_keyspace_res = session.ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await;
+    let create_keyspace_res = session.ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await;
     let keyspace_exists_error: DbError = match create_keyspace_res {
         Err(ExecutionError::LastAttemptError(RequestAttemptError::DbError(e, _))) => e,
         _ => panic!("Second CREATE KEYSPACE didn't return an error!"),
@@ -40,14 +40,13 @@ async fn test_db_errors() {
     // AlreadyExists when creating a table for the second time
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.tab (a text primary key)",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.tab (a text primary key)"
         ))
         .await
         .unwrap();
 
     let create_table_res = session
-        .ddl(format!("CREATE TABLE {}.tab (a text primary key)", ks))
+        .ddl(format!("CREATE TABLE {ks}.tab (a text primary key)"))
         .await;
     let create_tab_error: DbError = match create_table_res {
         Err(ExecutionError::LastAttemptError(RequestAttemptError::DbError(e, _))) => e,
@@ -76,7 +75,7 @@ async fn test_rate_limit_exceeded_exception() {
     }
 
     let ks = unique_keyspace_name();
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session.use_keyspace(ks.clone(), false).await.unwrap();
     session.ddl("CREATE TABLE tbl (pk int PRIMARY KEY, v int) WITH per_partition_rate_limit = {'max_writes_per_second': 1}").await.unwrap();
 
@@ -107,6 +106,6 @@ async fn test_rate_limit_exceeded_exception() {
         )) => {
             assert_eq!(op_type, OperationType::Write);
         }
-        err => panic!("Unexpected error type received: {:?}", err),
+        err => panic!("Unexpected error type received: {err:?}"),
     }
 }

--- a/scylla/tests/integration/session/history.rs
+++ b/scylla/tests/integration/session/history.rs
@@ -216,7 +216,7 @@ async fn iterator_query_history() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
     session
-    .ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+    .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
     .await
     .unwrap();
     session.use_keyspace(ks, true).await.unwrap();

--- a/scylla/tests/integration/session/new_session.rs
+++ b/scylla/tests/integration/session/new_session.rs
@@ -119,6 +119,6 @@ async fn test_connection_failure() {
     let res = SessionBuilder::new().known_node_addr(addr).build().await;
     match res {
         Ok(_) => panic!("Unexpected success"),
-        Err(err) => println!("Connection error (it was expected): {:?}", err),
+        Err(err) => println!("Connection error (it was expected): {err:?}"),
     }
 }

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -106,19 +106,15 @@ async fn test_iter_methods_with_modification_statements() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.t (a int, b int, c text, primary key (a, b))",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.t (a int, b int, c text, primary key (a, b))"
         ))
         .await
         .unwrap();
 
-    let mut query = Statement::from(format!(
-        "INSERT INTO {}.t (a, b, c) VALUES (1, 2, 'abc')",
-        ks
-    ));
+    let mut query = Statement::from(format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 2, 'abc')"));
     query.set_tracing(true);
     let mut rows_stream = session
         .query_iter(query, &[])
@@ -130,7 +126,7 @@ async fn test_iter_methods_with_modification_statements() {
     assert!(!rows_stream.tracing_ids().is_empty());
 
     let prepared_statement = session
-        .prepare(format!("INSERT INTO {}.t (a, b, c) VALUES (?, ?, ?)", ks))
+        .prepare(format!("INSERT INTO {ks}.t (a, b, c) VALUES (?, ?, ?)"))
         .await
         .unwrap();
     let query_pager = session

--- a/scylla/tests/integration/session/retries.rs
+++ b/scylla/tests/integration/session/retries.rs
@@ -36,7 +36,7 @@ async fn speculative_execution_is_fired() {
             .unwrap();
 
         let ks = unique_keyspace_name();
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
         session.use_keyspace(ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key)")
@@ -112,7 +112,7 @@ async fn retries_occur() {
             .unwrap();
 
         let ks = unique_keyspace_name();
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
         session.use_keyspace(ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key)")
@@ -192,7 +192,7 @@ async fn speculative_execution_panic_regression_test() {
             .unwrap();
 
         let ks = unique_keyspace_name();
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
         session.use_keyspace(ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key)")

--- a/scylla/tests/integration/session/use_keyspace.rs
+++ b/scylla/tests/integration/session/use_keyspace.rs
@@ -13,18 +13,17 @@ async fn test_use_keyspace() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
 
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.tab (a text primary key)",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.tab (a text primary key)"
         ))
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("INSERT INTO {}.tab (a) VALUES ('test1')", ks), &[])
+        .query_unpaged(format!("INSERT INTO {ks}.tab (a) VALUES ('test1')"), &[])
         .await
         .unwrap();
 
@@ -108,28 +107,24 @@ async fn test_use_keyspace_case_sensitivity() {
     let ks_lower = unique_keyspace_name().to_lowercase();
     let ks_upper = ks_lower.to_uppercase();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS \"{}\" WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks_lower)).await.unwrap();
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS \"{}\" WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks_upper)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS \"{ks_lower}\" WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS \"{ks_upper}\" WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
 
     session
-        .ddl(format!(
-            "CREATE TABLE {}.tab (a text primary key)",
-            ks_lower
-        ))
+        .ddl(format!("CREATE TABLE {ks_lower}.tab (a text primary key)"))
         .await
         .unwrap();
 
     session
         .ddl(format!(
-            "CREATE TABLE \"{}\".tab (a text primary key)",
-            ks_upper
+            "CREATE TABLE \"{ks_upper}\".tab (a text primary key)"
         ))
         .await
         .unwrap();
 
     session
         .query_unpaged(
-            format!("INSERT INTO {}.tab (a) VALUES ('lowercase')", ks_lower),
+            format!("INSERT INTO {ks_lower}.tab (a) VALUES ('lowercase')"),
             &[],
         )
         .await
@@ -137,7 +132,7 @@ async fn test_use_keyspace_case_sensitivity() {
 
     session
         .query_unpaged(
-            format!("INSERT INTO \"{}\".tab (a) VALUES ('uppercase')", ks_upper),
+            format!("INSERT INTO \"{ks_upper}\".tab (a) VALUES ('uppercase')"),
             &[],
         )
         .await
@@ -184,26 +179,22 @@ async fn test_raw_use_keyspace() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
 
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.tab (a text primary key)",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.tab (a text primary key)"
         ))
         .await
         .unwrap();
 
     session
-        .query_unpaged(
-            format!("INSERT INTO {}.tab (a) VALUES ('raw_test')", ks),
-            &[],
-        )
+        .query_unpaged(format!("INSERT INTO {ks}.tab (a) VALUES ('raw_test')"), &[])
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("use    \"{}\"    ;", ks), &[])
+        .query_unpaged(format!("use    \"{ks}\"    ;"), &[])
         .await
         .unwrap();
 
@@ -240,7 +231,7 @@ async fn test_get_keyspace_name() {
     // No keyspace is set in config, so get_keyspace() should return None.
     let session = create_new_session_builder().build().await.unwrap();
     assert_eq!(session.get_keyspace(), None);
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     assert_eq!(session.get_keyspace(), None);
 
     // Call use_keyspace(), get_keyspace now should return the new keyspace name

--- a/scylla/tests/integration/statements/consistency.rs
+++ b/scylla/tests/integration/statements/consistency.rs
@@ -56,7 +56,7 @@ const CREATE_TABLE_STR: &str = "CREATE TABLE consistency_tests (a int, b int, PR
 const QUERY_STR: &str = "INSERT INTO consistency_tests (a, b) VALUES (?, 1)";
 
 async fn create_schema(session: &Session, ks: &str) {
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
     session.use_keyspace(ks, false).await.unwrap();
 
     session.ddl(CREATE_TABLE_STR).await.unwrap();

--- a/scylla/tests/integration/statements/execution_profiles.rs
+++ b/scylla/tests/integration/statements/execution_profiles.rs
@@ -165,19 +165,18 @@ async fn test_execution_profiles() {
         let ks = unique_keyspace_name();
 
         /* Prepare schema */
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
         session
             .ddl(
                 format!(
-                    "CREATE TABLE IF NOT EXISTS {}.t (a int, b int, c text, primary key (a, b))",
-                    ks
+                    "CREATE TABLE IF NOT EXISTS {ks}.t (a int, b int, c text, primary key (a, b))"
                 ),
             )
             .await
             .unwrap();
 
-        let mut query = Statement::from(format!("INSERT INTO {}.t (a, b, c) VALUES (1, 2, 'abc')", ks));
-        let mut prepared = session.prepare(format!("INSERT INTO {}.t (a, b, c) VALUES (1, 2, 'abc')", ks)).await.unwrap();
+        let mut query = Statement::from(format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 2, 'abc')"));
+        let mut prepared = session.prepare(format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 2, 'abc')")).await.unwrap();
         let mut batch = Batch::new_with_statements(BatchType::Unlogged, vec![BatchStatement::Query(query.clone())]);
 
         while profile_rx.try_recv().is_ok() {}

--- a/scylla/tests/integration/statements/named_bind_markers.rs
+++ b/scylla/tests/integration/statements/named_bind_markers.rs
@@ -12,12 +12,12 @@ async fn test_named_bind_markers() {
     let ks = unique_keyspace_name();
 
     session
-        .ddl(format!("CREATE KEYSPACE {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks))
+        .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
         .await
         .unwrap();
 
     session
-        .query_unpaged(format!("USE {}", ks), &[])
+        .query_unpaged(format!("USE {ks}"), &[])
         .await
         .unwrap();
 

--- a/scylla/tests/integration/statements/timestamps.rs
+++ b/scylla/tests/integration/statements/timestamps.rs
@@ -22,18 +22,17 @@ async fn test_timestamp() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.t_timestamp (a text, b text, primary key (a))",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.t_timestamp (a text, b text, primary key (a))"
         ))
         .await
         .unwrap();
 
     session.await_schema_agreement().await.unwrap();
 
-    let query_str = format!("INSERT INTO {}.t_timestamp (a, b) VALUES (?, ?)", ks);
+    let query_str = format!("INSERT INTO {ks}.t_timestamp (a, b) VALUES (?, ?)");
 
     // test regular query timestamps
 
@@ -99,7 +98,7 @@ async fn test_timestamp() {
 
     let query_rows_result = session
         .query_unpaged(
-            format!("SELECT a, b, WRITETIME(b) FROM {}.t_timestamp", ks),
+            format!("SELECT a, b, WRITETIME(b) FROM {ks}.t_timestamp"),
             &[],
         )
         .await
@@ -152,36 +151,26 @@ async fn test_timestamp_generator() {
         .await
         .unwrap();
     let ks = unique_keyspace_name();
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.t_generator (a int primary key, b int)",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.t_generator (a int primary key, b int)"
         ))
         .await
         .unwrap();
 
     let prepared = session
-        .prepare(format!(
-            "INSERT INTO {}.t_generator (a, b) VALUES (1, 1)",
-            ks
-        ))
+        .prepare(format!("INSERT INTO {ks}.t_generator (a, b) VALUES (1, 1)"))
         .await
         .unwrap();
     session.execute_unpaged(&prepared, []).await.unwrap();
 
-    let unprepared = Statement::new(format!(
-        "INSERT INTO {}.t_generator (a, b) VALUES (2, 2)",
-        ks
-    ));
+    let unprepared = Statement::new(format!("INSERT INTO {ks}.t_generator (a, b) VALUES (2, 2)"));
     session.query_unpaged(unprepared, []).await.unwrap();
 
     let mut batch = Batch::new(BatchType::Unlogged);
     let stmt = session
-        .prepare(format!(
-            "INSERT INTO {}.t_generator (a, b) VALUES (3, 3)",
-            ks
-        ))
+        .prepare(format!("INSERT INTO {ks}.t_generator (a, b) VALUES (3, 3)"))
         .await
         .unwrap();
     batch.append_statement(stmt);
@@ -189,7 +178,7 @@ async fn test_timestamp_generator() {
 
     let query_rows_result = session
         .query_unpaged(
-            format!("SELECT a, b, WRITETIME(b) FROM {}.t_generator", ks),
+            format!("SELECT a, b, WRITETIME(b) FROM {ks}.t_generator"),
             &[],
         )
         .await

--- a/scylla/tests/integration/statements/transparent_reprepare.rs
+++ b/scylla/tests/integration/statements/transparent_reprepare.rs
@@ -9,14 +9,14 @@ use crate::utils::{
 
 async fn rename(session: &Session, rename_str: &str) {
     session
-        .ddl(format!("ALTER TABLE tab RENAME {}", rename_str))
+        .ddl(format!("ALTER TABLE tab RENAME {rename_str}"))
         .await
         .unwrap();
 }
 
 async fn rename_caching(session: &CachingSession, rename_str: &str) {
     session
-        .ddl(format!("ALTER TABLE tab RENAME {}", rename_str))
+        .ddl(format!("ALTER TABLE tab RENAME {rename_str}"))
         .await
         .unwrap();
 }
@@ -35,7 +35,7 @@ async fn test_unprepared_reprepare_in_execute() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session.use_keyspace(ks, false).await.unwrap();
 
     session
@@ -102,7 +102,7 @@ async fn test_unprepared_reprepare_in_batch() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session.use_keyspace(ks, false).await.unwrap();
 
     session
@@ -165,7 +165,7 @@ async fn test_unprepared_reprepare_in_caching_session_execute() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session.use_keyspace(ks, false).await.unwrap();
 
     let caching_session: CachingSession = CachingSession::from(session, 64);

--- a/scylla/tests/integration/statements/unprepared.rs
+++ b/scylla/tests/integration/statements/unprepared.rs
@@ -19,39 +19,38 @@ async fn test_unprepared_statement() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}", ks)).await.unwrap();
+    session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
     session
         .ddl(format!(
-            "CREATE TABLE IF NOT EXISTS {}.t (a int, b int, c text, primary key (a, b))",
-            ks
+            "CREATE TABLE IF NOT EXISTS {ks}.t (a int, b int, c text, primary key (a, b))"
         ))
         .await
         .unwrap();
 
     session
         .query_unpaged(
-            format!("INSERT INTO {}.t (a, b, c) VALUES (1, 2, 'abc')", ks),
+            format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 2, 'abc')"),
             &[],
         )
         .await
         .unwrap();
     session
         .query_unpaged(
-            format!("INSERT INTO {}.t (a, b, c) VALUES (7, 11, '')", ks),
+            format!("INSERT INTO {ks}.t (a, b, c) VALUES (7, 11, '')"),
             &[],
         )
         .await
         .unwrap();
     session
         .query_unpaged(
-            format!("INSERT INTO {}.t (a, b, c) VALUES (1, 4, 'hello')", ks),
+            format!("INSERT INTO {ks}.t (a, b, c) VALUES (1, 4, 'hello')"),
             &[],
         )
         .await
         .unwrap();
 
     let query_result = session
-        .query_unpaged(format!("SELECT a, b, c FROM {}.t", ks), &[])
+        .query_unpaged(format!("SELECT a, b, c FROM {ks}.t"), &[])
         .await
         .unwrap();
 
@@ -79,7 +78,7 @@ async fn test_unprepared_statement() {
         ]
     );
     let query_result = session
-        .query_iter(format!("SELECT a, b, c FROM {}.t", ks), &[])
+        .query_iter(format!("SELECT a, b, c FROM {ks}.t"), &[])
         .await
         .unwrap();
     let specs = query_result.column_specs();
@@ -89,7 +88,7 @@ async fn test_unprepared_statement() {
         assert_eq!(spec.table_spec().ks_name(), ks);
     }
     let mut results_from_manual_paging = vec![];
-    let query = Statement::new(format!("SELECT a, b, c FROM {}.t", ks)).with_page_size(1);
+    let query = Statement::new(format!("SELECT a, b, c FROM {ks}.t")).with_page_size(1);
     let mut paging_state = PagingState::start();
     let mut watchdog = 0;
     loop {
@@ -135,7 +134,7 @@ async fn test_prepare_query_with_values() {
             .unwrap();
 
         let ks = unique_keyspace_name();
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
         session.use_keyspace(ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key)")
@@ -186,7 +185,7 @@ async fn test_query_with_no_values() {
             .unwrap();
 
         let ks = unique_keyspace_name();
-        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}", ks)).await.unwrap();
+        session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
         session.use_keyspace(ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key)")

--- a/scylla/tests/integration/types/cql_value.rs
+++ b/scylla/tests/integration/types/cql_value.rs
@@ -12,9 +12,8 @@ async fn test_cqlvalue_udt() {
     let ks = unique_keyspace_name();
     session
         .ddl(format!(
-            "CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = \
-            {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}",
-            ks
+            "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = \
+            {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
         ))
         .await
         .unwrap();
@@ -63,9 +62,8 @@ async fn test_cqlvalue_duration() {
     let ks = unique_keyspace_name();
     session
         .ddl(format!(
-            "CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = \
-                {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}",
-            ks
+            "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = \
+                {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
         ))
         .await
         .unwrap();

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -76,7 +76,7 @@ pub(crate) fn unique_keyspace_name() -> String {
             .as_secs(),
         cnt
     );
-    println!("Unique name: {}", name);
+    println!("Unique name: {name}");
     name
 }
 


### PR DESCRIPTION
Replaces: https://github.com/scylladb/scylla-rust-driver/pull/1386

`clippy::uninlined_format_args` warns about format strings that have its variables listed after format string, instead of having it directly in curly braces.
Advantages of that? Shorter code that plays better with `cargo fmt`, and no need to jump with your eyes between string and values to understand the format.

There are a lot of changes, but they are fully mechanical, performed by clippy itself using `cargo clippy --all-targets --fix --allow-dirty` after I fixed first three occurrences myself.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
