### PR TITLE
Coordinator: Clarify connection_address semantics

### DIFF
--- a/scylla/src/response/coordinator.rs
+++ b/scylla/src/response/coordinator.rs
@@ -11,6 +11,11 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Coordinator {
     /// Translated address, i.e., one that the connection is opened against.
+    ///
+    /// This may be different than [`Node::address`], and may be different on different
+    /// connections to the same node, because of various driver mechanisms (address translation,
+    /// shard-aware port, client routes). You should never use this
+    /// for node identification. Use [`Node::host_id`] of the [`Self::node`] for that.
     connection_address: SocketAddr,
     /// The node that served as coordinator.
     node: Arc<Node>,
@@ -28,6 +33,11 @@ impl Coordinator {
     }
 
     /// Translated address, i.e., one that the connection is opened against.
+    ///
+    /// This may be different than [`Node::address`], and may be different on different
+    /// connections to the same node, because of various driver mechanisms (address translation,
+    /// shard-aware port, client routes). You should never use this
+    /// for node identification. Use [`Node::host_id`] of the [`Self::node`] for that.
     #[inline]
     pub fn connection_address(&self) -> SocketAddr {
         self.connection_address


### PR DESCRIPTION
Connection address may be different for different connections to the same node. This was not obvious to users, who may try to identify the node using this address. This commit clarifies the semantics in the doc comment.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1513

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
