### PR TITLE
Support client-routes routing

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,6 +19,25 @@ final-status-level = "slow"
 filter = 'binary_id(scylla) & (test(network::connection::) | test(client::caching_session::) | test(network::connection_pool::))'
 slow-timeout = { period = "20s", terminate-after = 6 }
 
+# Client-routes topology-change tests do decommission + add or
+# stop + resume which can easily exceed the default timeout.
+[[profile.default.overrides]]
+filter = '(binary_id(scylla::integration) & test(ccm::client_routes::test_client_routes_multi_dc_topology_change))'
+slow-timeout = { period = "60s", terminate-after = 6 }
+
+[[profile.default.overrides]]
+filter = '(binary_id(scylla::integration) & test(ccm::client_routes::test_client_routes_node_stop_resume))'
+slow-timeout = { period = "60s", terminate-after = 6 }
+
+# Rolling restart does 3 stop+start cycles; scale-out adds 3 nodes.
+[[profile.default.overrides]]
+filter = '(binary_id(scylla::integration) & test(ccm::client_routes::test_client_routes_rolling_restart))'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
+[[profile.default.overrides]]
+filter = '(binary_id(scylla::integration) & test(ccm::client_routes::test_client_routes_scale_out))'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
 # CCM tests may need to configure cluster. This takes even
 # more time than typical integration test.
 [[profile.default.overrides]]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,9 +95,14 @@ jobs:
       # unstable-host-listener feature.
       - name: Cargo check with unstable-host-listener  feature
         run: cargo clippy --all-targets --features "unstable-host-listener"
+
       # unstable-reconnect-policy feature.
       - name: Cargo check with unstable-reconnect-policy feature
         run: cargo clippy --all-targets --features "unstable-reconnect-policy"
+
+      # unstable-client-routes feature.
+      - name: Cargo check with unstable-client-routes feature
+        run: cargo check --all-targets -p scylla --features "unstable-client-routes"
 
       # No scylla_unstable flag with features
       - name: Cargo check without scylla_unstable

--- a/docs/source/connecting/client-routes.md
+++ b/docs/source/connecting/client-routes.md
@@ -1,0 +1,140 @@
+# Client Routes (Private Networking)
+
+When connecting to ScyllaDB Cloud clusters via private networking (e.g. AWS PrivateLink or
+GCP Private Service Connect), nodes are not reachable at the addresses they broadcast to each other.
+Instead, each node is reachable through a proxy endpoint whose address is stored in the
+`system.client_routes` table. The driver needs to be told to use this table for routing —  that is
+what the **Client Routes** feature provides.
+
+## Overview
+
+In a Client Routes setup:
+
+1. Each proxy endpoint is identified by a **connection ID** —  a string that the cloud
+   infrastructure assigns to a particular PrivateLink / Private Service Connect connection.
+2. On session startup, as well as on each metadata refresh, the driver queries `system.client_routes`
+   to discover which (address, port) pair to use for each cluster node, filtering by the configured
+   connection IDs.
+3. The driver subscribes to `CLIENT_ROUTES_CHANGE` events so it can update routing
+   information without a full metadata refresh when the table contents change.
+
+### Limitations
+
+1. Mixed clusters (with both nodes reachable only through ClientRoutes and nodes reachable only directly)
+   **are not supported**. All nodes must be reachable through ClientRoutes, in particular have corresponding
+   entries in `system.client_routes`; otherwise, the driver will fail to contact them.
+2. TLS **is not yet supported**.
+
+## Prerequisites
+
+Enable the `unstable-client-routes` Cargo feature:
+
+```toml
+[dependencies]
+scylla = { version = "...", features = ["unstable-client-routes"] }
+```
+
+## Basic usage
+
+```rust
+# extern crate scylla;
+# extern crate tokio;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::client::client_routes::{ClientRoutesConfig, ClientRoutesProxy};
+use scylla::client::session::Session;
+use scylla::client::session_builder::ClientRoutesSessionBuilder;
+
+// The connection ID assigned by your cloud provider for this PrivateLink /
+// Private Service Connect connection.
+let connection_id = "my-connection-id".to_string();
+
+// Create a proxy configuration for this connection ID.
+let proxy = ClientRoutesProxy::new_with_connection_id(connection_id);
+
+// Build a ClientRoutesConfig (at least one proxy is required).
+let config = ClientRoutesConfig::new(vec![proxy])?;
+
+// Build the session.  Use the contact point(s) provided by your cloud setup.
+let session: Session = ClientRoutesSessionBuilder::new(config)
+    .known_node("my-privatelink-endpoint.amazonaws.com:9042")
+    .build()
+    .await?;
+
+# Ok(())
+# }
+```
+
+## Multiple connection IDs
+
+If your deployment routes traffic through more than one proxy (e.g. one per availability zone),
+pass all of them:
+
+```rust
+# extern crate scylla;
+# extern crate tokio;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::client::client_routes::{ClientRoutesConfig, ClientRoutesProxy};
+use scylla::client::session::Session;
+use scylla::client::session_builder::ClientRoutesSessionBuilder;
+
+let proxies = vec![
+    ClientRoutesProxy::new_with_connection_id("conn-id-az-1".into()),
+    ClientRoutesProxy::new_with_connection_id("conn-id-az-2".into()),
+];
+
+let config = ClientRoutesConfig::new(proxies)?;
+
+let session: Session = ClientRoutesSessionBuilder::new(config)
+    .known_node("endpoint-az-1.amazonaws.com:9042")
+    .known_node("endpoint-az-2.amazonaws.com:9042")
+    .build()
+    .await?;
+
+# Ok(())
+# }
+```
+
+## Overriding the hostname
+
+By default, the hostname for each proxy is read from `system.client_routes`.
+You can override it if your environment requires a different DNS name or IP
+(e.g. for local testing):
+
+```rust
+# extern crate scylla;
+# extern crate tokio;
+# use std::error::Error;
+# async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
+use scylla::client::client_routes::{ClientRoutesConfig, ClientRoutesProxy};
+use scylla::client::session::Session;
+use scylla::client::session_builder::ClientRoutesSessionBuilder;
+
+let proxy = ClientRoutesProxy::new_with_connection_id("my-connection-id".into())
+    .with_overridden_hostname("127.0.0.1".into());
+
+let config = ClientRoutesConfig::new(vec![proxy])?;
+
+let session: Session = ClientRoutesSessionBuilder::new(config)
+    .known_node("127.0.0.1:9042")
+    .build()
+    .await?;
+
+# Ok(())
+# }
+```
+
+## Differences from a regular session
+
+`ClientRoutesSessionBuilder` supports most of the same options as the regular `SessionBuilder`
+(compression, authentication, execution profiles, etc.) with two exceptions:
+
+* **Address translation** is managed internally by the Client Routes infrastructure,
+  so `address_translator()` is not available.
+* **TLS** is not yet supported on Client Routes sessions.
+
+Additionally, _advanced shard awareness_ (the driver choosing a source port to target a specific
+shard) is disabled by default because the proxy infrastructure does not preserve it.
+**Note:** _basic shard awareness_ still works, meaning that driver routes requests optimally - to
+the correct shards.

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -65,5 +65,6 @@ However, you can set the `cluster_metadata_refresh_interval` to a non-negative v
    compression
    authentication
    tls
+   client-routes
 
 ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,6 +20,7 @@ scylla = { path = "../scylla", features = [
     "num-bigint-04",
     "bigdecimal-04",
     "metrics",
+    "unstable-client-routes",
 ] }
 tokio = { version = "1.34", features = ["full"] }
 tracing = { version = "0.1.25", features = ["log"] }
@@ -133,6 +134,10 @@ path = "tls-rustls.rs"
 [[example]]
 name = "execution_profile"
 path = "execution_profile.rs"
+
+[[example]]
+name = "client-routes"
+path = "client-routes.rs"
 
 [package.metadata.cargo-semver-checks.lints]
 workspace = true

--- a/examples/client-routes.rs
+++ b/examples/client-routes.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use scylla::client::{
+    client_routes::{ClientRoutesConfig, ClientRoutesProxy},
+    session_builder::ClientRoutesSessionBuilder,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let connection_id = "d1d64c5d-cc27-5607-a636-d96975e89340";
+    let uri = "127.0.0.1:12137";
+    println!("Connecting to {uri} via ClientRoutes ...");
+
+    let proxy = ClientRoutesProxy::new_with_connection_id(connection_id.into());
+
+    let config = ClientRoutesConfig::new(vec![proxy])?;
+
+    let session = ClientRoutesSessionBuilder::new(config)
+        .known_node(uri)
+        .build()
+        .await?;
+
+    session.query_unpaged(
+        "CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}",
+        &[]
+    )
+    .await?;
+
+    println!("Ok.");
+
+    Ok(())
+}

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -261,6 +261,8 @@ pub enum CqlEventParseError {
     TopologyChangeEventParseError(ClusterChangeEventParseError),
     #[error("Failed to deserialize status change event: {0}")]
     StatusChangeEventParseError(ClusterChangeEventParseError),
+    #[error("Failed to deserialize client routes change event: {0}")]
+    ClientRoutesChangeEventParseError(ClientRoutesChangeEventParseError),
 }
 
 /// An error type returned when deserialization of
@@ -298,6 +300,29 @@ pub enum ClusterChangeEventParseError {
     NodeAddressParseError(LowLevelDeserializationError),
     #[error("Unknown type of change: {0}")]
     UnknownTypeOfChange(String),
+}
+
+/// An error type returned when deserialization of ClientRoutesChangeEvent fails.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum ClientRoutesChangeEventParseError {
+    #[error("Malformed type of change: {0}")]
+    TypeOfChangeParseError(LowLevelDeserializationError),
+    #[error("Unknown type of change: {0}")]
+    UnknownTypeOfChange(String),
+    #[error("Malformed connection ids: {0}")]
+    ConnectionIdsParseError(LowLevelDeserializationError),
+    #[error("Malformed host ids: {0}")]
+    HostIdsParseError(LowLevelDeserializationError),
+    #[error("Unable to parse host id as UUID: {0}")]
+    HostIdsUuidParseError(uuid::Error),
+    #[error(
+        "Connection and host ids length mismatch: there are {connection_ids_count} connection ids and {host_ids_count} host ids"
+    )]
+    ConnectionHostIdsLengthMismatch {
+        connection_ids_count: usize,
+        host_ids_count: usize,
+    },
 }
 
 /// An error type returned when deserialization

--- a/scylla-cql/src/frame/request/register.rs
+++ b/scylla-cql/src/frame/request/register.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use crate::frame::{
     frame_errors::CqlRequestSerializationError,
     request::{RequestOpcode, SerializableRequest},
-    server_event_type::EventType,
+    server_event_type::{EventType, EventTypeV2},
     types,
 };
 
@@ -18,7 +18,30 @@ pub struct Register {
     pub event_types_to_register_for: Vec<EventType>,
 }
 
+/// The CQL protocol-level representation of an `REGISTER` request,
+/// used to subscribe for server events.
+pub struct RegisterV2 {
+    /// A list of event types to register for.
+    pub event_types_to_register_for: Vec<EventTypeV2>,
+}
+
 impl SerializableRequest for Register {
+    const OPCODE: RequestOpcode = RequestOpcode::Register;
+
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {
+        let event_types_list = self
+            .event_types_to_register_for
+            .iter()
+            .map(|event| event.to_string())
+            .collect::<Vec<_>>();
+
+        types::write_string_list(&event_types_list, buf)
+            .map_err(RegisterSerializationError::EventTypesSerialization)?;
+        Ok(())
+    }
+}
+
+impl SerializableRequest for RegisterV2 {
     const OPCODE: RequestOpcode = RequestOpcode::Register;
 
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), CqlRequestSerializationError> {

--- a/scylla-cql/src/frame/response/event.rs
+++ b/scylla-cql/src/frame/response/event.rs
@@ -3,7 +3,7 @@
 use crate::frame::frame_errors::{
     ClusterChangeEventParseError, CqlEventParseError, SchemaChangeEventParseError,
 };
-use crate::frame::server_event_type::EventType;
+use crate::frame::server_event_type::{EventType, EventTypeV2};
 use crate::frame::types;
 use std::net::SocketAddr;
 
@@ -13,6 +13,22 @@ use std::net::SocketAddr;
 // TODO(2.0): Remove the "Change" postfix from variants.
 #[expect(clippy::enum_variant_names)]
 pub enum Event {
+    /// Topology changed.
+    TopologyChange(TopologyChangeEvent),
+    /// Status of a node changed.
+    StatusChange(StatusChangeEvent),
+    /// Schema changed.
+    SchemaChange(SchemaChangeEvent),
+}
+
+/// Event that the server notified the client about.
+#[derive(Debug)]
+// The postfix "Change" is used in all variants just because all currently existing events happen to be
+// about changes in the cluster, so it makes sense to use the same postfix for all of them.
+// If we add a new event type that is not about changes, then clippy will no longer complain.
+#[expect(clippy::enum_variant_names)]
+#[non_exhaustive]
+pub enum EventV2 {
     /// Topology changed.
     TopologyChange(TopologyChangeEvent),
     /// Status of a node changed.
@@ -126,6 +142,28 @@ impl Event {
                     .map_err(CqlEventParseError::StatusChangeEventParseError)?,
             )),
             EventType::SchemaChange => Ok(Self::SchemaChange(SchemaChangeEvent::deserialize(buf)?)),
+        }
+    }
+}
+
+impl EventV2 {
+    /// Deserialize an event from the provided buffer.
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, CqlEventParseError> {
+        let event_type: EventTypeV2 = types::read_string(buf)
+            .map_err(CqlEventParseError::EventTypeParseError)?
+            .parse()?;
+        match event_type {
+            EventTypeV2::TopologyChange => Ok(Self::TopologyChange(
+                TopologyChangeEvent::deserialize(buf)
+                    .map_err(CqlEventParseError::TopologyChangeEventParseError)?,
+            )),
+            EventTypeV2::StatusChange => Ok(Self::StatusChange(
+                StatusChangeEvent::deserialize(buf)
+                    .map_err(CqlEventParseError::StatusChangeEventParseError)?,
+            )),
+            EventTypeV2::SchemaChange => {
+                Ok(Self::SchemaChange(SchemaChangeEvent::deserialize(buf)?))
+            }
         }
     }
 }

--- a/scylla-cql/src/frame/response/event.rs
+++ b/scylla-cql/src/frame/response/event.rs
@@ -1,7 +1,10 @@
 //! CQL protocol-level representation of an `EVENT` response.
 
+use uuid::Uuid;
+
 use crate::frame::frame_errors::{
-    ClusterChangeEventParseError, CqlEventParseError, SchemaChangeEventParseError,
+    ClientRoutesChangeEventParseError, ClusterChangeEventParseError, CqlEventParseError,
+    SchemaChangeEventParseError,
 };
 use crate::frame::server_event_type::{EventType, EventTypeV2};
 use crate::frame::types;
@@ -35,6 +38,8 @@ pub enum EventV2 {
     StatusChange(StatusChangeEvent),
     /// Schema changed.
     SchemaChange(SchemaChangeEvent),
+    /// Client routes changed.
+    ClientRoutesChange(ClientRoutesChangeEvent),
 }
 
 /// Event that notifies about changes in the cluster topology.
@@ -126,6 +131,20 @@ pub enum SchemaChangeType {
     Invalid,
 }
 
+/// Event that notifies about changes in the client routes.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ClientRoutesChangeEvent {
+    /// Client routes were updated for the specified connection and host IDs.
+    UpdateNodes {
+        /// Affected connection IDs.
+        connection_ids: Vec<String>,
+
+        /// Affected host IDs.
+        host_ids: Vec<Uuid>,
+    },
+}
+
 impl Event {
     /// Deserialize an event from the provided buffer.
     pub fn deserialize(buf: &mut &[u8]) -> Result<Self, CqlEventParseError> {
@@ -164,6 +183,10 @@ impl EventV2 {
             EventTypeV2::SchemaChange => {
                 Ok(Self::SchemaChange(SchemaChangeEvent::deserialize(buf)?))
             }
+            EventTypeV2::ClientRoutesChange => Ok(Self::ClientRoutesChange(
+                ClientRoutesChangeEvent::deserialize(buf)
+                    .map_err(CqlEventParseError::ClientRoutesChangeEventParseError)?,
+            )),
         }
     }
 }
@@ -302,5 +325,55 @@ impl StatusChangeEvent {
                 type_of_change.to_string(),
             )),
         }
+    }
+}
+
+impl ClientRoutesChangeEvent {
+    /// Deserialize a client routes change event from the provided buffer.
+    pub fn deserialize(buf: &mut &[u8]) -> Result<Self, ClientRoutesChangeEventParseError> {
+        let type_of_change = types::read_string(buf)
+            .map_err(ClientRoutesChangeEventParseError::TypeOfChangeParseError)?;
+
+        match type_of_change {
+            "UPDATE_NODES" => {
+                // The only client routes change event type defined in the protocol is "UPDATE_NODES",
+                // so let's continue.
+            }
+            _ => {
+                return Err(ClientRoutesChangeEventParseError::UnknownTypeOfChange(
+                    type_of_change.to_string(),
+                ));
+            }
+        }
+
+        let connection_ids = types::read_string_list(buf)
+            .map_err(ClientRoutesChangeEventParseError::ConnectionIdsParseError)?;
+        let connection_ids_count = connection_ids.len();
+
+        let (host_ids_count, host_ids_str_iter) = types::read_string_list_iter(buf)
+            .map_err(ClientRoutesChangeEventParseError::HostIdsParseError)?;
+
+        if connection_ids_count != host_ids_count {
+            return Err(
+                ClientRoutesChangeEventParseError::ConnectionHostIdsLengthMismatch {
+                    connection_ids_count,
+                    host_ids_count,
+                },
+            );
+        }
+
+        let host_ids: Vec<Uuid> = host_ids_str_iter
+            .map(|r| {
+                let host_id_str =
+                    r.map_err(ClientRoutesChangeEventParseError::HostIdsParseError)?;
+                Uuid::try_parse(host_id_str)
+                    .map_err(ClientRoutesChangeEventParseError::HostIdsUuidParseError)
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self::UpdateNodes {
+            connection_ids,
+            host_ids,
+        })
     }
 }

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -164,6 +164,29 @@ pub enum Response {
     Event(event::Event),
 }
 
+/// A CQL response that has been received from the server.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ResponseV2 {
+    /// ERROR response, returned by the server when an error occurs.
+    Error(Error),
+    /// READY response, indicating that the server is ready to process requests,
+    /// typically after a connection is established.
+    Ready,
+    /// RESULT response, containing the result of a statement execution.
+    Result(result::Result),
+    /// AUTHENTICATE response, indicating that the server requires authentication.
+    Authenticate(authenticate::Authenticate),
+    /// AUTH_SUCCESS response, indicating that the authentication was successful.
+    AuthSuccess(authenticate::AuthSuccess),
+    /// AUTH_CHALLENGE response, indicating that the server requires further authentication.
+    AuthChallenge(authenticate::AuthChallenge),
+    /// SUPPORTED response, containing the features supported by the server.
+    Supported(Supported),
+    /// EVENT response, containing an event that occurred on the server.
+    Event(event::EventV2),
+}
+
 impl Response {
     /// Returns the kind of this response.
     pub fn to_response_kind(&self) -> CqlResponseKind {
@@ -250,6 +273,76 @@ impl Response {
     }
 }
 
+impl ResponseV2 {
+    /// Returns the kind of this response.
+    pub fn to_response_kind(&self) -> CqlResponseKind {
+        match self {
+            Self::Error(_) => CqlResponseKind::Error,
+            Self::Ready => CqlResponseKind::Ready,
+            Self::Result(_) => CqlResponseKind::Result,
+            Self::Authenticate(_) => CqlResponseKind::Authenticate,
+            Self::AuthSuccess(_) => CqlResponseKind::AuthSuccess,
+            Self::AuthChallenge(_) => CqlResponseKind::AuthChallenge,
+            Self::Supported(_) => CqlResponseKind::Supported,
+            Self::Event(_) => CqlResponseKind::Event,
+        }
+    }
+
+    /// Deserialize a response from the given bytes.
+    pub fn deserialize(
+        features: &ProtocolFeatures,
+        opcode: ResponseOpcode,
+        buf_bytes: bytes::Bytes,
+        cached_metadata: Option<&Arc<ResultMetadata<'static>>>,
+    ) -> Result<Self, CqlResponseParseError> {
+        let buf = &mut &*buf_bytes;
+        let response = match opcode {
+            ResponseOpcode::Error => Self::Error(Error::deserialize(features, buf)?),
+            ResponseOpcode::Ready => Self::Ready,
+            ResponseOpcode::Authenticate => {
+                Self::Authenticate(authenticate::Authenticate::deserialize(buf)?)
+            }
+            ResponseOpcode::Supported => Self::Supported(Supported::deserialize(buf)?),
+            ResponseOpcode::Result => Self::Result(result::deserialize_with_features(
+                buf_bytes,
+                cached_metadata,
+                features,
+            )?),
+            ResponseOpcode::Event => Self::Event(event::EventV2::deserialize(buf)?),
+            ResponseOpcode::AuthChallenge => {
+                Self::AuthChallenge(authenticate::AuthChallenge::deserialize(buf)?)
+            }
+            ResponseOpcode::AuthSuccess => {
+                Self::AuthSuccess(authenticate::AuthSuccess::deserialize(buf)?)
+            }
+        };
+
+        Ok(response)
+    }
+
+    pub fn deserialize_metadata(
+        self,
+    ) -> Result<ResponseWithDeserializedMetadataV2, ResultMetadataAndRowsCountParseError> {
+        let result = match self {
+            Self::Error(e) => ResponseWithDeserializedMetadataV2::Error(e),
+            Self::Ready => ResponseWithDeserializedMetadataV2::Ready,
+            Self::Result(res) => {
+                ResponseWithDeserializedMetadataV2::Result(res.deserialize_metadata()?)
+            }
+            Self::Authenticate(auth) => ResponseWithDeserializedMetadataV2::Authenticate(auth),
+            Self::AuthSuccess(auth_succ) => {
+                ResponseWithDeserializedMetadataV2::AuthSuccess(auth_succ)
+            }
+            Self::AuthChallenge(auth_chal) => {
+                ResponseWithDeserializedMetadataV2::AuthChallenge(auth_chal)
+            }
+            Self::Supported(sup) => ResponseWithDeserializedMetadataV2::Supported(sup),
+            Self::Event(eve) => ResponseWithDeserializedMetadataV2::Event(eve),
+        };
+        Ok(result)
+    }
+}
+
 /// A CQL response that has been received from the server.
 #[derive(Debug)]
 pub enum ResponseWithDeserializedMetadata {
@@ -306,6 +399,69 @@ impl ResponseWithDeserializedMetadata {
             }
             Self::Supported(sup) => NonErrorResponseWithDeserializedMetadata::Supported(sup),
             Self::Event(eve) => NonErrorResponseWithDeserializedMetadata::Event(eve),
+        };
+
+        Ok(non_error_response)
+    }
+}
+
+/// A CQL response that has been received from the server.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ResponseWithDeserializedMetadataV2 {
+    /// ERROR response, returned by the server when an error occurs.
+    Error(Error),
+    /// READY response, indicating that the server is ready to process requests,
+    /// typically after a connection is established.
+    Ready,
+    /// RESULT response, containing the result of a statement execution.
+    Result(result::ResultWithDeserializedMetadata),
+    /// AUTHENTICATE response, indicating that the server requires authentication.
+    Authenticate(authenticate::Authenticate),
+    /// AUTH_SUCCESS response, indicating that the authentication was successful.
+    AuthSuccess(authenticate::AuthSuccess),
+    /// AUTH_CHALLENGE response, indicating that the server requires further authentication.
+    AuthChallenge(authenticate::AuthChallenge),
+    /// SUPPORTED response, containing the features supported by the server.
+    Supported(Supported),
+    /// EVENT response, containing an event that occurred on the server.
+    Event(event::EventV2),
+}
+
+impl ResponseWithDeserializedMetadataV2 {
+    /// Returns the kind of this response.
+    pub fn to_response_kind(&self) -> CqlResponseKind {
+        match self {
+            Self::Error(_) => CqlResponseKind::Error,
+            Self::Ready => CqlResponseKind::Ready,
+            Self::Result(_) => CqlResponseKind::Result,
+            Self::Authenticate(_) => CqlResponseKind::Authenticate,
+            Self::AuthSuccess(_) => CqlResponseKind::AuthSuccess,
+            Self::AuthChallenge(_) => CqlResponseKind::AuthChallenge,
+            Self::Supported(_) => CqlResponseKind::Supported,
+            Self::Event(_) => CqlResponseKind::Event,
+        }
+    }
+
+    /// Converts this response into a `NonErrorResponseV2`, returning an error if it is an `Error` response.
+    pub fn into_non_error_response(
+        self,
+    ) -> Result<NonErrorResponseWithDeserializedMetadataV2, error::Error> {
+        let non_error_response = match self {
+            Self::Error(e) => return Err(e),
+            Self::Ready => NonErrorResponseWithDeserializedMetadataV2::Ready,
+            Self::Result(res) => NonErrorResponseWithDeserializedMetadataV2::Result(res),
+            Self::Authenticate(auth) => {
+                NonErrorResponseWithDeserializedMetadataV2::Authenticate(auth)
+            }
+            Self::AuthSuccess(auth_succ) => {
+                NonErrorResponseWithDeserializedMetadataV2::AuthSuccess(auth_succ)
+            }
+            Self::AuthChallenge(auth_chal) => {
+                NonErrorResponseWithDeserializedMetadataV2::AuthChallenge(auth_chal)
+            }
+            Self::Supported(sup) => NonErrorResponseWithDeserializedMetadataV2::Supported(sup),
+            Self::Event(eve) => NonErrorResponseWithDeserializedMetadataV2::Event(eve),
         };
 
         Ok(non_error_response)
@@ -372,6 +528,45 @@ pub enum NonErrorResponseWithDeserializedMetadata {
 }
 
 impl NonErrorResponseWithDeserializedMetadata {
+    /// Returns the kind of this non-error response.
+    pub fn to_response_kind(&self) -> CqlResponseKind {
+        match self {
+            Self::Ready => CqlResponseKind::Ready,
+            Self::Result(_) => CqlResponseKind::Result,
+            Self::Authenticate(_) => CqlResponseKind::Authenticate,
+            Self::AuthSuccess(_) => CqlResponseKind::AuthSuccess,
+            Self::AuthChallenge(_) => CqlResponseKind::AuthChallenge,
+            Self::Supported(_) => CqlResponseKind::Supported,
+            Self::Event(_) => CqlResponseKind::Event,
+        }
+    }
+}
+
+/// A CQL response that has been received from the server, excluding error responses.
+/// This is used to handle responses that are not errors, allowing for easier processing
+/// of valid responses without need to handle error case any later.
+/// The difference from [NonErrorResponse] is that Result::Rows variant holds [result::DeserializedMetadataAndRawRows]
+/// instead of [result::RawMetadataAndRawRows].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum NonErrorResponseWithDeserializedMetadataV2 {
+    /// See [`Response::Ready`].
+    Ready,
+    /// See [`Response::Result`].
+    Result(result::ResultWithDeserializedMetadata),
+    /// See [`Response::Authenticate`].
+    Authenticate(authenticate::Authenticate),
+    /// See [`Response::AuthSuccess`].
+    AuthSuccess(authenticate::AuthSuccess),
+    /// See [`Response::AuthChallenge`].
+    AuthChallenge(authenticate::AuthChallenge),
+    /// See [`Response::Supported`].
+    Supported(Supported),
+    /// See [`Response::Event`].
+    Event(event::EventV2),
+}
+
+impl NonErrorResponseWithDeserializedMetadataV2 {
     /// Returns the kind of this non-error response.
     pub fn to_response_kind(&self) -> CqlResponseKind {
         match self {

--- a/scylla-cql/src/frame/server_event_type.rs
+++ b/scylla-cql/src/frame/server_event_type.rs
@@ -33,6 +33,8 @@ pub enum EventTypeV2 {
     StatusChange,
     /// Represents a change in the schema, such as table creation or modification.
     SchemaChange,
+    /// Represents a change in the client routes.
+    ClientRoutesChange,
 }
 
 impl fmt::Display for EventType {
@@ -53,6 +55,7 @@ impl fmt::Display for EventTypeV2 {
             Self::TopologyChange => "TOPOLOGY_CHANGE",
             Self::StatusChange => "STATUS_CHANGE",
             Self::SchemaChange => "SCHEMA_CHANGE",
+            Self::ClientRoutesChange => "CLIENT_ROUTES_CHANGE",
         };
 
         write!(f, "{s}")
@@ -80,6 +83,7 @@ impl FromStr for EventTypeV2 {
             "TOPOLOGY_CHANGE" => Ok(Self::TopologyChange),
             "STATUS_CHANGE" => Ok(Self::StatusChange),
             "SCHEMA_CHANGE" => Ok(Self::SchemaChange),
+            "CLIENT_ROUTES_CHANGE" => Ok(Self::ClientRoutesChange),
             _ => Err(CqlEventParseError::UnknownEventType(s.to_string())),
         }
     }

--- a/scylla-cql/src/frame/server_event_type.rs
+++ b/scylla-cql/src/frame/server_event_type.rs
@@ -24,7 +24,7 @@ pub enum EventType {
 // about changes in the cluster, so it makes sense to use the same postfix for all of them.
 // If we add a new event type that is not about changes, then clippy will no longer complain.
 #[expect(clippy::enum_variant_names)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum EventTypeV2 {
     /// Represents a change in the cluster topology, such as node addition or removal.

--- a/scylla-cql/src/frame/server_event_type.rs
+++ b/scylla-cql/src/frame/server_event_type.rs
@@ -19,6 +19,22 @@ pub enum EventType {
     SchemaChange,
 }
 
+/// Represents the type of a CQL event.
+// The postfix "Change" is used in all variants just because all currently existing events happen to be
+// about changes in the cluster, so it makes sense to use the same postfix for all of them.
+// If we add a new event type that is not about changes, then clippy will no longer complain.
+#[expect(clippy::enum_variant_names)]
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum EventTypeV2 {
+    /// Represents a change in the cluster topology, such as node addition or removal.
+    TopologyChange,
+    /// Represents a change in the status of a node, such as up or down.
+    StatusChange,
+    /// Represents a change in the schema, such as table creation or modification.
+    SchemaChange,
+}
+
 impl fmt::Display for EventType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match &self {
@@ -31,7 +47,32 @@ impl fmt::Display for EventType {
     }
 }
 
+impl fmt::Display for EventTypeV2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match &self {
+            Self::TopologyChange => "TOPOLOGY_CHANGE",
+            Self::StatusChange => "STATUS_CHANGE",
+            Self::SchemaChange => "SCHEMA_CHANGE",
+        };
+
+        write!(f, "{s}")
+    }
+}
+
 impl FromStr for EventType {
+    type Err = CqlEventParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TOPOLOGY_CHANGE" => Ok(Self::TopologyChange),
+            "STATUS_CHANGE" => Ok(Self::StatusChange),
+            "SCHEMA_CHANGE" => Ok(Self::SchemaChange),
+            _ => Err(CqlEventParseError::UnknownEventType(s.to_string())),
+        }
+    }
+}
+
+impl FromStr for EventTypeV2 {
     type Err = CqlEventParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -478,6 +478,35 @@ pub fn read_string_list(buf: &mut &[u8]) -> Result<Vec<String>, LowLevelDeserial
     Ok(v)
 }
 
+/// Creates an iterator over CQL string list.
+/// Returns pair (list length, list iterator).
+pub(crate) fn read_string_list_iter<'buf>(
+    buf: &mut &'buf [u8],
+) -> Result<
+    (
+        usize,
+        impl Iterator<Item = Result<&'buf str, LowLevelDeserializationError>>,
+    ),
+    LowLevelDeserializationError,
+> {
+    let mut remaining = read_short_length(buf)?;
+
+    Ok((
+        remaining,
+        std::iter::from_fn(move || {
+            if remaining == 0 {
+                return None;
+            }
+            let res = read_string(buf);
+            match res {
+                Ok(_) => remaining -= 1,
+                Err(_) => remaining = 0,
+            }
+            Some(res)
+        }),
+    ))
+}
+
 pub fn write_string_list(
     v: &[String],
     buf: &mut impl BufMut,

--- a/scylla-proxy/src/lib.rs
+++ b/scylla-proxy/src/lib.rs
@@ -1,6 +1,7 @@
 mod actions;
 mod errors;
 mod frame;
+pub mod nlb;
 mod proxy;
 
 pub type TargetShard = u16;

--- a/scylla-proxy/src/nlb.rs
+++ b/scylla-proxy/src/nlb.rs
@@ -1,0 +1,367 @@
+//! A lightweight L4 (TCP) load balancer for testing custom routing / NLB setups.
+//!
+//! [`NlbFrontend`] listens on a single address and randomly distributes incoming
+//! connections across a set of backend addresses. It operates purely at the
+//! TCP level -- no CQL frame awareness -- which matches the behaviour of
+//! real cloud NLBs (AWS NLB, GCP TCP LB, etc.).
+//!
+//! The original NLBs used in the Cloud have multiple ports, each routing traffic
+//! to given set of backend addresses. Hence, [`NlbFrontend`] corresponds to
+//! a single NLB's port. Some `NlbFrontend`s will route to a single node
+//! (the per-node NLB ports), and one `NlbFrontend` will load balance among
+//! all nodes in a group (normally, a DC).
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! # async fn example() {
+//! use scylla_proxy::nlb::NlbFrontend;
+//! use std::net::SocketAddr;
+//!
+//! let nlb = NlbFrontend::builder()
+//!     .listen_addr("127.0.0.1:0".parse().unwrap())
+//!     .backend("127.0.0.1:9042".parse().unwrap())
+//!     .backend("127.0.0.2:9042".parse().unwrap())
+//!     .backend("127.0.0.3:9042".parse().unwrap())
+//!     .build();
+//!
+//! let running = nlb.run().await.unwrap();
+//! println!("NLB listening on {}", running.listen_addr());
+//! // ... use the NLB ...
+//! running.finish().await;
+//! # }
+//! ```
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use tokio::io::{self, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinSet;
+use tracing::{debug, error, info};
+
+/// Builder for [`NlbFrontend`].
+pub struct NlbFrontendBuilder {
+    listen_addr: Option<SocketAddr>,
+    backends: Vec<SocketAddr>,
+}
+
+impl NlbFrontendBuilder {
+    /// Set the address the NLB will listen on.
+    ///
+    /// Use port 0 to let the OS pick an available port; retrieve the actual
+    /// bound address via [`RunningNlbFrontend::listen_addr`].
+    pub fn listen_addr(mut self, addr: SocketAddr) -> Self {
+        self.listen_addr = Some(addr);
+        self
+    }
+
+    /// Add a backend address. Connections are distributed across backends
+    /// randomly.
+    pub fn backend(mut self, addr: SocketAddr) -> Self {
+        self.backends.push(addr);
+        self
+    }
+
+    /// Add multiple backend addresses at once.
+    pub fn backends(mut self, addrs: impl IntoIterator<Item = SocketAddr>) -> Self {
+        self.backends.extend(addrs);
+        self
+    }
+
+    /// Build the [`NlbFrontend`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if no listen address or no backends have been set.
+    pub fn build(self) -> NlbFrontend {
+        assert!(
+            self.listen_addr.is_some(),
+            "NlbFrontend requires a listen address"
+        );
+        assert!(
+            !self.backends.is_empty(),
+            "NlbFrontend requires at least one backend"
+        );
+        NlbFrontend {
+            listen_addr: self.listen_addr.unwrap(),
+            backends: self.backends,
+        }
+    }
+}
+
+/// A lightweight L4 TCP load balancer that randomly distributes connections across backends.
+///
+/// See the [module-level documentation](self) for details.
+pub struct NlbFrontend {
+    listen_addr: SocketAddr,
+    backends: Vec<SocketAddr>,
+}
+
+impl NlbFrontend {
+    /// Create a new [`NlbFrontendBuilder`].
+    pub fn builder() -> NlbFrontendBuilder {
+        NlbFrontendBuilder {
+            listen_addr: None,
+            backends: vec![],
+        }
+    }
+
+    /// Start the NLB, binding to the configured listen address.
+    ///
+    /// Returns a [`RunningNlbFrontend`] handle for shutdown and address queries.
+    pub async fn run(self) -> Result<RunningNlbFrontend, io::Error> {
+        let listener = TcpListener::bind(self.listen_addr).await?;
+        let listen_addr = listener.local_addr()?;
+        info!("NLB frontend listening on {}", listen_addr);
+
+        let shared = Arc::new(NlbShared {
+            backends: RwLock::new(self.backends),
+            connection_tasks: tokio::sync::Mutex::new(JoinSet::new()),
+        });
+
+        let shared_for_handle = shared.clone();
+
+        let handle = tokio::task::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, peer_addr)) => {
+                        let connection_shared = shared.clone();
+                        shared.connection_tasks.lock().await.spawn(async move {
+                            let result =
+                                Self::handle_connection(stream, peer_addr, &connection_shared)
+                                    .await;
+
+                            if let Err(e) = result {
+                                debug!("NLB connection from {} ended: {}", peer_addr, e);
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        error!("NLB accept error: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(RunningNlbFrontend {
+            listen_addr,
+            handle,
+            shared: shared_for_handle,
+        })
+    }
+
+    async fn handle_connection(
+        driver_stream: TcpStream,
+        driver_addr: SocketAddr,
+        shared: &NlbShared,
+    ) -> Result<(), io::Error> {
+        // Pick a random backend.
+        // Acquire the read lock only long enough to clone a SocketAddr.
+        let backend_addr = {
+            let backends = shared
+                .backends
+                .read()
+                .expect("NlbShared backends RwLock poisoned");
+            if backends.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "NLB has no backends configured",
+                ));
+            }
+            let idx = rand::random_range(0..backends.len());
+            backends[idx]
+        };
+
+        debug!(
+            "NLB routing connection from {} to backend {}",
+            driver_addr, backend_addr
+        );
+
+        let (mut driver_read, mut driver_write) = driver_stream.into_split();
+
+        let backend_tcp = TcpStream::connect(backend_addr).await?;
+        let (mut backend_read, mut backend_write) = backend_tcp.into_split();
+
+        // --- Bidirectional copy via two concurrent tasks ---
+        //
+        // When one direction's `io::copy` completes (the read side sent EOF),
+        // we must `shutdown()` the write side of the *other* direction so that
+        // the remote peer sees EOF too.  Without this, a backend FIN (e.g.
+        // when a per-node NLB shuts down) would leave the driver-side socket
+        // open indefinitely -- the driver's control connection would appear
+        // alive even though the backend is gone.
+        let d2b = async {
+            let r = io::copy(&mut driver_read, &mut backend_write).await;
+            let _ = backend_write.shutdown().await;
+            r
+        };
+        let b2d = async {
+            let r = io::copy(&mut backend_read, &mut driver_write).await;
+            let _ = driver_write.shutdown().await;
+            r
+        };
+
+        match tokio::try_join!(d2b, b2d) {
+            Ok((to_backend, to_driver)) => {
+                debug!(
+                    "NLB connection {} -> {} finished: {} bytes to backend, {} bytes to driver",
+                    driver_addr, backend_addr, to_backend, to_driver
+                );
+            }
+            Err(e) => {
+                debug!(
+                    "NLB connection {} -> {} error: {}",
+                    driver_addr, backend_addr, e
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Shared state for the NLB frontend, accessed by all connection handlers.
+struct NlbShared {
+    /// Backend addresses, protected by a `RwLock` to allow dynamic updates
+    /// via [`RunningNlbFrontend::set_backends`]. Uses `std::sync::RwLock`
+    /// (not `tokio::sync::RwLock`) because the lock is held only long enough
+    /// to clone a `SocketAddr` -- no async work under the lock.
+    backends: RwLock<Vec<SocketAddr>>,
+    connection_tasks: tokio::sync::Mutex<JoinSet<()>>,
+}
+
+/// Handle for a running NLB frontend. Allows querying the listen address,
+/// dynamically updating backends, and shutting down the NLB.
+pub struct RunningNlbFrontend {
+    listen_addr: SocketAddr,
+    handle: tokio::task::JoinHandle<()>,
+    /// Shared state, retained so callers can update backends at runtime.
+    shared: Arc<NlbShared>,
+}
+
+impl RunningNlbFrontend {
+    /// Returns the address the NLB is listening on.
+    ///
+    /// This is particularly useful when the NLB was started with port 0,
+    /// since the OS will have assigned an actual port.
+    pub fn listen_addr(&self) -> SocketAddr {
+        self.listen_addr
+    }
+
+    /// Replace the set of backend addresses at runtime.
+    ///
+    /// New connections will be routed to the updated backends. Existing
+    /// connections are unaffected (they are already piping data to the
+    /// backend they were assigned at connection time).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `RwLock` is poisoned (should never happen).
+    pub fn set_backends(&self, backends: Vec<SocketAddr>) {
+        info!(
+            "NLB on {} updating backends to: {:?}",
+            self.listen_addr, backends
+        );
+        let mut guard = self
+            .shared
+            .backends
+            .write()
+            .expect("NlbShared backends RwLock poisoned");
+        *guard = backends;
+    }
+
+    /// Shut down the NLB frontend and wait for all connection handlers to
+    /// finish (or be cancelled).
+    pub async fn finish(self) {
+        // First stop and wait for the main task. This guarantees no new connection tasks will be spawned.
+        self.handle.abort();
+        let _ = self.handle.await;
+        // Now we can abort and wait for all the connection tasks.
+        self.shared.connection_tasks.lock().await.shutdown().await;
+        info!("NLB frontend on {} has shut down", self.listen_addr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Smoke test: NLB distributes connections across two backends.
+    #[tokio::test]
+    async fn test_nlb_random_balancing() {
+        // Start two "backend" echo servers.
+        let backend1 = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend2 = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let b1_addr = backend1.local_addr().unwrap();
+        let b2_addr = backend2.local_addr().unwrap();
+
+        // Echo server that prefixes responses with a tag byte.
+        fn spawn_echo(listener: TcpListener, tag: u8) {
+            tokio::spawn(async move {
+                loop {
+                    let (mut stream, _) = match listener.accept().await {
+                        Ok(s) => s,
+                        Err(_) => break,
+                    };
+                    let tag = tag;
+                    tokio::spawn(async move {
+                        let mut buf = [0u8; 64];
+                        loop {
+                            let n = match stream.read(&mut buf).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(n) => n,
+                            };
+                            let mut resp = vec![tag];
+                            resp.extend_from_slice(&buf[..n]);
+                            if stream.write_all(&resp).await.is_err() {
+                                break;
+                            }
+                        }
+                    });
+                }
+            });
+        }
+
+        spawn_echo(backend1, b'1');
+        spawn_echo(backend2, b'2');
+
+        // Start NLB.
+        let nlb = NlbFrontend::builder()
+            .listen_addr("127.0.0.1:0".parse().unwrap())
+            .backend(b1_addr)
+            .backend(b2_addr)
+            .build();
+        let running = nlb.run().await.unwrap();
+        let nlb_addr = running.listen_addr();
+
+        // Make enough connections that both backends are hit with
+        // overwhelming probability (p(all same) = 2 * 0.5^20 ≈ 2e-6).
+        let mut saw_backend = [false; 2];
+        for _ in 0..20 {
+            let mut conn = TcpStream::connect(nlb_addr).await.unwrap();
+            conn.write_all(b"hi").await.unwrap();
+            let mut buf = [0u8; 3];
+            conn.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf[1..], b"hi");
+            match buf[0] {
+                b'1' => saw_backend[0] = true,
+                b'2' => saw_backend[1] = true,
+                other => panic!("Unexpected tag byte: {}", other),
+            }
+        }
+
+        assert!(
+            saw_backend[0] && saw_backend[1],
+            "Expected both backends to be hit, but saw_backend = {:?}",
+            saw_backend
+        );
+
+        // Clean up.
+        running.finish().await;
+    }
+}

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -75,6 +75,9 @@ unstable-nodejs-rs = ["scylla-cql/unstable-nodejs-rs"]
 unstable-host-listener = []
 # Enables unstable reconnection policy configuration.
 unstable-reconnect-policy = []
+# Enables fetching contents of the `system.client_routes` table.
+# Needed for custom routing (AWS PrivateLink, GCP PSC, etc.).
+unstable-client-routes = []
 
 
 [dependencies]

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -106,9 +106,6 @@ pub(crate) trait ClientRoutesSubscriber: Send + Sync {
     /// fetched in response to a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
     /// The snapshot contains all entries that match connection ids and host ids
     /// present in the event.
-    // Note: I can't use `expect`, because then the compiler yells that it's not met...
-    // But when I use no attribute, then `dead_code` get triggered...
-    #[allow(dead_code)] // TODO: remove once event handling is added in a further commit.
     fn merge_client_routes_update(
         &self,
         event: &ClientRoutesChangeEvent,

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -1,0 +1,3 @@
+//! Routing configuration, enabling routing using `system.client_routes`.
+//!
+//! Enables connecting to Scylla Cloud clusters using AWS PrivateLink or GCP Private Service Connect, among others.

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -2,10 +2,21 @@
 //!
 //! Enables connecting to Scylla Cloud clusters using AWS PrivateLink or GCP Private Service Connect, among others.
 
+use async_trait::async_trait;
 use scylla_cql::frame::response::event::ClientRoutesChangeEvent;
 
-use crate::cluster::metadata::ClientRoutes;
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::sync::RwLock;
+use std::time::Duration;
 use thiserror::Error;
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::cluster::metadata::{ClientRoute, ClientRoutes};
+use crate::cluster::node::resolve_hostname;
+use crate::errors::TranslationError;
+use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 
 /// Represents a single ClientRoutes proxy, identified by a connection ID.
 ///
@@ -21,7 +32,6 @@ use thiserror::Error;
 /// be useful for testing and for some cloud architectures.
 #[derive(Debug, Clone)]
 pub struct ClientRoutesProxy {
-    #[expect(unused)] // temporarily, removed in further commit
     connection_id: String,
     overridden_hostname: Option<String>,
 }
@@ -58,7 +68,6 @@ impl From<String> for ClientRoutesProxy {
 /// Routing configuration for Scylla Cloud.
 #[derive(Debug, Clone)]
 pub struct ClientRoutesConfig {
-    #[expect(unused)] // temporarily, removed in further commit
     proxies: Vec<ClientRoutesProxy>,
 }
 
@@ -97,10 +106,1501 @@ pub(crate) trait ClientRoutesSubscriber: Send + Sync {
     /// fetched in response to a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
     /// The snapshot contains all entries that match connection ids and host ids
     /// present in the event.
-    #[expect(dead_code)] // TODO: remove once event handling is added in a further commit.
+    // Note: I can't use `expect`, because then the compiler yells that it's not met...
+    // But when I use no attribute, then `dead_code` get triggered...
+    #[allow(dead_code)] // TODO: remove once event handling is added in a further commit.
     fn merge_client_routes_update(
         &self,
         event: &ClientRoutesChangeEvent,
         client_routes: ClientRoutes,
     );
+}
+
+/// Translator for client routes: uses content of system.client_routes
+/// to translate addresses of nodes in the cluster for the driver.
+/// Used in PrivateLink, among others.
+pub(crate) struct ClientRoutesAddressTranslator {
+    connection_ids: Vec<String>,
+    hostname_overrides: HashMap<String, String>,
+    client_routes: RwLock<HashMap<Uuid, KnownHostRoutes>>,
+    hostname_resolution_timeout: Option<Duration>,
+    use_tls: bool,
+}
+
+/// Known routes for a host, with a distinguished preferred ("sticky" route).
+#[derive(Debug)]
+struct KnownHostRoutes {
+    sticky_route: ClientRoute,
+    other_routes: HashSet<RouteCmpByConnId>,
+}
+
+/// Wrapper over ClientRoute, used to compare by connection id only.
+#[derive(Debug)]
+struct RouteCmpByConnId(ClientRoute);
+impl PartialEq for RouteCmpByConnId {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.connection_id == other.0.connection_id
+    }
+}
+impl Eq for RouteCmpByConnId {}
+impl std::hash::Hash for RouteCmpByConnId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.connection_id.hash(state);
+    }
+}
+impl std::borrow::Borrow<str> for RouteCmpByConnId {
+    fn borrow(&self) -> &str {
+        &self.0.connection_id
+    }
+}
+
+impl From<RouteCmpByConnId> for ClientRoute {
+    fn from(RouteCmpByConnId(route): RouteCmpByConnId) -> Self {
+        route
+    }
+}
+
+impl From<ClientRoute> for RouteCmpByConnId {
+    fn from(route: ClientRoute) -> Self {
+        Self(route)
+    }
+}
+
+impl ClientRoutesAddressTranslator {
+    pub(crate) fn new(
+        config: ClientRoutesConfig,
+        hostname_resolution_timeout: Option<Duration>,
+        use_tls: bool,
+    ) -> Self {
+        let connection_ids = config
+            .proxies
+            .iter()
+            .map(|proxy| proxy.connection_id.clone())
+            .collect();
+        let hostname_overrides = config
+            .proxies
+            .into_iter()
+            .filter_map(|proxy| {
+                proxy
+                    .overridden_hostname
+                    .map(|hostname_override| (proxy.connection_id, hostname_override))
+            })
+            .collect();
+
+        Self {
+            connection_ids,
+            hostname_overrides,
+            client_routes: RwLock::new(HashMap::new()),
+            hostname_resolution_timeout,
+            use_tls,
+        }
+    }
+}
+
+// We want connection ids to be "sticky": once a connection is successfully established to a node
+// using some connection id, we want the driver to continue using that connection id as a safety measure.
+// See https://github.com/scylladb/scylla-rust-driver/pull/1582#discussion_r2965490779 for discussion.
+impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
+    fn get_connection_ids(&self) -> &[String] {
+        &self.connection_ids
+    }
+
+    fn replace_client_routes(&self, mut new_routes: ClientRoutes) {
+        let mut guard = self.client_routes.write().unwrap();
+
+        // Handle existing entries, i.e. ones for hosts that we already had routes to:
+        // - remove dangling routes;
+        // - update routes in a sticky way, if possible;
+        // - replace a route to given host with a route having different connection id, otherwise.
+        guard.retain(
+            |host_id, known_host_routes| match new_routes.routes.remove(host_id) {
+                Some(mut new_routes_for_host) => {
+                    // We have some route for that host. Let's first try to preserve connection id stickiness.
+
+                    let (new_sticky_route, other_routes) = match new_routes_for_host
+                        .remove(&known_host_routes.sticky_route.connection_id)
+                    {
+                        Some(new_sticky_route) => {
+                            // We have the sticky route available. Let's update it.
+                            (new_sticky_route, new_routes_for_host.into_values())
+                        }
+                        None => {
+                            // Can't preserve stickiness - entry with previously used connection id is absent.
+                            // Let's use any route for that host as the sticky route.
+                            let mut new_routes_for_host = new_routes_for_host.into_values();
+                            let Some(new_sticky_route) = new_routes_for_host.next() else {
+                                // Should never happen: `new_routes_for_host` hashmap is always created as nonempty.
+                                // As a defensive measure, don't panic though. It is logically correct to assume no
+                                // routes for this host.
+                                return false;
+                            };
+                            (new_sticky_route, new_routes_for_host)
+                        }
+                    };
+
+                    // We always replace the sticky route because it could get updated
+                    // (wrt hostname or ports, for example).
+                    known_host_routes.sticky_route = new_sticky_route;
+
+                    // Let's update non-sticky routes.
+                    known_host_routes.other_routes.clear();
+                    known_host_routes
+                        .other_routes
+                        .extend(other_routes.map(RouteCmpByConnId));
+
+                    true
+                }
+
+                // No entry for that host in the new client routes. Let's remove the dangling entry.
+                None => false,
+            },
+        );
+
+        // Add entries for hosts that weren't present in the map before.
+        // Entries for previously present hosts have already been removed from the new entries map.
+        guard.extend(
+            new_routes
+                .routes
+                .into_iter()
+                .flat_map(|(host_id, routes_for_host)| {
+                    let mut values = routes_for_host.into_values();
+                    // TODO: consider if we should pick randomly here, because perhaps users expect uniform distribution
+                    // over the routes to given host.
+                    let Some(sticky_route) = values.next() else {
+                        // Should never happen: `routes_for_host` hashmap is always created as nonempty.
+                        // As a defensive measure, don't panic though. It is logically correct to assume no
+                        // routes for this host.
+                        return None;
+                    };
+                    let other_routes = values.map(RouteCmpByConnId).collect();
+                    let host_routes = KnownHostRoutes {
+                        sticky_route,
+                        other_routes,
+                    };
+                    Some((host_id, host_routes))
+                }),
+        );
+    }
+
+    fn merge_client_routes_update(
+        &self,
+        event: &ClientRoutesChangeEvent,
+        new_routes: ClientRoutes,
+    ) {
+        #[deny(clippy::wildcard_enum_match_arm)]
+        let (connection_ids, host_ids) = match event {
+            ClientRoutesChangeEvent::UpdateNodes {
+                connection_ids,
+
+                host_ids,
+            } => (connection_ids, host_ids),
+            _ => unreachable!("clippy testifies the match is exhaustive"),
+        };
+
+        let mut guard = self.client_routes.write().unwrap();
+
+        // Iterate over all entries listed in the event.
+        // Filter only those with connection ids that the driver cares about.
+        // For each, determine the type of the entry change: deletion, creation or update.
+        for (connection_id, &host_id) in connection_ids
+            .iter()
+            .zip(host_ids)
+            .filter(|(connection_id, _host_id)| self.get_connection_ids().contains(connection_id))
+        {
+            let new_routes_for_host = new_routes.routes.get(&host_id);
+            let maybe_route = new_routes_for_host
+                .as_ref()
+                .and_then(|host_routes| host_routes.get(connection_id).cloned());
+            match maybe_route {
+                None => {
+                    // Route specified in the event is absent, which means that the event reported route deletion.
+                    let Some(known_host_routes) = guard.get_mut(&host_id) else {
+                        // We didn't have any routes for that host, so nothing to be deleted.
+                        continue;
+                    };
+
+                    // If the route was in other_routes, we remove it here. Else, this is no-op.
+                    known_host_routes
+                        .other_routes
+                        .remove(connection_id.as_str());
+
+                    // If the route was the sticky route, we need to replace it with any from other_routes, if present.
+                    // Otherwise, we remove the whole entry for that host.
+                    if &known_host_routes.sticky_route.connection_id == connection_id {
+                        if let Some(RouteCmpByConnId(replacement_route)) =
+                            known_host_routes.other_routes.extract_if(|_| true).next()
+                        {
+                            known_host_routes.sticky_route = replacement_route;
+                        } else {
+                            guard.remove(&host_id);
+                        }
+                    }
+                }
+
+                Some(new_route) => {
+                    // Route specified in the event is present, which means that the event reported route creation or update.
+                    // In both cases, we just insert it. Let's just handle the sticky route update separately.
+                    match guard.get_mut(&host_id) {
+                        // There have already been routes for that host.
+                        Some(host_routes) => {
+                            // Let's see if the new route is the sticky one.
+                            if host_routes.sticky_route.connection_id == new_route.connection_id {
+                                // We update the sticky route.
+                                host_routes.sticky_route = new_route;
+                            } else {
+                                // We add a new route or update an existing one.
+                                host_routes.other_routes.insert(RouteCmpByConnId(new_route));
+                            }
+                        }
+                        // There was no route for that host yet.
+                        None => {
+                            guard.insert(
+                                host_id,
+                                KnownHostRoutes {
+                                    sticky_route: new_route,
+                                    other_routes: HashSet::new(),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl AddressTranslator for ClientRoutesAddressTranslator {
+    async fn translate_address(
+        &self,
+        untranslated_peer: &UntranslatedPeer,
+    ) -> Result<SocketAddr, TranslationError> {
+        let host_id = untranslated_peer.host_id;
+
+        let hostport = {
+            let client_routes_guard = self.client_routes.read().unwrap();
+
+            let Some(host_routes) = client_routes_guard.get(&host_id) else {
+                // If the node is not present in client_routes, we return an error.
+                // This is crucial, because if we returned the original address, driver would attempt to connect
+                // directly, which could happen to succeed and silently make driver connected not through the
+                // intended proxy infrastructure (e.g., PL/PSC).
+                // Note that there can be scenarios where there are nodes that are intentionally not covered
+                // by client_routes table, meaning that connecting to them directly is expected.
+                // This is for example when some nodes belong to a PrivateLink setup and some don't.
+                // **We don't support such settings yet.**
+                return Err(TranslationError::NoRuleForHost(host_id));
+            };
+            let client_route = &host_routes.sticky_route;
+
+            // Check for overridden hostname first, as it takes precedence over the one from client_routes table.
+            let hostname = self
+                .hostname_overrides
+                .get(&client_route.connection_id)
+                // If no override found for this connection ID, use the hostname from client_routes table.
+                // This is typical case.
+                .unwrap_or(&client_route.hostname);
+
+            let port = if self.use_tls {
+                client_route
+                    .tls_port
+                    .ok_or_else(|| TranslationError::MissingPortForHost(host_id))?
+            } else {
+                client_route
+                    .port
+                    .ok_or_else(|| TranslationError::MissingPortForHost(host_id))?
+            };
+
+            format!("{}:{}", hostname, port)
+        };
+
+        let addr = resolve_hostname(&hostport, self.hostname_resolution_timeout)
+            .await
+            .map_err(TranslationError::DnsLookupFailed)?;
+
+        debug!(
+            "ClientRoutesAddressTranslator: translated host_id {} to address {}",
+            host_id, addr
+        );
+
+        Ok(addr)
+    }
+}
+
+// Tests by Claude Opus 4.6, reviewed and improved by @wprzytula.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::metadata::{ClientRoute, ClientRoutes};
+    use assert_matches::assert_matches;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use uuid::Uuid;
+
+    use scylla_cql::frame::response::event::ClientRoutesChangeEvent;
+
+    fn make_peer(host_id: Uuid, addr: SocketAddr) -> UntranslatedPeer<'static> {
+        UntranslatedPeer {
+            host_id,
+            untranslated_address: addr,
+            datacenter: None,
+            rack: None,
+        }
+    }
+
+    fn make_client_routes(routes: Vec<ClientRoute>) -> ClientRoutes {
+        let mut cr = ClientRoutes::default();
+        cr.extend(routes);
+        cr
+    }
+
+    fn make_config(proxies: Vec<ClientRoutesProxy>) -> ClientRoutesConfig {
+        ClientRoutesConfig::new(proxies).unwrap()
+    }
+
+    fn localhost_addr(port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+    }
+
+    // When client_routes haven't been fetched yet (the translator was just created and
+    // update_client_routes was never called), translate_address cannot perform any
+    // translation. It returns an error, because the driver must not connect directly
+    // to nodes that are supposed to be reached through the proxy infrastructure.
+    // Contact points are not affected — they use `NodeAddr::Untranslatable`, which
+    // bypasses the translator entirely.
+    #[tokio::test]
+    async fn translate_address_errors_when_no_client_routes() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let original_addr = localhost_addr(9042);
+        let peer = make_peer(host_id, original_addr);
+
+        let result = translator.translate_address(&peer).await;
+        assert_matches!(result, Err(TranslationError::NoRuleForHost(id)) if id == host_id);
+    }
+
+    // After routes have been loaded, nodes whose host_id is not present in
+    // client_routes get an error — the driver must not connect to them directly.
+    #[tokio::test]
+    async fn translate_address_errors_when_host_id_not_in_routes() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let route_host_id = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: route_host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: Some(9142),
+        }]);
+        translator.replace_client_routes(routes);
+
+        // The peer has a different host_id that is not present in client_routes.
+        let different_host_id = Uuid::new_v4();
+        let original_addr = localhost_addr(19042);
+        let peer = make_peer(different_host_id, original_addr);
+
+        let result = translator.translate_address(&peer).await;
+        assert_matches!(result, Err(TranslationError::NoRuleForHost(id)) if id == different_host_id);
+    }
+
+    // When a matching route exists and TLS is not enabled, the translator should
+    // resolve the route's hostname combined with its plaintext `port` field.
+    // This is the standard client routes translation path: the client_routes table
+    // tells the driver which hostname and port to use for each node.
+    #[tokio::test]
+    async fn translate_with_client_routes_resolves_hostname_and_port() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: Some(9142),
+        }]);
+        translator.replace_client_routes(routes);
+
+        let peer = make_peer(host_id, localhost_addr(19999));
+        let result = translator.translate_address(&peer).await.unwrap();
+
+        assert_eq!(result, localhost_addr(9042));
+    }
+
+    // A typical custom routing setup has multiple nodes, each with its own entry in
+    // the client_routes table, potentially served by different connection_ids
+    // (i.e. different client routes proxies). This test verifies that when
+    // multiple nodes are present in client_routes, each peer is independently
+    // translated to the correct address based on its own host_id and matching
+    // route. This is the standard multi-node happy path.
+    #[tokio::test]
+    async fn translate_address_multiple_nodes_each_resolved_independently() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-2".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id_a = Uuid::new_v4();
+        let host_id_b = Uuid::new_v4();
+
+        let routes = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_id_a,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: Some(9142),
+            },
+            ClientRoute {
+                connection_id: "conn-2".to_owned(),
+                host_id: host_id_b,
+                hostname: "127.0.0.2".to_string(),
+                port: Some(9043),
+                tls_port: Some(9143),
+            },
+        ]);
+        translator.replace_client_routes(routes);
+
+        // Each peer should be translated to the address from its own route,
+        // regardless of the other route's contents.
+        let peer_a = make_peer(host_id_a, localhost_addr(19999));
+        let result_a = translator.translate_address(&peer_a).await.unwrap();
+        assert_eq!(result_a, localhost_addr(9042));
+
+        let peer_b = make_peer(host_id_b, localhost_addr(19999));
+        let result_b = translator.translate_address(&peer_b).await.unwrap();
+        let expected_b = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 9043);
+        assert_eq!(result_b, expected_b);
+    }
+
+    // When TLS is enabled (`use_tls=true`), the translator must use the route's
+    // `tls_port` instead of the plaintext `port`, because the TLS proxy
+    // typically listens on a different port.
+    #[tokio::test]
+    async fn translate_with_client_routes_uses_tls_port_when_use_tls() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, true);
+
+        let host_id = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: Some(9142),
+        }]);
+        translator.replace_client_routes(routes);
+
+        let peer = make_peer(host_id, localhost_addr(19999));
+        let result = translator.translate_address(&peer).await.unwrap();
+
+        assert_eq!(result, localhost_addr(9142));
+    }
+
+    // The client_routes table allows `port` to be null (only `tls_port` may be
+    // set). If TLS is not enabled but the route has no plaintext port, the
+    // translator cannot construct a valid address and must report the error
+    // via MissingPortForHost so the driver can surface a clear diagnostic.
+    #[tokio::test]
+    async fn translate_with_client_routes_errors_when_port_missing() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: None,
+            tls_port: Some(9142),
+        }]);
+        translator.replace_client_routes(routes);
+
+        let peer = make_peer(host_id, localhost_addr(19999));
+        let result = translator.translate_address(&peer).await;
+
+        assert_matches!(result, Err(TranslationError::MissingPortForHost(id)) if id == host_id);
+    }
+
+    // Symmetric to the test above: when TLS is enabled but the route has no
+    // `tls_port`, the translator cannot construct a valid TLS address and must
+    // return MissingPortForHost.
+    #[tokio::test]
+    async fn translate_with_client_routes_errors_when_tls_port_missing() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, true);
+
+        let host_id = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        translator.replace_client_routes(routes);
+
+        let peer = make_peer(host_id, localhost_addr(19999));
+        let result = translator.translate_address(&peer).await;
+
+        assert_matches!(result, Err(TranslationError::MissingPortForHost(id)) if id == host_id);
+    }
+
+    // A ClientRoutesProxy can override the hostname for a given connection_id.
+    // This is useful for testing and for cloud architectures where the hostname
+    // advertised in client_routes is not directly reachable from the client,
+    // but an alternative hostname (e.g. a local DNS alias) is.
+    // When the proxy's connection_id matches the route's, the overridden
+    // hostname should take precedence over the one from client_routes.
+    #[tokio::test]
+    async fn translate_with_client_routes_uses_overridden_hostname() {
+        let proxy = ClientRoutesProxy::new_with_connection_id("conn-1".to_string())
+            .with_overridden_hostname("127.0.0.2".to_string());
+        let config = make_config(vec![proxy]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        translator.replace_client_routes(routes);
+
+        let peer = make_peer(host_id, localhost_addr(19999));
+        let result = translator.translate_address(&peer).await.unwrap();
+
+        // The overridden hostname 127.0.0.2 should be used, not the route's 127.0.0.1.
+        let expected = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 9042);
+        assert_eq!(result, expected);
+    }
+
+    // When a hostname override exists on a proxy but its connection_id does
+    // not match the route's connection_id, the override must not apply. The
+    // translator should fall back to the hostname from the client_routes table.
+    // This verifies that overrides are scoped to matching connection_ids only.
+    #[tokio::test]
+    async fn translate_with_client_routes_falls_back_to_route_hostname_when_no_override() {
+        // "conn-other" has an override but won't match the route's "conn-1".
+        let proxy = ClientRoutesProxy::new_with_connection_id("conn-other".to_string())
+            .with_overridden_hostname("127.0.0.2".to_string());
+        let config = make_config(vec![
+            proxy,
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        translator.replace_client_routes(routes);
+
+        let peer = make_peer(host_id, localhost_addr(19999));
+        let result = translator.translate_address(&peer).await.unwrap();
+
+        // No override matched "conn-1", so the route's hostname (127.0.0.1) is used.
+        assert_eq!(result, localhost_addr(9042));
+    }
+
+    // The ClientRoutesSubscriber trait allows the cluster worker to push updated
+    // client_routes to the translator after each metadata refresh. This test
+    // verifies the full lifecycle: before any routes are stored, the translator
+    // returns an error (no translation possible); after replace_client_routes
+    // is called, the translator uses the stored routes for subsequent
+    // translate_address calls.
+    #[tokio::test]
+    async fn update_client_routes_makes_subsequent_translations_use_routes() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let original_addr = localhost_addr(19999);
+        let peer = make_peer(host_id, original_addr);
+
+        // Before updating: no routes stored, so translation fails.
+        let result = translator.translate_address(&peer).await;
+        assert_matches!(result, Err(TranslationError::NoRuleForHost(id)) if id == host_id);
+
+        // Push client routes, simulating what the cluster worker does after
+        // fetching the system.client_routes table.
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        translator.replace_client_routes(routes);
+
+        // After updating: the route is found and the translated address is returned.
+        let result = translator.translate_address(&peer).await.unwrap();
+        assert_eq!(result, localhost_addr(9042));
+
+        // Push a second update with a different port, simulating a subsequent
+        // metadata refresh that returned changed routing information.
+        let updated_routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9043),
+            tls_port: None,
+        }]);
+        translator.replace_client_routes(updated_routes);
+
+        // The translator should reflect the second update, not remain stuck
+        // on the first one.
+        let result = translator.translate_address(&peer).await.unwrap();
+        assert_eq!(result, localhost_addr(9043));
+    }
+
+    // When host_id and connection_id stay the same but non-key properties
+    // (hostname, port) change, the translator's map must reflect those
+    // updates. Verified via both full replacement and merge event.
+    #[tokio::test]
+    async fn non_key_property_updates_are_reflected() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let peer = make_peer(host_id, localhost_addr(19999));
+
+        // Initial state: hostname 127.0.0.1, port 9042.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9042),
+        );
+
+        // --- Full replacement path ---
+
+        // Port changes.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9043),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9043),
+        );
+
+        // Hostname changes (127.0.0.1 →  127.0.0.2).
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.2".to_string(),
+            port: Some(9043),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 9043),
+        );
+
+        // Both hostname and port change simultaneously.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.3".to_string(),
+            port: Some(9044),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)), 9044),
+        );
+
+        // --- Merge event path ---
+
+        let make_event = || ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned()],
+            host_ids: vec![host_id],
+        };
+
+        // Port changes via merge.
+        translator.merge_client_routes_update(
+            &make_event(),
+            make_client_routes(vec![ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id,
+                hostname: "127.0.0.3".to_string(),
+                port: Some(9050),
+                tls_port: None,
+            }]),
+        );
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)), 9050),
+        );
+
+        // Hostname changes via merge.
+        translator.merge_client_routes_update(
+            &make_event(),
+            make_client_routes(vec![ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id,
+                hostname: "127.0.0.4".to_string(),
+                port: Some(9050),
+                tls_port: None,
+            }]),
+        );
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 4)), 9050),
+        );
+
+        // Both hostname and port change via merge.
+        translator.merge_client_routes_update(
+            &make_event(),
+            make_client_routes(vec![ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id,
+                hostname: "127.0.0.5".to_string(),
+                port: Some(9060),
+                tls_port: None,
+            }]),
+        );
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 5)), 9060),
+        );
+    }
+
+    // `replace_client_routes` receives a full snapshot of the client_routes
+    // table (filtered by connection ids, of course).  Hosts that were previously
+    // known but are absent from the new snapshot must be removed, so the translator
+    // falls back to the original (untranslated) address for them.
+    #[tokio::test]
+    async fn replace_client_routes_removes_hosts_absent_from_snapshot() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_a = Uuid::new_v4();
+        let host_b = Uuid::new_v4();
+
+        // Initial snapshot: both hosts present.
+        let routes = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_a,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_b,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+        ]);
+        translator.replace_client_routes(routes);
+
+        // Both should translate.
+        let peer_a = make_peer(host_a, localhost_addr(19999));
+        let peer_b = make_peer(host_b, localhost_addr(19998));
+        assert_eq!(
+            translator.translate_address(&peer_a).await.unwrap(),
+            localhost_addr(9042)
+        );
+        assert_eq!(
+            translator.translate_address(&peer_b).await.unwrap(),
+            localhost_addr(9043)
+        );
+
+        // Second snapshot: only host_a remains.
+        let routes2 = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host_a,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9044),
+            tls_port: None,
+        }]);
+        translator.replace_client_routes(routes2);
+
+        // host_a got the updated port.
+        assert_eq!(
+            translator.translate_address(&peer_a).await.unwrap(),
+            localhost_addr(9044)
+        );
+        // host_b was removed →  translation fails.
+        assert_matches!(
+            translator.translate_address(&peer_b).await,
+            Err(TranslationError::NoRuleForHost(id)) if id == host_b
+        );
+    }
+
+    // `merge_client_routes_update` receives a partial update (triggered by a
+    // CLIENT_ROUTES_CHANGED event) that covers only the affected hosts.
+    // Hosts absent from the partial update must be preserved — they are not
+    // being removed from the cluster, they simply weren't part of this event.
+    #[tokio::test]
+    async fn merge_client_routes_update_preserves_hosts_absent_from_update() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_a = Uuid::new_v4();
+        let host_b = Uuid::new_v4();
+
+        // Initial full snapshot: both hosts present.
+        let routes = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_a,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_b,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+        ]);
+        translator.replace_client_routes(routes);
+
+        // Partial update: only host_a changed its port.
+        // The event mentions only host_a; host_b is unaffected.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned()],
+            host_ids: vec![host_a],
+        };
+        let partial = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host_a,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9044),
+            tls_port: None,
+        }]);
+        translator.merge_client_routes_update(&event, partial);
+
+        // host_a got the updated port.
+        let peer_a = make_peer(host_a, localhost_addr(19999));
+        assert_eq!(
+            translator.translate_address(&peer_a).await.unwrap(),
+            localhost_addr(9044)
+        );
+        // host_b still translates with the original port (not removed).
+        let peer_b = make_peer(host_b, localhost_addr(19998));
+        assert_eq!(
+            translator.translate_address(&peer_b).await.unwrap(),
+            localhost_addr(9043)
+        );
+    }
+
+    // When the event mentions a (connection_id, host_id) pair but the
+    // re-fetched ClientRoutes no longer contains a matching entry, the
+    // translator removes that host from its map.  This happens when a node
+    // is decommissioned: the event says "this route changed", but the
+    // follow-up query returns nothing for that host.
+    //
+    // Three sub-cases are checked:
+    // - host_a: event says (conn-1, host_a), routes still have (conn-1,
+    //   host_a) →  resilient, NOT removed, updated.
+    // - host_b: event says (conn-1, host_b), routes have NO entry for
+    //   host_b at all →  dangling, removed.
+    // - host_c: event says (conn-1, host_c), routes have host_c but only
+    //   under conn-2 (not conn-1) →  old entry is dangling and deleted,
+    //   but merge_update re-adds host_c with the conn-2 route.
+    #[tokio::test]
+    async fn merge_client_routes_update_removes_dangling_entries() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-2".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_a = Uuid::new_v4();
+        let host_b = Uuid::new_v4();
+        let host_c = Uuid::new_v4();
+
+        // Initial full snapshot: all three hosts present under conn-1.
+        let routes = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_a,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_b,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_c,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9044),
+                tls_port: None,
+            },
+        ]);
+        translator.replace_client_routes(routes);
+
+        let peer_a = make_peer(host_a, localhost_addr(19999));
+        let peer_b = make_peer(host_b, localhost_addr(19998));
+        let peer_c = make_peer(host_c, localhost_addr(19997));
+
+        // All three should translate.
+        assert_eq!(
+            translator.translate_address(&peer_a).await.unwrap(),
+            localhost_addr(9042)
+        );
+        assert_eq!(
+            translator.translate_address(&peer_b).await.unwrap(),
+            localhost_addr(9043)
+        );
+        assert_eq!(
+            translator.translate_address(&peer_c).await.unwrap(),
+            localhost_addr(9044)
+        );
+
+        // Event mentions all three hosts under conn-1.
+        // Re-fetched routes:
+        //   host_a: still has conn-1 (updated port) →  resilient
+        //   host_b: completely absent →  dangling, removed
+        //   host_c: present but only under conn-2 (conn-1 gone) →  old
+        //           entry dangling, deleted; re-added via merge_update
+        //           with conn-2's route
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec![
+                "conn-1".to_owned(),
+                "conn-1".to_owned(),
+                "conn-1".to_owned(),
+                "conn-2".to_owned(),
+            ],
+            host_ids: vec![host_a, host_b, host_c, host_c],
+        };
+        let partial = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_a,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9050),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-2".to_owned(),
+                host_id: host_c,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9060),
+                tls_port: None,
+            },
+        ]);
+        translator.merge_client_routes_update(&event, partial);
+
+        // Resilient: host_a updated to new port, not removed.
+        assert_eq!(
+            translator.translate_address(&peer_a).await.unwrap(),
+            localhost_addr(9050)
+        );
+        // Dangling (absent): host_b removed →  translation fails.
+        assert_matches!(
+            translator.translate_address(&peer_b).await,
+            Err(TranslationError::NoRuleForHost(id)) if id == host_b
+        );
+        // Dangling (different connection_id): old conn-1 entry deleted,
+        // re-added via merge_update with conn-2's route.
+        assert_eq!(
+            translator.translate_address(&peer_c).await.unwrap(),
+            localhost_addr(9060)
+        );
+    }
+
+    // Connection IDs are "sticky": once a host is associated with a given
+    // connection ID, the translator prefers to keep using that same connection
+    // ID on subsequent updates (as long as a route with that ID is still
+    // available for the host). This avoids unnecessary NLB switching and prevents
+    // breakdown in case of misconfiguration when updating client_routes table.
+    //
+    // When the sticky connection ID disappears, the translator must switch to
+    // the remaining one. Tested via both full replacement and merge event.
+    #[tokio::test]
+    async fn merge_update_prefers_sticky_connection_id() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-0".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let peer = make_peer(host_id, localhost_addr(19999));
+
+        // Initial: host_id gets conn-1 with port 9042.
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        translator.replace_client_routes(routes);
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9042)
+        );
+
+        // Update: both conn-1 (port 9043) and conn-0 (port 9044) available.
+        // The translator should stick to conn-1 because that's the one
+        // previously established.
+        let routes2 = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-0".to_owned(),
+                host_id,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9044),
+                tls_port: None,
+            },
+        ]);
+        translator.replace_client_routes(routes2);
+
+        // Sticky: conn-1's port (9043) should be used, not conn-0's (9044).
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9043)
+        );
+
+        // Case 1 via full replacement: conn-1 disappears, only conn-0 remains.
+        // BEFORE: {(conn-1, host_id), (conn-0, host_id)}, AFTER: {(conn-0, host_id)}.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-0".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9050),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9050)
+        );
+
+        // Re-establish conn-1 stickiness for the merge variant.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9060),
+            tls_port: None,
+        }]));
+        translator.replace_client_routes(make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9061),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-0".to_owned(),
+                host_id,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9062),
+                tls_port: None,
+            },
+        ]));
+        // Verify conn-1 is sticky again.
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9061)
+        );
+
+        // Case 1 via merge event: conn-1 disappears, only conn-0 remains and is updated.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned(), "conn-0".to_owned()],
+            host_ids: vec![host_id, host_id],
+        };
+        translator.merge_client_routes_update(
+            &event,
+            make_client_routes(vec![ClientRoute {
+                connection_id: "conn-0".to_owned(),
+                host_id,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9070),
+                tls_port: None,
+            }]),
+        );
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9070)
+        );
+    }
+
+    // When the previously-used connection ID is no longer available for a
+    // host in the update AND no other connection ID was previously known,
+    // the translator falls back to whichever connection ID is available.
+    // Tested via both full replacement and merge event.
+    #[tokio::test]
+    async fn merge_update_falls_back_when_sticky_connection_id_absent() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-0".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let peer = make_peer(host_id, localhost_addr(19999));
+
+        // Initial: host_id gets conn-1 with port 9042.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9042)
+        );
+
+        // Case 2 via full replacement: conn-1 gone, conn-0 is brand new.
+        // BEFORE: {(conn-1, host_id)}, AFTER: {(conn-0, host_id)}.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-0".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9044),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9044)
+        );
+
+        // Re-establish conn-1 for the merge variant.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9050),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9050)
+        );
+
+        // Case 2 via merge event: conn-1 gone, conn-0 is brand new.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned(), "conn-0".to_owned()],
+            host_ids: vec![host_id, host_id],
+        };
+        translator.merge_client_routes_update(
+            &event,
+            make_client_routes(vec![ClientRoute {
+                connection_id: "conn-0".to_owned(),
+                host_id,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9060),
+                tls_port: None,
+            }]),
+        );
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9060)
+        );
+    }
+
+    // Regression test for the bug that deletion events cleared unrelated hosts'
+    // routes.
+    //
+    // Before the fix, `merge_client_routes_update` delegated to a shared
+    // `merge_update` helper that iterated over *all* hosts present in the
+    // re-fetched `new_routes` — including hosts that appeared in the re-fetch
+    // as cross-product artifacts of the `WHERE connection_id IN ? AND host_id
+    // IN ?` query, but were NOT listed in the event itself.
+    //
+    // Scenario: host_x has a sticky route under conn-1; the event only
+    // mentions host_y.  The re-fetch query (`WHERE connection_id IN [conn-2]
+    // AND host_id IN [host_y]`) should not return host_x, but if the caller
+    // passes extra data for host_x (simulating a cross-product artifact),
+    // the old `merge_update` would process host_x, fail the sticky check
+    // (conn-1 not in {conn-2}), and clobber the existing route with conn-2.
+    //
+    // The fix scopes merging to only the (connection_id, host_id) pairs
+    // listed in the event, so unrelated hosts are left untouched.
+    #[tokio::test]
+    async fn merge_event_cross_product_does_not_clobber_unrelated_host() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-2".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_x = Uuid::new_v4();
+        let host_y = Uuid::new_v4();
+        let peer_x = make_peer(host_x, localhost_addr(19999));
+        let peer_y = make_peer(host_y, localhost_addr(19998));
+
+        // Initial state: host_x reachable via conn-1 (port 9042),
+        //                host_y has no route yet.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host_x,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer_x).await.unwrap(),
+            localhost_addr(9042),
+        );
+
+        // Event mentions only host_y under conn-2.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-2".to_owned()],
+            host_ids: vec![host_y],
+        };
+        // The re-fetch contains host_y's route (expected) AND host_x under
+        // conn-2 (cross-product artifact — the event never mentioned host_x).
+        let refetched = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-2".to_owned(),
+                host_id: host_y,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9099),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-2".to_owned(),
+                host_id: host_x,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9088),
+                tls_port: None,
+            },
+        ]);
+        translator.merge_client_routes_update(&event, refetched);
+
+        // host_y should now translate via conn-2.
+        assert_eq!(
+            translator.translate_address(&peer_y).await.unwrap(),
+            localhost_addr(9099),
+        );
+        // host_x's conn-1 route must be preserved — the event never
+        // mentioned host_x, so the cross-product artifact must be ignored.
+        assert_eq!(
+            translator.translate_address(&peer_x).await.unwrap(),
+            localhost_addr(9042),
+        );
+    }
+
+    // Regression test for the bug described I once introduced and then fixed.
+    //
+    // When one connection ID for a host is deleted and the re-fetch (scoped to
+    // only that connection ID) returns nothing, the code would remove the host
+    // entirely.  But the host may still be reachable via another connection ID
+    // whose route was previously held. The driver should not lose the host.
+    #[tokio::test]
+    async fn merge_event_deletion_should_not_lose_host_when_other_conn_ids_not_refetched() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-2".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_x = Uuid::new_v4();
+        let peer = make_peer(host_x, localhost_addr(19999));
+
+        // Initial state: host_x has routes under both conn-1 and conn-2.
+        // Stickiness picks conn-1 (inserted first).
+        translator.replace_client_routes(make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_x,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-2".to_owned(),
+                host_id: host_x,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+        ]));
+
+        // Event: conn-1 for host_x changed (it was deleted in the DB).
+        // Re-fetch scoped to conn-1 + host_x returns nothing.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned()],
+            host_ids: vec![host_x],
+        };
+        translator.merge_client_routes_update(&event, ClientRoutes::default());
+
+        // Correct behaviour: host_x should still be translatable.
+        // The driver previously knew about conn-2's route for this host, so it
+        // should fall back to that rather than losing the host entirely.
+        let result = translator.translate_address(&peer).await.unwrap();
+        assert_ne!(
+            result,
+            localhost_addr(19999),
+            "host_x must not fall back to the untranslated address; \
+             the previously-held conn-2 route should still be usable",
+        );
+    }
+
+    // Regression test for the double-iteration consumption bug in `merge_client_routes_update`,
+    // which I introduced at some point of development and then fixed.
+    //
+    // When the event lists the same host_id under two connection IDs, the
+    // first iteration would call `new_routes.routes.remove(host_id)`, consuming
+    // the entire routes-for-host map.  The second iteration would get `None` from
+    // `remove` and incorrectly enter the deletion branch, removing the host
+    // that was just (re-)inserted by the first iteration.
+    #[tokio::test]
+    async fn merge_event_same_host_two_conn_ids_second_iteration_should_not_delete() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-2".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_x = Uuid::new_v4();
+        let peer = make_peer(host_x, localhost_addr(19999));
+
+        // Initial state: host_x reachable via conn-1, port 9042.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host_x,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9042),
+        );
+
+        // Event: both conn-1 and conn-2 changed for host_x.
+        // Re-fetch: conn-1 was deleted, conn-2 was created with port 9099.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned(), "conn-2".to_owned()],
+            host_ids: vec![host_x, host_x],
+        };
+        let refetched = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-2".to_owned(),
+            host_id: host_x,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9099),
+            tls_port: None,
+        }]);
+        translator.merge_client_routes_update(&event, refetched);
+
+        // Correct behaviour: host_x should be reachable via conn-2 at port 9099.
+        // The first iteration handles (conn-1, host_x) — deletion + re-insert
+        // with conn-2.  The second iteration handles (conn-2, host_x) — should
+        // recognise that the route is present and keep it, not delete it.
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9099),
+        );
+    }
+
+    // Duplicate entries in a merge event (same connection_id and host_id
+    // appearing multiple times) are handled correctly: the route is applied
+    // once and subsequent duplicate occurrences are no-ops, not
+    // misinterpreted as deletions.
+    //
+    // Without deduplication, `merge_client_routes_update` consumed the route
+    // from `new_routes` via `remove()` on the first occurrence.  The second
+    // occurrence found `None` and entered the deletion branch, incorrectly
+    // removing the route that was just applied.
+    #[tokio::test]
+    async fn merge_event_duplicate_entries_are_idempotent() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_id = Uuid::new_v4();
+        let peer = make_peer(host_id, localhost_addr(19999));
+
+        // Initial state: host has a route via conn-1 at port 9042.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9042),
+        );
+
+        // Event with duplicate: (conn-1, host_id) appears twice.
+        // Re-fetch contains the updated route (port 9099).
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned(), "conn-1".to_owned()],
+            host_ids: vec![host_id, host_id],
+        };
+        let refetched = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9099),
+            tls_port: None,
+        }]);
+        translator.merge_client_routes_update(&event, refetched);
+
+        // The route should be updated to port 9099, not deleted.
+        assert_eq!(
+            translator.translate_address(&peer).await.unwrap(),
+            localhost_addr(9099),
+        );
+    }
 }

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -1,3 +1,29 @@
 //! Routing configuration, enabling routing using `system.client_routes`.
 //!
 //! Enables connecting to Scylla Cloud clusters using AWS PrivateLink or GCP Private Service Connect, among others.
+
+use scylla_cql::frame::response::event::ClientRoutesChangeEvent;
+
+use crate::cluster::metadata::ClientRoutes;
+
+#[expect(dead_code)] // TODO: removed in a next commit.
+pub(crate) trait ClientRoutesSubscriber: Send + Sync {
+    /// Specifies connection IDs that are to be monitored, i.e., whose entries
+    /// shall be fetched from `system.client_routes`.
+    fn get_connection_ids(&self) -> &[String];
+
+    /// Replaces the old knowledge about client routes with a new full snapshot.
+    /// The snapshot contains all entries that match any of connection ids yielded by
+    /// [Self::get_connection_ids]. In particular, no filtering by host ids is done.
+    fn replace_client_routes(&self, client_routes: ClientRoutes);
+
+    /// Merges existing knowledge about client routes with a partial snapshot,
+    /// fetched in response to a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
+    /// The snapshot contains all entries that match connection ids and host ids
+    /// present in the event.
+    fn merge_client_routes_update(
+        &self,
+        event: &ClientRoutesChangeEvent,
+        client_routes: ClientRoutes,
+    );
+}

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -5,6 +5,83 @@
 use scylla_cql::frame::response::event::ClientRoutesChangeEvent;
 
 use crate::cluster::metadata::ClientRoutes;
+use thiserror::Error;
+
+/// Represents a single ClientRoutes proxy, identified by a connection ID.
+///
+/// The proxy is used to connect to Scylla Cloud clusters using custom routing.
+/// Each proxy corresponds to a specific connection ID, and allows connecting
+/// to some subset of the cluster's nodes, as determined by the configured
+/// architecture setup in Scylla Cloud and by the contents of the
+/// `system.client_routes` table in the system keyspace of the cluster.
+///
+/// The hostname for the proxy will be obtained from `system.client_routes` table,
+/// using the connection ID for filtering.
+/// Optionally, the hostname can be overridden with a custom one, which can
+/// be useful for testing and for some cloud architectures.
+#[derive(Debug, Clone)]
+pub struct ClientRoutesProxy {
+    #[expect(unused)] // temporarily, removed in further commit
+    connection_id: String,
+    overridden_hostname: Option<String>,
+}
+
+impl ClientRoutesProxy {
+    /// Creates a new ClientRoutes proxy configuration with the given connection ID.
+    /// The hostname will be obtained from client_routes table, using the connection ID
+    /// for filtering.
+    pub fn new_with_connection_id(connection_id: String) -> Self {
+        Self {
+            connection_id,
+            overridden_hostname: None,
+        }
+    }
+
+    /// Overrides the hostname obtained from client_routes table with the provided one.
+    ///
+    /// Useful for testing and for some cloud architectures.
+    pub fn with_overridden_hostname(mut self, hostname: String) -> Self {
+        self.overridden_hostname = Some(hostname);
+        self
+    }
+}
+
+// For convenience, allow creating ClientRoutesProxy directly from a connection ID string.
+// Overriding the hostname is rare enough that it doesn't warrant a separate From implementation,
+// and can be done with the builder-like API.
+impl From<String> for ClientRoutesProxy {
+    fn from(connection_id: String) -> Self {
+        Self::new_with_connection_id(connection_id)
+    }
+}
+
+/// Routing configuration for Scylla Cloud.
+#[derive(Debug, Clone)]
+pub struct ClientRoutesConfig {
+    #[expect(unused)] // temporarily, removed in further commit
+    proxies: Vec<ClientRoutesProxy>,
+}
+
+impl ClientRoutesConfig {
+    /// Creates a new routing configuration for Scylla Cloud.
+    pub fn new(proxies: Vec<ClientRoutesProxy>) -> Result<Self, ClientRoutesConfigError> {
+        if proxies.is_empty() {
+            return Err(ClientRoutesConfigError::EmptyConnectionIds);
+        }
+        Ok(Self { proxies })
+    }
+}
+
+// TODO: consider introducing ClientRoutesConfigBuilder for more future-proof design.
+
+/// Error that occurred when creating [ClientRoutesConfig].
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum ClientRoutesConfigError {
+    /// Passed no connection ids.
+    #[error("Passed no connection ids")]
+    EmptyConnectionIds,
+}
 
 pub(crate) trait ClientRoutesSubscriber: Send + Sync {
     /// Specifies connection IDs that are to be monitored, i.e., whose entries

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -6,7 +6,6 @@ use scylla_cql::frame::response::event::ClientRoutesChangeEvent;
 
 use crate::cluster::metadata::ClientRoutes;
 
-#[expect(dead_code)] // TODO: removed in a next commit.
 pub(crate) trait ClientRoutesSubscriber: Send + Sync {
     /// Specifies connection IDs that are to be monitored, i.e., whose entries
     /// shall be fetched from `system.client_routes`.
@@ -21,6 +20,7 @@ pub(crate) trait ClientRoutesSubscriber: Send + Sync {
     /// fetched in response to a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
     /// The snapshot contains all entries that match connection ids and host ids
     /// present in the event.
+    #[expect(dead_code)] // TODO: remove once event handling is added in a further commit.
     fn merge_client_routes_update(
         &self,
         event: &ClientRoutesChangeEvent,

--- a/scylla/src/client/mod.rs
+++ b/scylla/src/client/mod.rs
@@ -19,6 +19,8 @@ pub mod execution_profile;
 
 pub mod pager;
 
+pub mod client_routes;
+
 pub mod caching_session;
 
 mod self_identity;

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -17,7 +17,7 @@ use scylla_cql::deserialize::row::{ColumnIterator, DeserializeRow};
 use scylla_cql::deserialize::{DeserializationError, TypeCheckError};
 use scylla_cql::frame::frame_errors::ResultMetadataAndRowsCountParseError;
 use scylla_cql::frame::request::query::PagingState;
-use scylla_cql::frame::response::NonErrorResponseWithDeserializedMetadata;
+use scylla_cql::frame::response::NonErrorResponseWithDeserializedMetadataV2 as NonErrorResponseWithDeserializedMetadata;
 use scylla_cql::frame::response::result::{
     DeserializedMetadataAndRawRows, SchemaChange, SetKeyspace,
 };

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -5,6 +5,7 @@ use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle, Executi
 use super::pager::{PreparedPagerConfig, QueryPager};
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
+use crate::client::client_routes::ClientRoutesConfig;
 use crate::cluster::node::{KnownNode, NodeRef};
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::{
@@ -309,7 +310,6 @@ pub struct SessionConfig {
 
     /// Routing configuration for Scylla Cloud. If set, Session will connect
     /// to Scylla Cloud clusters using custom routing based on `system.client_routes`.
-    #[expect(unused)] // TODO: Will get used soon.
     #[cfg(feature = "unstable-client-routes")]
     pub(crate) client_routes_config: Option<super::client_routes::ClientRoutesConfig>,
 
@@ -1129,6 +1129,17 @@ impl Session {
             }
         };
 
+        let client_routes_config: Option<ClientRoutesConfig> = {
+            #[cfg(feature = "unstable-client-routes")]
+            {
+                config.client_routes_config
+            }
+            #[cfg(not(feature = "unstable-client-routes"))]
+            {
+                None
+            }
+        };
+
         let cluster = Cluster::new(
             known_nodes,
             pool_config,
@@ -1142,6 +1153,7 @@ impl Session {
             tablet_receiver,
             #[cfg(feature = "metrics")]
             Arc::clone(&metrics),
+            client_routes_config,
         )
         .await?;
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -490,6 +490,20 @@ impl Default for SessionConfig {
     }
 }
 
+impl SessionConfig {
+    /// [SessionConfig] may unfortunately represent invalid configurations. We need to rule them out
+    /// at runtime by running validation.
+    #[expect(clippy::result_large_err)] // TODO(2.0): Make NewSessionError smaller.
+    fn validate(&self) -> Result<(), NewSessionError> {
+        // Ensure there is at least one known node
+        if self.known_nodes.is_empty() {
+            return Err(NewSessionError::EmptyKnownNodesList);
+        }
+
+        Ok(())
+    }
+}
+
 pub(crate) enum RunRequestResult<ResT> {
     IgnoredWriteError,
     Completed(ResT),
@@ -1013,12 +1027,9 @@ impl Session {
     /// # }
     /// ```
     pub async fn connect(config: SessionConfig) -> Result<Self, NewSessionError> {
-        let known_nodes = config.known_nodes;
+        config.validate()?;
 
-        // Ensure there is at least one known node
-        if known_nodes.is_empty() {
-            return Err(NewSessionError::EmptyKnownNodesList);
-        }
+        let known_nodes = config.known_nodes;
 
         let (tablet_sender, tablet_receiver) = tokio::sync::mpsc::channel(TABLET_CHANNEL_SIZE);
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -307,6 +307,12 @@ pub struct SessionConfig {
     /// between the nodes and the driver.
     pub address_translator: Option<Arc<dyn AddressTranslator>>,
 
+    /// Routing configuration for Scylla Cloud. If set, Session will connect
+    /// to Scylla Cloud clusters using custom routing based on `system.client_routes`.
+    #[expect(unused)] // TODO: Will get used soon.
+    #[cfg(feature = "unstable-client-routes")]
+    pub(crate) client_routes_config: Option<super::client_routes::ClientRoutesConfig>,
+
     /// The host filter decides whether any connections should be opened
     /// to the node or not. The driver will also avoid filtered out nodes when
     /// re-establishing the control connection.
@@ -418,6 +424,8 @@ impl SessionConfig {
             tracing_info_fetch_consistency: Consistency::One,
             cluster_metadata_refresh_interval: Duration::from_secs(60),
             identity: SelfIdentity::default(),
+            #[cfg(feature = "unstable-client-routes")]
+            client_routes_config: None,
         }
     }
 
@@ -498,6 +506,25 @@ impl SessionConfig {
         // Ensure there is at least one known node
         if self.known_nodes.is_empty() {
             return Err(NewSessionError::EmptyKnownNodesList);
+        }
+
+        // Ensure no illegal configuration with Client Routes
+        #[cfg(feature = "unstable-client-routes")]
+        if self.client_routes_config.is_some() {
+            if self.address_translator.is_some() {
+                return Err(NewSessionError::IllegalConfig(
+                    "User-provided address translator is not supported if ClientRoutesConfig is provided, \
+                        because the driver uses its own custom translator for client routes".into(),
+                ));
+            }
+
+            if self.tls_context.is_some() {
+                return Err(NewSessionError::IllegalConfig(
+                    "TLS is not (yet) supported if ClientRoutesConfig is provided, \
+                        because of architectural limitations that are out of the driver's scope"
+                        .into(),
+                ));
+            }
         }
 
         Ok(())

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -44,7 +44,7 @@ use arc_swap::ArcSwapOption;
 use futures::future::join_all;
 use futures::future::try_join_all;
 use itertools::Itertools;
-use scylla_cql::frame::response::NonErrorResponseWithDeserializedMetadata;
+use scylla_cql::frame::response::NonErrorResponseWithDeserializedMetadataV2 as NonErrorResponseWithDeserializedMetadata;
 use scylla_cql::frame::response::error::DbError;
 use scylla_cql::serialize::batch::BatchValues;
 use scylla_cql::serialize::row::{SerializeRow, SerializedValues};

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -179,7 +179,13 @@ impl GenericSessionBuilder<DefaultMode> {
         self.config.add_known_nodes_addr(node_addrs);
         self
     }
+}
 
+/// Constraint for session builder kinds that support setting AddressTranslator on them.
+pub trait SessionBuilderKindSupportsAddressTranslation: SessionBuilderKind {}
+impl SessionBuilderKindSupportsAddressTranslation for DefaultMode {}
+
+impl<K: SessionBuilderKindSupportsAddressTranslation> GenericSessionBuilder<K> {
     /// Uses a custom address translator for peer addresses retrieved from the cluster.
     /// By default, no translation is performed.
     ///

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -43,6 +43,18 @@ impl SessionBuilderKind for DefaultMode {}
 /// Builder for regular sessions.
 pub type SessionBuilder = GenericSessionBuilder<DefaultMode>;
 
+/// Session builder kind used to create sessions connected to clusters with custom routing based on `system.client_routes`.
+#[cfg(feature = "unstable-client-routes")]
+#[derive(Clone)]
+pub enum ClientRoutesMode {}
+#[cfg(feature = "unstable-client-routes")]
+impl sealed::Sealed for ClientRoutesMode {}
+#[cfg(feature = "unstable-client-routes")]
+impl SessionBuilderKind for ClientRoutesMode {}
+/// Builder for ClientRoutes sessions.
+#[cfg(feature = "unstable-client-routes")]
+pub type ClientRoutesSessionBuilder = GenericSessionBuilder<ClientRoutesMode>;
+
 /// Used to conveniently configure new Session instances.
 ///
 /// Most likely you will want to use [`SessionBuilder`]
@@ -72,10 +84,10 @@ pub struct GenericSessionBuilder<Kind: SessionBuilderKind> {
 
 // NOTE: this `impl` block contains configuration options specific for default mode.
 // This includes: list of contact points, address translation, and TLS configuration.
-// Alternative ways to connect to the cluster, like legacy Scylla Cloud Serverless, or
-// AWS Private Link (if we introduce it in the future), may internally utilize address translation,
-// or TLS configuration (for example for SNI). We don't want users to be able to create invalid
-// configuration, so such options should not be available for those builder types.
+// Alternative ways to connect to the cluster, like AWS Private Link, may internally
+// utilize address translation, or TLS configuration (for example for SNI).
+// We don't want users to be able to create invalid configuration, so such options
+// should not be available for those builder types.
 impl GenericSessionBuilder<DefaultMode> {
     /// Creates new SessionBuilder with default configuration
     /// # Default configuration
@@ -89,9 +101,67 @@ impl GenericSessionBuilder<DefaultMode> {
     }
 }
 
+// NOTE: this `impl` block contains configuration options specific for ClientRoutes mode.
+// We don't want users to be able to create invalid configuration, so some options available
+// in the default builder, like address translator configuration, should not be available for
+// this builder type. On the other hand, if there are some options specific for ClientRoutes sessions,
+// they should be added to this block as well.
+#[cfg(feature = "unstable-client-routes")]
+impl GenericSessionBuilder<ClientRoutesMode> {
+    /// Creates new [`ClientRoutesSessionBuilder`] with given config.
+    ///
+    /// This SessionBuilder kind is used to create sessions connected to ClientRoutes clusters.
+    /// It requires [`ClientRoutesConfig`], which contains at least contact points and connection ids,
+    /// which are both used to establish the connection to the cluster.
+    ///
+    /// **Note:** Mixed clusters (with both nodes reachable only through ClientRoutes and nodes
+    /// reachable only directly) **are not supported**. All nodes must be reachable through ClientRoutes,
+    /// in particular have corresponding entries in `system.client_routes`. Otherwise, the driver will
+    /// fail to contact them.
+    ///
+    /// **Note:** Advanced shard awareness (clever port setting by the driver to target
+    /// a desired shard) is not yet supported in ClientRoutes Scylla Cloud deployments
+    /// at the moment of writing, so using shard-aware port is disabled by default.
+    ///
+    /// # Example
+    /// ```
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use scylla::client::session::Session;
+    /// use scylla::client::session_builder::ClientRoutesSessionBuilder;
+    /// use scylla::client::client_routes::{ClientRoutesConfig, ClientRoutesProxy};
+    ///
+    /// let contact_points = ["my-ClientRoutes-contact-point.amazonaws.com:9042".to_owned()];
+    /// let proxies = vec![
+    ///     ClientRoutesProxy::new_with_connection_id("my-ClientRoutes-connection-id".to_owned()),
+    /// ];
+    /// let client_routes_config = ClientRoutesConfig::new(proxies)?;
+    /// let session: Session = ClientRoutesSessionBuilder::new(client_routes_config)
+    ///     .known_nodes(contact_points)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new(config: super::client_routes::ClientRoutesConfig) -> Self {
+        ClientRoutesSessionBuilder {
+            config: SessionConfig {
+                client_routes_config: Some(config),
+                // Advanced shard awareness (clever port setting by the driver to target
+                // a desired shard) is not yet supported in ClientRoutes Cloud deployments
+                // at the moment of writing, so this is disabled by default.
+                disallow_shard_aware_port: true,
+                ..SessionConfig::new()
+            },
+            kind: PhantomData,
+        }
+    }
+}
+
 /// Constraint for session builder kinds that support setting known nodes.
 pub trait SessionBuilderKindSupportsKnownNodes: SessionBuilderKind {}
 impl SessionBuilderKindSupportsKnownNodes for DefaultMode {}
+#[cfg(feature = "unstable-client-routes")]
+impl SessionBuilderKindSupportsKnownNodes for ClientRoutesMode {}
 
 impl<K: SessionBuilderKindSupportsKnownNodes> GenericSessionBuilder<K> {
     /// Add a known node with a hostname

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -87,7 +87,13 @@ impl GenericSessionBuilder<DefaultMode> {
             kind: PhantomData,
         }
     }
+}
 
+/// Constraint for session builder kinds that support setting known nodes.
+pub trait SessionBuilderKindSupportsKnownNodes: SessionBuilderKind {}
+impl SessionBuilderKindSupportsKnownNodes for DefaultMode {}
+
+impl<K: SessionBuilderKindSupportsKnownNodes> GenericSessionBuilder<K> {
     /// Add a known node with a hostname
     /// # Examples
     /// ```

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -328,6 +328,9 @@ impl<K: SessionBuilderKindSupportsAddressTranslation> GenericSessionBuilder<K> {
 /// Constraint for session builder kinds that support setting TLS config on them.
 pub trait SessionBuilderKindSupportsTls: SessionBuilderKind {}
 impl SessionBuilderKindSupportsTls for DefaultMode {}
+// TODO: support TLS for ClientRoutesMode once Cloud comes up with a solution.
+// #[cfg(feature = "unstable-client-routes")]
+// impl SessionBuilderKindSupportsTls for ClientRoutesMode {}
 
 impl<K: SessionBuilderKindSupportsTls> GenericSessionBuilder<K> {
     /// TLS feature

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -241,7 +241,13 @@ impl GenericSessionBuilder<DefaultMode> {
         self.config.address_translator = Some(translator);
         self
     }
+}
 
+/// Constraint for session builder kinds that support setting TLS config on them.
+pub trait SessionBuilderKindSupportsTls: SessionBuilderKind {}
+impl SessionBuilderKindSupportsTls for DefaultMode {}
+
+impl<K: SessionBuilderKindSupportsTls> GenericSessionBuilder<K> {
     /// TLS feature
     ///
     /// Provide SessionBuilder with TlsContext that will be

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -180,85 +180,6 @@ impl GenericSessionBuilder<DefaultMode> {
         self
     }
 
-    /// Set username and password for plain text authentication.\
-    /// If the database server will require authentication\
-    ///
-    /// # Example
-    /// ```
-    /// # use scylla::client::session::Session;
-    /// # use scylla::client::session_builder::SessionBuilder;
-    /// # use scylla::client::Compression;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .use_keyspace("my_keyspace_name", false)
-    ///     .user("cassandra", "cassandra")
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn user(mut self, username: impl Into<String>, passwd: impl Into<String>) -> Self {
-        self.config.authenticator = Some(Arc::new(PlainTextAuthenticator::new(
-            username.into(),
-            passwd.into(),
-        )));
-        self
-    }
-
-    /// Set custom authenticator provider to create an authenticator instance during a session creation.
-    ///
-    /// # Example
-    /// ```
-    /// # use std::sync::Arc;
-    /// use bytes::Bytes;
-    /// # use scylla::client::session::Session;
-    /// # use scylla::client::session_builder::SessionBuilder;
-    /// use async_trait::async_trait;
-    /// use scylla::authentication::{AuthenticatorProvider, AuthenticatorSession, AuthError};
-    /// # use scylla::client::Compression;
-    ///
-    /// struct CustomAuthenticator;
-    ///
-    /// #[async_trait]
-    /// impl AuthenticatorSession for CustomAuthenticator {
-    ///     async fn evaluate_challenge(&mut self, token: Option<&[u8]>) -> Result<Option<Vec<u8>>, AuthError> {
-    ///         Ok(None)
-    ///     }
-    ///
-    ///     async fn success(&mut self, token: Option<&[u8]>) -> Result<(), AuthError> {
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// struct CustomAuthenticatorProvider;
-    ///
-    /// #[async_trait]
-    /// impl AuthenticatorProvider for CustomAuthenticatorProvider {
-    ///     async fn start_authentication_session(&self, _authenticator_name: &str) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError> {
-    ///         Ok((None, Box::new(CustomAuthenticator)))
-    ///     }
-    /// }
-    ///
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .use_keyspace("my_keyspace_name", false)
-    ///     .user("cassandra", "cassandra")
-    ///     .authenticator_provider(Arc::new(CustomAuthenticatorProvider))
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn authenticator_provider(
-        mut self,
-        authenticator_provider: Arc<dyn AuthenticatorProvider>,
-    ) -> Self {
-        self.config.authenticator = Some(authenticator_provider);
-        self
-    }
-
     /// Uses a custom address translator for peer addresses retrieved from the cluster.
     /// By default, no translation is performed.
     ///
@@ -373,6 +294,85 @@ impl GenericSessionBuilder<DefaultMode> {
 // This block contains configuration options that make sense both for any `Session` type.
 // If an option fit only some of them, it should be put in a specialised block.
 impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
+    /// Set username and password for plain text authentication.\
+    /// If the database server will require authentication\
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// # use scylla::client::Compression;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .use_keyspace("my_keyspace_name", false)
+    ///     .user("cassandra", "cassandra")
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn user(mut self, username: impl Into<String>, passwd: impl Into<String>) -> Self {
+        self.config.authenticator = Some(Arc::new(PlainTextAuthenticator::new(
+            username.into(),
+            passwd.into(),
+        )));
+        self
+    }
+
+    /// Set custom authenticator provider to create an authenticator instance during a session creation.
+    ///
+    /// # Example
+    /// ```
+    /// # use std::sync::Arc;
+    /// use bytes::Bytes;
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// use async_trait::async_trait;
+    /// use scylla::authentication::{AuthenticatorProvider, AuthenticatorSession, AuthError};
+    /// # use scylla::client::Compression;
+    ///
+    /// struct CustomAuthenticator;
+    ///
+    /// #[async_trait]
+    /// impl AuthenticatorSession for CustomAuthenticator {
+    ///     async fn evaluate_challenge(&mut self, token: Option<&[u8]>) -> Result<Option<Vec<u8>>, AuthError> {
+    ///         Ok(None)
+    ///     }
+    ///
+    ///     async fn success(&mut self, token: Option<&[u8]>) -> Result<(), AuthError> {
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// struct CustomAuthenticatorProvider;
+    ///
+    /// #[async_trait]
+    /// impl AuthenticatorProvider for CustomAuthenticatorProvider {
+    ///     async fn start_authentication_session(&self, _authenticator_name: &str) -> Result<(Option<Vec<u8>>, Box<dyn AuthenticatorSession>), AuthError> {
+    ///         Ok((None, Box::new(CustomAuthenticator)))
+    ///     }
+    /// }
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .use_keyspace("my_keyspace_name", false)
+    ///     .user("cassandra", "cassandra")
+    ///     .authenticator_provider(Arc::new(CustomAuthenticatorProvider))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn authenticator_provider(
+        mut self,
+        authenticator_provider: Arc<dyn AuthenticatorProvider>,
+    ) -> Self {
+        self.config.authenticator = Some(authenticator_provider);
+        self
+    }
+
     /// Sets the local ip address all TCP sockets are bound to.
     ///
     /// By default, this option is set to `None`, which is equivalent to:

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -30,12 +30,16 @@ pub(super) struct ControlConnection {
 }
 
 impl ControlConnection {
-    pub(super) fn new(conn: Arc<Connection>, cache: Arc<ControlConnectionCache>) -> Self {
+    pub(super) fn new(
+        conn: Arc<Connection>,
+        cache: Arc<ControlConnectionCache>,
+        client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
+    ) -> Self {
         Self {
             conn,
             overridden_serverside_timeout: None,
             cache,
-            client_routes_subscriber: None, // TODO: pass it from MetadataReader.
+            client_routes_subscriber,
         }
     }
 
@@ -278,8 +282,11 @@ mod tests {
             .unwrap();
 
             let connected_to_scylladb = conn.get_shard_info().is_some();
-            let conn_with_default_timeout =
-                ControlConnection::new(Arc::new(conn), Arc::new(ControlConnectionCache::new()));
+            let conn_with_default_timeout = ControlConnection::new(
+                Arc::new(conn),
+                Arc::new(ControlConnectionCache::new()),
+                None,
+            );
 
             // No custom timeout set.
             {

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 
+use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::client::pager::QueryPager;
 use crate::errors::{NextPageError, NextRowError, RequestAttemptError, RequestError};
 use crate::network::Connection;
@@ -25,6 +26,7 @@ pub(super) struct ControlConnection {
     /// The custom server-side timeout set for requests executed on the control connection.
     overridden_serverside_timeout: Option<Duration>,
     cache: Arc<ControlConnectionCache>,
+    client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
 }
 
 impl ControlConnection {
@@ -33,6 +35,7 @@ impl ControlConnection {
             conn,
             overridden_serverside_timeout: None,
             cache,
+            client_routes_subscriber: None, // TODO: pass it from MetadataReader.
         }
     }
 
@@ -42,6 +45,10 @@ impl ControlConnection {
             overridden_serverside_timeout: overridden_timeout,
             ..self
         }
+    }
+
+    pub(super) fn client_routes_subscriber(&self) -> Option<&Arc<dyn ClientRoutesSubscriber>> {
+        self.client_routes_subscriber.as_ref()
     }
 
     pub(super) fn get_connect_address(&self) -> SocketAddr {

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -360,7 +360,6 @@ impl ControlConnection {
 
 /// Represents an entry of `system.client_routes` table, in a more raw form (ports as i32).
 #[derive(DeserializeRow)]
-#[expect(unused)] // temporarily, removed in further commit
 #[scylla(crate = "crate")]
 pub(crate) struct ClientRoutesEntry {
     // PRIMARY KEY (connection_id, host_id)

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -30,20 +30,21 @@ use scylla_cql::utils::parse::{ParseErrorCause, ParseResult, ParserState};
 use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
-use crate::DeserializeRow;
-use crate::client::pager::QueryPager;
-use crate::cluster::NodeAddr;
-use crate::cluster::control_connection::ControlConnection;
-use crate::cluster::metadata::{
+use super::{
     CollectionType, Column, ColumnKind, ColumnType, Keyspace, MaterializedView, Metadata,
     MissingUserDefinedType, NativeType, Peer, SingleKeyspaceMetadataError, Strategy, Table,
     UserDefinedType,
 };
+
+use crate::DeserializeRow;
+use crate::client::pager::QueryPager;
+use crate::cluster::NodeAddr;
+use crate::cluster::control_connection::ControlConnection;
 use crate::deserialize::DeserializeOwnedRow;
 use crate::errors::{
-    DbError, KeyspaceStrategyError, KeyspacesMetadataError, MetadataError, MetadataFetchError,
-    MetadataFetchErrorKind, NextPageError, NextRowError, PeersMetadataError, RequestAttemptError,
-    RequestError, TablesMetadataError, UdtMetadataError,
+    ClientRoutesMetadataError, DbError, KeyspaceStrategyError, KeyspacesMetadataError,
+    MetadataError, MetadataFetchError, MetadataFetchErrorKind, NextPageError, NextRowError,
+    PeersMetadataError, RequestAttemptError, RequestError, TablesMetadataError, UdtMetadataError,
 };
 use crate::routing::Token;
 
@@ -333,7 +334,88 @@ impl ControlConnection {
             rack,
         })
     }
+}
 
+/*
+ * CREATE TABLE system.client_routes (
+ *     connection_id text,
+ *     host_id uuid,
+ *     address text,          -- DNS hostname of the proxy reachable via client_routes routing
+ *     port int,              -- CQL plaintext port
+ *     tls_port int,          -- CQL TLS port
+ *     alternator_port int,
+ *     alternator_https_port int,
+ *     PRIMARY KEY (connection_id, host_id)
+ * );
+ */
+
+/* There are two separate structs:
+ * 1. ClientRoutesEntry
+ * 2. ClientRoute
+ * They differ just by types to represent ports: i32 in ClientRoutesEntry and u16 for ClientRoute.
+ * The reason is that only signed integers implement DeserializeValue.
+ * So, we utilise the derive macro to implement DeserializeRow automatically on ClientRoutesEntry,
+ * and then convert ClientRoutesEntry to a ClientRoute.
+ */
+
+/// Represents an entry of `system.client_routes` table, in a more raw form (ports as i32).
+#[derive(DeserializeRow)]
+#[expect(unused)] // temporarily, removed in further commit
+#[scylla(crate = "crate")]
+pub(crate) struct ClientRoutesEntry {
+    // PRIMARY KEY (connection_id, host_id)
+    pub(crate) connection_id: String,
+    // DB's REST API throws HTTP 500 if `host_id` is invalid UUID.
+    pub(crate) host_id: Uuid,
+
+    // DB's REST API throws HTTP 400 if `address` is null.
+    #[scylla(rename = "address")]
+    pub(crate) hostname: String,
+
+    // DB's REST API throws HTTP 400 if both `port` and `tls_port` are null,
+    // allows inserting either of them as null as long as the other is not null.
+
+    // Nullable, not part of the primary key. DB's REST API allows inserting null.
+    pub(crate) port: Option<i32>,
+    // Nullable, not part of the primary key. DB's REST API allows inserting null.
+    pub(crate) tls_port: Option<i32>,
+}
+
+impl TryFrom<ClientRoutesEntry> for super::ClientRoute {
+    type Error = ClientRoutesMetadataError;
+
+    fn try_from(
+        ClientRoutesEntry {
+            connection_id,
+            host_id,
+            hostname,
+            port,
+            tls_port,
+        }: ClientRoutesEntry,
+    ) -> Result<Self, Self::Error> {
+        fn parse_port(
+            port: Option<i32>,
+            is_tls: bool,
+        ) -> Result<Option<u16>, ClientRoutesMetadataError> {
+            port.map(|port| {
+                u16::try_from(port)
+                    .map_err(|_| ClientRoutesMetadataError::InvalidPortValue { port, is_tls })
+            })
+            .transpose()
+        }
+        let port = parse_port(port, false)?;
+        let tls_port = parse_port(tls_port, true)?;
+        Ok(Self {
+            connection_id,
+            host_id,
+            hostname,
+            port,
+            tls_port,
+        })
+    }
+}
+
+impl ControlConnection {
     fn query_filter_keyspace_name<'a, R>(
         &'a self,
         query_str: &'a str,

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -40,6 +40,7 @@ use crate::DeserializeRow;
 use crate::client::pager::QueryPager;
 use crate::cluster::NodeAddr;
 use crate::cluster::control_connection::ControlConnection;
+use crate::cluster::metadata::ClientRoutes;
 use crate::deserialize::DeserializeOwnedRow;
 use crate::errors::{
     ClientRoutesMetadataError, DbError, KeyspaceStrategyError, KeyspacesMetadataError,
@@ -163,8 +164,24 @@ impl ControlConnection {
     ) -> Result<Metadata, MetadataError> {
         let peers_query = self.query_peers(connect_port);
         let keyspaces_query = self.query_keyspaces(keyspace_to_fetch, fetch_schema);
+        let client_routes_query = async {
+            let Some(subscriber) = self.client_routes_subscriber() else {
+                return Ok(ClientRoutes::default());
+            };
+            let connection_ids = subscriber.get_connection_ids();
+            self.query_client_routes(connection_ids, &[]).await
+        };
 
-        let (peers, keyspaces) = tokio::try_join!(peers_query, keyspaces_query)?;
+        let peers: Vec<Peer>;
+        let client_routes: ClientRoutes;
+        let keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>;
+
+        (peers, client_routes, keyspaces) =
+            tokio::try_join!(peers_query, client_routes_query, keyspaces_query)?;
+
+        if let Some(client_routes_subscriber) = self.client_routes_subscriber() {
+            client_routes_subscriber.replace_client_routes(client_routes);
+        }
 
         // There must be at least one peer
         if peers.is_empty() {
@@ -415,6 +432,69 @@ impl TryFrom<ClientRoutesEntry> for super::ClientRoute {
 }
 
 impl ControlConnection {
+    pub(super) async fn query_client_routes(
+        &self,
+        // List of connection ids that are accepted.
+        // If empty, all connection ids are accepted.
+        connection_ids: &[String],
+        // List of host ids that are accepted.
+        // If empty, all host ids are accepted.
+        host_ids: &[Uuid],
+    ) -> Result<ClientRoutes, MetadataError> {
+        async fn query_client_routes_with_values(
+            conn: &ControlConnection,
+            query_str: &str,
+            values: &(dyn scylla_cql::serialize::row::SerializeRow + Sync),
+        ) -> Result<ClientRoutes, MetadataError> {
+            conn.query_iter(query_str, values)
+                .into_stream()
+                .map(|pager_res| {
+                    let pager = pager_res?;
+                    let stream = pager.rows_stream::<ClientRoutesEntry>()?;
+                    Ok::<_, MetadataFetchErrorKind>(stream.map_err(MetadataFetchErrorKind::from))
+                })
+                .try_flatten()
+                // Add table context to the error.
+                .map_err(|error| MetadataFetchError {
+                    error,
+                    table: "system.client_routes",
+                })
+                .map_err(MetadataError::from)
+                .map(|r| {
+                    r.and_then(|c| super::ClientRoute::try_from(c).map_err(MetadataError::from))
+                })
+                .try_collect()
+                .await
+        }
+
+        let filter_by_connection_ids = !connection_ids.is_empty();
+        let filter_by_host_ids = !host_ids.is_empty();
+
+        let (query_str, values): (&str, &(dyn scylla_cql::serialize::row::SerializeRow + Sync)) =
+            match (filter_by_connection_ids, filter_by_host_ids) {
+                (true, true) => (
+                    "SELECT connection_id, host_id, address, port, tls_port FROM system.client_routes WHERE connection_id IN ? AND host_id IN ?",
+                    &(connection_ids, host_ids),
+                ),
+                (true, false) => (
+                    "SELECT connection_id, host_id, address, port, tls_port FROM system.client_routes WHERE connection_id IN ?",
+                    &(connection_ids,),
+                ),
+                (false, true) => (
+                    "SELECT connection_id, host_id, address, port, tls_port FROM system.client_routes WHERE host_id IN ? ALLOW FILTERING",
+                    &(host_ids,),
+                ),
+                (false, false) => (
+                    "SELECT connection_id, host_id, address, port, tls_port FROM system.client_routes ALLOW FILTERING",
+                    &(),
+                ),
+            };
+
+        let routes = query_client_routes_with_values(self, query_str, values).await?;
+
+        Ok(routes)
+    }
+
     fn query_filter_keyspace_name<'a, R>(
         &'a self,
         query_str: &'a str,

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -441,6 +441,7 @@ impl ControlConnection {
         // If empty, all host ids are accepted.
         host_ids: &[Uuid],
     ) -> Result<ClientRoutes, MetadataError> {
+        #[expect(clippy::result_large_err)]
         async fn query_client_routes_with_values(
             conn: &ControlConnection,
             query_str: &str,
@@ -535,6 +536,7 @@ impl ControlConnection {
             .try_flatten()
     }
 
+    #[expect(clippy::result_large_err)]
     async fn query_keyspaces(
         &self,
         keyspaces_to_fetch: &[String],
@@ -663,6 +665,7 @@ impl TryFrom<UdtRow> for UdtRowWithParsedFieldTypes {
 }
 
 impl ControlConnection {
+    #[expect(clippy::result_large_err)]
     async fn query_user_defined_types(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1006,6 +1009,7 @@ mod toposort_tests {
 }
 
 impl ControlConnection {
+    #[expect(clippy::result_large_err)]
     async fn query_tables(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1053,6 +1057,7 @@ impl ControlConnection {
         Ok(result)
     }
 
+    #[expect(clippy::result_large_err)]
     async fn query_views(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1112,6 +1117,7 @@ impl ControlConnection {
         Ok(result)
     }
 
+    #[expect(clippy::result_large_err)]
     async fn query_tables_schema(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1491,6 +1497,7 @@ fn freeze_type(typ: PreColumnType) -> PreColumnType {
 }
 
 impl ControlConnection {
+    #[expect(clippy::result_large_err)]
     async fn query_table_partitioners(
         &self,
     ) -> Result<PerKsTable<Option<String>>, MetadataFetchError> {

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -280,7 +280,6 @@ pub enum Strategy {
 
 /// Represents an entry of `system.client_routes` table, in a more refined form (port as u16).
 #[derive(Debug, Clone)]
-#[expect(unused)] // temporarily, removed in further commit
 pub(crate) struct ClientRoute {
     pub(crate) connection_id: String,
     pub(crate) host_id: Uuid,

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -293,6 +293,30 @@ pub(crate) struct ClientRoute {
     pub(crate) tls_port: Option<u16>,
 }
 
+/// A subset of client routes present in the `system.client_routes` table.
+/// This is always filtered by specified connection ids, and may be filtered by
+/// host ids, too.
+#[derive(Debug, Default)] // Default is needed for `try_collect()`.
+#[expect(unused)] // temporarily, removed in further commit
+pub(crate) struct ClientRoutes {
+    // Routes are grouped by host id first, because this is how AddressTranslator
+    // looks them up. Then, routes for given host id are grouped by connection id,
+    // because it's the AddressTranslator's responsibility to choose the proper connection id.
+    pub(crate) routes: HashMap<Uuid, HashMap<String, ClientRoute>>,
+}
+
+// Needed for `Stream::try_collect()` to work.
+impl Extend<ClientRoute> for ClientRoutes {
+    fn extend<T: IntoIterator<Item = ClientRoute>>(&mut self, into_iter: T) {
+        for route in into_iter {
+            self.routes
+                .entry(route.host_id)
+                .or_default() // Insert empty HashMap.
+                .insert(route.connection_id.clone(), route);
+        }
+    }
+}
+
 impl Metadata {
     /// Creates new, dummy metadata from a given list of peers.
     ///

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -14,11 +14,13 @@
 //!     - [NativeType],
 //!     - [UserDefinedType],
 //!     - [CollectionType],
-//!
+//  - client routes:
+//    - [ClientRoute]
 
 mod fetching;
 pub(super) mod reader;
 
+use crate::cluster::node::{NodeAddr, ResolvedContactPoint};
 use crate::routing::Token;
 
 use scylla_cql::frame::response::result::ColumnSpec;
@@ -26,8 +28,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
-
-use crate::cluster::node::{NodeAddr, ResolvedContactPoint};
 
 // Re-export of CQL types.
 pub use scylla_cql::frame::response::result::{
@@ -276,6 +276,21 @@ pub enum Strategy {
         /// Additional parameters of the strategy, which the driver does not understand.
         data: HashMap<String, String>,
     },
+}
+
+/// Represents an entry of `system.client_routes` table, in a more refined form (port as u16).
+#[derive(Debug, Clone)]
+#[expect(unused)] // temporarily, removed in further commit
+pub(crate) struct ClientRoute {
+    pub(crate) connection_id: String,
+    pub(crate) host_id: Uuid,
+    pub(crate) hostname: String,
+    // At least one of `port` and `tls_port` must be non-null, as per the REST API constraints.
+    // This is not validated by the driver, as it anyway requires specific one to be non-null
+    // based on the `use_tls` setting, so the non-nullability of _any_ of them is not helpful
+    // for the driver.
+    pub(crate) port: Option<u16>,
+    pub(crate) tls_port: Option<u16>,
 }
 
 impl Metadata {

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -297,7 +297,6 @@ pub(crate) struct ClientRoute {
 /// This is always filtered by specified connection ids, and may be filtered by
 /// host ids, too.
 #[derive(Debug, Default)] // Default is needed for `try_collect()`.
-#[expect(unused)] // temporarily, removed in further commit
 pub(crate) struct ClientRoutes {
     // Routes are grouped by host id first, because this is how AddressTranslator
     // looks them up. Then, routes for given host id are grouped by connection id,

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -21,6 +21,7 @@ use rand::seq::{IndexedRandom, SliceRandom};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, warn};
 
+use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{ControlConnection, ControlConnectionCache};
 use crate::cluster::metadata::{Metadata, PeerEndpoint, UntranslatedEndpoint};
@@ -75,6 +76,7 @@ pub(crate) struct MetadataReader {
     // When no known peer is reachable, initial known nodes are resolved once again as a fallback
     // and establishing control connection to them is attempted.
     initial_known_nodes: Vec<KnownNode>,
+    client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
 
     // ====================================================================
     // Mutable state of MetadataReader. It will change during its lifetime.
@@ -87,6 +89,7 @@ pub(crate) struct MetadataReader {
 
 impl MetadataReader {
     /// Creates new MetadataReader, which connects to initially_known_peers in the background
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         initial_known_nodes: Vec<KnownNode>,
         hostname_resolution_timeout: Option<Duration>,
@@ -95,6 +98,7 @@ impl MetadataReader {
         keyspaces_to_fetch: Vec<String>,
         fetch_schema: bool,
         host_filter: &Option<Arc<dyn HostFilter>>,
+        client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
     ) -> Result<Self, NewSessionError> {
         let (initial_peers, resolved_hostnames) =
             resolve_contact_points(&initial_known_nodes, hostname_resolution_timeout).await;
@@ -119,6 +123,7 @@ impl MetadataReader {
             connection_config.clone(),
             request_serverside_timeout,
             Arc::clone(&cc_cache),
+            client_routes_subscriber.as_ref().map(Arc::clone),
         )
         .await;
 
@@ -136,6 +141,7 @@ impl MetadataReader {
             host_filter: host_filter.clone(),
             initial_known_nodes,
             cc_cache,
+            client_routes_subscriber,
         })
     }
 
@@ -309,6 +315,7 @@ impl MetadataReader {
                 self.control_connection_config.clone(),
                 self.request_serverside_timeout,
                 Arc::clone(&self.cc_cache),
+                self.client_routes_subscriber.as_ref().map(Arc::clone),
             )
             .await;
 
@@ -421,6 +428,7 @@ impl MetadataReader {
                     self.control_connection_config.clone(),
                     self.request_serverside_timeout,
                     Arc::clone(&self.cc_cache),
+                    self.client_routes_subscriber.as_ref().map(Arc::clone),
                 )
                 .await;
             }
@@ -432,6 +440,7 @@ impl MetadataReader {
         mut config: ConnectionConfig,
         request_serverside_timeout: Option<Duration>,
         cache: Arc<ControlConnectionCache>,
+        client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
     ) -> ControlConnectionState {
         let (sender, receiver) = tokio::sync::mpsc::channel(32);
         // setting event_sender field in connection config will cause control connection to
@@ -452,7 +461,7 @@ impl MetadataReader {
 
         match open_result {
             Ok((con, recv)) => ControlConnectionState::Working(WorkingControlConnection {
-                connection: ControlConnection::new(Arc::new(con), cache)
+                connection: ControlConnection::new(Arc::new(con), cache, client_routes_subscriber)
                     .override_serverside_timeout(request_serverside_timeout),
                 error_channel: recv,
                 events_channel: receiver,

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -27,6 +27,7 @@ use crate::cluster::metadata::{Metadata, PeerEndpoint, UntranslatedEndpoint};
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionError, ConnectionPoolError, MetadataError, NewSessionError};
 use crate::frame::response::event::EventV2 as Event;
+use crate::frame::server_event_type::EventTypeV2 as EventType;
 use crate::network::{ConnectionConfig, open_connection};
 use crate::policies::host_filter::HostFilter;
 use crate::utils::safe_format::IteratorSafeFormatExt;
@@ -436,7 +437,12 @@ impl MetadataReader {
         // setting event_sender field in connection config will cause control connection to
         // - send REGISTER message to receive server events
         // - send received events via server_event_sender
-        config.event_sender = Some(sender);
+        let events_to_register_for = vec![
+            EventType::TopologyChange,
+            EventType::StatusChange,
+            EventType::SchemaChange,
+        ];
+        config.event_sender = Some((sender, events_to_register_for));
         let open_result = open_connection(
             &endpoint,
             None,

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use rand::rng;
 use rand::seq::{IndexedRandom, SliceRandom};
+use scylla_cql::frame::response::event::ClientRoutesChangeEvent;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, warn};
 
@@ -478,5 +479,68 @@ impl MetadataReader {
                 last_endpoint: endpoint,
             },
         }
+    }
+
+    /// Performs a partial fetch of `system.client_routes`. Partial means that filtering is done
+    /// not only by connection ids known to the driver (which is always the case), but also
+    /// by host ids - only for the hosts whose ids are present in the event payload.
+    ///
+    /// Then, the updates are fed to the [`ClientRoutesSubscriber`] for merging with previous knowledge.
+    pub(in super::super) async fn fetch_client_route_updates_on_event(
+        &mut self,
+        evt: &ClientRoutesChangeEvent,
+    ) -> Result<(), MetadataError> {
+        let working_connection = match &self.control_connection_state {
+            ControlConnectionState::Working(working_connection) => working_connection,
+            ControlConnectionState::Broken { last_error: e, .. } => {
+                return Err(e.clone());
+            }
+        };
+
+        let Some(subscriber) = &self.client_routes_subscriber else {
+            // No subscriber, but received an event? Strange enough, but nothing to be done here.
+            warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
+            return Ok(());
+        };
+
+        #[deny(clippy::wildcard_enum_match_arm)]
+        let (connection_ids, host_ids) = match evt {
+            ClientRoutesChangeEvent::UpdateNodes {
+                connection_ids,
+                host_ids,
+            } => (connection_ids, host_ids),
+            _ => unreachable!("clippy testifies that the match is exhaustive"),
+        };
+
+        // TODO: this is wasteful - it allocates both strings and a vec.
+        // This won't be a performance problem, because UPDATE_NODES events are not frequent.
+        // As an optimization, we can implement ser/de for some special new iterator type,
+        // to avoid the need to allocate when serializing collections.
+        let connection_ids: Vec<String> = connection_ids
+            .iter()
+            .filter(|&conn_id| subscriber.get_connection_ids().contains(conn_id))
+            .cloned()
+            .collect();
+
+        if connection_ids.is_empty() {
+            // The event contained no relevant connection IDs.
+            // Nothing to be done.
+            return Ok(());
+        }
+
+        // Although this is vaguely documented, the semantics of an event with connection ids [A, B, C] and host ids [X, Y, Z]
+        // is that the following entries were added/updated/removed: `[(A, X), (B, Y), (C, Z)]`.
+        // Unfortunately, we can't really query Scylla this way. Therefore, we do the query: `WHERE connection id IN ? AND host id IN ?`,
+        // which fetches possibly more routes than necessary, for example `(A, Z)` or `(C, Y)`.
+        // This is a tradeoff - the only alternative is issuing multiple queries, one per connection id.
+        // I believe the tradeoff here is correct.
+        let client_routes = working_connection
+            .connection
+            .query_client_routes(&connection_ids, host_ids)
+            .await?;
+
+        subscriber.merge_client_routes_update(evt, client_routes);
+
+        Ok(())
     }
 }

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -26,7 +26,7 @@ use crate::cluster::control_connection::{ControlConnection, ControlConnectionCac
 use crate::cluster::metadata::{Metadata, PeerEndpoint, UntranslatedEndpoint};
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionError, ConnectionPoolError, MetadataError, NewSessionError};
-use crate::frame::response::event::Event;
+use crate::frame::response::event::EventV2 as Event;
 use crate::network::{ConnectionConfig, open_connection};
 use crate::policies::host_filter::HostFilter;
 use crate::utils::safe_format::IteratorSafeFormatExt;

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -446,11 +446,15 @@ impl MetadataReader {
         // setting event_sender field in connection config will cause control connection to
         // - send REGISTER message to receive server events
         // - send received events via server_event_sender
-        let events_to_register_for = vec![
+        let mut events_to_register_for = vec![
             EventType::TopologyChange,
             EventType::StatusChange,
             EventType::SchemaChange,
         ];
+        if client_routes_subscriber.is_some() {
+            events_to_register_for.push(EventType::ClientRoutesChange);
+        }
+
         config.event_sender = Some((sender, events_to_register_for));
         let open_result = open_connection(
             &endpoint,

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -283,14 +283,14 @@ pub(crate) struct ResolvedContactPoint {
     pub(crate) address: SocketAddr,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub(crate) enum DnsLookupError {
     #[error("Failed to perform DNS lookup within {0}ms")]
     Timeout(u128),
     #[error("Empty address list returned by DNS for {0}")]
     EmptyAddressListForHost(String),
     #[error(transparent)]
-    IoError(std::io::Error),
+    IoError(Arc<std::io::Error>),
 }
 
 /// Performs a DNS lookup with provided optional timeout.
@@ -300,12 +300,14 @@ async fn lookup_host_with_timeout(
 ) -> Result<impl Iterator<Item = SocketAddr>, DnsLookupError> {
     if let Some(timeout) = hostname_resolution_timeout {
         match tokio::time::timeout(timeout, lookup_host(host)).await {
-            Ok(res) => res.map_err(DnsLookupError::IoError),
+            Ok(res) => res.map_err(|io_err| DnsLookupError::IoError(Arc::new(io_err))),
             // Elapsed error from tokio library does not provide any context.
             Err(_) => Err(DnsLookupError::Timeout(timeout.as_millis())),
         }
     } else {
-        lookup_host(host).await.map_err(DnsLookupError::IoError)
+        lookup_host(host)
+            .await
+            .map_err(|io_err| DnsLookupError::IoError(Arc::new(io_err)))
     }
 }
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -1,10 +1,9 @@
 use itertools::Itertools;
-use thiserror::Error;
 use tokio::net::{ToSocketAddrs, lookup_host};
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::errors::{ConnectionPoolError, UseKeyspaceError};
+use crate::errors::{ConnectionPoolError, DnsLookupError, UseKeyspaceError};
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{Connection, ConnectivityChangeEvent};
 use crate::network::{NodeConnectionPool, PoolConfig};
@@ -283,20 +282,6 @@ pub(crate) struct ResolvedContactPoint {
     pub(crate) address: SocketAddr,
 }
 
-/// Error that occurred during DNS lookup.
-#[derive(Error, Debug, Clone)]
-pub(crate) enum DnsLookupError {
-    /// Timed out during DNS lookup.
-    #[error("Failed to perform DNS lookup within {0}ms")]
-    Timeout(u128),
-    /// DNS lookup returned an empty address list for a given hostname.
-    #[error("Empty address list returned by DNS for {0}")]
-    EmptyAddressListForHost(String),
-    /// I/O error occurred during DNS lookup.
-    #[error("An I/O error occurred during DNS lookup: {0}")]
-    IoError(Arc<std::io::Error>),
-}
-
 /// Performs a DNS lookup with provided optional timeout.
 async fn lookup_host_with_timeout(
     host: impl ToSocketAddrs,
@@ -343,7 +328,7 @@ pub(crate) async fn resolve_hostname(
 
     addrs
         .find_or_last(|addr| matches!(addr, SocketAddr::V4(_)))
-        .ok_or_else(|| DnsLookupError::EmptyAddressListForHost(hostname.to_owned()))
+        .ok_or_else(|| DnsLookupError::EmptyAddressListForHost(hostname.into()))
 }
 
 /// Transforms the given [`InternalKnownNode`]s into [`ContactPoint`]s.

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -290,7 +290,7 @@ pub(crate) enum DnsLookupError {
     #[error("Empty address list returned by DNS for {0}")]
     EmptyAddressListForHost(String),
     #[error(transparent)]
-    IoError(#[from] std::io::Error),
+    IoError(std::io::Error),
 }
 
 /// Performs a DNS lookup with provided optional timeout.
@@ -300,12 +300,12 @@ async fn lookup_host_with_timeout(
 ) -> Result<impl Iterator<Item = SocketAddr>, DnsLookupError> {
     if let Some(timeout) = hostname_resolution_timeout {
         match tokio::time::timeout(timeout, lookup_host(host)).await {
-            Ok(res) => res.map_err(Into::into),
+            Ok(res) => res.map_err(DnsLookupError::IoError),
             // Elapsed error from tokio library does not provide any context.
             Err(_) => Err(DnsLookupError::Timeout(timeout.as_millis())),
         }
     } else {
-        lookup_host(host).await.map_err(Into::into)
+        lookup_host(host).await.map_err(DnsLookupError::IoError)
     }
 }
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -283,13 +283,17 @@ pub(crate) struct ResolvedContactPoint {
     pub(crate) address: SocketAddr,
 }
 
+/// Error that occurred during DNS lookup.
 #[derive(Error, Debug, Clone)]
 pub(crate) enum DnsLookupError {
+    /// Timed out during DNS lookup.
     #[error("Failed to perform DNS lookup within {0}ms")]
     Timeout(u128),
+    /// DNS lookup returned an empty address list for a given hostname.
     #[error("Empty address list returned by DNS for {0}")]
     EmptyAddressListForHost(String),
-    #[error(transparent)]
+    /// I/O error occurred during DNS lookup.
+    #[error("An I/O error occurred during DNS lookup: {0}")]
     IoError(Arc<std::io::Error>),
 }
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -150,6 +150,7 @@ impl Cluster {
             keyspaces_to_fetch,
             fetch_schema_metadata,
             &host_filter,
+            None, // TODO: pass actual subscriber
         )
         .await?;
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -2,7 +2,7 @@ use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::cluster::metadata::reader::ControlConnectionEvent;
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
-use crate::frame::response::event::Event;
+use crate::frame::response::event::EventV2 as Event;
 use crate::network::{ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
 #[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -358,6 +358,20 @@ impl ClusterWorker {
                             debug!("Received server event: {:?}", event);
                             match event {
                                 Event::TopologyChange(_) => (), // Refresh immediately
+                                Event::ClientRoutesChange(evt) => {
+                                    let res = self.metadata_reader.fetch_client_route_updates_on_event(&evt).await;
+                                    match res {
+                                        Ok(()) => continue, // Don't go to refreshing.
+                                        Err(err) =>
+                                        {
+                                            error!(
+                                                "Error when fetching client route updates: {err}. \
+                                                Proceeding with metadata refresh, because the control connection is likely defunct."
+                                            );
+                                            // Refresh immediately.
+                                        }
+                                    }
+                                }
                                 Event::StatusChange(_status) => {
                                     // TODO: Tracking status using events is unreliable because of
                                     // the possibility of losing events when control connection is broken.

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -1,3 +1,6 @@
+use crate::client::client_routes::{
+    ClientRoutesAddressTranslator, ClientRoutesConfig, ClientRoutesSubscriber,
+};
 use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::cluster::metadata::reader::ControlConnectionEvent;
 use crate::cluster::{KnownNode, Node};
@@ -6,6 +9,7 @@ use crate::frame::response::event::EventV2 as Event;
 use crate::network::{ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
 #[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
+use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::host_listener::{HostEvent, HostEventContext, HostListener};
 use crate::routing::locator::tablets::{RawTablet, TabletsInfo};
@@ -121,7 +125,7 @@ impl Cluster {
     #[expect(clippy::too_many_arguments)]
     pub(crate) async fn new(
         known_nodes: Vec<KnownNode>,
-        pool_config: PoolConfig,
+        mut pool_config: PoolConfig,
         keyspaces_to_fetch: Vec<String>,
         fetch_schema_metadata: bool,
         metadata_request_serverside_timeout: Option<Duration>,
@@ -131,6 +135,7 @@ impl Cluster {
         cluster_metadata_refresh_interval: Duration,
         tablet_receiver: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
         #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
+        client_routes_config: Option<ClientRoutesConfig>,
     ) -> Result<Cluster, NewSessionError> {
         let (refresh_sender, refresh_receiver) = tokio::sync::mpsc::channel(32);
         let (use_keyspace_sender, use_keyspace_receiver) = tokio::sync::mpsc::channel(32);
@@ -142,6 +147,18 @@ impl Cluster {
         let (connectivity_events_sender, connectivity_events_receiver) =
             tokio::sync::mpsc::unbounded_channel();
 
+        let client_routes_address_translator = client_routes_config.as_ref().map(|config| {
+            let translator = Arc::new(ClientRoutesAddressTranslator::new(
+                config.clone(),
+                hostname_resolution_timeout,
+                pool_config.connection_config.tls_provider.is_some(),
+            ));
+            pool_config.connection_config.address_translator =
+                Some(Arc::clone(&translator) as Arc<dyn AddressTranslator>);
+
+            translator
+        });
+
         let mut metadata_reader = MetadataReader::new(
             known_nodes,
             hostname_resolution_timeout,
@@ -150,13 +167,15 @@ impl Cluster {
             keyspaces_to_fetch,
             fetch_schema_metadata,
             &host_filter,
-            None, // TODO: pass actual subscriber
+            client_routes_address_translator
+                .map(|translator| translator as Arc<dyn ClientRoutesSubscriber>),
         )
         .await?;
 
         let mut node_status = HashMap::new();
 
         let metadata = metadata_reader.read_metadata(true).await?;
+
         let cluster_state = ClusterState::new(
             metadata,
             &pool_config,
@@ -427,6 +446,7 @@ impl ClusterWorker {
     async fn perform_refresh(&mut self) -> Result<(), MetadataError> {
         // Read latest Metadata
         let metadata = self.metadata_reader.read_metadata(false).await?;
+
         let cluster_state: Arc<ClusterState> = self.cluster_state.load_full();
 
         let new_cluster_state = Arc::new(

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -336,6 +336,10 @@ pub enum MetadataError {
     /// Bad tables metadata.
     #[error("Bad tables metadata: {0}")]
     Tables(#[from] TablesMetadataError),
+
+    /// Bad client routes metadata.
+    #[error("Bad client routes metadata: {0}")]
+    ClientRoutes(#[from] ClientRoutesMetadataError),
 }
 
 /// An error occurred during metadata fetch.
@@ -476,6 +480,20 @@ pub enum TablesMetadataError {
         column_name: String,
         /// Kind of the column that is unknown.
         column_kind: String,
+    },
+}
+
+/// An error that occurred during client routes metadata fetch.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum ClientRoutesMetadataError {
+    /// Failed to parse CQL type returned from system.client_routes query.
+    #[error("Invalid port value: {port}, is TLS port? {is_tls}")]
+    InvalidPortValue {
+        /// Invalid port value.
+        port: i32,
+        /// Whether the port is the TLS port (ordinary port otherwise)
+        is_tls: bool,
     },
 }
 

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -171,6 +171,10 @@ pub enum NewSessionError {
     /// 'USE KEYSPACE <>' request failed.
     #[error("'USE KEYSPACE <>' request failed: {0}")]
     UseKeyspaceError(#[from] UseKeyspaceError),
+
+    /// Provided combination of Session configuration options is unsupported.
+    #[error("Provided combination of Session configuration options is unsupported: {0}")]
+    IllegalConfig(Box<str>),
 }
 
 /// An error that occurred during `USE KEYSPACE <>` request.

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -313,6 +313,7 @@ pub enum TracingError {
 /// The errors that occur during metadata fetch are contained in [`MetadataFetchError`].
 /// Remaining errors (logical errors) are contained in the variants corresponding to the
 /// specific part of the metadata.
+// TODO(2.0): reduce size of this type.
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum MetadataError {
@@ -662,9 +663,28 @@ pub enum TranslationError {
     #[error("An I/O error occurred during address translation: {0}")]
     IoError(Arc<std::io::Error>),
 
+    /// DNS lookup failed during address translation.
+    #[error("DNS lookup failed: {0}")]
+    DnsLookupFailed(DnsLookupError),
+
     /// Custom error, for example from user-implemented policy.
     #[error(transparent)]
     Custom(#[from] CustomTranslationError),
+}
+
+/// Error that occurred during DNS lookup.
+#[derive(Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum DnsLookupError {
+    /// Timed out during DNS lookup.
+    #[error("Failed to perform DNS lookup within {0}ms")]
+    Timeout(u128),
+    /// DNS lookup returned an empty address list for a given hostname.
+    #[error("Empty address list returned by DNS for {0}")]
+    EmptyAddressListForHost(Box<str>),
+    /// I/O error occurred during DNS lookup.
+    #[error("An I/O error occurred during DNS lookup: {0}")]
+    IoError(Arc<std::io::Error>),
 }
 
 /// An error that occurred during connection setup request execution.

--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -650,6 +650,10 @@ pub enum TranslationError {
     #[error("No rule for address {0}")]
     NoRuleForAddress(SocketAddr),
 
+    /// Driver failed to find a translation rule for a provided host id.
+    #[error("No rule for host with id {0}")]
+    NoRuleForHost(Uuid),
+
     /// A translation rule for a provided address was found, but the translated address was invalid.
     #[error("Failed to parse translated address: {translated_addr_str}, reason: {reason}")]
     InvalidAddressInRule {
@@ -666,6 +670,10 @@ pub enum TranslationError {
     /// DNS lookup failed during address translation.
     #[error("DNS lookup failed: {0}")]
     DnsLookupFailed(DnsLookupError),
+
+    /// system.client_routes is missing a port for a host.
+    #[error("Missing port for host {0} in system.client_routes")]
+    MissingPortForHost(Uuid),
 
     /// Custom error, for example from user-implemented policy.
     #[error(transparent)]

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1995,7 +1995,7 @@ async fn maybe_translated_addr(
 ) -> Result<SocketAddr, TranslationError> {
     match (endpoint, address_translator) {
         (UntranslatedEndpoint::ContactPoint(addr), _) => {
-            // Contact points' addressed are not indended to be translated.
+            // Contact points' addresses are not intended to be translated.
             Ok(addr.address)
         }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -287,7 +287,7 @@ pub(crate) struct ConnectionConfig {
     pub(crate) tls_provider: Option<TlsProvider>,
     pub(crate) connect_timeout: std::time::Duration,
     // should be Some only in control connections,
-    pub(crate) event_sender: Option<mpsc::Sender<Event>>,
+    pub(crate) event_sender: Option<(mpsc::Sender<Event>, Vec<EventType>)>,
     pub(crate) default_consistency: Consistency,
     pub(crate) authenticator: Option<Arc<dyn AuthenticatorProvider>>,
     pub(crate) address_translator: Option<Arc<dyn AddressTranslator>>,
@@ -355,7 +355,7 @@ pub(crate) struct HostConnectionConfig {
     pub(crate) tls_config: Option<TlsConfig>,
     pub(crate) connect_timeout: std::time::Duration,
     // should be Some only in control connections,
-    pub(crate) event_sender: Option<mpsc::Sender<Event>>,
+    pub(crate) event_sender: Option<(mpsc::Sender<Event>, Vec<EventType>)>,
     pub(crate) default_consistency: Consistency,
     pub(crate) authenticator: Option<Arc<dyn AuthenticatorProvider>>,
     pub(crate) address_translator: Option<Arc<dyn AddressTranslator>>,
@@ -1622,7 +1622,7 @@ impl Connection {
         let r = Self::reader(
             BufReader::with_capacity(8192, read_half),
             &handler_map,
-            config.event_sender,
+            config.event_sender.map(|(sender, _)| sender),
             config.compression,
         );
         let w = Self::writer(
@@ -2158,13 +2158,8 @@ pub(crate) async fn open_connection(
     }
 
     /* If this is a control connection, REGISTER to receive all event types. */
-    if connection.config.event_sender.is_some() {
-        let all_event_types = vec![
-            EventType::TopologyChange,
-            EventType::StatusChange,
-            EventType::SchemaChange,
-        ];
-        connection.register(all_event_types).await?;
+    if let Some((_, ref event_types)) = connection.config.event_sender {
+        connection.register(event_types.clone()).await?;
     }
 
     Ok((connection, error_receiver))

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -14,9 +14,9 @@ use crate::errors::{
 use crate::frame::protocol_features::ProtocolFeatures;
 use crate::frame::{
     self, FrameParams, SerializedRequest,
-    request::{self, SerializableRequest, batch, execute, query, register},
-    response::{Response, ResponseOpcode, event::Event, result},
-    server_event_type::EventType,
+    request::{self, SerializableRequest, batch, execute, query},
+    response::{ResponseOpcode, ResponseV2 as Response, event::EventV2 as Event, result},
+    server_event_type::EventTypeV2 as EventType,
 };
 use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 use crate::policies::timestamp_generator::TimestampGenerator;
@@ -34,12 +34,15 @@ use scylla_cql::frame::frame_errors::CqlResponseParseError;
 use scylla_cql::frame::request::CqlRequestKind;
 use scylla_cql::frame::request::options::{self, Options};
 use scylla_cql::frame::request::query::QueryParameters;
+use scylla_cql::frame::request::register::RegisterV2 as Register;
 use scylla_cql::frame::response::authenticate::Authenticate;
 use scylla_cql::frame::response::result::{
     ResultMetadata, ResultWithDeserializedMetadata, TableSpec,
 };
 use scylla_cql::frame::response::{self, error};
-use scylla_cql::frame::response::{Error, ResponseWithDeserializedMetadata};
+use scylla_cql::frame::response::{
+    Error, ResponseWithDeserializedMetadataV2 as ResponseWithDeserializedMetadata,
+};
 use scylla_cql::frame::types::SerialConsistency;
 use scylla_cql::serialize::batch::{BatchValues, BatchValuesIterator};
 use scylla_cql::serialize::raw_batch::RawBatchValuesAdapter;
@@ -1393,7 +1396,7 @@ impl Connection {
             ConnectionSetupRequestError::new(CqlRequestKind::Register, kind)
         };
 
-        let register_frame = register::Register {
+        let register_frame = Register {
             event_types_to_register_for,
         };
 

--- a/scylla/src/response/request_response.rs
+++ b/scylla/src/response/request_response.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use scylla_cql::frame::request::query::PagingStateResponse;
 use scylla_cql::frame::response::{
-    NonErrorResponseWithDeserializedMetadata, ResponseWithDeserializedMetadata,
+    NonErrorResponseWithDeserializedMetadataV2 as NonErrorResponseWithDeserializedMetadata,
+    ResponseWithDeserializedMetadataV2 as ResponseWithDeserializedMetadata,
 };
 use tracing::error;
 use uuid::Uuid;

--- a/scylla/tests/integration/ccm/client_routes.rs
+++ b/scylla/tests/integration/ccm/client_routes.rs
@@ -1,0 +1,1068 @@
+//! Integration tests for custom routing via `system.client_routes`.
+//!
+//! These tests require a CCM cluster and exercise the full client-routes flow:
+//! driver →  NLB →  proxy →  Scylla, with `system.client_routes` providing
+//! address translation rules.
+//!
+//! Each test uses per-node CQL-aware proxies with feedback channels to verify:
+//! 1. The driver opens connections to ALL nodes
+//! 2. The driver can query ALL nodes
+//! 3. The driver connects through NLBs (address translation works)
+//!
+//! Proxy feedback alone proves all 3 requirements: if a proxy sees CQL traffic,
+//! it necessarily went through the NLB (since the driver only knows NLB
+//! addresses from `client_routes` and real node addresses, but not proxy addresses).
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::ccm::lib::CLUSTER_VERSION;
+use crate::ccm::lib::client_routes::{
+    ClientRoutesCluster, FeedbackItem, drain_feedback, run_client_routes_test,
+};
+use crate::ccm::lib::cluster::ClusterOptions;
+use crate::ccm::lib::node::NodeId;
+use crate::utils::{setup_tracing, unique_keyspace_name};
+
+use scylla::client::session::Session;
+use tracing::info;
+
+/// Number of queries per test phase. Must be large enough to statistically
+/// hit all nodes via random-replica token-aware routing.
+const QUERIES_PER_PHASE: i32 = 100;
+
+/// Timeout for waiting for the driver to open connections to all proxy nodes.
+/// Must be generous enough for the driver to discover new/restarted nodes,
+/// but short enough to fail promptly if the driver has a bug (e.g.,
+/// `Untranslatable` marking prevents address translation for a node).
+const CONNECTION_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ---------------------------------------------------------------------------
+// Cluster option factories
+// ---------------------------------------------------------------------------
+
+fn cluster_3_nodes() -> ClusterOptions {
+    ClusterOptions {
+        name: "client_routes_3_nodes".to_string(),
+        version: CLUSTER_VERSION.clone(),
+        nodes_per_dc: vec![3],
+        ..ClusterOptions::default()
+    }
+}
+
+fn cluster_2dc_2_2() -> ClusterOptions {
+    ClusterOptions {
+        name: "client_routes_2dc".to_string(),
+        version: CLUSTER_VERSION.clone(),
+        nodes_per_dc: vec![2, 2],
+        ..ClusterOptions::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create keyspace + table and run N queries, returning the session
+// ---------------------------------------------------------------------------
+
+async fn create_test_schema(session: &Session, ks_name: &str, rf: &str) {
+    session
+        .query_unpaged(
+            format!(
+                "CREATE KEYSPACE IF NOT EXISTS {} \
+                 WITH replication = {{'class': 'NetworkTopologyStrategy', {}}}",
+                ks_name, rf
+            ),
+            &[],
+        )
+        .await
+        .expect("Failed to create keyspace");
+
+    session
+        .query_unpaged(
+            format!(
+                "CREATE TABLE IF NOT EXISTS {}.data (id int PRIMARY KEY, value text)",
+                ks_name
+            ),
+            &[],
+        )
+        .await
+        .expect("Failed to create table");
+}
+
+async fn run_queries(session: &Session, ks_name: &str, count: i32) {
+    for i in 0..count {
+        session
+            .query_unpaged(
+                format!(
+                    "INSERT INTO {}.data (id, value) VALUES ({}, 'v{}')",
+                    ks_name, i, i
+                ),
+                &[],
+            )
+            .await
+            .unwrap_or_else(|e| panic!("Query {} failed: {}", i, e));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Basic connectivity (1 DC, 3 nodes)
+// ---------------------------------------------------------------------------
+
+/// **Goal**: Verify that the driver can connect to all nodes through the
+/// NLB →  proxy →  node chain using `system.client_routes` address translation,
+/// and that token-aware routing distributes queries across all nodes.
+///
+/// **Added value**: This is the fundamental smoke test for the entire
+/// client-routes feature. If this fails, the address translation pipeline
+/// (route fetching, NLB address substitution, connection opening) is broken.
+/// All other tests build on the assumption that this basic flow works.
+///
+/// **Scenario** (1 DC, 3 nodes):
+/// 1. Build a session using client-routes configuration.
+/// 2. Wait for the driver to open connections to all 3 proxy nodes.
+/// 3. Create a keyspace (RF=3) and table, then run 100 INSERT queries.
+/// 4. Assert: total proxy feedback == 100 and every node received ≥ 1 query.
+async fn basic_connectivity(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'replication_factor': 3").await;
+
+    // Set up feedback AFTER schema creation (schema queries would pollute counts).
+    let mut rxs = plc.setup_query_feedback();
+
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Feedback: per_node={:?}, total={}", per_node, total);
+
+    assert_eq!(
+        total, QUERIES_PER_PHASE as usize,
+        "Total feedback ({}) must equal queries performed ({})",
+        total, QUERIES_PER_PHASE
+    );
+    for (&node_id, &count) in &per_node {
+        assert!(
+            count >= 1,
+            "Node {} received 0 queries — driver didn't reach all nodes",
+            node_id
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_client_routes_basic_connectivity() {
+    setup_tracing();
+    run_client_routes_test(cluster_3_nodes, basic_connectivity).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Node stop/resume (1 DC, 3 nodes)
+// ---------------------------------------------------------------------------
+
+/// **Goal**: Verify the driver gracefully handles a node going down and
+/// coming back up, continuing to route queries only to live nodes and
+/// resuming routing to the restarted node once it recovers.
+///
+/// **Added value**: Tests the interaction between client-routes address
+/// translation and the driver's node-down/node-up detection. A stopped
+/// node's proxy chain is torn down (preventing the driver from sending
+/// queries into a black hole), and a restarted node gets a fresh chain
+/// with a new NLB port, requiring the driver to pick up the route update.
+/// Without this test, we wouldn't know if the driver correctly stops
+/// routing to unavailable nodes or re-discovers restarted ones.
+///
+/// **Scenario** (1 DC, 3 nodes):
+/// 1. **Phase 1** — all 3 running: 100 queries →  total == 100, all 3 ≥ 1.
+/// 2. Stop node 1 via CCM, tear down its proxy chain, re-post routes.
+/// 3. **Phase 2** — node 1 down: 100 queries →  total == 100, node 1 == 0,
+///    nodes 2+3 ≥ 1.
+/// 4. Restart node 1 via CCM, rebuild proxy chain, wait for driver connection.
+/// 5. **Phase 3** — all 3 running again: 100 queries →  total == 100, all 3 ≥ 1.
+async fn node_stop_resume(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'replication_factor': 3").await;
+
+    // --- Phase 1: all nodes running ---
+    info!("=== Phase 1: all nodes running ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 1: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for (&node_id, &count) in &per_node {
+        assert!(count >= 1, "Phase 1: node {} got 0 queries", node_id);
+    }
+
+    // --- Stop node 1 ---
+    info!("Stopping node 1...");
+    {
+        let node = plc
+            .cluster_mut()
+            .nodes_mut()
+            .get_mut_by_id(1)
+            .expect("Node 1 not found");
+        node.stop(None).await.expect("Failed to stop node 1");
+    }
+    // Tear down the proxy chain for node 1 so the driver can't route
+    // queries through the dead NLB/proxy. Also re-posts routes without
+    // node 1.
+    plc.stop_node_chain(1)
+        .await
+        .expect("Failed to stop proxy chain for node 1");
+
+    // --- Phase 2: node 1 down ---
+    info!("=== Phase 2: node 1 down ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 2: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    assert_eq!(
+        *per_node.get(&1).unwrap_or(&0),
+        0,
+        "Phase 2: node 1 should receive 0 queries (it's stopped)"
+    );
+    for (&node_id, &count) in &per_node {
+        if node_id != 1 {
+            assert!(count >= 1, "Phase 2: node {} got 0 queries", node_id);
+        }
+    }
+
+    // --- Restart node 1 ---
+    info!("Restarting node 1...");
+    {
+        let node = plc
+            .cluster_mut()
+            .nodes_mut()
+            .get_mut_by_id(1)
+            .expect("Node 1 not found");
+        node.start(None).await.expect("Failed to restart node 1");
+    }
+    // Rebuild the proxy chain for node 1 (the old proxy worker died when
+    // the node was stopped) and re-post routes with the new NLB port.
+    plc.restart_node_chain(1)
+        .await
+        .expect("Failed to restart proxy chain for node 1");
+    // Wait for the driver to discover the restarted node and open a
+    // connection through the new proxy chain.
+    plc.wait_for_connections_to_node(1, CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not reconnect to restarted node 1");
+
+    // --- Phase 3: all nodes running again ---
+    info!("=== Phase 3: all nodes running again ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 3: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for (&node_id, &count) in &per_node {
+        assert!(count >= 1, "Phase 3: node {} got 0 queries", node_id);
+    }
+}
+
+#[tokio::test]
+async fn test_client_routes_node_stop_resume() {
+    setup_tracing();
+    run_client_routes_test(cluster_3_nodes, node_stop_resume).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Multi-DC basic (2 DCs, 2+2 nodes)
+// ---------------------------------------------------------------------------
+
+/// **Goal**: Verify that client-routes address translation works correctly
+/// across multiple datacenters, each with its own connection ID and
+/// contact-point NLB.
+///
+/// **Added value**: Multi-DC is the primary production use case for
+/// client-routes (cloud deployments with per-DC NLBs). This test ensures
+/// the driver fetches and applies per-DC route entries with distinct
+/// connection IDs, and that token-aware routing distributes queries to
+/// nodes in both DCs. A single-DC test would miss bugs in connection-ID
+/// scoping or DC-aware NLB aggregation.
+///
+/// **Scenario** (2 DCs, 2+2 nodes):
+/// 1. Build a session using client-routes with 2 DCs.
+/// 2. Wait for connections to all 4 proxy nodes.
+/// 3. Create a keyspace (RF: dc1=2, dc2=2) and table, run 100 queries.
+/// 4. Assert: total == 100, each of the 4 nodes received ≥ 1 query.
+async fn multi_dc_basic(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    // Wait for the driver to open connections to all proxy nodes.
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'dc1': 2, 'dc2': 2").await;
+
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Feedback: per_node={:?}, total={}", per_node, total);
+
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    let active_nodes = plc.active_node_ids();
+    assert_eq!(active_nodes.len(), 4, "Expected 4 active nodes");
+    for &node_id in &active_nodes {
+        let count = *per_node.get(&node_id).unwrap_or(&0);
+        assert!(
+            count >= 1,
+            "Node {} received 0 queries — driver didn't reach all nodes across DCs",
+            node_id
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_client_routes_multi_dc_basic() {
+    setup_tracing();
+    run_client_routes_test(cluster_2dc_2_2, multi_dc_basic).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Multi-DC topology change (2 DCs, decommission + add)
+// ---------------------------------------------------------------------------
+
+/// **Goal**: Verify the driver correctly handles decommissioning a node and
+/// adding a new one in a multi-DC cluster, with route updates propagated
+/// at each step.
+///
+/// **Added value**: Tests the full lifecycle of topology membership changes
+/// under client-routes: route removal before decommission (so the driver
+/// stops opening new connections to the node, while existing ones keep
+/// serving requests until the node is actually decommissioned), and route
+/// addition after a new node joins (so the driver discovers and routes to
+/// it). Without this test, we wouldn't know if the driver's route cache
+/// stays consistent across node removals and additions in a multi-DC setup.
+///
+/// **Scenario** (2 DCs, 2+2 nodes):
+/// 1. **Phase 1** — all 4 nodes: 100 queries →  total == 100, all 4 ≥ 1.
+/// 2. Decommission the highest-ID node in DC2 (routes posted without it
+///    before the actual CCM decommission).
+/// 3. **Phase 2** — 3 nodes: 100 queries →  total == 100, decommissioned
+///    node absent from feedback, remaining 3 ≥ 1.
+/// 4. Add a new node to DC2, discover its host ID, start its proxy chain.
+/// 5. **Phase 3** — 4 nodes again: 100 queries →  total == 100, all 4 ≥ 1
+///    (including the newly added node).
+async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    // Wait for the driver to open connections to all proxy nodes.
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'dc1': 1, 'dc2': 1").await;
+
+    // Identify nodes. In a 2+2 setup, CCM node IDs are 1,2 (DC1) and 3,4 (DC2).
+    let initial_nodes = plc.active_node_ids();
+    assert_eq!(initial_nodes.len(), 4, "Expected 4 initial nodes");
+    info!("Initial nodes: {:?}", initial_nodes);
+
+    // The node to decommission: the highest ID in DC2 (should be node 4).
+    let node_to_decommission = *initial_nodes.iter().max().expect("non-empty");
+    info!("Will decommission node {}", node_to_decommission);
+
+    // --- Phase 1: all 4 nodes ---
+    info!("=== Phase 1: all 4 nodes ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 1: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &initial_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 1: node {} got 0 queries",
+            node_id
+        );
+    }
+
+    // --- Decommission node from DC2 ---
+    // Routes are posted (without this node) BEFORE the actual topology change.
+    info!("Decommissioning node {}...", node_to_decommission);
+    plc.decommission_node(node_to_decommission)
+        .await
+        .expect("Failed to decommission node");
+
+    // --- Phase 2: 3 nodes remaining ---
+    info!("=== Phase 2: 3 nodes remaining ===");
+    let remaining_nodes = plc.active_node_ids();
+    assert_eq!(remaining_nodes.len(), 3);
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 2: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    // Decommissioned node should not have a feedback channel at all.
+    assert!(
+        !per_node.contains_key(&node_to_decommission),
+        "Phase 2: decommissioned node {} should not have feedback",
+        node_to_decommission
+    );
+    for &node_id in &remaining_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 2: node {} got 0 queries",
+            node_id
+        );
+    }
+
+    // --- Add new node to DC2 ---
+    // Cluster::add_node() uses 1-based CCM DC naming: 2 = dc2.
+    info!("Adding new node to DC2...");
+    let new_node_id = plc.add_node(Some(2)).await.expect("Failed to add new node");
+    info!("New node added: {}", new_node_id);
+    // Wait for the driver to discover the new node and open a connection
+    // through the new proxy chain.
+    plc.wait_for_connections_to_node(new_node_id, CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to newly added node");
+
+    // --- Phase 3: 4 nodes again (with new node) ---
+    info!("=== Phase 3: 4 nodes with new node ===");
+    let final_nodes = plc.active_node_ids();
+    assert_eq!(final_nodes.len(), 4);
+    assert!(
+        final_nodes.contains(&new_node_id),
+        "New node {} should be in active list",
+        new_node_id
+    );
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 3: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &final_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 3: node {} got 0 queries (including new node)",
+            node_id
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_client_routes_multi_dc_topology_change() {
+    setup_tracing();
+    run_client_routes_test(cluster_2dc_2_2, multi_dc_topology_change).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Rolling restart (1 DC, 3 nodes)
+// ---------------------------------------------------------------------------
+
+/// **Goal**: Verify the driver survives a rolling restart of all nodes,
+/// picking up new NLB ports after each restart and maintaining full-cluster
+/// query coverage throughout.
+///
+/// **Added value**: Rolling restarts are a standard operational procedure.
+/// Each restart gives the node's proxy chain a new OS-assigned NLB port,
+/// so the driver must re-read `system.client_routes` and reconnect. This
+/// test catches regressions where the driver fails to update its route
+/// cache incrementally, or where stale connections to old NLB ports cause
+/// query failures during the rolling window.
+///
+/// **Scenario** (1 DC, 3 nodes):
+/// 1. **Phase 0** (baseline): 100 queries →  total == 100, all 3 ≥ 1.
+/// 2. For each node 1, 2, 3 in turn:
+///    a. Stop the node via CCM, tear down its proxy chain.
+///    b. Start the node via CCM, rebuild proxy chain (new NLB port).
+///    c. Wait for the driver to connect through the new chain.
+///    d. 100 queries →  total == 100, all 3 ≥ 1.
+async fn rolling_restart(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'replication_factor': 3").await;
+
+    // --- Phase 0: baseline ---
+    info!("=== Phase 0: baseline (all 3 nodes) ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 0: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for (&node_id, &count) in &per_node {
+        assert!(count >= 1, "Phase 0: node {} got 0 queries", node_id);
+    }
+
+    // --- Rolling restart: stop + start each node in turn ---
+    for target_node in 1..=3u16 {
+        info!("=== Rolling restart: stopping node {} ===", target_node);
+
+        // Stop the CCM node.
+        {
+            let node = plc
+                .cluster_mut()
+                .nodes_mut()
+                .get_mut_by_id(target_node)
+                .expect("node not found");
+            node.stop(None)
+                .await
+                .unwrap_or_else(|e| panic!("Failed to stop node {}: {}", target_node, e));
+        }
+        plc.stop_node_chain(target_node)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to stop chain for node {}: {}", target_node, e));
+
+        // Start the CCM node again.
+        info!("Rolling restart: starting node {}...", target_node);
+        {
+            let node = plc
+                .cluster_mut()
+                .nodes_mut()
+                .get_mut_by_id(target_node)
+                .expect("node not found");
+            node.start(None)
+                .await
+                .unwrap_or_else(|e| panic!("Failed to start node {}: {}", target_node, e));
+        }
+        plc.restart_node_chain(target_node)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to restart chain for node {}: {}", target_node, e));
+
+        plc.wait_for_connections_to_node(target_node, CONNECTION_WAIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Driver did not reconnect to restarted node {}: {}",
+                    target_node, e
+                )
+            });
+
+        // Verify all 3 nodes receive traffic after this restart.
+        info!(
+            "=== Phase after restarting node {}: verifying all 3 nodes ===",
+            target_node
+        );
+        let mut rxs = plc.setup_query_feedback();
+        run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+        let (per_node, total) = drain_feedback(&mut rxs);
+        info!(
+            "After restarting node {}: per_node={:?}, total={}",
+            target_node, per_node, total
+        );
+        assert_eq!(
+            total, QUERIES_PER_PHASE as usize,
+            "After restarting node {}: total mismatch",
+            target_node
+        );
+        for (&node_id, &count) in &per_node {
+            assert!(
+                count >= 1,
+                "After restarting node {}: node {} got 0 queries",
+                target_node,
+                node_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_client_routes_rolling_restart() {
+    setup_tracing();
+    run_client_routes_test(cluster_3_nodes, rolling_restart).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: NLB port remap without Scylla restart (1 DC, 3 nodes)
+// ---------------------------------------------------------------------------
+
+/// **Goal**: Verify the driver detects route changes and reconnects through
+/// new NLB ports when the Scylla nodes themselves are NOT restarted — only
+/// the proxy/NLB layer is rebuilt.
+///
+/// **Added value**: This is the purest client-routes test. All other
+/// topology tests involve CCM node stop/start, which triggers Scylla-level
+/// `STATUS_CHANGE` events that could mask route-change detection bugs. By
+/// keeping Scylla nodes running and only changing the proxy chain (new NLB
+/// ports + updated routes), this test isolates the driver's
+/// `CLIENT_ROUTES_CHANGE` event handling and route-refresh logic from
+/// node-lifecycle events. A failure here means the driver cannot react to
+/// route-only changes.
+///
+/// **Scenario** (1 DC, 3 nodes):
+/// 1. **Phase 1** (baseline): 100 queries →  total == 100, all 3 ≥ 1.
+/// 2. Rebuild proxy chains for nodes 1 and 2 (Scylla stays up). New
+///    OS-assigned NLB ports, updated routes posted to ScyllaDB.
+/// 3. Wait for the driver to connect through the new NLB ports.
+/// 4. **Phase 2**: 100 queries →  total == 100, all 3 ≥ 1.
+async fn nlb_port_remap(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'replication_factor': 3").await;
+
+    // --- Phase 1: baseline ---
+    info!("=== Phase 1: baseline (all 3 nodes) ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 1: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for (&node_id, &count) in &per_node {
+        assert!(count >= 1, "Phase 1: node {} got 0 queries", node_id);
+    }
+
+    // --- Remap: rebuild proxy chains for nodes 1 and 2 ---
+    // Scylla nodes stay up; only the proxy + NLB are replaced, giving
+    // them new OS-assigned ports.
+    info!("=== Remapping NLB ports for nodes 1 and 2 ===");
+    plc.restart_node_chain(1)
+        .await
+        .expect("Failed to remap chain for node 1");
+    plc.restart_node_chain(2)
+        .await
+        .expect("Failed to remap chain for node 2");
+
+    // No metadata refresh here, because we want to rely on the CLIENT_ROUTES_CHANGE event.
+
+    // Wait for the driver to connect through the new NLB ports using
+    // the freshly-read routes.
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not reconnect through new NLB ports");
+
+    // --- Phase 2: verify traffic goes through new ports ---
+    info!("=== Phase 2: after NLB port remap ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 2: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for (&node_id, &count) in &per_node {
+        assert!(
+            count >= 1,
+            "Phase 2: node {} got 0 queries — driver didn't follow route update",
+            node_id
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_client_routes_nlb_port_remap() {
+    setup_tracing();
+    run_client_routes_test(cluster_3_nodes, nlb_port_remap).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Scale out (1 DC, 3 →  6 nodes)
+// ---------------------------------------------------------------------------
+
+/// **Goal**: Verify the driver correctly discovers and routes to dynamically
+/// added nodes, integrating them into the existing client-routes topology.
+///
+/// **Added value**: Scale-out (adding nodes to a live cluster) is a key
+/// cloud operations scenario. Each new node requires host-ID discovery, a
+/// fresh proxy chain, and a route update. This test verifies that the
+/// driver's route cache, connection pool, and token ring are all updated
+/// to include the new nodes. Without it, we wouldn't catch bugs where the
+/// driver ignores newly added nodes or fails to translate their addresses.
+///
+/// **Scenario** (1 DC, starts with 3 nodes):
+/// 1. **Phase 1** (3 nodes): 100 queries →  total == 100, all 3 ≥ 1.
+/// 2. Add 3 new nodes to DC1 one at a time (CCM add + start, discover
+///    host ID, start proxy chain, post updated routes).
+/// 3. Wait for the driver to connect to all 6 nodes.
+/// 4. **Phase 2** (6 nodes): 100 queries →  total == 100, all 6 ≥ 1.
+async fn scale_out(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'replication_factor': 3").await;
+
+    // --- Phase 1: initial 3 nodes ---
+    info!("=== Phase 1: initial 3 nodes ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 1: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for (&node_id, &count) in &per_node {
+        assert!(count >= 1, "Phase 1: node {} got 0 queries", node_id);
+    }
+
+    // --- Add 3 new nodes ---
+    let mut new_node_ids = Vec::new();
+    for i in 1..=3 {
+        info!("Adding node {} of 3...", i);
+        let new_id = plc
+            .add_node(None)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to add node {} of 3: {}", i, e));
+        info!("Added node {}", new_id);
+        new_node_ids.push(new_id);
+    }
+
+    // Expedite driver's connection to new nodes by triggering immediate metadata refresh.
+    session
+        .refresh_metadata()
+        .await
+        .expect("Driver failed to refresh metadata");
+
+    // Wait for the driver to discover all 6 nodes and open connections.
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all 6 nodes");
+
+    // --- Phase 2: all 6 nodes ---
+    info!("=== Phase 2: all 6 nodes ===");
+    let active = plc.active_node_ids();
+    assert_eq!(active.len(), 6, "Expected 6 active nodes, got {:?}", active);
+
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 2: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &active {
+        let count = *per_node.get(&node_id).unwrap_or(&0);
+        assert!(
+            count >= 1,
+            "Phase 2: node {} got 0 queries — driver didn't discover new node",
+            node_id
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_client_routes_scale_out() {
+    setup_tracing();
+    run_client_routes_test(cluster_3_nodes, scale_out).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Event-driven reroute (2 DCs, 2+2 nodes)
+// ---------------------------------------------------------------------------
+
+/// Wait for any of the given feedback receivers to produce a message.
+///
+/// Only one proxy hosts the control connection, so only one receiver will
+/// actually fire. This polls all receivers until any one gets a message.
+async fn wait_for_any_feedback(
+    receivers: &mut HashMap<NodeId, mpsc::UnboundedReceiver<FeedbackItem>>,
+    timeout: Duration,
+    context: &str,
+) {
+    let result = tokio::time::timeout(timeout, async {
+        loop {
+            for (_node_id, rx) in receivers.iter_mut() {
+                match rx.try_recv() {
+                    Ok(_feedback) => return,
+                    Err(mpsc::error::TryRecvError::Empty) => {}
+                    Err(mpsc::error::TryRecvError::Disconnected) => {}
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Timed out after {:?} waiting for feedback: {}",
+        timeout,
+        context
+    );
+}
+
+/// **Goal**: Verify the driver correctly processes `CLIENT_ROUTES_CHANGE`
+/// events injected via the proxy, re-reads routes, reconnects through
+/// updated NLB ports, handles cross-DC reroutes, and recovers from
+/// malformed events that kill the control connection.
+///
+/// **Added value**: This is the most comprehensive event-handling test.
+/// It exercises the driver's event-driven route refresh path (as opposed
+/// to polling) by injecting synthetic CQL events directly into the control
+/// connection. It covers: (a) event reception and re-query trigger,
+/// (b) full-DC reroute with real route changes, (c) cross-DC reroute,
+/// and (d) resilience to malformed events. Without this test, we wouldn't
+/// know if the driver's `CLIENT_ROUTES_CHANGE` event handler, CC
+/// reconnection logic, and metadata refresh pipeline work end-to-end.
+///
+/// **Scenario** (2 DCs, 2+2 nodes):
+/// 1. **Phase 1** (baseline): build session, create schema (RF dc1=2,
+///    dc2=2), 100 queries →  all 4 ≥ 1.
+/// 2. **Phase 2** (event injection, no route change): inject a
+///    `CLIENT_ROUTES_CHANGE` event for DC1 nodes. Verify the driver
+///    re-queries `system.client_routes` (detected via EXECUTE body
+///    matching). Verify all 4 nodes still work.
+/// 3. **Phase 3** (full-DC reroute): restart proxy chains for both DC1
+///    nodes (new NLB ports). ScyllaDB emits a real event. Wait for
+///    connections, verify all 4 ≥ 1.
+/// 4. **Phase 4** (cross-DC reroute): restart one node from each DC.
+///    Same verification.
+/// 5. **Phase 5** (malformed event recovery): inject a malformed event
+///    (mismatched array lengths). The CC dies, the driver reconnects and
+///    performs a full metadata refresh (detected via EXECUTE for
+///    `system.client_routes`). Verify all 4 nodes still work.
+async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
+    let session = plc
+        .make_session_builder()
+        .build()
+        .await
+        .expect("Failed to build client-routes session");
+
+    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+        .await
+        .expect("Driver did not connect to all proxy nodes");
+
+    let ks = unique_keyspace_name();
+    create_test_schema(&session, &ks, "'dc1': 2, 'dc2': 2").await;
+
+    // Identify nodes by DC. In a 2+2 setup, CCM node IDs are 1,2 (DC1)
+    // and 3,4 (DC2).
+    let all_nodes = plc.active_node_ids();
+    assert_eq!(all_nodes.len(), 4, "Expected 4 initial nodes");
+    let dc1_nodes: Vec<_> = all_nodes.iter().copied().filter(|&id| id <= 2).collect();
+    let dc2_nodes: Vec<_> = all_nodes.iter().copied().filter(|&id| id > 2).collect();
+    assert_eq!(dc1_nodes.len(), 2);
+    assert_eq!(dc2_nodes.len(), 2);
+    info!("DC1 nodes: {:?}, DC2 nodes: {:?}", dc1_nodes, dc2_nodes);
+
+    let requery_timeout = Duration::from_secs(10);
+
+    // ---------------------------------------------------------------
+    // Phase 1: Baseline
+    // ---------------------------------------------------------------
+    info!("=== Phase 1: baseline ===");
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 1: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &all_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 1: node {} got 0 queries",
+            node_id
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 2: Event injection — verify event processing
+    // ---------------------------------------------------------------
+    // Inject a CLIENT_ROUTES_CHANGE event for DC1 nodes (no actual route
+    // change). The driver should re-query system.client_routes.
+    info!(
+        "=== Phase 2: event injection for DC1 nodes {:?} ===",
+        dc1_nodes
+    );
+    let mut event_rxs = plc.setup_event_requery_detection();
+    let injected = plc.inject_event(&dc1_nodes);
+    assert!(injected >= 1, "Phase 2: event was not injected into any CC");
+
+    wait_for_any_feedback(
+        &mut event_rxs,
+        requery_timeout,
+        "Phase 2: driver did not re-query system.client_routes after injected event",
+    )
+    .await;
+    info!("Phase 2: driver re-queried system.client_routes after injected event");
+
+    // Verify all nodes still work after event processing.
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 2: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &all_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 2: node {} got 0 queries",
+            node_id
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 3: Full-DC reroute (both DC1 nodes)
+    // ---------------------------------------------------------------
+    // Restart proxy chains for both DC1 nodes. This gives them new NLB
+    // ports and posts updated routes. ScyllaDB emits a real
+    // CLIENT_ROUTES_CHANGE event, causing the driver to re-read routes
+    // and reconnect through the new ports.
+    info!(
+        "=== Phase 3: full-DC reroute (DC1 nodes {:?}) ===",
+        dc1_nodes
+    );
+    for &node_id in &dc1_nodes {
+        plc.restart_node_chain(node_id)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to restart chain for node {}: {}", node_id, e));
+    }
+
+    // Wait for the driver to connect through the new NLB ports.
+    for &node_id in &dc1_nodes {
+        plc.wait_for_connections_to_node(node_id, CONNECTION_WAIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase 3: driver did not reconnect to node {}: {}",
+                    node_id, e
+                )
+            });
+    }
+
+    // Verify traffic reaches all 4 nodes through the new ports.
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 3: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &all_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 3: node {} got 0 queries",
+            node_id
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 4: Cross-DC reroute (one node from each DC)
+    // ---------------------------------------------------------------
+    let cross_dc_nodes = [dc1_nodes[0], dc2_nodes[1]];
+    info!(
+        "=== Phase 4: cross-DC reroute (nodes {:?}) ===",
+        cross_dc_nodes
+    );
+
+    for &node_id in &cross_dc_nodes {
+        plc.restart_node_chain(node_id)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to restart chain for node {}: {}", node_id, e));
+    }
+
+    for &node_id in &cross_dc_nodes {
+        plc.wait_for_connections_to_node(node_id, CONNECTION_WAIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase 4: driver did not reconnect to node {}: {}",
+                    node_id, e
+                )
+            });
+    }
+
+    let mut rxs = plc.setup_query_feedback();
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 4: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &all_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 4: node {} got 0 queries",
+            node_id
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 5: Malformed event recovery
+    // ---------------------------------------------------------------
+    info!("=== Phase 5: malformed event ===");
+
+    // Set up detection for the metadata refresh that happens after the CC
+    // reconnects, then inject the malformed event.
+    let mut event_rxs = plc.setup_malformed_event_requery_detection();
+    let injected = plc.inject_malformed_event();
+    assert!(
+        injected >= 1,
+        "Phase 5: malformed event was not injected into any CC"
+    );
+
+    // Wait for the metadata refresh detection (EXECUTE for
+    // system.client_routes on the new CC). After the CC breaks and
+    // reconnects, the full metadata refresh re-fetches client_routes
+    // via EXECUTE.
+    // Note: in the current implementation of the control connection,
+    // the prepared statement is reused from the shared
+    // `ControlConnectionCache`, so no PREPARE is sent on the wire.
+    // That's why it's better to check for EXECUTE.
+    wait_for_any_feedback(
+        &mut event_rxs,
+        requery_timeout,
+        "Phase 5: driver did not perform full system.client_routes fetch after malformed event",
+    )
+    .await;
+
+    let mut rxs = plc.setup_query_feedback();
+
+    // Verify all 4 nodes still receive traffic.
+    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
+    let (per_node, total) = drain_feedback(&mut rxs);
+    info!("Phase 5: per_node={:?}, total={}", per_node, total);
+    assert_eq!(total, QUERIES_PER_PHASE as usize);
+    for &node_id in &all_nodes {
+        assert!(
+            *per_node.get(&node_id).unwrap_or(&0) >= 1,
+            "Phase 5: node {} got 0 queries after malformed event recovery",
+            node_id
+        );
+    }
+
+    info!("All phases passed — event-driven reroute works correctly");
+}
+
+#[tokio::test]
+async fn test_client_routes_event_driven_reroute() {
+    setup_tracing();
+    run_client_routes_test(cluster_2dc_2_2, event_driven_reroute).await;
+}

--- a/scylla/tests/integration/ccm/lib/cli_wrapper/cluster.rs
+++ b/scylla/tests/integration/ccm/lib/cli_wrapper/cluster.rs
@@ -283,6 +283,7 @@ pub(crate) struct ClusterAddNode<'ccm> {
     name: String,
     db_type: DBType,
     dc: Option<String>,
+    address: Option<String>,
 }
 
 impl Ccm {
@@ -292,6 +293,7 @@ impl Ccm {
             db_type,
             name,
             dc: None,
+            address: None,
         }
     }
 }
@@ -299,6 +301,11 @@ impl Ccm {
 impl ClusterAddNode<'_> {
     pub(crate) fn dc(mut self, dc: String) -> Self {
         self.dc = Some(dc);
+        self
+    }
+
+    pub(crate) fn address(mut self, addr: String) -> Self {
+        self.address = Some(addr);
         self
     }
 
@@ -313,6 +320,11 @@ impl ClusterAddNode<'_> {
         if let Some(dc) = self.dc.as_ref() {
             args.push("--data-center");
             args.push(dc.as_str())
+        }
+
+        if let Some(addr) = self.address.as_ref() {
+            args.push("-i");
+            args.push(addr.as_str());
         }
 
         match self.db_type {

--- a/scylla/tests/integration/ccm/lib/client_routes.rs
+++ b/scylla/tests/integration/ccm/lib/client_routes.rs
@@ -430,6 +430,269 @@ impl ClientRoutesCluster {
         Ok(())
     }
 
+    /// Decommission a node and tear down its proxy chain.
+    ///
+    /// Steps:
+    /// 1. Remove node from the contact-point NLB backends (no new connections)
+    /// 2. Decommission + delete the node via CCM (existing connections drain)
+    /// 3. Remove chain from dc_configs, post updated routes (cleanup)
+    /// 4. Shut down the node's proxy chain (proxy + NLB)
+    ///
+    /// The route entry is removed *after* the node leaves the cluster, not
+    /// before. Stale entries are harmless (the driver won't use a route for
+    /// a node that no longer exists in its topology), whereas removing the
+    /// route while the node is still alive would leave the driver without a
+    /// translated address for in-flight reconnection attempts.
+    pub(crate) async fn decommission_node(&mut self, node_id: NodeId) -> Result<(), Error> {
+        // Find which DC this node belongs to.
+        let dc_id = self
+            .cluster
+            .nodes()
+            .get_by_id(node_id)
+            .map(|n| n.datacenter_id())
+            .with_context(|| format!("Node {} not found in cluster", node_id))?;
+
+        // Step 1: remove from contact-point NLB so no new connections target it.
+        if let Some(dc_cfg) = self.dc_configs.get(&dc_id) {
+            // Temporarily rebuild the backend list without this node.
+            let backends: Vec<SocketAddr> = dc_cfg
+                .per_node_chains
+                .iter()
+                .filter(|(id, _)| **id != node_id)
+                .map(|(_, chain)| chain.proxy_addr())
+                .collect();
+            dc_cfg.contact_point_nlb.set_backends(backends);
+        }
+
+        // Step 2: decommission and delete from CCM.
+        // We avoid `inspect_err(|_| self.cluster.mark_as_failed())` because
+        // `node` already borrows `self.cluster` mutably. Instead, mark as
+        // failed explicitly on the error path.
+        let decommission_result: Result<(), Error> = async {
+            let node = self
+                .cluster
+                .nodes_mut()
+                .get_mut_by_id(node_id)
+                .expect("node must exist");
+            node.decommission()
+                .await
+                .with_context(|| format!("Failed to decommission node {}", node_id))?;
+            node.delete()
+                .await
+                .with_context(|| format!("Failed to delete node {}", node_id))?;
+            Ok(())
+        }
+        .await;
+        if let Err(e) = decommission_result {
+            self.cluster.mark_as_failed();
+            return Err(e);
+        }
+
+        // Step 3: remove chain from dc_configs + host_id, then post updated routes.
+        self.host_ids.remove(&node_id);
+        let chain = self
+            .dc_configs
+            .get_mut(&dc_id)
+            .and_then(|dc| dc.per_node_chains.remove(&node_id))
+            .with_context(|| format!("Node {} chain not found in DC {}", node_id, dc_id))?;
+
+        self.post_routes_to_all_nodes()
+            .await
+            .context("Failed to post updated routes after decommission")?;
+
+        // Step 4: shut down the proxy chain.
+        info!("Shutting down chain for decommissioned node {}", node_id);
+        shutdown_node_chain(chain, node_id).await;
+
+        Ok(())
+    }
+
+    /// Tear down the proxy chain for a stopped node.
+    ///
+    /// When a CCM node is stopped, the proxy worker loses its backend
+    /// connection and dies. Leaving the NLB alive is harmful: the driver
+    /// can still connect to the NLB, which forwards to the dead proxy,
+    /// which tries to connect to the dead backend and eventually times out.
+    ///
+    /// This method:
+    /// 1. Shuts down the NLB + proxy chain for the stopped node
+    /// 2. Re-posts routes *without* this node so the driver doesn't try to
+    ///    route queries to it
+    ///
+    /// The host_id mapping is preserved so `restart_node_chain()` can
+    /// re-establish everything later.
+    pub(crate) async fn stop_node_chain(&mut self, node_id: NodeId) -> Result<(), Error> {
+        let dc_id = self
+            .cluster
+            .nodes()
+            .get_by_id(node_id)
+            .map(|n| n.datacenter_id())
+            .with_context(|| format!("Node {} not found in cluster", node_id))?;
+
+        if let Some(old_chain) = self
+            .dc_configs
+            .get_mut(&dc_id)
+            .and_then(|dc| dc.per_node_chains.remove(&node_id))
+        {
+            shutdown_node_chain(old_chain, node_id).await;
+        }
+
+        // Re-post routes without this node so the driver stops routing to it.
+        self.post_routes_to_all_nodes()
+            .await
+            .context("Failed to re-post routes after stopping node chain")?;
+
+        // Update the per-DC contact-point NLB to exclude the stopped node.
+        if let Some(dc_cfg) = self.dc_configs.get(&dc_id) {
+            dc_cfg.refresh_contact_point_backends();
+        }
+
+        Ok(())
+    }
+
+    /// Restart the proxy chain for a node after it has been stopped and started
+    /// again via CCM.
+    ///
+    /// When a CCM node is stopped, the proxy worker loses its backend
+    /// connection and dies. After the CCM node restarts, we need a fresh proxy
+    /// chain. This method:
+    /// 1. Shuts down the old proxy chain if still present (ignoring expected errors)
+    /// 2. Starts a new proxy chain with a fresh proxy address + NLB
+    /// 3. Re-posts routes with the new NLB address
+    pub(crate) async fn restart_node_chain(&mut self, node_id: NodeId) -> Result<(), Error> {
+        // Find which DC this node belongs to.
+        let dc_id = self
+            .cluster
+            .nodes()
+            .get_by_id(node_id)
+            .map(|n| n.datacenter_id())
+            .with_context(|| format!("Node {} not found in cluster", node_id))?;
+
+        let real_ip = {
+            let node = self.cluster.nodes().get_by_id(node_id).unwrap();
+            node.broadcast_rpc_address()
+        };
+
+        // Shut down the old chain if still present (it may already have
+        // been removed by stop_node_chain).
+        if let Some(old_chain) = self
+            .dc_configs
+            .get_mut(&dc_id)
+            .and_then(|dc| dc.per_node_chains.remove(&node_id))
+        {
+            shutdown_node_chain(old_chain, node_id).await;
+        }
+
+        // Start fresh chain.
+        let new_chain = start_node_chain(SocketAddr::new(real_ip, 9042))
+            .await
+            .with_context(|| format!("Failed to start new chain for restarted node {}", node_id))?;
+        info!(
+            "Restarted chain for node {}: NLB {}",
+            node_id,
+            new_chain.nlb_addr(),
+        );
+
+        self.dc_configs
+            .get_mut(&dc_id)
+            .expect("DC must exist")
+            .per_node_chains
+            .insert(node_id, new_chain);
+
+        // Re-post routes so the driver picks up the new NLB port.
+        self.post_routes_to_all_nodes()
+            .await
+            .context("Failed to re-post routes after chain restart")?;
+
+        // Update the per-DC contact-point NLB to include the restarted node.
+        if let Some(dc_cfg) = self.dc_configs.get(&dc_id) {
+            dc_cfg.refresh_contact_point_backends();
+        }
+
+        Ok(())
+    }
+
+    /// Add a new node to a DC and start its proxy chain.
+    ///
+    /// `dc_id` uses **1-based** CCM DC naming: `Some(2)` →  DC2, `None` →  DC1.
+    ///
+    /// Steps:
+    /// 1. CCM add + start the node (needed to discover its host_id)
+    /// 2. Discover the new node's host_id
+    /// 3. Start proxy chain (needed so the route has an NLB address)
+    /// 4. Post updated routes (with the new node) to all nodes
+    /// 5. Add the new node to the contact-point NLB
+    ///
+    /// Routes are posted before the NLB update so the driver has a valid
+    /// translated address before new connections can reach the node through
+    /// the DC contact-point NLB.
+    ///
+    /// Returns the new node's ID.
+    pub(crate) async fn add_node(&mut self, dc_id: Option<u16>) -> Result<NodeId, Error> {
+        // Step 1: CCM add + start.
+        let new_node_id = {
+            let add_result = self.cluster.add_node(dc_id).await;
+            let node = match add_result {
+                Ok(node) => node,
+                Err(e) => {
+                    self.cluster.mark_as_failed();
+                    return Err(e.context("Failed to add node via CCM"));
+                }
+            };
+            let id = node.id();
+
+            // Step 2: start the node.
+            let start_result = node.start(None).await;
+            if let Err(e) = start_result {
+                self.cluster.mark_as_failed();
+                return Err(e.context(format!("Failed to start new node {}", id)));
+            }
+            id
+        };
+
+        // Step 3: discover host_id.
+        let node_ref = self
+            .cluster
+            .nodes()
+            .get_by_id(new_node_id)
+            .expect("just added node must exist");
+        let real_ip = node_ref.broadcast_rpc_address();
+        let real_addr = SocketAddr::new(real_ip, node_ref.native_transport_port());
+        let actual_dc_id = node_ref.datacenter_id();
+
+        let host_id = discover_single_host_id(real_addr)
+            .await
+            .with_context(|| format!("Failed to discover host_id for new node {}", new_node_id))?;
+        info!(
+            "New node {} host_id={}, DC={}",
+            new_node_id, host_id, actual_dc_id
+        );
+        self.host_ids.insert(new_node_id, host_id);
+
+        // Step 4: start proxy chain.
+        let chain = start_node_chain(SocketAddr::new(real_ip, 9042))
+            .await
+            .with_context(|| format!("Failed to start chain for new node {}", new_node_id))?;
+
+        self.dc_configs
+            .get_mut(&actual_dc_id)
+            .with_context(|| format!("DC {} not found in dc_configs", actual_dc_id))?
+            .per_node_chains
+            .insert(new_node_id, chain);
+
+        // Step 5: post updated routes (with the new node).
+        self.post_routes_to_all_nodes()
+            .await
+            .context("Failed to post updated routes after adding node")?;
+
+        // Update the per-DC contact-point NLB to include the new node.
+        if let Some(dc_cfg) = self.dc_configs.get(&actual_dc_id) {
+            dc_cfg.refresh_contact_point_backends();
+        }
+
+        Ok(new_node_id)
+    }
+
     async fn post_routes_to_all_nodes(&self) -> Result<(), Error> {
         let routes = self.build_route_entries();
         let route_json = serde_json_routes(&routes);

--- a/scylla/tests/integration/ccm/lib/client_routes.rs
+++ b/scylla/tests/integration/ccm/lib/client_routes.rs
@@ -33,6 +33,7 @@ use std::panic::AssertUnwindSafe;
 use std::time::Duration;
 
 use anyhow::{Context, Error, bail};
+use bytes::Bytes;
 use futures::FutureExt;
 use futures::StreamExt as _;
 use futures::TryStreamExt as _;
@@ -693,6 +694,202 @@ impl ClientRoutesCluster {
         Ok(new_node_id)
     }
 
+    /// Build the body of a `CLIENT_ROUTES_CHANGE` / `UPDATE_NODES` event for
+    /// the specified nodes.
+    ///
+    /// The resulting body contains parallel `connection_ids` and `host_ids`
+    /// arrays — one entry per target node, using each node's DC-specific
+    /// connection ID paired with its host UUID.
+    ///
+    /// Panics if any `node_id` is missing from `self.host_ids` or does not
+    /// belong to any DC.
+    pub(crate) fn build_event_body_for_nodes(&self, target_node_ids: &[NodeId]) -> Bytes {
+        let mut connection_ids: Vec<String> = Vec::new();
+        let mut host_id_strings: Vec<String> = Vec::new();
+
+        for &node_id in target_node_ids {
+            let uuid = self
+                .host_ids
+                .get(&node_id)
+                .unwrap_or_else(|| panic!("Node {} not found in host_ids", node_id));
+
+            let dc_cfg = self
+                .dc_configs
+                .values()
+                .find(|dc| dc.per_node_chains.contains_key(&node_id))
+                .unwrap_or_else(|| panic!("Node {} not found in any DC", node_id));
+
+            connection_ids.push(dc_cfg.connection_id.clone());
+            host_id_strings.push(uuid.to_string());
+        }
+
+        build_client_routes_change_body(&connection_ids, &host_id_strings)
+    }
+
+    /// Set up re-query detection rules on all proxy nodes.
+    ///
+    /// Installs a single request rule on every proxy that detects the driver's
+    /// event-triggered re-query of `system.client_routes`. The detection uses
+    /// `EXECUTE` opcode with `BodyContainsCaseSensitive(b"rust-driver-test")`
+    /// because the event-triggered query uses `WHERE connection_id IN ?`,
+    /// which serializes the connection ID string in the EXECUTE body.
+    ///
+    /// The actual event injection is performed separately via
+    /// [`inject_event`](Self::inject_event).
+    ///
+    /// Returns a map from `NodeId` to the feedback receiver. The test should
+    /// await a message on *any* receiver (only the proxy hosting the control
+    /// connection will produce one).
+    pub(crate) fn setup_event_requery_detection(
+        &mut self,
+    ) -> HashMap<NodeId, mpsc::UnboundedReceiver<FeedbackItem>> {
+        let mut receivers = HashMap::new();
+
+        for dc_cfg in self.dc_configs.values_mut() {
+            for (&node_id, chain) in dc_cfg.per_node_chains.iter_mut() {
+                let (tx, rx) = mpsc::unbounded_channel();
+
+                // Detect the driver's re-query of system.client_routes after
+                // receiving the injected event. The driver uses PREPARE+EXECUTE;
+                // the EXECUTE body contains the serialized connection_id string
+                // (e.g. "rust-driver-test-dc1") as a query parameter.
+                let requery_condition = Condition::RequestOpcode(RequestOpcode::Execute)
+                    .and(Condition::ConnectionRegisteredAnyEvent)
+                    .and(Condition::BodyContainsCaseSensitive(
+                        CONNECTION_ID_BASE.as_bytes().to_vec().into_boxed_slice(),
+                    ));
+
+                let requery_rule = RequestRule(
+                    requery_condition,
+                    RequestReaction::noop().with_feedback_when_performed(tx),
+                );
+
+                chain.running_proxy.running_nodes[0].change_request_rules(Some(vec![requery_rule]));
+
+                receivers.insert(node_id, rx);
+            }
+        }
+
+        receivers
+    }
+
+    /// Inject a well-formed `CLIENT_ROUTES_CHANGE` event into the control
+    /// connection via the proxy's proactive injection API.
+    ///
+    /// `target_node_ids` specifies which nodes appear in the event body's
+    /// parallel `(connection_id, host_id)` arrays.
+    ///
+    /// Returns the number of proxy nodes that successfully injected the event
+    /// (expected to be 1 — only the CC's proxy has a registered sender).
+    pub(crate) fn inject_event(&self, target_node_ids: &[NodeId]) -> usize {
+        let event_body = self.build_event_body_for_nodes(target_node_ids);
+
+        let mut injected = 0;
+        for dc_cfg in self.dc_configs.values() {
+            for chain in dc_cfg.per_node_chains.values() {
+                if chain.running_proxy.running_nodes[0].inject_event_to_cc(event_body.clone()) {
+                    injected += 1;
+                }
+            }
+        }
+
+        info!(
+            "inject_event: injected CLIENT_ROUTES_CHANGE on {} proxy node(s) for target nodes {:?}",
+            injected, target_node_ids,
+        );
+        injected
+    }
+
+    /// Set up metadata-refresh detection rules on all proxy nodes for
+    /// post-malformed-event recovery.
+    ///
+    /// Installs a single request rule on every proxy that detects an `EXECUTE`
+    /// on the control connection whose body contains the connection ID base
+    /// string. After a malformed event breaks the CC, the driver reconnects
+    /// and performs a full metadata refresh which re-fetches
+    /// `system.client_routes` via `WHERE connection_id IN ?`. The serialized
+    /// connection ID appears in the EXECUTE body.
+    ///
+    /// We match on EXECUTE (not PREPARE) because in the current driver's
+    /// implementation, `ControlConnectionCache` is shared across CC reconnections,
+    /// so the prepared statement from the old CC is reused — no PREPARE is sent.
+    ///
+    /// The actual malformed event injection is performed separately via
+    /// [`inject_malformed_event`](Self::inject_malformed_event).
+    ///
+    /// Returns a map from `NodeId` to the feedback receiver.
+    pub(crate) fn setup_malformed_event_requery_detection(
+        &mut self,
+    ) -> HashMap<NodeId, mpsc::UnboundedReceiver<FeedbackItem>> {
+        let mut receivers = HashMap::new();
+
+        for dc_cfg in self.dc_configs.values_mut() {
+            for (&node_id, chain) in dc_cfg.per_node_chains.iter_mut() {
+                let (tx, rx) = mpsc::unbounded_channel();
+
+                // Detect the metadata refresh (EXECUTE for
+                // system.client_routes on the new control connection).
+                // The EXECUTE body contains the serialized connection_id
+                // string as a query parameter.
+                let requery_condition = Condition::RequestOpcode(RequestOpcode::Execute)
+                    .and(Condition::ConnectionRegisteredAnyEvent)
+                    .and(Condition::BodyContainsCaseSensitive(
+                        CONNECTION_ID_BASE.as_bytes().to_vec().into_boxed_slice(),
+                    ));
+
+                let requery_rule = RequestRule(
+                    requery_condition,
+                    RequestReaction::noop().with_feedback_when_performed(tx),
+                );
+
+                chain.running_proxy.running_nodes[0].change_request_rules(Some(vec![requery_rule]));
+
+                receivers.insert(node_id, rx);
+            }
+        }
+
+        receivers
+    }
+
+    /// Inject a malformed `CLIENT_ROUTES_CHANGE` event into the control
+    /// connection via the proxy's proactive injection API.
+    ///
+    /// The event body has mismatched array lengths (3 connection_ids, 2
+    /// host_ids), which causes the driver's event parser to fail with
+    /// `ConnectionHostIdsLengthMismatch`, killing the reader task and
+    /// breaking the control connection.
+    ///
+    /// Returns the number of proxy nodes that successfully injected the event
+    /// (expected to be 1).
+    pub(crate) fn inject_malformed_event(&self) -> usize {
+        let malformed_body = build_client_routes_change_body(
+            &[
+                "bogus-conn-1".to_string(),
+                "bogus-conn-2".to_string(),
+                "bogus-conn-3".to_string(),
+            ],
+            &[
+                "00000000-0000-0000-0000-000000000001".to_string(),
+                "00000000-0000-0000-0000-000000000002".to_string(),
+            ],
+        );
+
+        let mut injected = 0;
+        for dc_cfg in self.dc_configs.values() {
+            for chain in dc_cfg.per_node_chains.values() {
+                if chain.running_proxy.running_nodes[0].inject_event_to_cc(malformed_body.clone()) {
+                    injected += 1;
+                }
+            }
+        }
+
+        info!(
+            "inject_malformed_event: injected malformed CLIENT_ROUTES_CHANGE on {} proxy node(s)",
+            injected,
+        );
+        injected
+    }
+
     async fn post_routes_to_all_nodes(&self) -> Result<(), Error> {
         let routes = self.build_route_entries();
         let route_json = serde_json_routes(&routes);
@@ -1041,6 +1238,30 @@ pub(crate) fn drain_feedback(
     }
 
     (per_node, total)
+}
+
+// ---------------------------------------------------------------------------
+// Event body construction
+// ---------------------------------------------------------------------------
+
+/// Build the body of a `CLIENT_ROUTES_CHANGE` / `UPDATE_NODES` CQL event frame.
+///
+/// The on-wire layout (CQL protocol v2 events) is:
+/// ```text
+/// [string: "CLIENT_ROUTES_CHANGE"]   -- event type
+/// [string: "UPDATE_NODES"]           -- type of change
+/// [string_list: connection_ids]      -- affected connection IDs
+/// [string_list: host_ids]            -- affected host IDs (UUID strings)
+/// ```
+fn build_client_routes_change_body(connection_ids: &[String], host_ids: &[String]) -> Bytes {
+    use scylla_cql::frame::types::{write_string, write_string_list};
+
+    let mut buf = Vec::new();
+    write_string("CLIENT_ROUTES_CHANGE", &mut buf).unwrap();
+    write_string("UPDATE_NODES", &mut buf).unwrap();
+    write_string_list(connection_ids, &mut buf).unwrap();
+    write_string_list(host_ids, &mut buf).unwrap();
+    Bytes::from(buf)
 }
 
 // ---------------------------------------------------------------------------

--- a/scylla/tests/integration/ccm/lib/client_routes.rs
+++ b/scylla/tests/integration/ccm/lib/client_routes.rs
@@ -351,6 +351,85 @@ impl ClientRoutesCluster {
             .collect()
     }
 
+    /// Waits until every active proxy node has at least one driver connection.
+    ///
+    /// After topology changes (restart, add node), the driver takes time to
+    /// discover the new/restarted node and open a connection. Calling this
+    /// before issuing queries prevents races where all queries miss the
+    /// new node because the driver hasn't connected yet.
+    ///
+    /// Times out after `timeout` to avoid hanging forever if the driver fails to connect.
+    pub(crate) async fn wait_for_connections_to_all_nodes(
+        &self,
+        timeout: Duration,
+    ) -> Result<(), Error> {
+        let futs: Vec<_> = self
+            .dc_configs
+            .values()
+            .flat_map(|dc| {
+                dc.per_node_chains.iter().map(move |(&node_id, chain)| {
+                    let proxy = &chain.running_proxy;
+                    async move {
+                        proxy.wait_for_connection().await;
+                        info!("Proxy for node {} has a driver connection", node_id);
+                    }
+                })
+            })
+            .collect();
+
+        tokio::time::timeout(timeout, futures::future::join_all(futs))
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "Timed out waiting for driver connections to all proxy nodes. \
+                     Active node IDs: {:?}",
+                    self.active_node_ids()
+                )
+            })?;
+
+        Ok(())
+    }
+
+    /// Waits until the proxy responsible for given node has at least one driver
+    /// connection.
+    ///
+    /// After topology changes (restart, add node), the driver takes time to
+    /// discover the new/restarted node and open a connection. Calling this
+    /// before issuing queries prevents races where all queries miss the
+    /// new node because the driver hasn't connected yet.
+    ///
+    /// Times out after `timeout` to avoid hanging forever if the driver fails to connect.
+    pub(crate) async fn wait_for_connections_to_node(
+        &self,
+        node_id: NodeId,
+        timeout: Duration,
+    ) -> Result<(), Error> {
+        let fut = self
+            .dc_configs
+            .values()
+            .find_map(|dc| {
+                dc.per_node_chains.get(&node_id).map(|chain| {
+                    let proxy = &chain.running_proxy;
+                    async move {
+                        proxy.wait_for_connection().await;
+                        info!("Proxy for node {} has a driver connection", node_id);
+                    }
+                })
+            })
+            .unwrap_or_else(|| panic!("Node {} not present in the DcConfigs", node_id));
+
+        tokio::time::timeout(timeout, fut).await.map_err(|_| {
+            anyhow::anyhow!(
+                "Timed out waiting for driver connection to node {}. \
+                     Active node IDs: {:?}",
+                node_id,
+                self.active_node_ids()
+            )
+        })?;
+
+        Ok(())
+    }
+
     async fn post_routes_to_all_nodes(&self) -> Result<(), Error> {
         let routes = self.build_route_entries();
         let route_json = serde_json_routes(&routes);

--- a/scylla/tests/integration/ccm/lib/client_routes.rs
+++ b/scylla/tests/integration/ccm/lib/client_routes.rs
@@ -1,0 +1,851 @@
+//! Test helpers for `system.client_routes`-based integration tests.
+//!
+//! [`ClientRoutesCluster`] wraps a CCM [`Cluster`] and layers on:
+//! - Per-node CQL-aware proxy instances (for feedback verification)
+//! - Per-node NLBs (one per node, each pointing at that node's proxy)
+//! - Host-ID discovery and REST-API route posting with DC-specific connection IDs
+//!
+//! ## Test chain per node
+//!
+//! ```text
+//! Driver →  Per-node NLB →  Per-node Proxy (1 node) →  Real ScyllaDB
+//! ```
+//!
+//! The proxy provides CQL-level feedback (proves queries reached nodes). Since
+//! the driver only knows NLB addresses (from `client_routes`), if a proxy sees
+//! CQL traffic, it necessarily went through the NLB. So proxy feedback alone
+//! proves all 3 custom routing requirements:
+//! 1. The driver opens connections to ALL nodes.
+//! 2. The driver can query ALL nodes.
+//! 3. The driver connects through NLBs (address translation works).
+//!
+//! ## Per-node proxy instances
+//!
+//! Each ScyllaDB node gets its own independent `Proxy` instance (with 1 `Node`).
+//! This is required because `RunningProxy` cannot add/remove nodes at runtime
+//! (topology is fixed at `Proxy::run()` time). For dynamic topology tests,
+//! adding a node = start a new proxy; removing = finish one, without disrupting
+//! others.
+
+use std::collections::{BTreeMap, HashMap};
+use std::net::{IpAddr, SocketAddr};
+use std::panic::AssertUnwindSafe;
+use std::time::Duration;
+
+use anyhow::{Context, Error, bail};
+use futures::FutureExt;
+use futures::StreamExt as _;
+use futures::TryStreamExt as _;
+use scylla::client::client_routes::{ClientRoutesConfig, ClientRoutesProxy};
+use scylla::client::session_builder::ClientRoutesSessionBuilder;
+use scylla_proxy::nlb::{NlbFrontend, RunningNlbFrontend};
+use scylla_proxy::{
+    Condition, Node as ProxyNode, Proxy, Reaction, RequestOpcode, RequestReaction, RequestRule,
+    RunningProxy, ShardAwareness, get_exclusive_local_address,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tracing::{debug, info};
+use uuid::Uuid;
+
+use super::cluster::{Cluster, ClusterOptions};
+use super::node::NodeId;
+
+/// Re-export the feedback frame type used by proxy feedback channels.
+pub(crate) type FeedbackItem = (
+    scylla_proxy::RequestFrame,
+    Option<scylla_proxy::TargetShard>,
+);
+
+/// Base name for test connection IDs. Each DC gets `"{BASE}-dc{dc_id}"`.
+const CONNECTION_ID_BASE: &str = "rust-driver-test";
+
+// ---------------------------------------------------------------------------
+// Per-node proxy chain
+// ---------------------------------------------------------------------------
+
+/// A per-node proxy chain: CQL-aware proxy + NLB frontend.
+///
+/// ```text
+/// NLB (nlb_addr) →  Proxy (proxy_addr) →  Real ScyllaDB (real_addr)
+/// ```
+struct NodeChain {
+    /// The running CQL-aware proxy (single-node). Provides feedback channels.
+    running_proxy: RunningProxy,
+    /// The proxy's listen address (used as backend for both per-node NLB
+    /// and per-DC contact-point NLB).
+    proxy_addr: SocketAddr,
+    /// The NLB frontend that the driver connects to.
+    nlb: RunningNlbFrontend,
+}
+
+impl NodeChain {
+    /// The address that the driver (or contact-point NLB) should connect to.
+    fn nlb_addr(&self) -> SocketAddr {
+        self.nlb.listen_addr()
+    }
+
+    /// The proxy's listen address (used as per-DC NLB backend).
+    fn proxy_addr(&self) -> SocketAddr {
+        self.proxy_addr
+    }
+}
+
+/// Start a proxy + NLB chain for a single Scylla node (plaintext).
+///
+/// 1. Allocate a unique proxy address via `get_exclusive_local_address()`
+/// 2. Build and run a single-node `Proxy` (proxy_addr →  real_addr)
+/// 3. Build and run an NLB frontend (OS-assigned port →  proxy_addr)
+async fn start_node_chain(real_addr: SocketAddr) -> Result<NodeChain, Error> {
+    let proxy_ip = get_exclusive_local_address();
+    let proxy_addr = SocketAddr::new(proxy_ip, 9042);
+
+    let node = ProxyNode::builder()
+        .real_address(real_addr)
+        .proxy_address(proxy_addr)
+        .shard_awareness(ShardAwareness::QueryNode)
+        .build();
+
+    let running_proxy = Proxy::new([node])
+        .run()
+        .await
+        .with_context(|| format!("Failed to start proxy for real node {}", real_addr))?;
+
+    let nlb = NlbFrontend::builder()
+        .listen_addr("127.0.0.1:0".parse().unwrap())
+        .backend(proxy_addr)
+        .build()
+        .run()
+        .await
+        .with_context(|| format!("Failed to start NLB for proxy {}", proxy_addr))?;
+
+    Ok(NodeChain {
+        running_proxy,
+        proxy_addr,
+        nlb,
+    })
+}
+
+/// Shut down a proxy chain for a node.
+///
+/// The NLB is shut down first, then the proxy. Proxy errors are expected
+/// (the backend may already be dead) and are logged rather than propagated.
+async fn shutdown_node_chain(chain: NodeChain, node_id: NodeId) {
+    chain.nlb.finish().await;
+    if let Err(e) = chain.running_proxy.finish().await {
+        info!("Proxy for node {} reported (expected): {}", node_id, e);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-DC configuration
+// ---------------------------------------------------------------------------
+
+/// Per-datacenter NLB and route configuration.
+struct DcConfig {
+    /// Connection ID for this DC (e.g. `"rust-driver-test-dc0"`).
+    connection_id: String,
+    /// Per-node chains for nodes in this DC, keyed by CCM node ID.
+    per_node_chains: HashMap<NodeId, NodeChain>,
+    /// Per-DC round-robin NLB for contact points.
+    ///
+    /// Backends are the per-node proxy addresses.
+    contact_point_nlb: RunningNlbFrontend,
+}
+
+impl DcConfig {
+    /// Returns the per-DC contact-point NLB address.
+    fn contact_point_addr(&self) -> SocketAddr {
+        self.contact_point_nlb.listen_addr()
+    }
+
+    /// Update the per-DC contact-point NLB's backends to reflect the current
+    /// set of per-node proxy addresses.
+    ///
+    /// Call this after any topology change (stop/restart/add/decommission)
+    /// that alters which per-node chains are active in this DC.
+    fn refresh_contact_point_backends(&self) {
+        let backends: Vec<SocketAddr> = self
+            .per_node_chains
+            .values()
+            .map(|chain| chain.proxy_addr())
+            .collect();
+        info!(
+            "DC {} refreshing contact-point NLB backends: {:?}",
+            self.connection_id, backends
+        );
+        self.contact_point_nlb.set_backends(backends);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ClientRoutesCluster
+// ---------------------------------------------------------------------------
+
+/// A CCM cluster wrapped with per-node proxy chains and `system.client_routes`
+/// route management.
+///
+/// Provides everything needed to build a [`ClientRoutesSessionBuilder`] that
+/// connects through simulated NLBs with CQL-level feedback verification.
+pub(crate) struct ClientRoutesCluster {
+    /// The underlying CCM cluster.
+    cluster: Cluster,
+    /// Per-DC configuration, keyed by datacenter_id (0-based).
+    dc_configs: BTreeMap<u16, DcConfig>,
+    /// Mapping from CCM node ID to its Scylla host_id UUID.
+    host_ids: HashMap<NodeId, Uuid>,
+}
+
+impl ClientRoutesCluster {
+    /// Build the cluster, discover host IDs, start proxy chains, and post routes.
+    ///
+    /// Returns `Ok(None)` if the cluster does not support `system.client_routes`
+    /// (e.g., the ScyllaDB version is too old). The caller should skip the test
+    /// in that case.
+    ///
+    /// Full lifecycle:
+    /// 1. CCM cluster create + init
+    /// 2. CCM cluster start
+    /// 3. Check `system.client_routes` table existence (skip if absent)
+    /// 4. Discover each node's `host_id` via a direct CQL connection
+    /// 5. Start per-node proxy chains
+    /// 6. POST client routes via Scylla's REST API on each node
+    async fn setup(opts: ClusterOptions) -> Result<Option<Self>, Error> {
+        let mut cluster = Cluster::new(opts)
+            .await
+            .context("Failed to create cluster")?;
+        cluster
+            .init()
+            .await
+            .inspect_err(|_| cluster.mark_as_failed())
+            .context("Failed to init cluster")?;
+
+        cluster
+            .start(None)
+            .await
+            .inspect_err(|_| cluster.mark_as_failed())
+            .context("Failed to start cluster")?;
+
+        // Step 3: check that `system.client_routes` exists.
+        if !client_routes_table_exists(&cluster).await? {
+            info!(
+                "system.client_routes table not found — \
+                 this ScyllaDB version does not support client routes, skipping test"
+            );
+            return Ok(None);
+        }
+
+        // Step 4: discover host IDs (uses plaintext port 9042).
+        info!("Starting host ID discovery. Starting a driver Session for that...");
+        let host_ids = discover_host_ids(&cluster)
+            .await
+            .inspect_err(|_| cluster.mark_as_failed())
+            .context("Failed to discover host IDs")?;
+        info!("Discovered host IDs: {:?}", host_ids);
+
+        // Step 4: start per-node proxy chains.
+        info!("Starting per-node proxy chains");
+        let dc_configs = build_dc_configs(&cluster)
+            .await
+            .inspect_err(|_| cluster.mark_as_failed())
+            .context("Failed to build DC configs / start proxy chains")?;
+
+        for (dc_id, dc_cfg) in &dc_configs {
+            info!(
+                "DC {}: connection_id={}, contact={}, {} per-node chains",
+                dc_id,
+                dc_cfg.connection_id,
+                dc_cfg.contact_point_addr(),
+                dc_cfg.per_node_chains.len(),
+            );
+        }
+
+        let mut plc = ClientRoutesCluster {
+            cluster,
+            dc_configs,
+            host_ids,
+        };
+
+        // Step 5: POST client routes to all nodes.
+        info!("POSTing client routes to all nodes");
+        plc.post_routes_to_all_nodes()
+            .await
+            .inspect_err(|_| plc.cluster.mark_as_failed())
+            .context("Failed to post client routes")?;
+
+        info!("Finished POSTing client routes to all nodes");
+
+        Ok(Some(plc))
+    }
+
+    /// Build a [`ClientRoutesSessionBuilder`] configured to connect through the NLBs.
+    ///
+    /// Creates one [`ClientRoutesProxy`] per DC (each with its DC-specific
+    /// connection ID) and uses the per-DC contact-point NLB as the contact point.
+    pub(crate) fn make_session_builder(&self) -> ClientRoutesSessionBuilder {
+        let (proxies, contact_points): (Vec<_>, Vec<_>) = self
+            .dc_configs
+            .values()
+            .map(|dc_cfg| {
+                let proxy = ClientRoutesProxy::new_with_connection_id(dc_cfg.connection_id.clone())
+                    .with_overridden_hostname("127.0.0.1".to_string());
+                let contact_point = dc_cfg.contact_point_addr().to_string();
+                (proxy, contact_point)
+            })
+            .unzip();
+
+        let config = ClientRoutesConfig::new(proxies).expect("valid config");
+        ClientRoutesSessionBuilder::new(config).known_nodes(contact_points)
+    }
+
+    /// Set up QUERY feedback rules on proxy nodes.
+    ///
+    /// Returns a map from `NodeId` to the feedback receiver for that node.
+    /// Each call replaces previous rules/senders, so new queries go to new
+    /// channels. This allows "fresh" counting per test phase.
+    ///
+    /// The condition matches only user QUERY frames, excluding control
+    /// connection traffic (REGISTER-ed connections).
+    pub(crate) fn setup_query_feedback(
+        &mut self,
+    ) -> HashMap<NodeId, mpsc::UnboundedReceiver<FeedbackItem>> {
+        let mut receivers = HashMap::new();
+
+        for dc_cfg in self.dc_configs.values_mut() {
+            for (&node_id, chain) in dc_cfg.per_node_chains.iter_mut() {
+                let (tx, rx) = mpsc::unbounded_channel();
+
+                let condition = Condition::RequestOpcode(RequestOpcode::Query)
+                    .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+                let rule = RequestRule(
+                    condition,
+                    RequestReaction::noop().with_feedback_when_performed(tx),
+                );
+
+                // Each proxy has exactly 1 node (index 0).
+                chain.running_proxy.running_nodes[0].change_request_rules(Some(vec![rule]));
+
+                receivers.insert(node_id, rx);
+            }
+        }
+
+        receivers
+    }
+
+    pub(crate) fn cluster_mut(&mut self) -> &mut Cluster {
+        &mut self.cluster
+    }
+
+    /// Returns the mapping from CCM node ID to Scylla host_id.
+    #[expect(dead_code)]
+    pub(crate) fn host_ids(&self) -> &HashMap<NodeId, Uuid> {
+        &self.host_ids
+    }
+
+    /// Returns all active node IDs across all DCs.
+    pub(crate) fn active_node_ids(&self) -> Vec<NodeId> {
+        self.dc_configs
+            .values()
+            .flat_map(|dc| dc.per_node_chains.keys().copied())
+            .collect()
+    }
+
+    async fn post_routes_to_all_nodes(&self) -> Result<(), Error> {
+        let routes = self.build_route_entries();
+        let route_json = serde_json_routes(&routes);
+        info!("Posting client routes: {}", route_json);
+
+        // Collect the set of node IDs that have active proxy chains.
+        let active_ids: std::collections::HashSet<NodeId> = self
+            .dc_configs
+            .values()
+            .flat_map(|dc| dc.per_node_chains.keys().copied())
+            .collect();
+
+        for node in self.cluster.nodes().iter() {
+            if !active_ids.contains(&node.id()) {
+                debug!(
+                    "Skipping route POST to node {} ({}) — no active chain",
+                    node.id(),
+                    node.broadcast_rpc_address()
+                );
+                continue;
+            }
+            let node_ip = node.broadcast_rpc_address();
+            post_client_routes_raw(node_ip, &route_json)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to POST client routes to node {} ({})",
+                        node.id(),
+                        node_ip
+                    )
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Build the JSON-serializable route entries from current state.
+    ///
+    /// Each node's route uses the connection ID of its DC. The `port` field
+    /// points to the NLB. `tls_port` is set to the same value as `port`
+    /// because the REST API rejects port 0; the driver never uses TLS in
+    /// these tests, so the value is irrelevant.
+    fn build_route_entries(&self) -> Vec<RouteEntry> {
+        let mut entries = Vec::new();
+
+        for (dc_id, dc_cfg) in &self.dc_configs {
+            for (&node_id, chain) in &dc_cfg.per_node_chains {
+                if let Some(&host_id) = self.host_ids.get(&node_id) {
+                    let nlb = chain.nlb_addr();
+                    entries.push(RouteEntry {
+                        connection_id: dc_cfg.connection_id.clone(),
+                        host_id,
+                        address: nlb.ip().to_string(),
+                        port: nlb.port(),
+                        // For now, both are at the same port. TLS is anyway not tested, as not yet
+                        // supported. Once it's supported, this needs to be adjusted to a different port
+                        // than plaintext.
+                        tls_port: nlb.port(),
+                    });
+                } else {
+                    debug!(
+                        "Skipping route for node {} in DC {} — no host_id",
+                        node_id, dc_id
+                    );
+                }
+            }
+        }
+
+        entries
+    }
+
+    /// Shut down all proxy chains and per-DC contact-point NLBs.
+    async fn shutdown_all(self) {
+        for (dc_id, dc_cfg) in self.dc_configs {
+            debug!("Shutting down per-DC contact-point NLB for DC {}", dc_id);
+            dc_cfg.contact_point_nlb.finish().await;
+
+            for (node_id, chain) in dc_cfg.per_node_chains {
+                debug!("Shutting down chain for DC {} node {}", dc_id, node_id);
+                shutdown_node_chain(chain, node_id).await;
+            }
+        }
+        info!("All proxy chains and NLBs shut down");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DC config builder
+// ---------------------------------------------------------------------------
+
+/// Group cluster nodes by DC and start per-node proxy chains + per-DC
+/// contact-point NLBs.
+///
+/// For each DC:
+/// - One proxy chain per node
+/// - One per-DC round-robin NLB (used as contact point)
+/// - A connection ID of the form `"rust-driver-test-dc{dc_id}"`
+///
+/// ```text
+/// Driver →  Per-DC NLB →  Proxy →  ScyllaDB :9042
+/// ```
+async fn build_dc_configs(cluster: &Cluster) -> Result<BTreeMap<u16, DcConfig>, Error> {
+    // Group nodes by DC: DcId -> {(NodeId, IpAddr)}.
+    let dc_nodes: BTreeMap<u16, Vec<(NodeId, IpAddr)>> =
+        cluster
+            .nodes()
+            .iter()
+            .fold(BTreeMap::new(), |mut acc, node| {
+                acc.entry(node.datacenter_id())
+                    .or_default()
+                    .push((node.id(), node.broadcast_rpc_address()));
+                acc
+            });
+
+    futures::stream::iter(dc_nodes)
+        .then(|(dc_id, nodes)| async move {
+            let connection_id = format!("{}-dc{}", CONNECTION_ID_BASE, dc_id);
+
+            // Start per-node proxy chains.
+            let mut per_node_chains = HashMap::new();
+            for (node_id, real_ip) in &nodes {
+                let chain = start_node_chain(SocketAddr::new(*real_ip, 9042))
+                    .await
+                    .with_context(|| {
+                        format!("Failed to start chain for DC {} node {}", dc_id, node_id)
+                    })?;
+                per_node_chains.insert(*node_id, chain);
+            }
+
+            // Start per-DC round-robin NLB.
+            let backends: Vec<SocketAddr> = per_node_chains
+                .values()
+                .map(|chain| chain.proxy_addr())
+                .collect();
+
+            let contact_point_nlb = NlbFrontend::builder()
+                .listen_addr("127.0.0.1:0".parse().unwrap())
+                .backends(backends.iter().copied())
+                .build()
+                .run()
+                .await
+                .with_context(|| {
+                    format!("Failed to start per-DC contact-point NLB for DC {}", dc_id)
+                })?;
+
+            info!(
+                "DC {} contact-point NLB: {} →  {:?}",
+                dc_id,
+                contact_point_nlb.listen_addr(),
+                backends,
+            );
+
+            Ok::<_, Error>((
+                dc_id,
+                DcConfig {
+                    connection_id,
+                    per_node_chains,
+                    contact_point_nlb,
+                },
+            ))
+        })
+        .try_collect()
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Feature detection
+// ---------------------------------------------------------------------------
+
+/// Check whether the `system.client_routes` table exists on this cluster.
+///
+/// Opens a short-lived session to the first node and queries
+/// `system_schema.tables`. Returns `false` if the table is absent
+/// (ScyllaDB version too old), `Err` on connection/query failure.
+async fn client_routes_table_exists(cluster: &Cluster) -> Result<bool, Error> {
+    use scylla::client::session_builder::SessionBuilder;
+
+    let first_node = cluster
+        .nodes()
+        .iter()
+        .next()
+        .context("Cluster has no nodes")?;
+    let contact = SocketAddr::new(
+        first_node.broadcast_rpc_address(),
+        first_node.native_transport_port(),
+    );
+    let session = SessionBuilder::new()
+        .known_node(contact.to_string())
+        .build()
+        .await
+        .with_context(|| format!("Failed to connect to cluster via {}", contact))?;
+
+    let result = session
+        .query_unpaged(
+            "SELECT table_name FROM system_schema.tables \
+             WHERE keyspace_name = 'system' AND table_name = 'client_routes'",
+            &[],
+        )
+        .await
+        .context("Failed to query system_schema.tables")?;
+
+    let rows = result.into_rows_result().context("Expected rows result")?;
+    Ok(rows.rows_num() > 0)
+}
+
+// ---------------------------------------------------------------------------
+// Host-ID discovery
+// ---------------------------------------------------------------------------
+
+/// Uses the driver's cluster metadata (via `Session::get_cluster_state()`) to
+/// reliably discover host_ids for all CCM nodes.
+///
+/// This avoids querying `system.local` / `system.peers` directly, which is
+/// unreliable because queries go through the load balancer and `system.local`
+/// returns the *queried* node's data (not necessarily the contact point's).
+/// The Session already discovers all nodes during initialization, so we can
+/// simply read the metadata it has collected.
+async fn discover_host_ids(cluster: &Cluster) -> Result<HashMap<NodeId, Uuid>, Error> {
+    use scylla::client::session_builder::SessionBuilder;
+
+    // Connect to the first node — the session will discover the whole cluster.
+    let first_node = cluster
+        .nodes()
+        .iter()
+        .next()
+        .context("Cluster has no nodes")?;
+    let contact = SocketAddr::new(
+        first_node.broadcast_rpc_address(),
+        first_node.native_transport_port(),
+    );
+    let session = SessionBuilder::new()
+        .known_node(contact.to_string())
+        .build()
+        .await
+        .with_context(|| format!("Failed to connect to cluster via {}", contact))?;
+
+    // Read the cluster metadata that the session has already collected.
+    let state = session.get_cluster_state();
+    let nodes_info = state.get_nodes_info();
+
+    // Build a map: IP address →  host_id from the driver's metadata.
+    let addr_to_host_id: HashMap<IpAddr, Uuid> = nodes_info
+        .iter()
+        .map(|node| (node.address.ip(), node.host_id))
+        .collect();
+
+    debug!(
+        "Cluster metadata address →  host_id map ({} nodes): {:?}",
+        addr_to_host_id.len(),
+        addr_to_host_id
+    );
+
+    // Match CCM nodes by their broadcast_rpc_address.
+    let mut host_ids = HashMap::new();
+    for node in cluster.nodes().iter() {
+        let rpc_ip = node.broadcast_rpc_address();
+        let host_id = addr_to_host_id.get(&rpc_ip).with_context(|| {
+            format!(
+                "Node {} ({}) not found in driver cluster metadata — cluster may not be fully up. \
+                 Known addresses: {:?}",
+                node.id(),
+                rpc_ip,
+                addr_to_host_id.keys().collect::<Vec<_>>()
+            )
+        })?;
+        host_ids.insert(node.id(), *host_id);
+        debug!("Node {} ({}): host_id = {}", node.id(), rpc_ip, host_id);
+    }
+
+    Ok(host_ids)
+}
+
+/// Connect to a single Scylla node and retrieve its `host_id`.
+///
+/// Uses the driver's cluster metadata (same approach as [`discover_host_ids`]).
+/// Retries with backoff because a newly-added CCM node may not be ready
+/// immediately after `node.start()`.
+async fn discover_single_host_id(addr: SocketAddr) -> Result<Uuid, Error> {
+    use scylla::client::session_builder::SessionBuilder;
+
+    let max_attempts = 10;
+    let mut last_err = None;
+
+    for attempt in 1..=max_attempts {
+        match SessionBuilder::new()
+            .known_node(addr.to_string())
+            .build()
+            .await
+        {
+            Ok(session) => {
+                let state = session.get_cluster_state();
+                let nodes_info = state.get_nodes_info();
+                // Find the node matching our address.
+                if let Some(node) = nodes_info.iter().find(|n| n.address.ip() == addr.ip()) {
+                    return Ok(node.host_id);
+                }
+                // If the target node isn't in metadata, fall back to looking
+                // for any single node (the session only knows one contact point).
+                if nodes_info.len() == 1 {
+                    return Ok(nodes_info[0].host_id);
+                }
+                last_err = Some(anyhow::anyhow!(
+                    "Node {} not found in session metadata ({} nodes known)",
+                    addr,
+                    nodes_info.len()
+                ));
+            }
+            Err(e) => {
+                last_err = Some(anyhow::anyhow!("Attempt {}: {}", attempt, e));
+            }
+        }
+
+        if attempt < max_attempts {
+            info!(
+                "discover_single_host_id: attempt {}/{} for {} failed, retrying...",
+                attempt, max_attempts, addr
+            );
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("No attempts made")))
+}
+
+// ---------------------------------------------------------------------------
+// Feedback drain helpers
+// ---------------------------------------------------------------------------
+
+/// Drain all feedback channels and return per-node counts and total count.
+///
+/// This is non-blocking: it drains whatever is currently buffered in each
+/// channel. Call this after all queries have completed and a short delay.
+pub(crate) fn drain_feedback(
+    receivers: &mut HashMap<NodeId, mpsc::UnboundedReceiver<FeedbackItem>>,
+) -> (HashMap<NodeId, usize>, usize) {
+    let mut per_node = HashMap::new();
+    let mut total = 0usize;
+
+    for (&node_id, rx) in receivers.iter_mut() {
+        let mut count = 0usize;
+        while let Ok(_feedback) = rx.try_recv() {
+            count += 1;
+        }
+        per_node.insert(node_id, count);
+        total += count;
+    }
+
+    (per_node, total)
+}
+
+// ---------------------------------------------------------------------------
+// Route posting (raw HTTP)
+// ---------------------------------------------------------------------------
+
+/// A single route entry for the REST API JSON payload.
+struct RouteEntry {
+    connection_id: String,
+    host_id: Uuid,
+    address: String,
+    port: u16,
+    tls_port: u16,
+}
+
+/// Serialize route entries to JSON without pulling in serde_json.
+fn serde_json_routes(routes: &[RouteEntry]) -> String {
+    let entries: Vec<String> = routes
+        .iter()
+        .map(|r| {
+            format!(
+                r#"{{"connection_id":"{}","host_id":"{}","address":"{}","port":{},"tls_port":{}}}"#,
+                r.connection_id, r.host_id, r.address, r.port, r.tls_port
+            )
+        })
+        .collect();
+    format!("[{}]", entries.join(","))
+}
+
+/// POST client routes to a single Scylla node via its REST API.
+///
+/// Uses raw HTTP/1.1 over TCP to avoid adding an HTTP client dependency.
+/// Retries up to `MAX_POST_ATTEMPTS` times with backoff because a freshly
+/// started node's REST API may not be ready immediately (returns HTTP 500).
+async fn post_client_routes_raw(node_ip: IpAddr, json_body: &str) -> Result<(), Error> {
+    const MAX_POST_ATTEMPTS: u32 = 10;
+    const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+    let api_addr = SocketAddr::new(node_ip, 10000);
+    let mut last_err = None;
+
+    for attempt in 1..=MAX_POST_ATTEMPTS {
+        match post_client_routes_raw_once(api_addr, node_ip, json_body).await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                info!(
+                    "POST routes to {} attempt {}/{} failed: {}",
+                    api_addr, attempt, MAX_POST_ATTEMPTS, e
+                );
+                last_err = Some(e);
+                if attempt < MAX_POST_ATTEMPTS {
+                    tokio::time::sleep(RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("No POST attempts made")))
+}
+
+/// Single attempt to POST client routes. Called by [`post_client_routes_raw`].
+async fn post_client_routes_raw_once(
+    api_addr: SocketAddr,
+    node_ip: IpAddr,
+    json_body: &str,
+) -> Result<(), Error> {
+    let mut stream = TcpStream::connect(api_addr)
+        .await
+        .with_context(|| format!("Failed to connect to REST API at {}", api_addr))?;
+
+    let request = format!(
+        "POST /v2/client-routes HTTP/1.1\r\n\
+         Host: {}:{}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        node_ip,
+        10000,
+        json_body.len(),
+        json_body
+    );
+
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .context("Failed to send HTTP request")?;
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .context("Failed to read HTTP response")?;
+    let response_str = String::from_utf8_lossy(&response);
+
+    let status_line = response_str.lines().next().unwrap_or("(empty response)");
+    debug!("REST API response from {}: {}", api_addr, status_line);
+
+    if !status_line.contains("200") && !status_line.contains("201") {
+        bail!(
+            "REST API at {} returned unexpected status: {}\nFull response:\n{}",
+            api_addr,
+            status_line,
+            response_str
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+/// Run a `system.client_routes`-based integration test.
+///
+/// This is the client-routes equivalent of [`super::run_ccm_test`]. It:
+/// 1. Creates and starts a CCM cluster with the given options
+/// 2. Discovers host IDs, starts per-node proxy chains, and posts client routes
+/// 3. Runs the test body with a [`ClientRoutesCluster`]
+/// 4. Shuts down all proxy chains and NLBs, cleans up the cluster
+pub(crate) async fn run_client_routes_test<C, T>(make_cluster_options: C, test_body: T)
+where
+    C: FnOnce() -> ClusterOptions,
+    T: AsyncFnOnce(&mut ClientRoutesCluster) -> (),
+{
+    let opts = make_cluster_options();
+    let Some(mut plc) = ClientRoutesCluster::setup(opts)
+        .await
+        .expect("Failed to set up client-routes test cluster")
+    else {
+        info!("Skipping client-routes test (unsupported by this cluster version)");
+        return;
+    };
+
+    let result = AssertUnwindSafe(test_body(&mut plc)).catch_unwind().await;
+
+    let cluster_failed = result.is_err();
+    if cluster_failed {
+        plc.cluster.mark_as_failed();
+    }
+
+    // Shut down proxy chains + NLBs first, then let Cluster's Drop handle CCM.
+    plc.shutdown_all().await;
+
+    if let Err(err) = result {
+        std::panic::resume_unwind(err);
+    }
+}

--- a/scylla/tests/integration/ccm/lib/cluster.rs
+++ b/scylla/tests/integration/ccm/lib/cluster.rs
@@ -322,21 +322,34 @@ impl Cluster {
         not(all(scylla_unstable, feature = "unstable-host-listener")),
         expect(dead_code)
     )]
+    /// Add a new node to the cluster in the given datacenter.
+    ///
+    /// `datacenter_id` uses **1-based** CCM naming: `1` →  `dc1`, `2` →  `dc2`, etc.
+    /// The value stored in [`NodeOptions::datacenter_id`] is **0-based** (matching
+    /// the convention used by [`Cluster::new`]).
     pub(crate) async fn add_node(
         &mut self,
         datacenter_id: Option<u16>,
     ) -> Result<&mut Node, Error> {
         let id = self.nodes.get_free_node_id().expect("No available node id");
-        let datacenter_id = datacenter_id.unwrap_or(1);
+        // CCM uses 1-based DC names: dc1, dc2, …
+        let ccm_dc_id = datacenter_id.unwrap_or(1);
         let node_options = NodeOptions {
             id,
-            datacenter_id,
+            // Store as 0-based to match the convention from Cluster::new().
+            datacenter_id: ccm_dc_id - 1,
             ..NodeOptions::from_cluster_opts(&self.opts)
         };
-        let datacenter_name = format!("dc{datacenter_id}");
+        let datacenter_name = format!("dc{ccm_dc_id}");
+        // Pass the node's IP explicitly via `-i`. Without it, CCM
+        // auto-assigns based on `len(nodelist) + 1`, which diverges from
+        // our `get_free_node_id()` when there are gaps (e.g., after a
+        // decommission reuses a lower ID).
+        let node_ip = self.opts.ip_prefix.to_ipaddress(id).to_string();
         self.ccm_cmd
             .cluster_add_node(self.opts.db_type, node_options.name())
             .dc(datacenter_name)
+            .address(node_ip)
             .run()
             .await?;
         Ok(self.append_node(node_options))

--- a/scylla/tests/integration/ccm/lib/cluster.rs
+++ b/scylla/tests/integration/ccm/lib/cluster.rs
@@ -85,15 +85,12 @@ impl NodeList {
         self.0.iter_mut()
     }
 
-    #[expect(dead_code)]
+    #[allow(dead_code)]
     pub(crate) fn get_by_id(&self, id: NodeId) -> Option<&Node> {
         self.iter().find(|node| node.id() == id)
     }
 
-    #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-host-listener")),
-        expect(dead_code)
-    )]
+    #[allow(dead_code)]
     pub(crate) fn get_mut_by_id(&mut self, id: NodeId) -> Option<&mut Node> {
         self.iter_mut().find(|node| node.id() == id)
     }
@@ -106,13 +103,7 @@ impl NodeList {
         self.iter().map(|node| node.contact_endpoint()).collect()
     }
 
-    #[cfg_attr(
-        not(any(
-            all(scylla_unstable, feature = "unstable-host-listener"),
-            all(feature = "openssl-010", feature = "rustls-023")
-        )),
-        expect(dead_code)
-    )]
+    #[allow(dead_code)]
     pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
@@ -319,7 +310,10 @@ impl Cluster {
     }
 
     #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-host-listener")),
+        not(any(
+            all(scylla_unstable, feature = "unstable-host-listener"),
+            feature = "unstable-client-routes",
+        )),
         expect(dead_code)
     )]
     /// Add a new node to the cluster in the given datacenter.
@@ -403,7 +397,8 @@ impl Cluster {
     #[cfg_attr(
         not(any(
             all(scylla_unstable, feature = "unstable-host-listener"),
-            all(feature = "openssl-010", feature = "rustls-023")
+            all(feature = "openssl-010", feature = "rustls-023"),
+            feature = "unstable-client-routes",
         )),
         expect(dead_code)
     )]

--- a/scylla/tests/integration/ccm/lib/mod.rs
+++ b/scylla/tests/integration/ccm/lib/mod.rs
@@ -15,7 +15,7 @@ use ip_allocator::IpAllocator;
 use tracing::info;
 
 pub(crate) static CLUSTER_VERSION: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("SCYLLA_TEST_CLUSTER").unwrap_or("release:2025.3.3".to_string())
+    std::env::var("SCYLLA_TEST_CLUSTER").unwrap_or("release:2026.1.0".to_string())
 });
 
 static TEST_KEEP_CLUSTER_ON_FAILURE: LazyLock<bool> = LazyLock::new(|| {

--- a/scylla/tests/integration/ccm/lib/mod.rs
+++ b/scylla/tests/integration/ccm/lib/mod.rs
@@ -1,4 +1,6 @@
 mod cli_wrapper;
+#[cfg(feature = "unstable-client-routes")]
+pub(crate) mod client_routes;
 pub(crate) mod cluster;
 mod ip_allocator;
 mod logged_cmd;

--- a/scylla/tests/integration/ccm/lib/node.rs
+++ b/scylla/tests/integration/ccm/lib/node.rs
@@ -21,8 +21,7 @@ pub(crate) struct NodeOptions {
     /// Examples: `release:6.2.2`, `unstable:master/2021-05-24T17:16:53Z`
     #[expect(dead_code)]
     pub(crate) version: String,
-    /// Datacenter ID
-    #[expect(dead_code)]
+    /// Datacenter ID (0-based index matching position in `ClusterOptions::nodes_per_dc`).
     pub(crate) datacenter_id: u16,
     /// CCM allocates node ip addresses based on this prefix:
     /// if ip_prefix = `127.0.1.`, then `node1` address is `127.0.1.1`, `node2` address is `127.0.1.2`
@@ -102,6 +101,15 @@ impl Node {
         9042
     }
 
+    /// Returns the 0-based datacenter index for this node.
+    ///
+    /// Corresponds to the position in [`ClusterOptions::nodes_per_dc`].
+    /// CCM names these `dc1`, `dc2`, … (1-based), so CCM DC name = `dc{datacenter_id + 1}`.
+    #[cfg_attr(not(feature = "unstable-client-routes"), expect(dead_code))]
+    pub(crate) fn datacenter_id(&self) -> u16 {
+        self.opts.datacenter_id
+    }
+
     /// Executes `ccm updateconf` and applies it for this node.
     /// It accepts the key-value pairs to update the configuration.
     ///
@@ -150,7 +158,10 @@ impl Node {
     /// This method starts the node. User can provide optional [`NodeStartOptions`] to control the behavior of the node start.
     /// If `None` is provided, the default options are used (see the implementation of Default for [`NodeStartOptions`]).
     #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-host-listener")),
+        not(any(
+            all(scylla_unstable, feature = "unstable-host-listener"),
+            feature = "unstable-client-routes",
+        )),
         expect(dead_code)
     )]
     pub(crate) async fn start(&mut self, opts: Option<NodeStartOptions>) -> Result<(), Error> {
@@ -166,7 +177,10 @@ impl Node {
     }
 
     #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-host-listener")),
+        not(any(
+            all(scylla_unstable, feature = "unstable-host-listener"),
+            feature = "unstable-client-routes",
+        )),
         expect(dead_code)
     )]
     pub(crate) async fn stop(&mut self, opts: Option<NodeStopOptions>) -> Result<(), Error> {
@@ -176,7 +190,10 @@ impl Node {
     }
 
     #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-host-listener")),
+        not(any(
+            all(scylla_unstable, feature = "unstable-host-listener"),
+            feature = "unstable-client-routes",
+        )),
         expect(dead_code)
     )]
     pub(crate) async fn decommission(&mut self) -> Result<(), Error> {
@@ -189,7 +206,10 @@ impl Node {
     }
 
     #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-host-listener")),
+        not(any(
+            all(scylla_unstable, feature = "unstable-host-listener"),
+            feature = "unstable-client-routes",
+        )),
         expect(dead_code)
     )]
     pub(crate) async fn delete(&mut self) -> Result<(), Error> {

--- a/scylla/tests/integration/ccm/mod.rs
+++ b/scylla/tests/integration/ccm/mod.rs
@@ -1,6 +1,8 @@
 mod lib;
 
 mod authenticate;
+#[cfg(feature = "unstable-client-routes")]
+mod client_routes;
 mod example;
 #[cfg(all(scylla_unstable, feature = "unstable-host-listener"))]
 mod host_listener;


### PR DESCRIPTION
Fixes: #1570

Note to reviewers: Both unit and integration tests were created by Claude Opus 4.6 and reviewed by me. It solved that incredibly well!

## Background

PrivateLink routing is based on the recently introduced `system.client_routes` table. Driver needs to fetch it and perform address translation based on its contents.

We were told that some nodes in the cluster may be reachable via ClientRoutes and others directly, so the translator should behave as identity function in case `system.client_routes` misses entry for given node.
However, these scenarios involve inherent races, which result in driver nondeterministically opening connections either directly or via ClientRoutes. Therefore, **we decided to not support such scenarios**. All nodes must be reachable via ClientRoutes.

## What's done

### New cargo feature: `"unstable-client-routes"`
It guards driver's inner structures and logic regarding fetching and storing `system.client_routes` entries, as well as reacting to `CLIENT_ROUTES_CHANGE` CQL event. Moreover, it guards driver's public API than enables configuring the driver to connect to client routes-dependent architecture, for instance AWS PrivateLink or GCP Private Service Connect.

### Even more mess in scylla-cql

I needed to add a new event type (`CLIENT_ROUTES_CHANGE`). The problem is, neither `Event` nor `EventType` were marked as `#[non_exhaustive]`...
Not to introduce breaking changes, I duplicated the whole family of entities:
- `EventV2`,
- `EventTypeV2`,
- `RegisterV2`,
- `ResponseWithDeserializedMetadataV2`,
- `NonErrorResponseWithDeserializedMetadataV2`.
Ugh. Let's hope it'll become better once we extract `scylla-cql-core`. For now, to reduce clutter in `scylla` crate, I imported new entities with aliases for older names, so that `EventV2` is still seen as `Event` by the code.

### Represent `ClientRoutes`
I introduced entities that represent `system.client_routes` entries. They are fetched in two situtations:
1. Upon metadata refresh - then they are only filtered by configured connection ids - entries for all host ids are fetched.
2. Upon `CLIENT_ROUTES_CHANGE` event - then they are filtered by both connection ids and host ids, those which are contained in the event payload.

### `ClientRoutesSubscriber` trait
The `pub(crate) trait ClientRoutesSubscriber` is intended to cleanly separate fetching client routes (done by the driver's core - `ControlConnection`) and using client routes (by `ClientRoutesAddressTranslator`). Each time metadata refresh happens, `replace_client_routes()` is called with the fresh `ClientRoutes`. In reaction to each `CLIENT_ROUTES_CHANGE` event, `merge_client_routes_update()` is called with fresh (partial, filtered) `ClientRoutes`.

### `ClientRoutesSessionBuilder`
A new builder kind, dedicated for client routes support. It delegates ClientRoutes configuration to `ClientRoutesConfig`. Currently, it consists of just one element:
1. `ClientRoutesProxy`s. These are essentially connection ids (in case of PrivateLink, identifiers of PrivateLink instances), optionally coupled with hostname override. This feature was requested by @dkropachev for various purposes. If the hostname override is present for given connection id, hostnames present in `system.client_routes` for given connection id are ignored and the override is used instead.

### `ClientRoutesAddressTranslator`

The translator implements both `AddressTranslator` and `ClientRoutesSubscriber` traits. Therefore, it gets fed with `ClientRoutes` each time they are updated, decided how to merge old knowledge with the update to yield new knowledge, and translates addresses by looking up the host id in the map and using hostname stored there. Alternatively, if `ClientRoutesProxy` with the connection id paired with that host id in the `ClientRoutes` entry contains a hostname override, the overridden hostname is used. Then, the hostname (overridden or stored in `ClientRoutes`) is resolved and the obtained address is returned. The port is read from `ClientRoutes`: TLS port if `TlsContext` is set on `SessionConfig`, or plaintext port otherwise. Note that TLS is not supported yet with ClientRoutes.
As already noted, some nodes in the cluster may be routable via client routes and others directly, so the translator must behave as identity function in case `system.client_routes` misses entry for given node.
As also noted, it's desired to have connection id _"stickiness"_ in the translator: once a connection id was chosen for a host id, it should be used consistency until it's no longer available in the client_routes.

Claude Opus 4.6 wrote unit tests for the translator, and I improved them.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
