### PR TITLE
macros: Add support for C-style enum serialization

### DIFF
--- a/docs/source/data-types/primitive.md
+++ b/docs/source/data-types/primitive.md
@@ -1,4 +1,4 @@
-# Bool, Tinyint, Smallint, Int, Bigint, Float, Double
+# Bool, Tinyint, Smallint, Int, Bigint, Float, Double, C-style Enum
 
 ### Bool
 
@@ -200,5 +200,33 @@ while let Some((double_value,)) = iter.try_next().await? {
     println!("{:?}", double_value);
 }
 # Ok(())
+# }
+```
+
+### C-style Enums
+
+With this feature, you can map Rust C-style enums to integer columns (`int`, `smallint`, `tinyint`) in ScyllaDB.
+
+When you have a C-style enum (an enum where all variants are unit variants), simply add the standard Rust `#[repr(TYPE)]` attribute (e.g. `#[repr(i32)]`). The driver will detect this attribute and use the corresponding integer type for serialization.
+
+#### Supported Types
+You can use standard Rust signed integer types: `i8`, `i16`, `i32`, `i64`.
+
+#### Example
+
+```rust
+# extern crate scylla;
+# async fn check_only_compiles() {
+use scylla::{SerializeValue, DeserializeValue};
+
+// Defines an enum that will be stored as an 'int' in ScyllaDB.
+#[derive(SerializeValue, DeserializeValue, PartialEq, Debug, Clone, Copy)]
+#[repr(i32)]
+enum Status {
+    New = 0,
+    Processing = 1,
+    Completed = 2,
+    Failed = 99,
+}
 # }
 ```

--- a/scylla-cql/src/types_tests.rs
+++ b/scylla-cql/src/types_tests.rs
@@ -302,3 +302,233 @@ mod derive_macros_integration {
         }
     }
 }
+
+mod enum_serialization_tests {
+    use crate::_macro_internal::DeserializationError;
+    use crate::deserialize::FrameSlice;
+    use crate::deserialize::value::BuiltinDeserializationError;
+    use crate::deserialize::value::DeserializeValue;
+    use crate::frame::response::result::{ColumnType, NativeType};
+    use crate::serialize::value::SerializeValue;
+    use crate::serialize::writers::CellWriter;
+    use bytes::Bytes;
+    use scylla_macros::{DeserializeValue, SerializeValue};
+
+    // --- TEST HELPERS ---
+
+    fn assert_round_trip<T>(value: T, typ: ColumnType, expected_bytes: &[u8])
+    where
+        T: SerializeValue
+            + for<'f, 'm> DeserializeValue<'f, 'm>
+            + PartialEq
+            + std::fmt::Debug
+            + Copy,
+    {
+        // Serialization Test
+        let mut data = Vec::new();
+        let writer = CellWriter::new(&mut data);
+        value.serialize(&typ, writer).unwrap();
+
+        // Verify length header (4 bytes big endian) + data
+        let len = expected_bytes.len() as i32;
+        let mut expected_full = len.to_be_bytes().to_vec();
+        expected_full.extend_from_slice(expected_bytes);
+
+        assert_eq!(data, expected_full, "Serialization failed (byte mismatch)");
+
+        // Deserialization Test
+        // Simulate reading from a frame (skip 4 bytes length header)
+        let payload = Bytes::copy_from_slice(expected_bytes);
+        let slice = FrameSlice::new(&payload);
+
+        let deserialized = T::deserialize(&typ, Some(slice)).expect("Deserialization failed");
+        assert_eq!(
+            value, deserialized,
+            "Deserialized value does not match input"
+        );
+    }
+
+    fn assert_deser_error<T, F>(typ: ColumnType, bad_bytes: &[u8], check_error: F)
+    where
+        T: for<'f, 'm> DeserializeValue<'f, 'm> + std::fmt::Debug,
+        F: FnOnce(DeserializationError),
+    {
+        let payload = Bytes::copy_from_slice(bad_bytes);
+        let slice = FrameSlice::new(&payload);
+        let result = T::deserialize(&typ, Some(slice));
+
+        match result {
+            Ok(v) => panic!("Expected error, but deserialization succeeded: {:?}", v),
+            Err(e) => check_error(e),
+        }
+    }
+
+    // --- ENUM DEFINITIONS ---
+
+    #[derive(SerializeValue, DeserializeValue, Debug, PartialEq, Copy, Clone)]
+    #[scylla(crate = "crate")]
+    #[repr(i32)]
+    enum DefaultInt {
+        A = 0,
+        B = 1,
+        C = 100,
+    }
+
+    #[derive(SerializeValue, DeserializeValue, Debug, PartialEq, Copy, Clone)]
+    #[scylla(crate = "crate")]
+    #[repr(i8)]
+    enum TinyEnum {
+        Small = 10,
+        Max = 127,
+    }
+
+    #[derive(SerializeValue, DeserializeValue, Debug, PartialEq, Copy, Clone)]
+    #[scylla(crate = "crate")]
+    #[repr(i16)]
+    enum SmallEnum {
+        Kilo = 1000,
+        BigKilo = 30000,
+    }
+
+    #[derive(SerializeValue, DeserializeValue, Debug, PartialEq, Copy, Clone)]
+    #[repr(i64)]
+    #[scylla(crate = "crate")]
+    enum BigEnum {
+        Big = 5_000_000_000,
+    }
+
+    #[derive(SerializeValue, DeserializeValue, Debug, PartialEq, Copy, Clone)]
+    #[scylla(crate = "crate")]
+    #[repr(i32)]
+    enum Gaps {
+        First = 1,
+        Jump = 5,
+        FarAway = 99,
+    }
+
+    #[derive(SerializeValue, DeserializeValue, Debug, PartialEq, Copy, Clone)]
+    #[scylla(crate = "crate")]
+    #[repr(i32)]
+    enum NegativeEnum {
+        MinusOne = -1,
+        MinusHundred = -100,
+    }
+
+    #[derive(SerializeValue, DeserializeValue, Debug, PartialEq, Copy, Clone)]
+    #[scylla(crate = "crate")]
+    #[repr(i32)]
+    enum ImplicitEnum {
+        First,
+        Second,
+        Third,
+    }
+
+    // --- TESTS ---
+
+    #[test]
+    fn test_i32_standard() {
+        let typ = ColumnType::Native(NativeType::Int);
+        assert_round_trip(DefaultInt::A, typ.clone(), &[0, 0, 0, 0]);
+        assert_round_trip(DefaultInt::C, typ.clone(), &[0, 0, 0, 100]);
+    }
+
+    #[test]
+    fn test_i8_tinyint() {
+        let typ = ColumnType::Native(NativeType::TinyInt);
+        assert_round_trip(TinyEnum::Small, typ.clone(), &[10]);
+        assert_round_trip(TinyEnum::Max, typ.clone(), &[0x7F]);
+    }
+
+    #[test]
+    fn test_i16_smallint() {
+        let typ = ColumnType::Native(NativeType::SmallInt);
+        assert_round_trip(SmallEnum::Kilo, typ.clone(), &[0x03, 0xE8]);
+        assert_round_trip(SmallEnum::BigKilo, typ.clone(), &30000i16.to_be_bytes());
+    }
+
+    #[test]
+    fn test_i64_bigint() {
+        let typ = ColumnType::Native(NativeType::BigInt);
+        assert_round_trip(BigEnum::Big, typ.clone(), &5_000_000_000i64.to_be_bytes());
+    }
+
+    #[test]
+    fn test_gaps_in_discriminants() {
+        let typ = ColumnType::Native(NativeType::Int);
+        assert_round_trip(Gaps::First, typ.clone(), &1i32.to_be_bytes());
+        assert_round_trip(Gaps::Jump, typ.clone(), &5i32.to_be_bytes());
+        assert_round_trip(Gaps::FarAway, typ.clone(), &99i32.to_be_bytes());
+
+        let bad_val = 2i32.to_be_bytes();
+        assert_deser_error::<Gaps, _>(typ.clone(), &bad_val, |err| {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("Enum value does not match any variant: 2"),
+                "Got unexpected error message: {}",
+                msg
+            );
+        });
+    }
+
+    #[test]
+    fn test_negative_discriminants() {
+        let typ = ColumnType::Native(NativeType::Int);
+        assert_round_trip(NegativeEnum::MinusOne, typ.clone(), &(-1i32).to_be_bytes());
+        assert_round_trip(
+            NegativeEnum::MinusHundred,
+            typ.clone(),
+            &(-100i32).to_be_bytes(),
+        );
+    }
+
+    #[test]
+    fn test_implicit_discriminants() {
+        let typ = ColumnType::Native(NativeType::Int);
+        assert_round_trip(ImplicitEnum::First, typ.clone(), &0i32.to_be_bytes());
+        assert_round_trip(ImplicitEnum::Second, typ.clone(), &1i32.to_be_bytes());
+        assert_round_trip(ImplicitEnum::Third, typ.clone(), &2i32.to_be_bytes());
+    }
+
+    #[test]
+    fn test_invalid_data_errors() {
+        let typ = ColumnType::Native(NativeType::Int);
+        let out_of_range = 999i32.to_be_bytes();
+        assert_deser_error::<DefaultInt, _>(typ.clone(), &out_of_range, |err| {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("Enum value does not match any variant: 999"),
+                "Got unexpected error message: {}",
+                msg
+            );
+        });
+
+        let too_short = vec![0, 0, 1];
+        assert_deser_error::<DefaultInt, _>(typ.clone(), &too_short, |err| {
+            assert!(
+                err.downcast_ref::<BuiltinDeserializationError>().is_some(),
+                "Expected BuiltinDeserializationError, got: {:?}",
+                err
+            );
+        });
+    }
+
+    #[test]
+    fn test_null_handling() {
+        let typ = ColumnType::Native(NativeType::Int);
+        let result = <DefaultInt as DeserializeValue>::deserialize(&typ, None);
+        assert!(
+            result.is_err(),
+            "Deserializing NULL into non-Option enum should fail"
+        );
+    }
+
+    #[test]
+    fn test_type_check_mismatch() {
+        let bad_typ = ColumnType::Native(NativeType::Text);
+        let check = <DefaultInt as DeserializeValue>::type_check(&bad_typ);
+        assert!(
+            check.is_err(),
+            "Should return TypeCheck error (Int vs Text)"
+        );
+    }
+}

--- a/scylla-macros/src/deserialize/value.rs
+++ b/scylla-macros/src/deserialize/value.rs
@@ -6,6 +6,7 @@ use proc_macro2::Span;
 use syn::{ext::IdentExt, parse_quote};
 
 use crate::Flavor;
+use crate::enum_attrs::EnumAttrs;
 
 use super::{DeserializeCommonFieldAttrs, DeserializeCommonStructAttrs};
 
@@ -34,6 +35,12 @@ struct StructAttrs {
 }
 
 impl DeserializeCommonStructAttrs for StructAttrs {
+    fn crate_path(&self) -> Option<&syn::Path> {
+        self.crate_path.as_ref()
+    }
+}
+
+impl DeserializeCommonStructAttrs for EnumAttrs {
     fn crate_path(&self) -> Option<&syn::Path> {
         self.crate_path.as_ref()
     }
@@ -82,29 +89,123 @@ impl DeserializeCommonFieldAttrs for Field {
 pub(crate) fn deserialize_value_derive(
     tokens_input: TokenStream,
 ) -> Result<syn::ItemImpl, syn::Error> {
-    let input = syn::parse(tokens_input)?;
+    let input: syn::DeriveInput = syn::parse(tokens_input)?;
 
-    let implemented_trait: syn::Path = parse_quote!(DeserializeValue);
-    let implemented_trait_name = implemented_trait
-        .segments
-        .last()
-        .unwrap()
-        .ident
-        .unraw()
-        .to_string();
-    let constraining_trait = implemented_trait.clone();
-    let s = StructDesc::new(&input, &implemented_trait_name, constraining_trait)?;
+    match &input.data {
+        syn::Data::Enum(data_enum) => deserialize_value_derive_enum(&input, data_enum),
+        syn::Data::Struct(_) => {
+            let implemented_trait: syn::Path = parse_quote!(DeserializeValue);
+            let implemented_trait_name = implemented_trait
+                .segments
+                .last()
+                .unwrap()
+                .ident
+                .unraw()
+                .to_string();
+            let constraining_trait = implemented_trait.clone();
+            let s = StructDesc::new(&input, &implemented_trait_name, constraining_trait)?;
 
-    validate_attrs(&s.attrs, s.fields())?;
+            validate_attrs(&s.attrs, s.fields())?;
 
-    let items = [
-        s.generate_type_check_method().into(),
-        s.generate_deserialize_method().into(),
-    ];
+            let items = [
+                s.generate_type_check_method().into(),
+                s.generate_deserialize_method().into(),
+            ];
 
-    Ok(s.generate_impl(implemented_trait, items))
+            Ok(s.generate_impl(implemented_trait, items))
+        }
+        syn::Data::Union(_) => Err(syn::Error::new_spanned(
+            input,
+            "DeserializeValue cannot be derived for unions",
+        )),
+    }
 }
 
+fn deserialize_value_derive_enum(
+    input: &syn::DeriveInput,
+    data_enum: &syn::DataEnum,
+) -> Result<syn::ItemImpl, syn::Error> {
+    use crate::enum_attrs::{EnumAttrs, get_enum_repr_type, validate_c_style_enum};
+
+    validate_c_style_enum(data_enum)?;
+
+    let attrs = EnumAttrs::from_attributes(&input.attrs)?;
+    let crate_path = <EnumAttrs as DeserializeCommonStructAttrs>::macro_internal_path(&attrs);
+
+    let repr_type_str = get_enum_repr_type(input)?;
+    let repr_type: syn::Type = syn::parse_str(&repr_type_str)
+        .map_err(|_| syn::Error::new_spanned(input, "Failed to parse repr type"))?;
+
+    let mut match_arms = Vec::new();
+
+    for variant in &data_enum.variants {
+        let variant_ident = &variant.ident;
+
+        match_arms.push(quote::quote! {
+            v if v == Self::#variant_ident as #repr_type => {
+                ::std::result::Result::Ok(Self::#variant_ident)
+            }
+        });
+    }
+
+    let (_, ty_generics, where_clause) = input.generics.split_for_impl();
+    let impl_generics = &input.generics.params;
+    let struct_name = &input.ident;
+
+    let (frame_lifetime, metadata_lifetime) =
+        super::generate_pair_of_unique_lifetimes_for_impl(&input.generics);
+
+    let predicates = super::generate_lifetime_constraints_for_impl(
+        &input.generics,
+        parse_quote!(DeserializeValue),
+        &frame_lifetime,
+    );
+
+    let res = parse_quote! {
+        #[automatically_derived]
+        impl<#frame_lifetime, #metadata_lifetime, #impl_generics> #crate_path::DeserializeValue<#frame_lifetime, #metadata_lifetime> for #struct_name #ty_generics
+        where #repr_type: ::std::fmt::Debug + ::std::marker::Copy, #(#predicates),* #where_clause
+        {
+            fn type_check(
+                typ: &#crate_path::ColumnType,
+            ) -> ::std::result::Result<(), #crate_path::TypeCheckError> {
+                <#repr_type as #crate_path::DeserializeValue<#frame_lifetime, #metadata_lifetime>>::type_check(typ)
+            }
+
+            fn deserialize(
+                typ: &#metadata_lifetime #crate_path::ColumnType<#metadata_lifetime>,
+                v: ::std::option::Option<#crate_path::FrameSlice<#frame_lifetime>>,
+            ) -> ::std::result::Result<Self, #crate_path::DeserializationError> {
+                let raw_val = <#repr_type as #crate_path::DeserializeValue<#frame_lifetime, #metadata_lifetime>>::deserialize(typ, v)
+                    .map_err(#crate_path::value_deser_error_replace_rust_name::<Self>)?;
+
+                match raw_val {
+                    #(#match_arms)*
+                    val => {
+                        #[derive(Debug)]
+                        struct UnknownEnumVariant<T>(T);
+
+                        impl<T: ::std::fmt::Debug> ::std::fmt::Display for UnknownEnumVariant<T> {
+                            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                                ::std::write!(f, "Enum value does not match any variant: {:?}", self.0)
+                            }
+                        }
+
+                        impl<T: ::std::fmt::Debug> ::std::error::Error for UnknownEnumVariant<T> {}
+
+                        ::std::result::Result::Err(
+                            #crate_path::DeserializationError::new(
+                                UnknownEnumVariant(val)
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    };
+
+    Ok(res)
+}
 fn validate_attrs(attrs: &StructAttrs, fields: &[Field]) -> Result<(), darling::Error> {
     let mut errors = darling::Error::accumulator();
 

--- a/scylla-macros/src/enum_attrs.rs
+++ b/scylla-macros/src/enum_attrs.rs
@@ -1,0 +1,70 @@
+use darling::FromAttributes;
+use syn::parse_quote;
+
+#[derive(FromAttributes)]
+#[darling(attributes(scylla))]
+pub(crate) struct EnumAttrs {
+    #[darling(rename = "crate")]
+    pub(crate) crate_path: Option<syn::Path>,
+}
+
+impl EnumAttrs {
+    pub(crate) fn macro_internal_path(&self) -> syn::Path {
+        self.crate_path
+            .as_ref()
+            .map(|p| parse_quote!(#p::_macro_internal))
+            .unwrap_or_else(|| parse_quote!(::scylla::_macro_internal))
+    }
+}
+
+pub(crate) fn get_enum_repr_type(input: &syn::DeriveInput) -> Result<String, syn::Error> {
+    let mut repr_type = None;
+
+    for attr in &input.attrs {
+        if !attr.path().is_ident("repr") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            let path = &meta.path;
+            let Some(ident) = path.get_ident() else {
+                return Ok(());
+            };
+            let s = ident.to_string();
+            match s.as_str() {
+                "i8" | "i16" | "i32" | "i64" => {
+                    repr_type = Some(s);
+                }
+                _ => {}
+            }
+            Ok(())
+        })?;
+    }
+
+    match repr_type {
+        Some(t) => Ok(t),
+        None => Err(syn::Error::new_spanned(
+            input,
+            "SerializeValue/DeserializeValue for enums requires a standard #[repr(...)] attribute with a signed integer type (i8, i16, i32, i64). Example: #[repr(i32)]",
+        )),
+    }
+}
+
+pub(crate) fn validate_c_style_enum(data_enum: &syn::DataEnum) -> Result<(), syn::Error> {
+    if data_enum.variants.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &data_enum.variants,
+            "Cannot derive trait for enums with no variants",
+        ));
+    }
+
+    for variant in &data_enum.variants {
+        if !variant.fields.is_empty() {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "Trait can only be derived for enums with unit variants (no data fields).",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/scylla-macros/src/lib.rs
+++ b/scylla-macros/src/lib.rs
@@ -22,7 +22,7 @@
 
 use darling::{FromMeta, ToTokens};
 use proc_macro::TokenStream;
-
+pub(crate) mod enum_attrs;
 mod parser;
 
 // Flavor of serialization/deserialization macros ({De,S}erialize{Value,Row}).
@@ -85,6 +85,23 @@ mod serialize;
 ///     a: i32,
 ///     b: Option<String>,
 ///     // No "c" field - it is not mandatory by default for all fields to be present
+/// }
+/// ```
+///
+/// # C-style Enums
+///
+/// You can derive `SerializeValue` for C-style enums (enums with only unit variants)
+/// to serialize them as integers. The macro reads the standard `#[repr(TYPE)]` attribute
+/// to determine the integer type.
+///
+/// ```rust
+/// # use scylla::SerializeValue;
+/// #[derive(SerializeValue, Clone, Copy)]
+/// #[repr(i32)]
+/// enum Color {
+///     Red = 0,
+///     Green = 1,
+///     Blue = 2,
 /// }
 /// ```
 ///
@@ -430,6 +447,26 @@ pub fn deserialize_row_derive(tokens_input: TokenStream) -> TokenStream {
 ///     a: i32,
 ///     b: Option<String>,
 ///     c: &'a [u8],
+/// }
+/// ```
+///
+/// # C-style Enums
+///
+/// You can derive `DeserializeValue` for C-style enums to deserialize them from integers.
+/// The macro will verify that the value from the database matches one of the enum variants.
+/// The macro reads the standard `#[repr(TYPE)]` attribute to determine the integer type.
+/// **Note:** The derive macro currently only supports explicit integer literals as discriminants
+/// (e.g., `Variant = 1`). Complex constant expressions (e.g., `Variant = 1 << 3`)
+/// or references to constants (e.g., `Variant = MY_CONST`) are not supported.
+///
+/// ```rust
+/// # use scylla::DeserializeValue;
+/// #[derive(DeserializeValue, Clone, Copy, Debug, PartialEq)]
+/// #[scylla(crate = "scylla_cql")]
+/// #[repr(i16)]
+/// enum ErrorCode {
+///     NotFound = 404,
+///     ServerBug = 500,
 /// }
 /// ```
 ///

--- a/scylla/tests/integration/macros/hygiene.rs
+++ b/scylla/tests/integration/macros/hygiene.rs
@@ -185,6 +185,39 @@ macro_rules! test_crate {
             };
         }
 
+        #[test]
+        fn test_enum_ser_deser() {
+            use crate::utils::setup_tracing;
+            use ::bytes::Bytes;
+            use ::std::assert_eq;
+            use ::std::vec::Vec;
+            use _scylla::deserialize::value::DeserializeValue;
+            use _scylla::deserialize::FrameSlice;
+            use _scylla::frame::response::result::{ColumnType, NativeType};
+            use _scylla::serialize::value::SerializeValue;
+            use _scylla::serialize::writers::CellWriter;
+
+            setup_tracing();
+
+            let val = TestEnum::A;
+            let typ = ColumnType::Native(NativeType::Int);
+
+            let mut buf = Vec::new();
+            let writer = CellWriter::new(&mut buf);
+            SerializeValue::serialize(&val, &typ, writer).unwrap();
+
+            let expected = ::std::vec![0, 0, 0, 4, 0, 0, 0, 1];
+            assert_eq!(buf, expected);
+
+            assert!(<TestEnum as DeserializeValue>::type_check(&typ).is_ok());
+
+            let bytes_buf = Bytes::copy_from_slice(&buf);
+            let slice = FrameSlice::new(&bytes_buf).read_cql_bytes().unwrap();
+            let deserialized = <TestEnum as DeserializeValue>::deserialize(&typ, slice).unwrap();
+
+            assert_eq!(deserialized, val);
+        }
+
         // Test attributes for value struct with name flavor
         #[derive(
             _scylla::DeserializeValue, _scylla::SerializeValue, PartialEq, Debug,
@@ -342,6 +375,21 @@ macro_rules! test_crate {
             c: ::core::primitive::i32,
             #[scylla(default_when_null)]
             d: ::core::primitive::i32,
+        }
+
+        #[derive(
+            _scylla::DeserializeValue,
+            _scylla::SerializeValue,
+            PartialEq,
+            Debug,
+            Clone,
+            Copy,
+        )]
+        #[scylla(crate = _scylla)]
+        #[repr(i32)]
+        enum TestEnum {
+            A = 1,
+            B = 2,
         }
     };
 }


### PR DESCRIPTION
## Motivation
Users often map C-style enums (enums with unit variants and integer discriminants) to integer columns in ScyllaDB (e.g., `tinyint`, `smallint`, `int`). Currently, users must manually implement `SerializeValue` and `DeserializeValue` for these enums, which involves tedious boilerplate for matching variants to integers and vice versa.

## Solution
This commit extends `SerializeValue` and `DeserializeValue` macros to support C-style enums directly.
Users can now annotate their enum with `#[scylla(repr = "TYPE")]` (e.g., `"i8"`, `"i32"`), and the macro will generate code that:
- Serializes the enum variant as its integer discriminant.
- Deserializes an integer from the DB and matches it back to the corresponding enum variant.

**Behavior details:**
- If a discriminant is not specified explicitly, standard Rust rules apply (starts at 0, increments by 1).
- Deserialization fails with a proper error if the integer value from the DB does not match any known variant.
- Type checking delegates to the underlying integer type (e.g., `i32` checks against `Int` column).

## What's done

### Refactored DeserializeValue derive
- Refactored `deserialize_value_derive` to handle `Data::Enum` separately.
- Added parsing for the `#[scylla(repr = "...")]` attribute via `EnumAttrs`.
- Implemented `deserialize_value_derive_enum`, which generates a `match` statement mapping integers from the database back to enum variants.

### Refactored SerializeValue derive
- Refactored `serialize_value_derive` to handle `Data::Enum`.
- Implemented `derive_serialize_value_enum`, which casts the enum variant to the representation type (e.g., `*self as i32`) before serialization.

## What has been tested

### Tests
Added comprehensive tests covering:
- **Integer sizes:** Support for `i8` (TinyInt), `i16` (SmallInt), `i32` (Int), and `i64` (BigInt).
- **Discriminants:** Tested standard auto-incrementing discriminants and manual discriminants with gaps.
- **Error Handling:** Verified that deserialization fails with a clear error when the database value doesn't match any enum variant.
- **Type Checking:** Verified that using an enum wrapper incorrectly (e.g., against a `Text` column) produces a type check error.

Fixes: #923 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
