### PR TITLE
connection pool: introduce refill trigger and use it upon client routes change and STATUS_CHANGE UP

### DIFF
--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -100,17 +100,23 @@ pub(crate) trait ClientRoutesSubscriber: Send + Sync {
     /// Replaces the old knowledge about client routes with a new full snapshot.
     /// The snapshot contains all entries that match any of connection ids yielded by
     /// [Self::get_connection_ids]. In particular, no filtering by host ids is done.
-    fn replace_client_routes(&self, client_routes: ClientRoutes);
+    ///
+    /// Returns the set of host IDs whose routes were added or changed
+    /// compared to the previous state (i.e., hosts that may need pool refill).
+    fn replace_client_routes(&self, client_routes: ClientRoutes) -> HashSet<Uuid>;
 
     /// Merges existing knowledge about client routes with a partial snapshot,
     /// fetched in response to a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
     /// The snapshot contains all entries that match connection ids and host ids
     /// present in the event.
+    ///
+    /// Returns the set of host IDs that were added or updated (i.e., hosts
+    /// that now have a route and may need pool refill).
     fn merge_client_routes_update(
         &self,
         event: &ClientRoutesChangeEvent,
         client_routes: ClientRoutes,
-    );
+    ) -> HashSet<Uuid>;
 }
 
 /// Translator for client routes: uses content of system.client_routes
@@ -202,8 +208,10 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
         &self.connection_ids
     }
 
-    fn replace_client_routes(&self, mut new_routes: ClientRoutes) {
+    fn replace_client_routes(&self, mut new_routes: ClientRoutes) -> HashSet<Uuid> {
         let mut guard = self.client_routes.write().unwrap();
+
+        let mut added_or_updated_host_ids: HashSet<Uuid> = HashSet::new();
 
         // Handle existing entries, i.e. ones for hosts that we already had routes to:
         // - remove dangling routes;
@@ -235,6 +243,13 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
                         }
                     };
 
+                    // Detect if the route actually changed — if so, the pool may
+                    // need an immediate refill (e.g. it could be in exponential
+                    // backoff due to a stale address).
+                    if known_host_routes.sticky_route != new_sticky_route {
+                        added_or_updated_host_ids.insert(*host_id);
+                    }
+
                     // We always replace the sticky route because it could get updated
                     // (wrt hostname or ports, for example).
                     known_host_routes.sticky_route = new_sticky_route;
@@ -255,6 +270,7 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
 
         // Add entries for hosts that weren't present in the map before.
         // Entries for previously present hosts have already been removed from the new entries map.
+        // These are newly routable hosts — their pools may need an immediate refill.
         guard.extend(
             new_routes
                 .routes
@@ -274,16 +290,19 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
                         sticky_route,
                         other_routes,
                     };
+                    added_or_updated_host_ids.insert(host_id);
                     Some((host_id, host_routes))
                 }),
         );
+
+        added_or_updated_host_ids
     }
 
     fn merge_client_routes_update(
         &self,
         event: &ClientRoutesChangeEvent,
         new_routes: ClientRoutes,
-    ) {
+    ) -> HashSet<Uuid> {
         #[deny(clippy::wildcard_enum_match_arm)]
         let (connection_ids, host_ids) = match event {
             ClientRoutesChangeEvent::UpdateNodes {
@@ -295,6 +314,7 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
         };
 
         let mut guard = self.client_routes.write().unwrap();
+        let mut added_or_updated_host_ids = HashSet::new();
 
         // Iterate over all entries listed in the event.
         // Filter only those with connection ids that the driver cares about.
@@ -337,6 +357,7 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
                 Some(new_route) => {
                     // Route specified in the event is present, which means that the event reported route creation or update.
                     // In both cases, we just insert it. Let's just handle the sticky route update separately.
+                    added_or_updated_host_ids.insert(host_id);
                     match guard.get_mut(&host_id) {
                         // There have already been routes for that host.
                         Some(host_routes) => {
@@ -363,6 +384,8 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
                 }
             }
         }
+
+        added_or_updated_host_ids
     }
 }
 
@@ -1599,5 +1622,464 @@ mod tests {
             translator.translate_address(&peer).await.unwrap(),
             localhost_addr(9099),
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for the returned HashSet<Uuid> (pool refill triggering)
+    // ---------------------------------------------------------------
+
+    // `replace_client_routes`: adding a brand-new host returns its id.
+    #[test]
+    fn replace_returns_newly_added_host() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        let returned = translator.replace_client_routes(routes);
+        assert_eq!(returned, HashSet::from([host]));
+    }
+
+    // `replace_client_routes`: when an existing host's route is unchanged,
+    // its id must NOT be in the returned set (no refill needed).
+    #[test]
+    fn replace_omits_unchanged_host() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        let route = || {
+            make_client_routes(vec![ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: Some(9142),
+            }])
+        };
+
+        // First call adds the host.
+        translator.replace_client_routes(route());
+        // Second call with identical data → no change.
+        let returned = translator.replace_client_routes(route());
+        assert!(
+            returned.is_empty(),
+            "Unchanged host should not be returned, got: {:?}",
+            returned
+        );
+    }
+
+    // `replace_client_routes`: changing the port of an existing host
+    // returns its id.
+    #[test]
+    fn replace_returns_host_with_changed_port() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+
+        let returned = translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9099),
+            tls_port: None,
+        }]));
+        assert_eq!(returned, HashSet::from([host]));
+    }
+
+    // `replace_client_routes`: changing the tls_port of an existing host
+    // returns its id.
+    #[test]
+    fn replace_returns_host_with_changed_tls_port() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: Some(9142),
+        }]));
+
+        let returned = translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: Some(9199),
+        }]));
+        assert_eq!(returned, HashSet::from([host]));
+    }
+
+    // `replace_client_routes`: changing the hostname of an existing host
+    // returns its id.
+    #[test]
+    fn replace_returns_host_with_changed_hostname() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+
+        let returned = translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.2".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+        assert_eq!(returned, HashSet::from([host]));
+    }
+
+    // `replace_client_routes`: a host removed from the snapshot (present
+    // before, absent now) must NOT be in the returned set — its pool is
+    // about to be torn down, not refilled.
+    #[test]
+    fn replace_omits_removed_host() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_a = Uuid::new_v4();
+        let host_b = Uuid::new_v4();
+        translator.replace_client_routes(make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_a,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_b,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+        ]));
+
+        // Second snapshot: only host_a remains, unchanged.
+        let returned = translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host_a,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+        assert!(
+            returned.is_empty(),
+            "Removed and unchanged hosts should not be returned, got: {:?}",
+            returned
+        );
+    }
+
+    // `replace_client_routes`: mixed scenario — one host added, one updated,
+    // one unchanged, one removed. Only added and updated appear in the result.
+    #[test]
+    fn replace_returns_correct_subset_for_mixed_changes() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_unchanged = Uuid::new_v4();
+        let host_updated = Uuid::new_v4();
+        let host_removed = Uuid::new_v4();
+        let host_added = Uuid::new_v4();
+
+        translator.replace_client_routes(make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_unchanged,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_updated,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_removed,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9044),
+                tls_port: None,
+            },
+        ]));
+
+        let returned = translator.replace_client_routes(make_client_routes(vec![
+            // unchanged
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_unchanged,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            // updated port
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_updated,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9099),
+                tls_port: None,
+            },
+            // host_removed absent
+            // newly added
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_added,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9050),
+                tls_port: None,
+            },
+        ]));
+        assert_eq!(returned, HashSet::from([host_updated, host_added]));
+    }
+
+    // `replace_client_routes`: when the sticky connection_id disappears and
+    // a different connection_id takes over, the host is reported as updated
+    // if the new route differs from the old sticky route.
+    #[test]
+    fn replace_returns_host_when_sticky_connection_id_changes() {
+        let config = make_config(vec![
+            ClientRoutesProxy::new_with_connection_id("conn-1".to_string()),
+            ClientRoutesProxy::new_with_connection_id("conn-2".to_string()),
+        ]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        // Initial: sticky route is conn-1 at port 9042.
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+
+        // Second snapshot: only conn-2 available, different port.
+        let returned = translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-2".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9099),
+            tls_port: None,
+        }]));
+        assert_eq!(returned, HashSet::from([host]));
+    }
+
+    // `merge_client_routes_update`: a new host added via event is returned.
+    #[test]
+    fn merge_returns_newly_added_host() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned()],
+            host_ids: vec![host],
+        };
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        let returned = translator.merge_client_routes_update(&event, routes);
+        assert_eq!(returned, HashSet::from([host]));
+    }
+
+    // `merge_client_routes_update`: an existing host updated via event
+    // is returned.
+    #[test]
+    fn merge_returns_updated_host() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned()],
+            host_ids: vec![host],
+        };
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9099),
+            tls_port: None,
+        }]);
+        let returned = translator.merge_client_routes_update(&event, routes);
+        assert_eq!(returned, HashSet::from([host]));
+    }
+
+    // `merge_client_routes_update`: a host deleted by the event (route
+    // absent from re-fetch) must NOT be in the returned set.
+    #[test]
+    fn merge_omits_deleted_host() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        translator.replace_client_routes(make_client_routes(vec![ClientRoute {
+            connection_id: "conn-1".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]));
+
+        // Event references the host, but re-fetch is empty → deletion.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned()],
+            host_ids: vec![host],
+        };
+        let returned = translator.merge_client_routes_update(&event, make_client_routes(vec![]));
+        assert!(
+            returned.is_empty(),
+            "Deleted host should not be returned, got: {:?}",
+            returned
+        );
+    }
+
+    // `merge_client_routes_update`: an event entry whose connection_id is
+    // not in the translator's list is ignored entirely.
+    #[test]
+    fn merge_ignores_irrelevant_connection_id() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-other".to_owned()],
+            host_ids: vec![host],
+        };
+        let routes = make_client_routes(vec![ClientRoute {
+            connection_id: "conn-other".to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(9042),
+            tls_port: None,
+        }]);
+        let returned = translator.merge_client_routes_update(&event, routes);
+        assert!(
+            returned.is_empty(),
+            "Irrelevant connection_id should be ignored, got: {:?}",
+            returned
+        );
+    }
+
+    // `merge_client_routes_update`: mixed scenario — one host added, one
+    // updated, one deleted. Only added and updated appear in the result.
+    #[test]
+    fn merge_returns_correct_subset_for_mixed_changes() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_updated = Uuid::new_v4();
+        let host_deleted = Uuid::new_v4();
+        let host_added = Uuid::new_v4();
+
+        translator.replace_client_routes(make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_updated,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9042),
+                tls_port: None,
+            },
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_deleted,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9043),
+                tls_port: None,
+            },
+        ]));
+
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec![
+                "conn-1".to_owned(),
+                "conn-1".to_owned(),
+                "conn-1".to_owned(),
+            ],
+            host_ids: vec![host_updated, host_deleted, host_added],
+        };
+        let routes = make_client_routes(vec![
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_updated,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9099),
+                tls_port: None,
+            },
+            // host_deleted absent from re-fetch
+            ClientRoute {
+                connection_id: "conn-1".to_owned(),
+                host_id: host_added,
+                hostname: "127.0.0.1".to_string(),
+                port: Some(9050),
+                tls_port: None,
+            },
+        ]);
+        let returned = translator.merge_client_routes_update(&event, routes);
+        assert_eq!(returned, HashSet::from([host_updated, host_added]));
     }
 }

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -16,7 +16,7 @@
 
 use std::borrow::BorrowMut;
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Formatter};
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
@@ -179,9 +179,12 @@ impl ControlConnection {
         (peers, client_routes, keyspaces) =
             tokio::try_join!(peers_query, client_routes_query, keyspaces_query)?;
 
-        if let Some(client_routes_subscriber) = self.client_routes_subscriber() {
-            client_routes_subscriber.replace_client_routes(client_routes);
-        }
+        let client_routes_updated_hosts =
+            if let Some(client_routes_subscriber) = self.client_routes_subscriber() {
+                client_routes_subscriber.replace_client_routes(client_routes)
+            } else {
+                HashSet::new()
+            };
 
         // There must be at least one peer
         if peers.is_empty() {
@@ -193,7 +196,11 @@ impl ControlConnection {
             return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists));
         }
 
-        Ok(Metadata { peers, keyspaces })
+        Ok(Metadata {
+            peers,
+            keyspaces,
+            client_routes_updated_hosts,
+        })
     }
 }
 

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -24,7 +24,7 @@ use crate::cluster::node::{NodeAddr, ResolvedContactPoint};
 use crate::routing::Token;
 
 use scylla_cql::frame::response::result::ColumnSpec;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
@@ -54,6 +54,11 @@ pub(crate) enum SingleKeyspaceMetadataError {
 pub(crate) struct Metadata {
     pub(crate) peers: Vec<Peer>,
     pub(crate) keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>,
+
+    /// Host IDs whose client routes were added or updated during this metadata fetch.
+    /// Used to trigger immediate pool refills for nodes that may have been in backoff
+    /// due to `TranslationError::NoRuleForHost`.
+    pub(crate) client_routes_updated_hosts: HashSet<Uuid>,
 }
 
 /// Represents a node in the cluster, as fetched from the `system.{peers,local}` tables.
@@ -279,7 +284,7 @@ pub enum Strategy {
 }
 
 /// Represents an entry of `system.client_routes` table, in a more refined form (port as u16).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ClientRoute {
     pub(crate) connection_id: String,
     pub(crate) host_id: Uuid,
@@ -342,6 +347,7 @@ impl Metadata {
         Metadata {
             peers,
             keyspaces: HashMap::new(),
+            client_routes_updated_hosts: HashSet::new(),
         }
     }
 }

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -13,6 +13,7 @@
 //! - Host filtering to ensure the control connection is established to an accepted node
 //!
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -21,6 +22,7 @@ use rand::seq::{IndexedRandom, SliceRandom};
 use scylla_cql::frame::response::event::ClientRoutesChangeEvent;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, warn};
+use uuid::Uuid;
 
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
@@ -489,7 +491,7 @@ impl MetadataReader {
     pub(in super::super) async fn fetch_client_route_updates_on_event(
         &mut self,
         evt: &ClientRoutesChangeEvent,
-    ) -> Result<(), MetadataError> {
+    ) -> Result<HashSet<Uuid>, MetadataError> {
         let working_connection = match &self.control_connection_state {
             ControlConnectionState::Working(working_connection) => working_connection,
             ControlConnectionState::Broken { last_error: e, .. } => {
@@ -500,7 +502,7 @@ impl MetadataReader {
         let Some(subscriber) = &self.client_routes_subscriber else {
             // No subscriber, but received an event? Strange enough, but nothing to be done here.
             warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
-            return Ok(());
+            return Ok(HashSet::new());
         };
 
         #[deny(clippy::wildcard_enum_match_arm)]
@@ -525,7 +527,7 @@ impl MetadataReader {
         if connection_ids.is_empty() {
             // The event contained no relevant connection IDs.
             // Nothing to be done.
-            return Ok(());
+            return Ok(HashSet::new());
         }
 
         // Although this is vaguely documented, the semantics of an event with connection ids [A, B, C] and host ids [X, Y, Z]
@@ -539,8 +541,8 @@ impl MetadataReader {
             .query_client_routes(&connection_ids, host_ids)
             .await?;
 
-        subscriber.merge_client_routes_update(evt, client_routes);
+        let updated_hosts = subscriber.merge_client_routes_update(evt, client_routes);
 
-        Ok(())
+        Ok(updated_hosts)
     }
 }

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -217,6 +217,16 @@ impl Node {
         self.pool.is_some()
     }
 
+    /// Signals the node's connection pool to retry connecting immediately,
+    /// resetting its exponential backoff.
+    ///
+    /// This is a no-op if the node has no pool (disabled by host filter).
+    pub(crate) fn trigger_pool_refill(&self) {
+        if let Some(pool) = &self.pool {
+            pool.trigger_immediate_refill();
+        }
+    }
+
     pub(crate) async fn use_keyspace(
         &self,
         keyspace_name: VerifiedKeyspaceName,

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -82,6 +82,23 @@ impl ClusterState {
         }
     }
 
+    /// Triggers immediate pool refills for given nodes. This resets exponential
+    /// backoff for those nodes, so they will be retried immediately instead of
+    /// waiting for the next retry timeout.
+    ///
+    /// Suitable, among others, for nodes whose client routes were added or updated.
+    pub(super) fn trigger_pool_refills_for_hosts(&self, host_ids: impl Iterator<Item = Uuid>) {
+        for host_id in host_ids {
+            if let Some(node) = self.known_peers.get(&host_id) {
+                debug!(
+                    host_id = %host_id,
+                    "Triggering immediate pool refill for relevant Node"
+                );
+                node.trigger_pool_refill();
+            }
+        }
+    }
+
     /// Creates new ClusterState using information about topology held in `metadata`.
     /// Uses provided `known_peers` hashmap to recycle nodes if possible.
     #[allow(clippy::too_many_arguments)]

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -13,6 +13,7 @@ use itertools::Itertools;
 use scylla_cql::frame::response::result::TableSpec;
 use scylla_cql::serialize::row::{RowSerializationContext, SerializeRow, SerializedValues};
 use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
@@ -97,6 +98,27 @@ impl ClusterState {
                 node.trigger_pool_refill();
             }
         }
+    }
+
+    /// Triggers an immediate pool refill for the node with the given broadcast
+    /// address. Used when a `STATUS_CHANGE UP` event hints that a node is back
+    /// and its pool (likely in exponential backoff) should retry immediately.
+    pub(super) fn trigger_pool_refill_for_addr(&self, addr: SocketAddr) {
+        for node in self.known_peers.values() {
+            if node.address.into_inner() == addr {
+                debug!(
+                    address = %addr,
+                    host_id = %node.host_id,
+                    "STATUS_CHANGE UP: triggering immediate pool refill"
+                );
+                node.trigger_pool_refill();
+                return;
+            }
+        }
+        debug!(
+            address = %addr,
+            "STATUS_CHANGE UP: no known node with this address"
+        );
     }
 
     /// Creates new ClusterState using information about topology held in `metadata`.

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -17,6 +17,7 @@ use crate::routing::locator::tablets::{RawTablet, TabletsInfo};
 use arc_swap::ArcSwap;
 use futures::future::join_all;
 use futures::{FutureExt, future::RemoteHandle};
+use scylla_cql::frame::response::event::StatusChangeEvent;
 use scylla_cql::frame::response::result::TableSpec;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -375,19 +376,40 @@ impl ClusterWorker {
                                         }
                                     }
                                 }
-                                Event::StatusChange(_status) => {
-                                    // TODO: Tracking status using events is unreliable because of
-                                    // the possibility of losing events when control connection is broken.
-                                    // Maybe a better thing to do here is to treat those events as hints?
-                                    // What I mean by that?
-                                    // - Don't store the status at all.
-                                    // - When receiving down event, and the driver still sees the node
-                                    //   as connected, then try to send a keepalive query to its connections.
-                                    // - When receiving up event, and we have no connections to the node,
-                                    //   then try to open new connections.
-                                    continue;
+                                Event::StatusChange(status) => {
+                                    // Tracking node status using events is unreliable because of the possibility of losing events
+                                    // when control connection is broken. A better thing to do here is to treat those events as hints
+                                    // for:
+                                    // - PoolRefiller - UP triggers immediate pool refill attempt, and
+                                    // - Keepaliver - DOWN triggers immediate keepalive query attempt.
+
+                                    match status {
+                                        StatusChangeEvent::Up(addr) => {
+                                            // When receiving an UP event, it is likely that the node just came back up and is now reachable.
+                                            // We optimistically trigger pool refill for this node.
+                                            // This is not guaranteed to be correct. It is for example possible that a network partition happened,
+                                            // the node lost connectivity to the cluster and driver; then it regained connectivity to the cluster,
+                                            // but not to the driver, and thus is still unreachable from the driver's perspective.
+                                            // However, in this case triggering pool refill is not harmful - if the node is actually reachable,
+                                            // then new connections will be opened to it, and if it is not reachable,
+                                            // then connection attempts will fail and the node will be marked as unreachable by `PoolRefiller`,
+                                            // so it won't be targeted by the load balancing policy.
+                                            self.cluster_state.load().trigger_pool_refill_for_addr(addr);
+                                        },
+                                        StatusChangeEvent::Down(_addr) => {
+                                            // TODO: When receiving a DOWN event, and the driver still sees the node as connected,
+                                            // send a keepalive query to its connections to verify liveness.
+                                            // The node is supposedly DOWN, so connections to this node are likely defunct.
+                                            // We expect that the keepalive query fails, in which case connections will be closed.
+                                            // As a result, the connection pool will report 0 connections to this node,
+                                            // and thus the node will not be targeted by the LoadBalancingPolicy,
+                                            // which is the desired behaviour. However, if the keepalive query succeeds,
+                                            // then the node is likely still alive (got stale event?), and we can keep targeting it.
+                                        },
+                                    }
+                                    continue; // Don't go to refreshing.
                                 },
-                                _ => continue, // Don't go to refreshing
+                                _ => continue, // Don't go to refreshing.
                             }
                         }
                     }

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -361,7 +361,10 @@ impl ClusterWorker {
                                 Event::ClientRoutesChange(evt) => {
                                     let res = self.metadata_reader.fetch_client_route_updates_on_event(&evt).await;
                                     match res {
-                                        Ok(_updated_hosts) => continue, // Don't go to refreshing.
+                                        Ok(updated_hosts) => {
+                                            self.cluster_state.load().trigger_pool_refills_for_hosts(updated_hosts.iter().copied());
+                                            continue; // Don't go to refreshing.
+                                        }
                                         Err(err) =>
                                         {
                                             error!(
@@ -460,6 +463,7 @@ impl ClusterWorker {
     async fn perform_refresh(&mut self) -> Result<(), MetadataError> {
         // Read latest Metadata
         let metadata = self.metadata_reader.read_metadata(false).await?;
+        let client_routes_updated_hosts = metadata.client_routes_updated_hosts.clone();
 
         let cluster_state: Arc<ClusterState> = self.cluster_state.load_full();
 
@@ -486,6 +490,9 @@ impl ClusterWorker {
             )
             .await,
         );
+
+        new_cluster_state
+            .trigger_pool_refills_for_hosts(client_routes_updated_hosts.iter().copied());
 
         new_cluster_state
             .wait_until_all_pools_are_initialized()

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -361,7 +361,7 @@ impl ClusterWorker {
                                 Event::ClientRoutesChange(evt) => {
                                     let res = self.metadata_reader.fetch_client_route_updates_on_event(&evt).await;
                                     match res {
-                                        Ok(()) => continue, // Don't go to refreshing.
+                                        Ok(_updated_hosts) => continue, // Don't go to refreshing.
                                         Err(err) =>
                                         {
                                             error!(

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -190,6 +190,10 @@ pub(crate) struct NodeConnectionPool {
     use_keyspace_request_sender: mpsc::Sender<UseKeyspaceRequest>,
     _refiller_handle: Arc<RemoteHandle<()>>,
     pool_updated_notify: Arc<Notify>,
+    /// Signaled to make the pool refiller retry immediately, resetting
+    /// its backoff. Used when client routes change makes previously
+    /// untranslatable addresses translatable.
+    refill_now_notify: Arc<Notify>,
     endpoint: Arc<RwLock<UntranslatedEndpoint>>,
 }
 
@@ -223,6 +227,7 @@ impl NodeConnectionPool {
     ) -> Self {
         let (use_keyspace_request_sender, use_keyspace_request_receiver) = mpsc::channel(1);
         let pool_updated_notify = Arc::new(Notify::new());
+        let refill_now_notify = Arc::new(Notify::new());
 
         let (host_pool_config, host_reconnect_policy) = pool_config.to_host_pool_config(&endpoint);
 
@@ -234,6 +239,7 @@ impl NodeConnectionPool {
             connectivity_events_sender,
             current_keyspace,
             pool_updated_notify.clone(),
+            refill_now_notify.clone(),
             pool_empty_notifier,
             #[cfg(feature = "metrics")]
             metrics,
@@ -249,6 +255,7 @@ impl NodeConnectionPool {
             use_keyspace_request_sender,
             _refiller_handle: Arc::new(refiller_handle),
             pool_updated_notify,
+            refill_now_notify,
             endpoint: arced_endpoint,
         }
     }
@@ -265,6 +272,15 @@ impl NodeConnectionPool {
 
     pub(crate) fn update_endpoint(&self, new_endpoint: PeerEndpoint) {
         *self.endpoint.write().unwrap() = UntranslatedEndpoint::Peer(new_endpoint);
+    }
+
+    /// Signals the pool refiller to retry immediately, resetting its backoff.
+    ///
+    /// Used when client routes are updated: previously untranslatable addresses
+    /// may now be translatable, so the pool should retry without waiting for
+    /// the exponential backoff timer.
+    pub(crate) fn trigger_immediate_refill(&self) {
+        self.refill_now_notify.notify_one();
     }
 
     pub(crate) fn sharder(&self) -> Option<Sharder> {
@@ -496,6 +512,9 @@ struct PoolRefiller {
     // Signaled when the connection pool is updated
     pool_updated_notify: Arc<Notify>,
 
+    // Signaled to make the refiller retry immediately with reset backoff
+    refill_now_notify: Arc<Notify>,
+
     // Signaled when the connection pool becomes empty
     pool_empty_notifier: mpsc::Sender<()>,
 
@@ -518,6 +537,7 @@ impl PoolRefiller {
         connectivity_events_sender: Option<(Uuid, mpsc::UnboundedSender<ConnectivityChangeEvent>)>,
         current_keyspace: Option<VerifiedKeyspaceName>,
         pool_updated_notify: Arc<Notify>,
+        refill_now_notify: Arc<Notify>,
         pool_empty_notifier: mpsc::Sender<()>,
         #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
         reconnect_policy: Box<dyn ReconnectPolicySession>,
@@ -549,6 +569,7 @@ impl PoolRefiller {
             current_keyspace,
 
             pool_updated_notify,
+            refill_now_notify,
             pool_empty_notifier,
 
             #[cfg(feature = "metrics")]
@@ -629,6 +650,23 @@ impl PoolRefiller {
                         trace!("[{}] Keyspace request channel dropped, stopping asynchronous pool worker", self.endpoint_description());
                         return;
                     }
+                }
+
+                _ = self.refill_now_notify.notified() => {
+                    debug!(
+                        "[{}] Immediate refill requested, resetting backoff",
+                        self.endpoint_description()
+                    );
+                    // This resets the backoff, so the reconnect policy will go back to the initial delay after this.
+                    self.refill_delay_strategy.on_successful_fill();
+                    // This is best-effort reset. Note that a refill may be undergoing, and if a new error is encountered
+                    // during that refill, this will be set to true again.
+                    self.had_error_since_last_refill = false;
+
+                    // Reschedule the refill with the possibly shorter delay.
+                    // Rationale: we may have already scheduled a refill with a longer delay, but that's not a problem -
+                    // we unschedule that refill here and then the block below will schedule a new refill with the correct delay.
+                    scheduled_refill = None;
                 }
             }
             trace!(

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -574,15 +574,28 @@ impl PoolRefiller {
             self.endpoint_description()
         );
 
-        let mut next_refill_time = tokio::time::Instant::now();
-        let mut refill_scheduled = true;
+        struct ScheduledRefill {
+            when: tokio::time::Instant,
+        }
+
+        let mut scheduled_refill = Some(ScheduledRefill {
+            when: tokio::time::Instant::now(),
+        });
 
         loop {
             tokio::select! {
-                _ = tokio::time::sleep_until(next_refill_time), if refill_scheduled => {
+                // Note that some default value must be passed to avoid `unwrap()` here; the guard ensures that `scheduled_refill` is `Some`
+                // when the sleep future is polled, but it does not ensure that `scheduled_refill` is `Some` when the sleep future
+                // is created. With `unwrap()`, we'd get a panic here.
+                // The future created with the default value will not be polled anyway, because the guard prevents that.
+                //
+                // `tokio::select!`'s documentation:
+                // > Additionally, each branch may include an optional if precondition. If the precondition returns false, then the branch is disabled.
+                // > **The provided <async expression> is still evaluated** but the resulting future is never polled.
+                _ = tokio::time::sleep_until(scheduled_refill.as_ref().map_or(tokio::time::Instant::now(), |r| r.when)), if scheduled_refill.is_some() => {
                     self.had_error_since_last_refill = false;
                     self.start_filling();
-                    refill_scheduled = false;
+                    scheduled_refill = None;
                 }
 
                 evt = self.ready_connections.select_next_some(), if !self.ready_connections.is_empty() => {
@@ -623,7 +636,7 @@ impl PoolRefiller {
             );
 
             // Schedule refilling here
-            if !refill_scheduled && self.need_filling() {
+            if scheduled_refill.is_none() && self.need_filling() {
                 if self.had_error_since_last_refill {
                     self.refill_delay_strategy.on_fill_error();
                 } else {
@@ -636,8 +649,9 @@ impl PoolRefiller {
                     delay.as_millis(),
                 );
 
-                next_refill_time = tokio::time::Instant::now() + delay;
-                refill_scheduled = true;
+                scheduled_refill = Some(ScheduledRefill {
+                    when: tokio::time::Instant::now() + delay,
+                });
             }
         }
     }

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1434,6 +1434,7 @@ mod tests {
             let info = Metadata {
                 peers,
                 keyspaces: HashMap::new(),
+                client_routes_updated_hosts: Default::default(),
             };
 
             let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -164,6 +164,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
     Metadata {
         peers: Vec::from(peers),
         keyspaces,
+        client_routes_updated_hosts: Default::default(),
     }
 }
 

--- a/scylla/tests/integration/ccm/client_routes.rs
+++ b/scylla/tests/integration/ccm/client_routes.rs
@@ -37,7 +37,7 @@ const QUERIES_PER_PHASE: i32 = 100;
 /// Must be generous enough for the driver to discover new/restarted nodes,
 /// but short enough to fail promptly if the driver has a bug (e.g.,
 /// `Untranslatable` marking prevents address translation for a node).
-const CONNECTION_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECTION_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
 
 // ---------------------------------------------------------------------------
 // Cluster option factories


### PR DESCRIPTION
Refs: #1615
Refs: #1239

## Solved problem
When client routes change (e.g., during rolling restarts or NLB port remaps), connection pools for affected nodes may be in exponential backoff due to failed connections to stale proxy addresses. The driver waits for the backoff timer to expire before retrying — up to 10 seconds — even though it already knows the new address.

Similarly, when a node comes back up after being down, the pool may be deep in exponential backoff. The driver receives a `STATUS_CHANGE UP` event but previously ignored it entirely, so reconnection was delayed until the next backoff-driven retry.

This PR makes the driver immediately retry connections in both cases.

## Changes

**Commit 1: `connection_pool: expose immediate refill trigger`**

Adds `trigger_immediate_refill()` to `PoolRefiller`, which sends a notification that bypasses the exponential backoff timer. `Node` gets a corresponding `trigger_pool_refill()` method.

**Commit 2: `client_routes: return updated host IDs from route methods`**

`replace_client_routes()` and `merge_client_routes_update()` now return `HashSet<Uuid>` — the host IDs whose routes were added or changed. Adds 13 unit tests covering all return-value cases (unchanged routes, changed hostname/port/tls\_port, new hosts, removed hosts, etc.). The returned values are not yet wired to callers.

**Commit 3: `trigger immediate pool refill upon client routes update`**

Wires the host IDs from commit 2 into pool refill triggering through two paths:
- **Full refresh**: `fetching.rs` → `Metadata.client_routes_updated_hosts` → `worker.rs perform_refresh()` → `ClusterState::trigger_pool_refills_for_hosts()`
- **Event**: `reader.rs fetch_client_route_updates_on_event()` returns `HashSet<Uuid>` → `worker.rs` → `ClusterState::trigger_pool_refills_for_hosts()`

Reduces `CONNECTION_WAIT_TIMEOUT` in integration tests from 10s to 3s, since pools now recover much faster.

**Commit 4: `connection_pool: trigger immediate refill on STATUS_CHANGE UP`**

When the driver receives a `STATUS_CHANGE UP` event for a node, triggers an immediate pool refill, resetting accumulated backoff. Previously, `STATUS_CHANGE` events were completely ignored; the existing TODO comment suggested treating UP events as hints to open new connections — this commit implements exactly that. DOWN events remain ignored: the pool notices the node is down when connections fail and enters backoff naturally.

## Testing
- 13 new unit tests for the host ID returning logic in `ClientRoutesAddressTranslator`
- Existing integration tests (`ccm::client_routes::*`) exercise the full path

## Future possibilities

As part of the ongoing metadata handling refactor, the refill triggering mechanism may be useful.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
