### PR TITLE
Increase test_pager_timeouts timeouts

### DIFF
--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -305,7 +305,7 @@ async fn test_pager_timeouts() {
 
             // Case 2: the second page fetch times out.
             {
-                let timeout = Duration::from_millis(100);
+                let timeout = Duration::from_millis(200);
                 prepared.set_request_timeout(Some(timeout));
 
                 running_proxy.running_nodes.iter_mut().for_each(|node| {
@@ -320,7 +320,7 @@ async fn test_pager_timeouts() {
                         RequestRule(
                             Condition::RequestOpcode(RequestOpcode::Execute)
                                 .and(Condition::not(Condition::ConnectionRegisteredAnyEvent)),
-                            RequestReaction::delay(timeout + Duration::from_millis(10))
+                            RequestReaction::delay(timeout + Duration::from_millis(100))
                         )
                     ]));
                 });


### PR DESCRIPTION
The timeouts were too low for cassandra. Let's try with 2x increase.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1483

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
