### PR TITLE
integration: enable vector type tests for ScyllaDB

### DIFF
--- a/scylla/tests/integration/types/cql_collections.rs
+++ b/scylla/tests/integration/types/cql_collections.rs
@@ -343,8 +343,6 @@ async fn test_cql_tuple_db_repr_shorter_than_metadata() {
         .unwrap();
 }
 
-// TODO: Remove this ignore when vector type is supported in ScyllaDB
-#[cfg_attr(not(cassandra_tests), ignore)]
 #[tokio::test]
 async fn test_vector_type_metadata() {
     setup_tracing();
@@ -382,8 +380,6 @@ async fn test_vector_type_metadata() {
     session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
-// TODO: Remove this ignore when vector type is supported in ScyllaDB
-#[cfg_attr(not(cassandra_tests), ignore)]
 #[tokio::test]
 async fn test_vector_type_unprepared() {
     setup_tracing();
@@ -448,8 +444,6 @@ async fn test_vector_type_unprepared() {
     session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
-// TODO: Remove this ignore when vector type is supported in ScyllaDB
-#[cfg_attr(not(cassandra_tests), ignore)]
 #[tokio::test]
 async fn test_vector_type_prepared() {
     setup_tracing();
@@ -554,8 +548,6 @@ async fn test_vector_single_type<
     session.ddl(drop_statement).await.unwrap();
 }
 
-// TODO: Remove this ignore when vector type is available in ScyllaDB
-#[cfg_attr(not(cassandra_tests), ignore)]
 #[tokio::test]
 async fn test_vector_type_all_types() {
     setup_tracing();


### PR DESCRIPTION
ScyllaDB now supports vector type, so we can enable the vector type tests that were previously ignored for ScyllaDB.

**However**, there's a bug in Vector implementation (https://github.com/scylladb/scylladb/issues/26704), which makes the tests fail. This PR shall then be merged once the bug is fixed and a new stable release with the fix is available at docker, so the CI gets it.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
