### PR TITLE
scylla-cql: Avoid index-access to buffer

### DIFF
--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -305,8 +305,11 @@ pub enum ClusterChangeEventParseError {
 #[non_exhaustive]
 #[derive(Debug, Error, Clone)]
 pub enum PreparedParseError {
+    // TODO(2.0): This variant is unused, and should be removed.
     #[error("Malformed prepared statement's id length: {0}")]
     IdLengthParseError(LowLevelDeserializationError),
+    #[error("Malformed prepared statement's id: {0}")]
+    IdParseError(LowLevelDeserializationError),
     #[error("Invalid result metadata: {0}")]
     ResultMetadataParseError(ResultMetadataParseError),
     #[error("Invalid prepared metadata: {0}")]

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -14,7 +14,7 @@ use crate::frame::frame_errors::{
 use crate::frame::request::query::PagingStateResponse;
 use crate::frame::response::event::SchemaChangeEvent;
 use crate::frame::types;
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -1229,11 +1229,10 @@ fn deser_set_keyspace(buf: &mut &[u8]) -> StdResult<SetKeyspace, SetKeyspacePars
 }
 
 fn deser_prepared(buf: &mut &[u8]) -> StdResult<Prepared, PreparedParseError> {
-    let id_len = types::read_short(buf)
-        .map_err(|err| PreparedParseError::IdLengthParseError(err.into()))?
-        as usize;
-    let id: Bytes = buf[0..id_len].to_owned().into();
-    buf.advance(id_len);
+    let id = types::read_short_bytes(buf)
+        .map_err(PreparedParseError::IdParseError)?
+        .to_owned()
+        .into();
     let prepared_metadata =
         deser_prepared_metadata(buf).map_err(PreparedParseError::PreparedMetadataParseError)?;
     let (result_metadata, paging_state_response) =


### PR DESCRIPTION
If buffer is too short and we index past its end, code will panic. This is not desirable - we want to return errors on invalid protocol messages.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
