### PR TITLE
data-types.md improvements

### DIFF
--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -3,7 +3,7 @@
 The driver maps database data types to matching Rust types
 to achieve seamless sending and receiving of CQL values.
 
-See the following chapters for examples on how to send and receive each data type.
+See the following chapters for examples on how to send and receive each data type. Please note that using some of those types requires enabling respective feature flags. Details are available in chapters for such data types.
 
 See [Statement values](../statements/values.md) for more information about sending values along with statements.\
 See [Query result](../statements/result.md) for more information about retrieving values from queries


### PR DESCRIPTION
`data-types.md` had some issues:
- For `Decimal` CQL type, nonexisting `bigdecimal::Decimal` type was specified, instead of `bigdecimal::BigDecimal`.
- Borrowed versions of `CqlVarint` and `CqlDecimal` were not mentioned.

Additionally, in https://github.com/scylladb/scylla-rust-driver/issues/1376 user requested to add information about feature flags to the types that require them.
I tried to do this, but resulting page looked clutter imo. Instead, I added a note about some types requiring feature flags, guiding users to the chapters for more details.


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1376

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [ ] ~~PR description sums up the changes and reasons why they should be introduced.~~
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
