### PR TITLE
Drop keyspaces after tests

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -29,6 +29,8 @@ jobs:
     - name: Run tests on cassandra
       run: |
         RUSTFLAGS="--cfg cassandra_tests" RUST_LOG=trace SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --features "full-serialization" -- --skip test_views_in_schema_info --skip test_large_batch_statements
+    - name: Check for stale test keyspaces
+      run: SCYLLA_URI=172.42.0.2:9042 cargo run --bin find_stale_test_keyspaces
     - name: Stop the cluster
       if: ${{ always() }}
       run: docker compose -f test/cluster/cassandra/docker-compose.yml stop

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run tests on cassandra
       run: |
-        CDC='disabled' RUSTFLAGS="--cfg cassandra_tests" RUST_LOG=trace SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --features "full-serialization" -- --skip test_views_in_schema_info --skip test_large_batch_statements
+        RUSTFLAGS="--cfg cassandra_tests" RUST_LOG=trace SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --features "full-serialization" -- --skip test_views_in_schema_info --skip test_large_batch_statements
     - name: Stop the cluster
       if: ${{ always() }}
       run: docker compose -f test/cluster/cassandra/docker-compose.yml stop

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,6 +100,8 @@ jobs:
     - name: Run tests
       run: |
         RUST_LOG=trace SCYLLA_URI=172.42.0.2:9042 SCYLLA_URI2=172.42.0.3:9042 SCYLLA_URI3=172.42.0.4:9042 cargo test --features "full-serialization"
+    - name: Check for stale test keyspaces
+      run: SCYLLA_URI=172.42.0.2:9042 cargo run --bin find_stale_test_keyspaces
     - name: Stop the cluster
       if: ${{ always() }}
       run: docker compose -f test/cluster/docker-compose.yml stop

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -2278,6 +2278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "utils"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "scylla",
+ "tokio",
+]
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "scylla-macros",
     "scylla-cql",
     "scylla-proxy",
+    "utils",
 ]
 resolver = "2"

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -833,11 +833,9 @@ mod tests {
 
     // Checks whether the PartitionerName is cached properly.
     #[tokio::test]
+    #[cfg_attr(cassandra_tests, ignore)]
     async fn test_partitioner_name_caching() {
         setup_tracing();
-        if option_env!("CDC") == Some("disabled") {
-            return;
-        }
 
         // This test uses CDC which is not yet compatible with Scylla's tablets.
         let session: CachingSession = CachingSession::from(new_for_test(false).await, 100);

--- a/scylla/tests/integration/ccm/authenticate.rs
+++ b/scylla/tests/integration/ccm/authenticate.rs
@@ -60,8 +60,9 @@ async fn authenticate_superuser_cluster_one_node() {
         let ks = unique_keyspace_name();
 
         session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-        session.use_keyspace(ks, false).await.unwrap();
+        session.use_keyspace(&ks, false).await.unwrap();
         session.ddl("DROP TABLE IF EXISTS t;").await.unwrap();
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
         tracing::info!("Ok.");
     }
@@ -124,8 +125,9 @@ async fn custom_authentication_cluster_one_node() {
         let ks = unique_keyspace_name();
 
         session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-        session.use_keyspace(ks, false).await.unwrap();
+        session.use_keyspace(&ks, false).await.unwrap();
         session.ddl("DROP TABLE IF EXISTS t;").await.unwrap();
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
         tracing::info!("Ok.");
     }

--- a/scylla/tests/integration/load_balancing/lwt_optimisation.rs
+++ b/scylla/tests/integration/load_balancing/lwt_optimisation.rs
@@ -77,7 +77,7 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
             create_ks += " and TABLETS = { 'enabled': false}";
         }
         session.ddl(create_ks).await.unwrap();
-        session.use_keyspace(ks, false).await.unwrap();
+        session.use_keyspace(&ks, false).await.unwrap();
 
         session
             .ddl("CREATE TABLE t (a int primary key, b int)")
@@ -161,6 +161,8 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
             // ...else we assert that replicas were shuffled as in case of non-LWT.
             assert_multiple_replicas_queried(&mut prepared_rxs);
         }
+
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
         running_proxy
     }).await;

--- a/scylla/tests/integration/load_balancing/shards.rs
+++ b/scylla/tests/integration/load_balancing/shards.rs
@@ -82,6 +82,8 @@ async fn test_consistent_shard_awareness() {
             }
         }
 
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+
         running_proxy
     }).await;
     match res {

--- a/scylla/tests/integration/load_balancing/simple_strategy.rs
+++ b/scylla/tests/integration/load_balancing/simple_strategy.rs
@@ -59,4 +59,6 @@ async fn simple_strategy_test() {
     rows.sort();
 
     assert_eq!(rows, vec![(1, 2, 3), (4, 5, 6), (7, 8, 9)]);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -343,7 +343,11 @@ async fn test_default_policy_is_tablet_aware() {
                 )
                 .await
                 {
-                    Ok(_) => return running_proxy, // Test succeeded
+                    Ok(_) => {
+                        // Test succeeded
+                        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+                        return running_proxy;
+                    }
                     Err(e) => {
                         let new_tablets = get_tablets(&session, &ks, "t").await;
                         if tablets == new_tablets {
@@ -426,6 +430,8 @@ async fn test_tablet_feedback_not_sent_for_unprepared_queries() {
 
             let feedbacks: usize = feedback_rxs.iter_mut().map(count_tablet_feedbacks).sum();
             assert_eq!(feedbacks, 0);
+
+            session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
             running_proxy
         },
@@ -572,6 +578,8 @@ async fn test_lwt_optimization_works_with_tablets() {
 
                 assert_eq!(queried_nodes, 1);
             }
+
+            session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
             running_proxy
         },

--- a/scylla/tests/integration/load_balancing/token_awareness.rs
+++ b/scylla/tests/integration/load_balancing/token_awareness.rs
@@ -62,4 +62,6 @@ async fn test_token_awareness() {
         // Again, verify that only one node was involved
         assert_eq!(tracing_info.nodes().len(), 1);
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/macros/complex_pk.rs
+++ b/scylla/tests/integration/macros/complex_pk.rs
@@ -9,7 +9,7 @@ async fn test_macros_complex_pk() {
     let ks = unique_keyspace_name();
 
     session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-    session.use_keyspace(ks, true).await.unwrap();
+    session.use_keyspace(&ks, true).await.unwrap();
     session
         .ddl("CREATE TABLE IF NOT EXISTS complex_pk (a int, b int, c text, d int, e int, primary key ((a,b,c),d))")
         .await
@@ -52,4 +52,6 @@ async fn test_macros_complex_pk() {
             .unwrap();
         assert_eq!(input, output)
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/metadata/configuration.rs
+++ b/scylla/tests/integration/metadata/configuration.rs
@@ -237,7 +237,7 @@ async fn test_refresh_metadata_after_schema_agreement() {
     assert_eq!(
         udt,
         Some(&Arc::new(UserDefinedType {
-            keyspace: ks.into(),
+            keyspace: ks.clone().into(),
             name: "udt".into(),
             field_types: Vec::from([
                 ("field1".into(), ColumnType::Native(NativeType::Int)),
@@ -246,6 +246,8 @@ async fn test_refresh_metadata_after_schema_agreement() {
             ])
         }))
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -320,6 +322,8 @@ async fn test_turning_off_schema_fetching() {
     );
     assert_eq!(keyspace.tables.len(), 0);
     assert_eq!(keyspace.user_defined_types.len(), 0);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -361,4 +365,11 @@ async fn test_keyspaces_to_fetch() {
         .unwrap();
     assert!(session_all.get_cluster_state().get_keyspace(&ks1).is_some());
     assert!(session_all.get_cluster_state().get_keyspace(&ks2).is_some());
+
+    for ks in [&ks1, &ks2] {
+        session_default
+            .ddl(format!("DROP KEYSPACE {ks}"))
+            .await
+            .unwrap();
+    }
 }

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -392,11 +392,9 @@ async fn test_primary_key_ordering_in_metadata() {
 }
 
 #[tokio::test]
+#[cfg_attr(cassandra_tests, ignore)]
 async fn test_table_partitioner_in_metadata() {
     setup_tracing();
-    if option_env!("CDC") == Some("disabled") {
-        return;
-    }
 
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -240,6 +240,8 @@ async fn test_schema_types_in_metadata() {
             frozen: true
         }
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -300,6 +302,8 @@ async fn test_user_defined_types_in_metadata() {
     let type_c = &user_defined_types["type_c"];
 
     assert_eq!(*type_c, udt_type_c_def(&ks));
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -345,6 +349,8 @@ async fn test_column_kinds_in_metadata() {
     assert_eq!(columns["d"].kind, ColumnKind::Static);
     assert_eq!(columns["e"].kind, ColumnKind::PartitionKey);
     assert_eq!(columns["f"].kind, ColumnKind::Regular);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -389,6 +395,8 @@ async fn test_primary_key_ordering_in_metadata() {
 
     assert_eq!(table.partition_key, vec!["c", "e"]);
     assert_eq!(table.clustering_key, vec!["b", "a"]);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -434,6 +442,8 @@ async fn test_table_partitioner_in_metadata() {
         cdc_table.partitioner.as_ref().unwrap(),
         "com.scylladb.dht.CDCPartitioner"
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -491,7 +501,9 @@ async fn test_views_in_schema_info() {
     assert_eq!(
         views_base_table,
         std::collections::HashSet::from([&"t".to_string()])
-    )
+    );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 /// This test case indicates that we support enough CQL types to parse schema keyspace information.

--- a/scylla/tests/integration/session/cluster_reachability.rs
+++ b/scylla/tests/integration/session/cluster_reachability.rs
@@ -35,6 +35,8 @@ async fn test_all_nodes_are_reachable_and_serving() {
     )
     .await
     .unwrap();
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 async fn prepare_schema(session: &Session, ks: &str, table: &str) {

--- a/scylla/tests/integration/session/db_errors.rs
+++ b/scylla/tests/integration/session/db_errors.rs
@@ -60,6 +60,8 @@ async fn test_db_errors() {
             table: "tab".to_string()
         }
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -108,4 +110,6 @@ async fn test_rate_limit_exceeded_exception() {
         }
         err => panic!("Unexpected error type received: {err:?}"),
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/session/history.rs
+++ b/scylla/tests/integration/session/history.rs
@@ -219,7 +219,7 @@ async fn iterator_query_history() {
     .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
     .await
     .unwrap();
-    session.use_keyspace(ks, true).await.unwrap();
+    session.use_keyspace(&ks, true).await.unwrap();
 
     session
         .ddl("CREATE TABLE t (p int primary key)")
@@ -295,4 +295,6 @@ async fn iterator_query_history() {
     );
 
     assert!(displayed_str.starts_with(displayed_prefix),);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -64,7 +64,7 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
         create_ks += " and TABLETS = { 'enabled': false}";
     }
     session.ddl(create_ks).await.unwrap();
-    session.use_keyspace(ks, true).await.unwrap();
+    session.use_keyspace(&ks, true).await.unwrap();
     session
         .ddl("CREATE TABLE t (pk int PRIMARY KEY, v int)")
         .await
@@ -99,6 +99,8 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
 
     assert!(retried_flag.load(Ordering::Relaxed));
     while iter.try_next().await.unwrap().is_some() {}
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -140,4 +142,6 @@ async fn test_iter_methods_with_modification_statements() {
         .await
         .ok_or(())
         .unwrap_err(); // assert empty
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/session/tracing.rs
+++ b/scylla/tests/integration/session/tracing.rs
@@ -33,6 +33,8 @@ async fn test_tracing() {
     test_tracing_query_iter(&session, ks.clone()).await;
     test_tracing_execute_iter(&session, ks.clone()).await;
     test_tracing_batch(&session, ks.clone()).await;
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 async fn test_tracing_query(session: &Session, ks: String) {

--- a/scylla/tests/integration/session/use_keyspace.rs
+++ b/scylla/tests/integration/session/use_keyspace.rs
@@ -98,6 +98,8 @@ async fn test_use_keyspace() {
     rows2.sort();
 
     assert_eq!(rows2, vec!["test1".to_string(), "test2".to_string()]);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -157,7 +159,7 @@ async fn test_use_keyspace_case_sensitivity() {
 
     // Use uppercase keyspace with case sensitivity
     // Should select the uppercase one
-    session.use_keyspace(ks_upper, true).await.unwrap();
+    session.use_keyspace(&ks_upper, true).await.unwrap();
 
     let rows: Vec<String> = session
         .query_unpaged("SELECT * from tab", &[])
@@ -171,6 +173,15 @@ async fn test_use_keyspace_case_sensitivity() {
         .collect();
 
     assert_eq!(rows, vec!["uppercase".to_string()]);
+
+    session
+        .ddl(format!("DROP KEYSPACE \"{ks_lower}\""))
+        .await
+        .unwrap();
+    session
+        .ddl(format!("DROP KEYSPACE \"{ks_upper}\""))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -221,6 +232,8 @@ async fn test_raw_use_keyspace() {
         .query_unpaged(format!("use    {}    ;", ks.to_uppercase()), &[])
         .await
         .is_ok());
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -246,4 +259,6 @@ async fn test_get_keyspace_name() {
         .await
         .unwrap();
     assert_eq!(*session.get_keyspace().unwrap(), ks);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/statements/consistency.rs
+++ b/scylla/tests/integration/statements/consistency.rs
@@ -245,6 +245,8 @@ async fn check_for_all_consistencies_and_setting_options<
             .unwrap();
         rx = check_consistencies(consistency, serial_consistency, rx).await;
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 // Checks that the expected consistency and serial_consistency are set

--- a/scylla/tests/integration/statements/coordinator.rs
+++ b/scylla/tests/integration/statements/coordinator.rs
@@ -16,7 +16,7 @@ use scylla::statement::batch::{Batch, BatchStatement, BatchType};
 use scylla::statement::Statement;
 use uuid::Uuid;
 
-use crate::utils::{create_new_session_builder, setup_tracing, unique_keyspace_name};
+use crate::utils::{create_new_session_builder, setup_tracing, unique_keyspace_name, PerformDDL};
 
 #[tokio::test]
 async fn test_enforce_request_coordinator() {
@@ -118,10 +118,10 @@ async fn test_enforce_non_existent_request_coordinator() {
 async fn test_exposed_request_coordinator() {
     setup_tracing();
     let session = create_new_session_builder().build().await.unwrap();
+    let ks = unique_keyspace_name();
 
     // Create schema for batches.
     {
-        let ks = unique_keyspace_name();
         session
             .ddl(
                 format!(
@@ -130,7 +130,7 @@ async fn test_exposed_request_coordinator() {
             )
             .await
             .unwrap();
-        session.use_keyspace(ks, true).await.unwrap();
+        session.use_keyspace(&ks, true).await.unwrap();
         session
             .ddl("CREATE TABLE IF NOT EXISTS test (a int PRIMARY KEY)")
             .await
@@ -242,4 +242,6 @@ async fn test_exposed_request_coordinator() {
             }
         }
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/statements/coordinator.rs
+++ b/scylla/tests/integration/statements/coordinator.rs
@@ -123,17 +123,16 @@ async fn test_exposed_request_coordinator() {
     {
         let ks = unique_keyspace_name();
         session
-            .query_unpaged(
+            .ddl(
                 format!(
                     "CREATE KEYSPACE IF NOT EXISTS {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
                 ),
-                (),
             )
             .await
             .unwrap();
         session.use_keyspace(ks, true).await.unwrap();
         session
-            .query_unpaged("CREATE TABLE IF NOT EXISTS test (a int PRIMARY KEY)", ())
+            .ddl("CREATE TABLE IF NOT EXISTS test (a int PRIMARY KEY)")
             .await
             .unwrap();
     }

--- a/scylla/tests/integration/statements/execution_profiles.rs
+++ b/scylla/tests/integration/statements/execution_profiles.rs
@@ -318,6 +318,8 @@ async fn test_execution_profiles() {
             running_proxy.running_nodes[i].change_request_rules(None);
         }
 
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+
         running_proxy
     }).await;
     match res {

--- a/scylla/tests/integration/statements/named_bind_markers.rs
+++ b/scylla/tests/integration/statements/named_bind_markers.rs
@@ -60,4 +60,6 @@ async fn test_named_bind_markers() {
     for wrongmap in wrongmaps {
         assert!(session.execute_unpaged(&prepared, &wrongmap).await.is_err());
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/statements/prepared.rs
+++ b/scylla/tests/integration/statements/prepared.rs
@@ -215,6 +215,7 @@ async fn test_prepared_config() {
 }
 
 #[tokio::test]
+#[cfg_attr(cassandra_tests, ignore)]
 async fn test_prepared_partitioner() {
     setup_tracing();
 
@@ -248,10 +249,6 @@ async fn test_prepared_partitioner() {
         prepared_statement_for_main_table.get_partitioner_name(),
         &PartitionerName::Murmur3
     );
-
-    if option_env!("CDC") == Some("disabled") {
-        return;
-    }
 
     session
         .ddl("CREATE TABLE IF NOT EXISTS t2 (a int primary key) WITH cdc = {'enabled':true}")

--- a/scylla/tests/integration/statements/prepared.rs
+++ b/scylla/tests/integration/statements/prepared.rs
@@ -187,6 +187,8 @@ async fn test_prepared_statement() {
             (17, 16, "I'm prepared!!!", 7, None)
         );
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 /// Tests that PreparedStatement inherits the StatementConfig from Statement
@@ -230,7 +232,7 @@ async fn test_prepared_partitioner() {
     }
 
     session.ddl(create_ks).await.unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl("CREATE TABLE IF NOT EXISTS t1 (a int primary key)")
@@ -267,6 +269,8 @@ async fn test_prepared_partitioner() {
         prepared_statement_for_cdc_log.get_partitioner_name(),
         &PartitionerName::CDC
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -425,6 +429,8 @@ async fn test_token_calculation() {
         )
         .await;
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -477,6 +483,8 @@ async fn test_prepared_statement_col_specs() {
         spec("c", ColumnType::Native(NativeType::SmallInt)),
     ];
     assert_eq!(result_set_col_specs, expected_result_set_col_specs);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -501,7 +509,7 @@ async fn test_skip_result_metadata() {
 
         let ks = unique_keyspace_name();
         session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
-        session.use_keyspace(ks, false).await.unwrap();
+        session.use_keyspace(&ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key, b int, c text)")
             .await
@@ -556,7 +564,7 @@ async fn test_skip_result_metadata() {
             let ks = unique_keyspace_name();
 
             session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-            session.use_keyspace(ks, true).await.unwrap();
+            session.use_keyspace(&ks, true).await.unwrap();
 
             type RowT = (i32, i32, String);
             session
@@ -622,7 +630,11 @@ async fn test_skip_result_metadata() {
                 }
                 assert_eq!(results_from_manual_paging, rs);
             }
+
+            session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
         }
+
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
         running_proxy
     }).await;

--- a/scylla/tests/integration/statements/timestamps.rs
+++ b/scylla/tests/integration/statements/timestamps.rs
@@ -123,6 +123,8 @@ async fn test_timestamp() {
     .collect::<Vec<_>>();
 
     assert_eq!(results, expected_results);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -186,10 +188,14 @@ async fn test_timestamp_generator() {
         .into_rows_result()
         .unwrap();
 
-    let timestamps_locked = timestamps.lock().unwrap();
-    assert!(query_rows_result
-        .rows::<(i32, i32, i64)>()
-        .unwrap()
-        .map(|row_result| row_result.unwrap())
-        .all(|(_a, _b, writetime)| timestamps_locked.contains(&writetime)));
+    {
+        let timestamps_locked = timestamps.lock().unwrap();
+        assert!(query_rows_result
+            .rows::<(i32, i32, i64)>()
+            .unwrap()
+            .map(|row_result| row_result.unwrap())
+            .all(|(_a, _b, writetime)| timestamps_locked.contains(&writetime)));
+    }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/statements/transparent_reprepare.rs
+++ b/scylla/tests/integration/statements/transparent_reprepare.rs
@@ -36,7 +36,7 @@ async fn test_unprepared_reprepare_in_execute() {
     let ks = unique_keyspace_name();
 
     session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl("CREATE TABLE IF NOT EXISTS tab (a int, b int, c int, primary key (a, b, c))")
@@ -86,6 +86,8 @@ async fn test_unprepared_reprepare_in_execute() {
         .collect();
     all_rows.sort_unstable();
     assert_eq!(all_rows, vec![(1, 2, 3), (1, 3, 2)]);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 // A tests which checks that Session::batch automatically reprepares PreparedStatemtns if they become unprepared.
@@ -103,7 +105,7 @@ async fn test_unprepared_reprepare_in_batch() {
     let ks = unique_keyspace_name();
 
     session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl("CREATE TABLE IF NOT EXISTS tab (a int, b int, c int, primary key (a, b, c))")
@@ -149,6 +151,8 @@ async fn test_unprepared_reprepare_in_batch() {
         .collect();
     all_rows.sort_unstable();
     assert_eq!(all_rows, vec![(1, 2, 3), (1, 3, 2), (4, 5, 6), (4, 6, 5)]);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 // A tests which checks that Session::execute automatically reprepares PreparedStatemtns if they become unprepared.
@@ -166,7 +170,7 @@ async fn test_unprepared_reprepare_in_caching_session_execute() {
     let ks = unique_keyspace_name();
 
     session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     let caching_session: CachingSession = CachingSession::from(session, 64);
 
@@ -215,4 +219,9 @@ async fn test_unprepared_reprepare_in_caching_session_execute() {
         .collect();
     all_rows.sort_unstable();
     assert_eq!(all_rows, vec![(1, 2, 3), (1, 3, 2)]);
+
+    caching_session
+        .ddl(format!("DROP KEYSPACE {ks}"))
+        .await
+        .unwrap();
 }

--- a/scylla/tests/integration/statements/unprepared.rs
+++ b/scylla/tests/integration/statements/unprepared.rs
@@ -114,6 +114,8 @@ async fn test_unprepared_statement() {
         watchdog += 1;
     }
     assert_eq!(results_from_manual_paging, results);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -135,7 +137,7 @@ async fn test_prepare_query_with_values() {
 
         let ks = unique_keyspace_name();
         session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
-        session.use_keyspace(ks, false).await.unwrap();
+        session.use_keyspace(&ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key)")
             .await
@@ -156,6 +158,9 @@ async fn test_prepare_query_with_values() {
             _res = session.query_unpaged(s, (0,)) => (),
             _ = tokio::time::sleep(TIMEOUT_PER_REQUEST) => panic!("Rules did not work: no received response"),
         };
+
+        running_proxy.turn_off_rules();
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
         running_proxy
     }).await;
@@ -186,7 +191,7 @@ async fn test_query_with_no_values() {
 
         let ks = unique_keyspace_name();
         session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
-        session.use_keyspace(ks, false).await.unwrap();
+        session.use_keyspace(&ks, false).await.unwrap();
         session
             .ddl("CREATE TABLE t (a int primary key)")
             .await
@@ -207,6 +212,8 @@ async fn test_query_with_no_values() {
             _res = session.query_unpaged(s, ()) => (),
             _ = tokio::time::sleep(TIMEOUT_PER_REQUEST) => panic!("Rules did not work: no received response"),
         };
+
+        session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 
         running_proxy
     }).await;

--- a/scylla/tests/integration/types/cql_collections.rs
+++ b/scylla/tests/integration/types/cql_collections.rs
@@ -94,6 +94,11 @@ async fn test_cql_list() {
         &list_cql_value_empty_selected,
     )
     .await;
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -158,6 +163,11 @@ async fn test_cql_set() {
         &set_cql_value_empty_selected,
     )
     .await;
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -209,6 +219,11 @@ async fn test_cql_map() {
         &map_cql_value_empty_selected,
     )
     .await;
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -232,6 +247,11 @@ async fn test_cql_tuple() {
         Some(CqlValue::Text("cql_value_text".to_string())),
     ]);
     insert_and_select(&session, table_name, &tuple_cql_value, &tuple_cql_value).await;
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 // TODO: Remove this ignore when vector type is supported in ScyllaDB
@@ -269,6 +289,8 @@ async fn test_vector_type_metadata() {
             dimensions: 2,
         },
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 // TODO: Remove this ignore when vector type is supported in ScyllaDB
@@ -333,6 +355,8 @@ async fn test_vector_type_unprepared() {
             vec!["afoo".to_string(), "abar".to_string()]
         )
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 // TODO: Remove this ignore when vector type is supported in ScyllaDB
@@ -383,6 +407,8 @@ async fn test_vector_type_prepared() {
             vec!["afoo".to_string(), "abar".to_string()]
         )
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 async fn test_vector_single_type<
@@ -603,6 +629,8 @@ async fn test_vector_type_all_types() {
         vec![vec![vec![1, 2], vec![3, 4]], vec![vec![5, 6], vec![7, 8]]],
     )
     .await;
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 /// ScyllaDB does not distinguish empty collections from nulls. That is, INSERTing an empty collection
@@ -666,4 +694,6 @@ async fn test_deserialize_empty_collections() {
     )
     .await;
     assert!(map.is_empty());
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/types/cql_types.rs
+++ b/scylla/tests/integration/types/cql_types.rs
@@ -104,6 +104,11 @@ where
         let expected_value = T::from_str(test).ok().unwrap();
         assert_eq!(read_values, vec![expected_value.clone(), expected_value]);
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[cfg(any(feature = "num-bigint-03", feature = "num-bigint-04"))]
@@ -173,7 +178,7 @@ async fn test_cql_varint() {
         ))
         .await
         .unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl(format!(
@@ -212,6 +217,8 @@ async fn test_cql_varint() {
 
         assert_eq!(read_values, vec![cql_varint])
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[cfg(feature = "bigdecimal-04")]
@@ -290,6 +297,11 @@ async fn test_counter() {
         let expected_value = Counter(i64::from_str(test).unwrap());
         assert_eq!(read_values, vec![expected_value]);
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "chrono-04")]
@@ -386,6 +398,11 @@ async fn test_naive_date_04() {
             assert_eq!(read_date, *naive_date);
         }
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -441,6 +458,11 @@ async fn test_cql_date() {
         )
         .await
         .unwrap_err();
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "time-03")]
@@ -528,6 +550,11 @@ async fn test_date_03() {
             assert_eq!(read_date, *date);
         }
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -612,6 +639,11 @@ async fn test_cql_time() {
             .await
             .unwrap_err();
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "chrono-04")]
@@ -693,6 +725,11 @@ async fn test_naive_time_04() {
         )
         .await
         .unwrap_err();
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "time-03")]
@@ -764,6 +801,11 @@ async fn test_time_03() {
             .unwrap();
         assert_eq!(read_time, *time);
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -837,6 +879,11 @@ async fn test_cql_timestamp() {
 
         assert_eq!(read_timestamp, *timestamp_duration);
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "chrono-04")]
@@ -1005,6 +1052,11 @@ async fn test_date_time_04() {
         )
         .await
         .unwrap_err();
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "time-03")]
@@ -1157,6 +1209,11 @@ async fn test_offset_date_time_03() {
         .first_row::<(OffsetDateTime,)>()
         .unwrap();
     assert_eq!(read_datetime, nanosecond_precision_2nd_half_rounded);
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -1228,6 +1285,11 @@ async fn test_timeuuid() {
 
         assert_eq!(read_timeuuid.as_bytes(), timeuuid_bytes);
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -1243,7 +1305,7 @@ async fn test_timeuuid_ordering() {
         ))
         .await
         .unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl("CREATE TABLE tab (p int, t timeuuid, PRIMARY KEY (p, t))")
@@ -1305,6 +1367,8 @@ async fn test_timeuuid_ordering() {
 
         assert_eq!(sorted_timeuuid_vals, rust_sorted_timeuuids);
     }
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -1387,6 +1451,11 @@ async fn test_inet() {
 
         assert_eq!(read_inet, *inet);
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -1457,6 +1526,11 @@ async fn test_blob() {
 
         assert_eq!(read_blob, *blob);
     }
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -1475,7 +1549,7 @@ async fn test_udt_after_schema_update() {
         ))
         .await
         .unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl(format!("DROP TABLE IF EXISTS {table_name}"))
@@ -1582,6 +1656,8 @@ async fn test_udt_after_schema_update() {
             third: None,
         }
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -1626,6 +1702,11 @@ async fn test_empty() {
         .unwrap();
 
     assert_eq!(empty, CqlValue::Empty);
+
+    session
+        .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -1644,7 +1725,7 @@ async fn test_udt_with_missing_field() {
         ))
         .await
         .unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl(format!("DROP TABLE IF EXISTS {table_name}"))
@@ -1811,6 +1892,8 @@ async fn test_udt_with_missing_field() {
         },
     )
     .await;
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -1821,7 +1904,7 @@ async fn test_unusual_serializerow_impls() {
     let ks = unique_keyspace_name();
 
     session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
-    session.use_keyspace(ks, false).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl("CREATE TABLE IF NOT EXISTS tab (a int, b int, c varchar, primary key (a, b, c))")
@@ -1871,4 +1954,6 @@ async fn test_unusual_serializerow_impls() {
             (1, 3, "Box dyn".to_owned())
         ]
     );
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/types/cql_value.rs
+++ b/scylla/tests/integration/types/cql_value.rs
@@ -26,7 +26,7 @@ async fn test_cqlvalue_udt() {
     session.ddl("CREATE TABLE IF NOT EXISTS cqlvalue_udt_test (k int, my cqlvalue_udt_type, primary key (k))").await.unwrap();
 
     let udt_cql_value = CqlValue::UserDefinedType {
-        keyspace: ks,
+        keyspace: ks.clone(),
         name: "cqlvalue_udt_type".to_string(),
         fields: vec![
             ("int_val".to_string(), Some(CqlValue::Int(42))),
@@ -52,6 +52,8 @@ async fn test_cqlvalue_udt() {
     let (received_udt_cql_value,) = rows_result.single_row::<(CqlValue,)>().unwrap();
 
     assert_eq!(received_udt_cql_value, udt_cql_value);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
 #[tokio::test]
@@ -145,4 +147,6 @@ async fn test_cqlvalue_duration() {
     );
 
     assert_matches!(rows_iter.next(), None);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+edition = "2021"
+name = "utils"
+publish = false
+version = "0.0.0"
+
+[dependencies]
+scylla = { path = "../scylla" }
+tokio = { version = "1.34", features = ["rt", "rt-multi-thread", "macros"] }
+futures = "0.3.6"
+
+[[bin]]
+name = "find_stale_test_keyspaces"

--- a/utils/src/bin/find_stale_test_keyspaces.rs
+++ b/utils/src/bin/find_stale_test_keyspaces.rs
@@ -1,0 +1,54 @@
+use futures::{stream, StreamExt};
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+
+#[tokio::main]
+async fn main() {
+    let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "127.0.0.1:9042".to_string());
+
+    println!("Connecting to {uri} ...");
+
+    let session: Session = SessionBuilder::new()
+        .known_node(uri)
+        .build()
+        .await
+        .expect("Can't connect to cluster");
+    session
+        .refresh_metadata()
+        .await
+        .expect("Can't refresh metadata");
+    let state = session.get_cluster_state();
+    let keyspaces_stream = stream::iter(state.keyspaces_iter());
+    let nr_stale = keyspaces_stream
+        .filter_map(|(name, _ks)| {
+            let session = &session;
+            async move {
+                if !name.starts_with("test_rust_") {
+                    return None;
+                }
+                let describe_result = session
+                    .query_unpaged(format!("DESCRIBE {name}"), &[])
+                    .await
+                    .expect("Can't perform DESCRIBE request")
+                    .into_rows_result()
+                    .expect("Wrong response type for DESCRIBE request");
+                println!("Found stale keyspace: {name}");
+                println!("Schema:");
+                for (_, _, _, describe_text) in describe_result
+                    .rows::<(&str, &str, &str, &str)>()
+                    .expect("Wrong response metadata for DESCRIBE request")
+                    .map(|r| r.expect("Failed to deserialize a row of RESPONSE request"))
+                {
+                    println!("{describe_text}");
+                }
+
+                Some(())
+            }
+        })
+        .count()
+        .await;
+
+    if nr_stale > 0 {
+        panic!("Found stale keyspaces");
+    }
+}


### PR DESCRIPTION
Our tests create a lot of keyspaces, but never drop them.
This is an issue for several reasons:
- DB may have performance problems when there are a lot of keyspaces. I often see issues locally when I run tests multiple times, and I then need to restart the cluster.
- DB may behave differently when there are a lot of keyspaces. For example, Scylla won't create enough tablets for a table (even if requested) if there is a lot of other tables.

This PR:
- Edits all the tests to make them drop their keyspace at the end.
- Adds a small utility program to find leftover keyspaces.
- Adds CI steps to check for leftover keyspaces using this program.

Related to: https://github.com/scylladb/scylla-rust-driver/pull/1412

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] I added appropriate `Fixes:` annotations to PR description.
