### PR TITLE
Disable tablets for SimpleStrategy test

### DIFF
--- a/scylla/tests/integration/load_balancing/simple_strategy.rs
+++ b/scylla/tests/integration/load_balancing/simple_strategy.rs
@@ -1,4 +1,6 @@
-use crate::utils::{PerformDDL as _, create_new_session_builder, unique_keyspace_name};
+use crate::utils::{
+    PerformDDL as _, create_new_session_builder, scylla_supports_tablets, unique_keyspace_name,
+};
 
 /// It's recommended to use NetworkTopologyStrategy everywhere, so most tests use only NetworkTopologyStrategy.
 /// We still support SimpleStrategy, so to make sure that SimpleStrategy works correctly this test runs
@@ -8,10 +10,16 @@ async fn simple_strategy_test() {
     let ks = unique_keyspace_name();
     let session = create_new_session_builder().build().await.unwrap();
 
+    let disable_tablets_str = if scylla_supports_tablets(&session).await {
+        " AND TABLETS = {'enabled': false}"
+    } else {
+        ""
+    };
+
     session
         .ddl(format!(
             "CREATE KEYSPACE {ks} WITH REPLICATION = \
-                {{'class': 'SimpleStrategy', 'replication_factor': 1}}"
+                {{'class': 'SimpleStrategy', 'replication_factor': 1}}{disable_tablets_str}"
         ))
         .await
         .unwrap();


### PR DESCRIPTION
Recently scylla introduced an unannounced breaking change: SimpleStrategy keyspaces can't be created without explicitly disabling tablets. We already migrated to use NTS in tests, apart from one test that verifies SimpleStrategy works. To keep this test working, we need to disable tablets for this keyspace.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
