### PR TITLE
Fix flaky test_schema_await_required_host_absent

### DIFF
--- a/scylla/tests/integration/session/schema_agreement.rs
+++ b/scylla/tests/integration/session/schema_agreement.rs
@@ -407,6 +407,24 @@ async fn test_schema_await_required_host_absent() {
 
             // Cleanup
             running_proxy.running_nodes[1].change_request_rules(Some(vec![]));
+            // Prepare a new session. The old one has a very small schema agreement timeout,
+            // so awaiting schema agreement may fail (especially on Cassandra). We do need to await
+            // because:
+            // 1. CREATE KEYSPACE may not have propagated yet, which would cause the DROP below to fail,
+            //    so we need to await before DROP
+            // 2. We have a tool that verifies all keyspaces are dropped after tests.
+            //    If we don't auto-await after DROP, it is theoretically possible for this
+            //    tool to see the undropped keyspace.
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map.clone()))
+                // Let's have small pool for quicker session creation.
+                .pool_size(PoolSize::PerHost(1.try_into().unwrap()))
+                // Let's try more often to speed up the test.
+                .schema_agreement_interval(Duration::from_millis(50))
+                .build()
+                .await
+                .unwrap();
             session.await_schema_agreement().await.unwrap();
             session
                 .query_unpaged(format!("DROP KEYSPACE {ks}"), &[])


### PR DESCRIPTION
It was failing when awaiting agreement after DROP KEYSPACE. This was caused by too short agreement timeout, which is necessary for the test.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1632

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
