### PR TITLE
Add nodejs-rs driver endpoint for raw rows.

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -101,6 +101,9 @@ harness = false
 [lints.rust]
 unnameable_types = "warn"
 unreachable_pub = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(nodejs_rs_unstable)',
+] }
 
 [package.metadata.cargo-semver-checks.lints]
 workspace = true

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -836,6 +836,13 @@ impl DeserializedMetadataAndRawRows {
         );
         TypedRowIterator::new(raw)
     }
+
+    /// Allows to retrieve raw rows, without the need for deserialization
+    /// Intended to be used only in nodejs-rs driver only.
+    #[cfg(nodejs_rs_unstable)]
+    pub fn raw_rows(&self) -> &Bytes {
+        &self.raw_rows
+    }
 }
 
 /// Represents the result of a CQL `RESULT` response.

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -405,6 +405,13 @@ impl QueryRowsResult {
             request_coordinator,
         )
     }
+
+    /// Allows to obtain reference to `DeserializedMetadataAndRawRows`, without the need for owned object deconstruction.
+    /// Intended to be used only in nodejs-rs driver only.
+    #[cfg(nodejs_rs_unstable)]
+    pub fn raw_rows_with_metadata(&self) -> &DeserializedMetadataAndRawRows {
+        &self.raw_rows_with_metadata
+    }
 }
 
 /// An error returned by [`QueryResult::into_rows_result`]


### PR DESCRIPTION
Deserialization on the rust side, for the NodeJS driver has significant overhead, compared to the deserialization done by the JS driver from raw rows.

This commit introduces the endpoints that allow nodejs-rs driver to access raw rows parts of the query result.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
~~- [ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
~~- [ ] I have adjusted the documentation in `./docs/source/`.~~
~~- [ ] I added appropriate `Fixes:` annotations to PR description.~~
