### PR TITLE
codewide: rename Scylla -> ScyllaDB

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
-    - name: Setup 3-node Scylla cluster
+    - name: Setup 3-node ScyllaDB cluster
       run: |
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
         docker compose -f test/cluster/docker-compose.yml up -d --wait

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To run a cargo test suite, use the command below (note that you must have Docker
 ```bash
 make test
 ```
-When on non-Linux machine, however, it can be impossible to connect to containerized Scylla instance from outside Docker.\
+When on non-Linux machine, however, it can be impossible to connect to containerized ScyllaDB instance from outside Docker.\
 If you are using macOS, we provide a `dockerized-test` make target for running tests inside another Docker container:
 ```bash
 make dockerized-test
@@ -110,7 +110,7 @@ There are a few scenarios:
          using command like `cargo update -p toml_datetime --precise 0.6.3` and go back to step 3.
       5. Rename `Cargo.lock` to `Cargo.lock.msrv`.
 
-### Semver checking 
+### Semver checking
 
 Our CI runs cargo semver-checks and labels PRs that introduce breaking changes.
 If you don't intend to change public API, you can perform the checks locally,

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -130,7 +130,7 @@ For an example, see four last commits of this PR: https://github.com/scylladb/sc
 
 Commits that update `scylla-proxy` / `scylla-macros` / `scylla-cql` change:
 - `version` field in relevant `Cargo.toml`
-- Version number in crates that depend on given crate (so a commit bumping `scylla-macros` will also change version of 
+- Version number in crates that depend on given crate (so a commit bumping `scylla-macros` will also change version of
 `scylla-macros` in `scylla` and `scylla-cql` crates).
 - Version number of the crate in `Cargo.lock.msrv`
 
@@ -249,7 +249,7 @@ should contain links to relevant PR / PRs.
 
 ```
 The ScyllaDB team is pleased to announce ScyllaDB Rust Driver X.Y.Z,
-an asynchronous CQL driver for Rust, optimized for Scylla, but also compatible with Apache Cassandra!
+an asynchronous CQL driver for Rust, optimized for ScyllaDB, but also compatible with Apache Cassandra!
 
 Some interesting statistics:
 
@@ -300,4 +300,3 @@ Contributors since the last release:
 | 17      | Mercedes Marks    |
 
 ```
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a client-side driver for [ScyllaDB] written in pure Rust with a fully as
 Although optimized for ScyllaDB, the driver is also compatible with [Apache Cassandra®].
 
 ## Getting Started
-The [documentation book](https://rust-driver.docs.scylladb.com/stable/index.html) is a good place to get started. Another useful resource is the Rust and Scylla [lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University.
+The [documentation book](https://rust-driver.docs.scylladb.com/stable/index.html) is a good place to get started. Another useful resource is the Rust and ScyllaDB [lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University.
 
 ## Examples
 ```rust
@@ -27,7 +27,7 @@ while let Some((a, b, c)) = stream.try_next().await? {
 ```
 
 Please see the full [example](examples/basic.rs) program for more information.
-You can also run the example as follows if you have a Scylla server running:
+You can also run the example as follows if you have a ScyllaDB server running:
 
 ```sh
 SCYLLA_URI="127.0.0.1:9042" cargo run --example basic

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,6 @@
 [book]
-title = "Scylla Rust Driver"
-description = "Documentation for Scylla Rust Driver"
+title = "ScyllaDB Rust Driver"
+description = "Documentation for ScyllaDB Rust Driver"
 authors = []
 language = "en"
 multilingual = false
@@ -16,8 +16,8 @@ git-repository-url = "https://github.com/scylladb/scylla-rust-driver"
 [preprocessor.sphinx]
 command = '''bash -c '
 if test -f "./docs/sphinx_preprocessor.py"; then
-    python ./docs/sphinx_preprocessor.py "$@" 
-else 
+    python ./docs/sphinx_preprocessor.py "$@"
+else
     python ./sphinx_preprocessor.py "$@"
 fi' run_preprocessor
 '''

--- a/docs/source/SUMMARY.md
+++ b/docs/source/SUMMARY.md
@@ -1,10 +1,10 @@
 # Summary
 
-[Scylla Rust Driver](index.md)
+[ScyllaDB Rust Driver](index.md)
 
 - [Quick start](quickstart/quickstart.md)
     - [Creating a project](quickstart/create-project.md)
-    - [Running Scylla using Docker](quickstart/scylla-docker.md)
+    - [Running ScyllaDB using Docker](quickstart/scylla-docker.md)
     - [Connecting and executing a simple CQL statement](quickstart/example.md)
 
 - [Migration guides](migration-guides/migration-guides.md)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,9 +49,9 @@ autosectionlabel_prefix_document = True
 master_doc = 'contents'
 
 # General information about the project.
-project = 'Scylla Rust Driver'
+project = 'ScyllaDB Rust Driver'
 copyright = str(date.today().year) + ', ScyllaDB. All rights reserved.'
-author = u'Scylla Project Contributors'
+author = u'ScyllaDB Project Contributors'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -116,7 +116,7 @@ html_theme_options = {
     'github_repository': 'scylladb/scylla-rust-driver',
     'github_issues_repository': 'scylladb/scylla-rust-driver',
     'hide_banner': 'true',
-    'site_description': 'Scylla Driver for Rust.',
+    'site_description': 'ScyllaDB Driver for Rust.',
     'hide_edit_this_page_button': 'false',
     'hide_feedback_buttons': 'false',
     'versions_unstable': UNSTABLE_VERSIONS,

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -1,6 +1,6 @@
 # Connecting to the cluster
 
-Scylla is a distributed database, which means that it operates on multiple nodes running independently.
+ScyllaDB is a distributed database, which means that it operates on multiple nodes running independently.
 When creating a `Session` you can specify a few known nodes to which the driver will try connecting:
 ```rust
 # extern crate scylla;
@@ -56,9 +56,9 @@ If you need to share `Session` with different threads / Tokio tasks etc. use `Ar
 The driver refreshes the cluster metadata periodically, which contains information about cluster topology as well as the cluster schema. By default, the driver refreshes the cluster metadata every 60 seconds.
 However, you can set the `cluster_metadata_refresh_interval` to a non-negative value to periodically refresh the cluster metadata. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
 
-## Scylla Cloud Serverless
+## ScyllaDB Cloud Serverless
 
-Scylla Serverless is an elastic and dynamic deployment model. When creating a `Session` you need to
+ScyllaDB Serverless is an elastic and dynamic deployment model. When creating a `Session` you need to
 specify the secure connection bundle as follows:
 
 ```rust

--- a/docs/source/data-types/udt.md
+++ b/docs/source/data-types/udt.md
@@ -1,5 +1,5 @@
 # User defined types
-Scylla allows users to define their own data types with named fields (See [the official documentation](https://opensource.docs.scylladb.com/stable/cql/types.html#user-defined-types))\
+ScyllaDB allows users to define their own data types with named fields (See [the official documentation](https://opensource.docs.scylladb.com/stable/cql/types.html#user-defined-types))\
 To use user defined types in the driver, you can create a corresponding struct in Rust, and use it to read and write UDT values.
 
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,13 +1,13 @@
-# Scylla Rust Driver
+# ScyllaDB Rust Driver
 This book contains documentation for [scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver) - a driver
-for the [Scylla](https://scylladb.com) database written in Rust.
+for [ScyllaDB](https://scylladb.com) written in Rust.
 Although optimized for Scylla, the driver is also compatible with [Apache Cassandra®](https://cassandra.apache.org/).
 
 ### Other documentation
 * [Examples](https://github.com/scylladb/scylla-rust-driver/tree/main/examples)
-* [Rust and Scylla lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University
+* [Rust and ScyllaDB lesson](https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/) on Scylla University
 * [API documentation](https://docs.rs/scylla)
-* [Scylla documentation](https://docs.scylladb.com)
+* [ScyllaDB documentation](https://docs.scylladb.com)
 * [Cassandra® documentation](https://cassandra.apache.org/doc/latest/)
 
 

--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -1,6 +1,6 @@
 # DefaultPolicy
 
-`DefaultPolicy` is the default load balancing policy in Scylla Rust Driver. It
+`DefaultPolicy` is the default load balancing policy in ScyllaDB Rust Driver. It
 can be configured to be datacenter-aware and token-aware. Datacenter failover
 for queries with non-local consistency mode is also supported.
 

--- a/docs/source/quickstart/quickstart.md
+++ b/docs/source/quickstart/quickstart.md
@@ -8,7 +8,7 @@ Topics Include:
 
 * [Create a Rust Project](create-project.md)
 * [Example](example.md)
-* [Install Scylla with Docker](scylla-docker.md)
+* [Install ScyllaDB with Docker](scylla-docker.md)
 
 
 ```{eval-rst}

--- a/docs/source/quickstart/scylla-docker.md
+++ b/docs/source/quickstart/scylla-docker.md
@@ -1,10 +1,10 @@
-# Running Scylla using Docker
+# Running ScyllaDB using Docker
 
-To make queries we will need a running Scylla instance. The easiest way is to use a [Docker](https://www.docker.com/) image.\
+To make queries we will need a running ScyllaDB instance. The easiest way is to use a [Docker](https://www.docker.com/) image.\
 Please [install Docker](https://docs.docker.com/engine/install) if it's not installed.
 
 ### Running scylla
-To start Scylla run:
+To start ScyllaDB run:
 ```bash
 # on Linux sudo might be required
 docker run --rm -it -p 9042:9042 scylladb/scylla --smp 2
@@ -14,10 +14,9 @@ Docker will download the image, then after minute or two there should be a messa
 ```shell
 Starting listening for CQL clients on 172.17.0.2:9042
 ```
-This means that Scylla is ready to receive queries
+This means that ScyllaDB is ready to receive queries
 
 To stop this instance press `Ctrl + C`
 
 ### More information
 More information about this image can be found on [dockerhub](https://hub.docker.com/r/scylladb/scylla)
-

--- a/docs/source/retry-policy/downgrading-consistency.md
+++ b/docs/source/retry-policy/downgrading-consistency.md
@@ -25,12 +25,12 @@ The lower consistency level to use for retries is determined by the following ru
   - if 1, 2 or 3 replicas responded, use the corresponding level `Consistency::One`, `Consistency::Two` or
       `Consistency::Three`.
 
-Note that if the initial consistency level was `Consistency::EachQuorum`, Scylla returns the number
+Note that if the initial consistency level was `Consistency::EachQuorum`, ScyllaDB returns the number
 of live replicas _in the datacenter that failed to reach consistency_, not the overall
 number in the cluster. Therefore if this number is 0, we still retry at `Consistency::One`, on the
 assumption that a host may still be up in another datacenter.
 The reasoning being this retry policy is the following one. If, based on the information the
-Scylla coordinator node returns, retrying the operation with the initially requested
+ScyllaDB coordinator node returns, retrying the operation with the initially requested
 consistency has a chance to succeed, do it. Otherwise, if based on this information we know
 **the initially requested consistency level cannot be achieved currently**, then:
   - For writes, ignore the exception (thus silently failing the consistency requirement) if we

--- a/docs/source/statements/lwt.md
+++ b/docs/source/statements/lwt.md
@@ -4,7 +4,7 @@ A lightweight transaction statement can be expressed just like any other stateme
 
 
 ### Format of the statement
-A lightweight transaction statement is not a separate type - it can be expressed just like any other statements: via `Statement`, `PreparedStatement`, batches, and so on. The difference lays in the statement string itself - when it contains a condition (e.g. `IF NOT EXISTS`), it becomes a lightweight transaction. It's important to remember that CQL specification requires a separate, additional consistency level to be defined for LWT statements - `serial_consistency_level`. The serial consistency level can only be set to two values: `SerialConsistency::Serial` or `SerialConsistency::LocalSerial`. The "local" variant makes the transaction consistent only within the same datacenter. For convenience, Scylla Rust Driver sets the default consistency level to `LocalSerial`, as it's more commonly used. For cross-datacenter consistency, please remember to always override the default with `SerialConsistency::Serial`.
+A lightweight transaction statement is not a separate type - it can be expressed just like any other statements: via `Statement`, `PreparedStatement`, batches, and so on. The difference lays in the statement string itself - when it contains a condition (e.g. `IF NOT EXISTS`), it becomes a lightweight transaction. It's important to remember that CQL specification requires a separate, additional consistency level to be defined for LWT statements - `serial_consistency_level`. The serial consistency level can only be set to two values: `SerialConsistency::Serial` or `SerialConsistency::LocalSerial`. The "local" variant makes the transaction consistent only within the same datacenter. For convenience, ScyllaDB Rust Driver sets the default consistency level to `LocalSerial`, as it's more commonly used. For cross-datacenter consistency, please remember to always override the default with `SerialConsistency::Serial`.
 ```rust
 # extern crate scylla;
 # use scylla::client::session::Session;
@@ -29,4 +29,3 @@ session.query_unpaged(my_statement, (to_insert,)).await?;
 The rest of the API remains identical for LWT and non-LWT statements.
 
 See [Statement API documentation](https://docs.rs/scylla/latest/scylla/statement/struct.Statement.html) for more options
-

--- a/docs/source/tracing/tracing.md
+++ b/docs/source/tracing/tracing.md
@@ -6,7 +6,7 @@ There are two separate ways to get information about what happened with a query:
 ### Tracing
 
 Tracing is a feature provided by Scylla. When sending a query we can set a flag that signifies that we would like it to be traced.
-After completing the query Scylla provides a `tracing_id` which can be used to fetch information about it - which nodes it was sent to, what operations were performed etc.
+After completing the query ScyllaDB provides a `tracing_id` which can be used to fetch information about it - which nodes it was sent to, what operations were performed etc.
 
 Queries that support tracing:
 * [`Session::query_unpaged()`](basic.md)
@@ -17,7 +17,7 @@ Queries that support tracing:
 * [`Session::prepare()`](prepare.md)
 
 After obtaining the tracing id you can use `Session::get_tracing_info()` to query tracing information.\
-`TracingInfo` contains values that are the same in Scylla and Cassandra®, skipping any database-specific ones.\
+`TracingInfo` contains values that are the same in ScyllaDB and Cassandra®, skipping any database-specific ones.\
 If `TracingInfo` does not contain some needed value it's possible to query it manually from the tables
 `system_traces.sessions` and `system_traces.events`
 

--- a/scylla/src/client/self_identity.rs
+++ b/scylla/src/client/self_identity.rs
@@ -22,7 +22,7 @@ pub struct SelfIdentity<'id> {
     //   application variables are not.
     //
     // ### A:
-    // The following options are not exposed anywhere in Scylla tables.
+    // The following options are not exposed anywhere in ScyllaDB tables.
     // They come directly from CPP driver, and they are supported in Cassandra
     //
     // See https://github.com/scylladb/cpp-driver/blob/fa0f27069a625057984d1fa58f434ea99b86c83f/include/cassandra.h#L2916.

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -189,7 +189,7 @@ pub struct SessionConfig {
     pub connect_timeout: Duration,
 
     /// Size of the per-node connection pool, i.e. how many connections the driver should keep to each node.
-    /// The default is `PerShard(1)`, which is the recommended setting for Scylla clusters.
+    /// The default is `PerShard(1)`, which is the recommended setting for ScyllaDB clusters.
     pub connection_pool_size: PoolSize,
 
     /// If true, prevents the driver from connecting to the shard-aware port, even if the node supports it.

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -662,7 +662,7 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// use scylla::client::PoolSize;
     ///
     /// // This session will establish 4 connections to each node.
-    /// // For Scylla clusters, this number will be divided across shards
+    /// // For ScyllaDB clusters, this number will be divided across shards
     /// let session: Session = SessionBuilder::new()
     ///     .known_node("127.0.0.1:9042")
     ///     .pool_size(PoolSize::PerHost(NonZeroUsize::new(4).unwrap()))
@@ -688,7 +688,7 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     ///
     /// In order to be able to use the shard-aware port effectively, the port needs to be
     /// reachable and not behind a NAT which changes source ports (the driver uses the source port
-    /// to tell Scylla which shard to assign). However, the driver is designed to behave in a robust
+    /// to tell ScyllaDB which shard to assign). However, the driver is designed to behave in a robust
     /// way if those conditions are not met - if the driver fails to connect to the port or gets
     /// a connection to the wrong shard, it will re-attempt the connection to the regular transport port.
     ///

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -418,10 +418,10 @@ mod deserialize {
         // +optional
         clientKeyPath: Option<String>,
 
-        // Username is the username for basic authentication to the Scylla cluster.
+        // Username is the username for basic authentication to the ScyllaDB cluster.
         // +optional
         username: Option<String>,
-        // Password is the password for basic authentication to the Scylla cluster.
+        // Password is the password for basic authentication to the ScyllaDB cluster.
         // +optional
         password: Option<String>,
     }
@@ -437,7 +437,7 @@ mod deserialize {
         // +optional
         certificateAuthorityData: Option<String>,
 
-        // Server is the initial contact point of the Scylla cluster.
+        // Server is the initial contact point of the ScyllaDB cluster.
         // Example: https://hostname:port
         server: String,
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -26,7 +26,7 @@ use std::{
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
 
 /// This enum is introduced to support address translation only upon opening a connection,
-/// as well as to cope with a bug present in older Cassandra and Scylla releases.
+/// as well as to cope with a bug present in older Cassandra and ScyllaDB releases.
 /// The bug involves misconfiguration of rpc_address and/or broadcast_rpc_address
 /// in system.local to 0.0.0.0. Mitigation involves replacing the faulty address
 /// with connection's address, but then that address must not be subject to `AddressTranslator`,

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -34,7 +34,7 @@ use tracing::{debug, error, trace, warn};
 pub enum PoolSize {
     /// Indicates that the pool should establish given number of connections to the node.
     ///
-    /// If this option is used with a Scylla cluster, it is not guaranteed that connections will be
+    /// If this option is used with a ScyllaDB cluster, it is not guaranteed that connections will be
     /// distributed evenly across shards. Use this option if you cannot use the shard-aware port
     /// and you suffer from the "connection storm" problems.
     PerHost(NonZeroUsize),
@@ -43,7 +43,7 @@ pub enum PoolSize {
     ///
     /// Cassandra nodes will be treated as if they have only one shard.
     ///
-    /// The recommended setting for Scylla is one connection per shard - `PerShard(1)`.
+    /// The recommended setting for ScyllaDB is one connection per shard - `PerShard(1)`.
     PerShard(NonZeroUsize),
 }
 
@@ -492,15 +492,15 @@ struct PoolRefiller {
     connection_errors:
         FuturesUnordered<Pin<Box<dyn Future<Output = BrokenConnectionEvent> + Send + 'static>>>,
 
-    // When connecting, Scylla always assigns the shard which handles the least
+    // When connecting, ScyllaDB always assigns the shard which handles the least
     // number of connections. If there are some non-shard-aware clients
     // connected to the same node, they might cause the shard distribution
-    // to be heavily biased and Scylla will be very reluctant to assign some shards.
+    // to be heavily biased and ScyllaDB will be very reluctant to assign some shards.
     //
     // In order to combat this, if the pool is not full and we get a connection
     // for a shard which was already filled, we keep those additional connections
-    // in order to affect how Scylla assigns shards. A similar method is used
-    // in Scylla's forks of the java and gocql drivers.
+    // in order to affect how ScyllaDB assigns shards. A similar method is used
+    // in ScyllaDB's forks of the java and gocql drivers.
     //
     // The number of those connections is bounded by the number of shards multiplied
     // by a constant factor, and are all closed when they exceed this number.
@@ -729,8 +729,8 @@ impl PoolRefiller {
                 .map(|conns| target.get().saturating_sub(conns.len()))
                 .sum::<usize>(),
         };
-        // When connecting to Scylla through non-shard-aware port,
-        // Scylla alone will choose shards for us. We hope that
+        // When connecting to ScyllaDB through non-shard-aware port,
+        // ScyllaDB alone will choose shards for us. We hope that
         // they will distribute across shards in the way we want,
         // but we have no guarantee, so we might have to retry
         // connecting later.
@@ -861,7 +861,7 @@ impl PoolRefiller {
 
                     self.start_opening_connection(None);
                 } else {
-                    // We got unlucky and Scylla didn't distribute
+                    // We got unlucky and ScyllaDB didn't distribute
                     // shards across connections evenly.
                     // We will retry in the next iteration,
                     // for now put it into the excess connection

--- a/scylla/src/network/mod.rs
+++ b/scylla/src/network/mod.rs
@@ -1,7 +1,7 @@
 //! This module holds entities that represent connections to the cluster
 //! and management over those connections (connection pooling).
 //! This includes two main abstractions:
-//! - Connection - a single, possibly encrypted, connection to a Scylla node over CQL protocol,
+//! - Connection - a single, possibly encrypted, connection to a ScyllaDB node over CQL protocol,
 //! - NodeConnectionPool - a manager that keeps a desired number of connections opened to each shard.
 
 mod connection;

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -93,7 +93,7 @@ impl RawTablet {
         };
 
         Some(Ok(RawTablet {
-            // +1 because Scylla sends left-open range, so received
+            // +1 because ScyllaDB sends left-open range, so received
             // number is the last token not belonging to this tablet.
             first_token: Token::new(first_token + 1),
             last_token: Token::new(last_token),
@@ -708,7 +708,7 @@ mod tests {
         custom_payload.insert(
             CUSTOM_PAYLOAD_TABLETS_V1_KEY.to_string(),
             // Skipping length because `SerializeValue::serialize` adds length at the
-            // start of serialized value while Scylla sends the value without initial
+            // start of serialized value while ScyllaDB sends the value without initial
             // length.
             Bytes::copy_from_slice(&data[4..]),
         );

--- a/scylla/src/routing/locator/token_ring.rs
+++ b/scylla/src/routing/locator/token_ring.rs
@@ -2,7 +2,7 @@ use crate::routing::Token;
 
 /// A token ring is a continuous hash ring. It defines association by hashing a key
 /// onto the ring and then walking the ring in one direction.
-/// Cassandra and Scylla use it for determining data ownership which allows for efficient load balancing.
+/// Cassandra and ScyllaDB use it for determining data ownership which allows for efficient load balancing.
 /// The token ring is used by the driver to find the replicas for a given token.
 /// Each ring member has a token (i64 number) which defines the member's position on the ring.
 /// The ring is circular and can be traversed in the order of increasing tokens.

--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use sharding::{ShardInfo, ShardingError};
 /// a valid token. It is used to represent infinity.
 /// For this reason tokens are normalized - i64::MIN
 /// is replaced with i64::MAX. See this fragment of
-/// Scylla code for more information:
+/// ScyllaDB code for more information:
 /// <https://github.com/scylladb/scylladb/blob/4be70bfc2bc7f133cab492b4aac7bab9c790a48c/dht/token.hh#L32>
 ///
 /// This struct is a wrapper over i64 that performs this normalization

--- a/scylla/src/routing/partitioner.rs
+++ b/scylla/src/routing/partitioner.rs
@@ -349,8 +349,8 @@ impl PartitionerHasher for CDCPartitionerHasher {
 
     fn finish(&self) -> Token {
         match self.state {
-            // Looking at Scylla code it seems that here we actually want token with this value.
-            // If the value is too short Scylla returns `dht::minimum_token()`:
+            // Looking at ScyllaDB code it seems that here we actually want token with this value.
+            // If the value is too short ScyllaDB returns `dht::minimum_token()`:
             // https://github.com/scylladb/scylladb/blob/4be70bfc2bc7f133cab492b4aac7bab9c790a48c/cdc/cdc_partitioner.cc#L32
             // When you call `long_token` on `minimum_token` it will actually return `i64::MIN`:
             // https://github.com/scylladb/scylladb/blob/0a7854ea4de04f20b71326ba5940b5fac6f7241a/dht/token.cc#L21-L35

--- a/scylla/src/routing/sharding.rs
+++ b/scylla/src/routing/sharding.rs
@@ -96,7 +96,7 @@ impl Sharder {
         (((biased_token as u128) * (self.nr_shards.get() as u128)) >> 64) as Shard
     }
 
-    /// If we connect to Scylla using Scylla's shard aware port, then Scylla assigns a shard to the
+    /// If we connect to ScyllaDB using ScyllaDB's shard aware port, then ScyllaDB assigns a shard to the
     /// connection based on the source port. This calculates the assigned shard.
     pub fn shard_of_source_port(&self, source_port: u16) -> Shard {
         (source_port % self.nr_shards.get()) as Shard

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -118,7 +118,7 @@ pub(crate) fn create_new_session_builder() -> GenericSessionBuilder<impl Session
 
     // The reason why we enable so long waiting for TracingInfo is... Cassandra. (Yes, again.)
     // In Cassandra Java Driver, the wait time for tracing info is 10 seconds, so here we do the same.
-    // However, as Scylla usually gets TracingInfo ready really fast (our default interval is hence 3ms),
+    // However, as ScyllaDB usually gets TracingInfo ready really fast (our default interval is hence 3ms),
     // we stick to a not-so-much-terribly-long interval here.
     session_builder
         .tracing_info_fetch_attempts(NonZeroU32::new(200).unwrap())
@@ -149,7 +149,7 @@ impl LoadBalancingPolicy for SchemaQueriesLBP {
         _query: &'a RoutingInfo,
         cluster: &'a ClusterState,
     ) -> Option<(NodeRef<'a>, Option<Shard>)> {
-        // I'm not sure if Scylla can handle concurrent DDL queries to different shard,
+        // I'm not sure if ScyllaDB can handle concurrent DDL queries to different shard,
         // in other words if its local lock is per-node or per shard.
         // Just to be safe, let's use explicit shard.
         cluster.get_nodes_info().first().map(|node| (node, Some(0)))
@@ -184,7 +184,7 @@ impl RetrySession for SchemaQueriesRetrySession {
                 // In this case we really should do something about it in the
                 // core, because it is absurd for DDL queries to fail this often.
                 if self.count >= 10 {
-                    error!("Received TENTH(!) group 0 concurrent modification error during DDL. Please fix Scylla Core.");
+                    error!("Received TENTH(!) group 0 concurrent modification error during DDL. Please fix ScyllaDB Core.");
                     RetryDecision::DontRetry
                 } else {
                     warn!("Received group 0 concurrent modification error during DDL. Performing retry #{}.", self.count);

--- a/scylla/tests/integration/ccm/lib/cluster.rs
+++ b/scylla/tests/integration/ccm/lib/cluster.rs
@@ -24,9 +24,9 @@ pub(crate) const DEFAULT_SMP: u16 = 1;
 pub(crate) struct ClusterOptions {
     /// Cluster Name
     pub(crate) name: String,
-    /// What to database to run: Scylla or Cassandra
+    /// What to database to run: ScyllaDB or Cassandra
     pub(crate) db_type: DBType,
-    /// Scylla or Cassandra version string that goes to CCM.
+    /// ScyllaDB or Cassandra version string that goes to CCM.
     /// Examples: `release:6.2.2`, `unstable:master/2021-05-24T17:16:53Z`
     pub(crate) version: String,
     /// CCM allocates node ip addresses based on this prefix:


### PR DESCRIPTION
This name change has been widely adopted in the company's products, documentation, and marketing materials. However, the Rust Driver retained much of the legacy naming, which is now updated.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
