### PR TITLE
Move throughput benchmarks from nodejs-rs driver repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "benchmarks",
     "examples",
     "scylla",
     "scylla-macros",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+edition = "2024"
+name = "benchmark"
+version = "0.0.0"
+
+[dependencies]
+scylla = { path = "../scylla", features = ["chrono-04"] }
+tokio = { version = "1.34", features = ["full"] }
+uuid = "1"
+futures = "0.3"
+chrono = "0.4"
+
+[[bin]]
+name = "select_benchmark"
+path = "src/select.rs"
+
+[[bin]]
+name = "large_select_benchmark"
+path = "src/large_select.rs"
+
+[[bin]]
+name = "insert_benchmark"
+path = "src/insert.rs"
+
+[[bin]]
+name = "concurrent_insert_benchmark"
+path = "src/concurrent_insert.rs"
+
+[[bin]]
+name = "concurrent_select_benchmark"
+path = "src/concurrent_select.rs"
+
+[[bin]]
+name = "batch_benchmark"
+path = "src/batch.rs"
+
+[[bin]]
+name = "paging_benchmark"
+path = "src/paging.rs"
+
+[[bin]]
+name = "concurrent_paging_benchmark"
+path = "src/concurrent_paging.rs"
+
+[[bin]]
+name = "deser_benchmark"
+path = "src/deser.rs"
+
+[[bin]]
+name = "concurrent_deser_benchmark"
+path = "src/concurrent_deser.rs"
+
+[[bin]]
+name = "ser_benchmark"
+path = "src/ser.rs"
+
+[[bin]]
+name = "concurrent_ser_benchmark"
+path = "src/concurrent_ser.rs"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,55 @@
+
+# Benchmarks
+
+Each benchmark recreates the table before execution to ensure consistent and isolated results.
+
+- **concurrent insert**
+
+This benchmark spawns concurrent Tokio tasks, each calling `Session::execute_unpaged`
+with a prepared statement to insert `n` rows in total containing `uuid` and `int` into the database.
+Afterwards, it checks that the number of rows inserted is correct.
+
+- **insert**
+
+This benchmark executes `n` sequential `Session::execute_unpaged` prepared statement calls,
+each inserting a single row containing `uuid` and `int`, waiting for the result before executing the next one.
+
+- **concurrent select**
+
+This benchmark first inserts `10` rows containing `uuid` and `int`.
+Afterwards it spawns concurrent Tokio tasks, each calling `Session::execute_unpaged`
+to select all inserted rows from the database, repeating `n` times in total.
+
+- **select**
+
+This benchmark first inserts 10 rows containing `uuid` and `int`.
+Afterwards it executes `n` sequential `Session::execute_unpaged` prepared statement calls,
+each selecting all inserted rows, waiting for the result before executing the next one.
+
+- **concurrent deserialization**
+
+This benchmark spawns concurrent Tokio tasks to insert `n` rows containing
+`uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database using `Session::execute_unpaged`.
+Afterwards it spawns concurrent Tokio tasks to select all (`n`) inserted rows from the database `n` times.
+
+- **deserialization**
+
+This benchmark executes `n` sequential `Session::execute_unpaged` calls to insert a single row containing
+`uuid`, `int`, `timeuuid`, `inet`, `date`, `time`, waiting for each result before executing the next.
+Afterwards it executes `n` sequential `Session::execute_unpaged` calls to select all (`n`) inserted rows.
+
+- **concurrent serialization**
+
+This benchmark spawns concurrent Tokio tasks, each calling `Session::execute_unpaged` with a prepared statement,
+to insert `n*n` rows in total containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database.
+
+- **serialization**
+
+This benchmark executes `n*n` sequential `Session::execute_unpaged` prepared statement calls,
+each inserting a single row containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time`,
+waiting for each result before executing the next.
+
+- **batch**
+
+This benchmark uses `Session::batch` to insert `n` rows containing `uuid` and `int` into the database.
+Afterwards, it checks that the number of rows inserted is correct.

--- a/benchmarks/config.yml
+++ b/benchmarks/config.yml
@@ -1,0 +1,51 @@
+defaults:
+  name: rust-driver
+
+backends:
+  - benchmark-name: insert
+    build-command: cargo build -p benchmark --bin insert_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh insert_benchmark
+
+  - benchmark-name: concurrent_insert
+    build-command: cargo build -p benchmark --bin concurrent_insert_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh concurrent_insert_benchmark
+
+  - benchmark-name: select
+    build-command: cargo build -p benchmark --bin select_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh select_benchmark
+
+  - benchmark-name: concurrent_select
+    build-command: cargo build -p benchmark --bin concurrent_select_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh concurrent_select_benchmark
+
+  - benchmark-name: batch
+    build-command: cargo build -p benchmark --bin batch_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh batch_benchmark
+
+  - benchmark-name: paging
+    build-command: cargo build -p benchmark --bin paging_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh paging_benchmark
+
+  - benchmark-name: concurrent_paging
+    build-command: cargo build -p benchmark --bin concurrent_paging_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh concurrent_paging_benchmark
+
+  - benchmark-name: large_select
+    build-command: cargo build -p benchmark --bin large_select_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh large_select_benchmark
+
+  - benchmark-name: deser
+    build-command: cargo build -p benchmark --bin deser_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh deser_benchmark
+
+  - benchmark-name: concurrent_deser
+    build-command: cargo build -p benchmark --bin concurrent_deser_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh concurrent_deser_benchmark
+
+  - benchmark-name: ser
+    build-command: cargo build -p benchmark --bin ser_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh ser_benchmark
+
+  - benchmark-name: concurrent_ser
+    build-command: cargo build -p benchmark --bin concurrent_ser_benchmark -r
+    run-command: ./benchmarks/run-rust-benchmark.sh concurrent_ser_benchmark

--- a/benchmarks/run-rust-benchmark.sh
+++ b/benchmarks/run-rust-benchmark.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Wrapper on the command for the drivers benchmark runner
+# Usage: run-rust-benchmark.sh <binary-name> <N>
+set -euo pipefail
+
+BINARY="$1"
+N="$2"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+CNT="$N" "$REPO_ROOT/target/release/$BINARY"

--- a/benchmarks/src/batch.rs
+++ b/benchmarks/src/batch.rs
@@ -1,0 +1,52 @@
+use scylla::statement::batch::{Batch, BatchStatement};
+use std::cmp::min;
+use uuid::Uuid;
+
+use crate::common::SIMPLE_INSERT_QUERY;
+
+mod common;
+
+// Empirically determined max batch size, that doesn't cause database error.
+const STEP: i32 = 3971;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_simple_table_caching().await?;
+
+    let insert_query = SIMPLE_INSERT_QUERY;
+
+    for i in 0..((n + STEP - 1) / STEP) {
+        let c_len = min(n - (i * STEP), STEP);
+        let insert_vec = vec![
+            BatchStatement::Query(insert_query.into());
+            // Always using small enough values so it doesn't overflow.
+            c_len.try_into().unwrap()
+        ];
+
+        let statement: Batch =
+            Batch::new_with_statements(scylla::statement::batch::BatchType::Logged, insert_vec);
+
+        let mut params_vec = vec![];
+        for _ in 0..c_len {
+            params_vec.push((Uuid::new_v4(), 1));
+        }
+        session.batch(&statement, params_vec).await?;
+    }
+
+    let select_query = "SELECT COUNT(1) FROM benchmarks.basic USING TIMEOUT 120s;";
+
+    assert!(
+        session
+            .get_session()
+            .query_unpaged(select_query, &[])
+            .await?
+            .into_rows_result()?
+            .first_row::<(i64,)>()?
+            .0
+            == n.into()
+    );
+
+    Ok(())
+}

--- a/benchmarks/src/common.rs
+++ b/benchmarks/src/common.rs
@@ -1,0 +1,138 @@
+use std::{
+    env,
+    net::{IpAddr, Ipv4Addr},
+    str::FromStr,
+};
+
+use chrono::Local;
+use scylla::{
+    DeserializeValue, SerializeValue,
+    client::{caching_session::CachingSession, session::Session, session_builder::SessionBuilder},
+    value::{CqlDuration, CqlTimeuuid},
+};
+use uuid::Uuid;
+
+const DEFAULT_CACHE_SIZE: u32 = 512;
+
+#[allow(unused)]
+pub(crate) const SIMPLE_INSERT_QUERY: &str = "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
+#[allow(unused)]
+pub(crate) const DESER_INSERT_QUERY: &str = "INSERT INTO benchmarks.basic (id, val, tuuid, ip, date, time, tuple, udt, set1, duration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+async fn init_common(schema: &str) -> Result<Session, Box<dyn std::error::Error>> {
+    let uri: String = env::var("SCYLLA_URI").unwrap_or_else(|_| "172.42.0.2:9042".to_string());
+
+    let session = SessionBuilder::new().known_node(uri).build().await?;
+
+    session
+    .query_unpaged(
+        "CREATE KEYSPACE IF NOT EXISTS benchmarks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1' }", 
+        &[],
+    )
+    .await?;
+
+    session
+        .query_unpaged("DROP TABLE IF EXISTS benchmarks.basic", &[])
+        .await?;
+
+    session.query_unpaged(schema, &[]).await?;
+    Ok(session)
+}
+
+// This may be imported by binaries that use only one of the helpers
+#[allow(dead_code)]
+pub(crate) async fn init_simple_table_caching() -> Result<CachingSession, Box<dyn std::error::Error>>
+{
+    Ok(CachingSession::from(
+        init_common("CREATE TABLE benchmarks.basic (id uuid, val int, PRIMARY KEY(id))").await?,
+        DEFAULT_CACHE_SIZE as usize,
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) async fn init_simple_table() -> Result<Session, Box<dyn std::error::Error>> {
+    init_common("CREATE TABLE benchmarks.basic (id uuid, val int, PRIMARY KEY(id))").await
+}
+
+// This may be imported by binaries that use only one of the helpers
+#[allow(dead_code)]
+pub(crate) async fn init_deser_table() -> Result<Session, Box<dyn std::error::Error>> {
+    let session =
+        init_common("CREATE TYPE IF NOT EXISTS benchmarks.udt1 (field1 text, field2 int)").await;
+    if let Ok(s) = &session {
+        s.query_unpaged("CREATE TABLE benchmarks.basic (id uuid, val int, tuuid timeuuid, ip inet, date date, time time, tuple frozen<tuple<text, int>>, udt frozen<udt1>, set1 set<int>, duration duration, PRIMARY KEY(id))", &[]).await?;
+    }
+
+    session
+}
+
+#[derive(Debug, DeserializeValue, SerializeValue)]
+pub(crate) struct Udt1 {
+    field1: String,
+    field2: i32,
+}
+
+type DeserTuple = (
+    Uuid,
+    i32,
+    CqlTimeuuid,
+    IpAddr,
+    chrono::NaiveDate,
+    chrono::NaiveTime,
+    (&'static str, i32),
+    Udt1,
+    Vec<i32>,
+    CqlDuration,
+);
+
+// This may be imported by binaries that use only one of the helpers
+#[allow(dead_code)]
+pub(crate) fn get_deser_data() -> DeserTuple {
+    let id = Uuid::new_v4();
+    let tuuid = CqlTimeuuid::from_str("8e14e760-7fa8-11eb-bc66-000000000001").unwrap();
+    let ip: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
+    let now = Local::now();
+    let date = now.date_naive();
+    let time = now.time();
+    let tuple = (
+        "Litwo! Ojczyzno moja! ty jesteś jak zdrowie: Ile cię trzeba cenić, ten tylko się dowie, Kto cię stracił. Dziś piękność twą w całej ozdobie Widzę i opisuję, bo tęsknię po tobie.",
+        1,
+    );
+    let udt = Udt1{ field1: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis congue egestas sapien id maximus eget.".to_owned(), field2: 4321 };
+    let set = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11];
+    let duration = CqlDuration {
+        months: 1,
+        days: 2,
+        nanoseconds: 3,
+    };
+    (id, 100, tuuid, ip, date, time, tuple, udt, set, duration)
+}
+
+// This may be imported by binaries that use only one of the helpers
+#[allow(dead_code)]
+pub(crate) fn get_cnt() -> i32 {
+    env::var("CNT")
+        .ok()
+        .and_then(|s: String| s.parse::<i32>().ok())
+        .expect("CNT parameter is required.")
+}
+
+// This may be imported by binaries that use only one of the helpers
+#[allow(dead_code)]
+pub(crate) async fn check_row_cnt(
+    session: &Session,
+    n: i32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let select_query = "SELECT COUNT(1) FROM benchmarks.basic USING TIMEOUT 120s;";
+
+    assert_eq!(
+        session
+            .query_unpaged(select_query, &[])
+            .await?
+            .into_rows_result()?
+            .first_row::<(i64,)>()?
+            .0,
+        n.into()
+    );
+    Ok(())
+}

--- a/benchmarks/src/concurrent_deser.rs
+++ b/benchmarks/src/concurrent_deser.rs
@@ -1,0 +1,101 @@
+use futures::future::join_all;
+use scylla::client::session::Session;
+use scylla::statement::prepared::PreparedStatement;
+use scylla::value::Row;
+use std::sync::Arc;
+
+use crate::common::DESER_INSERT_QUERY;
+
+mod common;
+
+const CONCURRENCY: usize = 100;
+
+async fn insert_data(
+    session: Arc<Session>,
+    start_index: usize,
+    n: i32,
+    insert_query: &PreparedStatement,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut index = start_index;
+
+    while index < n as usize {
+        session
+            .execute_unpaged(insert_query, common::get_deser_data())
+            .await?;
+        index += CONCURRENCY;
+    }
+
+    Ok(())
+}
+
+async fn select_data(
+    session: Arc<Session>,
+    start_index: usize,
+    n: i32,
+    select_query: &PreparedStatement,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut index = start_index;
+
+    while index < n as usize {
+        let r = session
+            .execute_unpaged(select_query, &[])
+            .await?
+            .into_rows_result()?
+            .rows::<Row>()?
+            .collect::<Vec<_>>();
+        assert_eq!(r.len() as i32, n);
+        index += CONCURRENCY;
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_deser_table().await?;
+
+    let insert_query = session.prepare(DESER_INSERT_QUERY).await?;
+
+    let mut handles = vec![];
+    let session = Arc::new(session);
+
+    for i in 0..CONCURRENCY {
+        let session_clone = Arc::clone(&session);
+        let insert_query_clone = insert_query.clone();
+        handles.push(tokio::spawn(async move {
+            insert_data(session_clone, i, n, &insert_query_clone)
+                .await
+                .unwrap();
+        }));
+    }
+
+    let results = join_all(handles).await;
+
+    for result in results {
+        result.unwrap();
+    }
+
+    let select_query = session.prepare("SELECT * FROM benchmarks.basic").await?;
+
+    let mut handles = vec![];
+
+    for i in 0..CONCURRENCY {
+        let session_clone = Arc::clone(&session);
+        let select_query_clone = select_query.clone();
+        handles.push(tokio::spawn(async move {
+            select_data(session_clone, i, n, &select_query_clone)
+                .await
+                .unwrap();
+        }));
+    }
+
+    let results = join_all(handles).await;
+
+    for result in results {
+        result.unwrap();
+    }
+
+    Ok(())
+}

--- a/benchmarks/src/concurrent_insert.rs
+++ b/benchmarks/src/concurrent_insert.rs
@@ -1,0 +1,59 @@
+use futures::future::join_all;
+use scylla::client::session::Session;
+use scylla::statement::prepared::PreparedStatement;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::common::SIMPLE_INSERT_QUERY;
+
+mod common;
+
+const CONCURRENCY: usize = 100;
+
+async fn insert_data(
+    session: Arc<Session>,
+    start_index: usize,
+    n: i32,
+    insert_query: &PreparedStatement,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut index = start_index;
+
+    while index < n as usize {
+        let id = Uuid::new_v4();
+        session.execute_unpaged(insert_query, (id, 100)).await?;
+        index += CONCURRENCY;
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_simple_table().await?;
+
+    let insert_query = session.prepare(SIMPLE_INSERT_QUERY).await?;
+
+    let mut handles = vec![];
+    let session = Arc::new(session);
+
+    for i in 0..CONCURRENCY {
+        let session_clone = Arc::clone(&session);
+        let insert_query_clone = insert_query.clone();
+        handles.push(tokio::spawn(async move {
+            insert_data(session_clone, i, n, &insert_query_clone)
+                .await
+                .unwrap();
+        }));
+    }
+
+    let results = join_all(handles).await;
+    for result in results {
+        result.unwrap();
+    }
+
+    common::check_row_cnt(&session, n).await?;
+
+    Ok(())
+}

--- a/benchmarks/src/concurrent_paging.rs
+++ b/benchmarks/src/concurrent_paging.rs
@@ -1,0 +1,71 @@
+use scylla::{response::PagingState, statement::Statement};
+use std::{env, ops::ControlFlow, sync::Arc};
+use uuid::Uuid;
+
+use crate::common::SIMPLE_INSERT_QUERY;
+
+mod common;
+
+const CONCURRENCY_LEVEL: usize = 20;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = env::var("CNT")
+        .ok()
+        .and_then(|s: String| s.parse::<i32>().ok())
+        .expect("CNT parameter is required.");
+
+    let session = Arc::new(common::init_simple_table_caching().await?);
+
+    let insert_query = SIMPLE_INSERT_QUERY;
+    for _ in 0..50 {
+        let statement: Statement = insert_query.into();
+        let prepared = session.add_prepared_statement(&statement).await?;
+
+        let id = Uuid::new_v4();
+        session
+            .get_session()
+            .execute_unpaged(&prepared, (id, 10))
+            .await?;
+    }
+    let mut tasks = vec![];
+    for _ in 0..(CONCURRENCY_LEVEL) {
+        let session = session.clone();
+        tasks.push(tokio::task::spawn(async move {
+            let mut select_query = Statement::new("SELECT * FROM benchmarks.basic");
+            select_query.set_page_size(1);
+            let prepared = session.add_prepared_statement(&select_query).await.unwrap();
+
+            for _ in 0..n {
+                let mut state = PagingState::start();
+
+                let mut sm = 0;
+                loop {
+                    let (res, next) = session
+                        .get_session()
+                        .execute_single_page(&prepared, &[], state)
+                        .await
+                        .unwrap();
+                    res.into_rows_result()
+                        .unwrap()
+                        .rows::<(Uuid, i32)>()
+                        .unwrap()
+                        .for_each(|r| {
+                            sm += r.unwrap().1;
+                        });
+                    if let ControlFlow::Continue(ps) = next.into_paging_control_flow() {
+                        state = ps;
+                    } else {
+                        break;
+                    }
+                }
+                assert_eq!(sm, 500);
+            }
+        }));
+    }
+
+    for t in tasks {
+        t.await?;
+    }
+
+    Ok(())
+}

--- a/benchmarks/src/concurrent_select.rs
+++ b/benchmarks/src/concurrent_select.rs
@@ -1,0 +1,69 @@
+use futures::future::join_all;
+use scylla::client::session::Session;
+use scylla::statement::prepared::PreparedStatement;
+use scylla::value::Row;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::common::SIMPLE_INSERT_QUERY;
+
+mod common;
+
+const CONCURRENCY: usize = 100;
+
+async fn select_data(
+    session: Arc<Session>,
+    start_index: usize,
+    n: i32,
+    select_query: &PreparedStatement,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut index = start_index;
+
+    while index < n as usize {
+        let r = session
+            .execute_unpaged(select_query, &[])
+            .await?
+            .into_rows_result()?
+            .rows::<Row>()?
+            .collect::<Vec<_>>();
+        assert_eq!(r.len() as i32, 10);
+        index += CONCURRENCY;
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_simple_table().await?;
+
+    let insert_query = SIMPLE_INSERT_QUERY;
+    for _ in 0..10 {
+        let id = Uuid::new_v4();
+        session.query_unpaged(insert_query, (id, 100)).await?;
+    }
+
+    let select_query = session.prepare("SELECT * FROM benchmarks.basic").await?;
+
+    let mut handles = vec![];
+    let session = Arc::new(session);
+
+    for i in 0..CONCURRENCY {
+        let session_clone = Arc::clone(&session);
+        let select_query_clone = select_query.clone();
+        handles.push(tokio::spawn(async move {
+            select_data(session_clone, i, n, &select_query_clone)
+                .await
+                .unwrap();
+        }));
+    }
+
+    let results = join_all(handles).await;
+    for result in results {
+        result.unwrap();
+    }
+
+    Ok(())
+}

--- a/benchmarks/src/concurrent_ser.rs
+++ b/benchmarks/src/concurrent_ser.rs
@@ -1,0 +1,60 @@
+use futures::future::join_all;
+use scylla::client::session::Session;
+use scylla::statement::prepared::PreparedStatement;
+use std::sync::Arc;
+
+use crate::common::DESER_INSERT_QUERY;
+
+mod common;
+
+const CONCURRENCY: usize = 100;
+
+async fn insert_data(
+    session: Arc<Session>,
+    start_index: usize,
+    n: i32,
+    insert_query: &PreparedStatement,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut index = start_index;
+
+    while index < n as usize {
+        session
+            .execute_unpaged(insert_query, common::get_deser_data())
+            .await?;
+        index += CONCURRENCY;
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_deser_table().await?;
+
+    let insert_query = session.prepare(DESER_INSERT_QUERY).await?;
+
+    let mut handles = vec![];
+    let session = Arc::new(session);
+
+    for i in 0..CONCURRENCY {
+        let session_clone = Arc::clone(&session);
+        let insert_query_clone = insert_query.clone();
+        handles.push(tokio::spawn(async move {
+            insert_data(session_clone, i, n * n, &insert_query_clone)
+                .await
+                .unwrap();
+        }));
+    }
+
+    let results = join_all(handles).await;
+
+    for result in results {
+        result.unwrap();
+    }
+
+    common::check_row_cnt(&session, n * n).await?;
+
+    Ok(())
+}

--- a/benchmarks/src/deser.rs
+++ b/benchmarks/src/deser.rs
@@ -1,0 +1,41 @@
+use scylla::{client::caching_session::CachingSession, statement::Statement, value::Row};
+
+use crate::common::DESER_INSERT_QUERY;
+
+mod common;
+
+const DEFAULT_CACHE_SIZE: u32 = 512;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_deser_table().await?;
+
+    let session: CachingSession = CachingSession::from(session, DEFAULT_CACHE_SIZE as usize);
+
+    let insert_query = DESER_INSERT_QUERY;
+
+    for _ in 0..n {
+        let statement: Statement = insert_query.into();
+        let prepared = session.add_prepared_statement(&statement).await?;
+
+        session
+            .get_session()
+            .execute_unpaged(&prepared, common::get_deser_data())
+            .await?;
+    }
+
+    let select_query = "SELECT * FROM benchmarks.basic";
+    for _ in 0..n {
+        let r = session
+            .execute_unpaged(select_query, &[])
+            .await?
+            .into_rows_result()?
+            .rows::<Row>()?
+            .collect::<Vec<_>>();
+        assert_eq!(r.len() as i32, n);
+    }
+
+    Ok(())
+}

--- a/benchmarks/src/insert.rs
+++ b/benchmarks/src/insert.rs
@@ -1,0 +1,30 @@
+use scylla::statement::Statement;
+use uuid::Uuid;
+
+use crate::common::SIMPLE_INSERT_QUERY;
+
+mod common;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_simple_table_caching().await?;
+
+    let insert_query = SIMPLE_INSERT_QUERY;
+
+    for _ in 0..n {
+        let statement: Statement = insert_query.into();
+        let prepared = session.add_prepared_statement(&statement).await?;
+
+        let id = Uuid::new_v4();
+        session
+            .get_session()
+            .execute_unpaged(&prepared, (id, 100))
+            .await?;
+    }
+
+    common::check_row_cnt(session.get_session(), n).await?;
+
+    Ok(())
+}

--- a/benchmarks/src/large_select.rs
+++ b/benchmarks/src/large_select.rs
@@ -1,0 +1,9 @@
+use crate::parametrized_select::parametrized_select_benchmark;
+
+mod common;
+mod parametrized_select;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    parametrized_select_benchmark(5000).await
+}

--- a/benchmarks/src/paging.rs
+++ b/benchmarks/src/paging.rs
@@ -1,0 +1,53 @@
+use scylla::{response::PagingState, statement::Statement};
+use std::ops::ControlFlow;
+use uuid::Uuid;
+
+mod common;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_simple_table_caching().await?;
+
+    let insert_query = "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
+    for _ in 0..50 {
+        let statement: Statement = insert_query.into();
+        let prepared = session.add_prepared_statement(&statement).await?;
+
+        let id = Uuid::new_v4();
+        session
+            .get_session()
+            .execute_unpaged(&prepared, (id, 10))
+            .await?;
+    }
+
+    let mut select_query = Statement::new("SELECT * FROM benchmarks.basic");
+    select_query.set_page_size(1);
+    let prepared = session.add_prepared_statement(&select_query).await?;
+
+    for _ in 0..n {
+        let mut state = PagingState::start();
+
+        let mut sm = 0;
+        loop {
+            let (res, next) = session
+                .get_session()
+                .execute_single_page(&prepared, &[], state)
+                .await?;
+            res.into_rows_result()?
+                .rows::<(Uuid, i32)>()?
+                .for_each(|r| {
+                    sm += r.unwrap().1;
+                });
+            if let ControlFlow::Continue(ps) = next.into_paging_control_flow() {
+                state = ps;
+            } else {
+                break;
+            }
+        }
+        assert_eq!(sm, 500);
+    }
+
+    Ok(())
+}

--- a/benchmarks/src/parametrized_select.rs
+++ b/benchmarks/src/parametrized_select.rs
@@ -1,0 +1,38 @@
+use scylla::{statement::Statement, value::Row};
+use uuid::Uuid;
+
+use crate::common::{self, SIMPLE_INSERT_QUERY};
+
+pub async fn parametrized_select_benchmark(
+    num_of_rows: i32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_simple_table_caching().await?;
+
+    let insert_query = SIMPLE_INSERT_QUERY;
+    for _ in 0..num_of_rows {
+        let statement: Statement = insert_query.into();
+        let prepared = session.add_prepared_statement(&statement).await?;
+
+        let id = Uuid::new_v4();
+        session
+            .get_session()
+            .execute_unpaged(&prepared, (id, 100))
+            .await?;
+    }
+
+    let select_query = "SELECT * FROM benchmarks.basic";
+    for _ in 0..n {
+        let s = Statement::new(select_query).with_page_size(num_of_rows);
+        let r = session
+            .execute_unpaged(s, &[])
+            .await?
+            .into_rows_result()?
+            .rows::<Row>()?
+            .collect::<Vec<_>>();
+        assert_eq!(r.len() as i32, num_of_rows);
+    }
+
+    Ok(())
+}

--- a/benchmarks/src/select.rs
+++ b/benchmarks/src/select.rs
@@ -1,0 +1,9 @@
+use crate::parametrized_select::parametrized_select_benchmark;
+
+mod common;
+mod parametrized_select;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    parametrized_select_benchmark(10).await
+}

--- a/benchmarks/src/ser.rs
+++ b/benchmarks/src/ser.rs
@@ -1,0 +1,31 @@
+use scylla::{client::caching_session::CachingSession, statement::Statement};
+
+use crate::common::DESER_INSERT_QUERY;
+
+mod common;
+
+const DEFAULT_CACHE_SIZE: u32 = 512;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: i32 = common::get_cnt();
+
+    let session = common::init_deser_table().await?;
+
+    let session: CachingSession = CachingSession::from(session, DEFAULT_CACHE_SIZE as usize);
+
+    let insert_query = DESER_INSERT_QUERY;
+
+    for _ in 0..n * n {
+        let statement: Statement = insert_query.into();
+        let prepared = session.add_prepared_statement(&statement).await?;
+
+        session
+            .get_session()
+            .execute_unpaged(&prepared, common::get_deser_data())
+            .await?;
+    }
+
+    common::check_row_cnt(session.get_session(), n * n).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

When creating nodejs-rs driver, we have created a set of throughput benchmarks that we have used to compare the performance of the nodejs-rs driver with the node.js cassandra-driver and the scylla rust driver. This meant that we had some benchmark code for rust driver inside nodejs driver repository.

With two other wrappers creating benchmarks*, that are heavily based on the benchmarks from nodejs ZPP, we have decided with @wprzytula to move the code for the rust part of the benchmarks to the rust driver repository, so that it can be used by all three wrappers and maintained in one place.

This PR also adds a configuration for the [drivers benchmarker](https://github.com/scylladb-drivers-benchmarker/scylladb-drivers-benchmarker/tree/v0.1.0) tool, which can be used to collect and plot the results of the benchmark runs. 


* C# driver: https://github.com/scylladb-zpp-2025-csharp-rs-driver/csharp-driver/pull/100
* Python driver: https://github.com/scylladb-zpp-2025-python-rs-driver/python-rs-driver/pull/55

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
