### PR TITLE
.github/workflows/semver_checks.yml: Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -141,6 +141,8 @@ jobs:
   semver-push-tag:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-rust-driver/security/code-scanning/11](https://github.com/scylladb/scylla-rust-driver/security/code-scanning/11)

To fix this, add an explicit `permissions` block that limits the `GITHUB_TOKEN` to the least privilege needed. The `semver-push-tag` job only checks out code and runs local tools, so `contents: read` is sufficient. We should scope permissions at the job level for the flagged job without altering behavior of other jobs.

Concretely:

- In `.github/workflows/semver_checks.yml`, under `semver-push-tag:` (around line 141–144), add:
  ```yaml
  permissions:
    contents: read
  ```
  aligned with `runs-on`, `if`, etc.
- Do not change the existing `permissions` on `semver-pull-request-label`, and do not add unnecessary scopes.

No imports or additional methods are needed; this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
