### PR TITLE
fix(scylla-cql): reject lz4 frame bodies shorter than the 4-byte size prefix

### DIFF
--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -69,7 +69,7 @@ scylla-macros = { version = "=1.6.0", path = "../scylla-macros" }
 # AsyncRead trait used in read_response_frame
 tokio = { version = "1.40", features = ["io-util"] }
 # FrameSlice and other parts of public API
-bytes = "1.0.1"
+bytes = "1.10"
 # Tracing ids, CqlTimeuuid, ser/deser of CQL UUID
 uuid = "1.0"
 

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -360,6 +360,14 @@ pub fn decompress(
 ) -> Result<Vec<u8>, FrameBodyExtensionsParseError> {
     match compression {
         Compression::Lz4 => {
+            if comp_body.len() < std::mem::size_of::<u32>() {
+                return Err(FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(
+                    std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "lz4 frame body is shorter than its 4-byte size prefix",
+                    ),
+                )));
+            }
             let uncomp_len = comp_body.get_u32() as usize;
             let uncomp_body = lz4_flex::decompress(comp_body, uncomp_len)
                 .map_err(|err| FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(err)))?;
@@ -405,5 +413,19 @@ mod test {
         let result = decompress(&comp_body[..], compression).unwrap();
         assert_eq!(32, comp_body.len());
         assert_eq!(uncomp_body.as_bytes(), result);
+    }
+
+    #[test]
+    fn test_lz4_decompress_rejects_short_input() {
+        // A frame body shorter than the 4-byte size prefix must be rejected
+        // with an error rather than panicking inside `Buf::get_u32`.
+        for short in [&[][..], &[0x00][..], &[0x00, 0x00, 0x00][..]] {
+            let err = decompress(short, Compression::Lz4)
+                .expect_err("short lz4 frame must produce an error");
+            assert!(matches!(
+                err,
+                FrameBodyExtensionsParseError::Lz4DecompressError(_)
+            ));
+        }
     }
 }

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -18,6 +18,7 @@ pub mod types;
 use bytes::{Buf, BufMut, Bytes};
 use frame_errors::{
     CqlRequestSerializationError, FrameBodyExtensionsParseError, FrameHeaderParseError,
+    LowLevelDeserializationError,
 };
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
@@ -364,10 +365,10 @@ pub fn decompress(
                 .try_get_u32()
                 .map_err(|_| {
                     FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(
-                        std::io::Error::new(
+                        LowLevelDeserializationError::IoError(Arc::new(std::io::Error::new(
                             std::io::ErrorKind::UnexpectedEof,
                             "lz4 frame body is shorter than its 4-byte size prefix",
-                        ),
+                        ))),
                     ))
                 })? as usize;
             let uncomp_body = lz4_flex::decompress(comp_body, uncomp_len)

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -360,15 +360,16 @@ pub fn decompress(
 ) -> Result<Vec<u8>, FrameBodyExtensionsParseError> {
     match compression {
         Compression::Lz4 => {
-            if comp_body.len() < std::mem::size_of::<u32>() {
-                return Err(FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(
-                    std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
-                        "lz4 frame body is shorter than its 4-byte size prefix",
-                    ),
-                )));
-            }
-            let uncomp_len = comp_body.get_u32() as usize;
+            let uncomp_len = comp_body
+                .try_get_u32()
+                .map_err(|_| {
+                    FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(
+                        std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "lz4 frame body is shorter than its 4-byte size prefix",
+                        ),
+                    ))
+                })? as usize;
             let uncomp_body = lz4_flex::decompress(comp_body, uncomp_len)
                 .map_err(|err| FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(err)))?;
             Ok(uncomp_body)
@@ -417,8 +418,7 @@ mod test {
 
     #[test]
     fn test_lz4_decompress_rejects_short_input() {
-        // A frame body shorter than the 4-byte size prefix must be rejected
-        // with an error rather than panicking inside `Buf::get_u32`.
+        // A frame body shorter than the 4-byte size prefix must return an error.
         for short in [&[][..], &[0x00][..], &[0x00, 0x00, 0x00][..]] {
             let err = decompress(short, Compression::Lz4)
                 .expect_err("short lz4 frame must produce an error");

--- a/scylla-cql/src/frame/mod.rs
+++ b/scylla-cql/src/frame/mod.rs
@@ -361,16 +361,14 @@ pub fn decompress(
 ) -> Result<Vec<u8>, FrameBodyExtensionsParseError> {
     match compression {
         Compression::Lz4 => {
-            let uncomp_len = comp_body
-                .try_get_u32()
-                .map_err(|_| {
-                    FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(
-                        LowLevelDeserializationError::IoError(Arc::new(std::io::Error::new(
-                            std::io::ErrorKind::UnexpectedEof,
-                            "lz4 frame body is shorter than its 4-byte size prefix",
-                        ))),
-                    ))
-                })? as usize;
+            let uncomp_len = comp_body.try_get_u32().map_err(|_| {
+                FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(
+                    LowLevelDeserializationError::IoError(Arc::new(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "lz4 frame body is shorter than its 4-byte size prefix",
+                    ))),
+                ))
+            })? as usize;
             let uncomp_body = lz4_flex::decompress(comp_body, uncomp_len)
                 .map_err(|err| FrameBodyExtensionsParseError::Lz4DecompressError(Arc::new(err)))?;
             Ok(uncomp_body)

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -19,7 +19,7 @@ defaults = []
 [dependencies]
 scylla-cql = { version = "1.6.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
-bytes = "1.2.0"
+bytes = "1.10"
 futures = "0.3.6"
 tokio = { version = "1.40", features = [
     "net",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -95,7 +95,7 @@ tokio = { version = "1.40", features = [
 ] }
 tracing = "0.1.36"
 # Appears in various places of our public API.
-bytes = "1.0.1"
+bytes = "1.10"
 # Used for representing tracing ids and host ids.
 uuid = { version = "1.0", features = ["v4"] }
 # Used in history module to represent times of events.


### PR DESCRIPTION
Calling `Buf::get_u32()` on a short slice panicked inside bytes rather than producing `FrameBodyExtensionsParseError::Lz4DecompressError`. Validate the length up front so truncated server frames return a normal decode error.

Fixes: #1639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation for LZ4-compressed data processing with clearer error messages for malformed or incomplete inputs

* **Tests**
  * Added unit tests for LZ4 decompression to validate proper handling of edge cases with insufficient data

* **Chores**
  * Updated core library dependencies to latest stable versions for enhanced stability and compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/scylla-rust-driver/pull/1642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->