### PR TITLE
Implement / fix / optimize optional methods and traits for our iterators

### DIFF
--- a/scylla-cql/src/deserialize/result.rs
+++ b/scylla-cql/src/deserialize/result.rs
@@ -88,6 +88,9 @@ impl<'frame, 'metadata> Iterator for RawRowIterator<'frame, 'metadata> {
     }
 }
 
+// This iterator always yields exactly `self.remaining` items.
+impl<'frame, 'metadata> ExactSizeIterator for RawRowIterator<'frame, 'metadata> {}
+
 /// A typed version of [RawRowIterator] which deserializes the rows before
 /// returning them.
 #[derive(Debug)]

--- a/scylla-cql/src/deserialize/result.rs
+++ b/scylla-cql/src/deserialize/result.rs
@@ -148,6 +148,13 @@ where
     }
 }
 
+// This iterator only yields `None` if underlying `RawRowIterator` yields `None`.
+// `RawRowIterator` is `ExactSizeIterator`, so this one can be as well.
+impl<'frame, 'metadata, R> ExactSizeIterator for TypedRowIterator<'frame, 'metadata, R> where
+    R: DeserializeRow<'frame, 'metadata>
+{
+}
+
 // Technically not an iterator because it returns items that borrow from it,
 // and the std Iterator interface does not allow for that.
 /// A _lending_ iterator over serialized rows.

--- a/scylla-cql/src/deserialize/row.rs
+++ b/scylla-cql/src/deserialize/row.rs
@@ -100,6 +100,11 @@ impl<'frame, 'metadata> Iterator for ColumnIterator<'frame, 'metadata> {
     }
 }
 
+// In `next` we call `next()` on `self.specs` (which is a slice) and propagate `None`.
+// After that we can only return `Some`. It may be `Some(Err(_))`,
+// but it is still a valid iterator item.
+impl<'frame, 'metadata> ExactSizeIterator for ColumnIterator<'frame, 'metadata> {}
+
 /// A type that can be deserialized from a row that was returned from a query.
 ///
 /// For tips on how to write a custom implementation of this trait, see the

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1502,6 +1502,13 @@ where
     }
 }
 
+impl<'frame, 'metadata, K, V> ExactSizeIterator for MapIterator<'frame, 'metadata, K, V>
+where
+    K: DeserializeValue<'frame, 'metadata>,
+    V: DeserializeValue<'frame, 'metadata>,
+{
+}
+
 impl<'frame, 'metadata, K, V> DeserializeValue<'frame, 'metadata> for BTreeMap<K, V>
 where
     K: DeserializeValue<'frame, 'metadata> + Ord,

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1448,7 +1448,12 @@ where
     type Item = Result<(K, V), DeserializationError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let raw_k = match self.raw_iter.next() {
+        // Note the lack of `?` - we want each call to `next()` to consume EXACTLY two items
+        // from the inner iterator. This is necessary for correct and precise
+        // `size_hint`, and thus the implementation of `ExactSizeIterator`.
+        let raw_k_result = self.raw_iter.next();
+        let raw_v_result = self.raw_iter.next();
+        let raw_k = match raw_k_result {
             Some(Ok(raw_k)) => raw_k,
             Some(Err(err)) => {
                 return Some(Err(mk_deser_err::<Self>(
@@ -1458,7 +1463,7 @@ where
             }
             None => return None,
         };
-        let raw_v = match self.raw_iter.next() {
+        let raw_v = match raw_v_result {
             Some(Ok(raw_v)) => raw_v,
             Some(Err(err)) => {
                 return Some(Err(mk_deser_err::<Self>(
@@ -1488,15 +1493,12 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        // IMPORTANT: with the current implementation of `next` we cannot
-        // provide an exact type hint, or implementation of ExactSizeIterator.
-        // If each call to `next` consumed exactly two items from `self.raw_iter`,
-        // and always returned `Some` if both are `Some` then this iterator would be exact.
-        // Right now, if first call to `self.raw_iter.next()` returns `Some(Err(_))`,
-        // then we return early with `Some(Err(_))` as well, consuming only one item of
-        // inner iterator.
-        let len = self.raw_iter.len();
-        (len / 2, Some(len))
+        // Each call to `next()` consumes exactly two items from the iterator.
+        // If, and only if, both are `Some`, this iterator returns `Some`.
+        // This makes its item number precise, given that the inner iterator
+        // is ExactSizeIterator.
+        let len = self.raw_iter.len() / 2;
+        (len, Some(len))
     }
 }
 

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1337,6 +1337,39 @@ where
         (self.remaining, Some(self.remaining))
     }
 
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if let Some(element_length) = self.element_length {
+            // Fast path: fixed-size elements — skip n elements by advancing the frame
+            // slice by n * element_length bytes, without deserializing each skipped element.
+            if n >= self.remaining {
+                self.remaining = 0;
+                return None;
+            }
+            if n > 0 {
+                let bytes_to_skip = n * element_length;
+                if let Err(err) = self.slice.read_n_bytes(bytes_to_skip) {
+                    // We checked that `n < self.remaining`, so this won't cause
+                    // negative overflow.
+                    self.remaining -= n + 1;
+                    return Some(Err(mk_deser_err::<Self>(
+                        self.collection_type,
+                        BuiltinDeserializationErrorKind::RawCqlBytesReadError(err),
+                    )));
+                }
+                self.remaining -= n;
+            }
+            self.next_constant_length_elem(element_length)
+        } else {
+            // Variable-length elements: fall back to the default sequential behaviour.
+            for _ in 0..n {
+                // Discard the item (which may be Ok or Err); only stop on exhaustion.
+                let _ = self.next_variable_length_elem()?;
+            }
+            self.next_variable_length_elem()
+        }
+    }
+}
+
 // This iterator always returns exactly `self.remaining` elements.
 impl<'frame, 'metadata, T> ExactSizeIterator for VectorIterator<'frame, 'metadata, T> where
     T: DeserializeValue<'frame, 'metadata>

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1821,6 +1821,11 @@ impl<'frame, 'metadata> Iterator for UdtIterator<'frame, 'metadata> {
     }
 }
 
+// The iterator yields exactly one item per remaining field, regardless of whether
+// the serialized form contains a value for that field or not (missing fields are
+// reported as `Ok(None)`).
+impl<'frame, 'metadata> ExactSizeIterator for UdtIterator<'frame, 'metadata> {}
+
 // Container implementations
 
 impl<'frame, 'metadata, T: DeserializeValue<'frame, 'metadata>> DeserializeValue<'frame, 'metadata>

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1488,7 +1488,15 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.raw_iter.size_hint()
+        // IMPORTANT: with the current implementation of `next` we cannot
+        // provide an exact type hint, or implementation of ExactSizeIterator.
+        // If each call to `next` consumed exactly two items from `self.raw_iter`,
+        // and always returned `Some` if both are `Some` then this iterator would be exact.
+        // Right now, if first call to `self.raw_iter.next()` returns `Some(Err(_))`,
+        // then we return early with `Some(Err(_))` as well, consuming only one item of
+        // inner iterator.
+        let len = self.raw_iter.len();
+        (len / 2, Some(len))
     }
 }
 

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1336,6 +1336,11 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }
+
+// This iterator always returns exactly `self.remaining` elements.
+impl<'frame, 'metadata, T> ExactSizeIterator for VectorIterator<'frame, 'metadata, T> where
+    T: DeserializeValue<'frame, 'metadata>
+{
 }
 
 /// An iterator over a CQL map.

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1787,7 +1787,6 @@ impl<'frame, 'metadata> Iterator for UdtIterator<'frame, 'metadata> {
     );
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: Should we fail when there are too many fields?
         let (head, fields) = self.remaining_fields.split_first()?;
         self.remaining_fields = fields;
         let raw_res = match self.raw_iter.next() {

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1937,7 +1937,17 @@ impl<'frame> Iterator for FixedLengthBytesSequenceIterator<'frame> {
         self.remaining = self.remaining.checked_sub(1)?;
         Some(self.slice.read_cql_bytes())
     }
+
+    // Always yields exactly the requested number of elements.
+    // Some of them may be errors, but it is irrelevant for `size_hint`.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
 }
+
+// Always yields exactly the requested number of elements.
+// Some of them may be errors, but it is irrelevant here.
+impl<'frame> ExactSizeIterator for FixedLengthBytesSequenceIterator<'frame> {}
 
 /// Iterates over a sequence of `[bytes]` items from a frame subslice.
 ///

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1814,7 +1814,11 @@ impl<'frame, 'metadata> Iterator for UdtIterator<'frame, 'metadata> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.raw_iter.size_hint()
+        // The iterator yields exactly one item per remaining field, regardless of whether
+        // the serialized form contains a value for that field or not (missing fields are
+        // reported as `Ok(None)`).
+        let len = self.remaining_fields.len();
+        (len, Some(len))
     }
 }
 

--- a/scylla-cql/src/deserialize/value.rs
+++ b/scylla-cql/src/deserialize/value.rs
@@ -1044,10 +1044,18 @@ where
         }))
     }
 
+    // We only return `None` when underlying `FixedLengthBytesSequenceIterator` does.
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.raw_iter.size_hint()
     }
+}
+
+// We only return `None` when underlying `FixedLengthBytesSequenceIterator` does.
+// `FixedLengthBytesSequenceIterator` is ExactSize, so this can be too.
+impl<'frame, 'metadata, T> ExactSizeIterator for ListlikeIterator<'frame, 'metadata, T> where
+    T: DeserializeValue<'frame, 'metadata>
+{
 }
 
 impl<'frame, 'metadata, T> DeserializeValue<'frame, 'metadata> for Vec<T>

--- a/scylla-cql/src/deserialize/value_tests.rs
+++ b/scylla-cql/src/deserialize/value_tests.rs
@@ -24,7 +24,7 @@ use super::{
     BuiltinDeserializationError, BuiltinDeserializationErrorKind, BuiltinTypeCheckError,
     BuiltinTypeCheckErrorKind, DeserializeValue, ListlikeIterator, MapDeserializationErrorKind,
     MapIterator, MapTypeCheckErrorKind, MaybeEmpty, SetOrListDeserializationErrorKind,
-    SetOrListTypeCheckErrorKind, mk_deser_err,
+    SetOrListTypeCheckErrorKind, VectorIterator, mk_deser_err,
 };
 
 #[test]
@@ -358,6 +358,142 @@ fn test_deserialize_vector() {
         decoded_vec,
         CqlValue::Vector(vec![CqlValue::Int(1), CqlValue::Int(2)])
     );
+}
+
+// Tests for VectorIterator::nth, covering both code paths:
+//   - fast path: fixed-size element types (element_length = Some(n)), where nth skips
+//     n * element_length bytes in one shot without deserializing skipped elements.
+//   - slow path: variable-size element types (element_length = None), where nth falls back
+//     to sequential iteration.
+#[test]
+#[expect(clippy::iter_nth_zero)]
+fn test_vector_iterator_nth() {
+    // --- Fast path: f32 elements (4 bytes each, element_length = Some(4)) ---
+    {
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Float)),
+            dimensions: 5,
+        };
+        // Serialize [1.0, 2.0, 3.0, 4.0, 5.0] so we can deserialize it with VectorIterator.
+        let mut buf = Bytes::new();
+        serialize_to_buf(&typ, &vec![1.0_f32, 2.0, 3.0, 4.0, 5.0], &mut buf);
+
+        // nth(0) behaves like next(): returns the first element and advances by one.
+        {
+            let mut iter = deserialize::<VectorIterator<f32>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(0).transpose().unwrap(), Some(1.0_f32));
+            assert_eq!(iter.len(), 4);
+        }
+
+        // nth(2) skips the first two elements (1.0, 2.0) and returns the third (3.0).
+        {
+            let mut iter = deserialize::<VectorIterator<f32>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(2).transpose().unwrap(), Some(3.0_f32));
+            assert_eq!(iter.len(), 2);
+        }
+
+        // nth(4) returns the very last element and leaves the iterator empty.
+        {
+            let mut iter = deserialize::<VectorIterator<f32>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(4).transpose().unwrap(), Some(5.0_f32));
+            assert_eq!(iter.len(), 0);
+        }
+
+        // nth(n) where n == remaining exhausts the iterator and returns None.
+        {
+            let mut iter = deserialize::<VectorIterator<f32>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(5).transpose().unwrap(), None);
+            assert_eq!(iter.len(), 0);
+        }
+
+        // nth on an already-exhausted iterator returns None.
+        {
+            let mut iter = deserialize::<VectorIterator<f32>>(&typ, &buf).unwrap();
+            let _ = iter.nth(5);
+            assert_eq!(iter.nth(0).transpose().unwrap(), None);
+        }
+
+        // After nth(1) the remaining elements are accessible via next() in order.
+        {
+            let mut iter = deserialize::<VectorIterator<f32>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(1).transpose().unwrap(), Some(2.0_f32)); // skips 1.0, yields 2.0
+            assert_eq!(iter.next().transpose().unwrap(), Some(3.0_f32));
+            assert_eq!(iter.next().transpose().unwrap(), Some(4.0_f32));
+            assert_eq!(iter.next().transpose().unwrap(), Some(5.0_f32));
+            assert_eq!(iter.next().transpose().unwrap(), None);
+        }
+
+        // Two sequential nth calls advance through the vector correctly:
+        // first nth(1) yields element at index 1 (2.0), then nth(1) on the remaining
+        // [3.0, 4.0, 5.0] skips 3.0 and yields 4.0.
+        {
+            let mut iter = deserialize::<VectorIterator<f32>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(1).transpose().unwrap(), Some(2.0_f32));
+            assert_eq!(iter.nth(1).transpose().unwrap(), Some(4.0_f32));
+            assert_eq!(iter.len(), 1);
+        }
+    }
+
+    // --- Slow path: &str elements (Text, variable length, element_length = None) ---
+    {
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Text)),
+            dimensions: 5,
+        };
+        let mut buf = Bytes::new();
+        serialize_to_buf(
+            &typ,
+            &vec!["alice", "bob", "carol", "dave", "eve"],
+            &mut buf,
+        );
+
+        // nth(0) returns the first element.
+        {
+            let mut iter = deserialize::<VectorIterator<&str>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(0).transpose().unwrap(), Some("alice"));
+            assert_eq!(iter.len(), 4);
+        }
+
+        // nth(2) skips "alice" and "bob", returns "carol".
+        {
+            let mut iter = deserialize::<VectorIterator<&str>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(2).transpose().unwrap(), Some("carol"));
+            assert_eq!(iter.len(), 2);
+        }
+
+        // nth(4) returns the last element and leaves the iterator empty.
+        {
+            let mut iter = deserialize::<VectorIterator<&str>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(4).transpose().unwrap(), Some("eve"));
+            assert_eq!(iter.len(), 0);
+        }
+
+        // nth(n) where n == remaining returns None.
+        {
+            let mut iter = deserialize::<VectorIterator<&str>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(5).transpose().unwrap(), None);
+            assert_eq!(iter.len(), 0);
+        }
+
+        // After nth(1) the remaining elements are accessible via next() in order.
+        {
+            let mut iter = deserialize::<VectorIterator<&str>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(1).transpose().unwrap(), Some("bob")); // skips "alice", yields "bob"
+            assert_eq!(iter.next().transpose().unwrap(), Some("carol"));
+            assert_eq!(iter.next().transpose().unwrap(), Some("dave"));
+            assert_eq!(iter.next().transpose().unwrap(), Some("eve"));
+            assert_eq!(iter.next().transpose().unwrap(), None);
+        }
+
+        // Two sequential nth calls: nth(1) yields "bob", then nth(1) on the remaining
+        // ["carol", "dave", "eve"] skips "carol" and yields "dave".
+        {
+            let mut iter = deserialize::<VectorIterator<&str>>(&typ, &buf).unwrap();
+            assert_eq!(iter.nth(1).transpose().unwrap(), Some("bob"));
+            assert_eq!(iter.nth(1).transpose().unwrap(), Some("dave"));
+            assert_eq!(iter.len(), 1);
+        }
+    }
 }
 
 #[test]

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -607,20 +607,22 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
                 idx,
             } => (0, Some(replicas.len() - *idx)),
             ReplicaSetIteratorInner::ChainedNTS {
-                replicas: _,
-                replicas_idx: _,
+                replicas,
+                replicas_idx,
                 datacenter_repfactors,
                 locator,
                 token: _,
                 datacenter_idx,
             } => {
-                let yielded: usize = locator.datacenter_names()[0..*datacenter_idx]
+                let yielded_previous_dcs: usize = locator.datacenter_names()[0..*datacenter_idx]
                     .iter()
                     .filter_map(|name| datacenter_repfactors.get(name))
                     .sum();
+                let yielded: usize = yielded_previous_dcs + replicas_idx;
+                let left_current_dc = replicas.len() - replicas_idx;
 
                 (
-                    0,
+                    left_current_dc,
                     Some(datacenter_repfactors.values().sum::<usize>() - yielded),
                 )
             }

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -637,11 +637,46 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
 
                 self.next()
             }
-            _ => {
+            ReplicaSetIteratorInner::FilteredSimple { .. } => {
                 for _i in 0..n {
                     self.next()?;
                 }
 
+                self.next()
+            }
+            ReplicaSetIteratorInner::ChainedNTS {
+                replicas,
+                replicas_idx,
+                datacenter_repfactors,
+                locator,
+                token,
+                datacenter_idx,
+            } => {
+                // Note: `nth` API is indexed by 0, so `nth(0)` is the same as `next()`.
+                let mut remaining = n;
+                loop {
+                    let left_in_current = replicas.len() - *replicas_idx;
+                    if remaining < left_in_current {
+                        // Target is within the current datacenter's replicas.
+                        // Advance the index and break out to call self.next().
+                        *replicas_idx += remaining;
+                        break;
+                    }
+                    // Skip past the rest of the current datacenter.
+                    remaining -= left_in_current;
+                    if *datacenter_idx + 1 < locator.datacenters.len() {
+                        *datacenter_idx += 1;
+                        *replicas_idx = 0;
+                        let datacenter = &locator.datacenters[*datacenter_idx];
+                        let repfactor = *datacenter_repfactors.get(datacenter).unwrap_or(&0);
+                        *replicas =
+                            locator.get_network_strategy_replicas(*token, datacenter, repfactor);
+                    } else {
+                        // No more datacenters; exhausted.
+                        *replicas_idx = replicas.len();
+                        return None;
+                    }
+                }
                 self.next()
             }
         }

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -630,10 +630,20 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         match &mut self.inner {
-            ReplicaSetIteratorInner::Plain { replicas: _, idx }
-            | ReplicaSetIteratorInner::PlainSharded { replicas: _, idx } => {
-                *idx += n;
-
+            ReplicaSetIteratorInner::Plain { replicas, idx } => {
+                *idx = idx.saturating_add(n);
+                if *idx >= replicas.len() {
+                    *idx = replicas.len();
+                    return None;
+                }
+                self.next()
+            }
+            ReplicaSetIteratorInner::PlainSharded { replicas, idx } => {
+                *idx = idx.saturating_add(n);
+                if *idx >= replicas.len() {
+                    *idx = replicas.len();
+                    return None;
+                }
                 self.next()
             }
             ReplicaSetIteratorInner::FilteredSimple { .. } => {

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -572,11 +572,10 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
                 if let Some(replica) = replicas.get(*replicas_idx) {
                     *replicas_idx += 1;
                     Some(with_computed_shard(replica, self.token))
-                } else if *datacenter_idx + 1 < locator.datacenters.len() {
+                } else if let Some(datacenter) = locator.datacenters.get(*datacenter_idx + 1) {
                     *datacenter_idx += 1;
                     *replicas_idx = 0;
 
-                    let datacenter = &locator.datacenters[*datacenter_idx];
                     let repfactor = *datacenter_repfactors.get(datacenter).unwrap_or(&0);
                     *replicas =
                         locator.get_network_strategy_replicas(*token, datacenter, repfactor);
@@ -664,10 +663,9 @@ impl<'a> Iterator for ReplicaSetIterator<'a> {
                     }
                     // Skip past the rest of the current datacenter.
                     remaining -= left_in_current;
-                    if *datacenter_idx + 1 < locator.datacenters.len() {
+                    if let Some(datacenter) = locator.datacenters.get(*datacenter_idx + 1) {
                         *datacenter_idx += 1;
                         *replicas_idx = 0;
-                        let datacenter = &locator.datacenters[*datacenter_idx];
                         let repfactor = *datacenter_repfactors.get(datacenter).unwrap_or(&0);
                         *replicas =
                             locator.get_network_strategy_replicas(*token, datacenter, repfactor);

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -795,6 +795,34 @@ impl<'a> Iterator for ReplicasOrderedNTSIterator<'a> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.inner {
+            ReplicasOrderedNTSIteratorInner::FreshForPick {
+                datacenter_repfactors,
+                ..
+            } => {
+                // Haven't yielded anything yet; total replicas ≤ sum of all repfactors.
+                let upper: usize = datacenter_repfactors.values().sum();
+                (0, Some(upper))
+            }
+            ReplicasOrderedNTSIteratorInner::Picked {
+                datacenter_repfactors,
+                ..
+            } => {
+                // Already yielded 1 (the picked node); remaining ≤ sum of repfactors - 1.
+                let upper: usize = datacenter_repfactors
+                    .values()
+                    .sum::<usize>()
+                    .saturating_sub(1);
+                (0, Some(upper))
+            }
+            ReplicasOrderedNTSIteratorInner::ComputedFallback { replicas, idx } => {
+                let remaining = replicas.len() - *idx;
+                (remaining, Some(remaining))
+            }
+        }
+    }
 }
 
 impl<'a> Iterator for ReplicasOrderedIterator<'a> {

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -810,6 +810,17 @@ impl<'a> Iterator for ReplicasOrderedIterator<'a> {
             } => replicas_ordered_iter.next(),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.inner {
+            ReplicasOrderedIteratorInner::AlreadyRingOrdered { replica_set_iter } => {
+                replica_set_iter.size_hint()
+            }
+            ReplicasOrderedIteratorInner::PolyDatacenterNTS {
+                replicas_ordered_iter,
+            } => replicas_ordered_iter.size_hint(),
+        }
+    }
 }
 
 impl<'a> IntoIterator for ReplicasOrdered<'a> {

--- a/scylla/src/routing/locator/replication_info.rs
+++ b/scylla/src/routing/locator/replication_info.rs
@@ -200,6 +200,13 @@ where
 
         None
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // The lower bound is 0 because rack-filtering may cause fewer replicas
+        // to be found than requested. The upper bound is the number of replicas still
+        // to be found.
+        (0, Some(self.replicas_left_to_find))
+    }
 }
 
 #[cfg(test)]

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -227,6 +227,7 @@ async fn test_locator() {
     test_replica_set_choose(&locator);
     test_replica_set_choose_filtered(&locator);
     test_replica_set_iterator_nth(&locator);
+    test_replica_set_iterator_nth_large_n_regression(&locator);
 }
 
 fn test_datacenter_info(locator: &ReplicaLocator) {
@@ -740,6 +741,48 @@ fn test_replica_set_iterator_nth(locator: &ReplicaLocator) {
         let mut iter = make().into_iter();
         assert_eq!(port(iter.nth(1)), Some(G));
         assert_eq!(port(iter.nth(0)), Some(E));
+        assert_eq!(port(iter.next()), None);
+    }
+}
+
+// Regression test for a bug in ReplicaSetIterator::nth for the Plain and PlainSharded variants:
+// the original implementation did `*idx += n` with no overflow or bounds check.
+//
+// Two failure modes:
+// 1. Overflow: nth(usize::MAX) wraps the index around (debug build panics; release build
+//    silently produces a garbage index and may return a wrong element or corrupt state).
+// 2. size_hint underflow: any n that pushes idx past replicas.len() would make size_hint's
+//    `replicas.len() - *idx` subtract with underflow, panicking in debug or yielding a huge
+//    size estimate in release.
+//
+// The fix clamps idx to replicas.len() and returns None early when out of bounds, so both
+// failure modes are prevented.
+fn test_replica_set_iterator_nth_large_n_regression(locator: &ReplicaLocator) {
+    // Plain variant: SimpleStrategy RF=4, no DC filter, token 75 → [B, E, F, A] (len = 4)
+    let strategy = Strategy::SimpleStrategy {
+        replication_factor: 4,
+    };
+    let make = || locator.replicas_for_token(Token::new(75), &strategy, None, TABLE_INVALID);
+
+    // nth(usize::MAX) must return None without overflowing.
+    // Before the fix this would panic (debug) or silently wrap (release).
+    {
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(usize::MAX)), None);
+        // size_hint must not underflow after an out-of-bounds nth.
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        // The iterator must stay properly exhausted.
+        assert_eq!(port(iter.next()), None);
+    }
+
+    // nth(n) where n > len (but no arithmetic overflow) must also clamp correctly.
+    // Before the fix, idx would be set to e.g. 100, and size_hint would underflow on
+    // `replicas.len() (= 4) - *idx (= 100)`.
+    {
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(100)), None);
+        // Must not underflow.
+        assert_eq!(iter.size_hint(), (0, Some(0)));
         assert_eq!(port(iter.next()), None);
     }
 }

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -226,6 +226,7 @@ async fn test_locator() {
     test_replica_set_len(&locator);
     test_replica_set_choose(&locator);
     test_replica_set_choose_filtered(&locator);
+    test_replica_set_iterator_nth(&locator);
 }
 
 fn test_datacenter_info(locator: &ReplicaLocator) {
@@ -599,4 +600,146 @@ fn test_replica_set_choose_filtered(locator: &ReplicaLocator) {
         )
         .choose_filtered(&mut rng, |_| true);
     assert_eq!(empty, None);
+}
+
+// Helper: extract the address port from an iterator item, for easy node identification.
+fn port(item: Option<(NodeRef<'_>, crate::routing::Shard)>) -> Option<u16> {
+    item.map(|(node, _shard)| node.address.port())
+}
+
+// Tests for ReplicaSetIterator::nth, covering all iterator variants:
+//
+//   * Plain        – SimpleStrategy, no DC filter; O(1) index bump.
+//   * FilteredSimple – SimpleStrategy filtered to one DC; sequential O(n) skip.
+//   * ChainedNTS   – NetworkTopologyStrategy, no DC filter; DC-aware skip that
+//                    can cross datacenter boundaries in O(#DCs).
+//
+// The test topology (mock_metadata_for_token_aware_tests):
+//   Ring:  50  100 150 200 250 300 350 400 450 500 550 600 650 700 750 800 900
+//   Node:   A   B   E   F   A   C   D   A   F   G   D   B   C   C   E   G   B
+//   DC:    eu  eu  us  us  eu  eu  us  eu  us  eu  us  eu  eu  eu  us  eu  eu
+//
+//   Node–port mapping: A=1, B=2, C=3, D=4, E=5, F=6, G=7
+//   DC order in locator: ["eu", "us"]  (first-occurrence order on the ring)
+#[expect(clippy::iter_nth_zero)]
+fn test_replica_set_iterator_nth(locator: &ReplicaLocator) {
+    // -----------------------------------------------------------------------
+    // Plain variant (ReplicaSetIteratorInner::Plain)
+    // SimpleStrategy RF=4, no DC filter, token 75.
+    // Walking the ring from 75: B(100), E(150), F(200), A(250) → [B, E, F, A]
+    // -----------------------------------------------------------------------
+    {
+        let strategy = Strategy::SimpleStrategy {
+            replication_factor: 4,
+        };
+        let make = || locator.replicas_for_token(Token::new(75), &strategy, None, TABLE_INVALID);
+
+        // nth(0) is equivalent to next(): returns the first element.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(0)), Some(B));
+
+        // nth(1) skips B and returns E.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(1)), Some(E));
+
+        // nth(3) reaches the last element A, leaving the iterator empty.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(3)), Some(A));
+        assert_eq!(port(iter.next()), None);
+
+        // nth(4) is out of bounds (equal to len) and returns None.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(4)), None);
+
+        // After nth(1) (returns E), next() continues from F, then A, then exhausts.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(1)), Some(E));
+        assert_eq!(port(iter.next()), Some(F));
+        assert_eq!(port(iter.next()), Some(A));
+        assert_eq!(port(iter.next()), None);
+
+        // Two sequential nth calls: nth(1) → E, then nth(1) on [F, A] → A.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(1)), Some(E));
+        assert_eq!(port(iter.nth(1)), Some(A));
+        assert_eq!(port(iter.next()), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // FilteredSimple variant (ReplicaSetIteratorInner::FilteredSimple)
+    // SimpleStrategy RF=3, DC filter="eu", token 50.
+    // All RF=3 replicas for token 50: [A(50,eu), B(100,eu), E(150,us)]
+    // After filtering to "eu": [A, B]
+    // -----------------------------------------------------------------------
+    {
+        let strategy = Strategy::SimpleStrategy {
+            replication_factor: 3,
+        };
+        let make =
+            || locator.replicas_for_token(Token::new(50), &strategy, Some("eu"), TABLE_INVALID);
+
+        // nth(0) returns the first eu replica: A.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(0)), Some(A));
+
+        // nth(1) skips A and returns B (the last eu replica).
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(1)), Some(B));
+        assert_eq!(port(iter.next()), None);
+
+        // nth(2) is out of bounds and returns None.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(2)), None);
+
+        // After nth(0) (returns A), next() returns B, then exhausts.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(0)), Some(A));
+        assert_eq!(port(iter.next()), Some(B));
+        assert_eq!(port(iter.next()), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // ChainedNTS variant (ReplicaSetIteratorInner::ChainedNTS)
+    // NTS eu=2, us=1, no DC filter, token 75.
+    // eu replicas: [B, G] (B on rack r1, G on rack r2 — NTS picks distinct racks)
+    // us replicas: [E]
+    // Iteration order (eu DC first, then us): B, G, E
+    // -----------------------------------------------------------------------
+    {
+        let strategy = Strategy::NetworkTopologyStrategy {
+            datacenter_repfactors: [("eu".to_owned(), 2), ("us".to_owned(), 1)]
+                .into_iter()
+                .collect(),
+        };
+        let make = || locator.replicas_for_token(Token::new(75), &strategy, None, TABLE_INVALID);
+
+        // nth(0) returns B (first eu replica).
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(0)), Some(B));
+
+        // nth(1) skips B and returns G (second eu replica, within the same DC).
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(1)), Some(G));
+
+        // nth(2) crosses the DC boundary: skips both eu replicas and returns E (us).
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(2)), Some(E));
+        assert_eq!(port(iter.next()), None);
+
+        // nth(3) is out of bounds and returns None.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(3)), None);
+
+        // After nth(1) (returns G), next() crosses to the us DC and returns E.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(1)), Some(G));
+        assert_eq!(port(iter.next()), Some(E));
+        assert_eq!(port(iter.next()), None);
+
+        // Two sequential nth calls: nth(1) → G, then nth(0) on [E] → E.
+        let mut iter = make().into_iter();
+        assert_eq!(port(iter.nth(1)), Some(G));
+        assert_eq!(port(iter.nth(0)), Some(E));
+        assert_eq!(port(iter.next()), None);
+    }
 }


### PR DESCRIPTION
In our driver we have various `Iterator` implementations. They all have `next` method of course, because it is mandatory.
There are however some optional functionalities that iterators can implement, most notably: `nth` method, `size_hint` method, and `ExactSizeIterator` trait. Our approach to those have been mixed. Various of our iterators are missing some (or all) of those, despite being implementable without problems. some implementations were wrong or suboptimal.

This PR fixes all the problems I could find. 

There are 2 things I'm not sure about (see relevant commit messages):
- Should we have precise type hint and ExactSizeIterator for UdtIterator? There is a TODO message that might affect it but I don't fully understand it
- Do we want `nth` for `VectorIterator`?


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1627
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/674


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
