### PR TITLE
Connection pool: Don't panic on out of range shard

### DIFF
--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -358,7 +358,10 @@ impl NodeConnectionPool {
         }
 
         // If this fails try getting any other in random order
-        let mut shards_to_try: Vec<u16> = (0..shard).chain(shard + 1..nr_shards.get()).collect();
+        // We may attempt the original shard again, but its not a problem.
+        // An iteration of the loop below should be cheap for a shard with
+        // no connections.
+        let mut shards_to_try: Vec<u16> = (0..nr_shards.get()).collect();
 
         let orig_shard = shard;
         while !shards_to_try.is_empty() {

--- a/scylla/tests/integration/load_balancing/shards.rs
+++ b/scylla/tests/integration/load_balancing/shards.rs
@@ -107,11 +107,7 @@ async fn test_shard_out_of_range() {
             cluster: &'a ClusterState,
         ) -> Option<(NodeRef<'a>, Option<Shard>)> {
             let node = &cluster.get_nodes_info()[0];
-            match node.sharder() {
-                Some(sharder) => Some((node, Some(sharder.nr_shards.get() as u32))),
-                // For Cassandra let's pick some crazy shard number - it should be ignored anyway.
-                None => Some((node, Some(u16::MAX as u32))),
-            }
+            Some((node, Some(10000)))
         }
 
         fn fallback<'a>(


### PR DESCRIPTION
This has been fixed before, but not well enough.
The panic could still occur in the part that tried to get connections from random shards.
It was not detected, because regression test asked for a shard just one past the end of the array, which was not enough to trigger the error.

This commit both fixes the test (I made sure it is no passing before fixing the connection pool), and fixes the crash in connection pool.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1560

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
