### PR TITLE
Update used dependencies

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
     - name: Install mdbook
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.2
       with:
         tool: mdbook
     - name: Build the book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Setup rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install mdbook

--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   jira-sync:
-    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@main
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@45e7db1ba3b27a2ee342680a563593c5e2df692b
     with:
       caller_action: ${{ github.event.action }}
     secrets:

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup 3-node Cassandra cluster
         run: |
           docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -21,15 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup 3-node Cassandra cluster
         run: |
           docker compose -f test/cluster/cassandra/docker-compose.yml up -d --wait
         # A separate step for building to separate measuring time of compilation and testing
       - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
+        with:
+          tool: nextest
       - name: Run tests on cassandra
         run: |
           RUSTFLAGS="${RUSTFLAGS} --cfg cassandra_tests" RUST_LOG=trace cargo nextest run --all-features

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -21,14 +21,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           working-directory: docs
           enable-cache: true

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -21,13 +21,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           working-directory: docs
           enable-cache: true

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           working-directory: docs
           enable-cache: true

--- a/.github/workflows/milestone-sync.yml
+++ b/.github/workflows/milestone-sync.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   sync-manual:
     if: github.event_name == 'workflow_dispatch'
-    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@main
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@80b35e1904224052222a4f876fbe33d8a867e50e
     with:
       milestone: ${{ inputs.milestone }}
       config-path: milestone-sync/config.yaml
@@ -29,7 +29,7 @@ jobs:
 
   sync-automatic:
     if: github.event_name != 'workflow_dispatch'
-    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@main
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@80b35e1904224052222a4f876fbe33d8a867e50e
     with:
       config-path: milestone-sync/config.yaml
       github-event-name: ${{ github.event_name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-nextest
@@ -158,7 +158,7 @@ jobs:
   min_rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Rust ${{ env.rust_min }}
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -174,7 +174,7 @@ jobs:
   cargo_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Compile docs
@@ -185,7 +185,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install Rust Nightly
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: clippy, rustfmt
       - name: Print rustc version
@@ -118,11 +118,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
+        with:
+          tool: nextest
       - name: Print rustc version
         run: rustc --version
       - name: Setup 3-node ScyllaDB cluster
@@ -158,9 +160,9 @@ jobs:
   min_rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust ${{ env.rust_min }}
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: ${{ env.rust_min }}
       - name: Print Rust version
@@ -174,9 +176,9 @@ jobs:
   cargo_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: Compile docs
         run: RUSTDOCFLAGS=-Dwarnings cargo doc
 
@@ -185,12 +187,12 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust Nightly
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: nightly
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-docs-rs
       - run: cargo docs-rs -p scylla

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -43,7 +43,7 @@ jobs:
       output: ${{ steps.semver-pr-check.outputs.output }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: "2"
         ref: "refs/pull/${{ env.PR_ID }}/merge"
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 3
     steps:
     - name: Get ID of comment if posted previously.
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@v4
       id: find-comment
       with:
           issue-number: ${{ env.PR_ID }}
@@ -102,7 +102,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Report that there were no breaks
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
           issue-number: ${{ env.PR_ID }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -118,7 +118,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Post report on semver break
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
           issue-number: ${{ env.PR_ID }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -145,7 +145,7 @@ jobs:
       contents: read
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Setup rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install semver-checks

--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -43,7 +43,7 @@ jobs:
       output: ${{ steps.semver-pr-check.outputs.output }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: "2"
         ref: "refs/pull/${{ env.PR_ID }}/merge"
@@ -56,7 +56,7 @@ jobs:
     - name: Fetch PR base
       run: git fetch origin "$PR_BASE"
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
     - name: Install semver-checks
     # This is a temporary workaround because current cargo-semver-checks doesn't work with this repo,
     # and needs a fix. After the bug is fixed, we should revert to using taiki-e/install-action.
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 3
     steps:
     - name: Get ID of comment if posted previously.
-      uses: peter-evans/find-comment@v4
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: find-comment
       with:
           issue-number: ${{ env.PR_ID }}
@@ -102,7 +102,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Report that there were no breaks
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
           issue-number: ${{ env.PR_ID }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -118,7 +118,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Post report on semver break
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
           issue-number: ${{ env.PR_ID }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -145,11 +145,11 @@ jobs:
       contents: read
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
     - name: Install semver-checks
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
       with:
         tool: cargo-semver-checks
     - name: Run semver-checks to see if it agrees with version updates

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -200,6 +200,21 @@ The difference is that instead of `main` you need to use a version branch, which
 Backport the necessary changes to this branch before making version bump commits.
 Please note that in step 9 you still need to use `main`, as described in the section about documentation.
 
+### Updating workflows
+
+Note: There is no need to update workflows every release - this is used only for development purposes.
+This part should only be done if the current setup is insufficient
+(ex. there is a discovered vulnerability in current version, or there is a new feature).
+
+Currently GitHub workflows are fixed to specific commits. This is done to reduce the supply chain attack surface in this repository.
+When updating those workflows, to find the correct commit SHA for a new version, go to the action's repository on GitHub,
+navigate to the desired release tag, and copy the full commit SHA from the tag's commit page.
+
+#### Reviewer responsibility
+
+When reviewing PRs that update the dependencies used in CI,
+ensure the commit comes from the actual release of the action. To do so, open the relevant repository
+and verify that the commit hash on the release page matches the one specified in the action YAML file.
 
 ## Writing release notes
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended"
+    ],
+    "packageRules": [
+        {
+            "matchManagers": [
+                "github-actions"
+            ],
+            "pinDigests": true,
+            "minimumReleaseAge": "90 days"
+        },
+        {
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchPackageNames": [
+                "/^scylladb-actions\\//",
+                "/^scylladb\\//"
+            ],
+            "pinDigests": true,
+            "minimumReleaseAge": null
+        }
+    ]
+}


### PR DESCRIPTION

This PR pins all GH actions to specific commit versions. This is done to reduce the possibility for the supply chain atacks on this repo (see DRIVER-515)

Once this PR is merged, someone with admin permissions for this repo, would need to update the repository settings (Actions -> General -> `Allow scylladb, and select non-scylladb, actions and reusable workflows`) and provide the following allow-list and enable the following otpion: `Require actions to be pinned to a full-length commit SHA`.   

To ensure this list is complete, I've set up these settings on the fork repo, and all CI passes correctly:
https://github.com/adespawn/scylla-rust-driver/pull/1

**WARNING**: Enabling those settings would require all open PR to rebase on main to pass any CI.

```
Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4,
actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7,
actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd,
actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd,
actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444,
astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57,
peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9,
peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad,
scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@80b35e1904224052222a4f876fbe33d8a867e50e,
taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1,
taiki-e/install-action@e537394e10461340f56469a03c3e73f1705074a9,
```
Once those settings are updated, this would f​i​​x​​​ DRIVER-579. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~ (not relevant since manual action after PR merging is required to solve the issue)
