### PR TITLE
test many_connections: Decrease number of connections

### DIFF
--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1273,7 +1273,7 @@ mod tests {
     #[tokio::test]
     async fn many_connections() {
         setup_tracing();
-        let connections_number = 512;
+        let connections_number = 400;
 
         let connect_address: SocketAddr = std::env::var("SCYLLA_URI")
             .unwrap_or_else(|_| "172.42.0.2:9042".to_string())


### PR DESCRIPTION
On many systems there is a limit of 1024 file descriptors per process by default. Recently, for testing purposes, each connection get its descriptor duplicated (only in `cfg(test)`). This overflowed the limit. This commit decreases the number a bit.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1620

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
