### PR TITLE
.github/workflows/book.yml: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,6 +10,9 @@ on:
     branches:
     - '**'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-rust-driver/security/code-scanning/2](https://github.com/scylladb/scylla-rust-driver/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the least privilege needed. For this workflow, the steps only check out code and build/test locally; they do not interact with PRs, issues, or push changes. The only required permission is read access to repository contents.

The best fix is to add a top-level `permissions` block (at the same level as `on:` and `env:`) so it applies to all jobs in this workflow. Set `contents: read`, which is the minimal common baseline for workflows that just need to fetch code. This does not change any functional behavior, since the workflow already only reads repo contents, but it prevents accidental or future misuse of excessive permissions.

Concretely: in `.github/workflows/book.yml`, insert

```yaml
permissions:
  contents: read
```

after the `on:` section (e.g., after line 12 and before the existing `env:` block). No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
