### PR TITLE
metadata/fetching: delete address translation workaround for local nodes

### DIFF
--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -300,20 +300,8 @@ impl ControlConnection {
 
         let connect_port = local_address.port();
         let untranslated_address = SocketAddr::new(untranslated_ip_addr, connect_port);
-
-        let node_addr = match source {
-            NodeInfoSource::Local => {
-                // For the local node we should use connection's address instead of rpc_address.
-                // (The reason is that rpc_address in system.local can be wrong.)
-                // Thus, we replace address in local_rows with connection's address.
-                // We need to replace rpc_address with control connection address.
-                NodeAddr::Untranslatable(local_address)
-            }
-            NodeInfoSource::Peer => {
-                // The usual case - no translation.
-                NodeAddr::Translatable(untranslated_address)
-            }
-        };
+        // The fetched private addresses are subject to optional address translation.
+        let node_addr = NodeAddr::Translatable(untranslated_address);
 
         let tokens_str: Vec<String> = tokens.unwrap_or_default();
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -26,19 +26,22 @@ use std::{
 
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
 
-/// This enum is introduced to support address translation only upon opening a connection,
-/// as well as to cope with a bug present in older Cassandra and ScyllaDB releases.
-/// The bug involves misconfiguration of rpc_address and/or broadcast_rpc_address
-/// in system.local to 0.0.0.0. Mitigation involves replacing the faulty address
-/// with connection's address, but then that address must not be subject to `AddressTranslator`,
-/// so we carry that information using this enum. Address translation is never performed
-/// on `Untranslatable` variant.
+/// This enum is introduced to support address translation only upon opening a connection.
+///
+/// Address translation is never performed on `Untranslatable` variant, which is intended for
+/// contact points. The `Translatable` variant is used for addresses broadcast by nodes themselves.
+///
+/// Historically, this enum had another use: to cope with a bug present in older Cassandra and ScyllaDB
+/// releases: <https://github.com/scylladb/scylladb/issues/11201>. The bug involved misconfiguration
+/// of rpc_address and/or broadcast_rpc_address in system.local to 0.0.0.0. Mitigation involved
+/// replacing the faulty address with connection's address, but then that address had to not be subject
+/// to `AddressTranslator`, so we carried that information using this enum.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum NodeAddr {
     /// Fetched in Metadata with `query_peers()` (broadcast by a node itself).
     Translatable(SocketAddr),
-    /// Built from control connection's address upon `query_peers()` in order to mitigate the bug described above.
+    /// Stores contact points, because they are provided as already translated addresses.
     Untranslatable(SocketAddr),
 }
 


### PR DESCRIPTION
Fixes: #1599

This commit deletes a special case for local nodes wrt address translation. The special case was warranted by the bug described in https://github.com/scylladb/scylladb/issues/11201. As the bug was fixed in ScyllaDB 5.2 (2022), and Cassandra had fixed it even earlier, we believe it's safe to remove this workaround. Additionally, this will simplify introduction of the client routes feature support.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
