### PR TITLE
Configure session rack

### DIFF
--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -174,19 +174,6 @@ let policy = DefaultPolicy::builder()
 # }
 ```
 
-```rust
-# extern crate scylla;
-# fn test_if_compiles() {
-use scylla::policies::load_balancing::DefaultPolicy;
-
-let default_policy = DefaultPolicy::builder()
-        .prefer_datacenter("dc1".to_string())
-        .token_aware(true)
-        .permit_dc_failover(true)
-        .build();
-# }
-```
-
 ### Node order in produced plans
 
 The DefaultPolicy prefers to return nodes in the following order:

--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -5,6 +5,10 @@ can be configured to be datacenter-aware, rack-aware and token-aware.
 When the policy is datacenter-aware, you can configure whether to allow datacenter failover
 (sending query to a node from a remote datacenter).
 
+Node location preferences (datacenter/rack) can be configured at two levels:
+- **Session level** — via `SessionBuilder::prefer_datacenter()`, `SessionBuilder::prefer_datacenter_and_rack()`, or `SessionBuilder::prefer_no_datacenter()`. This sets a default preference used by all policies that don't override it.
+- **Policy level** — directly on `DefaultPolicyBuilder`. When set, the policy-level preference overrides the session-level one.
+
 ## Creating a DefaultPolicy
 
 `DefaultPolicy` can be created only using `DefaultPolicyBuilder`. The
@@ -12,7 +16,7 @@ When the policy is datacenter-aware, you can configure whether to allow datacent
 `DefaultPolicyBuilder`. Builder has the following configuration options
 and default values:
 
-- `preferences`, configured using `prefer_datacenter` and `prefer_datacenter_and_rack` methods: no particular datacenter/rack preference
+- `preferences`, configured using `prefer_datacenter`, `prefer_datacenter_and_rack`, `prefer_no_datacenter`, and `inherit_location_preference` methods: `None` (falls back to the session-level preference from `SessionConfig`). Use `prefer_no_datacenter` to explicitly treat all nodes equally regardless of session preference.
 - `is_token_aware`, configured using `token_aware` method: `true`
 - `permit_dc_failover`, configured using method with the same name: `false`
 - `latency_awareness`, configured using method with the same name: `None`
@@ -38,12 +42,27 @@ let default_policy = DefaultPolicy::builder()
 
 #### Preferences
 
-The `preferences` field in `DefaultPolicy` allows the load balancing
-policy to prioritize nodes based on their location. It has three modes:
+Node location preferences control how `DefaultPolicy` prioritizes nodes.
+Preferences are resolved at two levels:
 
-- no preference
-- preferred datacenter
-- preferred datacenter and rack
+1. **Session-level preference** — set via `SessionBuilder::prefer_datacenter()`,
+   `SessionBuilder::prefer_datacenter_and_rack()`, or `SessionBuilder::prefer_no_datacenter()`.
+   This is stored in `SessionConfig::node_location_preference` and passed to policies
+   through `RoutingInfo`.
+
+2. **Policy-level preference** — set directly on `DefaultPolicyBuilder` using
+   `prefer_datacenter()`, `prefer_datacenter_and_rack()`, or `prefer_no_datacenter()`.
+   When set (`Some`), this overrides the session-level preference.
+
+By default, `DefaultPolicy` has no policy-level preference (`None`), so it
+uses the session-level preference. The session-level default is `Any` (no
+preference), so out of the box all nodes are treated equally.
+
+The effective preference (after resolving the two levels) has three modes:
+
+- no preference — all nodes are treated as local
+- preferred datacenter — nodes in the preferred DC are "local", others are "remote"
+- preferred datacenter and rack — within the preferred DC, nodes in the preferred rack are tried first
 
 When a datacenter `"my_dc"` is preferred, the policy will treat nodes in `"my_dc"`
 as "local" nodes, and nodes in other datacenters as "remote" nodes. This affects

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -45,6 +45,7 @@ use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
 use crate::policies::retry::{RequestInfo, RetryDecision, RetrySession};
 use crate::response::query_result::ColumnSpecs;
 use crate::response::{Coordinator, NonErrorQueryResponse, QueryResponse};
+use crate::routing::NodeLocationPreference;
 use crate::statement::prepared::{PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
 use tracing::{Instrument, error, trace, trace_span, warn};
@@ -1089,6 +1090,7 @@ pub(crate) struct PreparedPagerConfig {
     pub(crate) cluster_state: Arc<ClusterState>,
     #[cfg(feature = "metrics")]
     pub(crate) metrics: Arc<Metrics>,
+    pub(crate) location_preference: Arc<NodeLocationPreference>,
 }
 
 /// An intermediate object that allows to construct a stream over a query
@@ -1218,6 +1220,7 @@ If you are using this API, you are probably doing something wrong."
         execution_profile: Arc<ExecutionProfileInner>,
         cluster_state: Arc<ClusterState>,
         #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
+        node_location_preference: Arc<NodeLocationPreference>,
     ) -> Result<Self, PagerExecutionError> {
         let (sender, receiver) = oneshot::channel::<ResultFirstPage>();
 
@@ -1236,12 +1239,6 @@ If you are using this API, you are probably doing something wrong."
             .map(PageQueryTimeouter::new);
 
         let page_size = statement.get_validated_page_size();
-
-        let routing_info = RoutingInfo {
-            consistency,
-            serial_consistency,
-            ..Default::default()
-        };
 
         let load_balancing_policy = Arc::clone(
             statement
@@ -1273,6 +1270,13 @@ If you are using this API, you are probably doing something wrong."
                         )
                         .await
                 }
+            };
+
+            let routing_info = RoutingInfo {
+                consistency,
+                serial_consistency,
+                node_location_preference: &node_location_preference,
+                ..Default::default()
             };
 
             let query_ref = &statement;
@@ -1373,6 +1377,7 @@ If you are using this API, you are probably doing something wrong."
                 token,
                 table: table_spec,
                 is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
+                node_location_preference: &config.location_preference,
             };
 
             let page_query = |connection: Arc<Connection>,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -1275,8 +1275,10 @@ If you are using this API, you are probably doing something wrong."
             let routing_info = RoutingInfo {
                 consistency,
                 serial_consistency,
+                token: None,
+                table: None,
+                is_confirmed_lwt: false,
                 node_location_preference: &node_location_preference,
-                ..Default::default()
             };
 
             let query_ref = &statement;

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1305,8 +1305,10 @@ impl Session {
                 .config
                 .serial_consistency
                 .unwrap_or(execution_profile.serial_consistency),
+            token: None,
+            table: None,
+            is_confirmed_lwt: false,
             node_location_preference: &self.node_location_preference,
-            ..Default::default()
         };
 
         let span = RequestSpan::new_query(&statement.contents);

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -36,6 +36,7 @@ use crate::response::query_result::{MaybeFirstRowError, QueryResult, RowsError};
 use crate::response::{
     Coordinator, NonErrorQueryResponse, PagingState, PagingStateResponse, QueryResponse,
 };
+use crate::routing::NodeLocationPreference;
 use crate::routing::partitioner::PartitionerName;
 use crate::routing::{Shard, ShardAwarePortRange};
 use crate::statement::batch::batch_values;
@@ -96,6 +97,7 @@ pub struct Session {
     tracing_info_fetch_attempts: NonZeroU32,
     tracing_info_fetch_interval: Duration,
     tracing_info_fetch_consistency: Consistency,
+    node_location_preference: Arc<NodeLocationPreference>,
     internal_statements: InternalStatements,
 }
 
@@ -139,6 +141,7 @@ impl std::fmt::Debug for Session {
             "tracing_info_fetch_consistency",
             &self.tracing_info_fetch_consistency,
         )
+        .field("node_location_preference", &self.node_location_preference)
         .finish()
     }
 }
@@ -176,6 +179,15 @@ impl From<Arc<rustls::ClientConfig>> for TlsContext {
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct SessionConfig {
+    /// The preferred location of nodes to contact.
+    ///
+    /// When set to a specific datacenter (or datacenter and rack), the driver
+    /// treats matching nodes as "local" and prioritizes them in query plans.
+    /// This acts as a default that load balancing policies can use or override.
+    ///
+    /// Default: [`NodeLocationPreference::Any`].
+    pub node_location_preference: NodeLocationPreference,
+
     /// List of database servers known on Session startup.
     /// Session will connect to these nodes to retrieve information about other nodes in the cluster.
     /// Each node can be represented as a hostname or an IP address.
@@ -383,6 +395,7 @@ impl SessionConfig {
     /// ```
     pub fn new() -> Self {
         SessionConfig {
+            node_location_preference: NodeLocationPreference::Any,
             known_nodes: Vec::new(),
             local_ip_address: None,
             shard_aware_local_port_range: ShardAwarePortRange::EPHEMERAL_PORT_RANGE,
@@ -1058,6 +1071,7 @@ impl Session {
     pub async fn connect(config: SessionConfig) -> Result<Self, NewSessionError> {
         config.validate()?;
 
+        let node_location_preference = config.node_location_preference;
         let known_nodes = config.known_nodes;
 
         let (tablet_sender, tablet_receiver) = tokio::sync::mpsc::channel(TABLET_CHANNEL_SIZE);
@@ -1177,6 +1191,7 @@ impl Session {
             tracing_info_fetch_attempts: config.tracing_info_fetch_attempts,
             tracing_info_fetch_interval: config.tracing_info_fetch_interval,
             tracing_info_fetch_consistency: config.tracing_info_fetch_consistency,
+            node_location_preference: Arc::new(node_location_preference),
             internal_statements: InternalStatements::default(),
         };
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -998,6 +998,7 @@ impl Session {
             token: first_value_token,
             table: table_spec,
             is_confirmed_lwt: false,
+            node_location_preference: &self.node_location_preference,
         };
 
         let span = RequestSpan::new_batch();
@@ -1304,6 +1305,7 @@ impl Session {
                 .config
                 .serial_consistency
                 .unwrap_or(execution_profile.serial_consistency),
+            node_location_preference: &self.node_location_preference,
             ..Default::default()
         };
 
@@ -1472,6 +1474,7 @@ impl Session {
             self.cluster.get_state(),
             #[cfg(feature = "metrics")]
             Arc::clone(&self.metrics),
+            Arc::clone(&self.node_location_preference),
         )
         .await
     }
@@ -1697,6 +1700,7 @@ impl Session {
             token,
             table: table_spec,
             is_confirmed_lwt: prepared.is_confirmed_lwt(),
+            node_location_preference: &self.node_location_preference,
         };
 
         let span = RequestSpan::new_prepared(
@@ -1797,6 +1801,7 @@ impl Session {
                 cluster_state: self.cluster.get_state(),
                 #[cfg(feature = "metrics")]
                 metrics: Arc::clone(&self.metrics),
+                location_preference: Arc::clone(&self.node_location_preference),
             },
         )
         .await

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -9,7 +9,7 @@ use crate::errors::NewSessionError;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::timestamp_generator::TimestampGenerator;
-use crate::routing::ShardAwarePortRange;
+use crate::routing::{NodeLocationPreference, ShardAwarePortRange};
 use crate::statement::Consistency;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
@@ -538,6 +538,36 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// ```
     pub fn compression(mut self, compression: Option<Compression>) -> Self {
         self.config.compression = compression;
+        self
+    }
+
+    /// Sets the preferred datacenter for this session.
+    ///
+    /// Nodes in the given datacenter will be treated as "local" and preferred
+    /// by load balancing policies that do not override this preference.
+    pub fn prefer_datacenter(mut self, datacenter_name: String) -> Self {
+        self.config.node_location_preference = NodeLocationPreference::Datacenter(datacenter_name);
+        self
+    }
+
+    /// Sets the preferred datacenter and rack for this session.
+    ///
+    /// Nodes in the given rack of the given datacenter are tried first,
+    /// followed by other nodes in the same datacenter, and then remote nodes.
+    /// This preference is used by load balancing policies that do not override it.
+    pub fn prefer_datacenter_and_rack(
+        mut self,
+        datacenter_name: String,
+        rack_name: String,
+    ) -> Self {
+        self.config.node_location_preference =
+            NodeLocationPreference::DatacenterAndRack(datacenter_name, rack_name);
+        self
+    }
+
+    /// Clears any node location preference, treating all nodes equally.
+    pub fn prefer_no_datacenter(mut self) -> Self {
+        self.config.node_location_preference = NodeLocationPreference::Any;
         self
     }
 

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -161,7 +161,7 @@ impl LoadBalancingPolicy for DefaultPolicy {
         {
             warn!(
                 "\
-Combining SimpleStrategy with preferred_datacenter set to Some and disabled datacenter failover may lead to empty query plans for some tokens.\
+Combining SimpleStrategy with DC preference and disabled datacenter failover may lead to empty query plans for some tokens.\
 It is better to give up using one of them: either operate in a keyspace with NetworkTopologyStrategy, which explicitly states\
 how many replicas there are in each datacenter (you probably want at least 1 to avoid empty plans while preferring that datacenter), \
 or refrain from preferring datacenters (which may ban all other datacenters, if datacenter failover happens to be not possible)."

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -145,7 +145,7 @@ impl LoadBalancingPolicy for DefaultPolicy {
         let routing_info = self.routing_info(query, cluster);
 
         if let Some(ref token_with_strategy) = routing_info.token_with_strategy
-            && self.preferences.datacenter().is_some()
+            && routing_info.preference.datacenter().is_some()
             && !self.permit_dc_failover
             && matches!(
                 token_with_strategy.strategy,
@@ -171,7 +171,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         /* Token-aware logic - if routing info is available, we know what are the replicas
          * for the statement. Try to pick one of them. */
         if let (Some(ts), Some(table_spec)) = (&routing_info.token_with_strategy, query.table) {
-            if let NodeLocationPreference::DatacenterAndRack(dc, rack) = &self.preferences {
+            if let NodeLocationPreference::DatacenterAndRack(dc, rack) = routing_info.preference {
                 // Try to pick some alive local rack random replica.
                 let local_rack_picked = self.pick_replica(
                     ts,
@@ -194,7 +194,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
             }
 
             if let NodeLocationPreference::DatacenterAndRack(dc, _)
-            | NodeLocationPreference::Datacenter(dc) = &self.preferences
+            | NodeLocationPreference::Datacenter(dc) = routing_info.preference
             {
                 // Try to pick some alive local random replica.
                 let picked = self.pick_replica(
@@ -218,7 +218,9 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
             }
 
             // If preferred datacenter is not specified, or if datacenter failover is possible, loosen restriction about locality.
-            if self.preferences.datacenter().is_none() || self.is_datacenter_failover_possible() {
+            if routing_info.preference.datacenter().is_none()
+                || self.is_datacenter_failover_possible(&routing_info)
+            {
                 // Try to pick some alive random replica.
                 let picked = self.pick_replica(
                     ts,
@@ -249,9 +251,9 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
 
         // Let's start with local nodes, i.e. those in the preferred datacenter.
         // If there was no preferred datacenter specified, all nodes are treated as local.
-        let local_nodes = self.preferred_node_set(cluster);
+        let local_nodes = self.preferred_node_set(cluster, &routing_info);
 
-        if let NodeLocationPreference::DatacenterAndRack(dc, rack) = &self.preferences {
+        if let NodeLocationPreference::DatacenterAndRack(dc, rack) = routing_info.preference {
             // Try to pick some alive random local rack node.
             let rack_predicate = Self::make_rack_predicate(
                 |node| (self.pick_predicate)(node, None),
@@ -273,7 +275,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
 
         let all_nodes = cluster.replica_locator().unique_nodes_in_global_ring();
         // If a datacenter failover is possible, loosen restriction about locality.
-        if self.is_datacenter_failover_possible() {
+        if self.is_datacenter_failover_possible(&routing_info) {
             let maybe_remote_node_picked =
                 self.pick_node(all_nodes, |node| (self.pick_predicate)(node, None));
             if let Some(alive_maybe_remote_node) = maybe_remote_node_picked {
@@ -291,7 +293,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         }
 
         // If a datacenter failover is possible, loosen restriction about locality.
-        if self.is_datacenter_failover_possible() {
+        if self.is_datacenter_failover_possible(&routing_info) {
             let maybe_down_maybe_remote_node_picked =
                 self.pick_node(all_nodes, |node| node.is_enabled());
             if let Some(down_but_enabled_maybe_remote_node) = maybe_down_maybe_remote_node_picked {
@@ -331,26 +333,29 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         {
             // Iterator over alive local rack replicas (shuffled or deterministically ordered,
             // depending on the statement being LWT or not).
-            let maybe_local_rack_replicas =
-                if let NodeLocationPreference::DatacenterAndRack(dc, rack) = &self.preferences {
-                    let local_rack_replicas = self.maybe_shuffled_replicas(
-                        ts,
-                        NodeLocationCriteria::DatacenterAndRack(dc, rack),
-                        |node, shard| Self::is_alive(node, Some(shard)),
-                        cluster,
-                        statement_type,
-                        table_spec,
-                    );
-                    Either::Left(local_rack_replicas)
-                } else {
-                    Either::Right(std::iter::empty())
-                };
+            let maybe_local_rack_replicas = if let NodeLocationPreference::DatacenterAndRack(
+                dc,
+                rack,
+            ) = routing_info.preference
+            {
+                let local_rack_replicas = self.maybe_shuffled_replicas(
+                    ts,
+                    NodeLocationCriteria::DatacenterAndRack(dc, rack),
+                    |node, shard| Self::is_alive(node, Some(shard)),
+                    cluster,
+                    statement_type,
+                    table_spec,
+                );
+                Either::Left(local_rack_replicas)
+            } else {
+                Either::Right(std::iter::empty())
+            };
 
             // Iterator over alive local datacenter replicas (shuffled or deterministically ordered,
             // depending on the statement being LWT or not).
             let maybe_local_replicas = if let NodeLocationPreference::DatacenterAndRack(dc, _)
             | NodeLocationPreference::Datacenter(dc) =
-                &self.preferences
+                routing_info.preference
             {
                 let local_replicas = self.maybe_shuffled_replicas(
                     ts,
@@ -366,8 +371,8 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
             };
 
             // If no datacenter is preferred, or datacenter failover is possible, loosen restriction about locality.
-            let maybe_remote_replicas = if self.preferences.datacenter().is_none()
-                || self.is_datacenter_failover_possible()
+            let maybe_remote_replicas = if routing_info.preference.datacenter().is_none()
+                || self.is_datacenter_failover_possible(&routing_info)
             {
                 // Iterator over alive replicas (shuffled or deterministically ordered,
                 // depending on the statement being LWT or not).
@@ -403,10 +408,10 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         /* We start having not alive nodes filtered out. */
 
         // All nodes in the local datacenter (if one is given).
-        let local_nodes = self.preferred_node_set(cluster);
+        let local_nodes = self.preferred_node_set(cluster, &routing_info);
 
         let robinned_local_rack_nodes =
-            if let NodeLocationPreference::DatacenterAndRack(dc, rack) = &self.preferences {
+            if let NodeLocationPreference::DatacenterAndRack(dc, rack) = routing_info.preference {
                 let rack_predicate = Self::make_rack_predicate(
                     |node| Self::is_alive(node, None),
                     NodeLocationCriteria::DatacenterAndRack(dc, rack),
@@ -427,7 +432,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         let all_nodes = cluster.replica_locator().unique_nodes_in_global_ring();
 
         // If a datacenter failover is possible, loosen restriction about locality.
-        let maybe_remote_nodes = if self.is_datacenter_failover_possible() {
+        let maybe_remote_nodes = if self.is_datacenter_failover_possible(&routing_info) {
             let robinned_all_nodes =
                 self.round_robin_nodes(all_nodes, |node| Self::is_alive(node, None));
 
@@ -443,7 +448,7 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
             .map(|node| (node, None));
 
         // If a datacenter failover is possible, loosen restriction about locality.
-        let maybe_down_nodes = if self.is_datacenter_failover_possible() {
+        let maybe_down_nodes = if self.is_datacenter_failover_possible(&routing_info) {
             Either::Left(
                 all_nodes
                     .iter()
@@ -570,7 +575,7 @@ impl DefaultPolicy {
         query: &'a RoutingInfo,
         cluster: &'a ClusterState,
     ) -> ProcessedRoutingInfo<'a> {
-        let mut routing_info = ProcessedRoutingInfo::new(query, cluster);
+        let mut routing_info = ProcessedRoutingInfo::new(query, cluster, &self.preferences);
 
         if !self.is_token_aware {
             routing_info.token_with_strategy = None;
@@ -581,8 +586,12 @@ impl DefaultPolicy {
 
     /// Returns all nodes in the local datacenter if one is given,
     /// or else all nodes in the cluster.
-    fn preferred_node_set<'a>(&'a self, cluster: &'a ClusterState) -> &'a [Arc<Node>] {
-        if let Some(preferred_datacenter) = self.preferences.datacenter() {
+    fn preferred_node_set<'a>(
+        &'a self,
+        cluster: &'a ClusterState,
+        routing_info: &ProcessedRoutingInfo<'_>,
+    ) -> &'a [Arc<Node>] {
+        if let Some(preferred_datacenter) = routing_info.preference.datacenter() {
             if let Some(nodes) = cluster
                 .replica_locator()
                 .unique_nodes_in_datacenter_ring(preferred_datacenter)
@@ -885,8 +894,8 @@ impl DefaultPolicy {
     }
 
     /// Returns true iff the datacenter failover is permitted for the statement being executed.
-    fn is_datacenter_failover_possible(&self) -> bool {
-        self.preferences.datacenter().is_some() && self.permit_dc_failover
+    fn is_datacenter_failover_possible(&self, routing_info: &ProcessedRoutingInfo<'_>) -> bool {
+        routing_info.preference.datacenter().is_some() && self.permit_dc_failover
     }
 }
 
@@ -1094,12 +1103,18 @@ impl Default for DefaultPolicyBuilder {
 
 struct ProcessedRoutingInfo<'a> {
     token_with_strategy: Option<TokenWithStrategy<'a>>,
+    preference: &'a NodeLocationPreference,
 }
 
 impl<'a> ProcessedRoutingInfo<'a> {
-    fn new(query: &'a RoutingInfo, cluster: &'a ClusterState) -> ProcessedRoutingInfo<'a> {
+    fn new(
+        query: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+        policy_preference: &'a NodeLocationPreference,
+    ) -> ProcessedRoutingInfo<'a> {
         Self {
             token_with_strategy: TokenWithStrategy::new(query, cluster),
+            preference: policy_preference,
         }
     }
 }

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1022,6 +1022,16 @@ impl DefaultPolicyBuilder {
         self
     }
 
+    /// Explicitly sets the preference to treat all nodes equally, with no
+    /// datacenter or rack preference.
+    ///
+    /// This overrides the session-level node location preference (if any),
+    /// ensuring that this policy always treats all nodes as local.
+    pub fn prefer_no_datacenter(mut self) -> Self {
+        self.preferences = Some(NodeLocationPreference::Any);
+        self
+    }
+
     /// Sets whether this policy is token-aware (balances load more consciously) or not.
     ///
     /// Token awareness refers to a mechanism by which the driver is aware

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -87,8 +87,9 @@ enum PickedReplica<'a> {
 /// in-flight-requests-aware policy.
 #[expect(clippy::type_complexity)]
 pub struct DefaultPolicy {
-    /// Preferences regarding node location. One of: rack and DC, DC, or no preference.
-    preferences: NodeLocationPreference,
+    /// Preferences regarding node location. One of: rack and DC, DC, no DC preference,
+    /// or fallback to Session-level preference.
+    preferences: Option<NodeLocationPreference>,
 
     /// Configures whether the policy takes token into consideration when creating plans.
     /// If this is set to `true` AND token, keyspace and table are available,
@@ -575,7 +576,7 @@ impl DefaultPolicy {
         query: &'a RoutingInfo,
         cluster: &'a ClusterState,
     ) -> ProcessedRoutingInfo<'a> {
-        let mut routing_info = ProcessedRoutingInfo::new(query, cluster, &self.preferences);
+        let mut routing_info = ProcessedRoutingInfo::new(query, cluster, self.preferences.as_ref());
 
         if !self.is_token_aware {
             routing_info.token_with_strategy = None;
@@ -902,7 +903,7 @@ impl DefaultPolicy {
 impl Default for DefaultPolicy {
     fn default() -> Self {
         Self {
-            preferences: NodeLocationPreference::Any,
+            preferences: None,
             is_token_aware: true,
             permit_dc_failover: false,
             pick_predicate: Box::new(Self::is_alive),
@@ -928,7 +929,7 @@ impl Default for DefaultPolicy {
 /// # }
 #[derive(Clone, Debug)]
 pub struct DefaultPolicyBuilder {
-    preferences: NodeLocationPreference,
+    preferences: Option<NodeLocationPreference>,
     is_token_aware: bool,
     permit_dc_failover: bool,
     latency_awareness: Option<LatencyAwarenessBuilder>,
@@ -939,7 +940,7 @@ impl DefaultPolicyBuilder {
     /// Creates a builder used to customise configuration of a new DefaultPolicy.
     pub fn new() -> Self {
         Self {
-            preferences: NodeLocationPreference::Any,
+            preferences: None,
             is_token_aware: true,
             permit_dc_failover: false,
             latency_awareness: None,
@@ -988,7 +989,7 @@ impl DefaultPolicyBuilder {
     /// Remote nodes will be excluded, even if they are alive and available
     /// to serve requests.
     pub fn prefer_datacenter(mut self, datacenter_name: String) -> Self {
-        self.preferences = NodeLocationPreference::Datacenter(datacenter_name);
+        self.preferences = Some(NodeLocationPreference::Datacenter(datacenter_name));
         self
     }
 
@@ -1014,7 +1015,10 @@ impl DefaultPolicyBuilder {
         datacenter_name: String,
         rack_name: String,
     ) -> Self {
-        self.preferences = NodeLocationPreference::DatacenterAndRack(datacenter_name, rack_name);
+        self.preferences = Some(NodeLocationPreference::DatacenterAndRack(
+            datacenter_name,
+            rack_name,
+        ));
         self
     }
 
@@ -1110,11 +1114,11 @@ impl<'a> ProcessedRoutingInfo<'a> {
     fn new(
         query: &'a RoutingInfo,
         cluster: &'a ClusterState,
-        policy_preference: &'a NodeLocationPreference,
+        policy_preference: Option<&'a NodeLocationPreference>,
     ) -> ProcessedRoutingInfo<'a> {
         Self {
             token_with_strategy: TokenWithStrategy::new(query, cluster),
-            preference: policy_preference,
+            preference: policy_preference.unwrap_or(&NodeLocationPreference::Any),
         }
     }
 }
@@ -1516,7 +1520,7 @@ mod tests {
         setup_tracing();
         let local_dc = "eu".to_string();
         let policy_with_disabled_dc_failover = DefaultPolicy {
-            preferences: NodeLocationPreference::Datacenter(local_dc.clone()),
+            preferences: Some(NodeLocationPreference::Datacenter(local_dc.clone())),
             permit_dc_failover: false,
             ..Default::default()
         };
@@ -1530,7 +1534,7 @@ mod tests {
         .await;
 
         let policy_with_enabled_dc_failover = DefaultPolicy {
-            preferences: NodeLocationPreference::Datacenter(local_dc.clone()),
+            preferences: Some(NodeLocationPreference::Datacenter(local_dc.clone())),
             permit_dc_failover: true,
             ..Default::default()
         };
@@ -1563,7 +1567,7 @@ mod tests {
             // Keyspace NTS with RF=2 with enabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1587,7 +1591,7 @@ mod tests {
             // Keyspace NTS with RF=2 with enabled DC failover, shuffling replicas disabled
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     fixed_seed: Some(123),
@@ -1612,7 +1616,7 @@ mod tests {
             // Keyspace NTS with RF=2 with DC with local Consistency. DC failover should still work.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     fixed_seed: Some(123),
@@ -1637,7 +1641,7 @@ mod tests {
             // Keyspace NTS with RF=2 with explicitly disabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -1659,7 +1663,7 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1683,7 +1687,7 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover, shuffling replicas disabled
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     fixed_seed: Some(123),
@@ -1708,7 +1712,7 @@ mod tests {
             // Keyspace NTS with RF=3 with disabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -1730,7 +1734,7 @@ mod tests {
             // Keyspace SS with RF=2 with enabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1754,7 +1758,7 @@ mod tests {
             // Keyspace SS with RF=2 with DC failover and local Consistency. DC failover should still work.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1781,7 +1785,7 @@ mod tests {
             // No token implies no token awareness
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1800,7 +1804,7 @@ mod tests {
             // No keyspace implies no token awareness
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1819,7 +1823,7 @@ mod tests {
             // Unknown preferred DC, failover permitted
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("au".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("au".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1841,7 +1845,7 @@ mod tests {
             // Unknown preferred DC, failover forbidden
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("au".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("au".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -1860,7 +1864,7 @@ mod tests {
             // No preferred DC, failover permitted
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Any,
+                    preferences: Some(NodeLocationPreference::Any),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1882,7 +1886,7 @@ mod tests {
             // No preferred DC, failover forbidden
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Any,
+                    preferences: Some(NodeLocationPreference::Any),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -1904,10 +1908,10 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover and rack-awareness
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r1".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -1931,10 +1935,10 @@ mod tests {
             // Keyspace SS with RF=2 with enabled rack-awareness, shuffling replicas disabled
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r1".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     fixed_seed: Some(123),
@@ -1959,10 +1963,10 @@ mod tests {
             // Keyspace SS with RF=2 with enabled rack-awareness and no local-rack replica
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r2".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -1985,10 +1989,10 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover and rack-awareness, no token provided
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r1".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2042,7 +2046,7 @@ mod tests {
             // Keyspace NTS with RF=2 with enabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2067,7 +2071,7 @@ mod tests {
             // Keyspace NTS with RF=2 with enabled DC failover, shuffling replicas disabled
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     fixed_seed: Some(123),
@@ -2093,7 +2097,7 @@ mod tests {
             // Keyspace NTS with RF=2 with DC failover and local Consistency. DC failover should still work.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2118,7 +2122,7 @@ mod tests {
             // Keyspace NTS with RF=2 with explicitly disabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -2141,7 +2145,7 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2166,7 +2170,7 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover, shuffling replicas disabled
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     fixed_seed: Some(123),
@@ -2192,7 +2196,7 @@ mod tests {
             // Keyspace NTS with RF=3 with disabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -2215,7 +2219,7 @@ mod tests {
             // Keyspace SS with RF=2 with enabled DC failover
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2240,7 +2244,7 @@ mod tests {
             // Keyspace SS with RF=2 with DC failover and local Consistency. DC failover should still work.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2265,7 +2269,7 @@ mod tests {
             // No token implies no token awareness
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2285,7 +2289,7 @@ mod tests {
             // No keyspace implies no token awareness
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2305,7 +2309,7 @@ mod tests {
             // Unknown preferred DC, failover permitted
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("au".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("au".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2328,7 +2332,7 @@ mod tests {
             // Unknown preferred DC, failover forbidden
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("au".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("au".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -2348,7 +2352,7 @@ mod tests {
             // No preferred DC, failover permitted
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Any,
+                    preferences: Some(NodeLocationPreference::Any),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2371,7 +2375,7 @@ mod tests {
             // No preferred DC, failover forbidden
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Any,
+                    preferences: Some(NodeLocationPreference::Any),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -2394,10 +2398,10 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover and rack-awareness
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r1".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2422,10 +2426,10 @@ mod tests {
             // Keyspace SS with RF=2 with enabled rack-awareness, shuffling replicas disabled
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r1".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     fixed_seed: Some(123),
@@ -2450,10 +2454,10 @@ mod tests {
             // Keyspace SS with RF=2 with enabled rack-awareness and no local-rack replica
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r2".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -2478,7 +2482,7 @@ mod tests {
             // Keyspace NTS with RF=2 with enabled DC failover.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2504,7 +2508,7 @@ mod tests {
             // Keyspace NTS with RF=3 with enabled DC failover.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     ..Default::default()
@@ -2530,10 +2534,10 @@ mod tests {
             // Keyspace NTS with RF=2.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::DatacenterAndRack(
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
                         "eu".to_owned(),
                         "r1".to_owned(),
-                    ),
+                    )),
                     is_token_aware: true,
                     permit_dc_failover: false,
                     ..Default::default()
@@ -2606,7 +2610,7 @@ mod tests {
             // This is a regression test after a bug was fixed.
             Test {
                 policy: DefaultPolicy {
-                    preferences: NodeLocationPreference::Any,
+                    preferences: Some(NodeLocationPreference::Any),
                     is_token_aware: true,
                     permit_dc_failover: true,
                     pick_predicate: Box::new(|node, _shard| node.address != id_to_invalid_addr(F)),
@@ -3321,7 +3325,7 @@ mod latency_awareness {
             };
 
             DefaultPolicy {
-                preferences: NodeLocationPreference::Datacenter("eu".to_owned()),
+                preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
                 permit_dc_failover: true,
                 is_token_aware: true,
                 pick_predicate,

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1032,6 +1032,19 @@ impl DefaultPolicyBuilder {
         self
     }
 
+    /// Clears the policy-level node location preference, so that the
+    /// session-level preference (from [`SessionConfig`](crate::client::session::SessionConfig))
+    /// is used instead.
+    ///
+    /// This is the default behaviour — calling this method is only needed
+    /// to undo a previous call to [`prefer_datacenter`](Self::prefer_datacenter),
+    /// [`prefer_datacenter_and_rack`](Self::prefer_datacenter_and_rack),
+    /// or [`prefer_no_datacenter`](Self::prefer_no_datacenter).
+    pub fn inherit_location_preference(mut self) -> Self {
+        self.preferences = None;
+        self
+    }
+
     /// Sets whether this policy is token-aware (balances load more consciously) or not.
     ///
     /// Token awareness refers to a mechanism by which the driver is aware

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1483,6 +1483,7 @@ mod tests {
         is_confirmed_lwt: false,
         consistency: Consistency::Quorum,
         serial_consistency: Some(SerialConsistency::Serial),
+        node_location_preference: &NodeLocationPreference::Any,
     };
 
     pub(super) fn test_default_policy_with_given_cluster_and_routing_info(

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -77,6 +77,12 @@ enum PickedReplica<'a> {
 /// When the policy is datacenter-aware, you can configure whether to allow datacenter failover
 /// (sending query to a node from a remote datacenter).
 ///
+/// Node location preferences can be set directly on this policy (via
+/// [`DefaultPolicyBuilder`]) or inherited from the session-level preference
+/// in [`SessionConfig`](crate::client::session::SessionConfig). When no
+/// policy-level preference is set (the default), the session-level preference
+/// is used.
+///
 /// Latency awareness is available, although **not recommended**:
 /// the penalisation mechanism it involves may interact badly with other
 /// mechanisms, such as LWT optimisation. Also, the very tactics of penalising
@@ -977,6 +983,8 @@ impl DefaultPolicyBuilder {
 
     /// Sets the datacenter to be preferred by this policy.
     ///
+    /// This overrides the session-level node location preference (if any).
+    ///
     /// Allows the load balancing policy to prioritize nodes based on their location.
     /// When a preferred datacenter is set, the policy will treat nodes in that
     /// datacenter as "local" nodes, and nodes in other datacenters as "remote" nodes.
@@ -994,6 +1002,8 @@ impl DefaultPolicyBuilder {
     }
 
     /// Sets the datacenter and rack to be preferred by this policy.
+    ///
+    /// This overrides the session-level node location preference (if any).
     ///
     /// Allows the load balancing policy to prioritize nodes based on their location
     /// as well as their availability zones in the preferred datacenter.

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -2683,6 +2683,101 @@ mod tests {
             );
         }
     }
+
+    #[tokio::test]
+    async fn test_default_policy_uses_routing_info_preference() {
+        setup_tracing();
+        let cluster = mock_cluster_state_for_token_unaware_tests().await;
+
+        // Test 1: Policy None + RI Datacenter("eu") → uses "eu"
+        {
+            let policy = DefaultPolicy {
+                preferences: None,
+                permit_dc_failover: true,
+                ..Default::default()
+            };
+            let eu_preference = NodeLocationPreference::Datacenter("eu".to_owned());
+            let routing_info = RoutingInfo {
+                node_location_preference: &eu_preference,
+                ..EMPTY_ROUTING_INFO
+            };
+            let expected = ExpectedGroupsBuilder::new()
+                .group([1, 2, 3])
+                .group([4, 5])
+                .build();
+            test_default_policy_with_given_cluster_and_routing_info(
+                &policy,
+                &cluster,
+                &routing_info,
+                &expected,
+            );
+        }
+
+        // Test 2: Policy None + RI Any → all nodes equal
+        {
+            let policy = DefaultPolicy {
+                preferences: None,
+                permit_dc_failover: true,
+                ..Default::default()
+            };
+            let routing_info = RoutingInfo {
+                node_location_preference: &NodeLocationPreference::Any,
+                ..EMPTY_ROUTING_INFO
+            };
+            let expected = ExpectedGroupsBuilder::new().group([1, 2, 3, 4, 5]).build();
+            test_default_policy_with_given_cluster_and_routing_info(
+                &policy,
+                &cluster,
+                &routing_info,
+                &expected,
+            );
+        }
+
+        // Test 3: Policy Datacenter("us") overrides RI Datacenter("eu")
+        {
+            let policy = DefaultPolicy {
+                preferences: Some(NodeLocationPreference::Datacenter("us".to_owned())),
+                permit_dc_failover: true,
+                ..Default::default()
+            };
+            let eu_preference = NodeLocationPreference::Datacenter("eu".to_owned());
+            let routing_info = RoutingInfo {
+                node_location_preference: &eu_preference,
+                ..EMPTY_ROUTING_INFO
+            };
+            let expected = ExpectedGroupsBuilder::new()
+                .group([4, 5])
+                .group([1, 2, 3])
+                .build();
+            test_default_policy_with_given_cluster_and_routing_info(
+                &policy,
+                &cluster,
+                &routing_info,
+                &expected,
+            );
+        }
+
+        // Test 4: Policy Some(Any) overrides RI Datacenter("eu") → all nodes equal
+        {
+            let policy = DefaultPolicy {
+                preferences: Some(NodeLocationPreference::Any),
+                permit_dc_failover: true,
+                ..Default::default()
+            };
+            let eu_preference = NodeLocationPreference::Datacenter("eu".to_owned());
+            let routing_info = RoutingInfo {
+                node_location_preference: &eu_preference,
+                ..EMPTY_ROUTING_INFO
+            };
+            let expected = ExpectedGroupsBuilder::new().group([1, 2, 3, 4, 5]).build();
+            test_default_policy_with_given_cluster_and_routing_info(
+                &policy,
+                &cluster,
+                &routing_info,
+                &expected,
+            );
+        }
+    }
 }
 
 mod latency_awareness {

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1128,7 +1128,7 @@ impl<'a> ProcessedRoutingInfo<'a> {
     ) -> ProcessedRoutingInfo<'a> {
         Self {
             token_with_strategy: TokenWithStrategy::new(query, cluster),
-            preference: policy_preference.unwrap_or(&NodeLocationPreference::Any),
+            preference: policy_preference.unwrap_or(query.node_location_preference),
         }
     }
 }

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -3,6 +3,7 @@ pub use self::latency_awareness::LatencyAwarenessBuilder;
 
 use super::{FallbackPlan, LoadBalancingPolicy, NodeRef, RoutingInfo};
 use crate::cluster::ClusterState;
+use crate::routing::NodeLocationPreference;
 use crate::{
     cluster::metadata::Strategy,
     cluster::node::Node,
@@ -31,30 +32,6 @@ impl<'a> NodeLocationCriteria<'a> {
         match self {
             Self::Any => None,
             Self::Datacenter(dc) | Self::DatacenterAndRack(dc, _) => Some(dc),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum NodeLocationPreference {
-    Any,
-    Datacenter(String),
-    DatacenterAndRack(String, String),
-}
-
-impl NodeLocationPreference {
-    fn datacenter(&self) -> Option<&str> {
-        match self {
-            Self::Any => None,
-            Self::Datacenter(dc) | Self::DatacenterAndRack(dc, _) => Some(dc),
-        }
-    }
-
-    #[expect(unused)]
-    fn rack(&self) -> Option<&str> {
-        match self {
-            Self::Any | Self::Datacenter(_) => None,
-            Self::DatacenterAndRack(_, rack) => Some(rack),
         }
     }
 }

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -3,6 +3,7 @@
 //! See [the book](https://rust-driver.docs.scylladb.com/stable/load-balancing/load-balancing.html) for more information
 
 use crate::cluster::{ClusterState, NodeRef};
+use crate::routing::NodeLocationPreference;
 use crate::{
     errors::RequestAttemptError,
     routing::{Shard, Token},
@@ -19,7 +20,7 @@ pub use plan::Plan;
 pub use single_target::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
 
 /// Represents info about statement that can be used by load balancing policies.
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct RoutingInfo<'a> {
     /// Consistency level for the request.
@@ -57,6 +58,22 @@ pub struct RoutingInfo<'a> {
     /// [`Consistency::Serial`]: types::Consistency::Serial
     /// [`Consistency::LocalSerial`]: types::Consistency::LocalSerial
     pub is_confirmed_lwt: bool,
+
+    /// The session-level node location preference to pass to load balancing policies.
+    pub node_location_preference: &'a NodeLocationPreference,
+}
+
+impl Default for RoutingInfo<'_> {
+    fn default() -> Self {
+        Self {
+            consistency: types::Consistency::default(),
+            serial_consistency: None,
+            token: None,
+            table: None,
+            is_confirmed_lwt: false,
+            node_location_preference: &NodeLocationPreference::Any,
+        }
+    }
 }
 
 impl RoutingInfo<'_> {

--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -57,13 +57,26 @@ impl Token {
 }
 
 #[derive(Debug, Clone)]
+/// Describes the preferred location of nodes to contact when executing requests.
+///
+/// This preference influences the order in which nodes appear in load balancing
+/// plans. Nodes matching the preference are considered "local" and are tried
+/// first, while non-matching nodes are considered "remote".
 pub(crate) enum NodeLocationPreference {
+    /// No location preference — all nodes are treated equally.
     Any,
+    /// Prefer nodes located in the given datacenter.
     Datacenter(String),
+    /// Prefer nodes located in the given datacenter and rack.
+    ///
+    /// Nodes in the specified rack of the specified datacenter are tried first,
+    /// followed by other nodes in the same datacenter, and finally nodes in
+    /// remote datacenters.
     DatacenterAndRack(String, String),
 }
 
 impl NodeLocationPreference {
+    /// Returns the preferred datacenter, if any.
     pub(crate) fn datacenter(&self) -> Option<&str> {
         match self {
             Self::Any => None,
@@ -71,6 +84,9 @@ impl NodeLocationPreference {
         }
     }
 
+    /// Returns the preferred rack, if any.
+    ///
+    /// This is `Some` only for the [`DatacenterAndRack`](Self::DatacenterAndRack) variant.
     #[expect(unused)]
     pub(crate) fn rack(&self) -> Option<&str> {
         match self {

--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -62,6 +62,7 @@ impl Token {
 /// This preference influences the order in which nodes appear in load balancing
 /// plans. Nodes matching the preference are considered "local" and are tried
 /// first, while non-matching nodes are considered "remote".
+#[non_exhaustive]
 pub enum NodeLocationPreference {
     /// No location preference — all nodes are treated equally.
     Any,

--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -62,7 +62,7 @@ impl Token {
 /// This preference influences the order in which nodes appear in load balancing
 /// plans. Nodes matching the preference are considered "local" and are tried
 /// first, while non-matching nodes are considered "remote".
-pub(crate) enum NodeLocationPreference {
+pub enum NodeLocationPreference {
     /// No location preference — all nodes are treated equally.
     Any,
     /// Prefer nodes located in the given datacenter.
@@ -77,7 +77,7 @@ pub(crate) enum NodeLocationPreference {
 
 impl NodeLocationPreference {
     /// Returns the preferred datacenter, if any.
-    pub(crate) fn datacenter(&self) -> Option<&str> {
+    pub fn datacenter(&self) -> Option<&str> {
         match self {
             Self::Any => None,
             Self::Datacenter(dc) | Self::DatacenterAndRack(dc, _) => Some(dc),
@@ -87,8 +87,7 @@ impl NodeLocationPreference {
     /// Returns the preferred rack, if any.
     ///
     /// This is `Some` only for the [`DatacenterAndRack`](Self::DatacenterAndRack) variant.
-    #[expect(unused)]
-    pub(crate) fn rack(&self) -> Option<&str> {
+    pub fn rack(&self) -> Option<&str> {
         match self {
             Self::Any | Self::Datacenter(_) => None,
             Self::DatacenterAndRack(_, rack) => Some(rack),

--- a/scylla/src/routing/mod.rs
+++ b/scylla/src/routing/mod.rs
@@ -55,3 +55,27 @@ impl Token {
         self.value
     }
 }
+
+#[derive(Debug, Clone)]
+pub(crate) enum NodeLocationPreference {
+    Any,
+    Datacenter(String),
+    DatacenterAndRack(String, String),
+}
+
+impl NodeLocationPreference {
+    pub(crate) fn datacenter(&self) -> Option<&str> {
+        match self {
+            Self::Any => None,
+            Self::Datacenter(dc) | Self::DatacenterAndRack(dc, _) => Some(dc),
+        }
+    }
+
+    #[expect(unused)]
+    pub(crate) fn rack(&self) -> Option<&str> {
+        match self {
+            Self::Any | Self::Datacenter(_) => None,
+            Self::DatacenterAndRack(_, rack) => Some(rack),
+        }
+    }
+}

--- a/scylla/tests/integration/statements/consistency.rs
+++ b/scylla/tests/integration/statements/consistency.rs
@@ -9,7 +9,7 @@ use scylla::client::session_builder::SessionBuilder;
 use scylla::cluster::NodeRef;
 use scylla::policies::load_balancing::{DefaultPolicy, LoadBalancingPolicy, RoutingInfo};
 use scylla::policies::retry::FallthroughRetryPolicy;
-use scylla::routing::{Shard, Token};
+use scylla::routing::{NodeLocationPreference, Shard, Token};
 use scylla::statement::SerialConsistency;
 use scylla::statement::batch::BatchStatement;
 use scylla::statement::batch::{Batch, BatchType};
@@ -354,6 +354,8 @@ pub(crate) struct OwnedRoutingInfo {
     token: Option<Token>,
     #[expect(unused)]
     is_confirmed_lwt: bool,
+    #[expect(unused)]
+    node_location_preference: NodeLocationPreference,
 }
 
 impl OwnedRoutingInfo {
@@ -364,6 +366,7 @@ impl OwnedRoutingInfo {
             token,
             table,
             is_confirmed_lwt,
+            node_location_preference,
             ..
         } = info;
         Self {
@@ -372,6 +375,7 @@ impl OwnedRoutingInfo {
             token,
             table: table.map(TableSpec::to_owned),
             is_confirmed_lwt,
+            node_location_preference: node_location_preference.clone(),
         }
     }
 }


### PR DESCRIPTION
This PR allows configuring preferred DC / Rack on a SessionBuilder level. Until now, it had to be configured on DefaultPolicy.
Why do this?
- Knowing a preferred DC / Rack will be useful to other parts of the driver. For example, we will now be able to make Control Connection prefer nodes in local rack / DC. It could potentially be useful with .e.g processing tablet hints for strongly consistent tables in local mode in the future. In 2.0 we could provide this information automatically to other parts of the driver, for example HostFilter, allowing writing a HostFilter that only connects to local DC, without the need to explicitly give it local dc name.
- Setting up preferred DC / rack is something that pretty much all users should do, so it should be as ergonomic as possible. Before, it required building ExecutionProfile and using DefaultPolicyBuilder:
```rust
    let session: Session = SessionBuilder::new()
        .known_node(uri)
        .default_execution_profile_handle(
            ExecutionProfile::builder()
                .load_balancing_policy(
                    DefaultPolicy::builder()
                        .prefer_datacenter_and_rack("dc1".to_string(), "rack1".to_string())
                        .build(),
                )
                .build()
                .into_handle(),
        )
        .build()
        .await?;
```
After the change this becomes:
```rust
    let session: Session = SessionBuilder::new()
        .known_node(uri)
        .prefer_datacenter_and_rack("dc1".to_string(), "rack1".to_string())
        .build()
        .await?;
```

The existing configuration on DefaultPolicyBuilder is of course preserved.
Now setting preference on DefaultPolicy will override Session-level preference. This means that existing code will continue to work as before: Session-level preference will be Any, possibly overwritten by policy-level preference.

`SessionBuilder` gets 3 new methods: `prefer_datacenter`, `prefer_datacenter_and_rack`, `prefer_no_datacenter`.
`DefaultPolicyBuilder` gets `prefer_no_datacenter` (overrider Session-level preference, makes policy non-dc-aware) and `inherit_location_preference` (fallback to Session-level preference). Note that the fallback is the default, so the latter method is only useful to set back the default changed by earlier call to e.g. `prefer_datacenter`.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1440

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
