### PR TITLE
cluster/state: add method to get node by host id

### DIFF
--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -290,6 +290,11 @@ impl ClusterState {
         &self.all_nodes
     }
 
+    /// Access details about specific node known to the driver, querying by host id.
+    pub fn get_node_by_host_id(&self, host_id: Uuid) -> Option<NodeRef<'_>> {
+        self.known_peers.get(&host_id)
+    }
+
     /// Compute token of a table partition key
     ///
     /// `partition_key` argument contains the values of all partition key


### PR DESCRIPTION
This will avoid the need to iterate over all nodes when looking for a specific one by the host id, which is a common operation.

Fixes: #1645

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
