### PR TITLE
Expose `scylla_version` on `Node`

### DIFF
--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -217,6 +217,7 @@ struct NodeInfoRow {
     datacenter: Option<String>,
     rack: Option<String>,
     tokens: Option<Vec<String>>,
+    release_version: Option<String>,
 }
 
 #[derive(DeserializeRow)]
@@ -230,6 +231,7 @@ struct LocalNodeInfoRow {
     rack: Option<String>,
     tokens: Option<Vec<String>>,
     cluster_name: Option<String>,
+    release_version: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -254,7 +256,7 @@ impl ControlConnection {
     ) -> Result<(Vec<Peer>, Option<String>), MetadataError> {
         let peers_query_stream = self
             .query_iter(
-                "SELECT host_id, rpc_address, data_center, rack, tokens FROM system.peers",
+                "SELECT host_id, rpc_address, data_center, rack, tokens, release_version FROM system.peers",
                 &(),
             )
             .map(|pager_res| {
@@ -273,7 +275,11 @@ impl ControlConnection {
             .and_then(|row| future::ok((NodeInfoSource::Peer, row, None::<String>)));
 
         let local_query_stream = self
-            .query_iter("SELECT host_id, rpc_address, data_center, rack, tokens, cluster_name FROM system.local WHERE key='local'", &())
+            .query_iter(
+                "SELECT host_id, rpc_address, data_center, rack, tokens, \
+                 cluster_name, release_version FROM system.local WHERE key='local'",
+                &(),
+            )
             .map(|pager_res| {
                 let pager = pager_res?;
                 let rows_stream = pager.rows_stream::<LocalNodeInfoRow>()?;
@@ -295,6 +301,7 @@ impl ControlConnection {
                     datacenter: row.datacenter,
                     rack: row.rack,
                     tokens: row.tokens,
+                    release_version: row.release_version,
                 };
                 future::ok((NodeInfoSource::Local, node_row, cluster_name))
             });
@@ -349,6 +356,7 @@ impl ControlConnection {
             datacenter,
             rack,
             tokens,
+            release_version,
         } = row;
 
         let host_id = match host_id {
@@ -398,6 +406,7 @@ impl ControlConnection {
             tokens,
             datacenter,
             rack,
+            release_version,
         })
     }
 }

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -76,6 +76,10 @@ pub struct Peer {
     pub datacenter: Option<String>,
     /// Rack this node is in, if known.
     pub rack: Option<String>,
+    /// The release version of the server running on this node, as reported in
+    /// `system.local` / `system.peers`. May be `None` if the column is absent
+    /// or the value is null.
+    pub release_version: Option<String>,
 }
 
 /// An endpoint for a node that the driver is to issue connections to,
@@ -115,6 +119,7 @@ pub(crate) struct PeerEndpoint {
     pub(crate) address: NodeAddr,
     pub(crate) datacenter: Option<String>,
     pub(crate) rack: Option<String>,
+    pub(crate) release_version: Option<String>,
 }
 
 impl Peer {
@@ -124,6 +129,7 @@ impl Peer {
             address: self.address,
             datacenter: self.datacenter.clone(),
             rack: self.rack.clone(),
+            release_version: self.release_version.clone(),
         }
     }
 
@@ -134,6 +140,7 @@ impl Peer {
                 address: self.address,
                 datacenter: self.datacenter,
                 rack: self.rack,
+                release_version: self.release_version,
             },
             self.tokens,
         )
@@ -341,6 +348,7 @@ impl Metadata {
                     datacenter: None,
                     rack: None,
                     host_id: Uuid::new_v4(),
+                    release_version: None,
                 }
             })
             .collect();

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -78,9 +78,9 @@ impl Display for NodeAddr {
 
 /// Node represents a cluster node along with its data and connections
 ///
-/// Note: if a Node changes its broadcast address, then it is not longer
-/// represented by the same instance of Node struct, but instead
-/// a new instance is created (for implementation reasons).
+/// Note: if a Node changes its broadcast address or release_version, it is no longer
+/// represented by the same instance of Node struct — a new instance is created instead
+/// (for implementation reasons).
 #[derive(Debug)]
 pub struct Node {
     /// Unique identifier of the node.
@@ -94,6 +94,10 @@ pub struct Node {
     pub datacenter: Option<String>,
     /// Rack of the node, if known.
     pub rack: Option<String>,
+    /// The release version of the server running on this node, as reported in
+    /// `system.local` / `system.peers`. May be `None` if the column is absent
+    /// or the value is null.
+    pub release_version: Option<String>,
 
     /// Connection pool for this node.
     ///
@@ -126,6 +130,7 @@ impl Node {
         let address = peer.address;
         let datacenter = peer.datacenter.clone();
         let rack = peer.rack.clone();
+        let release_version = peer.release_version.clone();
 
         // We aren't interested in the fact that the pool becomes empty, so we immediately drop the receiving part.
         let (pool_empty_notifier, _) = tokio::sync::mpsc::channel(1);
@@ -144,6 +149,7 @@ impl Node {
             address,
             datacenter,
             rack,
+            release_version,
             pool: Some(pool),
             #[cfg(test)]
             enabled_as_connected: AtomicBool::new(false),
@@ -155,35 +161,41 @@ impl Node {
         let address = peer.address;
         let datacenter = peer.datacenter.clone();
         let rack = peer.rack.clone();
+        let release_version = peer.release_version.clone();
 
         Node {
             host_id,
             address,
             datacenter,
             rack,
+            release_version,
             pool: None,
             #[cfg(test)]
             enabled_as_connected: AtomicBool::new(false),
         }
     }
 
-    /// Recreates a Node after it changes its IP, preserving the pool.
+    /// Recreates a Node after its address and/or release_version changes, preserving the pool.
     ///
-    /// All settings except address are inherited from `node`.
-    /// The underlying pool is preserved and notified about the IP change.
+    /// Datacenter, rack, and host_id are inherited from `node`. Address and release_version
+    /// are taken from `endpoint`. If the address changed, the pool is notified.
     /// # Arguments
     ///
     /// - `node` - previous definition of that node
-    /// - `address` - new address to connect to
-    pub(crate) fn inherit_with_ip_changed(node: &Node, endpoint: PeerEndpoint) -> Self {
+    /// - `endpoint` - fresh endpoint data from metadata
+    pub(crate) fn inherit_preserving_pool(node: &Node, endpoint: PeerEndpoint) -> Self {
         let address = endpoint.address;
-        if let Some(ref pool) = node.pool {
+        let release_version = endpoint.release_version.clone();
+        if node.address != address
+            && let Some(ref pool) = node.pool
+        {
             pool.update_endpoint(endpoint);
         }
         Self {
             address,
             datacenter: node.datacenter.clone(),
             rack: node.rack.clone(),
+            release_version,
             host_id: node.host_id,
             pool: node.pool.clone(),
             #[cfg(test)]
@@ -414,6 +426,7 @@ mod tests {
                 )))),
                 datacenter,
                 rack,
+                release_version: None,
                 pool: None,
                 enabled_as_connected: AtomicBool::new(false),
             }

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use std::{
     hash::{Hash, Hasher},
     net::SocketAddr,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
@@ -99,6 +99,12 @@ pub struct Node {
     /// or the value is null.
     pub release_version: Option<String>,
 
+    /// The ScyllaDB version running on this node, as reported by `system.versions`.
+    ///
+    /// Populated after the node's connection pool comes up, by the cluster
+    /// metadata task. It is written once per `Node` instance.
+    scylla_version: OnceLock<String>,
+
     /// Connection pool for this node.
     ///
     /// If the node is filtered out by the host filter, this will be [None].
@@ -150,6 +156,7 @@ impl Node {
             datacenter,
             rack,
             release_version,
+            scylla_version: OnceLock::new(),
             pool: Some(pool),
             #[cfg(test)]
             enabled_as_connected: AtomicBool::new(false),
@@ -169,6 +176,7 @@ impl Node {
             datacenter,
             rack,
             release_version,
+            scylla_version: OnceLock::new(),
             pool: None,
             #[cfg(test)]
             enabled_as_connected: AtomicBool::new(false),
@@ -196,6 +204,7 @@ impl Node {
             datacenter: node.datacenter.clone(),
             rack: node.rack.clone(),
             release_version,
+            scylla_version: OnceLock::new(),
             host_id: node.host_id,
             pool: node.pool.clone(),
             #[cfg(test)]
@@ -212,6 +221,20 @@ impl Node {
     /// this means it's not a ScyllaDB node.
     pub fn sharder(&self) -> Option<Sharder> {
         self.pool.as_ref()?.sharder()
+    }
+
+    /// The ScyllaDB version running on this node, as reported by `system.versions`.
+    ///
+    /// Returns `None` for Cassandra nodes (which have no `system.versions` table), for
+    /// nodes the driver has not queried yet, and when the query failed or timed out
+    /// (in which case it is retried on a later metadata refresh).
+    pub fn scylla_version(&self) -> Option<&str> {
+        self.scylla_version.get().map(String::as_str)
+    }
+
+    /// Write-once: the first call wins and later calls are ignored
+    pub(crate) fn set_scylla_version(&self, version: String) {
+        let _ = self.scylla_version.set(version);
     }
 
     /// Get a connection targetting the given shard
@@ -427,6 +450,7 @@ mod tests {
                 datacenter,
                 rack,
                 release_version: None,
+                scylla_version: OnceLock::new(),
                 pool: None,
                 enabled_as_connected: AtomicBool::new(false),
             }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -7,20 +7,45 @@ use crate::routing::locator::ReplicaLocator;
 use crate::routing::locator::tablets::{RawTablet, Tablet, TabletsInfo};
 use crate::routing::partitioner::{PartitionerName, calculate_token_for_partition_key};
 use crate::routing::{Shard, Token};
+use crate::statement::Statement;
 use crate::utils::safe_format::IteratorSafeFormatExt;
 
+use futures::future::join_all;
 use itertools::Itertools;
 use scylla_cql::frame::response::result::TableSpec;
 use scylla_cql::serialize::row::{RowSerializationContext, SerializeRow, SerializedValues};
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
 use super::metadata::{Keyspace, Metadata, Strategy};
 use super::node::{Node, NodeRef};
+
+const VERSION_QUERY_TIMEOUT: Duration = Duration::from_millis(500);
+
+async fn query_scylla_version(conn: &Arc<Connection>, stmt: &Statement) -> Option<String> {
+    let result = match tokio::time::timeout(VERSION_QUERY_TIMEOUT, conn.query_unpaged(stmt)).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            debug!("Failed to query system.versions: {e}");
+            return None;
+        }
+        Err(_elapsed) => {
+            debug!(
+                "Timed out querying system.versions after {:?}",
+                VERSION_QUERY_TIMEOUT
+            );
+            return None;
+        }
+    };
+    let rows = result.into_rows_result().ok()?;
+    let (version,) = rows.maybe_first_row::<(Option<String>,)>().ok()??;
+    version
+}
 
 /// Represents the state of the cluster, including known nodes, keyspaces, and replica locator.
 ///
@@ -80,12 +105,6 @@ impl std::fmt::Debug for ClusterStateNeatDebug<'_> {
 }
 
 impl ClusterState {
-    pub(crate) async fn wait_until_all_pools_are_initialized(&self) {
-        for node in self.locator.unique_nodes_in_global_ring().iter() {
-            node.wait_until_pool_initialized().await;
-        }
-    }
-
     /// Triggers immediate pool refills for given nodes. This resets exponential
     /// backoff for those nodes, so they will be retried immediately instead of
     /// waiting for the next retry timeout.
@@ -124,13 +143,55 @@ impl ClusterState {
         );
     }
 
-    /// Creates new ClusterState using information about topology held in `metadata`.
-    /// Uses provided `known_nodes` hashmap to recycle nodes if possible.
+    /// Creates a new `ClusterState` from freshly read `metadata`, recycling `Node` objects
+    /// from `known_nodes` where possible.
+    ///
+    /// Construction has two steps
+    /// 1. `ClusterState::build` assembles the full state (nodes, ring, keyspaces, tablets)
+    ///    but leaves every node's `scylla_version` empty.
+    /// 2. `ClusterState::populate_scylla_versions` waits for the pools to come up and will query
+    ///    `system.versions` on the nodes and set it
     #[allow(clippy::too_many_arguments)]
     // This allow(clippy::type_complexity) is here because I can't satisfy borrow checker while
     // having the closure type be a type alias.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn new(
+        metadata: Metadata,
+        pool_config: &PoolConfig,
+        known_nodes: &HashMap<Uuid, Arc<Node>>,
+        handle_topology_changes: &mut (
+                 dyn FnMut(&HashMap<Uuid, Arc<Node>>, &HashMap<Uuid, Arc<Node>>) + Send + Sync
+             ),
+        used_keyspace: &Option<VerifiedKeyspaceName>,
+        host_filter: Option<&dyn HostFilter>,
+        connectivity_events_sender: &mpsc::UnboundedSender<ConnectivityChangeEvent>,
+        tablets: TabletsInfo,
+        old_keyspaces: &HashMap<String, Keyspace>,
+        reconnected_nodes: &HashSet<Uuid>,
+        #[cfg(feature = "metrics")] metrics: &Arc<Metrics>,
+    ) -> Self {
+        let cluster_state = Self::build(
+            metadata,
+            pool_config,
+            known_nodes,
+            handle_topology_changes,
+            used_keyspace,
+            host_filter,
+            connectivity_events_sender,
+            tablets,
+            old_keyspaces,
+            reconnected_nodes,
+            #[cfg(feature = "metrics")]
+            metrics,
+        )
+        .await;
+        cluster_state.populate_scylla_versions().await;
+        cluster_state
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
+    async fn build(
         metadata: Metadata,
         pool_config: &PoolConfig,
         known_nodes: &HashMap<Uuid, Arc<Node>>,
@@ -143,6 +204,7 @@ impl ClusterState {
         connectivity_events_sender: &mpsc::UnboundedSender<ConnectivityChangeEvent>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
+        reconnected_nodes: &HashSet<Uuid>,
         #[cfg(feature = "metrics")] metrics: &Arc<Metrics>,
     ) -> Self {
         // Create new updated known_nodes and ring
@@ -186,7 +248,13 @@ impl ClusterState {
                     if node.address == peer_endpoint.address
                         && node.release_version == peer_endpoint.release_version
                     {
-                        Arc::clone(node)
+                        // reuse the existing Node unless the node reconnected, in which case a rolling
+                        // upgrade may have changed its version, so we recreate it to force a requery
+                        if reconnected_nodes.contains(&peer_host_id) {
+                            Arc::new(Node::inherit_preserving_pool(node, peer_endpoint))
+                        } else {
+                            Arc::clone(node)
+                        }
                     } else {
                         // Address and/or release_version changed - recreate Node struct but preserve the pool.
                         Arc::new(Node::inherit_preserving_pool(node, peer_endpoint))
@@ -294,6 +362,32 @@ impl ClusterState {
             locator,
             cluster_name: metadata.cluster_name,
         }
+    }
+
+    /// Waits for the pools to initialize, then queries `system.versions` on every enabled node
+    /// whose `scylla_version` is still empty (new, recreated, or a prior query failed), recording
+    /// the result. Queries run concurrently; failures leave the version empty to retry next refresh.
+    async fn populate_scylla_versions(&self) {
+        join_all(
+            self.known_nodes
+                .values()
+                .map(|node| node.wait_until_pool_initialized()),
+        )
+        .await;
+
+        let stmt = &Statement::new("SELECT version FROM system.versions");
+        join_all(self.known_nodes.values().filter_map(|node| {
+            if node.scylla_version().is_some() {
+                return None;
+            }
+            let conn = node.get_random_connection().ok()?;
+            Some(async move {
+                if let Some(version) = query_scylla_version(&conn, stmt).await {
+                    node.set_scylla_version(version);
+                }
+            })
+        }))
+        .await;
     }
 
     /// Returns the name of the cluster, as reported by the `cluster_name` column in `system.local`.
@@ -599,8 +693,18 @@ mod tests {
         known_nodes: &HashMap<Uuid, Arc<Node>>,
         host_filter: Option<&dyn HostFilter>,
     ) -> ClusterState {
+        build_cluster_state_with_reconnected(metadata, known_nodes, host_filter, &HashSet::new())
+            .await
+    }
+
+    async fn build_cluster_state_with_reconnected(
+        metadata: Metadata,
+        known_nodes: &HashMap<Uuid, Arc<Node>>,
+        host_filter: Option<&dyn HostFilter>,
+        reconnected_nodes: &HashSet<Uuid>,
+    ) -> ClusterState {
         let (tx, _rx) = mpsc::unbounded_channel();
-        ClusterState::new(
+        ClusterState::build(
             metadata,
             &Default::default(),
             known_nodes,
@@ -610,6 +714,7 @@ mod tests {
             &tx,
             TabletsInfo::new(),
             &HashMap::new(),
+            reconnected_nodes,
             #[cfg(feature = "metrics")]
             &Default::default(),
         )
@@ -739,5 +844,136 @@ mod tests {
             Arc::ptr_eq(&old_node, new_node),
             "Node object should be reused when disabled node's attributes haven't changed"
         );
+    }
+
+    async fn build_known_nodes_with_version(
+        peers: Vec<Peer>,
+        version: Option<&str>,
+    ) -> HashMap<Uuid, Arc<Node>> {
+        let state = build_cluster_state(make_metadata(peers), &HashMap::new(), None).await;
+        let map = state.known_nodes().clone();
+        if let Some(v) = version {
+            for node in map.values() {
+                node.set_scylla_version(v.to_owned());
+            }
+        }
+        map
+    }
+
+    // `build` decides, whether to reuse the existing Node or recreate it, and
+    // leaves scylla_version empty on any node that still needs querying.
+    // populate_scylla_versions queries exactly the enabled nodes whose version is None
+    #[tokio::test]
+    async fn build_classifies_existing_nodes() {
+        setup_tracing();
+
+        // (name, prior_version, change_address, reconnected, expect_reused, expect_version)
+        let cases = [
+            (
+                "unchanged + versioned → reused, kept",
+                Some("5.0.0"),
+                false,
+                false,
+                true,
+                Some("5.0.0"),
+            ),
+            (
+                "unchanged + unversioned → reused, empty (retry)",
+                None,
+                false,
+                false,
+                true,
+                None,
+            ),
+            (
+                "reconnected → recreated, cleared (upgrade)",
+                Some("5.0.0"),
+                false,
+                true,
+                false,
+                None,
+            ),
+            (
+                "address changed → recreated, cleared",
+                Some("5.0.0"),
+                true,
+                false,
+                false,
+                None,
+            ),
+        ];
+
+        for (name, prior_version, change_address, reconnected, expect_reused, expect_version) in
+            cases
+        {
+            let host_id = Uuid::new_v4();
+            let known_nodes = build_known_nodes_with_version(
+                vec![make_peer(host_id, make_addr(1), Some("dc1"), Some("r1"))],
+                prior_version,
+            )
+            .await;
+            let old_node = Arc::clone(known_nodes.get(&host_id).unwrap());
+
+            let new_addr = make_addr(if change_address { 2 } else { 1 });
+            let reconnected = if reconnected {
+                HashSet::from([host_id])
+            } else {
+                HashSet::new()
+            };
+            let state = build_cluster_state_with_reconnected(
+                make_metadata(vec![make_peer(host_id, new_addr, Some("dc1"), Some("r1"))]),
+                &known_nodes,
+                None,
+                &reconnected,
+            )
+            .await;
+            let new_node = state.known_nodes().get(&host_id).unwrap();
+
+            assert_eq!(
+                Arc::ptr_eq(&old_node, new_node),
+                expect_reused,
+                "{name}: Arc reuse"
+            );
+            assert_eq!(new_node.scylla_version(), expect_version, "{name}: version");
+            if change_address {
+                assert_eq!(new_node.address, new_addr, "{name}: address");
+            }
+        }
+    }
+
+    // build() assembles a correct ClusterState, and new nodes start with an empty scylla_version
+    #[tokio::test]
+    async fn build_assembles_state_with_empty_versions() {
+        setup_tracing();
+
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        let metadata = make_metadata(vec![
+            make_peer(id_a, make_addr(1), Some("dc1"), Some("r1")),
+            make_peer(id_b, make_addr(2), Some("dc1"), Some("r1")),
+        ]);
+
+        let state = build_cluster_state(metadata, &HashMap::new(), None).await;
+
+        assert_eq!(state.known_nodes.len(), 2, "expected 2 nodes");
+        assert!(state.known_nodes.contains_key(&id_a));
+        assert!(state.known_nodes.contains_key(&id_b));
+        assert_eq!(
+            state.all_nodes.len(),
+            state.known_nodes.len(),
+            "all_nodes and known_nodes must contain the same number of nodes"
+        );
+        assert_eq!(
+            state.cluster_name(),
+            "Test Cluster",
+            "cluster_name must match the metadata"
+        );
+        for node in state.get_nodes_info() {
+            assert_eq!(
+                node.scylla_version(),
+                None,
+                "a brand-new node must start without a version (so it gets queried)"
+            );
+        }
     }
 }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -158,22 +158,23 @@ impl ClusterState {
 
             let node = match (is_enabled, known_nodes.get(&peer_host_id)) {
                 // If the node is disabled, then we never want to have a connection pool to it.
-                // If it already existed, and was disabled, and all parameters (dc, rack, address) match
+                // If it already existed, and was disabled, and all parameters (dc, rack, address, release_version) match
                 // then we can reuse the object.
                 // Otherwise we need to create a new one.
                 (false, Some(node))
                     if !node.is_enabled()
                         && node.datacenter == peer_endpoint.datacenter
                         && node.rack == peer_endpoint.rack
-                        && node.address == peer_endpoint.address =>
+                        && node.address == peer_endpoint.address
+                        && node.release_version == peer_endpoint.release_version =>
                 {
                     Arc::clone(node)
                 }
                 (false, _) => Arc::new(Node::new_disabled(peer_endpoint)),
                 // Changing rack/datacenter but not ip address seems improbable
                 // so we can just create new node and connections in such case.
-                // Here we allow preserving the Node object in full if all attributes (dc, rack, address)
-                // match. If only address is different, we recreate Node object but share the same underlying pool.
+                // Here we allow preserving the Node object in full if all attributes (dc, rack, address, release_version)
+                // match. If only address or release_version differ, we recreate the Node struct but preserve the pool.
                 //
                 // IMPORTANT EDGE CASE: The old Node object might have been disabled. We know that the new Node object
                 // must be enabled, so there is no point in using the old one then.
@@ -182,11 +183,13 @@ impl ClusterState {
                         && node.datacenter == peer_endpoint.datacenter
                         && node.rack == peer_endpoint.rack =>
                 {
-                    if node.address == peer_endpoint.address {
+                    if node.address == peer_endpoint.address
+                        && node.release_version == peer_endpoint.release_version
+                    {
                         Arc::clone(node)
                     } else {
-                        // If IP changes, the Node struct is recreated, but the underlying pool is preserved and notified about the IP change.
-                        Arc::new(Node::inherit_with_ip_changed(node, peer_endpoint))
+                        // Address and/or release_version changed - recreate Node struct but preserve the pool.
+                        Arc::new(Node::inherit_preserving_pool(node, peer_endpoint))
                     }
                 }
                 (true, _) => Arc::new(Node::new(
@@ -558,6 +561,7 @@ mod tests {
             tokens: vec![Token::new(1)],
             datacenter: datacenter.map(String::from),
             rack: rack.map(String::from),
+            release_version: None,
         }
     }
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -19,7 +19,7 @@ use futures::future::join_all;
 use futures::{FutureExt, future::RemoteHandle};
 use scylla_cql::frame::response::event::StatusChangeEvent;
 use scylla_cql::frame::response::result::TableSpec;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, trace};
@@ -106,6 +106,11 @@ struct ClusterWorker {
     // This value determines how frequently the cluster
     // worker will refresh the cluster metadata
     cluster_metadata_refresh_interval: Duration,
+
+    // Host IDs of nodes that fired ConnectivityChangeEvent::Established since the last
+    // metadata refresh. Passed into ClusterState::new() so those nodes get a fresh Arc
+    // and their scylla_version is re-queried (handles rolling upgrades).
+    reconnected_nodes: HashSet<Uuid>,
 
     #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
@@ -194,11 +199,11 @@ impl Cluster {
             &connectivity_events_sender,
             TabletsInfo::new(),
             &HashMap::new(),
+            &HashSet::new(),
             #[cfg(feature = "metrics")]
             &metrics,
         )
         .await;
-        cluster_state.wait_until_all_pools_are_initialized().await;
 
         let cluster_state: Arc<ArcSwap<ClusterState>> =
             Arc::new(ArcSwap::from(Arc::new(cluster_state)));
@@ -221,6 +226,8 @@ impl Cluster {
             host_filter,
             host_listener,
             cluster_metadata_refresh_interval,
+
+            reconnected_nodes: HashSet::new(),
 
             #[cfg(feature = "metrics")]
             metrics,
@@ -512,18 +519,17 @@ impl ClusterWorker {
                 &self.connectivity_events_sender,
                 cluster_state.locator.tablets.clone(),
                 &cluster_state.keyspaces,
+                &self.reconnected_nodes,
                 #[cfg(feature = "metrics")]
                 &self.metrics,
             )
             .await,
         );
 
-        new_cluster_state
-            .trigger_pool_refills_for_hosts(client_routes_updated_hosts.iter().copied());
+        self.reconnected_nodes.clear();
 
         new_cluster_state
-            .wait_until_all_pools_are_initialized()
-            .await;
+            .trigger_pool_refills_for_hosts(client_routes_updated_hosts.iter().copied());
 
         self.update_cluster_state(new_cluster_state);
 
@@ -754,6 +760,7 @@ impl ClusterWorker {
             (NodeConnectivityStatus::Unreachable, ConnectivityChangeEvent::Established { .. }) => {
                 debug!("Node is now reachable again: {}", addr);
                 *connectivity = NodeConnectivityStatus::Connected;
+                self.reconnected_nodes.insert(host_id);
                 Some(HostEvent::Up)
             }
             _ => {

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1971,6 +1971,7 @@ async fn maybe_translated_addr(
                 address: NodeAddr::Translatable(addr),
                 datacenter,
                 rack,
+                ..
             }),
             Some(translator),
         ) => {

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1434,6 +1434,7 @@ mod tests {
                 &connectivity_events_sender,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                &HashSet::new(),
                 #[cfg(feature = "metrics")]
                 &Default::default(),
             )
@@ -1479,6 +1480,7 @@ mod tests {
                 &connectivity_events_sender,
                 TabletsInfo::new(),
                 &HashMap::new(),
+                &HashSet::new(),
                 #[cfg(feature = "metrics")]
                 &Default::default(),
             )
@@ -2070,6 +2072,7 @@ mod tests {
     async fn test_default_policy_with_lwt_statements() {
         setup_tracing();
         use crate::routing::locator::test::{A, B, C, D, E, F, G};
+        use std::collections::HashSet;
 
         let cluster = mock_cluster_state_for_token_aware_tests().await;
         struct Test<'a> {
@@ -2629,6 +2632,7 @@ mod tests {
             &connectivity_events_sender,
             TabletsInfo::new(),
             &HashMap::new(),
+            &HashSet::new(),
             #[cfg(feature = "metrics")]
             &Default::default(),
         )

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1457,6 +1457,7 @@ mod tests {
                     address: id_to_invalid_addr(*id),
                     tokens: vec![Token::new(*id as i64 * 100)],
                     host_id: Uuid::new_v4(),
+                    release_version: None,
                 })
                 .collect::<Vec<_>>();
 

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -64,6 +64,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(1),
             tokens: vec![Token::new(50), Token::new(250), Token::new(400)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // B
@@ -72,6 +73,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(2),
             tokens: vec![Token::new(100), Token::new(600), Token::new(900)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // C
@@ -80,6 +82,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(3),
             tokens: vec![Token::new(300), Token::new(650), Token::new(700)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // D
@@ -88,6 +91,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(4),
             tokens: vec![Token::new(350), Token::new(550)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // E
@@ -96,6 +100,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(5),
             tokens: vec![Token::new(150), Token::new(750)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // F
@@ -104,6 +109,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(6),
             tokens: vec![Token::new(200), Token::new(450)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
         Peer {
             // G
@@ -112,6 +118,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
             address: id_to_invalid_addr(7),
             tokens: vec![Token::new(500), Token::new(800)],
             host_id: Uuid::new_v4(),
+            release_version: None,
         },
     ];
 

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -579,4 +579,24 @@ async fn test_session_should_have_cluster_metadata() {
     );
 
     assert_eq!(state.cluster_name(), "TestCluster");
+
+    let (expected_version,): (Option<String>,) = session
+        .query_unpaged(
+            "SELECT release_version FROM system.local WHERE key='local'",
+            (),
+        )
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap()
+        .single_row()
+        .unwrap();
+
+    for node in state.get_nodes_info() {
+        assert_eq!(
+            node.release_version, expected_version,
+            "Node {} has unexpected release_version",
+            node.address
+        );
+    }
 }

--- a/scylla/tests/integration/metadata/mod.rs
+++ b/scylla/tests/integration/metadata/mod.rs
@@ -1,2 +1,3 @@
 mod configuration;
 mod contents;
+mod scylla_version;

--- a/scylla/tests/integration/metadata/scylla_version.rs
+++ b/scylla/tests/integration/metadata/scylla_version.rs
@@ -1,0 +1,321 @@
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use scylla::client::session_builder::SessionBuilder;
+use scylla::policies::address_translator::AddressTranslator;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, ShardAwareness,
+    WorkerError,
+};
+use tokio::sync::mpsc;
+
+use crate::utils::{create_new_session_builder, setup_tracing, test_with_3_node_cluster};
+
+/// ScyllaDB nodes report the `system.versions` value; Cassandra nodes report `None`.
+/// Runs on both backends.
+#[tokio::test]
+async fn test_scylla_version_matches_backend() {
+    setup_tracing();
+
+    let session = create_new_session_builder().build().await.unwrap();
+    let state = session.get_cluster_state();
+
+    // ScyllaDB-only and local; on Cassandra the query errors → no version. All nodes match.
+    let expected: Option<String> = match session
+        .query_unpaged("SELECT version FROM system.versions", ())
+        .await
+    {
+        Ok(result) => result
+            .into_rows_result()
+            .ok()
+            .and_then(|rows| rows.single_row::<(Option<String>,)>().ok())
+            .and_then(|(v,)| v),
+        Err(_) => None,
+    };
+
+    for node in state.get_nodes_info() {
+        if node.sharder().is_some() {
+            assert_eq!(
+                node.scylla_version(),
+                expected.as_deref(),
+                "ScyllaDB node {} should match system.versions (and be populated)",
+                node.address
+            );
+            assert!(
+                node.scylla_version().is_some(),
+                "ScyllaDB node {}",
+                node.address
+            );
+        } else {
+            assert_eq!(
+                node.scylla_version(),
+                None,
+                "Cassandra node {} should have no scylla_version",
+                node.address
+            );
+        }
+    }
+}
+
+/// A `system.versions` failure on one node leaves its version `None`, others populated, and
+/// the driver usable. Covers a server error and a dropped response (timeout) in one cluster.
+#[tokio::test]
+#[cfg_attr(cassandra_tests, ignore)]
+async fn test_scylla_version_degrades_on_query_failure() {
+    setup_tracing();
+
+    // Connect a fresh session (queries system.versions against the rule active on node 0), then
+    // assert node 0 has no version, the others do, and the driver still works.
+    async fn assert_node0_degrades(
+        proxy_uri: &str,
+        translator: Arc<dyn AddressTranslator>,
+        node0_real_ip: IpAddr,
+        scenario: &str,
+    ) {
+        let session = SessionBuilder::new()
+            .known_node(proxy_uri)
+            .address_translator(translator)
+            .build()
+            .await
+            .unwrap();
+
+        for node in session.get_cluster_state().get_nodes_info() {
+            if node.address.ip() == node0_real_ip {
+                assert_eq!(
+                    node.scylla_version(),
+                    None,
+                    "{scenario}: node {}",
+                    node.address
+                );
+            } else {
+                assert!(
+                    node.scylla_version().is_some(),
+                    "{scenario}: node {}",
+                    node.address
+                );
+            }
+        }
+
+        // Driver still usable despite the failure on one node.
+        session
+            .query_unpaged("SELECT * FROM system.local", ())
+            .await
+            .unwrap();
+    }
+
+    let versions_rule = |reaction: RequestReaction| {
+        RequestRule(
+            Condition::RequestOpcode(RequestOpcode::Query).and(
+                Condition::BodyContainsCaseInsensitive(Box::from(*b"system.versions")),
+            ),
+            reaction,
+        )
+    };
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            // translation_map maps real_addr → proxy_addr. Reverse it to find the real address
+            // behind proxy node 0 (where the rule is applied), so we can identify it in the
+            // cluster state (which stores real addresses).
+            let proxy0_addr: SocketAddr = proxy_uris[0].parse().unwrap();
+            let node0_real_ip = translation_map
+                .iter()
+                .find(|(_, proxy)| proxy.ip() == proxy0_addr.ip())
+                .map(|(real, _)| real.ip())
+                .expect("proxy0 address not found in translation_map");
+            let translator: Arc<dyn AddressTranslator> = Arc::new(translation_map);
+
+            // Server error on system.versions.
+            running_proxy.running_nodes[0].change_request_rules(Some(vec![versions_rule(
+                RequestReaction::forge().server_error(),
+            )]));
+            assert_node0_degrades(
+                proxy_uris[0].as_str(),
+                Arc::clone(&translator),
+                node0_real_ip,
+                "server error",
+            )
+            .await;
+
+            // Dropped response — the frame never arrives, so the driver's timeout fires.
+            running_proxy.running_nodes[0]
+                .change_request_rules(Some(vec![versions_rule(RequestReaction::drop_frame())]));
+            assert_node0_degrades(
+                proxy_uris[0].as_str(),
+                Arc::clone(&translator),
+                node0_real_ip,
+                "timeout",
+            )
+            .await;
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// A node whose initial `system.versions` query failed is retried on the next refresh.
+#[tokio::test]
+#[cfg_attr(cassandra_tests, ignore)]
+async fn test_scylla_version_repopulated_after_transient_failure() {
+    setup_tracing();
+
+    let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel();
+
+    let error_rule = RequestRule(
+        Condition::RequestOpcode(RequestOpcode::Query).and(Condition::BodyContainsCaseInsensitive(
+            Box::from(*b"system.versions"),
+        )),
+        RequestReaction::forge()
+            .server_error()
+            .with_feedback_when_performed(feedback_tx),
+    );
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            running_proxy.running_nodes[0].change_request_rules(Some(vec![error_rule]));
+
+            let proxy0_addr: SocketAddr = proxy_uris[0].parse().unwrap();
+            let node0_real_ip = translation_map
+                .iter()
+                .find(|(_, proxy)| proxy.ip() == proxy0_addr.ip())
+                .map(|(real, _)| real.ip())
+                .expect("proxy0 not in translation_map");
+
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            while feedback_rx.try_recv().is_ok() {}
+
+            // Node 0 should have None — the query was blocked during connect.
+            let node0_version_after_connect = session
+                .get_cluster_state()
+                .get_nodes_info()
+                .iter()
+                .find(|n| n.address.ip() == node0_real_ip)
+                .unwrap()
+                .scylla_version()
+                .map(str::to_owned);
+            assert_eq!(node0_version_after_connect, None);
+
+            // Remove the block. system.versions on node 0 will now respond normally.
+            running_proxy.running_nodes[0].change_request_rules(None);
+
+            // Trigger a refresh. No topology changed, so node 0's Arc is reused.
+            session.refresh_metadata().await.unwrap();
+
+            // Node 0 should now have a version — the transient failure is resolved.
+            let node0_version_after_refresh = session
+                .get_cluster_state()
+                .get_nodes_info()
+                .iter()
+                .find(|n| n.address.ip() == node0_real_ip)
+                .unwrap()
+                .scylla_version()
+                .map(str::to_owned);
+            assert!(
+                node0_version_after_refresh.is_some(),
+                "Node {} still has scylla_version = None after the transient failure was \
+                 resolved — system.versions is not retried for unchanged nodes",
+                node0_real_ip
+            );
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Unchanged nodes are not re-queried across a no-op metadata refresh.
+#[tokio::test]
+#[cfg_attr(cassandra_tests, ignore)]
+async fn test_scylla_version_not_requeried_for_unchanged_nodes() {
+    setup_tracing();
+
+    let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel();
+
+    let count_rule = RequestRule(
+        Condition::RequestOpcode(RequestOpcode::Query).and(Condition::BodyContainsCaseInsensitive(
+            Box::from(*b"system.versions"),
+        )),
+        RequestReaction::noop().with_feedback_when_performed(feedback_tx),
+    );
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            for node in &mut running_proxy.running_nodes {
+                node.change_request_rules(Some(vec![count_rule.clone()]));
+            }
+
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            let mut connect_count = 0;
+            while feedback_rx.try_recv().is_ok() {
+                connect_count += 1;
+            }
+            assert_eq!(
+                connect_count, 3,
+                "expected one system.versions query per node on connect"
+            );
+
+            let sorted_versions = |state: &scylla::cluster::ClusterState| {
+                let mut v: Vec<_> = state
+                    .get_nodes_info()
+                    .iter()
+                    .map(|n| (n.address, n.scylla_version().map(str::to_owned)))
+                    .collect();
+                v.sort_by_key(|(addr, _)| *addr);
+                v
+            };
+            let versions_before = sorted_versions(&session.get_cluster_state());
+
+            // trigger refresh with no topology changes
+            // No new system.versions queries should have been issued for unchanged nodes
+            session.refresh_metadata().await.unwrap();
+            assert!(
+                feedback_rx.try_recv().is_err(),
+                "system.versions was re-queried for unchanged nodes"
+            );
+
+            // existing values must be preserved not reset to None
+            let versions_after = sorted_versions(&session.get_cluster_state());
+            assert_eq!(
+                versions_before, versions_after,
+                "scylla_version changed across a no-op metadata refresh"
+            );
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/metadata/scylla_version.rs
+++ b/scylla/tests/integration/metadata/scylla_version.rs
@@ -121,7 +121,7 @@ async fn test_scylla_version_degrades_on_query_failure() {
             let proxy0_addr: SocketAddr = proxy_uris[0].parse().unwrap();
             let node0_real_ip = translation_map
                 .iter()
-                .find(|(_, proxy)| proxy.ip() == proxy0_addr.ip())
+                .find(|(_, proxy)| **proxy == proxy0_addr)
                 .map(|(real, _)| real.ip())
                 .expect("proxy0 address not found in translation_map");
             let translator: Arc<dyn AddressTranslator> = Arc::new(translation_map);
@@ -186,7 +186,7 @@ async fn test_scylla_version_repopulated_after_transient_failure() {
             let proxy0_addr: SocketAddr = proxy_uris[0].parse().unwrap();
             let node0_real_ip = translation_map
                 .iter()
-                .find(|(_, proxy)| proxy.ip() == proxy0_addr.ip())
+                .find(|(_, proxy)| **proxy == proxy0_addr)
                 .map(|(real, _)| real.ip())
                 .expect("proxy0 not in translation_map");
 

--- a/scylla/tests/integration/session/internal_requests.rs
+++ b/scylla/tests/integration/session/internal_requests.rs
@@ -34,12 +34,16 @@ async fn test_no_unprepared_internal_requests() {
 
         // Helper to check if any Query requests were issued.
         // We allow "USE " queries because they are intended to be unprepared and are not preparable in CQL.
+        // We allow "system.versions" queries because the driver queries each node's real ScyllaDB
+        // version from this virtual table during metadata refresh. Virtual tables cannot be
+        // prepared (they don't go through the normal storage engine), so this query must remain
+        // unprepared.
         let check_no_unprepared_queries =
             |section: &str,
              feedback_rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>| {
                 while let Ok((frame, _)) = feedback_rx.try_recv() {
                     let body_str = String::from_utf8_lossy(&frame.body);
-                    if !body_str.starts_with("USE ") {
+                    if !body_str.contains("USE ") && !body_str.contains("system.versions") {
                         panic!(
                             "Section {}: Forbidden unprepared query detected: {}",
                             section, body_str


### PR DESCRIPTION
Adds a per-node ScyllaDB version, read from the `system.versions` virtual table and exposed as `Node::scylla_version() -> Option<&str>`. The version is only knowable after a node's connection is up, so it is stored in a write-once `OnceLock` on `Node` and filled in by the cluster worker. The driver re-queries it on reconnect to track rolling upgrades.

## Changes

| Area | Change |
|---|---|
| `cluster/node.rs` | New `scylla_version: OnceLock<String>` field (private). Accessor `scylla_version() -> Option<&str>` and crate-internal `set_scylla_version(String)` (write-once). |
| `cluster/state.rs` | `ClusterState::new` split into `build` (assemble state, no versions) + `populate_scylla_versions` (wait for pools, query, record). New `query_scylla_version` helper. New `reconnected_nodes` parameter. |
| `cluster/worker.rs` | New `reconnected_nodes: HashSet<Uuid>` accumulated from `Established` connectivity events, consumed + cleared each refresh. The separate post-refresh pool-wait calls are removed (the wait now lives in `populate_scylla_versions`). |
| tests | New integration suite `metadata/scylla_version.rs` (4 tests) + `build`-based classification unit tests in `state.rs`. |

## Design

The version can only be written after the `Node` is shared into the token ring and no longer uniquely owned. So it is modelled as write-once interior mutability: a `OnceLock<String>` on `Node`, empty at construction and set once after the pool comes up.

A node that reconnects or changes address is a brand-new `Node`, so the version is never rewritten. Readers see either the empty or the populated value.

## Design: build, then populate

`ClusterState::new()` runs in two steps: `build`, then `populate_scylla_versions`.

### build

The pre-existing `ClusterState::new` body, unchanged except for the reconnect rule in node classification:

- **new** (not in previous `known_nodes`): `Node::new` (empty version)
- **address or release_version changed**: `inherit_preserving_pool` (fresh `Node`, empty version)
- **reconnected** since last refresh: `inherit_preserving_pool` (fresh `Node`, empty version)
- **otherwise unchanged**: `Arc::clone` (reused, keeps its version)

A node is queried by `populate_scylla_versions` if its version is empty.

### populate_scylla_versions

1. Wait for every pool to initialize, so the queries below have a connection.
2. For every node whose version is still `None`, query `system.versions` (in parallel, 500 ms timeout each) and set the result on the node.

## Rolling-upgrade handling (`reconnected_nodes`)

When a node's pool re-establishes after being unreachable, the worker receives `ConnectivityChangeEvent::Established` and records the node's `host_id` in `reconnected_nodes`. The next refresh passes that set into `build`, which recreates those nodes with an empty version so the new version is queried.

## Degradation behavior

`query_scylla_version` returns `None` (never errors) on a query error, a 500 ms timeout, an empty result, or a Cassandra node with no `system.versions`. A `None` is simply not written, leaving the `OnceLock` empty, so the node is retried on the next refresh.

## note

The pool-init wait moved into `populate_scylla_versions`, so `trigger_pool_refills_for_hosts` now runs fire-and-forget instead of awaited. Seems safe because refill only resets backoff and the load balancer skips disconnected nodes but please confirm.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
