### PR TITLE
Allow (de)serialization of Cow<'_, T> values

### DIFF
--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -35,7 +35,7 @@ Database types and their Rust equivalents:
 * `UDT (User defined type)` <----> Custom user structs with macros
 * `Vector` <----> `Vec<T>`
 
-Additionally, `Box` and `Arc` serialization and deserialization is supported for all above types.
+Additionally, `Box`, `Arc`, and `Cow` serialization and deserialization is supported for all above types.
 
 ```{eval-rst}
 .. toctree::

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -3,6 +3,7 @@
 // Note: When editing above doc-comment edit the corresponding comment on
 // re-export module in scylla crate too.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
 use std::hash::BuildHasher;
@@ -460,6 +461,15 @@ impl<T: SerializeValue + ?Sized> SerializeValue for Arc<T> {
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
         T::serialize(&**self, typ, writer).map_err(fix_rust_name_in_err::<Self>)
+    }
+}
+impl<T: SerializeValue + ?Sized + ToOwned> SerializeValue for Cow<'_, T> {
+    fn serialize<'b>(
+        &self,
+        typ: &ColumnType,
+        writer: CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, SerializationError> {
+        T::serialize(self.as_ref(), typ, writer).map_err(fix_rust_name_in_err::<Self>)
     }
 }
 impl<V: SerializeValue, S: BuildHasher + Default> SerializeValue for HashSet<V, S> {


### PR DESCRIPTION
There is already precedence for doing this for Arc<T> and Box<T> so this PR merely extends the same functionality to a another stdlib smart pointer. 

In particular this is useful for me when doing a maybe borrowed deserialization in serde where the string may or may not need to be owned (depending on whether the string was escaped in the input). This maybe borrowed deserialization is done by storing it in a `Cow<'_, str>`. I want to then store that `Cow<'_, str>` as `TEXT` in Scylla without too much work but prior to this PR that was not doable. 

While I personally only care about serializing `Cow<'_, str>` I figured the driver should be more general and allow for any T and for both serialization and deserialization as it is done for Arc and Box. The main difference is that I didn't need to special case Cow<str> as a generic implementation works just fine. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
