### PR TITLE
scylla: Write missing docstrings

### DIFF
--- a/scylla-cql/benches/benchmark.rs
+++ b/scylla-cql/benches/benchmark.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::borrow::Cow;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -140,6 +140,7 @@ required-features = ["unstable-testing"]
 [lints.rust]
 unnameable_types = "warn"
 unreachable_pub = "warn"
+missing-docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(scylla_cloud_tests)',
     'cfg(cassandra_tests)',

--- a/scylla/benches/benchmark.rs
+++ b/scylla/benches/benchmark.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use bytes::BytesMut;

--- a/scylla/src/authentication/mod.rs
+++ b/scylla/src/authentication/mod.rs
@@ -1,3 +1,5 @@
+//! Traits and implementations for custom authentication against a server.
+
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
 
@@ -25,7 +27,7 @@ pub trait AuthenticatorSession: Send + Sync {
 /// Trait used to represent a factory of [`AuthenticatorSession`] instances.
 /// A new [`AuthenticatorSession`] instance will be created for each session.
 ///
-/// The custom authenticator can be set using SessionBuilder::authenticator_provider method.  
+/// The custom authenticator can be set using SessionBuilder::authenticator_provider method.
 ///
 /// Default: [`PlainTextAuthenticator`] is the default authenticator which requires username and
 /// password. It can be set by using SessionBuilder::user(\"user\", \"pass\") method.

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -1,3 +1,6 @@
+//! Provides a convenient wrapper over the [`Session`] that caches
+//! prepared statements automatically and reuses them when possible.
+
 use crate::errors::{ExecutionError, PagerExecutionError, PrepareError};
 use crate::response::query_result::QueryResult;
 use crate::response::{PagingState, PagingStateResponse};
@@ -63,6 +66,7 @@ impl<S> CachingSession<S>
 where
     S: Default + BuildHasher + Clone,
 {
+    /// Builds a [`CachingSession`] from a [`Session`] and a cache size.
     pub fn from(session: Session, cache_size: usize) -> Self {
         Self {
             session: Arc::new(session),
@@ -246,10 +250,12 @@ where
         }
     }
 
+    /// Retrieves the maximum capacity of the prepared statements cache.
     pub fn get_max_capacity(&self) -> usize {
         self.max_capacity
     }
 
+    /// Retrieves the underlying [Session] instance.
     pub fn get_session(&self) -> &Session {
         &self.session
     }
@@ -297,11 +303,12 @@ where
 impl CachingSessionBuilder<RandomState> {
     /// Wraps a [Session] and creates a new [CachingSessionBuilder] instance,
     /// which can be used to create a new [CachingSession].
-    ///
     pub fn new(session: Session) -> Self {
         Self::new_shared(Arc::new(session))
     }
 
+    /// Wraps an Arc<[Session]> and creates a new [CachingSessionBuilder] instance,
+    /// which can be used to create a new [CachingSession].
     pub fn new_shared(session: Arc<Session>) -> Self {
         Self {
             session,

--- a/scylla/src/client/self_identity.rs
+++ b/scylla/src/client/self_identity.rs
@@ -4,46 +4,52 @@ use std::borrow::Cow;
 /// to be sent in STARTUP message.
 #[derive(Debug, Clone, Default)]
 pub struct SelfIdentity<'id> {
-    // Custom driver identity can be set if a custom driver build is running,
-    // or an entirely different driver is operating on top of Rust driver
-    // (e.g. cpp-rust-driver).
+    /// Custom driver identity can be set if a custom driver build is running,
+    /// or an entirely different driver is operating on top of Rust driver
+    /// (e.g. cpp-rust-driver).
     custom_driver_name: Option<Cow<'id, str>>,
+    /// Custom driver identity can be set if a custom driver build is running,
+    /// or an entirely different driver is operating on top of Rust driver
+    /// (e.g. cpp-rust-driver).
     custom_driver_version: Option<Cow<'id, str>>,
 
     // ### Q: Where do APPLICATION_NAME, APPLICATION_VERSION and CLIENT_ID come from?
     // - there are no columns in system.clients dedicated to those attributes,
     // - APPLICATION_NAME / APPLICATION_VERSION are not present in Scylla's source code at all,
     // - only 2 results in Cassandra source is some example in docs:
-    //   https://github.com/apache/cassandra/blob/d3cbf9c1f72057d2a5da9df8ed567d20cd272931/doc/modules/cassandra/pages/managing/operating/virtualtables.adoc?plain=1#L218.
+    //   <https://github.com/apache/cassandra/blob/d3cbf9c1f72057d2a5da9df8ed567d20cd272931/doc/modules/cassandra/pages/managing/operating/virtualtables.adoc?plain=1#L218>.
     //   APPLICATION_NAME and APPLICATION_VERSION appears in client_options which
     //   is an arbitrary dict where client can send any keys.
     // - driver variables are mentioned in protocol v5
-    //   (https://github.com/apache/cassandra/blob/d3cbf9c1f72057d2a5da9df8ed567d20cd272931/doc/native_protocol_v5.spec#L480),
+    //   (<https://github.com/apache/cassandra/blob/d3cbf9c1f72057d2a5da9df8ed567d20cd272931/doc/native_protocol_v5.spec#L480>),
     //   application variables are not.
     //
     // ### A:
     // The following options are not exposed anywhere in ScyllaDB tables.
     // They come directly from CPP driver, and they are supported in Cassandra
     //
-    // See https://github.com/scylladb/cpp-driver/blob/fa0f27069a625057984d1fa58f434ea99b86c83f/include/cassandra.h#L2916.
+    // See <https://github.com/scylladb/cpp-driver/blob/fa0f27069a625057984d1fa58f434ea99b86c83f/include/cassandra.h#L2916>.
     // As we want to support as big subset of its API as possible in cpp-rust-driver, I decided to expose API for setting
     // those particular key-value pairs, similarly to what cpp-driver does, and not an API to set arbitrary key-value pairs.
     //
     // Allowing users to set arbitrary options could break the driver by overwriting options that bear special meaning,
     // e.g. the shard-aware port. Therefore, I'm against such liberal API. OTOH, we need to expose APPLICATION_NAME,
     // APPLICATION_VERSION and CLIENT_ID for cpp-rust-driver.
-
-    // Application identity can be set to distinguish different applications
-    // connected to the same cluster.
+    /// Application identity can be set to distinguish different applications
+    /// connected to the same cluster.
     application_name: Option<Cow<'id, str>>,
+    /// Application identity can be set to distinguish different applications
+    /// connected to the same cluster.
     application_version: Option<Cow<'id, str>>,
 
-    // A (unique) client ID can be set to distinguish different instances
-    // of the same application connected to the same cluster.
+    /// A (unique) client ID can be set to distinguish different instances
+    /// of the same application connected to the same cluster.
     client_id: Option<Cow<'id, str>>,
 }
 
 impl<'id> SelfIdentity<'id> {
+    /// Creates a new empty instance of [`SelfIdentity`], which has all fields
+    /// set to `None`.
     pub fn new() -> Self {
         Self::default()
     }

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -173,19 +173,41 @@ pub struct SessionConfig {
     /// Preferred compression algorithm to use on connections.
     /// If it's not supported by database server Session will fall back to no compression.
     pub compression: Option<Compression>,
+
+    /// Whether to set the nodelay TCP flag.
     pub tcp_nodelay: bool,
+
+    /// TCP keepalive interval, which means how often keepalive messages
+    /// are sent **on TCP layer** when a connection is idle.
+    /// If `None`, no TCP keepalive messages are sent.
     pub tcp_keepalive_interval: Option<Duration>,
 
+    /// Handle to the default execution profile, which is used
+    /// for all statements that do not specify an execution profile.
     pub default_execution_profile_handle: ExecutionProfileHandle,
 
+    /// Keyspace to be used on all connections.
+    /// Each connection will send `"USE <keyspace_name>"` before sending any requests.
+    /// This can be later changed with [`Session::use_keyspace`].
     pub used_keyspace: Option<String>,
+
+    /// Whether the keyspace name is case-sensitive.
+    /// This is used to determine how the keyspace name is sent to the server:
+    /// - if case-insensitive, it is sent as-is,
+    /// - if case-sensitive, it is enclosed in double quotes.
     pub keyspace_case_sensitive: bool,
 
-    /// Provide our Session with TLS
+    /// TLS context used configure TLS connections to DB nodes.
     pub tls_context: Option<TlsContext>,
 
+    /// Custom authenticator provider to create an authenticator instance
+    /// upon session creation.
     pub authenticator: Option<Arc<dyn AuthenticatorProvider>>,
 
+    /// Timeout for establishing connections to a node.
+    ///
+    /// If it's higher than underlying os's default connection timeout, it won't have
+    /// any effect.
     pub connect_timeout: Duration,
 
     /// Size of the per-node connection pool, i.e. how many connections the driver should keep to each node.

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -124,11 +124,15 @@ impl std::fmt::Debug for Session {
     }
 }
 
+/// Represents a TLS context used to configure TLS connections to DB nodes.
+/// Abstracts over various TLS implementations, such as OpenSSL and Rustls.
 #[derive(Clone)] // Cheaply clonable - reference counted.
 #[non_exhaustive]
 pub enum TlsContext {
+    /// TLS context backed by OpenSSL 0.10.
     #[cfg(feature = "openssl-010")]
     OpenSsl010(openssl::ssl::SslContext),
+    /// TLS context backed by Rustls 0.23.
     #[cfg(feature = "rustls-023")]
     Rustls023(Arc<rustls::ClientConfig>),
 }

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -31,15 +31,23 @@ mod sealed {
     #[expect(unnameable_types)]
     pub trait Sealed {}
 }
+/// Kind of the session builder, used to distinguish between
+/// builders that create regular sessions and those that create custom
+/// sessions, such as cloud sessions.
+/// This is used to conditionally enable different sets of methods
+/// on the session builder based on its kind.
 pub trait SessionBuilderKind: sealed::Sealed + Clone {}
 
+/// Default session builder kind, used to create regular sessions.
 #[derive(Clone)]
 pub enum DefaultMode {}
 impl sealed::Sealed for DefaultMode {}
 impl SessionBuilderKind for DefaultMode {}
 
+/// Builder for regular sessions.
 pub type SessionBuilder = GenericSessionBuilder<DefaultMode>;
 
+/// Session builder kind for creating cloud sessions.
 #[cfg(feature = "unstable-cloud")]
 #[derive(Clone)]
 pub enum CloudMode {}
@@ -48,10 +56,17 @@ impl sealed::Sealed for CloudMode {}
 #[cfg(feature = "unstable-cloud")]
 impl SessionBuilderKind for CloudMode {}
 
+/// Builder for sessions that connect to Scylla Cloud.
 #[cfg(feature = "unstable-cloud")]
 pub type CloudSessionBuilder = GenericSessionBuilder<CloudMode>;
 
-/// SessionBuilder is used to create new Session instances
+/// Used to conveniently configure new Session instances.
+///
+/// Most likely you will want to use [`SessionBuilder`]
+/// (for building regular session). If you want to build a session
+/// that connects to Scylla Cloud, you will want to use
+/// `CloudSessionBuilder`.
+///
 /// # Example
 ///
 /// ```
@@ -69,6 +84,7 @@ pub type CloudSessionBuilder = GenericSessionBuilder<CloudMode>;
 /// ```
 #[derive(Clone)]
 pub struct GenericSessionBuilder<Kind: SessionBuilderKind> {
+    /// Configuration for the session being built.
     pub config: SessionConfig,
     kind: PhantomData<Kind>,
 }

--- a/scylla/src/cloud/config.rs
+++ b/scylla/src/cloud/config.rs
@@ -14,21 +14,27 @@ use crate::errors::TranslationError;
 use crate::network::tls::{TlsConfig, TlsError};
 use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 
+/// Error that can occur while parsing the cloud config yaml file.
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum CloudConfigError {
+    /// Error while opening cloud config yaml.
     #[error("Error while opening cloud config yaml: {0}")]
     YamlOpen(#[from] io::Error),
 
+    /// Error while parsing cloud config yaml.
     #[error("Error while parsing cloud config yaml: {0}")]
     YamlParse(#[from] serde_yaml::Error),
 
+    /// Error while decoding base64 key/cert.
     #[error("Error while decoding base64 key/cert: {0}")]
     Base64(#[from] base64::DecodeError),
 
+    /// Error during cloud config validation.
     #[error("Error during cloud config validation: {0}")]
     Validation(String),
 
+    /// Error during TLS key/cert parsing.
     #[error("Error during key/cert parsing: {0}")]
     Tls(#[from] TlsError),
 }
@@ -158,8 +164,10 @@ impl AddressTranslator for CloudConfig {
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum CloudTlsProvider {
+    /// OpenSSL 0.10 - backed TLS provider.
     #[cfg(feature = "openssl-010")]
     OpenSsl010,
+    /// Rustls 0.23 - backed TLS provider.
     #[cfg(feature = "rustls-023")]
     Rustls023,
 }

--- a/scylla/src/cloud/mod.rs
+++ b/scylla/src/cloud/mod.rs
@@ -1,3 +1,5 @@
+//! Support for connecting to ScyllaDB Serverless Cloud.
+
 mod config;
 
 pub use config::CloudConfig;

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -110,7 +110,7 @@ impl ClusterState {
                     let (peer_endpoint, tokens) = peer.into_peer_endpoint_and_tokens();
                     peer_tokens = tokens;
                     if node.address == peer_address {
-                        node.clone()
+                        Arc::clone(node)
                     } else {
                         // If IP changes, the Node struct is recreated, but the underlying pool is preserved and notified about the IP change.
                         Arc::new(Node::inherit_with_ip_changed(node, peer_endpoint))
@@ -131,10 +131,10 @@ impl ClusterState {
                 }
             };
 
-            new_known_peers.insert(peer_host_id, node.clone());
+            new_known_peers.insert(peer_host_id, Arc::clone(&node));
 
             for token in peer_tokens {
-                ring.push((token, node.clone()));
+                ring.push((token, Arc::clone(&node)));
             }
         }
 

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -102,6 +102,9 @@ pub mod _macro_internal {
 pub use scylla_cql::{DeserializeRow, DeserializeValue, SerializeRow, SerializeValue};
 
 pub mod value {
+    //! Defines CQL values of various types and their representations,
+    //! as well as conversion between them and other types.
+
     // Every `pub` item is re-exported here, apart from `deser_cql_value`.
     pub use scylla_cql::value::{
         Counter, CqlDate, CqlDecimal, CqlDecimalBorrowed, CqlDuration, CqlTime, CqlTimestamp,
@@ -110,6 +113,8 @@ pub mod value {
 }
 
 pub mod frame {
+    //! Abstractions of the CQL wire protocol.
+
     pub use scylla_cql::frame::{frame_errors, Authenticator, Compression};
     pub(crate) use scylla_cql::frame::{
         parse_response_body_extensions, protocol_features, read_response_frame, request,
@@ -117,13 +122,21 @@ pub mod frame {
     };
 
     pub mod types {
+        //! CQL binary protocol in-wire types.
+
         pub use scylla_cql::frame::types::{Consistency, SerialConsistency};
     }
 
     pub mod response {
+        //! CQL responses sent by the server.
+
         pub(crate) use scylla_cql::frame::response::*;
 
         pub mod result {
+            //! CQL protocol-level representation of a `RESULT` response.
+            //!
+            //! Contains lower-level types that are used to represent the result of a query.
+
             #[cfg(cpp_rust_unstable)]
             pub use scylla_cql::frame::response::result::DeserializedMetadataAndRawRows;
 

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -129,12 +129,16 @@ pub(crate) enum Tls {
 #[error(transparent)]
 #[non_exhaustive]
 pub enum TlsError {
+    /// Collection of errors coming from OpenSSL 0.10.
     #[cfg(feature = "openssl-010")]
     OpenSsl010(#[from] openssl::error::ErrorStack),
+    /// Invalid DNS name error, coming from rustls 0.23.
     #[cfg(feature = "rustls-023")]
     InvalidName(#[from] rustls::pki_types::InvalidDnsNameError),
+    /// PEM parsing error, coming from rustls 0.23.
     #[cfg(feature = "rustls-023")]
     PemParse(#[from] rustls::pki_types::pem::Error),
+    /// General error coming from rustls 0.23.
     #[cfg(feature = "rustls-023")]
     Rustls023(#[from] rustls::Error),
 }

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -1,3 +1,5 @@
+//! Collecting metrics of driver operations.
+
 use histogram::{AtomicHistogram, Histogram};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -9,8 +11,10 @@ const ORDER_TYPE: Ordering = Ordering::Relaxed;
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum MetricsError {
+    /// Computing histogram statistics failed.
     #[error("Histogram error: {0}")]
     HistogramError(#[from] Arc<dyn std::error::Error + Send + Sync>),
+    /// Histogram is empty, so statistics cannot be computed.
     #[error("Histogram is empty")]
     Empty,
 }
@@ -21,15 +25,25 @@ pub enum MetricsError {
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct Snapshot {
+    /// Minimum value in the histogram.
     pub min: u64,
+    /// Maximum value in the histogram.
     pub max: u64,
+    /// Mean value in the histogram.
     pub mean: u64,
+    /// Standard deviation of values in the histogram.
     pub stddev: u64,
+    /// Median value in the histogram.
     pub median: u64,
+    /// 75th percentile value in the histogram.
     pub percentile_75: u64,
+    /// 95th percentile value in the histogram.
     pub percentile_95: u64,
+    /// 98th percentile value in the histogram.
     pub percentile_98: u64,
+    /// 99th percentile value in the histogram.
     pub percentile_99: u64,
+    /// 99.9th percentile value in the histogram.
     pub percentile_99_9: u64,
 }
 
@@ -201,14 +215,23 @@ impl Default for RequestRateMeter {
     }
 }
 
+/// Various metrics collected by the driver.
 pub struct Metrics {
+    /// Number of errors that occurred in queries executed without `QueryPager`.
     errors_num: AtomicU64,
+    /// Number of queries executed without `QueryPager`.
     queries_num: AtomicU64,
+    /// Number of errors that occurred in queries executed with `QueryPager`.
     errors_iter_num: AtomicU64,
+    /// Number of queries executed with `QueryPager`.
     queries_iter_num: AtomicU64,
+    /// Number of times a retry policy has decided to retry a query.
     retries_num: AtomicU64,
+    /// Histogram that collects latencies of queries executed by the driver.
     histogram: Arc<AtomicHistogram>,
+    /// Collects rates of queries executed by the driver.
     meter: Arc<RequestRateMeter>,
+    /// Total number of connections ever opened to the cluster by the driver.
     total_connections: AtomicU64,
     connection_timeouts: AtomicU64,
     request_timeouts: AtomicU64,

--- a/scylla/src/observability/tracing.rs
+++ b/scylla/src/observability/tracing.rs
@@ -1,3 +1,13 @@
+//! Implements integration with cluster-side tracing mechanism.
+//!
+//! The mechanism is used to trace queries and their execution
+//! across the cluster, providing insights into query performance and execution flow.
+//!
+//! If user requests tracing for a query, the cluster will
+//! record the statement execution details in `system_traces.sessions` and `system_traces.events`,
+//! as well as return a tracing ID in the response, which can be used to query the tracing
+//! info later.
+
 use crate::value::CqlTimestamp;
 use crate::DeserializeRow;
 use itertools::Itertools;
@@ -10,15 +20,45 @@ use std::net::IpAddr;
 #[derive(Debug, DeserializeRow, Clone, PartialEq, Eq)]
 #[scylla(crate = "crate")]
 pub struct TracingInfo {
+    /// Address of the client that requested execution of the query.
     pub client: Option<IpAddr>,
+
+    /// Kind of a command that was executed, textually described.
+    ///
+    /// Example from the ScyllaDB documentation:
+    /// `QUERY`
     pub command: Option<String>,
+
+    /// Address of the coordinator node that executed the query.
     pub coordinator: Option<IpAddr>,
+
+    /// Duration of the query execution in microseconds.
     pub duration: Option<i32>,
+
+    /// Various parameters of the query execution.
+    ///
+    /// Example from the ScyllaDB documentation:
+    /// ```json
+    /// {
+    ///     'consistency_level': 'ONE',
+    ///     'page_size': '100',
+    ///     'query': 'INSERT into keyspace1.standard1 (key, "C0") VALUES (0x12345679, bigintAsBlob(123456));',
+    ///     'serial_consistency_level': 'SERIAL',
+    ///     'user_timestamp': '1469091441238107'
+    /// }
+    /// ```
     pub parameters: Option<HashMap<String, String>>,
+
+    /// Kind of the request, textually described.
+    ///
+    /// Example from the ScyllaDB documentation:
+    /// `Execute CQL3 query`
     pub request: Option<String>,
-    /// started_at is a timestamp - time since unix epoch
+
+    /// Point in time when the execution started - time since unix epoch.
     pub started_at: Option<CqlTimestamp>,
 
+    /// Events that happened during the traced execution.
     #[scylla(skip)]
     pub events: Vec<TracingEvent>,
 }
@@ -27,10 +67,29 @@ pub struct TracingInfo {
 #[derive(Debug, DeserializeRow, Clone, PartialEq, Eq)]
 #[scylla(crate = "crate")]
 pub struct TracingEvent {
+    /// Unique identifier of the event.
     pub event_id: CqlTimeuuid,
+
+    /// Description of the event.
+    /// Examples from the ScyllaDB documentation:
+    /// ```notrust
+    /// - Execute CQL3 query
+    /// - Parsing a statement [shard 1]
+    /// - Sending a mutation to /127.0.0.1 [shard 1]
+    /// - Request complete
+    /// ```
     pub activity: Option<String>,
+
+    /// Address of the node that generated the event.
     pub source: Option<IpAddr>,
+
+    /// Number of microseconds elapsed since the start of the query execution
+    /// on the node that generated the event.
     pub source_elapsed: Option<i32>,
+
+    /// Thread on which the event was generated.
+    /// Example from the ScyllaDB tracing:
+    /// `shard 0`
     pub thread: Option<String>,
 }
 

--- a/scylla/src/policies/address_translator.rs
+++ b/scylla/src/policies/address_translator.rs
@@ -1,3 +1,9 @@
+//! Address translation capabilities.
+//!
+//! These are needed when a DB node broadcasts an address that is not reachable
+//! from the client, or when the address is not the preferred one to use to reach
+//! the node. In such cases, the driver may translate the address to another one.
+
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::str::FromStr as _;
@@ -63,6 +69,9 @@ impl UntranslatedPeer<'_> {
 /// only IP addresses retrieved from or sent by Cassandra nodes to the driver are.
 #[async_trait]
 pub trait AddressTranslator: Send + Sync {
+    /// Translates an address received from a ScyllaDB node into a locally reachable address.
+    ///
+    /// Gets the whole `UntranslatedPeer` structure, which contains more information about the node.
     async fn translate_address(
         &self,
         untranslated_peer: &UntranslatedPeer,

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -22,16 +22,18 @@ pub use single_target::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
 #[derive(Default, Clone, Debug)]
 #[non_exhaustive]
 pub struct RoutingInfo<'a> {
-    /// Requested consistency information allows to route requests to the appropriate
-    /// datacenters. E.g. requests with a LOCAL_ONE consistency should be routed to the same
-    /// datacenter.
+    /// Consistency level for the request.
     pub consistency: types::Consistency,
+
+    /// Serial consistency level to be used for serial part of the request, if set.
     pub serial_consistency: Option<types::SerialConsistency>,
 
     /// Information that are the basis of token-aware routing:
     /// - token, keyspace for vnodes-based routing;
     /// - token, keyspace, table for tablets-based routing.
     pub token: Option<Token>,
+
+    /// Keyspace and table that the request is being executed against.
     pub table: Option<&'a TableSpec<'a>>,
 
     /// If, while preparing, we received from the cluster information that the statement is an LWT,
@@ -39,7 +41,7 @@ pub struct RoutingInfo<'a> {
     /// can be performed: the request should be routed to the replicas in a predefined order
     /// (i. e. always try first to contact replica A, then B if it fails, then C, etc.).
     /// If false, the request should be routed normally.
-    /// Note: this a Scylla-specific optimisation. Therefore, the flag will be always false for Cassandra.
+    /// Note: this a ScyllaDB-specific optimisation. Therefore, the flag will be always false for Cassandra.
     pub is_confirmed_lwt: bool,
 }
 

--- a/scylla/src/policies/load_balancing/plan.rs
+++ b/scylla/src/policies/load_balancing/plan.rs
@@ -66,6 +66,7 @@ enum PlanState<'a> {
 ///     }
 /// }
 /// ```
+// TODO(2.0): Unpub this.
 pub struct Plan<'a> {
     policy: &'a dyn LoadBalancingPolicy,
     routing_info: &'a RoutingInfo<'a>,
@@ -75,6 +76,8 @@ pub struct Plan<'a> {
 }
 
 impl<'a> Plan<'a> {
+    /// Asks the given [LoadBalancingPolicy] to compute a load balancing plan for the given `RoutingInfo`.
+    // TODO(2.0): Unpub this.
     pub fn new(
         policy: &'a dyn LoadBalancingPolicy,
         routing_info: &'a RoutingInfo<'a>,

--- a/scylla/src/policies/retry/default.rs
+++ b/scylla/src/policies/retry/default.rs
@@ -10,6 +10,7 @@ use super::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 pub struct DefaultRetryPolicy;
 
 impl DefaultRetryPolicy {
+    /// Creates a new instance of [DefaultRetryPolicy].
     pub fn new() -> DefaultRetryPolicy {
         DefaultRetryPolicy
     }
@@ -27,6 +28,7 @@ impl RetryPolicy for DefaultRetryPolicy {
     }
 }
 
+/// Implementation of [RetrySession] for [DefaultRetryPolicy].
 pub struct DefaultRetrySession {
     was_unavailable_retry: bool,
     was_read_timeout_retry: bool,
@@ -34,6 +36,8 @@ pub struct DefaultRetrySession {
 }
 
 impl DefaultRetrySession {
+    /// Creates a new instance of [DefaultRetrySession].
+    // TODO(2.0): unpub this.
     pub fn new() -> DefaultRetrySession {
         DefaultRetrySession {
             was_unavailable_retry: false,
@@ -43,6 +47,7 @@ impl DefaultRetrySession {
     }
 }
 
+// TODO(2.0): remove this.
 impl Default for DefaultRetrySession {
     fn default() -> DefaultRetrySession {
         DefaultRetrySession::new()

--- a/scylla/src/policies/retry/downgrading_consistency.rs
+++ b/scylla/src/policies/retry/downgrading_consistency.rs
@@ -13,6 +13,7 @@ use crate::errors::{DbError, RequestAttemptError, WriteType};
 pub struct DowngradingConsistencyRetryPolicy;
 
 impl DowngradingConsistencyRetryPolicy {
+    /// Creates a new instance of [DowngradingConsistencyRetryPolicy].
     pub fn new() -> DowngradingConsistencyRetryPolicy {
         DowngradingConsistencyRetryPolicy
     }
@@ -30,11 +31,14 @@ impl RetryPolicy for DowngradingConsistencyRetryPolicy {
     }
 }
 
+/// Implementation of [RetrySession] for [DowngradingConsistencyRetryPolicy].
 pub struct DowngradingConsistencyRetrySession {
     was_retry: bool,
 }
 
 impl DowngradingConsistencyRetrySession {
+    /// Creates a new instance of [DowngradingConsistencyRetrySession].
+    // TODO(2.0): unpub this.
     pub fn new() -> DowngradingConsistencyRetrySession {
         DowngradingConsistencyRetrySession { was_retry: false }
     }

--- a/scylla/src/policies/retry/fallthrough.rs
+++ b/scylla/src/policies/retry/fallthrough.rs
@@ -3,9 +3,12 @@ use super::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 /// Forwards all errors directly to the user, never retries
 #[derive(Debug)]
 pub struct FallthroughRetryPolicy;
+
+/// Implementation of [RetrySession] for [FallthroughRetryPolicy].
 pub struct FallthroughRetrySession;
 
 impl FallthroughRetryPolicy {
+    /// Creates a new instance of [FallthroughRetryPolicy].
     pub fn new() -> FallthroughRetryPolicy {
         FallthroughRetryPolicy
     }

--- a/scylla/src/policies/retry/mod.rs
+++ b/scylla/src/policies/retry/mod.rs
@@ -1,3 +1,5 @@
+//! Policies to decide whether to retry a request and how to do so.
+
 mod default;
 mod downgrading_consistency;
 mod fallthrough;

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -1,3 +1,8 @@
+//! Speculative execution mechanism allows the driver to send speculative requests to
+//! multiple nodes in the cluster when the current target takes too long to respond.
+//! This can help reduce latency for requests that may be slow due to network issues
+//! or node load.
+
 use futures::{
     future::FutureExt,
     stream::{FuturesUnordered, StreamExt},
@@ -12,10 +17,12 @@ use crate::errors::{RequestAttemptError, RequestError};
 use crate::observability::metrics::Metrics;
 use crate::response::Coordinator;
 
-/// Context is passed as an argument to `SpeculativeExecutionPolicy` methods
+/// [`Context`] is passed as an argument to [`SpeculativeExecutionPolicy`] methods.
 #[non_exhaustive]
 pub struct Context {
     #[cfg(feature = "metrics")]
+    /// Metrics instance that can be used as a context for deciding on speculative
+    /// execution.
     pub metrics: Arc<Metrics>,
 }
 
@@ -31,7 +38,7 @@ pub trait SpeculativeExecutionPolicy: std::fmt::Debug + Send + Sync {
     fn retry_interval(&self, context: &Context) -> Duration;
 }
 
-/// A SpeculativeExecutionPolicy that schedules a given number of speculative
+/// A [`SpeculativeExecutionPolicy`] that schedules a given number of speculative
 /// executions, separated by a fixed delay.
 #[derive(Debug, Clone)]
 pub struct SimpleSpeculativeExecutionPolicy {

--- a/scylla/src/policies/timestamp_generator.rs
+++ b/scylla/src/policies/timestamp_generator.rs
@@ -1,3 +1,7 @@
+//! Abstractions for timestamp generation on the client side,
+//! which can be used to impose chronological order on statement
+//! executions.
+
 use std::{
     sync::atomic::AtomicI64,
     time::{SystemTime, UNIX_EPOCH},
@@ -20,6 +24,7 @@ pub trait TimestampGenerator: Send + Sync {
 pub struct SimpleTimestampGenerator {}
 
 impl SimpleTimestampGenerator {
+    /// Creates a new simple timestamp generator.
     pub fn new() -> Self {
         SimpleTimestampGenerator {}
     }
@@ -56,7 +61,7 @@ pub struct MonotonicTimestampGenerator {
 }
 
 impl MonotonicTimestampGenerator {
-    /// Creates a new monotonic timestamp generator with default settings
+    /// Creates a new monotonic timestamp generator with default settings.
     pub fn new() -> Self {
         MonotonicTimestampGenerator {
             last: AtomicI64::new(0),
@@ -68,6 +73,9 @@ impl MonotonicTimestampGenerator {
         }
     }
 
+    /// Configures the generator to warn the user if clock skew is detected.
+    /// Warnings will be issued if the clock skew is bigger than `warning_threshold`
+    /// and will be repeated no more than once per `warning_interval`.
     pub fn with_warning_times(
         mut self,
         warning_threshold: Duration,
@@ -80,6 +88,7 @@ impl MonotonicTimestampGenerator {
         self
     }
 
+    /// Configures the generator to not warn the user if clock skew is detected.
     pub fn without_warnings(mut self) -> Self {
         self.config = None;
         self

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -1,3 +1,6 @@
+//! Types for representing results of CQL queries and iterating
+//! over them.
+
 use std::fmt::Debug;
 
 use thiserror::Error;
@@ -380,6 +383,8 @@ impl QueryRowsResult {
         }
     }
 
+    /// Deconstructs the `QueryRowsResult` into its components, which can be used by the caller
+    /// directly. Intended for use in CPP-Rust Driver only.
     #[cfg(cpp_rust_unstable)]
     pub fn into_inner(
         self,

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -1,3 +1,14 @@
+//! Abstractions that provide a way to find the set of owning nodes/shards for a given
+//! (token, replication strategy, table) tuple.
+//!
+//! They allow precomputation of token ranges for a given set of strategies,
+//! which can be used to speed up the process of finding replicas for a given token.
+//! Alternatively, they can compute the replicas on the fly.
+//!
+//! Two main replication mechanisms are supported:
+//! - token ring, which is the older mechanism used by ScyllaDB and Cassandra,
+//! - tablets, which is a newer mechanism used by ScyllaDB.
+
 mod precomputed_replicas;
 mod replicas;
 mod replication_info;
@@ -29,6 +40,9 @@ use tracing::debug;
 /// `ReplicaLocator` provides a way to find the set of owning nodes for a given (token,
 /// replication strategy, table) tuple. It does so by either using the precomputed
 /// token ranges, or doing the computation on the fly (precomputation is configurable).
+/// Two main replication mechanisms are supported:
+/// - token ring, which is the older mechanism used by ScyllaDB and Cassandra,
+/// - tablets, which is a newer mechanism used by ScyllaDB.
 #[derive(Debug, Clone)]
 pub struct ReplicaLocator {
     /// The data based on which `ReplicaLocator` computes replica sets.
@@ -630,6 +644,8 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
 }
 
 impl<'a> ReplicaSet<'a> {
+    /// Converts the [`ReplicaSet`], which is an (unordered) set of replicas for a given token and strategy,
+    /// into an ordered sequence of replicas.
     pub fn into_replicas_ordered(self) -> ReplicasOrdered<'a> {
         ReplicasOrdered { replica_set: self }
     }

--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -34,7 +34,7 @@ pub struct Token {
 }
 
 impl Token {
-    /// Creates a new token with given value, normalizing the value if necessary
+    /// Creates a new token with given value, normalizing the value if necessary.
     #[inline]
     pub fn new(value: i64) -> Self {
         Self {
@@ -49,6 +49,7 @@ impl Token {
     /// https://github.com/scylladb/scylla-rust-driver/blob/049dc3546d24e45106fed0fdb985ec2511ab5192/scylla/src/transport/partitioner.rs#L312-L322
     pub(crate) const INVALID: Self = Token { value: i64::MIN };
 
+    /// Retrieves the value of the token.
     #[inline]
     pub fn value(&self) -> i64 {
         self.value

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -1,3 +1,6 @@
+//! Defines the [`Batch`] type, which represents a batch of CQL statements
+//! that can be executed together.
+
 use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,6 +23,11 @@ pub use crate::frame::request::batch::BatchType;
 pub struct Batch {
     pub(crate) config: StatementConfig,
 
+    /// Statements that constitute this batch.
+    ///
+    /// Any mix of prepared and unprepared statements is allowed.
+    /// For maximum performance, it is recommended to use prepared statements
+    /// whenever possible.
     pub statements: Vec<BatchStatement>,
     batch_type: BatchType,
 }
@@ -45,6 +53,10 @@ impl Batch {
     }
 
     /// Creates a new, empty `Batch` of `batch_type` type with the provided statements.
+    ///
+    /// Any mix of prepared and unprepared statements is allowed.
+    /// For maximum performance, it is recommended to use prepared statements
+    /// whenever possible.
     pub fn new_with_statements(batch_type: BatchType, statements: Vec<BatchStatement>) -> Self {
         Self {
             batch_type,
@@ -54,6 +66,10 @@ impl Batch {
     }
 
     /// Appends a new statement to the batch.
+    ///
+    /// Both prepared and unprepared statements are allowed.
+    /// For maximum performance, it is recommended to use prepared statements
+    /// whenever possible.
     pub fn append_statement(&mut self, statement: impl Into<BatchStatement>) {
         self.statements.push(statement.into());
     }
@@ -218,11 +234,15 @@ impl Default for Batch {
     }
 }
 
-/// This enum represents a CQL statement, that can be part of batch.
+/// Represents a CQL statement that can be part of batch.
 #[derive(Clone)]
 #[non_exhaustive]
 pub enum BatchStatement {
+    /// Unprepared statement, which is a CQL query string.
+    // TODO(2.0): rename this variant to `Unprepared`.
     Query(Statement),
+    /// Prepared statement, which is a prepared statement ID.
+    // TODO(2.0): shorten this variant's name to `Prepared`.
     PreparedStatement(PreparedStatement),
 }
 

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -1,3 +1,6 @@
+//! Defines the [`PreparedStatement`] type, which represents a statement
+//! that has been prepared in advance on the server.
+
 use bytes::{Bytes, BytesMut};
 use scylla_cql::frame::response::result::{
     ColumnSpec, PartitionKeyIndex, ResultMetadata, TableSpec,
@@ -92,6 +95,7 @@ use crate::routing::Token;
 #[derive(Debug)]
 pub struct PreparedStatement {
     pub(crate) config: StatementConfig,
+    /// Tracing IDs of all queries used to prepare this statement.
     pub prepare_tracing_ids: Vec<Uuid>,
 
     id: Bytes,
@@ -147,10 +151,12 @@ impl PreparedStatement {
         }
     }
 
+    /// Retrieves the ID of this prepared statement.
     pub fn get_id(&self) -> &Bytes {
         &self.id
     }
 
+    /// Retrieves the statement string of this prepared statement.
     pub fn get_statement(&self) -> &str {
         &self.shared.statement
     }
@@ -503,16 +509,20 @@ impl PreparedStatement {
     }
 }
 
+/// Error when extracting partition key from bound values.
 #[derive(Clone, Debug, Error, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum PartitionKeyExtractionError {
+    /// No value with given partition key index was found in bound values.
     #[error("No value with given pk_index! pk_index: {0}, values.len(): {1}")]
     NoPkIndexValue(u16, u16),
 }
 
+/// Error when calculating token from partition key values.
 #[derive(Clone, Debug, Error, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum TokenCalculationError {
+    /// Value was too long to be used in partition key.
     #[error("Value bytes too long to create partition key, max 65 535 allowed! value.len(): {0}")]
     ValueTooLong(usize),
 }

--- a/scylla/src/statement/unprepared.rs
+++ b/scylla/src/statement/unprepared.rs
@@ -1,3 +1,5 @@
+//! Defines the [`Statement`] type, which represents an unprepared CQL statement.
+
 use super::{PageSize, StatementConfig};
 use crate::client::execution_profile::ExecutionProfileHandle;
 use crate::frame::types::{Consistency, SerialConsistency};
@@ -14,6 +16,7 @@ use std::time::Duration;
 pub struct Statement {
     pub(crate) config: StatementConfig,
 
+    /// The CQL statement text.
     pub contents: String,
     page_size: PageSize,
 }

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -1,3 +1,6 @@
+// Rigorous documentation is not necessary for integration tests.
+#![allow(missing_docs)]
+
 pub(crate) mod ccm;
 mod load_balancing;
 mod macros;


### PR DESCRIPTION
Party fixes: #1395

This is the second part of the effort to fill missing docstrings, on the way to enable `missing-docs` project-wide.

1. All public items of `scylla` crate were added docstrings where missing.
2. Integration tests and benchmarks had the requirement lifted (with `#[allow(missing_docs)]`), as they aren't intended to be read by users.
3. I paid attention to introduce meaningful documentation, not just repeat the items' names.
4. `missing-docs` lint was enabled in the `scylla`'s `Cargo.toml`.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
