### PR TITLE
connection, reader: Add more logging

### DIFF
--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use rand::rng;
 use rand::seq::{IndexedRandom, SliceRandom};
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::client::client_routes::ClientRoutesSubscriber;
@@ -351,6 +351,12 @@ impl MetadataReader {
 
         // If metadata fetch failed, we consider the connection broken.
         if let Err(err) = &res {
+            warn!(
+                endpoint = ?endpoint,
+                error = %err,
+                "Metadata fetch failed on node reached by endpoint"
+            );
+
             self.control_connection_state = ControlConnectionState::Broken {
                 last_error: err.clone(),
                 last_endpoint: endpoint,
@@ -471,19 +477,32 @@ impl MetadataReader {
         .await;
 
         match open_result {
-            Ok((con, recv)) => ControlConnectionState::Working(WorkingControlConnection {
-                connection: ControlConnection::new(Arc::new(con), cache, client_routes_subscriber)
+            Ok((con, recv)) => {
+                info!(
+                    "Opened control connection to endpoint {endpoint:?}, connect address {}",
+                    con.get_connect_address()
+                );
+                ControlConnectionState::Working(WorkingControlConnection {
+                    connection: ControlConnection::new(
+                        Arc::new(con),
+                        cache,
+                        client_routes_subscriber,
+                    )
                     .override_serverside_timeout(request_serverside_timeout),
-                error_channel: recv,
-                events_channel: receiver,
-                endpoint,
-            }),
-            Err(conn_err) => ControlConnectionState::Broken {
-                last_error: MetadataError::ConnectionPoolError(ConnectionPoolError::Broken {
-                    last_connection_error: conn_err,
-                }),
-                last_endpoint: endpoint,
-            },
+                    error_channel: recv,
+                    events_channel: receiver,
+                    endpoint,
+                })
+            }
+            Err(conn_err) => {
+                warn!("Failed opening control connection to endpoint {endpoint:?}: {conn_err}");
+                ControlConnectionState::Broken {
+                    last_error: MetadataError::ConnectionPoolError(ConnectionPoolError::Broken {
+                        last_connection_error: conn_err,
+                    }),
+                    last_endpoint: endpoint,
+                }
+            }
         }
     }
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -23,7 +23,7 @@ use futures::{FutureExt, future::RemoteHandle};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use super::metadata::reader::MetadataReader;
@@ -360,6 +360,7 @@ impl ClusterWorker {
                             // The first reconnect attempt will be immediate (by attempting metadata refresh below),
                             // and if it does not succeed, then `ControlConnectionState` will be set to `Broken`, so
                             // subsequent attempts will be issued every second.
+                            warn!("Got broken control connection event");
                         },
                         ControlConnectionEvent::ServerEvent(event) => {
                             debug!("Received server event: {:?}", event);

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1338,6 +1338,10 @@ impl Connection {
             ConnectionSetupRequestError::new(CqlRequestKind::Register, kind)
         };
 
+        debug!(
+            "Connection to {}: registering for events: {:?}",
+            self.connect_address, event_types_to_register_for
+        );
         let register_frame = Register {
             event_types_to_register_for,
         };

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1095,8 +1095,9 @@ impl Connection {
                 ..
             }) => {
                 debug!(
-                    "Connection::execute: Got DbError::Unprepared - repreparing statement with id {:?}",
-                    statement_id
+                    "Connection::execute: Got DbError::Unprepared - repreparing statement with id {:?}, statement string: {}",
+                    statement_id,
+                    prepared_statement.get_statement()
                 );
                 // Repreparation of a statement is needed
                 self.reprepare(prepared_statement.get_statement(), prepared_statement)
@@ -1209,8 +1210,9 @@ impl Connection {
                 ResponseWithDeserializedMetadata::Error(err) => match err.error {
                     DbError::Unprepared { statement_id } => {
                         debug!(
-                            "Connection::batch: got DbError::Unprepared - repreparing statement with id {:?}",
-                            statement_id
+                            "Connection::batch: got DbError::Unprepared - repreparing statement with id {:?}, statement strings: {:?}",
+                            statement_id,
+                            batch.debug_statements()
                         );
                         let prepared_statement = batch.statements.iter().find_map(|s| match s {
                             BatchStatement::PreparedStatement(s) if *s.get_id() == statement_id => {

--- a/scylla/src/statement/batch.rs
+++ b/scylla/src/statement/batch.rs
@@ -222,6 +222,27 @@ impl Batch {
     pub fn get_execution_profile_handle(&self) -> Option<&ExecutionProfileHandle> {
         self.config.execution_profile_handle.as_ref()
     }
+
+    /// Returns a Debug displayer for strings of statements contained in the batch.
+    pub(crate) fn debug_statements(&self) -> impl std::fmt::Debug {
+        struct DebugBatchStatements<'a>(&'a [BatchStatement]);
+        impl<'a> std::fmt::Debug for DebugBatchStatements<'a> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                fn get_statement(stmt: &BatchStatement) -> &str {
+                    match stmt {
+                        BatchStatement::Query(statement) => &statement.contents,
+                        BatchStatement::PreparedStatement(prepared_statement) => {
+                            prepared_statement.get_statement()
+                        }
+                    }
+                }
+                f.debug_list()
+                    .entries(self.0.iter().map(get_statement))
+                    .finish()
+            }
+        }
+        DebugBatchStatements(&self.statements)
+    }
 }
 
 impl Default for Batch {


### PR DESCRIPTION
When developing Client Routes feature, I missed some observability of the driver, so I added new logs and enriched existing logs.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
