### PR TITLE
batch: add request timeout setter/getter

### DIFF
--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::client::execution_profile::ExecutionProfileHandle;
 use crate::observability::history::HistoryListener;
@@ -121,6 +122,19 @@ impl Batch {
     /// Gets the default timestamp for this batch in microseconds.
     pub fn get_timestamp(&self) -> Option<i64> {
         self.config.timestamp
+    }
+
+    /// Sets the client-side timeout for this batch.
+    /// If not None, the driver will stop waiting for the request
+    /// to finish after `timeout` passed.
+    /// Otherwise, execution profile timeout will be applied.
+    pub fn set_request_timeout(&mut self, timeout: Option<Duration>) {
+        self.config.request_timeout = timeout
+    }
+
+    /// Gets client timeout associated with this batch.
+    pub fn get_request_timeout(&self) -> Option<Duration> {
+        self.config.request_timeout
     }
 
     /// Set the retry policy for this batch, overriding the one from execution profile if not None.

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -379,7 +379,7 @@ impl PreparedStatement {
     /// Sets the client-side timeout for this statement.
     /// If not None, the driver will stop waiting for the request
     /// to finish after `timeout` passed.
-    /// Otherwise, default session client timeout will be applied.
+    /// Otherwise, execution profile timeout will be applied.
     pub fn set_request_timeout(&mut self, timeout: Option<Duration>) {
         self.config.request_timeout = timeout
     }

--- a/scylla/src/statement/unprepared.rs
+++ b/scylla/src/statement/unprepared.rs
@@ -120,7 +120,7 @@ impl Statement {
     /// Sets the client-side timeout for this statement.
     /// If not None, the driver will stop waiting for the request
     /// to finish after `timeout` passed.
-    /// Otherwise, default session client timeout will be applied.
+    /// Otherwise, execution profile timeout will be applied.
     pub fn set_request_timeout(&mut self, timeout: Option<Duration>) {
         self.config.request_timeout = timeout
     }


### PR DESCRIPTION
Batch was missing request timeout setter and getter. As a bonus, docstrings were updated in PreparedStatement and Statement to account for execution profiles.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
