### PR TITLE
Make method public

### DIFF
--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1675,7 +1675,7 @@ pub struct FixedLengthBytesSequenceIterator<'frame> {
 }
 
 impl<'frame> FixedLengthBytesSequenceIterator<'frame> {
-    fn new(count: usize, slice: FrameSlice<'frame>) -> Self {
+    pub fn new(count: usize, slice: FrameSlice<'frame>) -> Self {
         Self {
             slice,
             remaining: count,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -839,7 +839,7 @@ impl DeserializedMetadataAndRawRows {
 
     /// Allows to retrieve raw rows, without the need for deserialization
     /// Intended to be used only in nodejs-rs driver only.
-    #[cfg(all(scylla_unstable, feature = "unstable-nodejs-rs"))]
+    // #[cfg(all(scylla_unstable, feature = "unstable-nodejs-rs"))]
     pub fn raw_rows(&self) -> &Bytes {
         &self.raw_rows
     }
@@ -1520,7 +1520,8 @@ mod test_utils {
         }
 
         /// Returns the size of the type in bytes, as it is seen by the vector type if it is treated as fixed size.
-        pub(crate) fn type_size(&self) -> Option<usize> {
+        #[allow(missing_docs)]
+        pub fn type_size(&self) -> Option<usize> {
             match self {
                 ColumnType::Native(n) => n.type_size(),
                 ColumnType::Tuple(_) => None,

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -676,7 +676,8 @@ pub(crate) fn unsigned_vint_encode(v: u64, buf: &mut Vec<u8>) {
     buf.put_uint(v, number_of_bytes as usize)
 }
 
-pub(crate) fn unsigned_vint_decode(buf: &mut &[u8]) -> Result<u64, std::io::Error> {
+#[allow(missing_docs)]
+pub fn unsigned_vint_decode(buf: &mut &[u8]) -> Result<u64, std::io::Error> {
     let first_byte = buf.read_u8()?;
     let extra_bytes = first_byte.leading_ones() as usize;
 

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -947,7 +947,7 @@ fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
     Ok(())
 }
 
-fn serialize_next_variable_length_elem<'t, T: SerializeValue + 't>(
+pub fn serialize_next_variable_length_elem<'t, T: SerializeValue + 't>(
     rust_name: &'static str,
     element_type: &ColumnType,
     typ: &ColumnType,

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -127,7 +127,7 @@ impl QueryResult {
         }
     }
 
-    pub(crate) fn deserialized_metadata_and_rows(&self) -> Option<&DeserializedMetadataAndRawRows> {
+    pub fn deserialized_metadata_and_rows(&self) -> Option<&DeserializedMetadataAndRawRows> {
         self.deserialized_metadata_and_rows.as_ref()
     }
 


### PR DESCRIPTION
Make serialize_next_variable_length_elem public for Python driver.