### PR TITLE
scylla: Re-export VectorIterator, and other Vector-related types

### DIFF
--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -231,7 +231,8 @@ pub mod deserialize {
             MapDeserializationErrorKind, MapIterator, MapTypeCheckErrorKind,
             SetOrListDeserializationErrorKind, SetOrListTypeCheckErrorKind,
             TupleDeserializationErrorKind, TupleTypeCheckErrorKind, UdtIterator,
-            UdtTypeCheckErrorKind,
+            UdtTypeCheckErrorKind, VectorDeserializationErrorKind, VectorIterator,
+            VectorTypeCheckErrorKind,
         };
 
         // Note: deprecated doesn't work on re-exports, users won't get the warning.


### PR DESCRIPTION
This makes it consistent with other types like MapIterator and MapTypeCheckErrorKind, and allows users to implement performant Vector type deserialization without reimplementing the whole thing themselves or adding dependency on scylla-cql.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1626

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
