### PR TITLE
PreparedStatement: put id and lwt in shared state

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -31,6 +31,11 @@ jobs:
       with:
         # We can't use cache here, or mdbook will complain about multiple candidates for dependency.
         cache: false
+    # This is a workaround for https://github.com/actions-rust-lang/setup-rust-toolchain/issues/79
+    # and https://github.com/rust-lang/mdBook/issues/2501
+    # When either mdbook or setup-rust-toolchain fix the issue, we can remove this.
+    - name: Set default toolchain globally
+      run: rustup default stable
     - name: Install mdbook
       uses: taiki-e/install-action@v2
       with:

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -96,6 +96,7 @@ use crate::routing::partitioner::{Partitioner, PartitionerHasher, PartitionerNam
 pub struct PreparedStatement {
     pub(crate) config: StatementConfig,
     /// Tracing IDs of all queries used to prepare this statement.
+    // TODO(2.0): Unpub this, move this to PreparedStatementSharedData, and expose a getter.
     pub prepare_tracing_ids: Vec<Uuid>,
 
     shared: Arc<PreparedStatementSharedData>,


### PR DESCRIPTION
Small possible improvement that I noticed when working on metadata id extension.

PreparedStatementSharedData was initially introduced for performance reasons, specifically to make cloning PreparedStatement cheaper. Now that we have it, I think we should put all shared state there. If we don't:
- It is confusing. If I see shared state, and I see that e.g. `id` is not a part of it, then I automatically begin to wonder if its not shared, of if its somehow mutable.
- (Minor) More stuff in shared -> cheaper cloning. Difference, if any, should be tiny.

prepare_tracing_ids unfortunately can't be moved because it is pub.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
