### PR TITLE
Release 1.6.0

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sphinx-docs"
-version = "1.5"
+version = "1.6"
 description = "ScyllaDB Documentation"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,6 @@ from datetime import date
 from pygments.lexers.configs import TOMLLexer
 from pygments.lexers.rust import RustLexer
 from sphinx.highlighting import lexers
-
 from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 sys.path.insert(0, os.path.abspath(".."))
@@ -14,14 +13,14 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0"]
+TAGS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0", "v1.6.0"]
 BRANCHES = ["main"]
 # Set the latest version.
-LATEST_VERSION = "v1.5.0"
+LATEST_VERSION = "v1.6.0"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["main"]
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1"]
+DEPRECATED_VERSIONS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0"]
 
 # -- General configuration
 

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "1.5"
+scylla = "1.6"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.88"
 description = "CQL data types and primitives, for interacting with ScyllaDB."

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -65,7 +65,7 @@ unstable-nodejs-rs = []
 # Important: We use precise version of scylla-macros. This enables
 # us to make breaking changes in the doc(hidden) interfaces that are
 # used by macros.
-scylla-macros = { version = "=1.5.0", path = "../scylla-macros" }
+scylla-macros = { version = "=1.6.0", path = "../scylla-macros" }
 # AsyncRead trait used in read_response_frame
 tokio = { version = "1.40", features = ["io-util"] }
 # FrameSlice and other parts of public API

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.88"
 description = "proc macros for the ScyllaDB async CQL driver"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-proxy"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Proxy layer between ScyllaDB driver and cluster that enables testing ScyllaDB drivers' behaviour in unfavourable conditions"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "1.5.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.6.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.2.0"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -151,7 +151,7 @@ smallvec = "1.8.0"
 num-bigint-03 = { package = "num-bigint", version = "0.3" }
 num-bigint-04 = { package = "num-bigint", version = "0.4" }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4" }
-scylla-proxy = { version = "0.0.5", path = "../scylla-proxy" }
+scylla-proxy = { version = "0.0.6", path = "../scylla-proxy" }
 criterion = "0.6"
 tokio = { version = "1.34", features = ["test-util", "process", "fs"] }
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -84,7 +84,7 @@ unstable-client-routes = []
 ###########################
 # Main, public dependencies
 ###########################
-scylla-cql = { version = "1.5.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.6.0", path = "../scylla-cql" }
 tokio = { version = "1.40", features = [
     "net",
     "time",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Async CQL driver for Rust, optimized for ScyllaDB, fully compatible with Apache Cassandra™"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 1.6.0,
an asynchronous CQL driver for Rust, optimized for ScyllaDB, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 6.5M downloads on crates!
- over 666 GitHub stars!

## Changes

**New features / enhancements:**

- Introduced "Client Routes Routing" (with some preceding internal and testing preparations in [#1590](https://github.com/scylladb/scylla-rust-driver/pull/1590)), which is a feature allowing the use of driver in deployments with mechanisms like AWS PrivateLink ([#1582](https://github.com/scylladb/scylla-rust-driver/pull/1582)).
- Exposed more configuration options for sockets opened by the driver ([#1577](https://github.com/scylladb/scylla-rust-driver/pull/1577)).
- `durable_writes` field was added to `Keyspace` struct ([#1578](https://github.com/scylladb/scylla-rust-driver/pull/1578)).
- ⚠️ Our MSRV was bumped to 1.88 ([#1602](https://github.com/scylladb/scylla-rust-driver/pull/1602)).
- ⚠️ Removed address translation workaround, because the root cause was fixed in Scylla a long time ago ([#1606](https://github.com/scylladb/scylla-rust-driver/pull/1606)).

**Bug fixes:**

- `Session::query_iter` / `Session::execute_iter` now correctly refresh driver metadata (if enabled in session config) after a DDL statement is executed using those APIs ([#1579](https://github.com/scylladb/scylla-rust-driver/pull/1579)).
- Fixed a bug in implementation of result metadata ID extension. This bug prevented reading the results of some special statements (like `LIST ROLES of`) if they were executed as prepared statements ([#1581](https://github.com/scylladb/scylla-rust-driver/pull/1581)).


**Documentation:**

- Fixed Github links displayed on [crates.io](https://crates.io/crates/scylla) by making them absolute instead of relative ([#1572](https://github.com/scylladb/scylla-rust-driver/pull/1572)).
- Updated Scylla theme to 1.9 ([#1584](https://github.com/scylladb/scylla-rust-driver/pull/1584)) and then to 1.9.2 ([#1608](https://github.com/scylladb/scylla-rust-driver/pull/1608)).
- Fixed improper `total_connections` metric docstring ([#1586](https://github.com/scylladb/scylla-rust-driver/pull/1586)).
- Bumped sphinx-multiversion-scylla to 0.3.8 ([#1605](https://github.com/scylladb/scylla-rust-driver/pull/1605)).


**CI / developer tool improvements:**

- Add various Scylla flags to our docker-compose.yml to make tests run faster ([#1574](https://github.com/scylladb/scylla-rust-driver/pull/1574)).
- Clippy fixes ([#1576](https://github.com/scylladb/scylla-rust-driver/pull/1576)).
- Book tests are now executed along other doctests, instead of using `mdbook test` ([#1591](github.com/scylladb/scylla-rust-driver/pull/1591)).
- Our MSRV check CI pipeline no longer checks `examples/` folder ([#1594](https://github.com/scylladb/scylla-rust-driver/pull/1594)).
- Introduced a tool to print sizes of our error types ([#1597](https://github.com/scylladb/scylla-rust-driver/pull/1597)).
- Recently Scylla stopped creating a default superuser `cassandra:cassandra`, which broke our tests. Fixed that by using flags to explicitly create the superuser ([#1601](https://github.com/scylladb/scylla-rust-driver/pull/1601)).
- Small fix for a test incorrectly handling proxy finish result ([#1603](https://github.com/scylladb/scylla-rust-driver/pull/1603)).
- Added `wait_for_connection` and `inject_event_to_cc` methods to our testing proxy ([#1610](https://github.com/scylladb/scylla-rust-driver/pull/1610)).
- Explicitly disable tablets for our one SingleStrategy tests, because Scylla started to throw errors on SimpleStrategy keyspace creation with tablets ([#1611](https://github.com/scylladb/scylla-rust-driver/pull/1611)).


Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

| commits | author                 |
|---------|------------------------|
|  61     | Wojciech Przytuła      |
|  13     | Karol Baryła           |
|  4      | Hanna Marszałek        |
|  3      | Dmitry Kropachev       |
|  3      | Jakub Janowski         |
|  2      | copilot-swe-agent[bot] |  
|  2      | dependabot[bot]        |
|  1      | Dani Tweig             |
|  1      | David Garcia           |
|  1      | Dawid Pawlik           |
|  1      | Copilot                |

