### PR TITLE
Fix reuseaddr connection

### DIFF
--- a/scylla/src/errors.rs
+++ b/scylla/src/errors.rs
@@ -615,7 +615,9 @@ impl ConnectionError {
     pub fn is_address_unavailable_for_use(&self) -> bool {
         if let ConnectionError::IoError(io_error) = self {
             match io_error.kind() {
-                ErrorKind::AddrInUse | ErrorKind::PermissionDenied => return true,
+                ErrorKind::AddrInUse
+                | ErrorKind::PermissionDenied
+                | ErrorKind::AddrNotAvailable => return true,
                 _ => {}
             }
         }

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1292,12 +1292,7 @@ mod tests {
             open_connection_to_shard_aware_port(&endpoint, 0, sharder.clone(), &connection_config)
         });
 
-        let joined = futures::future::join_all(conns).await;
-
-        // Check that each connection managed to connect successfully
-        for res in joined {
-            res.unwrap();
-        }
+        let _joined = futures::future::try_join_all(conns).await.unwrap();
     }
 
     // Open many connections to a node

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1312,5 +1312,17 @@ mod tests {
             ..Default::default()
         })
         .await;
+
+        test_many_connections_with_config(HostConnectionConfig {
+            compression: None,
+            tcp_socket_options: TcpSocketOptions {
+                nodelay: true,
+                reuse_address: Some(true),
+                ..Default::default()
+            },
+            tls_config: None,
+            ..Default::default()
+        })
+        .await;
     }
 }

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1268,12 +1268,7 @@ mod tests {
     use crate::test_utils::setup_tracing;
     use std::net::{SocketAddr, ToSocketAddrs};
 
-    // Open many connections to a node
-    // Port collision should occur
-    // If they are not handled this test will most likely fail
-    #[tokio::test]
-    async fn many_connections() {
-        setup_tracing();
+    async fn test_many_connections_with_config(connection_config: HostConnectionConfig) {
         let connections_number = 400;
 
         let connect_address: SocketAddr = std::env::var("SCYLLA_URI")
@@ -1282,16 +1277,6 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-
-        let connection_config = HostConnectionConfig {
-            compression: None,
-            tcp_socket_options: TcpSocketOptions {
-                nodelay: true,
-                ..Default::default()
-            },
-            tls_config: None,
-            ..Default::default()
-        };
 
         // This does not have to be the real sharder,
         // the test is only about port collisions, not connecting
@@ -1313,5 +1298,24 @@ mod tests {
         for res in joined {
             res.unwrap();
         }
+    }
+
+    // Open many connections to a node
+    // Port collision should occur
+    // If they are not handled this test will most likely fail
+    #[tokio::test]
+    async fn many_connections() {
+        setup_tracing();
+
+        test_many_connections_with_config(HostConnectionConfig {
+            compression: None,
+            tcp_socket_options: TcpSocketOptions {
+                nodelay: true,
+                ..Default::default()
+            },
+            tls_config: None,
+            ..Default::default()
+        })
+        .await;
     }
 }


### PR DESCRIPTION
Based on https://github.com/scylladb/scylla-rust-driver/pull/1618
Includes https://github.com/scylladb/scylla-rust-driver/pull/1621

When using REUSEADDR, the advanced shard awareness port iteration logic breaks. This is because a different error is returned in this case, which is not recognized by `is_address_unavailable_for_use`.
This PR slightly refactors test `many_connections` to allow testing with different configs, fixes the bug, and adds a regression test.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1619

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
