### PR TITLE
Improve client routes tests - part 2

### DIFF
--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -39,47 +39,6 @@ type ConnectionCloseSignaler = tokio::sync::broadcast::Sender<()>;
 type ErrorPropagator = mpsc::UnboundedSender<ProxyError>;
 type ErrorSink = mpsc::UnboundedReceiver<ProxyError>;
 
-/// Tracks the number of active driver connections to a proxy node.
-///
-/// Shared between the [`Doorkeeper`] (which increments on accept) and
-/// [`RunningNode`] (which exposes [`RunningNode::wait_for_connection`]).
-/// Each accepted connection gets an [`Arc<ConnectionLifetime>`] guard that
-/// decrements the count when the last worker for that connection exits.
-struct ConnectionTracker {
-    active_count: std::sync::atomic::AtomicUsize,
-    notify: tokio::sync::Notify,
-}
-
-impl ConnectionTracker {
-    /// Track a new connection.
-    ///
-    /// Increments active count and creates a per-connection lifetime guard.
-    /// When the guard ([ConnectionLifetime]) is Drop'ed,
-    /// the active count is decremented.
-    fn register_connection(self: &Arc<Self>) -> Arc<ConnectionLifetime> {
-        self.active_count.fetch_add(1, Ordering::Relaxed);
-        self.notify.notify_waiters();
-        Arc::new(ConnectionLifetime {
-            tracker: Arc::clone(self),
-        })
-    }
-}
-
-/// Per-connection guard that decrements the active connection count on drop.
-///
-/// Wrapped in [`Arc`] and cloned to each worker task spawned for a connection.
-/// When the last worker finishes and drops its clone, the inner value drops
-/// and the active count is decremented.
-struct ConnectionLifetime {
-    tracker: Arc<ConnectionTracker>,
-}
-
-impl Drop for ConnectionLifetime {
-    fn drop(&mut self) {
-        self.tracker.active_count.fetch_sub(1, Ordering::Relaxed);
-    }
-}
-
 static HARDCODED_OPTIONS_PARAMS: FrameParams = FrameParams {
     flags: 0,
     version: 0x04,
@@ -388,10 +347,6 @@ impl Proxy {
             .nodes
             .into_iter()
             .map(|node| {
-                let connection_tracker = Arc::new(ConnectionTracker {
-                    active_count: std::sync::atomic::AtomicUsize::new(0),
-                    notify: tokio::sync::Notify::new(),
-                });
                 let cc_event_sender = Arc::new(Mutex::new(HashMap::new()));
                 let running = {
                     let (request_rules, response_rules) = match node {
@@ -407,7 +362,6 @@ impl Proxy {
                     RunningNode {
                         request_rules: request_rules.clone(),
                         response_rules: response_rules.cloned(),
-                        connection_tracker: connection_tracker.clone(),
                         cc_event_sender: cc_event_sender.clone(),
                     }
                 };
@@ -417,7 +371,6 @@ impl Proxy {
                         terminate_signaler.clone(),
                         finish_guard.clone(),
                         error_propagator.clone(),
-                        connection_tracker,
                         cc_event_sender,
                     ),
                     running,
@@ -442,7 +395,6 @@ impl Proxy {
 pub struct RunningNode {
     request_rules: Arc<Mutex<Vec<RequestRule>>>,
     response_rules: Option<Arc<Mutex<Vec<ResponseRule>>>>,
-    connection_tracker: Arc<ConnectionTracker>,
 
     /// Senders to the driver-facing sockets of all control connections (those
     /// that sent REGISTER). Keyed by `connection_no` so that each connection
@@ -506,24 +458,6 @@ impl RunningNode {
         let mut new_rules = rules;
         new_rules.append(&mut *old_rules_guard);
         *old_rules_guard = new_rules;
-    }
-
-    /// Waits until at least one driver connection is active on this node.
-    ///
-    /// Returns immediately if there is already an active connection.
-    /// Otherwise blocks until a new connection is accepted by the
-    /// node's doorkeeper.
-    pub async fn wait_for_connection(&self) {
-        loop {
-            // Prepare the notification future BEFORE checking the count
-            // to avoid a race where a connection arrives between the check
-            // and the await.
-            let notified = self.connection_tracker.notify.notified();
-            if self.connection_tracker.active_count.load(Ordering::Relaxed) > 0 {
-                return;
-            }
-            notified.await;
-        }
     }
 
     /// Injects a CQL EVENT frame into all registered control connections.
@@ -630,22 +564,6 @@ impl RunningProxy {
             }
         }
     }
-
-    /// Waits until at least one driver connection is active on any node
-    /// in this proxy.
-    ///
-    /// For single-node proxies (typical in client-routes tests), this waits
-    /// until a driver has connected to the sole node. For multi-node
-    /// proxies, returns as soon as any node receives a connection.
-    pub async fn wait_for_connection(&self) {
-        // Build a future for each node and race them.
-        futures::future::select_all(
-            self.running_nodes
-                .iter()
-                .map(|n| Box::pin(n.wait_for_connection())),
-        )
-        .await;
-    }
 }
 
 /// A worker corresponding to a particular node. It listens in a loop for driver's connections
@@ -659,7 +577,6 @@ struct Doorkeeper {
     finish_guard: FinishGuard,
     shards_count: Option<u16>,
     error_propagator: ErrorPropagator,
-    connection_tracker: Arc<ConnectionTracker>,
     cc_event_sender: Arc<Mutex<HashMap<usize, mpsc::UnboundedSender<ResponseFrame>>>>,
 }
 
@@ -669,7 +586,6 @@ impl Doorkeeper {
         terminate_signaler: TerminateSignaler,
         finish_guard: FinishGuard,
         error_propagator: ErrorPropagator,
-        connection_tracker: Arc<ConnectionTracker>,
         cc_event_sender: Arc<Mutex<HashMap<usize, mpsc::UnboundedSender<ResponseFrame>>>>,
     ) -> Result<(), DoorkeeperError> {
         let listener = TcpListener::bind(node.proxy_addr())
@@ -706,7 +622,6 @@ impl Doorkeeper {
             terminate_signaler,
             finish_guard,
             error_propagator,
-            connection_tracker,
             cc_event_sender,
         };
         tokio::task::spawn(doorkeeper.run());
@@ -789,13 +704,6 @@ impl Doorkeeper {
         cluster_stream: Option<TcpStream>,
         shard: Option<TargetShard>,
     ) {
-        // Track a new connection: increment active count and create a
-        // per-connection lifetime guard. The guard is wrapped in Arc and
-        // cloned to each spawned worker task. When the last worker for this
-        // connection exits, the Arc's inner ConnectionLifetime drops and
-        // decrements the active count.
-        let conn_lifetime = self.connection_tracker.register_connection();
-
         let (driver_read, driver_write) = driver_stream.into_split();
 
         let new_worker = || ProxyWorker {
@@ -824,10 +732,8 @@ impl Doorkeeper {
         ) = compression::make_compression_infra();
 
         {
-            let guard = Arc::clone(&conn_lifetime);
             let worker = new_worker();
             tokio::task::spawn(async move {
-                let _conn = guard;
                 worker
                     .receiver_from_driver(
                         driver_read,
@@ -838,12 +744,10 @@ impl Doorkeeper {
             });
         }
         {
-            let guard = Arc::clone(&conn_lifetime);
             let worker = new_worker();
             let conn_close_sub = connection_close_tx.subscribe();
             let term_sub = self.terminate_signaler.subscribe();
             tokio::task::spawn(async move {
-                let _conn = guard;
                 worker
                     .sender_to_driver(
                         driver_write,
@@ -856,7 +760,6 @@ impl Doorkeeper {
             });
         }
         {
-            let guard = Arc::clone(&conn_lifetime);
             let worker = new_worker();
             let request_rules = Arc::clone(self.node.request_rules());
             let conn_close = connection_close_tx.clone();
@@ -865,7 +768,6 @@ impl Doorkeeper {
             let tx_cluster_clone = tx_cluster.clone();
             let cc_sender = Arc::clone(&self.cc_event_sender);
             tokio::task::spawn(async move {
-                let _conn = guard;
                 worker
                     .request_processor(
                         rx_request,
@@ -887,12 +789,10 @@ impl Doorkeeper {
         {
             let (cluster_read, cluster_write) = cluster_stream.unwrap().into_split();
             {
-                let guard = Arc::clone(&conn_lifetime);
                 let worker = new_worker();
                 let conn_close_sub = connection_close_tx.subscribe();
                 let term_sub = self.terminate_signaler.subscribe();
                 tokio::task::spawn(async move {
-                    let _conn = guard;
                     worker
                         .sender_to_cluster(
                             cluster_write,
@@ -905,10 +805,8 @@ impl Doorkeeper {
                 });
             }
             {
-                let guard = Arc::clone(&conn_lifetime);
                 let worker = new_worker();
                 tokio::task::spawn(async move {
-                    let _conn = guard;
                     worker
                         .receiver_from_cluster(
                             cluster_read,
@@ -919,13 +817,11 @@ impl Doorkeeper {
                 });
             }
             {
-                let guard = conn_lifetime;
                 let worker = new_worker();
                 let response_rules = Arc::clone(response_rules);
                 let conn_close = connection_close_tx.clone();
                 let event_flag = Arc::clone(&event_register_flag);
                 tokio::task::spawn(async move {
-                    let _conn = guard;
                     worker
                         .response_processor(
                             rx_response,
@@ -3215,135 +3111,6 @@ mod tests {
                     .unwrap();
             assert_eq!(received_frame, sent_frame);
         }
-
-        running_proxy.finish().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn connection_tracker_register_increments_and_drop_decrements() {
-        let tracker = Arc::new(ConnectionTracker {
-            active_count: std::sync::atomic::AtomicUsize::new(0),
-            notify: tokio::sync::Notify::new(),
-        });
-
-        assert_eq!(tracker.active_count.load(Ordering::Relaxed), 0);
-
-        let guard1 = tracker.register_connection();
-        assert_eq!(tracker.active_count.load(Ordering::Relaxed), 1);
-
-        let guard2 = tracker.register_connection();
-        assert_eq!(tracker.active_count.load(Ordering::Relaxed), 2);
-
-        // Cloning the Arc does NOT increment the count — only register_connection does.
-        let guard1_clone = Arc::clone(&guard1);
-        assert_eq!(tracker.active_count.load(Ordering::Relaxed), 2);
-
-        // Dropping the clone doesn't decrement yet (the original is still alive).
-        drop(guard1_clone);
-        assert_eq!(tracker.active_count.load(Ordering::Relaxed), 2);
-
-        // Dropping the last Arc for connection 1 decrements.
-        drop(guard1);
-        assert_eq!(tracker.active_count.load(Ordering::Relaxed), 1);
-
-        drop(guard2);
-        assert_eq!(tracker.active_count.load(Ordering::Relaxed), 0);
-    }
-
-    #[tokio::test]
-    async fn connection_tracker_register_notifies_waiters() {
-        let tracker = Arc::new(ConnectionTracker {
-            active_count: std::sync::atomic::AtomicUsize::new(0),
-            notify: tokio::sync::Notify::new(),
-        });
-
-        // Set up a waiter BEFORE registering a connection.
-        let notified = tracker.notify.notified();
-
-        // register_connection should notify.
-        let _guard = tracker.register_connection();
-
-        // The notification should resolve immediately (no timeout needed).
-        tokio::time::timeout(Duration::from_millis(200), notified)
-            .await
-            .expect("notify was not triggered by register_connection");
-    }
-
-    #[tokio::test]
-    async fn wait_for_connection_returns_immediately_when_connected() {
-        let node_real_addr = next_local_address_with_port(9876);
-        let node_proxy_addr = next_local_address_with_port(9876);
-        let proxy = Proxy::new([Node::new(
-            node_real_addr,
-            node_proxy_addr,
-            ShardAwareness::Unaware,
-            None,
-            None,
-        )]);
-        let running_proxy = proxy.run().await.unwrap();
-
-        let mock_node_listener = TcpListener::bind(node_real_addr).await.unwrap();
-
-        // Connect a driver and accept the backend connection.
-        let _driver_conn = TcpStream::connect(node_proxy_addr).await.unwrap();
-        let (_backend_conn, _) = mock_node_listener.accept().await.unwrap();
-
-        // wait_for_connection should return promptly (connection is already active).
-        tokio::time::timeout(
-            Duration::from_millis(200),
-            running_proxy.running_nodes[0].wait_for_connection(),
-        )
-        .await
-        .expect("wait_for_connection timed out despite active connection");
-
-        // Same via RunningProxy::wait_for_connection.
-        tokio::time::timeout(
-            Duration::from_millis(200),
-            running_proxy.wait_for_connection(),
-        )
-        .await
-        .expect("RunningProxy::wait_for_connection timed out despite active connection");
-
-        running_proxy.finish().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn wait_for_connection_blocks_until_driver_connects() {
-        let node_real_addr = next_local_address_with_port(9876);
-        let node_proxy_addr = next_local_address_with_port(9876);
-        let proxy = Proxy::new([Node::new(
-            node_real_addr,
-            node_proxy_addr,
-            ShardAwareness::Unaware,
-            None,
-            None,
-        )]);
-        let running_proxy = proxy.run().await.unwrap();
-
-        let mock_node_listener = TcpListener::bind(node_real_addr).await.unwrap();
-
-        // Before any driver connects, wait_for_connection should NOT return.
-        let result = tokio::time::timeout(
-            Duration::from_millis(20),
-            running_proxy.running_nodes[0].wait_for_connection(),
-        )
-        .await;
-        assert!(
-            result.is_err(),
-            "wait_for_connection returned before any driver connected"
-        );
-
-        // Now connect a driver and accept the backend side.
-        let _driver_conn = TcpStream::connect(node_proxy_addr).await.unwrap();
-        let (_backend_conn, _) = mock_node_listener.accept().await.unwrap();
-
-        // wait_for_connection should now resolve.
-        tokio::time::timeout(
-            Duration::from_millis(200),
-            running_proxy.running_nodes[0].wait_for_connection(),
-        )
-        .await
-        .expect("wait_for_connection timed out after driver connected");
 
         running_proxy.finish().await.unwrap();
     }

--- a/scylla/tests/integration/ccm/client_routes.rs
+++ b/scylla/tests/integration/ccm/client_routes.rs
@@ -13,7 +13,7 @@
 //! it necessarily went through the NLB (since the driver only knows NLB
 //! addresses from `client_routes` and real node addresses, but not proxy addresses).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -137,10 +137,10 @@ async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Failed to build client-routes session");
 
-    // Wait for the driver to open connections to all proxy nodes.
-    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+    // Wait for the driver to load routes and connect to all proxy nodes.
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
-        .expect("Driver did not connect to all proxy nodes");
+        .expect("Driver did not connect to all nodes");
 
     let ks = unique_keyspace_name();
     create_test_schema(&session, &ks, "'dc1': 1, 'dc2': 1").await;
@@ -198,6 +198,7 @@ async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
     info!("=== Phase 2: 3 nodes remaining ===");
     let remaining_nodes = plc.active_node_ids();
     assert_eq!(remaining_nodes.len(), 3);
+
     let mut rxs = plc.setup_query_feedback();
     run_queries(&session, &ks, QUERIES_PER_PHASE).await;
     let (per_node, total) = drain_feedback(&mut rxs);
@@ -224,9 +225,9 @@ async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
     info!("New node added: {}", new_node_id);
     // Wait for the driver to discover the new node and open a connection
     // through the new proxy chain.
-    plc.wait_for_connections_to_node(new_node_id, CONNECTION_WAIT_TIMEOUT)
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
-        .expect("Driver did not connect to newly added node");
+        .expect("Driver did not connect to all nodes after adding node");
 
     // --- Phase 3: 4 nodes again (with new node) ---
     info!("=== Phase 3: 4 nodes with new node ===");
@@ -286,9 +287,9 @@ async fn rolling_restart(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Failed to build client-routes session");
 
-    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
-        .expect("Driver did not connect to all proxy nodes");
+        .expect("Driver did not connect to all nodes");
 
     let ks = unique_keyspace_name();
     create_test_schema(&session, &ks, "'replication_factor': 3").await;
@@ -339,11 +340,11 @@ async fn rolling_restart(plc: &mut ClientRoutesCluster) {
             .await
             .unwrap_or_else(|e| panic!("Failed to restart chain for node {}: {}", target_node, e));
 
-        plc.wait_for_connections_to_node(target_node, CONNECTION_WAIT_TIMEOUT)
+        plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
             .await
             .unwrap_or_else(|e| {
                 panic!(
-                    "Driver did not reconnect to restarted node {}: {}",
+                    "Driver did not reconnect to all nodes after restarting node {}: {}",
                     target_node, e
                 )
             });
@@ -412,9 +413,9 @@ async fn nlb_port_remap(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Failed to build client-routes session");
 
-    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
-        .expect("Driver did not connect to all proxy nodes");
+        .expect("Driver did not connect to all nodes");
 
     let ks = unique_keyspace_name();
     create_test_schema(&session, &ks, "'replication_factor': 3").await;
@@ -445,7 +446,7 @@ async fn nlb_port_remap(plc: &mut ClientRoutesCluster) {
 
     // Wait for the driver to connect through the new NLB ports using
     // the freshly-read routes.
-    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
         .expect("Driver did not reconnect through new NLB ports");
 
@@ -498,9 +499,9 @@ async fn scale_out(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Failed to build client-routes session");
 
-    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
-        .expect("Driver did not connect to all proxy nodes");
+        .expect("Driver did not connect to all nodes");
 
     let ks = unique_keyspace_name();
     create_test_schema(&session, &ks, "'replication_factor': 3").await;
@@ -528,14 +529,9 @@ async fn scale_out(plc: &mut ClientRoutesCluster) {
         new_node_ids.push(new_id);
     }
 
-    // Expedite driver's connection to new nodes by triggering immediate metadata refresh.
-    session
-        .refresh_metadata()
-        .await
-        .expect("Driver failed to refresh metadata");
-
-    // Wait for the driver to discover all 6 nodes and open connections.
-    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+    // Wait for the driver to discover all 6 nodes, load their routes,
+    // and open data pool connections.
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
         .expect("Driver did not connect to all 6 nodes");
 
@@ -637,9 +633,9 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Failed to build client-routes session");
 
-    plc.wait_for_connections_to_all_nodes(CONNECTION_WAIT_TIMEOUT)
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
-        .expect("Driver did not connect to all proxy nodes");
+        .expect("Driver did not connect to all nodes");
 
     let ks = unique_keyspace_name();
     create_test_schema(&session, &ks, "'dc1': 2, 'dc2': 2").await;
@@ -726,17 +722,14 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
     }
 
     // Wait for the driver to connect through the new NLB ports.
-    plc.wait_for_connections_to_nodes(
-        Some(&HashSet::from_iter(dc1_nodes.iter().copied())),
-        CONNECTION_WAIT_TIMEOUT,
-    )
-    .await
-    .unwrap_or_else(|e| {
-        panic!(
-            "Phase 3: driver did not reconnect to all nodes from dc1: {}",
-            e
-        )
-    });
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "Phase 3: driver did not reconnect to all nodes after dc1 chain restarts: {}",
+                e
+            )
+        });
 
     // Verify traffic reaches all 4 nodes through the new ports.
     let mut rxs = plc.setup_query_feedback();
@@ -767,12 +760,9 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
             .unwrap_or_else(|e| panic!("Failed to restart chain for node {}: {}", node_id, e));
     }
 
-    plc.wait_for_connections_to_nodes(
-        Some(&HashSet::from(cross_dc_nodes)),
-        CONNECTION_WAIT_TIMEOUT,
-    )
-    .await
-    .unwrap_or_else(|e| panic!("Phase 4: driver did not reconnect to cross-dc nodes: {}", e));
+    plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("Phase 4: driver did not reconnect to cross-dc nodes: {}", e));
 
     let mut rxs = plc.setup_query_feedback();
     run_queries(&session, &ks, QUERIES_PER_PHASE).await;

--- a/scylla/tests/integration/ccm/client_routes.rs
+++ b/scylla/tests/integration/ccm/client_routes.rs
@@ -24,14 +24,10 @@ use crate::ccm::lib::client_routes::{
 };
 use crate::ccm::lib::cluster::ClusterOptions;
 use crate::ccm::lib::node::NodeId;
-use crate::utils::{setup_tracing, unique_keyspace_name};
+use crate::utils::{HEALTHCHECK_QUERY, execute_unprepared_statement_on_every_node, setup_tracing};
 
 use scylla::client::session::Session;
 use tracing::info;
-
-/// Number of queries per test phase. Must be large enough to statistically
-/// hit all nodes via random-replica token-aware routing.
-const QUERIES_PER_PHASE: i32 = 100;
 
 /// Timeout for waiting for the driver to open connections to all proxy nodes.
 /// Must be generous enough for the driver to discover new/restarted nodes,
@@ -62,46 +58,41 @@ fn cluster_2dc_2_2() -> ClusterOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: create keyspace + table and run N queries, returning the session
+// Helper: verify all active nodes receive queries via proxy feedback
 // ---------------------------------------------------------------------------
 
-async fn create_test_schema(session: &Session, ks_name: &str, rf: &str) {
-    session
-        .query_unpaged(
-            format!(
-                "CREATE KEYSPACE IF NOT EXISTS {} \
-                 WITH replication = {{'class': 'NetworkTopologyStrategy', {}}}",
-                ks_name, rf
-            ),
-            &[],
-        )
-        .await
-        .expect("Failed to create keyspace");
+/// Executes a query on every node in the cluster and verifies via proxy
+/// feedback that each node with a feedback channel actually received traffic.
+///
+/// This combines `execute_unprepared_statement_on_every_node` (which sends
+/// one query per node, targeting any shard) with proxy feedback verification
+/// (which proves the traffic went through the NLB →  proxy path).
+///
+/// We deliberately target nodes rather than individual shards: after a client
+/// routes update the pool may not be fully filled yet (only one shard
+/// connected), and targeting a specific missing shard would fail with
+/// `ConnectionPoolError(Broken)`.
+async fn assert_queries_reach_all_nodes(
+    session: &Session,
+    rxs: &mut HashMap<NodeId, mpsc::UnboundedReceiver<FeedbackItem>>,
+) {
+    execute_unprepared_statement_on_every_node(
+        session,
+        &session.get_cluster_state(),
+        &HEALTHCHECK_QUERY.into(),
+        &(),
+    )
+    .await
+    .unwrap();
 
-    session
-        .query_unpaged(
-            format!(
-                "CREATE TABLE IF NOT EXISTS {}.data (id int PRIMARY KEY, value text)",
-                ks_name
-            ),
-            &[],
-        )
-        .await
-        .expect("Failed to create table");
-}
-
-async fn run_queries(session: &Session, ks_name: &str, count: i32) {
-    for i in 0..count {
-        session
-            .query_unpaged(
-                format!(
-                    "INSERT INTO {}.data (id, value) VALUES ({}, 'v{}')",
-                    ks_name, i, i
-                ),
-                &[],
-            )
-            .await
-            .unwrap_or_else(|e| panic!("Query {} failed: {}", i, e));
+    let (per_node, _total) = drain_feedback(rxs);
+    for (&node_id, _rx) in rxs.iter() {
+        let count = *per_node.get(&node_id).unwrap_or(&0);
+        assert!(
+            count >= 1,
+            "Node {} received 0 queries — driver didn't reach it via proxy",
+            node_id
+        );
     }
 }
 
@@ -122,14 +113,14 @@ async fn run_queries(session: &Session, ks_name: &str, count: i32) {
 /// stays consistent across node removals and additions in a multi-DC setup.
 ///
 /// **Scenario** (2 DCs, 2+2 nodes):
-/// 1. **Phase 1** — all 4 nodes: 100 queries →  total == 100, all 4 ≥ 1.
+/// 1. **Phase 1** — all 4 nodes: queries reach all 4.
 /// 2. Decommission the highest-ID node in DC2 (routes posted without it
 ///    before the actual CCM decommission).
-/// 3. **Phase 2** — 3 nodes: 100 queries →  total == 100, decommissioned
-///    node absent from feedback, remaining 3 ≥ 1.
+/// 3. **Phase 2** — 3 nodes: queries reach remaining 3, decommissioned
+///    node absent from feedback.
 /// 4. Add a new node to DC2, discover its host ID, start its proxy chain.
-/// 5. **Phase 3** — 4 nodes again: 100 queries →  total == 100, all 4 ≥ 1
-///    (including the newly added node).
+/// 5. **Phase 3** — 4 nodes again: queries reach all 4 (including the
+///    newly added node).
 async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
     let session = plc
         .make_session_builder()
@@ -142,50 +133,19 @@ async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Driver did not connect to all nodes");
 
-    let ks = unique_keyspace_name();
-    create_test_schema(&session, &ks, "'dc1': 1, 'dc2': 1").await;
-
     // Identify nodes. In a 2+2 setup, CCM node IDs are 1,2 (DC1) and 3,4 (DC2).
     let initial_nodes = plc.active_node_ids();
     assert_eq!(initial_nodes.len(), 4, "Expected 4 initial nodes");
     info!("Initial nodes: {:?}", initial_nodes);
 
+    // --- Phase 1: all 4 nodes ---
+    info!("=== Phase 1: all 4 nodes ===");
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Feedback: per_node={:?}, total={}", per_node, total);
-
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    let active_nodes = plc.active_node_ids();
-    assert_eq!(active_nodes.len(), 4, "Expected 4 active nodes");
-    for &node_id in &active_nodes {
-        let count = *per_node.get(&node_id).unwrap_or(&0);
-        assert!(
-            count >= 1,
-            "Node {} received 0 queries — driver didn't reach all nodes across DCs",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // The node to decommission: the highest ID in DC2 (should be node 4).
     let node_to_decommission = *initial_nodes.iter().max().expect("non-empty");
     info!("Will decommission node {}", node_to_decommission);
-
-    // --- Phase 1: all 4 nodes ---
-    info!("=== Phase 1: all 4 nodes ===");
-    let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 1: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &initial_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 1: node {} got 0 queries",
-            node_id
-        );
-    }
 
     // --- Decommission node from DC2 ---
     // Routes are posted (without this node) BEFORE the actual topology change.
@@ -200,23 +160,7 @@ async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
     assert_eq!(remaining_nodes.len(), 3);
 
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 2: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    // Decommissioned node should not have a feedback channel at all.
-    assert!(
-        !per_node.contains_key(&node_to_decommission),
-        "Phase 2: decommissioned node {} should not have feedback",
-        node_to_decommission
-    );
-    for &node_id in &remaining_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 2: node {} got 0 queries",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // --- Add new node to DC2 ---
     // Cluster::add_node() uses 1-based CCM DC naming: 2 = dc2.
@@ -239,17 +183,7 @@ async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
         new_node_id
     );
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 3: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &final_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 3: node {} got 0 queries (including new node)",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 }
 
 #[tokio::test]
@@ -274,12 +208,12 @@ async fn test_client_routes_multi_dc_topology_change() {
 /// query failures during the rolling window.
 ///
 /// **Scenario** (1 DC, 3 nodes):
-/// 1. **Phase 0** (baseline): 100 queries →  total == 100, all 3 ≥ 1.
+/// 1. **Phase 0** (baseline): queries reach all 3.
 /// 2. For each node 1, 2, 3 in turn:
 ///    a. Stop the node via CCM, tear down its proxy chain.
 ///    b. Start the node via CCM, rebuild proxy chain (new NLB port).
 ///    c. Wait for the driver to connect through the new chain.
-///    d. 100 queries →  total == 100, all 3 ≥ 1.
+///    d. Queries reach all 3.
 async fn rolling_restart(plc: &mut ClientRoutesCluster) {
     let session = plc
         .make_session_builder()
@@ -291,19 +225,10 @@ async fn rolling_restart(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Driver did not connect to all nodes");
 
-    let ks = unique_keyspace_name();
-    create_test_schema(&session, &ks, "'replication_factor': 3").await;
-
     // --- Phase 0: baseline ---
     info!("=== Phase 0: baseline (all 3 nodes) ===");
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 0: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for (&node_id, &count) in &per_node {
-        assert!(count >= 1, "Phase 0: node {} got 0 queries", node_id);
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // --- Rolling restart: stop + start each node in turn ---
     for target_node in 1..=3u16 {
@@ -355,25 +280,7 @@ async fn rolling_restart(plc: &mut ClientRoutesCluster) {
             target_node
         );
         let mut rxs = plc.setup_query_feedback();
-        run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-        let (per_node, total) = drain_feedback(&mut rxs);
-        info!(
-            "After restarting node {}: per_node={:?}, total={}",
-            target_node, per_node, total
-        );
-        assert_eq!(
-            total, QUERIES_PER_PHASE as usize,
-            "After restarting node {}: total mismatch",
-            target_node
-        );
-        for (&node_id, &count) in &per_node {
-            assert!(
-                count >= 1,
-                "After restarting node {}: node {} got 0 queries",
-                target_node,
-                node_id
-            );
-        }
+        assert_queries_reach_all_nodes(&session, &mut rxs).await;
     }
 }
 
@@ -401,11 +308,11 @@ async fn test_client_routes_rolling_restart() {
 /// route-only changes.
 ///
 /// **Scenario** (1 DC, 3 nodes):
-/// 1. **Phase 1** (baseline): 100 queries →  total == 100, all 3 ≥ 1.
+/// 1. **Phase 1** (baseline): queries reach all 3.
 /// 2. Rebuild proxy chains for nodes 1 and 2 (Scylla stays up). New
 ///    OS-assigned NLB ports, updated routes posted to ScyllaDB.
 /// 3. Wait for the driver to connect through the new NLB ports.
-/// 4. **Phase 2**: 100 queries →  total == 100, all 3 ≥ 1.
+/// 4. **Phase 2**: queries reach all 3.
 async fn nlb_port_remap(plc: &mut ClientRoutesCluster) {
     let session = plc
         .make_session_builder()
@@ -417,19 +324,10 @@ async fn nlb_port_remap(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Driver did not connect to all nodes");
 
-    let ks = unique_keyspace_name();
-    create_test_schema(&session, &ks, "'replication_factor': 3").await;
-
     // --- Phase 1: baseline ---
     info!("=== Phase 1: baseline (all 3 nodes) ===");
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 1: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for (&node_id, &count) in &per_node {
-        assert!(count >= 1, "Phase 1: node {} got 0 queries", node_id);
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // --- Remap: rebuild proxy chains for nodes 1 and 2 ---
     // Scylla nodes stay up; only the proxy + NLB are replaced, giving
@@ -453,17 +351,7 @@ async fn nlb_port_remap(plc: &mut ClientRoutesCluster) {
     // --- Phase 2: verify traffic goes through new ports ---
     info!("=== Phase 2: after NLB port remap ===");
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 2: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for (&node_id, &count) in &per_node {
-        assert!(
-            count >= 1,
-            "Phase 2: node {} got 0 queries — driver didn't follow route update",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 }
 
 #[tokio::test]
@@ -487,11 +375,11 @@ async fn test_client_routes_nlb_port_remap() {
 /// driver ignores newly added nodes or fails to translate their addresses.
 ///
 /// **Scenario** (1 DC, starts with 3 nodes):
-/// 1. **Phase 1** (3 nodes): 100 queries →  total == 100, all 3 ≥ 1.
+/// 1. **Phase 1** (3 nodes): queries reach all 3.
 /// 2. Add 3 new nodes to DC1 one at a time (CCM add + start, discover
 ///    host ID, start proxy chain, post updated routes).
 /// 3. Wait for the driver to connect to all 6 nodes.
-/// 4. **Phase 2** (6 nodes): 100 queries →  total == 100, all 6 ≥ 1.
+/// 4. **Phase 2** (6 nodes): queries reach all 6.
 async fn scale_out(plc: &mut ClientRoutesCluster) {
     let session = plc
         .make_session_builder()
@@ -503,19 +391,10 @@ async fn scale_out(plc: &mut ClientRoutesCluster) {
         .await
         .expect("Driver did not connect to all nodes");
 
-    let ks = unique_keyspace_name();
-    create_test_schema(&session, &ks, "'replication_factor': 3").await;
-
     // --- Phase 1: initial 3 nodes ---
     info!("=== Phase 1: initial 3 nodes ===");
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 1: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for (&node_id, &count) in &per_node {
-        assert!(count >= 1, "Phase 1: node {} got 0 queries", node_id);
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // --- Add 3 new nodes ---
     let mut new_node_ids = Vec::new();
@@ -541,18 +420,7 @@ async fn scale_out(plc: &mut ClientRoutesCluster) {
     assert_eq!(active.len(), 6, "Expected 6 active nodes, got {:?}", active);
 
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 2: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &active {
-        let count = *per_node.get(&node_id).unwrap_or(&0);
-        assert!(
-            count >= 1,
-            "Phase 2: node {} got 0 queries — driver didn't discover new node",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 }
 
 #[tokio::test]
@@ -611,15 +479,14 @@ async fn wait_for_any_feedback(
 /// reconnection logic, and metadata refresh pipeline work end-to-end.
 ///
 /// **Scenario** (2 DCs, 2+2 nodes):
-/// 1. **Phase 1** (baseline): build session, create schema (RF dc1=2,
-///    dc2=2), 100 queries →  all 4 ≥ 1.
+/// 1. **Phase 1** (baseline): queries reach all 4.
 /// 2. **Phase 2** (event injection, no route change): inject a
 ///    `CLIENT_ROUTES_CHANGE` event for DC1 nodes. Verify the driver
 ///    re-queries `system.client_routes` (detected via EXECUTE body
 ///    matching). Verify all 4 nodes still work.
 /// 3. **Phase 3** (full-DC reroute): restart proxy chains for both DC1
 ///    nodes (new NLB ports). ScyllaDB emits a real event. Wait for
-///    connections, verify all 4 ≥ 1.
+///    connections, verify all 4 receive queries.
 /// 4. **Phase 4** (cross-DC reroute): restart one node from each DC.
 ///    Same verification.
 /// 5. **Phase 5** (malformed event recovery): inject a malformed event
@@ -636,9 +503,6 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
     plc.wait_for_pools_connected(&session, CONNECTION_WAIT_TIMEOUT)
         .await
         .expect("Driver did not connect to all nodes");
-
-    let ks = unique_keyspace_name();
-    create_test_schema(&session, &ks, "'dc1': 2, 'dc2': 2").await;
 
     // Identify nodes by DC. In a 2+2 setup, CCM node IDs are 1,2 (DC1)
     // and 3,4 (DC2).
@@ -657,17 +521,7 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
     // ---------------------------------------------------------------
     info!("=== Phase 1: baseline ===");
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 1: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &all_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 1: node {} got 0 queries",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // ---------------------------------------------------------------
     // Phase 2: Event injection — verify event processing
@@ -692,17 +546,7 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
 
     // Verify all nodes still work after event processing.
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 2: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &all_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 2: node {} got 0 queries",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // ---------------------------------------------------------------
     // Phase 3: Full-DC reroute (both DC1 nodes)
@@ -733,17 +577,7 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
 
     // Verify traffic reaches all 4 nodes through the new ports.
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 3: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &all_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 3: node {} got 0 queries",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // ---------------------------------------------------------------
     // Phase 4: Cross-DC reroute (one node from each DC)
@@ -765,17 +599,7 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
         .unwrap_or_else(|e| panic!("Phase 4: driver did not reconnect to cross-dc nodes: {}", e));
 
     let mut rxs = plc.setup_query_feedback();
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 4: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &all_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 4: node {} got 0 queries",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     // ---------------------------------------------------------------
     // Phase 5: Malformed event recovery
@@ -807,19 +631,7 @@ async fn event_driven_reroute(plc: &mut ClientRoutesCluster) {
     .await;
 
     let mut rxs = plc.setup_query_feedback();
-
-    // Verify all 4 nodes still receive traffic.
-    run_queries(&session, &ks, QUERIES_PER_PHASE).await;
-    let (per_node, total) = drain_feedback(&mut rxs);
-    info!("Phase 5: per_node={:?}, total={}", per_node, total);
-    assert_eq!(total, QUERIES_PER_PHASE as usize);
-    for &node_id in &all_nodes {
-        assert!(
-            *per_node.get(&node_id).unwrap_or(&0) >= 1,
-            "Phase 5: node {} got 0 queries after malformed event recovery",
-            node_id
-        );
-    }
+    assert_queries_reach_all_nodes(&session, &mut rxs).await;
 
     info!("All phases passed — event-driven reroute works correctly");
 }

--- a/scylla/tests/integration/ccm/client_routes.rs
+++ b/scylla/tests/integration/ccm/client_routes.rs
@@ -105,17 +105,18 @@ async fn assert_queries_reach_all_nodes(
 /// at each step.
 ///
 /// **Added value**: Tests the full lifecycle of topology membership changes
-/// under client-routes: route removal before decommission (so the driver
-/// stops opening new connections to the node, while existing ones keep
-/// serving requests until the node is actually decommissioned), and route
-/// addition after a new node joins (so the driver discovers and routes to
-/// it). Without this test, we wouldn't know if the driver's route cache
-/// stays consistent across node removals and additions in a multi-DC setup.
+/// under client-routes: contact-point NLB backend removal before
+/// decommission (so no new control connections target the node), followed
+/// by route update after decommission (so the driver learns the node is
+/// gone), and route addition after a new node joins (so the driver
+/// discovers and routes to it). Without this test, we wouldn't know if
+/// the driver's route cache stays consistent across node removals and
+/// additions in a multi-DC setup.
 ///
 /// **Scenario** (2 DCs, 2+2 nodes):
 /// 1. **Phase 1** — all 4 nodes: queries reach all 4.
-/// 2. Decommission the highest-ID node in DC2 (routes posted without it
-///    before the actual CCM decommission).
+/// 2. Remove the highest-ID node in DC2 from the contact-point NLB,
+///    decommission it via CCM, then post routes without it.
 /// 3. **Phase 2** — 3 nodes: queries reach remaining 3, decommissioned
 ///    node absent from feedback.
 /// 4. Add a new node to DC2, discover its host ID, start its proxy chain.
@@ -148,7 +149,8 @@ async fn multi_dc_topology_change(plc: &mut ClientRoutesCluster) {
     info!("Will decommission node {}", node_to_decommission);
 
     // --- Decommission node from DC2 ---
-    // Routes are posted (without this node) BEFORE the actual topology change.
+    // Contact-point NLB backend is removed before CCM decommission (prevents
+    // new control connections); routes are posted after decommission completes.
     info!("Decommissioning node {}...", node_to_decommission);
     plc.decommission_node(node_to_decommission)
         .await

--- a/scylla/tests/integration/ccm/lib/client_routes.rs
+++ b/scylla/tests/integration/ccm/lib/client_routes.rs
@@ -368,87 +368,61 @@ impl ClientRoutesCluster {
             .collect()
     }
 
-    /// Waits until every specified proxy node has at least one driver connection.
+    /// Waits until the driver's data pools report `is_connected()` for all
+    /// active nodes.
     ///
-    /// After topology changes (restart, add node), the driver takes time to
-    /// discover the new/restarted node and open a connection. Calling this
-    /// before issuing queries prevents races where all queries miss the
-    /// new node because the driver hasn't connected yet.
-    ///
-    /// Times out after `timeout` to avoid hanging forever if the driver fails to connect.
-    pub(crate) async fn wait_for_connections_to_nodes(
+    /// Does NOT call `refresh_metadata()`: the driver discovers routes via
+    /// its normal mechanisms (initial metadata fetch, `TOPOLOGY_CHANGE` and
+    /// `CLIENT_ROUTES_CHANGE` events) and reconnects via `STATUS_CHANGE UP`
+    /// or client-routes-triggered pool refills.
+    pub(crate) async fn wait_for_pools_connected(
         &self,
-        node_ids: Option<&HashSet<u16>>,
+        session: &Session,
         timeout: Duration,
     ) -> Result<(), Error> {
-        let futs: Vec<_> = self
-            .dc_configs
-            .values()
-            .flat_map(|dc| {
-                dc.per_node_chains.iter().filter_map(|(node_id, chain)| {
-                    let wait_fn = || {
-                        let proxy = &chain.running_proxy;
-                        async move {
-                            proxy.wait_for_connection().await;
-                            info!("Proxy for node {} has a driver connection", node_id);
-                        }
-                    };
-                    match node_ids {
-                        // Filter to a specific set of nodes if provided.
-                        Some(ids) => ids.contains(node_id).then(wait_fn),
-                        // No filter, wait for all nodes.
-                        None => Some(wait_fn()),
-                    }
-                })
-            })
+        let active = self.active_node_ids();
+        let expected_host_ids: HashSet<Uuid> = self
+            .host_ids
+            .iter()
+            .filter(|(node_id, _)| active.contains(node_id))
+            .map(|(_, &hid)| hid)
             .collect();
 
-        tokio::time::timeout(timeout, futures::future::join_all(futs))
-            .await
-            .map_err(|_| {
-                let target_ids = node_ids
-                    .map(|ids| ids.iter().copied().collect::<Vec<_>>())
-                    .unwrap_or_else(|| self.active_node_ids());
-                anyhow::anyhow!(
-                    "Timed out waiting for driver connections to proxy nodes: {:?}.",
-                    target_ids
-                )
-            })?;
+        tokio::time::timeout(timeout, async {
+            loop {
+                let state = session.get_cluster_state();
+                let all_connected = expected_host_ids.iter().all(|&hid| {
+                    state
+                        .get_node_by_host_id(hid)
+                        .is_some_and(|n| n.is_connected())
+                });
 
-        Ok(())
-    }
+                if all_connected {
+                    return;
+                }
 
-    /// Waits until every active proxy node has at least one driver connection.
-    ///
-    /// After topology changes (restart, add node), the driver takes time to
-    /// discover the new/restarted node and open a connection. Calling this
-    /// before issuing queries prevents races where all queries miss the
-    /// new node because the driver hasn't connected yet.
-    ///
-    /// Times out after `timeout` to avoid hanging forever if the driver fails to connect.
-    pub(crate) async fn wait_for_connections_to_all_nodes(
-        &self,
-        timeout: Duration,
-    ) -> Result<(), Error> {
-        self.wait_for_connections_to_nodes(None, timeout).await
-    }
-
-    /// Waits until the proxy responsible for given node has at least one driver
-    /// connection.
-    ///
-    /// After topology changes (restart, add node), the driver takes time to
-    /// discover the new/restarted node and open a connection. Calling this
-    /// before issuing queries prevents races where all queries miss the
-    /// new node because the driver hasn't connected yet.
-    ///
-    /// Times out after `timeout` to avoid hanging forever if the driver fails to connect.
-    pub(crate) async fn wait_for_connections_to_node(
-        &self,
-        node_id: NodeId,
-        timeout: Duration,
-    ) -> Result<(), Error> {
-        self.wait_for_connections_to_nodes(Some(&HashSet::from([node_id])), timeout)
-            .await
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .map_err(|_| {
+            let state = session.get_cluster_state();
+            let disconnected: Vec<_> = expected_host_ids
+                .iter()
+                .filter(|hid| {
+                    !state
+                        .get_nodes_info()
+                        .iter()
+                        .any(|n| n.host_id == **hid && n.is_connected())
+                })
+                .collect();
+            anyhow::anyhow!(
+                "Timed out after {:?} waiting for data pools to connect. \
+                 Disconnected host_ids: {:?}",
+                timeout,
+                disconnected
+            )
+        })
     }
 
     /// Decommission a node and tear down its proxy chain.

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -399,6 +399,24 @@ where
     try_join_all(tasks).await
 }
 
+/// Like [`for_each_target_execute`], but invokes the callback once per node
+/// (instead of once per shard). The callback receives only the node.
+async fn for_each_node_execute<ExecuteFn, ExecuteFut>(
+    cluster: &ClusterState,
+    execute: ExecuteFn,
+) -> Result<Vec<QueryResult>, ExecutionError>
+where
+    ExecuteFn: Fn(Arc<scylla::cluster::Node>) -> ExecuteFut,
+    ExecuteFut: Future<Output = Result<QueryResult, ExecutionError>>,
+{
+    let tasks = cluster
+        .get_nodes_info()
+        .iter()
+        .map(|node| execute(node.clone()));
+
+    try_join_all(tasks).await
+}
+
 pub(crate) async fn execute_prepared_statement_everywhere(
     session: &Session,
     cluster: &ClusterState,
@@ -427,6 +445,31 @@ pub(crate) async fn execute_unprepared_statement_everywhere(
 ) -> Result<Vec<QueryResult>, ExecutionError> {
     for_each_target_execute(cluster, |node, shard| async move {
         let policy = SingleTargetLoadBalancingPolicy::new(NodeIdentifier::Node(node), shard);
+        let execution_profile = ExecutionProfile::builder()
+            .load_balancing_policy(policy)
+            .build();
+        let mut statement = statement.clone();
+        statement.set_execution_profile_handle(Some(execution_profile.into_handle()));
+
+        session.query_unpaged(statement, values).await
+    })
+    .await
+}
+
+/// Like [`execute_unprepared_statement_everywhere`], but targets each node
+/// once (any shard) instead of every individual shard. This only requires
+/// at least one connection per node, making it suitable for scenarios where
+/// the pool may not be fully filled yet (e.g. right after a client routes
+/// update).
+#[allow(dead_code)]
+pub(crate) async fn execute_unprepared_statement_on_every_node(
+    session: &Session,
+    cluster: &ClusterState,
+    statement: &Statement,
+    values: &dyn SerializeRow,
+) -> Result<Vec<QueryResult>, ExecutionError> {
+    for_each_node_execute(cluster, |node| async move {
+        let policy = SingleTargetLoadBalancingPolicy::new(NodeIdentifier::Node(node), None);
         let execution_profile = ExecutionProfile::builder()
             .load_balancing_policy(policy)
             .build();


### PR DESCRIPTION
This is the second part of improvements to client routes integrations tests, enabled by #1630. Without #1630, tests would become extremely flaky.

## Features

- **Make connection verification more robust** - Now tests rely on driver connection pool's `is_connected()` method instead of custom proxy machinery. This avoids problematic timing issues that were present because and fights flakiness.
The old proxy machinery is removed, as it's considered a footgun.

- **Reduce boilerplate** — Eliminate `QUERIES_PER_PHASE`, `run_queries`, `create_test_schema`, and all keyspace creation logic. The new `assert_queries_reach_all_nodes` helper is a 10-line function that combines query execution with proxy feedback verification.

- **Deterministic query verification** — Replace the probabilistic 100-query spray (`run_queries` + keyspace/table creation) with `execute_unprepared_statement_on_every_node` using `HEALTHCHECK_QUERY`. Each node receives exactly one query, eliminating statistical flakiness while still verifying full-cluster reachability through proxy feedback.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
