### PR TITLE
semver-checks: Allow type_method_marked_deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ members = [
     "utils",
 ]
 resolver = "3"
+
+[workspace.metadata.cargo-semver-checks.lints]
+# We don't consider it a major change, so downgrade from deny
+type_method_marked_deprecated = { level = "warn" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -142,3 +142,6 @@ path = "tls-rustls.rs"
 [[example]]
 name = "execution_profile"
 path = "execution_profile.rs"
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -93,3 +93,6 @@ full-serialization = [
 [lints.rust]
 unnameable_types = "warn"
 unreachable_pub = "warn"
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -29,3 +29,6 @@ missing-docs = "warn"
 [dev-dependencies]
 scylla = { path = "../scylla" }
 scylla-cql = { path = "../scylla-cql" }
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -46,3 +46,6 @@ tokio = { version = "1.34", features = ["signal"] }
 
 [lints.rust]
 unreachable_pub = "warn"
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -147,3 +147,6 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(cpp_rust_unstable)',
     'cfg(ccm_tests)',
 ] }
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,3 +11,6 @@ futures = "0.3.6"
 
 [[bin]]
 name = "find_stale_test_keyspaces"
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true


### PR DESCRIPTION
By default, adding `#[deprecated]` to a method causes semver-checks to fail. Imo deprecating stuff is totally acceptable, and there is no reason to mark PRs as breaking because of that.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
