### PR TITLE
.gitignore: Add .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 .idea
 .idea/workspace.xml
 scylla/ccm_data/
+.DS_Store


### PR DESCRIPTION
Those files are automatically created by the built-in MacOS file manager program when opening a directory. It's harmless, but annoying, so ignore those files in .gitignore.