### PR TITLE
ccm: Fix `enable_password_authentication`

### DIFF
--- a/scylla/tests/integration/ccm/lib/cluster.rs
+++ b/scylla/tests/integration/ccm/lib/cluster.rs
@@ -276,7 +276,14 @@ impl Cluster {
     // Consider making it accept an enum in the future. Supported authenticators:
     // https://github.com/scylladb/scylladb/blob/529ff3efa57553eef6b0239b03b81581b70fb9ed/db/config.cc#L1045-L1051.
     pub(crate) async fn enable_password_authentication(&mut self) -> Result<(), Error> {
-        let args = [("authenticator", "PasswordAuthenticator")];
+        let args = [
+            ("authenticator", "PasswordAuthenticator"),
+            ("auth_superuser_name", "cassandra"),
+            (
+                "auth_superuser_salted_password",
+                "$6$x7IFjiX5VCpvNiFk$2IfjTvSyGL7zerpV.wbY7mJjaRCrJ/68dtT3UpT.sSmNYz1bPjtn3mH.kJKFvaZ2T4SbVeBijjmwGjcb83LlV/",
+            ),
+        ];
 
         self.updateconf(args).await
     }


### PR DESCRIPTION
Recently Scylla removed default superuser. To create it, username and password must be passed explicitly. This is what this commit does. Password hash is taken from
https://github.com/scylladb/python-driver/pull/778/changes

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] I added appropriate `Fixes:` annotations to PR description.
