### PR TITLE
Replace &String with &str where possible

### DIFF
--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -75,7 +75,7 @@ enum PreColumnType {
 impl PreColumnType {
     pub(crate) fn into_cql_type(
         self,
-        keyspace_name: &String,
+        keyspace_name: &str,
         keyspace_udts: &PerTable<Arc<UserDefinedType<'static>>>,
     ) -> Result<ColumnType<'static>, MissingUserDefinedType> {
         match self {
@@ -103,7 +103,7 @@ impl PreColumnType {
                     None => {
                         return Err(MissingUserDefinedType {
                             name,
-                            keyspace: keyspace_name.clone(),
+                            keyspace: keyspace_name.to_owned(),
                         });
                     }
                 };
@@ -123,7 +123,7 @@ enum PreCollectionType {
 impl PreCollectionType {
     pub(crate) fn into_collection_type(
         self,
-        keyspace_name: &String,
+        keyspace_name: &str,
         keyspace_udts: &PerTable<Arc<UserDefinedType<'static>>>,
     ) -> Result<CollectionType<'static>, MissingUserDefinedType> {
         match self {

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -348,13 +348,13 @@ pub(crate) async fn resolve_contact_points(
     // Find IP addresses of all known nodes passed in the config
     let mut initial_peers: Vec<ResolvedContactPoint> = Vec::with_capacity(known_nodes.len());
 
-    let mut to_resolve: Vec<&String> = Vec::new();
+    let mut to_resolve: Vec<&str> = Vec::new();
     let mut hostnames: Vec<String> = Vec::new();
 
     for node in known_nodes.iter() {
         match node {
             KnownNode::Hostname(hostname) => {
-                to_resolve.push(hostname);
+                to_resolve.push(hostname.as_str());
                 hostnames.push(hostname.clone());
             }
             KnownNode::Address(address) => {

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -484,27 +484,23 @@ async fn test_views_in_schema_info() {
     let tables = keyspace_meta
         .tables
         .keys()
-        .collect::<std::collections::HashSet<&String>>();
+        .map(|s| s.as_str())
+        .collect::<std::collections::HashSet<&str>>();
 
     let views = keyspace_meta
         .views
         .keys()
-        .collect::<std::collections::HashSet<&String>>();
+        .map(|s| s.as_str())
+        .collect::<std::collections::HashSet<&str>>();
     let views_base_table = keyspace_meta
         .views
         .values()
-        .map(|view_meta| &view_meta.base_table_name)
-        .collect::<std::collections::HashSet<&String>>();
+        .map(|view_meta| view_meta.base_table_name.as_str())
+        .collect::<std::collections::HashSet<&str>>();
 
-    assert_eq!(tables, std::collections::HashSet::from([&"t".to_string()]));
-    assert_eq!(
-        views,
-        std::collections::HashSet::from([&"mv1".to_string(), &"mv2".to_string()])
-    );
-    assert_eq!(
-        views_base_table,
-        std::collections::HashSet::from([&"t".to_string()])
-    );
+    assert_eq!(tables, std::collections::HashSet::from(["t"]));
+    assert_eq!(views, std::collections::HashSet::from(["mv1", "mv2"]));
+    assert_eq!(views_base_table, std::collections::HashSet::from(["t"]));
 
     session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/statements/batch.rs
+++ b/scylla/tests/integration/statements/batch.rs
@@ -105,7 +105,7 @@ async fn test_large_batch_statements() {
     session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }
 
-async fn create_test_session(session: Session, ks: &String) -> Session {
+async fn create_test_session(session: Session, ks: &str) -> Session {
     session
         .ddl(
             format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }}"),
@@ -120,11 +120,7 @@ async fn create_test_session(session: Session, ks: &String) -> Session {
     session
 }
 
-async fn write_batch(
-    session: &Session,
-    n: usize,
-    ks: &String,
-) -> Result<QueryResult, ExecutionError> {
+async fn write_batch(session: &Session, n: usize, ks: &str) -> Result<QueryResult, ExecutionError> {
     let mut batch_query = Batch::new(BatchType::Unlogged);
     let mut batch_values = Vec::new();
     let statement_str = format!("INSERT INTO {ks}.pairs (dummy, k, v) VALUES (0, ?, ?)");


### PR DESCRIPTION
Minor code style fix.
&str is more general, and more idiomatic for Rust. There were 2 places that I didn't change:
- CqlValue::as_ascii and CqlValue::as_text return &String, and we can't change them because of backwards compat.
- Benchmark code calls SerializedValue::add_value, which takes &T. String needs to be constructed anyway, because it uses String::from_iter.
Replaces https://github.com/scylladb/scylla-rust-driver/pull/1510

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
