### PR TITLE
macros: Add support for #[scylla(transparent)] attribute

### DIFF
--- a/scylla-cql/src/_macro_internal.rs
+++ b/scylla-cql/src/_macro_internal.rs
@@ -15,6 +15,7 @@ pub use crate::deserialize::value::{
     UdtDeserializationErrorKind, UdtIterator, UdtTypeCheckErrorKind as DeserUdtTypeCheckErrorKind,
     deser_error_replace_rust_name as value_deser_error_replace_rust_name,
     mk_deser_err as mk_value_deser_err, mk_typck_err as mk_value_typck_err,
+    typck_error_replace_rust_name as value_type_check_error_replace_rust_name,
 };
 pub use crate::deserialize::{DeserializationError, FrameSlice, TypeCheckError};
 pub use crate::serialize::row::{

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -682,7 +682,7 @@ where
 // collections
 
 make_error_replace_rust_name!(
-    pub(crate),
+    pub,
     typck_error_replace_rust_name,
     TypeCheckError,
     BuiltinTypeCheckError

--- a/scylla-macros/src/parser.rs
+++ b/scylla-macros/src/parser.rs
@@ -17,3 +17,15 @@ pub(crate) fn parse_named_fields<'a>(
         Data::Union(u) => Err(syn::Error::new_spanned(u.union_token, create_err_msg())),
     }
 }
+
+pub(crate) fn get_exactly_one<I>(iter: I) -> Option<I::Item>
+where
+    I: IntoIterator,
+{
+    let mut iter = iter.into_iter();
+    let item = iter.next()?;
+    if iter.next().is_some() {
+        return None;
+    }
+    Some(item)
+}

--- a/scylla/tests/integration/macros/mod.rs
+++ b/scylla/tests/integration/macros/mod.rs
@@ -1,2 +1,3 @@
 mod complex_pk;
 mod hygiene;
+mod transparent;

--- a/scylla/tests/integration/macros/transparent.rs
+++ b/scylla/tests/integration/macros/transparent.rs
@@ -1,0 +1,193 @@
+use bytes::Bytes;
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::value::DeserializeValue as DeserializeValueTrait;
+use scylla::frame::response::result::{ColumnType, NativeType};
+use scylla::serialize::value::SerializeValue as SerializeValueTrait;
+use scylla::serialize::writers::CellWriter;
+use scylla::{DeserializeValue, SerializeValue};
+
+fn assert_round_trip<T>(
+    value: T,
+    typ: ColumnType,
+    expected_bytes: &[u8], // Raw payload without length header
+) where
+    T: SerializeValueTrait
+        + for<'f, 'm> DeserializeValueTrait<'f, 'm>
+        + PartialEq
+        + std::fmt::Debug
+        + Copy,
+{
+    let mut data = Vec::new();
+    let writer = CellWriter::new(&mut data);
+    value.serialize(&typ, writer).unwrap();
+
+    // Verify length header (4 bytes big endian) + payload
+    let len = expected_bytes.len() as i32;
+    let mut expected_full = len.to_be_bytes().to_vec();
+    expected_full.extend_from_slice(expected_bytes);
+
+    assert_eq!(data, expected_full, "Serialization failed (byte mismatch)");
+
+    // Simulate reading from a frame (we skip the 4-byte length header)
+    let payload = Bytes::copy_from_slice(expected_bytes);
+    let slice = FrameSlice::new(&payload);
+
+    let deserialized = T::deserialize(&typ, Some(slice)).expect("Deserialization failed");
+    assert_eq!(
+        value, deserialized,
+        "Deserialized value does not match input"
+    );
+}
+
+// Tuple Struct with a primitive inner type (i32)
+#[derive(SerializeValue, DeserializeValue, PartialEq, Debug, Copy, Clone)]
+#[scylla(transparent)]
+struct TransparentTuple(i32);
+
+// Named Struct with a primitive inner type (i32)
+#[derive(SerializeValue, DeserializeValue, PartialEq, Debug, Copy, Clone)]
+#[scylla(transparent)]
+struct TransparentNamed {
+    val: i32,
+}
+
+// Deeply nested transparent structs (Wrapper around Wrapper around i32)
+#[derive(SerializeValue, DeserializeValue, PartialEq, Debug, Copy, Clone)]
+#[scylla(transparent)]
+struct Outer(Inner);
+
+#[derive(SerializeValue, DeserializeValue, PartialEq, Debug, Copy, Clone)]
+#[scylla(transparent)]
+struct Inner(i32);
+
+// A standard UDT struct that derives SerializeValue/DeserializeValue itself
+#[derive(SerializeValue, DeserializeValue, PartialEq, Debug, Clone)]
+struct MyUdt {
+    a: i32,
+    b: String,
+}
+
+// A transparent wrapper around the UDT
+#[derive(SerializeValue, DeserializeValue, PartialEq, Debug, Clone)]
+#[scylla(transparent)]
+struct TransparentOverUdt(MyUdt);
+
+#[test]
+fn test_transparent_tuple_struct() {
+    let typ = ColumnType::Native(NativeType::Int);
+    let val = 12345i32;
+    // 12345 in Big Endian hex is 0x00003039
+    let expected_bytes = &val.to_be_bytes();
+
+    assert_round_trip(TransparentTuple(val), typ, expected_bytes);
+}
+
+#[test]
+fn test_transparent_named_struct() {
+    let typ = ColumnType::Native(NativeType::Int);
+    let val = -123i32;
+    let expected_bytes = &val.to_be_bytes();
+
+    assert_round_trip(TransparentNamed { val }, typ, expected_bytes);
+}
+
+#[test]
+fn test_nested_transparent_structs() {
+    let typ = ColumnType::Native(NativeType::Int);
+    let val = 999i32;
+    let expected_bytes = &val.to_be_bytes();
+
+    // Outer(Inner(999)) should serialize exactly like i32(999)
+    assert_round_trip(Outer(Inner(val)), typ, expected_bytes);
+}
+
+#[test]
+fn test_type_check_delegation() {
+    // This test verifies that type checking is correctly delegated to the inner type.
+    // TransparentTuple wraps an i32. It should accept Int, but reject Text.
+
+    let valid_type = ColumnType::Native(NativeType::Int);
+    let invalid_type = ColumnType::Native(NativeType::Text);
+
+    assert!(
+        <TransparentTuple as DeserializeValueTrait>::type_check(&valid_type).is_ok(),
+        "TransparentTuple should accept Int column type"
+    );
+
+    let err = <TransparentTuple as DeserializeValueTrait>::type_check(&invalid_type);
+    assert!(
+        err.is_err(),
+        "TransparentTuple should reject Text column type (delegating to i32)"
+    );
+}
+
+#[test]
+fn test_deserialization_error_propagation() {
+    // Verify that errors from the inner type are propagated correctly.
+    // If we have less bytes than required for i32 (4 bytes), it should fail.
+
+    let typ = ColumnType::Native(NativeType::Int);
+    let bad_bytes = vec![0x00, 0x01]; // Only 2 bytes, i32 needs 4
+
+    let payload = Bytes::copy_from_slice(&bad_bytes);
+    let slice = FrameSlice::new(&payload);
+
+    let result = <TransparentTuple as DeserializeValueTrait>::deserialize(&typ, Some(slice));
+
+    assert!(
+        result.is_err(),
+        "Deserialization should fail when underlying data is invalid for inner type"
+    );
+}
+
+#[test]
+fn test_transparent_udt_wrapper() {
+    use scylla::frame::response::result::UserDefinedType;
+    use std::sync::Arc;
+
+    let udt_def = UserDefinedType {
+        keyspace: "ks".into(),
+        name: "my_udt".into(),
+        field_types: vec![
+            ("a".into(), ColumnType::Native(NativeType::Int)),
+            ("b".into(), ColumnType::Native(NativeType::Text)),
+        ],
+    };
+
+    let typ = ColumnType::UserDefinedType {
+        frozen: false,
+        definition: Arc::new(udt_def),
+    };
+
+    let inner = MyUdt {
+        a: 123,
+        b: "test_string".to_string(),
+    };
+    let wrapper = TransparentOverUdt(inner.clone());
+
+    let mut data_inner = Vec::new();
+    let writer_inner = CellWriter::new(&mut data_inner);
+    SerializeValueTrait::serialize(&inner, &typ, writer_inner).unwrap();
+
+    let mut data_wrapper = Vec::new();
+    let writer_wrapper = CellWriter::new(&mut data_wrapper);
+    SerializeValueTrait::serialize(&wrapper, &typ, writer_wrapper).unwrap();
+
+    assert_eq!(
+        data_inner, data_wrapper,
+        "Transparent wrapper serialized differently than the inner type"
+    );
+
+    assert!(
+        data_inner.len() > 4,
+        "Serialized data is too short to contain a length header"
+    );
+    let payload = Bytes::copy_from_slice(&data_inner[4..]);
+    let slice = FrameSlice::new(&payload);
+
+    let deserialized_wrapper =
+        <TransparentOverUdt as DeserializeValueTrait>::deserialize(&typ, Some(slice))
+            .expect("Failed to deserialize wrapper from inner bytes");
+
+    assert_eq!(deserialized_wrapper.0, inner);
+}


### PR DESCRIPTION
## Motivation
Users often employ the newtype pattern (i.e., define single-field structs) to wrap the driver's types that implement `{De,S}erialize{Value,Row}`. In such cases, they are currently forced to manually implement (trivially) the respective de/ser traits for those new types, which results in unnecessary boilerplate code.

## Solution
Add support for a new item-level attribute, `#[scylla(transparent)]`.
It is supported on:
- single-field structs (the original use case),
- single-variant enums (technically identical to single-field structs).

The semantics are simple: delegate the trait method's implementation (serialization, deserialization, and type checking) to the only field/variant of the struct/enum.

## What's done

### Implemented transparent logic in DeserializeValue derive
Refactored `deserialize_value_derive` to delegate to a new `derive_transparent` function when the attribute is present.
The implementation ensures that:
- `type_check` delegates to the inner type.
- `deserialize` delegates to the inner type and wraps the result in the newtype constructor.
- Generic `where` clauses are handled correctly by merging generated predicates with existing user predicates using `make_where_clause()`.

### Implemented transparent logic in SerializeValue derive
Modified `serialize_value_derive` to handle the `transparent` attribute.
- **For structs:** Serializes the single field directly.
- **For enums:** Matches the single variant and serializes its inner field.
- Added validation to ensure the attribute is only used on items with exactly one field.

### Updated Attribute Parsing
Updated `StructAttrs` and `Attributes` definitions in both deserialize and serialize modules to parse the `#[scylla(transparent)]` boolean flag via `darling`.

## What has been tested

### Tests
I added a comprehensive suite of tests covering:
- **Tuple Structs:** `struct Wrapper(i32)`
- **Named Structs:** `struct Wrapper { val: i32 }`
- **Enums:** Single variant tuple and named enums.
- **Nested Composition:** `Outer(Inner(i32))` to verify deep delegation.
- **Type Safety:** Verified that `type_check` correctly propagates errors (e.g., trying to read an `int` column as `text` through a wrapper fails).
- **Error Propagation:** Verified that deserialization errors (e.g., not enough bytes) are correctly propagated from the inner type through the wrapper.


Fixes: #1293 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
