### PR TITLE
Fix test_schema_await_with_unreachable_node

### DIFF
--- a/scylla/tests/integration/session/schema_agreement.rs
+++ b/scylla/tests/integration/session/schema_agreement.rs
@@ -48,6 +48,7 @@ async fn run_some_ddl_with_unreachable_node(
 
     // Cleanup
     running_proxy.running_nodes[paused].change_request_rules(Some(vec![]));
+    session.await_schema_agreement().await.unwrap();
     session
         .query_unpaged(format!("DROP KEYSPACE {ks}"), &[])
         .await


### PR DESCRIPTION
In some test cases we expect schema agreement to fail, for example when we prevent schema fetch query to a coordinator for DDL. In this case it is possible that schema doesn't propagate to some node, and we issue DROP KEYSPACE to such node, resulting in an error. Awaiting schema agreement after clearing proxy rules should fix that.

Explanation of the failing scenario (copied from https://github.com/scylladb/scylla-rust-driver/issues/1433#issuecomment-3532035813 ):

1. Session is correctly established, with connections to all 3 nodes through proxt (let's call them nodes 0, 1, 2).
2. We enter the first test case, and change proxy rules accordingly
3. CREATE KEYSPACE is sent to node 1 (as expected), and reaches the server
4. Non-error result is sent back from the server, and reaches the driver, so the keyspace was successfully created
5. Driver tries to await schema agreement, so it send a query to `system.local` to all 3 nodes
6. Query to node 1 is intercepted by the proxy, and connection dropped
7. Other queries complete successfully
8. Driver does not attempt another agreement check
9. Driver sends DROP KEYSPACE
10. Connection that was broken in step 6 is re-opened. I don't think it matters, but adding it for completeness
11. Driver receives error from DROP KEYSPACE
12. Driver receives two EVENTs related to schema changes in other tests
13. Driver receives EVENT about keyspace that we created in step 3 (!)
14. Driver reports error about keyspace we tried to drop not existing.

Fixes https://github.com/scylladb/scylla-rust-driver/issues/1433


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
