### PR TITLE
Add proxy-based test for DowngradingConsistencyRetryPolicy

### DIFF
--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -11,6 +11,8 @@ use crate::{
     TargetShard,
     frame::{FrameOpcode, FrameParams, RequestFrame, RequestOpcode, ResponseFrame, ResponseOpcode},
 };
+use scylla_cql::Consistency;
+use scylla_cql::frame::protocol_features::ProtocolFeatures;
 use scylla_cql::frame::response::error::DbError;
 
 /// Specifies when an associated [Reaction] will be performed.
@@ -51,6 +53,13 @@ pub enum Condition {
 
     /// True if any REGISTER was sent on this connection. Useful to filter out control connection messages.
     ConnectionRegisteredAnyEvent,
+
+    /// True iff the request frame has the given consistency level.
+    /// Only applicable to request frames (Query, Execute, Batch).
+    /// Returns false for response frames or requests that cannot be deserialized.
+    /// The provided [ProtocolFeatures] must match the features negotiated between
+    /// the driver and the server for correct deserialization of the frame.
+    RequestConsistency(Consistency, ProtocolFeatures),
 }
 
 /// The context in which [`Conditions`](Condition) are evaluated.
@@ -115,6 +124,26 @@ impl Condition {
             }
 
             Condition::ConnectionRegisteredAnyEvent => ctx.connection_has_events,
+
+            Condition::RequestConsistency(expected_cl, features) => match ctx.opcode {
+                FrameOpcode::Request(opcode) => {
+                    let frame = RequestFrame {
+                        params: FrameParams {
+                            version: 0x04,
+                            flags: 0,
+                            stream: 0,
+                        },
+                        opcode,
+                        body: ctx.frame_body.clone(),
+                    };
+                    frame
+                        .deserialize(features)
+                        .ok()
+                        .and_then(|req| req.get_consistency())
+                        == Some(*expected_cl)
+                }
+                FrameOpcode::Response(_) => false,
+            },
         }
     }
 

--- a/scylla/tests/integration/session/retries.rs
+++ b/scylla/tests/integration/session/retries.rs
@@ -1,14 +1,21 @@
-use crate::utils::{PerformDDL, setup_tracing, test_with_3_node_cluster, unique_keyspace_name};
+use crate::utils::{
+    PerformDDL, fetch_negotiated_features, setup_tracing, test_with_3_node_cluster,
+    unique_keyspace_name,
+};
+use assert_matches::assert_matches;
 use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::policies::retry::FallthroughRetryPolicy;
+use scylla::errors::{DbError, ExecutionError, RequestAttemptError};
+use scylla::policies::retry::{DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy};
 use scylla::policies::speculative_execution::SimpleSpeculativeExecutionPolicy;
 use scylla::statement::unprepared::Statement;
+use scylla_cql::Consistency;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc;
 use tracing::info;
 
 use scylla_proxy::{
@@ -160,6 +167,182 @@ async fn retries_occur() {
 
         running_proxy
     }).await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Tests that DowngradingConsistencyRetryPolicy retries with a lower consistency level
+/// when nodes return an Unavailable error.
+///
+/// Uses the proxy to forge Unavailable errors only for requests with CL=ALL,
+/// so the retried request (with downgraded CL) passes through to the real node.
+/// Feedback channels verify exactly which requests were sent and with what CLs.
+#[tokio::test]
+async fn downgrading_consistency_policy_downgrades_on_unavailable() {
+    setup_tracing();
+    let features = fetch_negotiated_features(None).await;
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let profile = ExecutionProfile::builder()
+                .retry_policy(Arc::new(DowngradingConsistencyRetryPolicy::new()))
+                .consistency(Consistency::All)
+                .build();
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .default_execution_profile_handle(profile.into_handle())
+                .build()
+                .await
+                .unwrap();
+
+            let ks = unique_keyspace_name();
+            session.ddl(format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
+            session.use_keyspace(&ks, false).await.unwrap();
+            session
+                .ddl("CREATE TABLE t (a int primary key)")
+                .await
+                .unwrap();
+
+            let execute_not_control = Condition::RequestOpcode(RequestOpcode::Execute)
+                .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+
+            // Cases 1 & 2: one node returns Unavailable(alive=2) for CL=ALL.
+            // The policy should downgrade CL from ALL to TWO and retry.
+            // Unavailable errors are always retried regardless of idempotency,
+            // so both cases expect the same behavior.
+            let test_unavailable_downgrade =
+                |running_proxy: &mut scylla_proxy::RunningProxy,
+                 is_idempotent: bool,
+                 value: i32| {
+                    let (error_tx, mut error_rx) = mpsc::unbounded_channel();
+                    let (pass_tx, mut pass_rx) = mpsc::unbounded_channel();
+
+                    let unavailable_error = DbError::Unavailable {
+                        consistency: Consistency::All,
+                        required: 3,
+                        alive: 2,
+                    };
+
+                    // Rule 1: Execute with CL=ALL → forge Unavailable, capture in error_tx
+                    // Rule 2: Execute (any other CL) → pass through, capture in pass_tx
+                    for node in running_proxy.running_nodes.iter_mut() {
+                        node.change_request_rules(Some(vec![
+                            RequestRule(
+                                execute_not_control
+                                    .clone()
+                                    .and(Condition::RequestConsistency(
+                                        Consistency::All,
+                                        features,
+                                    )),
+                                RequestReaction::forge_with_error(unavailable_error.clone())
+                                    .with_feedback_when_performed(error_tx.clone()),
+                            ),
+                            RequestRule(
+                                execute_not_control.clone(),
+                                RequestReaction::noop()
+                                    .with_feedback_when_performed(pass_tx.clone()),
+                            ),
+                        ]));
+                    }
+
+                    let session = &session;
+                    async move {
+                        let mut stmt = Statement::from("INSERT INTO t (a) VALUES (?)");
+                        stmt.set_is_idempotent(is_idempotent);
+                        session.query_unpaged(stmt, (value,)).await.unwrap();
+
+                        // Verify: exactly 1 request rejected (CL=ALL), exactly 1 retry passed (CL=TWO).
+                        let (rejected_frame, _) = error_rx.recv().await.unwrap();
+                        assert!(
+                            error_rx.try_recv().is_err(),
+                            "expected exactly 1 rejected request"
+                        );
+                        assert_eq!(
+                            rejected_frame
+                                .deserialize(&features)
+                                .unwrap()
+                                .get_consistency()
+                                .unwrap(),
+                            Consistency::All
+                        );
+
+                        let (passed_frame, _) = pass_rx.recv().await.unwrap();
+                        assert!(
+                            pass_rx.try_recv().is_err(),
+                            "expected exactly 1 passed request"
+                        );
+                        assert_eq!(
+                            passed_frame
+                                .deserialize(&features)
+                                .unwrap()
+                                .get_consistency()
+                                .unwrap(),
+                            Consistency::Two
+                        );
+                    }
+                };
+
+            info!("--- Case 1: idempotent query, Unavailable(alive=2) ---");
+            test_unavailable_downgrade(&mut running_proxy, true, 1).await;
+
+            info!("--- Case 2: non-idempotent query, Unavailable(alive=2) ---");
+            test_unavailable_downgrade(&mut running_proxy, false, 2).await;
+
+            // --- Case 3: Unavailable with alive=0, policy cannot downgrade ---
+            // With alive=0 and CL != EachQuorum, the policy returns DontRetry.
+            // Only 1 request should be sent, and the query should fail.
+            info!("--- Case 3: Unavailable(alive=0), no retry possible ---");
+            {
+                let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel();
+
+                let no_alive_error = DbError::Unavailable {
+                    consistency: Consistency::All,
+                    required: 3,
+                    alive: 0,
+                };
+
+                for node in running_proxy.running_nodes.iter_mut() {
+                    node.change_request_rules(Some(vec![RequestRule(
+                        execute_not_control.clone(),
+                        RequestReaction::forge_with_error(no_alive_error.clone())
+                            .with_feedback_when_performed(feedback_tx.clone()),
+                    )]));
+                }
+
+                let mut stmt = Statement::from("INSERT INTO t (a) VALUES (?)");
+                stmt.set_is_idempotent(true);
+                let err = session.query_unpaged(stmt, (3,)).await.unwrap_err();
+
+                // Verify the error propagated to the user is Unavailable.
+                assert_matches!(err, ExecutionError::LastAttemptError(RequestAttemptError::DbError(DbError::Unavailable {
+                    consistency: Consistency::All,
+                    required: 3,
+                    alive: 0,
+                }, _)));
+
+                // Verify exactly 1 request was sent (no retry).
+                let (frame, _) = feedback_rx.recv().await.unwrap();
+                assert!(feedback_rx.try_recv().is_err(), "expected exactly 1 request (no retry)");
+                assert_eq!(
+                    frame.deserialize(&features).unwrap().get_consistency().unwrap(),
+                    Consistency::All
+                );
+            }
+
+            info!("--- cleanup ---");
+            running_proxy.turn_off_rules();
+            session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+
+            running_proxy
+        },
+    )
+    .await;
 
     match res {
         Ok(()) => (),


### PR DESCRIPTION
Add a proxy-based integration test for DowngradingConsistencyRetryPolicy that verifies retry behavior on Unavailable errors, including that the consistency level is actually downgraded.

Based on https://github.com/scylladb/scylla-rust-driver/pull/1247

Refs: https://github.com/scylladb/scylla-rust-driver/issues/1271

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
