### PR TITLE
serialize: support `Bytes` -> CQL `blob` conversion

### DIFF
--- a/docs/source/data-types/blob.md
+++ b/docs/source/data-types/blob.md
@@ -1,5 +1,9 @@
 # Blob
-`Blob` is represented as `Vec<u8>`
+`Blob` is represented as one of:
+- `&[u8]`,
+- `Vec<u8>`,
+- `bytes::Bytes`,
+- `[u8; N]` (only serialization supported).
 
 
 ```rust

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -18,7 +18,7 @@ Database types and their Rust equivalents:
 * `Double` <----> `f64`
 * `Ascii`, `Text`, `Varchar` <----> `&str`, `String`, `Box<str>`, `Arc<str>`
 * `Counter` <----> `value::Counter`
-* `Blob` <----> `Vec<u8>`
+* `Blob` <----> `&[u8]`, `Vec<u8>`, `Bytes`, (and `[u8; N]` for serialization only)
 * `Inet` <----> `std::net::IpAddr`
 * `Uuid` <----> `uuid::Uuid`
 * `Timeuuid` <----> `value::CqlTimeuuid`

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -10,6 +10,7 @@ use std::net::IpAddr;
 use std::ops::Deref as _;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -323,6 +324,14 @@ impl<const N: usize> SerializeValue for [u8; N] {
         exact_type_check!(typ, Blob);
         writer
             .set_value(me.as_ref())
+            .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
+    });
+}
+impl SerializeValue for Bytes {
+    impl_serialize_via_writer!(|me, typ, writer| {
+        exact_type_check!(typ, Blob);
+        writer
+            .set_value(me)
             .map_err(|_| mk_ser_err::<Self>(typ, BuiltinSerializationErrorKind::SizeOverflow))?
     });
 }

--- a/scylla-cql/src/serialize/value_tests.rs
+++ b/scylla-cql/src/serialize/value_tests.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
+use bytes::Bytes;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -1828,6 +1829,15 @@ fn u8_slice_serialization() {
     let val = vec![1u8, 1, 1, 1];
     assert_eq!(
         do_serialize(val.as_slice(), &ColumnType::Native(NativeType::Blob)),
+        vec![0, 0, 0, 4, 1, 1, 1, 1]
+    );
+}
+
+#[test]
+fn bytes_serialization() {
+    let val = Bytes::from_static(&[1u8, 1, 1, 1]);
+    assert_eq!(
+        do_serialize(val, &ColumnType::Native(NativeType::Blob)),
         vec![0, 0, 0, 4, 1, 1, 1, 1]
     );
 }


### PR DESCRIPTION
Fixes: #1394

As noted in the issue, deserialization of `blob` to `Bytes` was supported, yet serialization in the opposite way was not possible, bringing major inconvenience to work with slices in UDT instead.

Such serialization has been thus added. Docs on `blob` has been updated.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
