### PR TITLE
.github/workflows/rust.yml: Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-rust-driver/security/code-scanning/14](https://github.com/scylladb/scylla-rust-driver/security/code-scanning/14)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions either at the workflow level (applies to all jobs) or at the `docs_rs` job level (applies only to that job). Since the workflow jobs all seem to only need to read the repository contents (for `actions/checkout`) and then run local tools, the minimal and correct fix is to set `permissions: contents: read` at the workflow root, which will satisfy CodeQL and follow the least-privilege principle without changing behavior.

Concretely, in `.github/workflows/rust.yml`, add a top-level `permissions:` block after the `name: Rust` line and before the `on:` block. This block should specify `contents: read`. No imports or additional methods are needed; this is purely a YAML configuration change within the workflow file. The rest of the workflow steps remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
