### PR TITLE
Add DeserializeRow support for tuple structs

### DIFF
--- a/docs/source/statements/result.md
+++ b/docs/source/statements/result.md
@@ -119,5 +119,33 @@ for row in result_rows.rows::<MyRow>()? {
 # }
 ```
 
+### Parsing row as a tuple struct
+It is also possible to receive a row as a tuple struct (a struct with unnamed fields).
+In this case, columns are matched by their **order** in the row (index), not by name.
+The first column from the query result maps to the first field of the tuple struct, the second column to the second field, and so on.
+
+```rust
+# extern crate scylla;
+# use scylla::client::session::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::DeserializeRow;
+
+#[derive(DeserializeRow)]
+struct Point(i32, i32);
+
+// Parse row as two int columns.
+// The first column maps to Point.0, the second to Point.1
+let result_rows = session
+    .query_unpaged("SELECT x, y from ks.points", &[])
+    .await?
+    .into_rows_result()?;
+
+for row in result_rows.rows::<Point>()? {
+    let point: Point = row?;
+}
+# Ok(())
+# }
+
 ### Other data types
 For parsing other data types see [Data Types](../data-types/data-types.md)

--- a/scylla-cql/src/deserialize/row.rs
+++ b/scylla-cql/src/deserialize/row.rs
@@ -106,8 +106,13 @@ impl<'frame, 'metadata> Iterator for ColumnIterator<'frame, 'metadata> {
 /// documentation of the parent module.
 ///
 /// The crate also provides a derive macro which allows to automatically
-/// implement the trait for a custom type. For more details on what the macro
-/// is capable of, see its documentation.
+/// implement the trait for a custom type.
+///
+/// The macro supports:
+/// * **Structs with named fields**: columns are matched by name.
+/// * **Tuple structs**: columns are matched by their order in the row.
+///
+/// For more details on what the macro is capable of, see its documentation.
 pub trait DeserializeRow<'frame, 'metadata>
 where
     Self: Sized,

--- a/scylla/tests/integration/macros/hygiene.rs
+++ b/scylla/tests/integration/macros/hygiene.rs
@@ -343,6 +343,13 @@ macro_rules! test_crate {
             #[scylla(default_when_null)]
             d: ::core::primitive::i32,
         }
+
+        #[derive(
+            _scylla::DeserializeRow, _scylla::SerializeRow, PartialEq, Debug,
+        )]
+        #[scylla(crate = _scylla)]
+        #[allow(dead_code)]
+        struct TestTupleRow(::core::primitive::i32, ::std::string::String);
     };
 }
 


### PR DESCRIPTION
## Motivation
Users often define data structures using tuple structs (structs with unnamed fields), such as `struct Point(f64, f64)` or `struct UserId(i32)`. Currently, the `DeserializeRow` derive macro only supports structs with named fields, where it maps database columns to Rust fields by name. This limitation forces users to either use named structs (which might not fit their domain model) or manually implement the deserialization traits, resulting in unnecessary boilerplate.

## Solution
This commit extends the `DeserializeRow` derive macro to support tuple structs.

When deriving `DeserializeRow` for a tuple struct, the macro generates an implementation that maps database columns to struct fields based on their **order** (index).
- The 1st column in the result set maps to the 0th field of the struct.
- The 2nd column maps to the 1st field, and so on.

## What's done
* **Refactored `deserialize_row_derive`**
    * Modified the entry point to detect `syn::Fields::Unnamed` (tuple structs).
    * Delegated logic to a new `deserialize_tuple_struct_derive` function for clear separation from named struct logic.

* **Implemented Tuple Logic**
    * **Type Checking:** The generated `type_check` method iterates through the provided `ColumnSpec` slice and the struct fields. It verifies that the database column type matches the expected Rust type for that position. It also verifies that the number of columns matches the number of fields.
    * **Deserialization:** The generated `deserialize` method consumes the `ColumnIterator` sequentially, deserializing each column into the corresponding field of the tuple struct.

* **Validation**
    * Ensured that strict column count checks are in place (errors are returned if the database returns too few or too many columns).

## What has been tested
### Tests
Added a suite of unit tests covering:

* **Single-field wrappers:** `struct Wrapper(i32)` (Newtype pattern).
* **Multi-field tuples:** `struct MultiTuple(i32, String, f64)` to verify correct ordering.
* **Type Safety:** Verified that `type_check` correctly returns an error if the column type (e.g., `Text`) does not match the field type (e.g., `Int`).
* **Error Handling:** Verified that mismatched column counts (e.g., empty row for a struct requiring fields) return appropriate errors.

Fixes: #852 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
