### PR TITLE
Fix clippy 1.89

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 # used by macros.
 scylla-macros = { version = "=1.3.1", path = "../scylla-macros" }
 # AsyncRead trait used in read_response_frame
-tokio = { version = "1.40", features = ["io-util", "time"] }
+tokio = { version = "1.40", features = ["io-util"] }
 # FrameSlice and other parts of public API
 bytes = "1.0.1"
 # Tracing ids, CqlTimeuuid, ser/deser of CQL UUID

--- a/scylla-cql/src/deserialize/result.rs
+++ b/scylla-cql/src/deserialize/result.rs
@@ -181,7 +181,7 @@ impl RawRowLendingIterator {
     /// continue.
     #[inline]
     #[expect(clippy::should_implement_trait)] // https://github.com/rust-lang/rust-clippy/issues/5004
-    pub fn next(&mut self) -> Option<Result<ColumnIterator, DeserializationError>> {
+    pub fn next(&mut self) -> Option<Result<ColumnIterator<'_, '_>, DeserializationError>> {
         self.remaining = self.remaining.checked_sub(1)?;
 
         // First create the slice encompassing the whole frame.

--- a/scylla-cql/src/deserialize/row_tests.rs
+++ b/scylla-cql/src/deserialize/row_tests.rs
@@ -92,6 +92,15 @@ struct TestUdtWithNoFieldsUnordered {}
 #[scylla(crate = crate, flavor = "enforce_order")]
 struct TestUdtWithNoFieldsOrdered {}
 
+// If deserialize is never called, rust warns that the struct is never constructed.
+// We don't want to `expect(dead_code)` on struct definitions, because that could silence
+// some warnings that this test is supposed to prevent.
+#[expect(unreachable_code, dead_code)]
+fn dummy_deserialize_udts() {
+    let _ = deserialize::<TestUdtWithNoFieldsUnordered>(todo!(), todo!()).unwrap();
+    let _ = deserialize::<TestUdtWithNoFieldsOrdered>(todo!(), todo!()).unwrap();
+}
+
 #[test]
 fn test_struct_deserialization_loose_ordering() {
     #[derive(DeserializeRow, PartialEq, Eq, Debug)]

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -1242,6 +1242,15 @@ struct TestUdtWithNoFieldsUnordered {}
 #[scylla(crate = crate, flavor = "enforce_order")]
 struct TestUdtWithNoFieldsOrdered {}
 
+// If deserialize is never called, rust warns that the struct is never constructed.
+// We don't want to `expect(dead_code)` on struct definitions, because that could silence
+// some warnings that this test is supposed to prevent.
+#[expect(unreachable_code, dead_code)]
+fn dummy_deserialize_udts() {
+    let _ = deserialize::<TestUdtWithNoFieldsUnordered>(todo!(), todo!()).unwrap();
+    let _ = deserialize::<TestUdtWithNoFieldsOrdered>(todo!(), todo!()).unwrap();
+}
+
 #[test]
 fn test_udt_loose_ordering() {
     #[derive(scylla_macros::DeserializeValue, PartialEq, Eq, Debug)]

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -49,7 +49,7 @@ impl<'a> RowSerializationContext<'a> {
 
     /// Returns column/bind marker specifications for given query.
     #[inline]
-    pub fn columns(&self) -> &'a [ColumnSpec] {
+    pub fn columns(&self) -> &'a [ColumnSpec<'_>] {
         self.columns
     }
 }
@@ -530,7 +530,7 @@ impl SerializedValues {
 
     /// Returns an iterator over the values serialized into the object so far.
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = RawValue> {
+    pub fn iter(&self) -> impl Iterator<Item = RawValue<'_>> {
         SerializedValuesIterator {
             serialized_values: &self.serialized_values,
         }

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -74,7 +74,7 @@ impl RequestFrame {
         .await
     }
 
-    pub fn deserialize(&self) -> Result<Request, RequestDeserializationError> {
+    pub fn deserialize(&self) -> Result<Request<'_>, RequestDeserializationError> {
         Request::deserialize(&mut &self.body[..], self.opcode)
     }
 }

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -621,7 +621,7 @@ impl QueryPager {
     /// borrows from self.
     ///
     /// This is cancel-safe.
-    async fn next(&mut self) -> Option<Result<ColumnIterator, NextRowError>> {
+    async fn next(&mut self) -> Option<Result<ColumnIterator<'_, '_>, NextRowError>> {
         let res = std::future::poll_fn(|cx| Pin::new(&mut *self).poll_fill_page(cx)).await;
         match res {
             Some(Ok(())) => {}
@@ -1085,7 +1085,7 @@ impl<RowT> TypedRowStream<RowT> {
 
     /// Returns specification of row columns
     #[inline]
-    pub fn column_specs(&self) -> ColumnSpecs {
+    pub fn column_specs(&self) -> ColumnSpecs<'_, '_> {
         self.raw_row_lending_stream.column_specs()
     }
 }

--- a/scylla/src/cluster/metadata.rs
+++ b/scylla/src/cluster/metadata.rs
@@ -1947,7 +1947,7 @@ fn parse_native_type(p: ParserState) -> ParseResult<(NativeType, ParserState)> {
     Ok((typ, p))
 }
 
-fn parse_user_defined_type(p: ParserState) -> ParseResult<(&str, ParserState)> {
+fn parse_user_defined_type(p: ParserState<'_>) -> ParseResult<(&str, ParserState<'_>)> {
     // Java identifiers allow letters, underscores and dollar signs at any position
     // and digits in non-first position. Dots are accepted here because the names
     // are usually fully qualified.

--- a/scylla/src/response/coordinator.rs
+++ b/scylla/src/response/coordinator.rs
@@ -35,7 +35,7 @@ impl Coordinator {
 
     /// The node that served as coordinator of the request.
     #[inline]
-    pub fn node(&self) -> NodeRef {
+    pub fn node(&self) -> NodeRef<'_> {
         &self.node
     }
 

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -276,7 +276,7 @@ impl PreparedStatement {
     }
 
     /// Return keyspace name and table name this statement is operating on.
-    pub fn get_table_spec(&self) -> Option<&TableSpec> {
+    pub fn get_table_spec(&self) -> Option<&TableSpec<'_>> {
         self.get_prepared_metadata()
             .col_specs
             .first()

--- a/scylla/tests/integration/macros/hygiene.rs
+++ b/scylla/tests/integration/macros/hygiene.rs
@@ -190,6 +190,7 @@ macro_rules! test_crate {
             _scylla::DeserializeValue, _scylla::SerializeValue, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla)]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestStructByName {
             a: ::core::primitive::i32,
             #[scylla(allow_missing)]
@@ -208,6 +209,7 @@ macro_rules! test_crate {
             _scylla::DeserializeValue, _scylla::SerializeValue, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla, forbid_excess_udt_fields)]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestStructByNameStrict {
             a: ::core::primitive::i32,
             #[scylla(allow_missing)]
@@ -226,6 +228,7 @@ macro_rules! test_crate {
             _scylla::DeserializeValue, _scylla::SerializeValue, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla, flavor = "enforce_order")]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestStructOrdered {
             a: ::core::primitive::i32,
             #[scylla(allow_missing)]
@@ -244,6 +247,7 @@ macro_rules! test_crate {
             _scylla::DeserializeValue, _scylla::SerializeValue, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla, flavor = "enforce_order", forbid_excess_udt_fields)]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestStructOrderedStrict {
             a: ::core::primitive::i32,
             #[scylla(allow_missing)]
@@ -262,6 +266,7 @@ macro_rules! test_crate {
             _scylla::DeserializeValue, _scylla::SerializeValue, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla, flavor = "enforce_order", skip_name_checks)]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestStructOrderedSkipped {
             a: ::core::primitive::i32,
             b: ::core::primitive::i32,
@@ -279,6 +284,7 @@ macro_rules! test_crate {
             _scylla::DeserializeValue, _scylla::SerializeValue, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla, flavor = "enforce_order", skip_name_checks, forbid_excess_udt_fields)]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestStructOrderedStrictSkipped {
             a: ::core::primitive::i32,
             b: ::core::primitive::i32,
@@ -296,6 +302,10 @@ macro_rules! test_crate {
             _scylla::DeserializeRow, _scylla::SerializeRow, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla)]
+        // We would like to have this `expect(dead_code)`, but it does not work for
+        // SerializeRow with by-name flavor. See https://github.com/scylladb/scylla-rust-driver/issues/1429
+        // After fixing the above issue, we can add allow(dead_code)
+        // After also bumping MSRV to 1.89+ we can add expect(dead_code).
         struct TestRowByName {
             #[scylla(skip)]
             a: ::core::primitive::i32,
@@ -311,6 +321,7 @@ macro_rules! test_crate {
             _scylla::DeserializeRow, _scylla::SerializeRow, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla, flavor = "enforce_order")]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestRowByOrder {
             #[scylla(skip)]
             a: ::core::primitive::i32,
@@ -326,6 +337,7 @@ macro_rules! test_crate {
             _scylla::DeserializeRow, _scylla::SerializeRow, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla, flavor = "enforce_order", skip_name_checks)]
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.89
         struct TestRowByOrderSkipped {
             #[scylla(skip)]
             a: ::core::primitive::i32,


### PR DESCRIPTION
As usual, clippy started to fail because of newly stabilized lints.
This PR fixes that.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
