### PR TITLE
routing: treat SERIAL/LOCAL_SERIAL consistency as LWT for routing

### DIFF
--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -187,4 +187,6 @@ rotated (similarly to a round robin with a random index).
 
 [^1]: There is an optimisation implemented for LWT requests that routes them
 to the replicas in the ring order (as it prevents contention due to Paxos conflicts), so replicas in that case are not shuffled in groups at all.
-In order for the optimisation to be applied, LWT statements must be prepared before.
+The optimisation is applied in two cases:
+1. when an LWT statement (containing an `IF` clause) is prepared — ScyllaDB sets a flag that the driver uses for routing;
+2. when a statement is executed with `Serial` or `LocalSerial` consistency (this is the only way to execute `SELECT` as LWT, since it may not contain an `IF` clause), the driver detects it automatically.

--- a/docs/source/statements/lwt.md
+++ b/docs/source/statements/lwt.md
@@ -28,4 +28,25 @@ session.query_unpaged(my_statement, (to_insert,)).await?;
 
 The rest of the API remains identical for LWT and non-LWT statements.
 
+### SELECT as LWT
+
+A `SELECT` statement can also be executed as a lightweight transaction by setting its consistency level to `Serial` or `LocalSerial`. Since `SELECT` statements never contain an `IF` clause, this is the only way to execute them as LWT. The driver automatically detects this case and applies LWT routing optimisation (deterministic replica ordering) for such requests.
+
+```rust
+# extern crate scylla;
+# use scylla::client::session::Session;
+# use std::error::Error;
+# async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
+use scylla::statement::unprepared::Statement;
+use scylla::statement::Consistency;
+
+let mut my_statement: Statement = Statement::new("SELECT * FROM ks.tab WHERE a = ?".to_string());
+// Setting consistency to Serial makes the server execute this SELECT via Paxos.
+my_statement.set_consistency(Consistency::Serial);
+
+session.query_unpaged(my_statement, (12345_i32,)).await?;
+# Ok(())
+# }
+```
+
 See [Statement API documentation](https://docs.rs/scylla/latest/scylla/statement/struct.Statement.html) for more options

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -185,7 +185,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         }
 
         /* LWT statements need to be routed differently: always to the same replica, to avoid Paxos contention. */
-        let statement_type = if query.is_confirmed_lwt {
+        let statement_type = if query.should_route_as_lwt() {
             StatementType::Lwt
         } else {
             StatementType::NonLwt
@@ -339,7 +339,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         let routing_info = self.routing_info(query, cluster);
 
         /* LWT statements need to be routed differently: always to the same replica, to avoid Paxos contention. */
-        let statement_type = if query.is_confirmed_lwt {
+        let statement_type = if query.should_route_as_lwt() {
             StatementType::Lwt
         } else {
             StatementType::NonLwt
@@ -2480,6 +2480,86 @@ mod tests {
                     .group([A]) // pick local DC
                     .group([C, G, B]) // local nodes
                     .build(),
+            },
+            // Consistency::Serial triggers LWT routing even without is_confirmed_lwt flag.
+            // This is the only way to execute SELECT as LWT (no IF clause in body).
+            // Keyspace NTS with RF=2 with enabled DC failover.
+            Test {
+                policy: DefaultPolicy {
+                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    is_token_aware: true,
+                    permit_dc_failover: true,
+                    ..Default::default()
+                },
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_2),
+                    consistency: Consistency::Serial,
+                    is_confirmed_lwt: false,
+                    ..Default::default()
+                },
+                // going through the ring, we get order: F , A , C , D , G , B , E
+                //                                      us  eu  eu  us  eu  eu  us
+                //                                      r2  r1  r1  r1  r2  r1  r1
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([A, G]) // pick + fallback local replicas
+                    .ordered([F, D]) // remote replicas
+                    .group([C, B]) // local nodes
+                    .group([E]) // remote nodes
+                    .build(),
+            },
+            // Consistency::LocalSerial triggers LWT routing even without is_confirmed_lwt flag.
+            // Keyspace NTS with RF=3 with enabled DC failover.
+            Test {
+                policy: DefaultPolicy {
+                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    is_token_aware: true,
+                    permit_dc_failover: true,
+                    ..Default::default()
+                },
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_3),
+                    consistency: Consistency::LocalSerial,
+                    is_confirmed_lwt: false,
+                    ..Default::default()
+                },
+                // going through the ring, we get order: F , A , C , D , G , B , E
+                //                                      us  eu  eu  us  eu  eu  us
+                //                                      r2  r1  r1  r1  r2  r1  r1
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([A, C, G]) // pick + fallback local replicas
+                    .ordered([F, D, E]) // remote replicas
+                    .group([B]) // local nodes
+                    .group([]) // remote nodes
+                    .build(),
+            },
+            // Consistency::Serial with DC failover disabled and rack-aware policy.
+            // Keyspace NTS with RF=2.
+            Test {
+                policy: DefaultPolicy {
+                    preferences: NodeLocationPreference::DatacenterAndRack(
+                        "eu".to_owned(),
+                        "r1".to_owned(),
+                    ),
+                    is_token_aware: true,
+                    permit_dc_failover: false,
+                    ..Default::default()
+                },
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_2),
+                    consistency: Consistency::Serial,
+                    is_confirmed_lwt: false,
+                    ..Default::default()
+                },
+                // going through the ring, we get order: F , A , C , D , G , B , E
+                //                                      us  eu  eu  us  eu  eu  us
+                //                                      r2  r1  r1  r1  r2  r1  r1
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([A, G]) // pick + fallback local replicas (A is r1, G is r2)
+                    .group([C, B]) // local nodes
+                    .build(), // failover is explicitly forbidden
             },
         ];
 

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -42,7 +42,41 @@ pub struct RoutingInfo<'a> {
     /// (i. e. always try first to contact replica A, then B if it fails, then C, etc.).
     /// If false, the request should be routed normally.
     /// Note: this a ScyllaDB-specific optimisation. Therefore, the flag will be always false for Cassandra.
+    ///
+    /// <div class="warning">
+    ///
+    /// This flag alone is not sufficient to determine whether a request should be
+    /// routed as LWT. A statement can also be executed with [`Consistency::Serial`] or
+    /// [`Consistency::LocalSerial`] as its consistency level, which makes the server treat it
+    /// as a Paxos (LWT) request — this is the only way to execute a `SELECT` as LWT,
+    /// since `SELECT` statements never contain an `IF` clause.
+    /// Use [`RoutingInfo::should_route_as_lwt()`] to correctly account for both cases.
+    ///
+    /// </div>
+    ///
+    /// [`Consistency::Serial`]: types::Consistency::Serial
+    /// [`Consistency::LocalSerial`]: types::Consistency::LocalSerial
     pub is_confirmed_lwt: bool,
+}
+
+impl RoutingInfo<'_> {
+    /// Returns `true` if the request should be routed using LWT optimisation
+    /// (i.e. deterministic replica ordering to reduce Paxos contention).
+    ///
+    /// This takes into account both the [`is_confirmed_lwt`](RoutingInfo::is_confirmed_lwt) flag
+    /// (set by ScyllaDB during prepare for statements containing `IF` clauses) and the
+    /// [`consistency`](RoutingInfo::consistency) level — a request executed with
+    /// [`Consistency::Serial`](types::Consistency::Serial) or
+    /// [`Consistency::LocalSerial`](types::Consistency::LocalSerial) is always treated
+    /// as LWT by the server, even if `is_confirmed_lwt` is `false` (e.g. for `SELECT`
+    /// statements, which never contain an `IF` clause).
+    pub fn should_route_as_lwt(&self) -> bool {
+        self.is_confirmed_lwt
+            || matches!(
+                self.consistency,
+                types::Consistency::Serial | types::Consistency::LocalSerial
+            )
+    }
 }
 
 /// The fallback list of nodes in the request plan.

--- a/scylla/src/statement/prepared.rs
+++ b/scylla/src/statement/prepared.rs
@@ -319,6 +319,21 @@ impl PreparedStatement {
     /// then C, etc.). If false, the query should be routed normally.
     /// Note: this a Scylla-specific optimisation. Therefore, the result
     /// will be always false for Cassandra.
+    ///
+    /// <div class="warning">
+    ///
+    /// This method alone is not sufficient to determine whether a request should be
+    /// routed as LWT. A statement can also be executed with [`Consistency::Serial`] or
+    /// [`Consistency::LocalSerial`] as its consistency level, which makes the server treat it
+    /// as a Paxos (LWT) request. This is the only way to execute a `SELECT` as LWT,
+    /// since `SELECT` statements never contain an `IF` clause.
+    /// The driver accounts for this case internally via
+    /// [`RoutingInfo::should_route_as_lwt()`](crate::policies::load_balancing::RoutingInfo::should_route_as_lwt).
+    ///
+    /// </div>
+    ///
+    /// [`Consistency::Serial`]: crate::statement::Consistency::Serial
+    /// [`Consistency::LocalSerial`]: crate::statement::Consistency::LocalSerial
     pub fn is_confirmed_lwt(&self) -> bool {
         self.shared.is_confirmed_lwt
     }


### PR DESCRIPTION
## Summary
- Add `RoutingInfo::should_route_as_lwt()` method that checks both
  `is_confirmed_lwt` and whether consistency is `Serial`/`LocalSerial`,
  and use it in `DefaultPolicy` instead of the raw flag.
- Add doc comment warnings on `RoutingInfo::is_confirmed_lwt` and
  `PreparedStatement::is_confirmed_lwt()` about the gap this method
  addresses.
- Add unit tests for `DefaultPolicy` covering `Serial` and
  `LocalSerial` consistency with `is_confirmed_lwt: false`.
- Update book docs (`lwt.md`, `default-policy.md`) to document SELECT
  as LWT via serial consistency and the routing optimisation it
  triggers.

## Motivation
When a statement is executed with `Consistency::Serial` or
`Consistency::LocalSerial`, the server treats it as a Paxos (LWT)
request. This is the only way to execute a `SELECT` as LWT, since
`SELECT` statements never contain an `IF` clause and therefore the
`is_confirmed_lwt` flag from prepare is always `false` for them.
Previously, `DefaultPolicy` only checked `is_confirmed_lwt` to decide
whether to apply deterministic replica ordering. This meant that
`SELECT` statements with serial consistency were routed with shuffled
replicas instead of deterministic order, causing unnecessary Paxos
contention.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1634

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
