### PR TITLE
Fix shorter tuple ser/deser (again)

### DIFF
--- a/scylla-cql-core/src/deserialize/value.rs
+++ b/scylla-cql-core/src/deserialize/value.rs
@@ -224,12 +224,19 @@ impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for CqlValue {
                     let t = type_names
                         .iter()
                         .map(|typ| -> Result<_, DeserializationError> {
-                            let raw = frame_slice.read_cql_bytes().map_err(|e| {
-                                mk_deser_err::<CqlValue>(
-                                    typ,
-                                    BuiltinDeserializationErrorKind::RawCqlBytesReadError(e),
-                                )
-                            })?;
+                            let raw = if frame_slice.is_empty() {
+                                // Special case: if there are no bytes left to read, consider the tuple element as null.
+                                // This is needed to handle tuples with fewer elements than expected
+                                // (see https://github.com/scylladb/scylla-rust-driver/issues/1452 for context).
+                                None
+                            } else {
+                                frame_slice.read_cql_bytes().map_err(|e| {
+                                    mk_deser_err::<CqlValue>(
+                                        typ,
+                                        BuiltinDeserializationErrorKind::RawCqlBytesReadError(e),
+                                    )
+                                })?
+                            };
                             raw.map(|v| CqlValue::deserialize(typ, Some(v))).transpose()
                         })
                         .collect::<Result<_, _>>()?;
@@ -1624,7 +1631,7 @@ macro_rules! impl_tuple {
                         {
                             let cql_bytes = if v.is_empty() {
                                 // Special case: if there are no bytes left to read, consider the tuple element as null.
-                                // This is needed to handle tuples with less elements than expected
+                                // This is needed to handle tuples with fewer elements than expected
                                 // (see https://github.com/scylladb/scylla-rust-driver/issues/1452 for context).
                                 None
                             } else {

--- a/scylla-cql-core/src/serialize/value.rs
+++ b/scylla-cql-core/src/serialize/value.rs
@@ -859,7 +859,10 @@ macro_rules! impl_tuple {
             ) -> Result<WrittenCellProof<'b>, SerializationError> {
                 let ($($tidents,)*) = match typ {
                     ColumnType::Tuple(typs) => match typs.as_slice() {
-                        [$($tidents),*] => ($($tidents,)*),
+                        // Allow CQL tuples with more fields than the Rust tuple.
+                        // The extra fields will simply not be serialized (treated as null by the server).
+                        // This mirrors how CqlValue::Tuple serialization works.
+                        [$($tidents),*, ..] => ($($tidents,)*),
                         _ => return Err(mk_typck_err::<Self>(
                             typ,
                             TupleTypeCheckErrorKind::WrongElementCount {

--- a/scylla/tests/integration/types/cql_collections.rs
+++ b/scylla/tests/integration/types/cql_collections.rs
@@ -385,6 +385,18 @@ async fn test_cql_tuple_db_repr_shorter_than_metadata() {
             // Total: 31 bytes
             assert_eq!(buf.len(), 31);
         }
+
+        // Verify that CqlValue::Tuple can be shorter than the DB column type indicates.
+        let tuple_ser_cql = CqlValue::Tuple(vec![
+            Some(CqlValue::Tuple(vec![
+                Some(CqlValue::Int(1)),
+                Some(CqlValue::Text("Ala".to_owned())),
+                // No third element
+            ])),
+            Some(CqlValue::Int(2)),
+            // No third element
+        ]);
+        insert_and_select(&session, table_name, &tuple_ser_cql, &tuple_deser).await;
     }
 
     session

--- a/scylla/tests/integration/types/cql_collections.rs
+++ b/scylla/tests/integration/types/cql_collections.rs
@@ -8,6 +8,7 @@ use scylla::value::{
     CqlDate, CqlDecimal, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlValue, CqlVarint,
 };
 use scylla::{client::session::Session, cluster::metadata::ColumnType};
+use scylla_cql::serialize::CellWriter;
 use scylla_cql::serialize::value::SerializeValue;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
@@ -362,6 +363,28 @@ async fn test_cql_tuple_db_repr_shorter_than_metadata() {
             None, // missing third field of outer tuple
         ]);
         insert_and_select(&session, table_name, &tuple_ser, &tuple_cql_deser).await;
+
+        // Test that shorter Rust tuple can also be successfully inserted, and is of correct form
+        // when selected.
+        let tuple_ser_raw = ((1, "Ala".to_owned()), 2);
+        insert_and_select(&session, table_name, &tuple_ser_raw, &tuple_deser).await;
+        // Check that the tuple does not serialize the missing elements.
+        {
+            let typ = Tuple(vec![
+                Tuple(vec![Native(Int), Native(Text), Native(Int)]),
+                Native(Int),
+                Tuple(vec![Native(Int)]),
+            ]);
+            let mut buf = vec![];
+            let _ = tuple_ser_raw
+                .serialize(&typ, CellWriter::new(&mut buf))
+                .unwrap();
+            // First inner tuple: [bytes] for Int (8 bytes) and [bytes] for "Ala" (7 bytes) + length prefix of tuple (4 bytes) = 19 bytes
+            // Int: 8 bytes
+            // Length prefix of outer tuple: 4 bytes
+            // Total: 31 bytes
+            assert_eq!(buf.len(), 31);
+        }
     }
 
     session

--- a/scylla/tests/integration/types/cql_collections.rs
+++ b/scylla/tests/integration/types/cql_collections.rs
@@ -297,6 +297,22 @@ async fn test_alter_column_add_field_to_tuple() {
 
     assert!(selected_value.2.is_none());
 
+    // Test CqlValue deserialization: the stored 2-element tuple should deserialize to a
+    // CqlValue::Tuple with 3 elements, where the third is None.
+    let selected_as_cql_value: CqlValue = session
+        .query_unpaged(format!("SELECT val FROM {table_name} WHERE p = 0"), ())
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap()
+        .single_row::<(CqlValue,)>()
+        .unwrap()
+        .0;
+    assert_eq!(
+        selected_as_cql_value,
+        CqlValue::Tuple(vec![Some(CqlValue::Int(1)), Some(CqlValue::Int(2)), None,])
+    );
+
     session
         .ddl(format!("DROP KEYSPACE {}", session.get_keyspace().unwrap()))
         .await
@@ -335,6 +351,17 @@ async fn test_cql_tuple_db_repr_shorter_than_metadata() {
         // The expected deserialized tuple has None for the missing elements.
         let tuple_deser = ((1, "Ala".to_owned(), None::<i32>), 2, None::<(i32,)>);
         insert_and_select(&session, table_name, &tuple_ser, &tuple_deser).await;
+
+        let tuple_cql_deser = CqlValue::Tuple(vec![
+            Some(CqlValue::Tuple(vec![
+                Some(CqlValue::Int(1)),
+                Some(CqlValue::Text("Ala".to_owned())),
+                None, // missing third field of inner tuple
+            ])),
+            Some(CqlValue::Int(2)),
+            None, // missing third field of outer tuple
+        ]);
+        insert_and_select(&session, table_name, &tuple_ser, &tuple_cql_deser).await;
     }
 
     session


### PR DESCRIPTION
CQL tuple of size N can be stored in DB (and returned to the driver) as a tuple of size M, for M <= N.

Both DBs allow inserting such shorter tuples directly. In Scylla they can also appear if you ALTER column, increasing the field count of the tuple.

We allowed serializing `CqlValue::Tuple` to a column with larger tuple for a very long time now.
Some time ago (~9 months) we also allowed deserializing Rust tuples from such shorter representation: https://github.com/scylladb/scylla-rust-driver/pull/1453

The problem is that the PR above forgot about `CqlValue::Tuple`! Without adjusting it, it is possible for values to exist in DB that are not deserializable to CqlValue, which is a problem (it is supposed to be able to represent all values).
The first thing that this PR does is fixing it (and adding regression test).

After fixing it, I thought it is weird that we allow both ser and deser of CqlValue::Tuple, and deser of Rust tuples, but not ser of Rust tuples. For consistency I changed it as well (and added a test).

Note: technically, all of this is behavior, not API. So we could theoretically change the behavior again in 1.x - Rust semver rules don't prohibit it.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1625



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
