### PR TITLE
scylla-cql-split, part 1: New public APIs

### DIFF
--- a/scylla-cql/src/deserialize/frame_slice.rs
+++ b/scylla-cql/src/deserialize/frame_slice.rs
@@ -82,9 +82,8 @@ impl<'frame> FrameSlice<'frame> {
     /// For correctness in an unlikely case that someone calls `to_bytes()` on such
     /// a deficient slice, a special treatment is added there that copies
     /// the slice into a new-allocation-based Bytes.
-    /// This is pub(crate) for the above reason.
     #[inline]
-    pub(crate) fn new_borrowed(frame_subslice: &'frame [u8]) -> Self {
+    pub fn new_borrowed(frame_subslice: &'frame [u8]) -> Self {
         Self {
             frame_subslice,
             original_frame: &EMPTY_BYTES,

--- a/scylla-cql/src/deserialize/frame_slice.rs
+++ b/scylla-cql/src/deserialize/frame_slice.rs
@@ -76,15 +76,16 @@ impl<'frame> FrameSlice<'frame> {
 
     /// Creates a new FrameSlice from a reference to a slice.
     ///
+    /// This should be avoided!
+    ///
     /// This method creates a not-fully-valid FrameSlice that does not hold
     /// the valid original frame Bytes. Thus, it is intended to be used in
     /// legacy code that does not operate on Bytes, but rather on borrowed slice only.
     /// For correctness in an unlikely case that someone calls `to_bytes()` on such
     /// a deficient slice, a special treatment is added there that copies
     /// the slice into a new-allocation-based Bytes.
-    /// This is pub(crate) for the above reason.
     #[inline]
-    pub(crate) fn new_borrowed(frame_subslice: &'frame [u8]) -> Self {
+    pub fn new_borrowed(frame_subslice: &'frame [u8]) -> Self {
         Self {
             frame_subslice,
             original_frame: &EMPTY_BYTES,

--- a/scylla-cql/src/deserialize/mod.rs
+++ b/scylla-cql/src/deserialize/mod.rs
@@ -104,8 +104,6 @@ impl DeserializationError {
 // - BEFORE an error is cloned (because otherwise the Arc::get_mut fails).
 macro_rules! make_error_replace_rust_name {
     ($privacy: vis, $fn_name: ident, $outer_err: ty, $inner_err: ident) => {
-        // Not part of the public API; used in derive macros.
-        #[doc(hidden)]
         #[allow(clippy::needless_pub_self)]
         $privacy fn $fn_name<RustT>(mut err: $outer_err) -> $outer_err {
             let rust_name = std::any::type_name::<RustT>();

--- a/scylla-cql/src/deserialize/mod.rs
+++ b/scylla-cql/src/deserialize/mod.rs
@@ -45,6 +45,15 @@ impl TypeCheckError {
     pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T> {
         self.0.downcast_ref()
     }
+
+    /// Try to get a mutable reference to the inner error by downcasting.
+    ///
+    /// This will only succeed if the `Arc` holding the error has no other
+    /// outstanding clones (i.e. the strong count is 1 and there are no weak
+    /// references).
+    pub fn try_downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T> {
+        Arc::get_mut(&mut self.0)?.downcast_mut()
+    }
 }
 
 /// An error indicating that a failure happened during deserialization.
@@ -77,6 +86,15 @@ impl DeserializationError {
     pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
         self.0.downcast_ref()
     }
+
+    /// Try to get a mutable reference to the inner error by downcasting.
+    ///
+    /// This will only succeed if the `Arc` holding the error has no other
+    /// outstanding clones (i.e. the strong count is 1 and there are no weak
+    /// references).
+    pub fn try_downcast_mut<T: Error + 'static>(&mut self) -> Option<&mut T> {
+        Arc::get_mut(&mut self.0)?.downcast_mut()
+    }
 }
 
 // This is a hack to enable setting the proper Rust type name in error messages,
@@ -91,21 +109,14 @@ macro_rules! make_error_replace_rust_name {
         #[allow(clippy::needless_pub_self)]
         $privacy fn $fn_name<RustT>(mut err: $outer_err) -> $outer_err {
             let rust_name = std::any::type_name::<RustT>();
-            match std::sync::Arc::get_mut(&mut err.0) {
-                Some(arc_mut) => {
-                    if let Some(err) = arc_mut.downcast_mut::<$inner_err>() {
-                        err.rust_name = rust_name;
-                    }
-                },
-                None => {
-                    if let Some(err) = err.0.downcast_ref::<$inner_err>() {
-                        if err.rust_name != rust_name {
-                            return <$outer_err>::new($inner_err {
-                                rust_name,
-                                ..err.clone()
-                            });
-                        }
-                    }
+            if let Some(inner) = err.try_downcast_mut::<$inner_err>() {
+                inner.rust_name = rust_name;
+            } else if let Some(inner) = err.downcast_ref::<$inner_err>() {
+                if inner.rust_name != rust_name {
+                    return <$outer_err>::new($inner_err {
+                        rust_name,
+                        ..inner.clone()
+                    });
                 }
             }
 

--- a/scylla-cql/src/deserialize/mod.rs
+++ b/scylla-cql/src/deserialize/mod.rs
@@ -104,8 +104,6 @@ impl DeserializationError {
 // - BEFORE an error is cloned (because otherwise the Arc::get_mut fails).
 macro_rules! make_error_replace_rust_name {
     ($(#[$attr:meta])* $privacy: vis, $fn_name: ident, $outer_err: ty, $inner_err: ident) => {
-        // Not part of the public API; used in derive macros.
-        #[doc(hidden)]
         #[allow(clippy::needless_pub_self)]
         $(#[$attr])*
         $privacy fn $fn_name<RustT>(mut err: $outer_err) -> $outer_err {

--- a/scylla-cql/src/deserialize/mod.rs
+++ b/scylla-cql/src/deserialize/mod.rs
@@ -103,10 +103,11 @@ impl DeserializationError {
 // - ONLY in proper type_check()/deserialize() implementation,
 // - BEFORE an error is cloned (because otherwise the Arc::get_mut fails).
 macro_rules! make_error_replace_rust_name {
-    ($privacy: vis, $fn_name: ident, $outer_err: ty, $inner_err: ident) => {
+    ($(#[$attr:meta])* $privacy: vis, $fn_name: ident, $outer_err: ty, $inner_err: ident) => {
         // Not part of the public API; used in derive macros.
         #[doc(hidden)]
         #[allow(clippy::needless_pub_self)]
+        $(#[$attr])*
         $privacy fn $fn_name<RustT>(mut err: $outer_err) -> $outer_err {
             let rust_name = std::any::type_name::<RustT>();
             if let Some(inner) = err.try_downcast_mut::<$inner_err>() {

--- a/scylla-cql/src/deserialize/row.rs
+++ b/scylla-cql/src/deserialize/row.rs
@@ -292,8 +292,7 @@ pub struct BuiltinTypeCheckError {
     pub kind: BuiltinTypeCheckErrorKind,
 }
 
-// Not part of the public API; used in derive macros.
-#[doc(hidden)]
+/// Creates a [`BuiltinTypeCheckError`] with the given kind.
 pub fn mk_typck_err<T>(
     cql_types: impl IntoIterator<Item = ColumnType<'static>>,
     kind: impl Into<BuiltinTypeCheckErrorKind>,
@@ -447,8 +446,7 @@ pub struct BuiltinDeserializationError {
     pub kind: BuiltinDeserializationErrorKind,
 }
 
-// Not part of the public API; used in derive macros.
-#[doc(hidden)]
+/// Creates a [`BuiltinDeserializationError`] with the given kind.
 pub fn mk_deser_err<T>(kind: impl Into<BuiltinDeserializationErrorKind>) -> DeserializationError {
     mk_deser_err_named(std::any::type_name::<T>(), kind)
 }

--- a/scylla-cql/src/deserialize/row.rs
+++ b/scylla-cql/src/deserialize/row.rs
@@ -148,6 +148,18 @@ impl<'frame, 'metadata> DeserializeRow<'frame, 'metadata> for ColumnIterator<'fr
 }
 
 make_error_replace_rust_name!(
+    /// Replaces the Rust type name in a [`BuiltinTypeCheckError`] wrapped inside
+    /// a [`TypeCheckError`] with the name of `RustT`.
+    ///
+    /// This is used to ensure that error messages report the correct Rust type name
+    /// even when the error originates from a helper/inner type used during deserialization,
+    /// rather than the top-level type being deserialized.
+    ///
+    /// # Assumptions
+    /// - This function should **only** be called inside a proper `type_check()` implementation.
+    /// - It should be called **before** the error is cloned, as it attempts to mutably access
+    ///   the inner error stored in `Arc`; if the `Arc` has already been cloned,
+    ///   a new [`BuiltinTypeCheckError`] will be allocated with the updated name instead.
     pub(self),
     _typck_error_replace_rust_name,
     TypeCheckError,
@@ -155,6 +167,18 @@ make_error_replace_rust_name!(
 );
 
 make_error_replace_rust_name!(
+    /// Replaces the Rust type name in a [`BuiltinDeserializationError`] wrapped inside
+    /// a [`DeserializationError`] with the name of `RustT`.
+    ///
+    /// This is used to ensure that error messages report the correct Rust type name
+    /// even when the error originates from a helper/inner type used during deserialization,
+    /// rather than the top-level type being deserialized.
+    ///
+    /// # Assumptions
+    /// - This function should **only** be called inside a proper `deserialize()` implementation.
+    /// - It should be called **before** the error is cloned, as it attempts to mutably access
+    ///   the inner error stored in `Arc`; if the `Arc` has already been cloned,
+    ///   a new [`BuiltinDeserializationError`] will be allocated with the updated name instead.
     pub,
     deser_error_replace_rust_name,
     DeserializationError,

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1815,8 +1815,7 @@ pub struct BuiltinTypeCheckError {
     pub kind: BuiltinTypeCheckErrorKind,
 }
 
-// Not part of the public API; used in derive macros.
-#[doc(hidden)]
+/// Creates a [`BuiltinTypeCheckError`] with the given kind.
 pub fn mk_typck_err<T>(
     cql_type: &ColumnType,
     kind: impl Into<BuiltinTypeCheckErrorKind>,
@@ -2164,8 +2163,7 @@ pub struct BuiltinDeserializationError {
     pub kind: BuiltinDeserializationErrorKind,
 }
 
-// Not part of the public API; used in derive macros.
-#[doc(hidden)]
+/// Creates a [`BuiltinDeserializationError`] with the given kind.
 pub fn mk_deser_err<T>(
     cql_type: &ColumnType,
     kind: impl Into<BuiltinDeserializationErrorKind>,

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -998,7 +998,7 @@ where
 ///
 /// It would be nice to have a rule to determine if the element type is fixed-length or not,
 /// however, we only have a heuristic. There are a few types that should, for all intents and purposes,
-/// be considered fixed-length, but are not, e.g TinyInt. See ColumnType::type_size() for the list.
+/// be considered fixed-length, but are not, e.g TinyInt. See ColumnType::type_size_for_vector() for the list.
 #[derive(Debug, Clone)]
 pub struct VectorIterator<'frame, 'metadata, T> {
     collection_type: &'metadata ColumnType<'metadata>,
@@ -1068,7 +1068,7 @@ where
             typ,
             element_type,
             *dimensions as usize,
-            element_type.type_size(),
+            element_type.type_size_for_vector(),
             v,
         ))
     }

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -730,6 +730,18 @@ where
 // collections
 
 make_error_replace_rust_name!(
+    /// Replaces the Rust type name in a [`BuiltinTypeCheckError`] wrapped inside
+    /// a [`TypeCheckError`] with the name of `RustT`.
+    ///
+    /// This is used to ensure that error messages report the correct Rust type name
+    /// even when the error originates from a helper/inner type used during deserialization,
+    /// rather than the top-level type being deserialized.
+    ///
+    /// # Assumptions
+    /// - This function should **only** be called inside a proper `type_check()` implementation.
+    /// - It should be called **before** the error is cloned, as it attempts to mutably access
+    ///   the inner error stored in `Arc`; if the `Arc` has already been cloned,
+    ///   a new [`BuiltinTypeCheckError`] will be allocated with the updated name instead.
     pub(crate),
     typck_error_replace_rust_name,
     TypeCheckError,
@@ -737,6 +749,18 @@ make_error_replace_rust_name!(
 );
 
 make_error_replace_rust_name!(
+    /// Replaces the Rust type name in a [`BuiltinDeserializationError`] wrapped inside
+    /// a [`DeserializationError`] with the name of `RustT`.
+    ///
+    /// This is used to ensure that error messages report the correct Rust type name
+    /// even when the error originates from a helper/inner type used during deserialization,
+    /// rather than the top-level type being deserialized.
+    ///
+    /// # Assumptions
+    /// - This function should **only** be called inside a proper `deserialize()` implementation.
+    /// - It should be called **before** the error is cloned, as it attempts to mutably access
+    ///   the inner error stored in `Arc`; if the `Arc` has already been cloned,
+    ///   a new [`BuiltinDeserializationError`] will be allocated with the updated name instead.
     pub,
     deser_error_replace_rust_name,
     DeserializationError,

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -473,6 +473,13 @@ pub struct ColumnSpecParseError {
     pub kind: ColumnSpecParseErrorKind,
 }
 
+impl ColumnSpecParseError {
+    /// Creates a new `ColumnSpecParseError` with the given column index and error kind.
+    pub fn new(column_index: usize, kind: ColumnSpecParseErrorKind) -> Self {
+        Self { column_index, kind }
+    }
+}
+
 /// The type of error that appeared during deserialization
 /// of a column specification.
 #[non_exhaustive]

--- a/scylla-cql/src/frame/frame_errors.rs
+++ b/scylla-cql/src/frame/frame_errors.rs
@@ -448,6 +448,13 @@ pub struct ColumnSpecParseError {
     pub kind: ColumnSpecParseErrorKind,
 }
 
+impl ColumnSpecParseError {
+    /// Creates a new `ColumnSpecParseError` with the given column index and error kind.
+    pub fn new(column_index: usize, kind: ColumnSpecParseErrorKind) -> Self {
+        Self { column_index, kind }
+    }
+}
+
 /// The type of error that appeared during deserialization
 /// of a column specification.
 #[non_exhaustive]

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -379,6 +379,16 @@ pub struct TryFromPrimitiveError<T: Copy + std::fmt::Debug> {
     primitive: T,
 }
 
+impl<T: Copy + std::fmt::Debug> TryFromPrimitiveError<T> {
+    /// Creates a new `TryFromPrimitiveError` with the given enum name and primitive value.
+    pub fn new(enum_name: &'static str, primitive: T) -> Self {
+        Self {
+            enum_name,
+            primitive,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -51,8 +51,7 @@ where
 }
 
 /// The type of a batch.
-#[derive(Clone, Copy)]
-#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BatchType {
     /// By default, all operations in the batch are performed as logged, to ensure all mutations
     /// eventually complete (or none will). See the notes on [UNLOGGED](BatchType::Unlogged) batches for more details.

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -133,12 +133,12 @@ where
         let mut n_serialized_statements = 0usize;
         let mut value_lists = self.values.batch_values_iter();
         for (idx, statement) in self.statements.iter().enumerate() {
-            BatchStatement::from(statement)
-                .serialize(buf)
-                .map_err(|err| BatchSerializationError::StatementSerialization {
+            serialize_batch_statement(&BatchStatement::from(statement), buf).map_err(|err| {
+                BatchSerializationError::StatementSerialization {
                     statement_idx: idx,
                     error: err,
-                })?;
+                }
+            })?;
 
             // Reserve two bytes for length
             let length_pos = buf.len();
@@ -224,42 +224,43 @@ where
     }
 }
 
-impl BatchStatement<'_> {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, RequestDeserializationError> {
-        let kind = buf.get_u8();
-        match kind {
-            0 => {
-                let text = Cow::Owned(types::read_long_string(buf)?.to_owned());
-                Ok(BatchStatement::Query { text })
-            }
-            1 => {
-                let id = types::read_short_bytes(buf)?.to_vec().into();
-                Ok(BatchStatement::Prepared { id })
-            }
-            _ => Err(RequestDeserializationError::UnexpectedBatchStatementKind(
-                kind,
-            )),
+fn deserialize_batch_statement(
+    buf: &mut &[u8],
+) -> Result<BatchStatement<'static>, RequestDeserializationError> {
+    let kind = buf.get_u8();
+    match kind {
+        0 => {
+            let text = Cow::Owned(types::read_long_string(buf)?.to_owned());
+            Ok(BatchStatement::Query { text })
         }
+        1 => {
+            let id = types::read_short_bytes(buf)?.to_vec().into();
+            Ok(BatchStatement::Prepared { id })
+        }
+        _ => Err(RequestDeserializationError::UnexpectedBatchStatementKind(
+            kind,
+        )),
     }
 }
 
-impl BatchStatement<'_> {
-    fn serialize(&self, buf: &mut impl BufMut) -> Result<(), BatchStatementSerializationError> {
-        match self {
-            Self::Query { text } => {
-                buf.put_u8(0);
-                types::write_long_string(text, buf)
-                    .map_err(BatchStatementSerializationError::StatementStringSerialization)?;
-            }
-            Self::Prepared { id } => {
-                buf.put_u8(1);
-                types::write_short_bytes(id, buf)
-                    .map_err(BatchStatementSerializationError::StatementIdSerialization)?;
-            }
+fn serialize_batch_statement(
+    statement: &BatchStatement<'_>,
+    buf: &mut impl BufMut,
+) -> Result<(), BatchStatementSerializationError> {
+    match statement {
+        BatchStatement::Query { text } => {
+            buf.put_u8(0);
+            types::write_long_string(text, buf)
+                .map_err(BatchStatementSerializationError::StatementStringSerialization)?;
         }
-
-        Ok(())
+        BatchStatement::Prepared { id } => {
+            buf.put_u8(1);
+            types::write_short_bytes(id, buf)
+                .map_err(BatchStatementSerializationError::StatementIdSerialization)?;
+        }
     }
+
+    Ok(())
 }
 
 impl<'s, 'b> From<&'s BatchStatement<'b>> for BatchStatement<'s> {
@@ -278,7 +279,7 @@ impl<'b> DeserializableRequest for Batch<'b, BatchStatement<'b>, Vec<SerializedV
         let statements_count: usize = types::read_short(buf)?.into();
         let statements_with_values = (0..statements_count)
             .map(|_| {
-                let batch_statement = BatchStatement::deserialize(buf)?;
+                let batch_statement = deserialize_batch_statement(buf)?;
 
                 // As stated in CQL protocol v4 specification, values names in Batch are broken and should be never used.
                 let values = SerializedValues::new_from_frame(buf)?;

--- a/scylla-cql/src/frame/request/batch.rs
+++ b/scylla-cql/src/frame/request/batch.rs
@@ -51,8 +51,7 @@ where
 }
 
 /// The type of a batch.
-#[derive(Clone, Copy)]
-#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum BatchType {
     /// By default, all operations in the batch are performed as logged, to ensure all mutations
     /// eventually complete (or none will). See the notes on [UNLOGGED](BatchType::Unlogged) batches for more details.

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -141,10 +141,7 @@ impl TryFrom<u8> for RequestOpcode {
             0x0B => Ok(Self::Register),
             0x0D => Ok(Self::Batch),
             0x0F => Ok(Self::AuthResponse),
-            _ => Err(TryFromPrimitiveError {
-                enum_name: "RequestOpcode",
-                primitive: value,
-            }),
+            _ => Err(TryFromPrimitiveError::new("RequestOpcode", value)),
         }
     }
 }

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -264,7 +264,7 @@ impl PagingStateResponse {
         matches!(*self, Self::NoMorePages)
     }
 
-    pub(crate) fn new_from_raw_bytes(raw_paging_state: Option<&[u8]>) -> Self {
+    pub fn new_from_raw_bytes(raw_paging_state: Option<&[u8]>) -> Self {
         match raw_paging_state {
             Some(raw_bytes) => Self::HasMorePages {
                 state: PagingState::new_from_raw_bytes(raw_bytes),

--- a/scylla-cql/src/frame/request/query.rs
+++ b/scylla-cql/src/frame/request/query.rs
@@ -264,7 +264,13 @@ impl PagingStateResponse {
         matches!(*self, Self::NoMorePages)
     }
 
-    pub(crate) fn new_from_raw_bytes(raw_paging_state: Option<&[u8]>) -> Self {
+    /// Creates a [PagingStateResponse] from raw paging state bytes as returned by the server.
+    ///
+    /// If `raw_paging_state` is `Some`, the response will indicate that there are more pages
+    /// to fetch, and the provided bytes will be used as the [PagingState] for resuming the query.
+    /// If `raw_paging_state` is `None`, the response will indicate that there are no more pages
+    /// to fetch.
+    pub fn new_from_raw_bytes(raw_paging_state: Option<&[u8]>) -> Self {
         match raw_paging_state {
             Some(raw_bytes) => Self::HasMorePages {
                 state: PagingState::new_from_raw_bytes(raw_bytes),

--- a/scylla-cql/src/frame/response/mod.rs
+++ b/scylla-cql/src/frame/response/mod.rs
@@ -134,10 +134,7 @@ impl TryFrom<u8> for ResponseOpcode {
             0x0C => Ok(Self::Event),
             0x0E => Ok(Self::AuthChallenge),
             0x10 => Ok(Self::AuthSuccess),
-            _ => Err(TryFromPrimitiveError {
-                enum_name: "ResponseOpcode",
-                primitive: value,
-            }),
+            _ => Err(TryFromPrimitiveError::new("ResponseOpcode", value)),
         }
     }
 }

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -167,7 +167,7 @@ impl NativeType {
     /// it is needed as the variable size types (`None`) are de/serialized
     /// differently than the fixed size types (`Some(size)`). Note that
     /// many fixed size types are treated as variable size by Cassandra.
-    pub(crate) fn type_size_for_vector(&self) -> Option<usize> {
+    pub fn type_size_for_vector(&self) -> Option<usize> {
         match self {
             NativeType::Ascii => None,
             NativeType::Boolean => Some(1),
@@ -267,7 +267,7 @@ impl ColumnType<'_> {
     }
 
     /// Returns the size of the type in bytes, as it is seen by the vector type if it is treated as fixed size.
-    pub(crate) fn type_size_for_vector(&self) -> Option<usize> {
+    pub fn type_size_for_vector(&self) -> Option<usize> {
         match self {
             ColumnType::Native(n) => n.type_size_for_vector(),
             ColumnType::Tuple(_) => None,

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -265,6 +265,19 @@ impl ColumnType<'_> {
             }
         }
     }
+
+    /// Returns the size of the type in bytes, as it is seen by the vector type if it is treated as fixed size.
+    pub(crate) fn type_size(&self) -> Option<usize> {
+        match self {
+            ColumnType::Native(n) => n.type_size(),
+            ColumnType::Tuple(_) => None,
+            ColumnType::Collection { .. } => None,
+            ColumnType::Vector { typ, dimensions } => {
+                typ.type_size().map(|size| size * usize::from(*dimensions))
+            }
+            ColumnType::UserDefinedType { .. } => None,
+        }
+    }
 }
 
 impl CollectionType<'_> {
@@ -1515,19 +1528,6 @@ mod test_utils {
                 }
                 Self::UserDefinedType { .. } => 0x0030,
                 Self::Tuple(_) => 0x0031,
-            }
-        }
-
-        /// Returns the size of the type in bytes, as it is seen by the vector type if it is treated as fixed size.
-        pub(crate) fn type_size(&self) -> Option<usize> {
-            match self {
-                ColumnType::Native(n) => n.type_size(),
-                ColumnType::Tuple(_) => None,
-                ColumnType::Collection { .. } => None,
-                ColumnType::Vector { typ, dimensions } => {
-                    typ.type_size().map(|size| size * usize::from(*dimensions))
-                }
-                ColumnType::UserDefinedType { .. } => None,
             }
         }
 

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1050,10 +1050,7 @@ fn mk_col_spec_parse_error(
     col_idx: usize,
     err: impl Into<ColumnSpecParseErrorKind>,
 ) -> ColumnSpecParseError {
-    ColumnSpecParseError {
-        column_index: col_idx,
-        kind: err.into(),
-    }
+    ColumnSpecParseError::new(col_idx, err.into())
 }
 
 fn deser_col_specs_generic<'frame, 'result>(

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -280,14 +280,14 @@ impl ColumnType<'_> {
     }
 
     /// Returns true if the type allows a special, empty value in addition to its
-    /// natural representation. For example, bigint represents a 32-bit integer,
+    /// natural representation. For example, bigint represents a 64-bit integer,
     /// but it can also hold a 0-bit empty value.
     ///
     /// It looks like Cassandra 4.1.3 rejects empty values for some more types than
     /// Scylla: date, time, smallint and tinyint. We will only check against
     /// Scylla's set of types supported for empty values as it's smaller;
     /// with Cassandra, some rejects will just have to be rejected on the db side.
-    pub(crate) fn supports_special_empty_value(&self) -> bool {
+    pub fn supports_special_empty_value(&self) -> bool {
         #[expect(clippy::match_like_matches_macro)]
         match self {
             ColumnType::Native(NativeType::Counter)

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -167,7 +167,7 @@ impl NativeType {
     /// it is needed as the variable size types (`None`) are de/serialized
     /// differently than the fixed size types (`Some(size)`). Note that
     /// many fixed size types are treated as variable size by Cassandra.
-    pub(crate) fn type_size(&self) -> Option<usize> {
+    pub(crate) fn type_size_for_vector(&self) -> Option<usize> {
         match self {
             NativeType::Ascii => None,
             NativeType::Boolean => Some(1),
@@ -267,14 +267,14 @@ impl ColumnType<'_> {
     }
 
     /// Returns the size of the type in bytes, as it is seen by the vector type if it is treated as fixed size.
-    pub(crate) fn type_size(&self) -> Option<usize> {
+    pub(crate) fn type_size_for_vector(&self) -> Option<usize> {
         match self {
-            ColumnType::Native(n) => n.type_size(),
+            ColumnType::Native(n) => n.type_size_for_vector(),
             ColumnType::Tuple(_) => None,
             ColumnType::Collection { .. } => None,
-            ColumnType::Vector { typ, dimensions } => {
-                typ.type_size().map(|size| size * usize::from(*dimensions))
-            }
+            ColumnType::Vector { typ, dimensions } => typ
+                .type_size_for_vector()
+                .map(|size| size * usize::from(*dimensions)),
             ColumnType::UserDefinedType { .. } => None,
         }
     }

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -278,6 +278,26 @@ impl ColumnType<'_> {
             ColumnType::UserDefinedType { .. } => None,
         }
     }
+
+    /// Returns true if the type allows a special, empty value in addition to its
+    /// natural representation. For example, bigint represents a 32-bit integer,
+    /// but it can also hold a 0-bit empty value.
+    ///
+    /// It looks like Cassandra 4.1.3 rejects empty values for some more types than
+    /// Scylla: date, time, smallint and tinyint. We will only check against
+    /// Scylla's set of types supported for empty values as it's smaller;
+    /// with Cassandra, some rejects will just have to be rejected on the db side.
+    pub(crate) fn supports_special_empty_value(&self) -> bool {
+        #[expect(clippy::match_like_matches_macro)]
+        match self {
+            ColumnType::Native(NativeType::Counter)
+            | ColumnType::Native(NativeType::Duration)
+            | ColumnType::Collection { .. }
+            | ColumnType::UserDefinedType { .. } => false,
+
+            _ => true,
+        }
+    }
 }
 
 impl CollectionType<'_> {
@@ -338,28 +358,6 @@ impl TableSpec<'static> {
         Self {
             ks_name: Cow::Owned(ks_name),
             table_name: Cow::Owned(table_name),
-        }
-    }
-}
-
-impl ColumnType<'_> {
-    /// Returns true if the type allows a special, empty value in addition to its
-    /// natural representation. For example, bigint represents a 32-bit integer,
-    /// but it can also hold a 0-bit empty value.
-    ///
-    /// It looks like Cassandra 4.1.3 rejects empty values for some more types than
-    /// Scylla: date, time, smallint and tinyint. We will only check against
-    /// Scylla's set of types supported for empty values as it's smaller;
-    /// with Cassandra, some rejects will just have to be rejected on the db side.
-    pub(crate) fn supports_special_empty_value(&self) -> bool {
-        #[expect(clippy::match_like_matches_macro)]
-        match self {
-            ColumnType::Native(NativeType::Counter)
-            | ColumnType::Native(NativeType::Duration)
-            | ColumnType::Collection { .. }
-            | ColumnType::UserDefinedType { .. } => false,
-
-            _ => true,
         }
     }
 }

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -74,10 +74,7 @@ impl TryFrom<u16> for Consistency {
             0x000A => Ok(Consistency::LocalOne),
             0x0008 => Ok(Consistency::Serial),
             0x0009 => Ok(Consistency::LocalSerial),
-            _ => Err(TryFromPrimitiveError {
-                enum_name: "Consistency",
-                primitive: value,
-            }),
+            _ => Err(TryFromPrimitiveError::new("Consistency", value)),
         }
     }
 }
@@ -104,10 +101,7 @@ impl TryFrom<i16> for SerialConsistency {
         match value {
             0x0008 => Ok(Self::Serial),
             0x0009 => Ok(Self::LocalSerial),
-            _ => Err(TryFromPrimitiveError {
-                enum_name: "SerialConsistency",
-                primitive: value,
-            }),
+            _ => Err(TryFromPrimitiveError::new("SerialConsistency", value)),
         }
     }
 }

--- a/scylla-cql/src/serialize/mod.rs
+++ b/scylla-cql/src/serialize/mod.rs
@@ -43,4 +43,13 @@ impl SerializationError {
     pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
         self.0.downcast_ref()
     }
+
+    /// Try to get a mutable reference to the inner error by downcasting.
+    ///
+    /// This will only succeed if the `Arc` holding the error has no other
+    /// outstanding clones (i.e. the strong count is 1 and there are no weak
+    /// references).
+    pub fn try_downcast_mut<T: Error + 'static>(&mut self) -> Option<&mut T> {
+        Arc::get_mut(&mut self.0)?.downcast_mut()
+    }
 }

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -327,7 +327,7 @@ pub struct BuiltinTypeCheckError {
     pub kind: BuiltinTypeCheckErrorKind,
 }
 
-#[doc(hidden)]
+/// Creates a [`BuiltinTypeCheckError`] with the given kind.
 pub fn mk_typck_err<T>(kind: impl Into<BuiltinTypeCheckErrorKind>) -> SerializationError {
     mk_typck_err_named(std::any::type_name::<T>(), kind)
 }
@@ -354,7 +354,8 @@ pub struct BuiltinSerializationError {
     pub kind: BuiltinSerializationErrorKind,
 }
 
-pub(crate) fn mk_ser_err<T>(kind: impl Into<BuiltinSerializationErrorKind>) -> SerializationError {
+/// Creates a [`BuiltinSerializationError`] with the given kind.
+pub fn mk_ser_err<T>(kind: impl Into<BuiltinSerializationErrorKind>) -> SerializationError {
     mk_ser_err_named(std::any::type_name::<T>(), kind)
 }
 

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -594,8 +594,7 @@ impl SerializedValues {
     }
 
     /// Creates value list from the request frame
-    /// This is used only for testing - request deserialization.
-    pub(crate) fn new_from_frame(buf: &mut &[u8]) -> Result<Self, LowLevelDeserializationError> {
+    pub fn new_from_frame(buf: &mut &[u8]) -> Result<Self, LowLevelDeserializationError> {
         let values_num = types::read_short(buf)?;
         let values_beg = *buf;
         for _ in 0..values_num {

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -9,9 +9,10 @@ use std::hash::BuildHasher;
 use std::{collections::HashMap, sync::Arc};
 
 use bytes::BufMut;
+
 use thiserror::Error;
 
-use crate::frame::request::RequestDeserializationError;
+use crate::frame::frame_errors::LowLevelDeserializationError;
 use crate::frame::response::result::ColumnType;
 use crate::frame::response::result::PreparedMetadata;
 use crate::frame::types;
@@ -594,7 +595,7 @@ impl SerializedValues {
 
     /// Creates value list from the request frame
     /// This is used only for testing - request deserialization.
-    pub(crate) fn new_from_frame(buf: &mut &[u8]) -> Result<Self, RequestDeserializationError> {
+    pub(crate) fn new_from_frame(buf: &mut &[u8]) -> Result<Self, LowLevelDeserializationError> {
         let values_num = types::read_short(buf)?;
         let values_beg = *buf;
         for _ in 0..values_num {

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -559,7 +559,8 @@ impl SerializedValues {
         self.serialized_values.len()
     }
 
-    pub(crate) fn write_to_request(&self, buf: &mut impl BufMut) {
+    /// Writes the serialized values to the request buffer, including the preceding u16 element count.
+    pub fn write_to_request(&self, buf: &mut impl BufMut) {
         buf.put_u16(self.element_count);
         buf.put(self.serialized_values.as_slice())
     }

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -559,7 +559,11 @@ impl SerializedValues {
         self.serialized_values.len()
     }
 
-    pub(crate) fn write_to_request(&self, buf: &mut impl BufMut) {
+    /// Writes the serialized values to the request buffer, including the preceding u16 element count.
+    ///
+    /// It will write a `[short]` N describing the number of elements,
+    /// and then N values, each of which is `[value]` (`[short]` and `[value]` are described by CQL protocol).
+    pub fn write_to_request(&self, buf: &mut impl BufMut) {
         buf.put_u16(self.element_count);
         buf.put(self.serialized_values.as_slice())
     }

--- a/scylla-cql/src/serialize/row.rs
+++ b/scylla-cql/src/serialize/row.rs
@@ -594,8 +594,13 @@ impl SerializedValues {
     }
 
     /// Creates value list from the request frame
-    /// This is used only for testing - request deserialization.
-    pub(crate) fn new_from_frame(buf: &mut &[u8]) -> Result<Self, LowLevelDeserializationError> {
+    ///
+    /// Passed buffer must contain `[short]` N specifying the number of values,
+    /// and then N values, each of which is a `[value]` (`[value]` and `[value]` are
+    /// described in CQL protocol).
+    /// Buffer may contain additional data, and will be advanced past all the values.
+    /// The format is, in other words: `[<n><value_1>...<value_n>]<arbitrary data>`.
+    pub fn new_from_frame(buf: &mut &[u8]) -> Result<Self, LowLevelDeserializationError> {
         let values_num = types::read_short(buf)?;
         let values_beg = *buf;
         for _ in 0..values_num {

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -1036,7 +1036,7 @@ fn serialize_vector<'t, 'b, T: SerializeValue + 't>(
         ));
     }
     let mut builder = writer.into_value_builder();
-    match element_type.type_size() {
+    match element_type.type_size_for_vector() {
         Some(_) => {
             for element in iter {
                 serialize_next_constant_length_elem(

--- a/scylla-cql/src/serialize/value.rs
+++ b/scylla-cql/src/serialize/value.rs
@@ -1130,7 +1130,8 @@ pub struct BuiltinTypeCheckError {
     pub kind: BuiltinTypeCheckErrorKind,
 }
 
-fn mk_typck_err<T: ?Sized>(
+/// Creates a [`BuiltinTypeCheckError`] with the given kind.
+pub fn mk_typck_err<T: ?Sized>(
     got: &ColumnType,
     kind: impl Into<BuiltinTypeCheckErrorKind>,
 ) -> SerializationError {
@@ -1163,7 +1164,8 @@ pub struct BuiltinSerializationError {
     pub kind: BuiltinSerializationErrorKind,
 }
 
-pub(crate) fn mk_ser_err<T: ?Sized>(
+/// Creates a [`BuiltinSerializationError`] with the given kind.
+pub fn mk_ser_err<T: ?Sized>(
     got: &ColumnType,
     kind: impl Into<BuiltinSerializationErrorKind>,
 ) -> SerializationError {


### PR DESCRIPTION
Final PR, if a reviewer wants to look into the bigger picture: https://github.com/scylladb/scylla-rust-driver/pull/1593

## Recap of the problem

We want to split scylla-cql into two crates, introducing a new crate: scylla-cql-core.
Why? scylla-cql is present in scylla public API. This means we cannot make major changes to scylla-cql without also bumping major version of scylla crate.
Unfortunately, not all of scylla-cql API is truly stable, and we need the ability to make breaking changes to it. We were bitten by this twice already, when implementing private link, and when implementing result metadata id.

The idea is to split off a new scylla-cql-core crate that contains parts of scylla-cql that really should be public. At the same time, definitions of those types in scylla-cql would become just re-exports from scylla-cql-core.
This is fine from a semver perspective.
After that, scylla-cql becomes a private dependency (public types in scylla are from scylla-cql-core), so we can introduce 2.0. Users depending on scylla-cql 1.x will keep compiling, and be able to interoperate with scylla crate, because the common parts of the API are present in
scylla-cql-core crate.
This is a bit similar to the https://github.com/dtolnay/semver-trick

## Approach

This is a big change. A lot of commits, a lot of changes, a lot of opportunities for things to go bad.
In order to be sure myself that this change is actually fine, and to allow reviewers to verify it, I plan to introduce it in parts:
- First PR (this one): Publishing some new scylla-cql APIs
- Second PR: Various internal refactors 
- Third PR: Introducing new crate and moving code.

My idea is to make it as obvious as possible that there are no breaking changes.
First PR will publish some APIs, and make other minor changes. Published APIs may be controversial, but there should be no room for a breaking change.
Second PR will move some code around, but mostly test related, and only inside scylla-cql. Its backwards compatibility should not be more difficult to judge than for any other PR.

Third PR will introduce the new crate, and move a lot of code into it. Because of first 2 PRs, it will require basically no other changes, and a diff viewer that highlights moved code differently than added / removed, should make it quite obvious that nothing is breaking there as well.
Note: I had to move much more stuff into core than I initially wanted, because they turned out to be unexpected parts of scylla public API, because of `From` impls, error types, or some niche constructors. We'll be able to fix it in 2.0. For now, the core will contain some unnecessary stuff, but I think it will be a win anyway.

## This PR

In order to split the crates we need to publish some new APIs.
Why? In many places, there is some type / module we want to move to core, but some other code in scylla-cql uses its functions / methods that are currently pub(crate).
We can either move the calling code as well, or publish the methods. Imo publishing the methods is almost always the right choice. In each commit I explained why I think its the correct choice in the given place.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1535


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
