### PR TITLE
Handle node attribute changes correctly w.r.t. HostFilter

### DIFF
--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -120,7 +120,6 @@ impl Node {
         pool_config: &PoolConfig,
         connectivity_events_sender: tokio::sync::mpsc::UnboundedSender<ConnectivityChangeEvent>,
         keyspace_name: Option<VerifiedKeyspaceName>,
-        enabled: bool,
         #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Self {
         let host_id = peer.host_id;
@@ -130,24 +129,39 @@ impl Node {
 
         // We aren't interested in the fact that the pool becomes empty, so we immediately drop the receiving part.
         let (pool_empty_notifier, _) = tokio::sync::mpsc::channel(1);
-        let pool = enabled.then(|| {
-            NodeConnectionPool::new(
-                UntranslatedEndpoint::Peer(peer),
-                pool_config,
-                Some((host_id, connectivity_events_sender)),
-                keyspace_name,
-                pool_empty_notifier,
-                #[cfg(feature = "metrics")]
-                metrics,
-            )
-        });
+        let pool = NodeConnectionPool::new(
+            UntranslatedEndpoint::Peer(peer),
+            pool_config,
+            Some((host_id, connectivity_events_sender)),
+            keyspace_name,
+            pool_empty_notifier,
+            #[cfg(feature = "metrics")]
+            metrics,
+        );
 
         Node {
             host_id,
             address,
             datacenter,
             rack,
-            pool,
+            pool: Some(pool),
+            #[cfg(test)]
+            enabled_as_connected: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn new_disabled(peer: PeerEndpoint) -> Self {
+        let host_id = peer.host_id;
+        let address = peer.address;
+        let datacenter = peer.datacenter.clone();
+        let rack = peer.rack.clone();
+
+        Node {
+            host_id,
+            address,
+            datacenter,
+            rack,
+            pool: None,
             #[cfg(test)]
             enabled_as_connected: AtomicBool::new(false),
         }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -484,6 +484,11 @@ impl ClusterState {
         // The returned iterator is nonempty, because it returns at least `first_working_pool`.
     }
 
+    #[cfg(test)]
+    fn known_peers(&self) -> &HashMap<Uuid, Arc<Node>> {
+        &self.known_peers
+    }
+
     pub(super) fn update_tablets(&mut self, raw_tablets: Vec<(TableSpec<'static>, RawTablet)>) {
         let replica_translator = |uuid: Uuid| self.known_peers.get(&uuid).cloned();
 
@@ -512,5 +517,213 @@ impl ClusterState {
             };
             self.locator.tablets.add_tablet(table, tablet);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::metadata::{Metadata, Peer};
+    use crate::cluster::node::NodeAddr;
+    use crate::policies::host_filter::HostFilter;
+    use crate::routing::locator::tablets::TabletsInfo;
+    use crate::test_utils::setup_tracing;
+
+    use std::collections::{HashMap, HashSet};
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    fn make_addr(id: u16) -> NodeAddr {
+        NodeAddr::Translatable(SocketAddr::from(([255, 255, 255, id as u8], id)))
+    }
+
+    fn make_peer(
+        host_id: Uuid,
+        address: NodeAddr,
+        datacenter: Option<&str>,
+        rack: Option<&str>,
+    ) -> Peer {
+        Peer {
+            host_id,
+            address,
+            tokens: vec![Token::new(1)],
+            datacenter: datacenter.map(String::from),
+            rack: rack.map(String::from),
+        }
+    }
+
+    fn make_metadata(peers: Vec<Peer>) -> Metadata {
+        Metadata {
+            peers,
+            keyspaces: HashMap::new(),
+            client_routes_updated_hosts: HashSet::new(),
+        }
+    }
+
+    /// A host filter that rejects peers whose address is in the reject set.
+    struct AddrRejectFilter {
+        rejected: HashSet<NodeAddr>,
+    }
+
+    impl AddrRejectFilter {
+        fn rejecting(addrs: impl IntoIterator<Item = NodeAddr>) -> Self {
+            Self {
+                rejected: addrs.into_iter().collect(),
+            }
+        }
+    }
+
+    impl HostFilter for AddrRejectFilter {
+        fn accept(&self, peer: &Peer) -> bool {
+            !self.rejected.contains(&peer.address)
+        }
+    }
+
+    /// Helper: build a ClusterState from metadata, old known_peers, and an optional host filter.
+    async fn build_cluster_state(
+        metadata: Metadata,
+        known_peers: &HashMap<Uuid, Arc<Node>>,
+        host_filter: Option<&dyn HostFilter>,
+    ) -> ClusterState {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ClusterState::new(
+            metadata,
+            &Default::default(),
+            known_peers,
+            &mut |_, _| (),
+            &None,
+            host_filter,
+            &tx,
+            TabletsInfo::new(),
+            &HashMap::new(),
+            #[cfg(feature = "metrics")]
+            &Default::default(),
+        )
+        .await
+    }
+
+    // Node's address changes so that host filter no longer rejects it.
+    // The node should become enabled, and the Node object must NOT be reused.
+    #[tokio::test]
+    async fn node_included_after_ip_change_not_filtered_anymore() {
+        setup_tracing();
+
+        let host_id = Uuid::new_v4();
+        let addr_rejected = make_addr(1);
+        let addr_accepted = make_addr(2);
+        let filter = AddrRejectFilter::rejecting([addr_rejected]);
+
+        // Build initial state: peer at addr_rejected ⇒ disabled.
+        let initial_metadata = make_metadata(vec![make_peer(
+            host_id,
+            addr_rejected,
+            Some("dc1"),
+            Some("r1"),
+        )]);
+        let initial_state =
+            build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
+        let old_node = initial_state.known_peers().get(&host_id).unwrap().clone();
+        assert!(
+            !old_node.is_enabled(),
+            "node should be disabled when its address is rejected"
+        );
+
+        // Refresh: same host_id moves to addr_accepted ⇒ should be enabled.
+        let new_metadata = make_metadata(vec![make_peer(
+            host_id,
+            addr_accepted,
+            Some("dc1"),
+            Some("r1"),
+        )]);
+        let new_state =
+            build_cluster_state(new_metadata, initial_state.known_peers(), Some(&filter)).await;
+        let new_node = new_state.known_peers().get(&host_id).unwrap();
+
+        assert!(
+            new_node.is_enabled(),
+            "node should be enabled after address change passes the filter"
+        );
+        assert!(
+            !Arc::ptr_eq(&old_node, new_node),
+            "Node object must NOT be reused when transitioning from disabled to enabled"
+        );
+    }
+
+    // Node's address changes so that host filter now rejects it.
+    // The node should become disabled, and the Node object must NOT be reused.
+    #[tokio::test]
+    async fn node_filtered_out_after_ip_change() {
+        setup_tracing();
+
+        let host_id = Uuid::new_v4();
+        let addr_accepted = make_addr(1);
+        let addr_rejected = make_addr(2);
+        let filter = AddrRejectFilter::rejecting([addr_rejected]);
+
+        // Build initial state: peer at addr_accepted ⇒ enabled.
+        let initial_metadata = make_metadata(vec![make_peer(
+            host_id,
+            addr_accepted,
+            Some("dc1"),
+            Some("r1"),
+        )]);
+        let initial_state =
+            build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
+        let old_node = initial_state.known_peers().get(&host_id).unwrap().clone();
+        assert!(
+            old_node.is_enabled(),
+            "node should be enabled when its address is accepted"
+        );
+
+        // Refresh: same host_id moves to addr_rejected ⇒ should be disabled.
+        let new_metadata = make_metadata(vec![make_peer(
+            host_id,
+            addr_rejected,
+            Some("dc1"),
+            Some("r1"),
+        )]);
+        let new_state =
+            build_cluster_state(new_metadata, initial_state.known_peers(), Some(&filter)).await;
+        let new_node = new_state.known_peers().get(&host_id).unwrap();
+
+        assert!(
+            !new_node.is_enabled(),
+            "node should be disabled after address change hits the filter"
+        );
+        assert!(
+            !Arc::ptr_eq(&old_node, new_node),
+            "Node object must NOT be reused when transitioning from enabled to disabled"
+        );
+    }
+
+    // A disabled node whose attributes (dc, rack, address) have not changed
+    // should reuse the same Node object (Arc::ptr_eq).
+    #[tokio::test]
+    async fn disabled_node_unchanged_attributes_reuses_object() {
+        setup_tracing();
+
+        let host_id = Uuid::new_v4();
+        let addr = make_addr(1);
+        let filter = AddrRejectFilter::rejecting([addr]);
+
+        // Build initial state: peer at addr ⇒ disabled.
+        let initial_metadata =
+            make_metadata(vec![make_peer(host_id, addr, Some("dc1"), Some("r1"))]);
+        let initial_state =
+            build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
+        let old_node = initial_state.known_peers().get(&host_id).unwrap().clone();
+        assert!(!old_node.is_enabled(), "node should be disabled");
+
+        // Refresh with identical attributes, still filtered out.
+        let new_metadata = make_metadata(vec![make_peer(host_id, addr, Some("dc1"), Some("r1"))]);
+        let new_state =
+            build_cluster_state(new_metadata, initial_state.known_peers(), Some(&filter)).await;
+        let new_node = new_state.known_peers().get(&host_id).unwrap();
+
+        assert!(!new_node.is_enabled(), "node should still be disabled");
+        assert!(
+            Arc::ptr_eq(&old_node, new_node),
+            "Node object should be reused when disabled node's attributes haven't changed"
+        );
     }
 }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -152,14 +152,14 @@ impl ClusterState {
             // Changing rack/datacenter but not ip address seems improbable
             // so we can just create new node and connections then
             let peer_host_id = peer.host_id;
-            let peer_address = peer.address;
-            let peer_tokens;
+            let (peer_endpoint, peer_tokens) = peer.into_peer_endpoint_and_tokens();
 
             let node: Arc<Node> = match known_peers.get(&peer_host_id) {
-                Some(node) if node.datacenter == peer.datacenter && node.rack == peer.rack => {
-                    let (peer_endpoint, tokens) = peer.into_peer_endpoint_and_tokens();
-                    peer_tokens = tokens;
-                    if node.address == peer_address {
+                Some(node)
+                    if node.datacenter == peer_endpoint.datacenter
+                        && node.rack == peer_endpoint.rack =>
+                {
+                    if node.address == peer_endpoint.address {
                         Arc::clone(node)
                     } else {
                         // If IP changes, the Node struct is recreated, but the underlying pool is preserved and notified about the IP change.
@@ -168,8 +168,6 @@ impl ClusterState {
                 }
                 _ => {
                     let is_enabled = host_filter.is_none_or(|f| f.accept(&peer));
-                    let (peer_endpoint, tokens) = peer.into_peer_endpoint_and_tokens();
-                    peer_tokens = tokens;
                     let node = if is_enabled {
                         Node::new(
                             peer_endpoint,

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -152,6 +152,7 @@ impl ClusterState {
             // Changing rack/datacenter but not ip address seems improbable
             // so we can just create new node and connections then
             let peer_host_id = peer.host_id;
+            let is_enabled = host_filter.is_none_or(|f| f.accept(&peer));
             let (peer_endpoint, peer_tokens) = peer.into_peer_endpoint_and_tokens();
 
             let node: Arc<Node> = match known_peers.get(&peer_host_id) {
@@ -167,7 +168,6 @@ impl ClusterState {
                     }
                 }
                 _ => {
-                    let is_enabled = host_filter.is_none_or(|f| f.accept(&peer));
                     let node = if is_enabled {
                         Node::new(
                             peer_endpoint,

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -30,9 +30,9 @@ use super::node::{Node, NodeRef};
 pub struct ClusterState {
     /// All nodes known to be part of the cluster, accessible by their host ID.
     /// Often refered to as "topology metadata".
-    pub(crate) known_peers: HashMap<Uuid, Arc<Node>>, // Invariant: nonempty after Cluster::new()
+    pub(crate) known_nodes: HashMap<Uuid, Arc<Node>>, // Invariant: nonempty after Cluster::new()
 
-    /// Contains the same set of nodes as `known_peers`.
+    /// Contains the same set of nodes as `known_nodes`.
     ///
     /// Introduced to fix the bug that zero-token nodes were missing from
     /// `ClusterState::get_nodes_info()` slice, because the slice was borrowed
@@ -69,7 +69,7 @@ impl std::fmt::Debug for ClusterStateNeatDebug<'_> {
         };
 
         f.debug_struct("ClusterState")
-            .field("known_peers", &cluster_state.known_peers)
+            .field("known_nodes", &cluster_state.known_nodes)
             .field("ring", &ring_printer)
             .field("keyspaces", &cluster_state.keyspaces.keys())
             .finish_non_exhaustive()
@@ -90,7 +90,7 @@ impl ClusterState {
     /// Suitable, among others, for nodes whose client routes were added or updated.
     pub(super) fn trigger_pool_refills_for_hosts(&self, host_ids: impl Iterator<Item = Uuid>) {
         for host_id in host_ids {
-            if let Some(node) = self.known_peers.get(&host_id) {
+            if let Some(node) = self.known_nodes.get(&host_id) {
                 debug!(
                     host_id = %host_id,
                     "Triggering immediate pool refill for relevant Node"
@@ -104,7 +104,7 @@ impl ClusterState {
     /// address. Used when a `STATUS_CHANGE UP` event hints that a node is back
     /// and its pool (likely in exponential backoff) should retry immediately.
     pub(super) fn trigger_pool_refill_for_addr(&self, addr: SocketAddr) {
-        for node in self.known_peers.values() {
+        for node in self.known_nodes.values() {
             if node.address.into_inner() == addr {
                 debug!(
                     address = %addr,
@@ -122,7 +122,7 @@ impl ClusterState {
     }
 
     /// Creates new ClusterState using information about topology held in `metadata`.
-    /// Uses provided `known_peers` hashmap to recycle nodes if possible.
+    /// Uses provided `known_nodes` hashmap to recycle nodes if possible.
     #[allow(clippy::too_many_arguments)]
     // This allow(clippy::type_complexity) is here because I can't satisfy borrow checker while
     // having the closure type be a type alias.
@@ -130,8 +130,8 @@ impl ClusterState {
     pub(crate) async fn new(
         metadata: Metadata,
         pool_config: &PoolConfig,
-        known_peers: &HashMap<Uuid, Arc<Node>>,
-        // Takes old and new known_peers maps as arguments.
+        known_nodes: &HashMap<Uuid, Arc<Node>>,
+        // Takes old and new known_nodes maps as arguments.
         handle_topology_changes: &mut (
                  dyn FnMut(&HashMap<Uuid, Arc<Node>>, &HashMap<Uuid, Arc<Node>>) + Send + Sync
              ),
@@ -142,8 +142,8 @@ impl ClusterState {
         old_keyspaces: &HashMap<String, Keyspace>,
         #[cfg(feature = "metrics")] metrics: &Arc<Metrics>,
     ) -> Self {
-        // Create new updated known_peers and ring
-        let mut new_known_peers: HashMap<Uuid, Arc<Node>> =
+        // Create new updated known_nodes and ring
+        let mut new_known_nodes: HashMap<Uuid, Arc<Node>> =
             HashMap::with_capacity(metadata.peers.len());
         let mut ring: Vec<(Token, Arc<Node>)> = Vec::new();
 
@@ -153,7 +153,7 @@ impl ClusterState {
             let is_enabled = host_filter.is_none_or(|f| f.accept(&peer));
             let (peer_endpoint, peer_tokens) = peer.into_peer_endpoint_and_tokens();
 
-            let node = match (is_enabled, known_peers.get(&peer_host_id)) {
+            let node = match (is_enabled, known_nodes.get(&peer_host_id)) {
                 // If the node is disabled, then we never want to have a connection pool to it.
                 // If it already existed, and was disabled, and all parameters (dc, rack, address) match
                 // then we can reuse the object.
@@ -196,14 +196,14 @@ impl ClusterState {
                 )),
             };
 
-            new_known_peers.insert(peer_host_id, Arc::clone(&node));
+            new_known_nodes.insert(peer_host_id, Arc::clone(&node));
 
             for token in peer_tokens {
                 ring.push((token, Arc::clone(&node)));
             }
         }
 
-        handle_topology_changes(known_peers, &new_known_peers);
+        handle_topology_changes(known_nodes, &new_known_nodes);
 
         let keyspaces: HashMap<String, Keyspace> = metadata
             .keyspaces
@@ -235,8 +235,8 @@ impl ClusterState {
         {
             let removed_nodes = {
                 let mut removed_nodes = HashSet::new();
-                for old_peer in known_peers {
-                    if !new_known_peers.contains_key(old_peer.0) {
+                for old_peer in known_nodes {
+                    if !new_known_nodes.contains_key(old_peer.0) {
                         removed_nodes.insert(*old_peer.0);
                     }
                 }
@@ -254,8 +254,8 @@ impl ClusterState {
 
             let recreated_nodes = {
                 let mut recreated_nodes = HashMap::new();
-                for (old_peer_id, old_peer_node) in known_peers {
-                    if let Some(new_peer_node) = new_known_peers.get(old_peer_id)
+                for (old_peer_id, old_peer_node) in known_nodes {
+                    if let Some(new_peer_node) = new_known_nodes.get(old_peer_id)
                         && !Arc::ptr_eq(old_peer_node, new_peer_node)
                     {
                         recreated_nodes.insert(*old_peer_id, Arc::clone(new_peer_node));
@@ -268,7 +268,7 @@ impl ClusterState {
             tablets.perform_maintenance(
                 &table_predicate,
                 &removed_nodes,
-                &new_known_peers,
+                &new_known_nodes,
                 &recreated_nodes,
             )
         }
@@ -282,8 +282,8 @@ impl ClusterState {
         .unwrap();
 
         ClusterState {
-            all_nodes: new_known_peers.values().cloned().collect(),
-            known_peers: new_known_peers,
+            all_nodes: new_known_nodes.values().cloned().collect(),
+            known_nodes: new_known_nodes,
             keyspaces,
             locator,
         }
@@ -306,7 +306,7 @@ impl ClusterState {
 
     /// Access details about specific node known to the driver, querying by host id.
     pub fn get_node_by_host_id(&self, host_id: Uuid) -> Option<NodeRef<'_>> {
-        self.known_peers.get(&host_id)
+        self.known_nodes.get(&host_id)
     }
 
     /// Compute token of a table partition key
@@ -406,9 +406,9 @@ impl ClusterState {
         impl Iterator<Item = (Uuid, impl Iterator<Item = Arc<Connection>> + use<>)> + use<'_>,
         ConnectionPoolError,
     > {
-        // The returned iterator is nonempty by nonemptiness invariant of `self.known_peers`.
-        assert!(!self.known_peers.is_empty());
-        let nodes_iter = self.known_peers.values();
+        // The returned iterator is nonempty by nonemptiness invariant of `self.known_nodes`.
+        assert!(!self.known_nodes.is_empty());
+        let nodes_iter = self.known_nodes.values();
         let mut connection_pool_per_node_iter = nodes_iter.map(|node| {
             node.get_working_connections()
                 .map(|pool| (node.host_id, pool))
@@ -420,7 +420,7 @@ impl ClusterState {
             connection_pool_per_node_iter
                 .by_ref()
                 .find_or_first(Result::is_ok)
-                .expect("impossible: known_peers was asserted to be nonempty");
+                .expect("impossible: known_nodes was asserted to be nonempty");
 
         // We have:
         // 1. either consumed the whole iterator without success and got the first error,
@@ -439,7 +439,7 @@ impl ClusterState {
         Ok(std::iter::once(first_working_pool)
             .chain(remaining_working_pools_iter)
             .map(|(host_id, pool)| (host_id, IntoIterator::into_iter(pool))))
-        // By an invariant `self.known_peers` is nonempty, so the returned iterator
+        // By an invariant `self.known_nodes` is nonempty, so the returned iterator
         // is nonempty, too.
     }
 
@@ -455,9 +455,9 @@ impl ClusterState {
     pub(crate) fn iter_working_connections_to_nodes(
         &self,
     ) -> Result<impl Iterator<Item = Arc<Connection>> + use<'_>, ConnectionPoolError> {
-        // The returned iterator is nonempty by nonemptiness invariant of `self.known_peers`.
-        assert!(!self.known_peers.is_empty());
-        let nodes_iter = self.known_peers.values();
+        // The returned iterator is nonempty by nonemptiness invariant of `self.known_nodes`.
+        assert!(!self.known_nodes.is_empty());
+        let nodes_iter = self.known_nodes.values();
         let mut single_connection_per_node_iter =
             nodes_iter.map(|node| node.get_random_connection());
 
@@ -467,7 +467,7 @@ impl ClusterState {
             single_connection_per_node_iter
                 .by_ref()
                 .find_or_first(Result::is_ok)
-                .expect("impossible: known_peers was asserted to be nonempty");
+                .expect("impossible: known_nodes was asserted to be nonempty");
 
         // We have:
         // 1. either consumed the whole iterator without success and got the first error,
@@ -485,12 +485,12 @@ impl ClusterState {
     }
 
     #[cfg(test)]
-    fn known_peers(&self) -> &HashMap<Uuid, Arc<Node>> {
-        &self.known_peers
+    fn known_nodes(&self) -> &HashMap<Uuid, Arc<Node>> {
+        &self.known_nodes
     }
 
     pub(super) fn update_tablets(&mut self, raw_tablets: Vec<(TableSpec<'static>, RawTablet)>) {
-        let replica_translator = |uuid: Uuid| self.known_peers.get(&uuid).cloned();
+        let replica_translator = |uuid: Uuid| self.known_nodes.get(&uuid).cloned();
 
         for (table, raw_tablet) in raw_tablets.into_iter() {
             // Should we skip tablets that belong to a keyspace not present in
@@ -504,7 +504,7 @@ impl ClusterState {
                 Ok(t) => t,
                 Err((t, f)) => {
                     debug!(
-                        "Nodes ({}) that are replicas for a tablet {{ks: {}, table: {}, range: [{}. {}]}} not present in current ClusterState.known_peers. \
+                        "Nodes ({}) that are replicas for a tablet {{ks: {}, table: {}, range: [{}. {}]}} not present in current ClusterState.known_nodes. \
                        Skipping these replicas until topology refresh",
                         f.iter().safe_format(", "),
                         table.ks_name(),
@@ -579,17 +579,17 @@ mod tests {
         }
     }
 
-    /// Helper: build a ClusterState from metadata, old known_peers, and an optional host filter.
+    /// Helper: build a ClusterState from metadata, old known_nodes, and an optional host filter.
     async fn build_cluster_state(
         metadata: Metadata,
-        known_peers: &HashMap<Uuid, Arc<Node>>,
+        known_nodes: &HashMap<Uuid, Arc<Node>>,
         host_filter: Option<&dyn HostFilter>,
     ) -> ClusterState {
         let (tx, _rx) = mpsc::unbounded_channel();
         ClusterState::new(
             metadata,
             &Default::default(),
-            known_peers,
+            known_nodes,
             &mut |_, _| (),
             &None,
             host_filter,
@@ -622,7 +622,7 @@ mod tests {
         )]);
         let initial_state =
             build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
-        let old_node = initial_state.known_peers().get(&host_id).unwrap().clone();
+        let old_node = initial_state.known_nodes().get(&host_id).unwrap().clone();
         assert!(
             !old_node.is_enabled(),
             "node should be disabled when its address is rejected"
@@ -636,8 +636,8 @@ mod tests {
             Some("r1"),
         )]);
         let new_state =
-            build_cluster_state(new_metadata, initial_state.known_peers(), Some(&filter)).await;
-        let new_node = new_state.known_peers().get(&host_id).unwrap();
+            build_cluster_state(new_metadata, initial_state.known_nodes(), Some(&filter)).await;
+        let new_node = new_state.known_nodes().get(&host_id).unwrap();
 
         assert!(
             new_node.is_enabled(),
@@ -669,7 +669,7 @@ mod tests {
         )]);
         let initial_state =
             build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
-        let old_node = initial_state.known_peers().get(&host_id).unwrap().clone();
+        let old_node = initial_state.known_nodes().get(&host_id).unwrap().clone();
         assert!(
             old_node.is_enabled(),
             "node should be enabled when its address is accepted"
@@ -683,8 +683,8 @@ mod tests {
             Some("r1"),
         )]);
         let new_state =
-            build_cluster_state(new_metadata, initial_state.known_peers(), Some(&filter)).await;
-        let new_node = new_state.known_peers().get(&host_id).unwrap();
+            build_cluster_state(new_metadata, initial_state.known_nodes(), Some(&filter)).await;
+        let new_node = new_state.known_nodes().get(&host_id).unwrap();
 
         assert!(
             !new_node.is_enabled(),
@@ -711,14 +711,14 @@ mod tests {
             make_metadata(vec![make_peer(host_id, addr, Some("dc1"), Some("r1"))]);
         let initial_state =
             build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
-        let old_node = initial_state.known_peers().get(&host_id).unwrap().clone();
+        let old_node = initial_state.known_nodes().get(&host_id).unwrap().clone();
         assert!(!old_node.is_enabled(), "node should be disabled");
 
         // Refresh with identical attributes, still filtered out.
         let new_metadata = make_metadata(vec![make_peer(host_id, addr, Some("dc1"), Some("r1"))]);
         let new_state =
-            build_cluster_state(new_metadata, initial_state.known_peers(), Some(&filter)).await;
-        let new_node = new_state.known_peers().get(&host_id).unwrap();
+            build_cluster_state(new_metadata, initial_state.known_nodes(), Some(&filter)).await;
+        let new_node = new_state.known_nodes().get(&host_id).unwrap();
 
         assert!(!new_node.is_enabled(), "node should still be disabled");
         assert!(

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -170,15 +170,19 @@ impl ClusterState {
                     let is_enabled = host_filter.is_none_or(|f| f.accept(&peer));
                     let (peer_endpoint, tokens) = peer.into_peer_endpoint_and_tokens();
                     peer_tokens = tokens;
-                    Arc::new(Node::new(
-                        peer_endpoint,
-                        pool_config,
-                        connectivity_events_sender.clone(),
-                        used_keyspace.clone(),
-                        is_enabled,
-                        #[cfg(feature = "metrics")]
-                        Arc::clone(metrics),
-                    ))
+                    let node = if is_enabled {
+                        Node::new(
+                            peer_endpoint,
+                            pool_config,
+                            connectivity_events_sender.clone(),
+                            used_keyspace.clone(),
+                            #[cfg(feature = "metrics")]
+                            Arc::clone(metrics),
+                        )
+                    } else {
+                        Node::new_disabled(peer_endpoint)
+                    };
+                    Arc::new(node)
                 }
             };
 

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -148,16 +148,35 @@ impl ClusterState {
         let mut ring: Vec<(Token, Arc<Node>)> = Vec::new();
 
         for peer in metadata.peers {
-            // Take existing Arc<Node> if possible, otherwise create new one
-            // Changing rack/datacenter but not ip address seems improbable
-            // so we can just create new node and connections then
+            // Take existing Arc<Node> if possible, otherwise create new one.
             let peer_host_id = peer.host_id;
             let is_enabled = host_filter.is_none_or(|f| f.accept(&peer));
             let (peer_endpoint, peer_tokens) = peer.into_peer_endpoint_and_tokens();
 
-            let node: Arc<Node> = match known_peers.get(&peer_host_id) {
-                Some(node)
-                    if node.datacenter == peer_endpoint.datacenter
+            let node = match (is_enabled, known_peers.get(&peer_host_id)) {
+                // If the node is disabled, then we never want to have a connection pool to it.
+                // If it already existed, and was disabled, and all parameters (dc, rack, address) match
+                // then we can reuse the object.
+                // Otherwise we need to create a new one.
+                (false, Some(node))
+                    if !node.is_enabled()
+                        && node.datacenter == peer_endpoint.datacenter
+                        && node.rack == peer_endpoint.rack
+                        && node.address == peer_endpoint.address =>
+                {
+                    Arc::clone(node)
+                }
+                (false, _) => Arc::new(Node::new_disabled(peer_endpoint)),
+                // Changing rack/datacenter but not ip address seems improbable
+                // so we can just create new node and connections in such case.
+                // Here we allow preserving the Node object in full if all attributes (dc, rack, address)
+                // match. If only address is different, we recreate Node object but share the same underlying pool.
+                //
+                // IMPORTANT EDGE CASE: The old Node object might have been disabled. We know that the new Node object
+                // must be enabled, so there is no point in using the old one then.
+                (true, Some(node))
+                    if node.is_enabled()
+                        && node.datacenter == peer_endpoint.datacenter
                         && node.rack == peer_endpoint.rack =>
                 {
                     if node.address == peer_endpoint.address {
@@ -167,21 +186,14 @@ impl ClusterState {
                         Arc::new(Node::inherit_with_ip_changed(node, peer_endpoint))
                     }
                 }
-                _ => {
-                    let node = if is_enabled {
-                        Node::new(
-                            peer_endpoint,
-                            pool_config,
-                            connectivity_events_sender.clone(),
-                            used_keyspace.clone(),
-                            #[cfg(feature = "metrics")]
-                            Arc::clone(metrics),
-                        )
-                    } else {
-                        Node::new_disabled(peer_endpoint)
-                    };
-                    Arc::new(node)
-                }
+                (true, _) => Arc::new(Node::new(
+                    peer_endpoint,
+                    pool_config,
+                    connectivity_events_sender.clone(),
+                    used_keyspace.clone(),
+                    #[cfg(feature = "metrics")]
+                    Arc::clone(metrics),
+                )),
             };
 
             new_known_peers.insert(peer_host_id, Arc::clone(&node));

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -478,7 +478,7 @@ impl ClusterWorker {
         keyspace_name: &VerifiedKeyspaceName,
     ) -> Result<(), UseKeyspaceError> {
         let use_keyspace_futures = cluster_state
-            .known_peers
+            .known_nodes
             .values()
             .map(|node| node.use_keyspace(keyspace_name.clone()));
         let use_keyspace_results: Vec<Result<(), UseKeyspaceError>> =
@@ -498,7 +498,7 @@ impl ClusterWorker {
             ClusterState::new(
                 metadata,
                 &self.pool_config,
-                &cluster_state.known_peers,
+                &cluster_state.known_nodes,
                 &mut |old_nodes, new_nodes| {
                     ClusterWorker::handle_topology_changes(
                         old_nodes,
@@ -538,14 +538,14 @@ impl ClusterWorker {
     ///
     /// Emit respective events to the [HostListener], if configured.
     fn handle_topology_changes(
-        known_peers: &HashMap<Uuid, Arc<Node>>,
-        new_known_peers: &HashMap<Uuid, Arc<Node>>,
+        known_nodes: &HashMap<Uuid, Arc<Node>>,
+        new_known_nodes: &HashMap<Uuid, Arc<Node>>,
         host_listener: Option<&dyn HostListener>,
         node_status: &mut HashMap<Uuid, NodeConnectivityStatus>,
     ) {
         // Nodes that were previously in the cluster but are not present anymore.
         let removed_nodes =
-            hash_map_difference(known_peers, new_known_peers).filter(|(_host_id, node)| {
+            hash_map_difference(known_nodes, new_known_nodes).filter(|(_host_id, node)| {
                 // If a host filter is configured, we only consider nodes that passed the filter
                 // as removed. Nodes that were filtered out are not considered part of the cluster,
                 // so their removal is not signaled.
@@ -553,14 +553,14 @@ impl ClusterWorker {
             });
         // Nodes that weren't previously in the cluster but are present now.
         let added_nodes =
-            hash_map_difference(new_known_peers, known_peers).filter(|(_host_id, node)| {
+            hash_map_difference(new_known_nodes, known_nodes).filter(|(_host_id, node)| {
                 // If a host filter is configured, we only consider nodes that passed the filter
                 // as added. Nodes that were filtered out are not considered part of the cluster,
                 // so their addition is not signaled.
                 node.is_enabled()
             });
         // Nodes that were present in both old and new cluster state, but have changed address.
-        let nodes_with_changed_address = known_peers
+        let nodes_with_changed_address = known_nodes
             .iter()
             .filter(|(_host_id, old_node)| {
                 // If a host filter is configured, we only consider nodes that passed the filter
@@ -569,7 +569,7 @@ impl ClusterWorker {
                 old_node.is_enabled()
             })
             .filter_map(|(host_id, old_node)| {
-                new_known_peers
+                new_known_nodes
                     .get(host_id)
                     // We only consider nodes with changed SocketAddr. If only NodeAddr variant changed
                     // (which happens mainly when control connection moves from one node to another),
@@ -737,7 +737,7 @@ impl ClusterWorker {
         let cluster_state = self.cluster_state.load();
 
         let (Some(node), Some(connectivity)) = (
-            cluster_state.known_peers.get(&host_id),
+            cluster_state.known_nodes.get(&host_id),
             self.node_status.get_mut(&host_id),
         ) else {
             trace!("Received connectivity change event for unknown host_id: {host_id}");

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -3294,7 +3294,7 @@ mod latency_awareness {
                 averages: &[(u16, Option<TimestampedAverage>)],
             ) {
                 let addr_to_host_id: HashMap<NodeAddr, Uuid> = cluster
-                    .known_peers
+                    .known_nodes
                     .values()
                     .map(|node| (node.address, node.host_id))
                     .collect();

--- a/scylla/src/policies/load_balancing/plan.rs
+++ b/scylla/src/policies/load_balancing/plan.rs
@@ -232,7 +232,7 @@ mod tests {
         };
         let locator = create_locator(&mock_metadata_for_token_aware_tests());
         let cluster_state = ClusterState {
-            known_peers: Default::default(),
+            known_nodes: Default::default(),
             all_nodes: Default::default(),
             keyspaces: Default::default(),
             locator,

--- a/scylla/src/policies/load_balancing/single_target.rs
+++ b/scylla/src/policies/load_balancing/single_target.rs
@@ -76,7 +76,7 @@ impl LoadBalancingPolicy for SingleTargetLoadBalancingPolicy {
     ) -> Option<(NodeRef<'a>, Option<Shard>)> {
         let node = match &self.node_identifier {
             NodeIdentifier::Node(node) => Some(node),
-            NodeIdentifier::HostId(host_id) => cluster.known_peers.get(host_id),
+            NodeIdentifier::HostId(host_id) => cluster.known_nodes.get(host_id),
             NodeIdentifier::NodeAddress(addr) => cluster
                 .all_nodes
                 .iter()

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -415,7 +415,7 @@ impl TableTablets {
             self.tablet_list.retain_mut(|tablet| {
                 let r = tablet.re_resolve_replicas(|id: Uuid| all_current_nodes.get(&id).cloned());
                 if let Err(failed) = &r {
-                    warn!("Nodes ({}) listed as replicas for a tablet {{ks: {}, table: {}, range: [{}. {}]}} are not present in ClusterState.known_peers, \
+                    warn!("Nodes ({}) listed as replicas for a tablet {{ks: {}, table: {}, range: [{}. {}]}} are not present in ClusterState.known_nodes, \
                            despite topology refresh. Removing problematic tablet.",
                            failed.iter().safe_format(", "), self.table_spec.ks_name(), self.table_spec.table_name(), tablet.first_token.value(), tablet.last_token.value());
                 }

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -192,7 +192,6 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
             &pool_config,
             connectivity_events_sender.clone(),
             None,
-            true,
             #[cfg(feature = "metrics")]
             Default::default(),
         ));


### PR DESCRIPTION
HostFilter can make its decision based on any of `Peer` fields: `host_id`, `address`, `tokens`, `datacenter`, `rack`.
`ClusterState::new` did not take it into accocunt - when address or token list changed, HostFilter was not consulted again.

This PR fixes the logic, making it more robust and imo easier to comprehensively understand.
Now HostFilter is consulted always, and is a source of truth for Node being enabled.
Node object is reused only if all attributes match, and HostFilter didn't change its decision between old and new node.
Pool is reused if both old and new nodes are enabled, and differ at most by tokens and address.

Tests for this logic are added.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1503

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
