### PR TITLE
metadata/reader: fix panic on runtime shutdown

### DIFF
--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -39,6 +39,7 @@ use crate::utils::safe_format::IteratorSafeFormatExt;
 pub(crate) enum ControlConnectionEvent {
     Broken,
     ServerEvent(Event),
+    Shutdown,
 }
 
 struct WorkingControlConnection {
@@ -175,7 +176,10 @@ impl MetadataReader {
                                 // We could theoretically recover by dropping a connection and creating new one,
                                 // but we would need to add an error variant to `BrokenConnectionErrorKind` that
                                 // could basically never happen. Let's panic instead.
-                                panic!("Error sender of control connection unexpectedly dropped. This is a bug in the driver, please open an issue!");
+                                warn!(concat!("Error sender of control connection unexpectedly dropped. The only case when this ",
+                                "may happen is during runtime shutdown. If you see this and the runtime isn't shutting down, ",
+                                "this is a bug in the driver. Then please open an issue!"));
+                                return ControlConnectionEvent::Shutdown;
                             },
                         };
                         self.control_connection_state = ControlConnectionState::Broken {

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -349,6 +349,11 @@ impl ClusterWorker {
 
                 control_connection_event = self.metadata_reader.wait_for_control_connection_event() => {
                     match control_connection_event {
+                        ControlConnectionEvent::Shutdown => {
+                            // The runtime is shutting down. We can stop working.
+                            debug!("Got shutdown control connection event. Shutting down ClusterWorker.");
+                            return;
+                        },
                         ControlConnectionEvent::Broken => {
                             // The control connection was broken. Acknowledge that and start attempting to reconnect.
                             // The first reconnect attempt will be immediate (by attempting metadata refresh below),


### PR DESCRIPTION
CPP RS Driver's CI started failing with a panic in `MetadataReader` when the runtime was shutting down. This is because the ClusterWorker task was still running and trying to receive control connection events, but the sender had already been dropped during shutdown.

This commit patches the code to handle this case gracefully by returning a newly added `Shutdown` event instead of panicking. ClusterWorker task can then handle this event by stopping its work and allowing the runtime to shut down cleanly.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
