### PR TITLE
codewide: silence warnings for uninhabited types

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -863,9 +863,17 @@ impl Session {
         let tls_provider = if let Some(tls_context) = config.tls_context {
             // To silence warnings when TlsContext is an empty enum (tls features are disabled).
             // In such case, TlsProvider is uninhabited.
-            #[allow(unused_variables)]
+            #[cfg_attr(
+                not(any(feature = "openssl-010", feature = "rustls-023")),
+                // TODO: make this expect() once MSRV is 1.92+.
+                allow(unreachable_code, unused_variables)
+            )]
             let provider = TlsProvider::new_with_global_context(tls_context);
-            #[allow(unreachable_code)]
+            #[cfg_attr(
+                not(any(feature = "openssl-010", feature = "rustls-023")),
+                // TODO: remove this once MSRV is 1.92+.
+                allow(unreachable_code)
+            )]
             Some(provider)
         } else {
             None

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -358,7 +358,14 @@ impl GenericSessionBuilder<DefaultMode> {
 "#
     )]
     pub fn tls_context(mut self, tls_context: Option<impl Into<TlsContext>>) -> Self {
-        self.config.tls_context = tls_context.map(|t| t.into());
+        #[cfg_attr(
+            not(any(feature = "openssl-010", feature = "rustls-023")),
+            // TODO: make this expect() once MSRV is 1.92+.
+            allow(unreachable_code)
+        )]
+        {
+            self.config.tls_context = tls_context.map(|t| t.into());
+        }
         self
     }
 }

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -50,6 +50,11 @@ impl TlsProvider {
     ) -> Option<TlsConfig> {
         match self {
             TlsProvider::GlobalContext(context) => {
+                #[cfg_attr(
+                    not(any(feature = "openssl-010", feature = "rustls-023")),
+                    // TODO: make this expect() once MSRV is 1.92+.
+                    allow(unreachable_code)
+                )]
                 Some(TlsConfig::new_with_global_context(context.clone()))
             }
         }


### PR DESCRIPTION
The update to Rust 1.92 made the compiler suddenly complain about unreachable_code when working with uninhabited types (enums with no variants). Such types are used in the driver to represent TLS entities when TLS features are disabled. This commit adds `cfg_attr` attributes with expect(unreachable_code) to silence those warnings.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
