### PR TITLE
Try to fix test_default_policy_is_tablet_aware

### DIFF
--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -189,7 +189,6 @@ async fn populate_internal_driver_tablet_info(
     prepared: &PreparedStatement,
     value_per_tablet: &[(i32, i32)],
     feedback_rxs: &mut [UnboundedReceiver<(ResponseFrame, Option<u16>)>],
-    tablet_count: usize,
 ) {
     // When the driver never received tablet info for any tablet in a given table,
     // then it will not be aware that the table is tablet-based and fall back
@@ -233,7 +232,7 @@ async fn populate_internal_driver_tablet_info(
         }
     }
 
-    assert_eq!(total_tablets_with_feedback, tablet_count);
+    assert_eq!(total_tablets_with_feedback, value_per_tablet.len());
 }
 
 /// Tests that, when using DefaultPolicy with TokenAwareness and querying table
@@ -297,7 +296,6 @@ async fn test_default_policy_is_tablet_aware() {
                 &prepared,
                 &value_lists,
                 &mut feedback_rxs,
-                TABLET_COUNT,
             )
             .await;
 


### PR DESCRIPTION
This is an attempt to fix test_default_policy_is_tablet_aware.
I did 2 things that should help:
- Introduced retries in case tablet migration happened
- Changed the way tablet info is populated, which can possibly decrease the chance of migration happening.

I executed the test 100 times locally, and it passed each time.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1380 (hopefully).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
