### PR TITLE
get_tracing_info: Wait for duration to be available

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1988,6 +1988,10 @@ impl Session {
             Some(tracing_info) => tracing_info,
         };
 
+        if tracing_info.duration.is_none() {
+            return Ok(None);
+        }
+
         // Get tracing events
         let tracing_event_rows_result = traces_events_res
             .into_rows_result()


### PR DESCRIPTION
In general it is impossible to reliably fetch tracing info. We can never know if all the events are already in the table, or if some replica will add new ones in the future. Tracing fetching is thus a best-effort heuristic.
One good heuristic is waiting for duration to be present - it implies that request was at least fully processed on coordinator. This is what this commit does.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/957

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
