### PR TITLE
Remove multilingual option for md book

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -3,7 +3,6 @@ title = "ScyllaDB Rust Driver"
 description = "Documentation for ScyllaDB Rust Driver"
 authors = []
 language = "en"
-multilingual = false
 src = "source"
 
 [rust]

--- a/docs/sphinx_preprocessor.py
+++ b/docs/sphinx_preprocessor.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     # load both the context and the book representations from stdin
     context, book = json.load(sys.stdin)
 
-    for section in book['sections']:
+    for section in book['items']:
         process_section(section)
 
     # we are done with the book's modification, we can just print it to stdout


### PR DESCRIPTION
With the release of md book 0.5.0 multilingual option was removed. This commit removes this option, as keeping it causes the build to fail. See: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#config-changes

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
