### PR TITLE
Remove unnecessary `'static` bounds

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -702,7 +702,7 @@ impl QueryPager {
     /// It only allows deserializing owned types, because [Stream] is not lending.
     /// Begins with performing type check.
     #[inline]
-    pub fn rows_stream<RowT: 'static + for<'frame, 'metadata> DeserializeRow<'frame, 'metadata>>(
+    pub fn rows_stream<RowT: for<'frame, 'metadata> DeserializeRow<'frame, 'metadata>>(
         self,
     ) -> Result<TypedRowStream<RowT>, TypeCheckError> {
         TypedRowStream::<RowT>::new(self)
@@ -1038,7 +1038,7 @@ impl QueryPager {
 ///
 /// Implements [Stream], but only permits deserialization of owned types.
 /// To use [Stream] API (only accessible for owned types), use [QueryPager::rows_stream].
-pub struct TypedRowStream<RowT: 'static> {
+pub struct TypedRowStream<RowT> {
     raw_row_lending_stream: QueryPager,
     _phantom: std::marker::PhantomData<RowT>,
 }


### PR DESCRIPTION
As far as I can tell these bounds are unnecessary.

I ran the static checks and they "failed" but they're also failing on main for me so I don't think I introduced the errors. CI is also failing but I see the same failures on other branches so again, I don't think my changes caused them.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
