### PR TITLE
Docs: Fix broken links

### DIFF
--- a/docs/source/statements/lwt.md
+++ b/docs/source/statements/lwt.md
@@ -49,4 +49,4 @@ session.query_unpaged(my_statement, (12345_i32,)).await?;
 # }
 ```
 
-See [Statement API documentation](https://docs.rs/scylla/latest/scylla/statement/struct.Statement.html) for more options
+See [Statement API documentation](https://docs.rs/scylla/latest/scylla/statement/unprepared/struct.Statement.html) for more options

--- a/docs/source/statements/prepared.md
+++ b/docs/source/statements/prepared.md
@@ -87,7 +87,7 @@ session.execute_unpaged(&prepared, (to_insert,)).await?;
 # }
 ```
 
-See [PreparedStatement API documentation](https://docs.rs/scylla/latest/scylla/statement/prepared_statement/struct.PreparedStatement.html)
+See [PreparedStatement API documentation](https://docs.rs/scylla/latest/scylla/statement/prepared/struct.PreparedStatement.html)
 for more options.
 
 > ***Note***

--- a/docs/source/statements/unprepared.md
+++ b/docs/source/statements/unprepared.md
@@ -49,7 +49,7 @@ session.query_unpaged(my_statement, (to_insert,)).await?;
 # Ok(())
 # }
 ```
-See [Statement API documentation](https://docs.rs/scylla/latest/scylla/statement/struct.Statement.html) for more options
+See [Statement API documentation](https://docs.rs/scylla/latest/scylla/statement/unprepared/struct.Statement.html) for more options
 
 ### Second argument - the values
 Statement text is constant, but the values may change.

--- a/docs/source/tracing/query-history.md
+++ b/docs/source/tracing/query-history.md
@@ -95,19 +95,19 @@ This is done by spawning a speculative fiber. Each spawned fiber performs sequen
 Many fibers can be spawned if the answer wasn't acquired in time.
 
 ### StructuredHistory
-[`StructuredHistory`](https://docs.rs/scylla/latest/scylla/history/struct.StructuredHistory.html)
+[`StructuredHistory`](https://docs.rs/scylla/latest/scylla/observability/history/struct.StructuredHistory.html)
 is a history representation that represents the history by listing attempts for each speculative fiber.
 
 ## HistoryListener trait, custom history collecting
 
 History can be collected by any struct implementing the
-[`HistoryListener`](https://docs.rs/scylla/latest/scylla/history/trait.HistoryListener.html) trait.
+[`HistoryListener`](https://docs.rs/scylla/latest/scylla/observability/history/trait.HistoryListener.html) trait.
 
 The implementation of `HistoryListener` provided by this crate is the
-[`HistoryCollector`](https://docs.rs/scylla/latest/scylla/history/struct.HistoryCollector.html).
+[`HistoryCollector`](https://docs.rs/scylla/latest/scylla/observability/history/struct.HistoryCollector.html).
 `HistoryCollector` simply collects all events along with their timestamps.
 
 Information collected by `HistoryCollector` is just a stream of events, in order to analyze it it's possible
 to convert it to a structured representation.
-[`StructuredHistory`](https://docs.rs/scylla/latest/scylla/history/struct.StructuredHistory.html)
+[`StructuredHistory`](https://docs.rs/scylla/latest/scylla/observability/history/struct.StructuredHistory.html)
 can be created by calling `HistoryCollector::clone_structured_history()`.


### PR DESCRIPTION
We have apparently forgot to update them when restructuring the modules before 1.0.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1662

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
