### PR TITLE
Expose cluster name in ClusterState

### DIFF
--- a/docs/source/schema/schema.md
+++ b/docs/source/schema/schema.md
@@ -27,6 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 ## Inspecting schema
 
 Once fetched, a snapshot of cluster's schema can be examined. The following information can be obtained:
+ - cluster name
  - keyspace
    - tables belonging to the keyspace
    - materialized views belonging to the keyspace
@@ -56,6 +57,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     session.refresh_metadata().await?;
 
     let cluster_state = &session.get_cluster_state();
+    println!("Cluster: {}", cluster_state.cluster_name());
     let keyspaces_iter = cluster_state.keyspaces_iter();
 
     for (keyspace_name, keyspace_info) in keyspaces_iter {

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -172,12 +172,14 @@ impl ControlConnection {
             self.query_client_routes(connection_ids, &[]).await
         };
 
-        let peers: Vec<Peer>;
+        let peers_and_cluster_name;
         let client_routes: ClientRoutes;
         let keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>;
 
-        (peers, client_routes, keyspaces) =
+        (peers_and_cluster_name, client_routes, keyspaces) =
             tokio::try_join!(peers_query, client_routes_query, keyspaces_query)?;
+
+        let (peers, cluster_name) = peers_and_cluster_name;
 
         let client_routes_updated_hosts =
             if let Some(client_routes_subscriber) = self.client_routes_subscriber() {
@@ -199,6 +201,7 @@ impl ControlConnection {
         Ok(Metadata {
             peers,
             keyspaces,
+            cluster_name,
             client_routes_updated_hosts,
         })
     }
@@ -214,6 +217,19 @@ struct NodeInfoRow {
     datacenter: Option<String>,
     rack: Option<String>,
     tokens: Option<Vec<String>>,
+}
+
+#[derive(DeserializeRow)]
+#[scylla(crate = "scylla_cql")]
+struct LocalNodeInfoRow {
+    host_id: Option<Uuid>,
+    #[scylla(rename = "rpc_address")]
+    untranslated_ip_addr: IpAddr,
+    #[scylla(rename = "data_center")]
+    datacenter: Option<String>,
+    rack: Option<String>,
+    tokens: Option<Vec<String>>,
+    cluster_name: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -232,7 +248,10 @@ impl NodeInfoSource {
 }
 
 impl ControlConnection {
-    async fn query_peers(&self, connect_port: u16) -> Result<Vec<Peer>, MetadataError> {
+    async fn query_peers(
+        &self,
+        connect_port: u16,
+    ) -> Result<(Vec<Peer>, Option<String>), MetadataError> {
         let peers_query_stream = self
             .query_iter(
                 "SELECT host_id, rpc_address, data_center, rack, tokens FROM system.peers",
@@ -251,13 +270,13 @@ impl ControlConnection {
                 error,
                 table: "system.peers",
             })
-            .and_then(|row_result| future::ok((NodeInfoSource::Peer, row_result)));
+            .and_then(|row| future::ok((NodeInfoSource::Peer, row, None::<String>)));
 
         let local_query_stream = self
-            .query_iter("SELECT host_id, rpc_address, data_center, rack, tokens FROM system.local WHERE key='local'", &())
+            .query_iter("SELECT host_id, rpc_address, data_center, rack, tokens, cluster_name FROM system.local WHERE key='local'", &())
             .map(|pager_res| {
                 let pager = pager_res?;
-                let rows_stream = pager.rows_stream::<NodeInfoRow>()?;
+                let rows_stream = pager.rows_stream::<LocalNodeInfoRow>()?;
                 Ok::<_, MetadataFetchErrorKind>(rows_stream)
             })
             .into_stream()
@@ -268,7 +287,17 @@ impl ControlConnection {
                 error,
                 table: "system.local",
             })
-            .and_then(|row_result| future::ok((NodeInfoSource::Local, row_result)));
+            .and_then(|row| {
+                let cluster_name = row.cluster_name;
+                let node_row = NodeInfoRow {
+                    host_id: row.host_id,
+                    untranslated_ip_addr: row.untranslated_ip_addr,
+                    datacenter: row.datacenter,
+                    rack: row.rack,
+                    tokens: row.tokens,
+                };
+                future::ok((NodeInfoSource::Local, node_row, cluster_name))
+            });
 
         let untranslated_rows = stream::select(peers_query_stream, local_query_stream);
 
@@ -277,23 +306,36 @@ impl ControlConnection {
 
         let translated_peers_futures = untranslated_rows.map(|row_result| async {
             match row_result {
-                Ok((source, row)) => Self::create_peer_from_row(source, row, local_address).await,
+                Ok((source, row, cluster_name)) => {
+                    let peer = Self::create_peer_from_row(source, row, local_address).await;
+                    (peer, cluster_name)
+                }
                 Err(err) => {
                     warn!(
                         "system.peers or system.local has an invalid row, skipping it: {}",
                         err
                     );
-                    None
+                    (None, None)
                 }
             }
         });
 
-        let peers = translated_peers_futures
+        let (peers, cluster_name) = translated_peers_futures
             .buffer_unordered(256)
-            .filter_map(std::future::ready)
             .collect::<Vec<_>>()
-            .await;
-        Ok(peers)
+            .await
+            .into_iter()
+            .fold(
+                (Vec::new(), None),
+                |(mut peers, cluster_name), (peer, name)| {
+                    if let Some(peer) = peer {
+                        peers.push(peer);
+                    }
+                    (peers, cluster_name.or(name))
+                },
+            );
+
+        Ok((peers, cluster_name))
     }
 
     async fn create_peer_from_row(

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -54,6 +54,7 @@ pub(crate) enum SingleKeyspaceMetadataError {
 pub(crate) struct Metadata {
     pub(crate) peers: Vec<Peer>,
     pub(crate) keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>,
+    pub(crate) cluster_name: Option<String>,
 
     /// Host IDs whose client routes were added or updated during this metadata fetch.
     /// Used to trigger immediate pool refills for nodes that may have been in backoff
@@ -347,6 +348,7 @@ impl Metadata {
         Metadata {
             peers,
             keyspaces: HashMap::new(),
+            cluster_name: None,
             client_routes_updated_hosts: HashSet::new(),
         }
     }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -49,6 +49,9 @@ pub struct ClusterState {
     /// for a given (token, replication strategy, table) tuple.
     /// It relies on both topology and schema metadata.
     pub(crate) locator: ReplicaLocator,
+
+    /// The name of the cluster, as reported by the `cluster_name` column in `system.local`.
+    pub(crate) cluster_name: Option<String>,
 }
 
 /// Enables printing [ClusterState] struct in a neat way, skipping the clutter involved by
@@ -286,7 +289,13 @@ impl ClusterState {
             known_nodes: new_known_nodes,
             keyspaces,
             locator,
+            cluster_name: metadata.cluster_name,
         }
+    }
+
+    /// Returns the name of the cluster, as reported by the `cluster_name` column in `system.local`.
+    pub fn cluster_name(&self) -> &str {
+        self.cluster_name.as_deref().unwrap_or("")
     }
 
     /// Access keyspace details collected by the driver.
@@ -557,6 +566,7 @@ mod tests {
             peers,
             keyspaces: HashMap::new(),
             client_routes_updated_hosts: HashSet::new(),
+            cluster_name: Some("Test Cluster".into()),
         }
     }
 

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1435,6 +1435,7 @@ mod tests {
                 peers,
                 keyspaces: HashMap::new(),
                 client_routes_updated_hosts: Default::default(),
+                cluster_name: Some("TestCluster".into()),
             };
 
             let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();

--- a/scylla/src/policies/load_balancing/plan.rs
+++ b/scylla/src/policies/load_balancing/plan.rs
@@ -236,6 +236,7 @@ mod tests {
             all_nodes: Default::default(),
             keyspaces: Default::default(),
             locator,
+            cluster_name: Some("TestCluster".into()),
         };
         let routing_info = RoutingInfo::default();
         let plan = Plan::new(&policy, &routing_info, &cluster_state);

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -164,6 +164,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
     Metadata {
         peers: Vec::from(peers),
         keyspaces,
+        cluster_name: Some("TestCluster".into()),
         client_routes_updated_hosts: Default::default(),
     }
 }

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -554,7 +554,7 @@ async fn test_durable_writes_in_metadata() {
 }
 
 #[tokio::test]
-async fn test_session_should_have_topology_metadata() {
+async fn test_session_should_have_cluster_metadata() {
     setup_tracing();
     let session = create_new_session_builder().build().await.unwrap();
     let state = session.get_cluster_state();
@@ -577,4 +577,6 @@ async fn test_session_should_have_topology_metadata() {
         got_addresses, expected_addresses,
         "Cluster node addresses do not match environment variables"
     );
+
+    assert_eq!(state.cluster_name(), "TestCluster");
 }

--- a/test/cluster/cassandra/docker-compose.yml
+++ b/test/cluster/cassandra/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
       - JVM_OPTS=-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=5000
+      - CASSANDRA_CLUSTER_NAME=TestCluster
   cassandra2:
     image: cassandra
     healthcheck:
@@ -40,6 +41,7 @@ services:
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
       - JVM_OPTS=-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=5000
+      - CASSANDRA_CLUSTER_NAME=TestCluster
     depends_on:
       cassandra1:
         condition: service_healthy
@@ -59,6 +61,7 @@ services:
       - HEAP_NEWSIZE=512M
       - MAX_HEAP_SIZE=2048M
       - JVM_OPTS=-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.ring_delay_ms=5000
+      - CASSANDRA_CLUSTER_NAME=TestCluster
     depends_on:
       cassandra2:
         condition: service_healthy

--- a/test/cluster/docker-compose.yml
+++ b/test/cluster/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       --logger-log-level=compaction=warn
       --logger-log-level=migration_manager=warn
       --shutdown-announce-in-ms=0
+      --cluster-name TestCluster
     healthcheck:
       test:
         [
@@ -69,6 +70,7 @@ services:
       --logger-log-level=compaction=warn
       --logger-log-level=migration_manager=warn
       --shutdown-announce-in-ms=0
+      --cluster-name TestCluster
     healthcheck:
       test:
         [
@@ -108,6 +110,7 @@ services:
       --logger-log-level=compaction=warn
       --logger-log-level=migration_manager=warn
       --shutdown-announce-in-ms=0
+      --cluster-name TestCluster
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.

## Description
Fetches `cluster_name` from the `cluster_name` column in `system.local` during metadata refresh and exposes it via `ClusterState::cluster_name() -> &str`, bringing the Rust driver in line with the Java and Python drivers.

### Changes:

- Extended the `system.local` query to select `cluster_name` via a dedicated `LocalNodeInfoRow` deserialization struct
- Added `cluster_name: Option<String>` to `Metadata` and `ClusterState`
- Exposed `ClusterState::cluster_name() -> &str` as a public API, returning `""` when the cluster name is unavailable
- Added integration test asserting the cluster name is correctly read from the running cluster
- Updated schema documentation
- Added `--cluster-name TestCluster` to the ScyllaDB test cluster docker-compose
- Added `CASSANDRA_CLUSTER_NAME=TestCluster` to the Cassandra test cluster docker-compose

Fixes: #1213