### PR TITLE
Clarify metrics docs

### DIFF
--- a/docs/source/metrics/metrics.md
+++ b/docs/source/metrics/metrics.md
@@ -4,7 +4,13 @@ This feature is available only under the crate feature `metrics`.
 
 During operation the driver collects various metrics.
 
-They can be accessed at any moment using `Session::get_metrics()`
+They can be accessed at any moment using `Session::get_metrics()`.
+
+Please note that those are driver-side metrics, not server-side.
+This means that latencies reported here will be different, because they also include
+the round trip time of a request and driver-side processing.
+
+If you need server-side metrics, please look into Scylla Monitoring Stack.
 
 ### Collected metrics:
 * Query latencies


### PR DESCRIPTION
This PR changes the example percentile in metrics docs from P99.9 to P99, and also clarifies differences between driver-side and server-side metrics.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1208

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.~~
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
