### PR TITLE
metadata: Expose release_version on Node

### DIFF
--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -217,6 +217,7 @@ struct NodeInfoRow {
     datacenter: Option<String>,
     rack: Option<String>,
     tokens: Option<Vec<String>>,
+    release_version: Option<String>,
 }
 
 #[derive(DeserializeRow)]
@@ -230,6 +231,7 @@ struct LocalNodeInfoRow {
     rack: Option<String>,
     tokens: Option<Vec<String>>,
     cluster_name: Option<String>,
+    release_version: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -254,7 +256,7 @@ impl ControlConnection {
     ) -> Result<(Vec<Peer>, Option<String>), MetadataError> {
         let peers_query_stream = self
             .query_iter(
-                "SELECT host_id, rpc_address, data_center, rack, tokens FROM system.peers",
+                "SELECT host_id, rpc_address, data_center, rack, tokens, release_version FROM system.peers",
                 &(),
             )
             .map(|pager_res| {
@@ -273,7 +275,11 @@ impl ControlConnection {
             .and_then(|row| future::ok((NodeInfoSource::Peer, row, None::<String>)));
 
         let local_query_stream = self
-            .query_iter("SELECT host_id, rpc_address, data_center, rack, tokens, cluster_name FROM system.local WHERE key='local'", &())
+            .query_iter(
+                "SELECT host_id, rpc_address, data_center, rack, tokens, \
+                 cluster_name, release_version FROM system.local WHERE key='local'",
+                &(),
+            )
             .map(|pager_res| {
                 let pager = pager_res?;
                 let rows_stream = pager.rows_stream::<LocalNodeInfoRow>()?;
@@ -295,6 +301,7 @@ impl ControlConnection {
                     datacenter: row.datacenter,
                     rack: row.rack,
                     tokens: row.tokens,
+                    release_version: row.release_version,
                 };
                 future::ok((NodeInfoSource::Local, node_row, cluster_name))
             });
@@ -349,6 +356,7 @@ impl ControlConnection {
             datacenter,
             rack,
             tokens,
+            release_version,
         } = row;
 
         let host_id = match host_id {
@@ -398,6 +406,7 @@ impl ControlConnection {
             tokens,
             datacenter,
             rack,
+            release_version,
         })
     }
 }

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -76,6 +76,10 @@ pub struct Peer {
     pub datacenter: Option<String>,
     /// Rack this node is in, if known.
     pub rack: Option<String>,
+    /// The release version of the server running on this node, as reported in
+    /// `system.local` / `system.peers`. May be `None` if the column is absent
+    /// or the value is null.
+    pub release_version: Option<String>,
 }
 
 /// An endpoint for a node that the driver is to issue connections to,
@@ -115,6 +119,7 @@ pub(crate) struct PeerEndpoint {
     pub(crate) address: NodeAddr,
     pub(crate) datacenter: Option<String>,
     pub(crate) rack: Option<String>,
+    pub(crate) release_version: Option<String>,
 }
 
 impl Peer {
@@ -124,6 +129,7 @@ impl Peer {
             address: self.address,
             datacenter: self.datacenter.clone(),
             rack: self.rack.clone(),
+            release_version: self.release_version.clone(),
         }
     }
 
@@ -134,6 +140,7 @@ impl Peer {
                 address: self.address,
                 datacenter: self.datacenter,
                 rack: self.rack,
+                release_version: self.release_version,
             },
             self.tokens,
         )
@@ -341,6 +348,7 @@ impl Metadata {
                     datacenter: None,
                     rack: None,
                     host_id: Uuid::new_v4(),
+                    release_version: None,
                 }
             })
             .collect();

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -78,9 +78,9 @@ impl Display for NodeAddr {
 
 /// Node represents a cluster node along with its data and connections
 ///
-/// Note: if a Node changes its broadcast address, then it is not longer
-/// represented by the same instance of Node struct, but instead
-/// a new instance is created (for implementation reasons).
+/// Note: if a Node changes its broadcast address or release_version, it is no longer
+/// represented by the same instance of Node struct — a new instance is created instead
+/// (for implementation reasons).
 #[derive(Debug)]
 pub struct Node {
     /// Unique identifier of the node.
@@ -94,6 +94,10 @@ pub struct Node {
     pub datacenter: Option<String>,
     /// Rack of the node, if known.
     pub rack: Option<String>,
+    /// The release version of the server running on this node, as reported in
+    /// `system.local` / `system.peers`. May be `None` if the column is absent
+    /// or the value is null.
+    pub release_version: Option<String>,
 
     /// Connection pool for this node.
     ///
@@ -126,6 +130,7 @@ impl Node {
         let address = peer.address;
         let datacenter = peer.datacenter.clone();
         let rack = peer.rack.clone();
+        let release_version = peer.release_version.clone();
 
         // We aren't interested in the fact that the pool becomes empty, so we immediately drop the receiving part.
         let (pool_empty_notifier, _) = tokio::sync::mpsc::channel(1);
@@ -144,6 +149,7 @@ impl Node {
             address,
             datacenter,
             rack,
+            release_version,
             pool: Some(pool),
             #[cfg(test)]
             enabled_as_connected: AtomicBool::new(false),
@@ -155,35 +161,41 @@ impl Node {
         let address = peer.address;
         let datacenter = peer.datacenter.clone();
         let rack = peer.rack.clone();
+        let release_version = peer.release_version.clone();
 
         Node {
             host_id,
             address,
             datacenter,
             rack,
+            release_version,
             pool: None,
             #[cfg(test)]
             enabled_as_connected: AtomicBool::new(false),
         }
     }
 
-    /// Recreates a Node after it changes its IP, preserving the pool.
+    /// Recreates a Node after its address and/or release_version changes, preserving the pool.
     ///
-    /// All settings except address are inherited from `node`.
-    /// The underlying pool is preserved and notified about the IP change.
+    /// Datacenter, rack, and host_id are inherited from `node`. Address and release_version
+    /// are taken from `endpoint`. If the address changed, the pool is notified.
     /// # Arguments
     ///
     /// - `node` - previous definition of that node
-    /// - `address` - new address to connect to
-    pub(crate) fn inherit_with_ip_changed(node: &Node, endpoint: PeerEndpoint) -> Self {
+    /// - `endpoint` - fresh endpoint data from metadata
+    pub(crate) fn inherit_preserving_pool(node: &Node, endpoint: PeerEndpoint) -> Self {
         let address = endpoint.address;
-        if let Some(ref pool) = node.pool {
+        let release_version = endpoint.release_version.clone();
+        if node.address != address
+            && let Some(ref pool) = node.pool
+        {
             pool.update_endpoint(endpoint);
         }
         Self {
             address,
             datacenter: node.datacenter.clone(),
             rack: node.rack.clone(),
+            release_version,
             host_id: node.host_id,
             pool: node.pool.clone(),
             #[cfg(test)]
@@ -414,6 +426,7 @@ mod tests {
                 )))),
                 datacenter,
                 rack,
+                release_version: None,
                 pool: None,
                 enabled_as_connected: AtomicBool::new(false),
             }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -158,22 +158,23 @@ impl ClusterState {
 
             let node = match (is_enabled, known_nodes.get(&peer_host_id)) {
                 // If the node is disabled, then we never want to have a connection pool to it.
-                // If it already existed, and was disabled, and all parameters (dc, rack, address) match
+                // If it already existed, and was disabled, and all parameters (dc, rack, address, release_version) match
                 // then we can reuse the object.
                 // Otherwise we need to create a new one.
                 (false, Some(node))
                     if !node.is_enabled()
                         && node.datacenter == peer_endpoint.datacenter
                         && node.rack == peer_endpoint.rack
-                        && node.address == peer_endpoint.address =>
+                        && node.address == peer_endpoint.address
+                        && node.release_version == peer_endpoint.release_version =>
                 {
                     Arc::clone(node)
                 }
                 (false, _) => Arc::new(Node::new_disabled(peer_endpoint)),
                 // Changing rack/datacenter but not ip address seems improbable
                 // so we can just create new node and connections in such case.
-                // Here we allow preserving the Node object in full if all attributes (dc, rack, address)
-                // match. If only address is different, we recreate Node object but share the same underlying pool.
+                // Here we allow preserving the Node object in full if all attributes (dc, rack, address, release_version)
+                // match. If only address or release_version differ, we recreate the Node struct but preserve the pool.
                 //
                 // IMPORTANT EDGE CASE: The old Node object might have been disabled. We know that the new Node object
                 // must be enabled, so there is no point in using the old one then.
@@ -182,11 +183,13 @@ impl ClusterState {
                         && node.datacenter == peer_endpoint.datacenter
                         && node.rack == peer_endpoint.rack =>
                 {
-                    if node.address == peer_endpoint.address {
+                    if node.address == peer_endpoint.address
+                        && node.release_version == peer_endpoint.release_version
+                    {
                         Arc::clone(node)
                     } else {
-                        // If IP changes, the Node struct is recreated, but the underlying pool is preserved and notified about the IP change.
-                        Arc::new(Node::inherit_with_ip_changed(node, peer_endpoint))
+                        // Address and/or release_version changed - recreate Node struct but preserve the pool.
+                        Arc::new(Node::inherit_preserving_pool(node, peer_endpoint))
                     }
                 }
                 (true, _) => Arc::new(Node::new(
@@ -558,6 +561,7 @@ mod tests {
             tokens: vec![Token::new(1)],
             datacenter: datacenter.map(String::from),
             rack: rack.map(String::from),
+            release_version: None,
         }
     }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1971,6 +1971,7 @@ async fn maybe_translated_addr(
                 address: NodeAddr::Translatable(addr),
                 datacenter,
                 rack,
+                ..
             }),
             Some(translator),
         ) => {

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1457,6 +1457,7 @@ mod tests {
                     address: id_to_invalid_addr(*id),
                     tokens: vec![Token::new(*id as i64 * 100)],
                     host_id: Uuid::new_v4(),
+                    release_version: None,
                 })
                 .collect::<Vec<_>>();
 

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -64,6 +64,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(1),
             tokens: vec![Token::new(50), Token::new(250), Token::new(400)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // B
@@ -72,6 +73,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(2),
             tokens: vec![Token::new(100), Token::new(600), Token::new(900)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // C
@@ -80,6 +82,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(3),
             tokens: vec![Token::new(300), Token::new(650), Token::new(700)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // D
@@ -88,6 +91,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(4),
             tokens: vec![Token::new(350), Token::new(550)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // E
@@ -96,6 +100,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(5),
             tokens: vec![Token::new(150), Token::new(750)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // F
@@ -104,6 +109,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(6),
             tokens: vec![Token::new(200), Token::new(450)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // G
@@ -112,6 +118,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(7),
             tokens: vec![Token::new(500), Token::new(800)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
     ];
 

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -579,4 +579,24 @@ async fn test_session_should_have_cluster_metadata() {
     );
 
     assert_eq!(state.cluster_name(), "TestCluster");
+
+    let (expected_version,): (Option<String>,) = session
+        .query_unpaged(
+            "SELECT release_version FROM system.local WHERE key='local'",
+            (),
+        )
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap()
+        .single_row()
+        .unwrap();
+
+    for node in state.get_nodes_info() {
+        assert_eq!(
+            node.release_version, expected_version,
+            "Node {} has unexpected release_version",
+            node.address
+        );
+    }
 }


### PR DESCRIPTION
## metadata: Expose release_version on Node and Peer

Adds `release_version: Option<String>` to `Peer` and `Node`, populated from the `release_version` column in `system.peers` and `system.local`.

This mirrors the per-node version API available in other drivers:
- Python driver: `Host.release_version`
- Java driver: `Node.getCassandraVersion()`

## Changes

- Added `release_version` to `NodeInfoRow` and `LocalNodeInfoRow` deserialization structs and extended the `system.peers` / `system.local` queries accordingly
- Added `pub release_version: Option<String>` to `Peer` and `Node`
- Threaded the field through `PeerEndpoint` and all `Node` constructors
- Renamed `inherit_with_ip_changed` to `inherit_preserving_pool` and extended it to handle address and/or `release_version` changes while preserving the connection pool
- Updated node reuse guards in `ClusterState` to detect `release_version` changes and recreate the `Node` struct (while preserving the pool)
- Added assertion to `test_session_should_have_cluster_metadata` integration test

## Design decisions

**Per-node only.** A cluster-level version API was considered (as in the earlier PR #1307) but rejected — other drivers don't expose one, and the concept is semantically ambiguous during rolling upgrades.

**Node reuse on version change.** When `release_version` changes (e.g. during a rolling upgrade), the node reuse guards detect the change and recreate the `Node` struct via `inherit_preserving_pool`, which preserves the connection pool. A rolling upgrade stops the node first dropping all connections, but the pool may already have reconnected by the time metadata refresh detects the version change — recreating the pool unnecessarily is avoided.

**Known limitation.** The integration test validates `release_version` by comparing against `SELECT release_version FROM system.local`, which returns the coordinator node's version. In a homogeneous cluster this is correct; in a mixed-version cluster the assertion could give false positives for non-coordinator nodes.

Fixes: #1286

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
  > `schema.md` covers schema metadata (keyspaces, tables, columns, UDTs). Node topology metadata (datacenter, rack, release_version) accessible via `get_nodes_info()` is not documented anywhere in the docs. Given that #1666 recently added `cluster_name` to this page, it may be reasonable to extend it further to cover node metadata — happy to do so if the reviewer agrees.
- [x] I added appropriate `Fixes:` annotations to PR description.