### PR TITLE
docs: describe idempotence interaction and DefaultRetryPolicy decision matrix

### DIFF
--- a/docs/source/retry-policy/default.md
+++ b/docs/source/retry-policy/default.md
@@ -3,6 +3,39 @@ This is the retry policy used by default. It retries when there is a high chance
 This policy is based on the one in [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.11/manual/core/retries/).
 The behaviour is the same.
 
+### Decision matrix
+
+The exact retry decision per error class, taken from the implementation in
+`scylla::policies::retry::DefaultRetryPolicy`:
+
+| Error                                                   | Idempotent statement                | Non-idempotent statement |
+| ------------------------------------------------------- | ----------------------------------- | ------------------------ |
+| Broken connection                                       | retry on next target                | don't retry              |
+| `DbError::Overloaded` / `ServerError` / `TruncateError` | retry on next target                | don't retry              |
+| `DbError::Unavailable`                                  | retry on next target (at most once) | retry on next target (at most once) |
+| `DbError::ReadTimeout` (received >= required, no data)  | retry on same target (at most once) | retry on same target (at most once) |
+| `DbError::ReadTimeout` (other shapes)                   | don't retry                         | don't retry              |
+| `DbError::WriteTimeout`, `WriteType::BatchLog`          | retry on same target (at most once) | don't retry              |
+| `DbError::WriteTimeout` (other write types)             | don't retry                         | don't retry              |
+| `DbError::IsBootstrapping`                              | retry on next target                | retry on next target     |
+| `RequestAttemptError::UnableToAllocStreamId`            | retry on next target                | retry on next target     |
+| `Consistency::is_serial()` (LWT)                        | don't retry                         | don't retry              |
+| Anything else (`SyntaxError`, `Invalid`, `Unauthorized`, `RateLimitReached`, parser errors, ...) | don't retry | don't retry |
+
+Two cross-cutting rules to keep in mind:
+
+* **Serial consistency short-circuits everything**: if `RequestInfo.consistency`
+  is one of the `*_SERIAL` levels (LWT path), `DefaultRetryPolicy` returns
+  `DontRetry` regardless of the error and idempotence. This is a safety net for
+  Paxos-routed writes, where the second attempt would re-enter the LWT
+  protocol with surprising semantics.
+* **Per-session "at most once" guards**: `Unavailable`, `ReadTimeout`, and
+  `WriteTimeout` each have a `was_*_retry` flag on the session that flips
+  after the first retry. Subsequent occurrences of the same error class on
+  the same `RetrySession` return `DontRetry` even if everything else still
+  qualifies. The flags are reset by `RetrySession::reset()` between
+  requests, so each new request gets a fresh budget.
+
 ### Examples
 To use in `Session`:
 ```rust

--- a/docs/source/retry-policy/retry-policy.md
+++ b/docs/source/retry-policy/retry-policy.md
@@ -12,6 +12,29 @@ By default there are three retry policies:
 
 It's possible to implement a custom `Retry Policy` by implementing the traits `RetryPolicy` and `RetrySession`.
 
+### Idempotence and retry policies
+
+Retry policies and [speculative execution](../speculative-execution/speculative.md)
+treat idempotence differently:
+
+* **Speculative execution** strictly requires `is_idempotent = true`.
+  Without it, speculative fibers do not start at all, even if a
+  `SpeculativeExecutionPolicy` is configured on the `Session`.
+* **Retry policies** receive `is_idempotent` as one input on `RequestInfo`
+  and decide for themselves. They can - and the bundled policies do -
+  retry some non-idempotent statements when the failure mode makes
+  re-execution safe (for example, the [Default Retry Policy](default.md)
+  retries on `IsBootstrapping` and `UnableToAllocStreamId` regardless of
+  idempotence, because the request is known not to have reached the
+  server). Conversely, on errors where the request may have already
+  partially executed (broken connection, `Overloaded`, `ServerError`,
+  `TruncateError`), retries only happen when the statement is marked
+  idempotent.
+
+Marking a statement idempotent therefore unlocks speculative execution
+entirely *and* widens the set of error classes the retry policies will act
+on.
+
 ### Query idempotence
 A query is idempotent if it can be applied multiple times without changing the result of the initial application
 

--- a/docs/source/speculative-execution/speculative.md
+++ b/docs/source/speculative-execution/speculative.md
@@ -15,6 +15,30 @@ Available speculative execution strategies:
 Speculative execution is not enabled by default, and currently only
 non-iter session methods use it.
 
+### When does speculative execution actually fire?
+
+Even with a `SpeculativeExecutionPolicy` configured on the `Session`,
+speculative fibers only start if **the statement is marked idempotent**
+(see [Query idempotence](../retry-policy/retry-policy.md#query-idempotence)).
+For non-idempotent statements the policy is bypassed and only the original
+execution runs - this avoids duplicating side-effecting writes when several
+fibers race to the same coordinator. Use `Statement::set_is_idempotent(true)`
+or `PreparedStatement::set_is_idempotent(true)` on queries that are safe to
+re-run.
+
+### Errors from running fibers
+
+Once speculative fibers are running, the result of each fiber is checked
+against an internal classifier. Errors that look transient on this
+particular target (for example, a connection-pool error or an attempt that
+another node could still satisfy) are ignored so the remaining fibers keep
+racing. Errors that mean the *whole request* should fail - not just one
+fiber - are returned immediately, and no more speculative attempts are
+started. From a user perspective this means some kinds of failure produce a
+fast error even when speculative execution is configured: speculative
+fibers are an optimization for slow responses, not a substitute for retry
+on definitive errors.
+
 ```{eval-rst}
 .. toctree::
    :hidden:

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -28,6 +28,12 @@ pub struct Context {
 
 /// The policy that decides if the driver will send speculative queries to the
 /// next targets when the current target takes too long to respond.
+///
+/// Speculative execution only fires for statements explicitly marked as
+/// idempotent ([`Statement::set_is_idempotent(true)`](crate::statement::unprepared::Statement::set_is_idempotent) or
+/// [`PreparedStatement::set_is_idempotent(true)`](crate::statement::prepared::PreparedStatement::set_is_idempotent)). Non-idempotent statements
+/// bypass this policy entirely so the driver does not duplicate side-effecting
+/// writes across racing fibers.
 // TODO(2.0): Consider renaming the methods to get rid of "retry" naming.
 pub trait SpeculativeExecutionPolicy: std::fmt::Debug + Send + Sync {
     /// The maximum number of speculative executions that will be triggered


### PR DESCRIPTION
## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #1285

## Summary

#1285 noted four gaps the docs were laconic about:

1. Speculative execution will only work if the statement is marked
   idempotent. That fact lives in the source but isn't surfaced in
   `speculative-execution/speculative.md` or in the
   `SpeculativeExecutionPolicy` trait doc-comment.
2. `RetryPolicy` does not strictly require idempotent requests - the
   policy decides what to do and *can* take idempotency into consideration.
3. `DefaultRetryPolicy` has complex logic that today gets one summary line
   plus a "behaviour same as Java driver" link. People building bespoke
   policies have to read the source to know what the bundled one actually
   does.
4. Speculative execution has logic that decides whether to fail early based
   on the error returned, and that's also not documented anywhere.

This PR addresses all four without changing any runtime behaviour.

## Changes

`docs/source/speculative-execution/speculative.md`
- Adds a "When does speculative execution actually fire?" section that
  states the idempotence prerequisite and points readers at
  `Statement::set_is_idempotent` /
  `PreparedStatement::set_is_idempotent`.
- Adds an "Errors from running fibers" section describing how the internal
  classifier (`can_be_ignored` in `scylla/src/policies/speculative_execution.rs`)
  treats transient-on-this-target errors vs definitive errors that fail
  the whole request, so users understand why some failures still produce a
  fast error even with speculative execution enabled.

`docs/source/retry-policy/retry-policy.md`
- Adds an "Idempotence and retry policies" section contrasting the strict
  idempotence gate on speculative execution with the retry policies'
  per-error treatment. Calls out specific `DefaultRetryPolicy` behaviour
  taken from the source: `IsBootstrapping` and `UnableToAllocStreamId`
  retry regardless of idempotence (the request is known not to have
  reached the server), while `Overloaded` / `ServerError` /
  `TruncateError` / broken connection retry only when the statement is
  idempotent.

`docs/source/retry-policy/default.md`
- Adds a "Decision matrix" table listing every error class
  `DefaultRetryPolicy::decide_should_retry` reasons about, with the
  retry verdict for idempotent vs non-idempotent statements. Pulled
  directly from `scylla/src/policies/retry/default.rs` so the docs match
  the implementation.
- Adds two cross-cutting notes:
  - Serial consistency (LWT path) short-circuits to `DontRetry` regardless
    of error and idempotence.
  - The per-session `was_unavailable_retry` / `was_read_timeout_retry` /
    `was_write_timeout_retry` flags cap each error class at one retry per
    `RetrySession`, with the cap reset on `RetrySession::reset()`.

`scylla/src/policies/speculative_execution.rs`
- Extends the `SpeculativeExecutionPolicy` trait doc-comment with one
  paragraph stating the `is_idempotent` prerequisite, so the docs.rs
  rendering matches the book.

## Testing

This is documentation-only (plus one trait doc-comment). Verified locally:

```
$ cargo check -p scylla
    Checking scylla v1.6.0 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.01s
$ cargo doc -p scylla --no-deps --quiet
$ # exit 0, no warnings
```

The Markdown changes follow the existing toctree structure under
`docs/source/`. No behaviour changes, no public-API changes - only
descriptive text and one trait doc-comment.

## Source-of-truth references

Every claim in the new docs maps to a specific code location:

- "Speculative execution requires idempotent statements" -
  `scylla/src/client/session.rs:2072`:
  `Some(speculative) if statement_config.is_idempotent =>`. The match
  falls through (no speculative fibers) for non-idempotent statements.
- "Speculative execution early-fails on definitive errors" -
  `can_be_ignored` in `scylla/src/policies/speculative_execution.rs`,
  called from the select loop in the same file.
- "DefaultRetryPolicy decision matrix" -
  `scylla/src/policies/retry/default.rs::decide_should_retry`. Each row
  in the table maps to a specific match arm.
- "Serial consistency short-circuits" - `default.rs` line ~63:
  `if request_info.consistency.is_serial() { return RetryDecision::DontRetry; }`.
- "Per-session at-most-once flags" -
  `was_unavailable_retry` / `was_read_timeout_retry` /
  `was_write_timeout_retry` fields on `DefaultRetrySession`, reset by
  `RetrySession::reset` (`*self = DefaultRetrySession::new()`).
