### PR TITLE
Release 1.4.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,10 +13,10 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ['v1.2.0', 'v1.3.0', 'v1.3.1', 'v1.4.0']
+TAGS = ['v1.2.0', 'v1.3.0', 'v1.3.1', 'v1.4.0', 'v1.4.1']
 BRANCHES = ['main']
 # Set the latest version.
-LATEST_VERSION = 'v1.4.0'
+LATEST_VERSION = 'v1.4.1'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['main']
 # Set which versions are deprecated

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Async CQL driver for Rust, optimized for ScyllaDB, fully compatible with Apache Cassandra™"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 1.4.1,
an asynchronous CQL driver for Rust, optimized for Scylla, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 5.200k downloads on crates!
- over 650 GitHub stars!

## Changes

1.4.0 failed to build on https://docs.rs/ . We fixed the bug and introduced a CI pipeline to prevent such issues in the future ([#1468](https://github.com/scylladb/scylla-rust-driver/pull/1468)).

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!
