### PR TITLE
Fix Clippy 1.90 lints

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2024"
 name = "examples"
 publish = false
 version = "0.0.0"
+rust-version = "1.85"
 
 [dev-dependencies]
 anyhow = "1.0.33"

--- a/scylla-cql/src/serialize/row_tests.rs
+++ b/scylla-cql/src/serialize/row_tests.rs
@@ -225,6 +225,7 @@ fn test_map_errors() {
 // etc. that usually pop up when generating code for empty structs.
 #[derive(SerializeRow)]
 #[scylla(crate = crate)]
+#[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.90
 struct TestRowWithNoColumns {}
 
 #[derive(SerializeRow, Debug, PartialEq, Eq, Default)]

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -631,7 +631,7 @@ impl DeserializeUnorderedGenerator<'_> {
         let field_idents = fields.iter().map(|f| f.ident.as_ref().unwrap());
         let nonskipped_field_names = fields
             .iter()
-            .filter(|&f| (!f.skip))
+            .filter(|&f| !f.skip)
             .map(|f| f.cql_name_literal());
 
         let field_finalizers = fields.iter().map(|f| self.generate_finalize_field(f));

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1061,7 +1061,7 @@ impl ProxyWorker {
 
     async fn receiver_from_driver(
         self,
-        mut read_half: (impl AsyncRead + Unpin),
+        mut read_half: impl AsyncRead + Unpin,
         request_processor_tx: mpsc::UnboundedSender<RequestFrame>,
         compression: CompressionReader,
     ) {
@@ -1096,7 +1096,7 @@ impl ProxyWorker {
 
     async fn receiver_from_cluster(
         self,
-        mut read_half: (impl AsyncRead + Unpin),
+        mut read_half: impl AsyncRead + Unpin,
         response_processor_tx: mpsc::UnboundedSender<ResponseFrame>,
         compression: CompressionReader,
     ) {
@@ -1133,7 +1133,7 @@ impl ProxyWorker {
 
     async fn sender_to_driver(
         self,
-        mut write_half: (impl AsyncWrite + Unpin),
+        mut write_half: impl AsyncWrite + Unpin,
         mut responses_rx: mpsc::UnboundedReceiver<ResponseFrame>,
         mut connection_close_notifier: ConnectionCloseNotifier,
         mut terminate_notifier: TerminateNotifier,
@@ -1180,7 +1180,7 @@ impl ProxyWorker {
 
     async fn sender_to_cluster(
         self,
-        mut write_half: (impl AsyncWrite + Unpin),
+        mut write_half: impl AsyncWrite + Unpin,
         mut requests_rx: mpsc::UnboundedReceiver<RequestFrame>,
         mut connection_close_notifier: ConnectionCloseNotifier,
         mut terminate_notifier: TerminateNotifier,

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1317,7 +1317,7 @@ impl Connection {
     ) -> Result<RemoteHandle<()>, std::io::Error> {
         async fn spawn_router_and_get_handle(
             config: HostConnectionConfig,
-            stream: (impl AsyncRead + AsyncWrite + Send + 'static),
+            stream: impl AsyncRead + AsyncWrite + Send + 'static,
             receiver: mpsc::Receiver<Task>,
             error_sender: tokio::sync::oneshot::Sender<ConnectionError>,
             orphan_notification_receiver: mpsc::UnboundedReceiver<RequestId>,
@@ -1402,7 +1402,7 @@ impl Connection {
 
     async fn router(
         config: HostConnectionConfig,
-        stream: (impl AsyncRead + AsyncWrite),
+        stream: impl AsyncRead + AsyncWrite,
         receiver: mpsc::Receiver<Task>,
         error_sender: tokio::sync::oneshot::Sender<ConnectionError>,
         orphan_notification_receiver: mpsc::UnboundedReceiver<RequestId>,
@@ -1468,7 +1468,7 @@ impl Connection {
     }
 
     async fn reader(
-        mut read_half: (impl AsyncRead + Unpin),
+        mut read_half: impl AsyncRead + Unpin,
         handler_map: &StdMutex<ResponseHandlerMap>,
         event_sender: Option<mpsc::Sender<Event>>,
         compression: Option<Compression>,
@@ -1553,7 +1553,7 @@ impl Connection {
     }
 
     async fn writer(
-        mut write_half: (impl AsyncWrite + Unpin),
+        mut write_half: impl AsyncWrite + Unpin,
         handler_map: &StdMutex<ResponseHandlerMap>,
         mut task_receiver: mpsc::Receiver<Task>,
         write_coalescing_delay: Option<WriteCoalescingDelay>,

--- a/scylla/tests/integration/macros/hygiene.rs
+++ b/scylla/tests/integration/macros/hygiene.rs
@@ -302,10 +302,7 @@ macro_rules! test_crate {
             _scylla::DeserializeRow, _scylla::SerializeRow, PartialEq, Debug,
         )]
         #[scylla(crate = _scylla)]
-        // We would like to have this `expect(dead_code)`, but it does not work for
-        // SerializeRow with by-name flavor. See https://github.com/scylladb/scylla-rust-driver/issues/1429
-        // After fixing the above issue, we can add allow(dead_code)
-        // After also bumping MSRV to 1.89+ we can add expect(dead_code).
+        #[allow(dead_code)] // TODO: Change to expect after bumping MSRV to 1.90
         struct TestRowByName {
             #[scylla(skip)]
             a: ::core::primitive::i32,


### PR DESCRIPTION
Two things were caught by new version of Clippy:
- Unnecessary parentheses.
- Unused structs, that should have been caught before. It wasn't, most likely because of Clippy bug.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1429

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
