### PR TITLE
Cargo.toml: Disable lints about #[deprecated]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,18 @@ resolver = "3"
 
 [workspace.metadata.cargo-semver-checks.lints]
 # We don't consider it a major change, so downgrade from deny
+enum_struct_variant_field_marked_deprecated = { level = "warn" }
+enum_tuple_variant_field_marked_deprecated = { level = "warn" }
+enum_variant_marked_deprecated = { level = "warn" }
+function_marked_deprecated = { level = "warn" }
+global_value_marked_deprecated = { level = "warn" }
+macro_marked_deprecated = { level = "warn" }
+proc_macro_marked_deprecated = { level = "warn" }
+struct_field_marked_deprecated = { level = "warn" }
+trait_associated_const_marked_deprecated = { level = "warn" }
+trait_associated_type_marked_deprecated = { level = "warn" }
+trait_marked_deprecated = { level = "warn" }
+trait_method_marked_deprecated = { level = "warn" }
+type_associated_const_marked_deprecated = { level = "warn" }
+type_marked_deprecated = { level = "warn" }
 type_method_marked_deprecated = { level = "warn" }


### PR DESCRIPTION
cargo-semver-check by default fails when #[deprecated] is added. In one of previous PRs, I disabled this check, but I did not notice there are more similar lints. Here I downgrade them all.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
