### PR TITLE
Reject trailing custom type parser input

### DIFF
--- a/scylla-cql-core/src/frame/frame_errors.rs
+++ b/scylla-cql-core/src/frame/frame_errors.rs
@@ -680,6 +680,9 @@ pub enum CustomTypeParseError {
     InvalidUtf8(Vec<u8>),
     #[error("Wrong number of parameters {actual}, expected: {expected}")]
     InvalidParameterCount { actual: usize, expected: usize },
+    /// Input remained after parsing a complete custom type name.
+    #[error("Unexpected trailing characters: {0}")]
+    UnexpectedTrailingCharacters(String),
 }
 
 /// An error type returned when deserialization of CQL type name fails.

--- a/scylla-cql/src/frame/response/custom_type_parser.rs
+++ b/scylla-cql/src/frame/response/custom_type_parser.rs
@@ -54,7 +54,14 @@ impl<'result> CustomTypeParser<'result> {
 
     pub(crate) fn parse(input: &'result str) -> Result<ColumnType<'result>, CustomTypeParseError> {
         let mut parser = CustomTypeParser::new(input);
-        parser.do_parse()
+        let typ = parser.do_parse()?;
+        if parser.parser.is_at_eof() {
+            Ok(typ)
+        } else {
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                parser.parser.s.to_owned(),
+            ))
+        }
     }
 
     fn is_identifier_char(c: char) -> bool {
@@ -379,12 +386,16 @@ impl<'result> CustomTypeParser<'result> {
                 .map_err(|_| CustomTypeParseError::BadHexString(name.to_owned()))?;
             name = self.read_next_identifier();
         }
+        let parser_before_params = self.parser;
         self.skip_blank();
         let result = self.parser.accept("(");
         match result {
             // Here we do not change the parser state, because we want to keep the state as it was before the accept.
             Ok(_) => self.get_complex_abstract_type(name),
-            Err(_) => CustomTypeParser::get_simple_abstract_type(name),
+            Err(_) => {
+                self.parser = parser_before_params;
+                CustomTypeParser::get_simple_abstract_type(name)
+            }
         }
     }
 }
@@ -598,6 +609,32 @@ mod tests {
         assert_eq!(
             CustomTypeParser::parse("zz:org.apache.cassandra.db.marshal.Int32Type"),
             Err(CustomTypeParseError::BadHexString("zz".to_string()))
+        );
+
+        assert_eq!(
+            CustomTypeParser::parse("org.apache.cassandra.db.marshal.Int32Type garbage"),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                " garbage".to_string()
+            ))
+        );
+
+        assert_eq!(
+            CustomTypeParser::parse(
+                "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)garbage"
+            ),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                "garbage".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn custom_cassandra_type_parser_rejects_trailing_whitespace() {
+        assert_eq!(
+            CustomTypeParser::parse("org.apache.cassandra.db.marshal.Int32Type \t\n"),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                " \t\n".to_string()
+            ))
         );
     }
 }


### PR DESCRIPTION
## Summary

- Make `CustomTypeParser::parse` reject input left after a complete custom type name, including trailing whitespace.
- Preserve whitespace handling inside valid complex type syntax, such as before parameter lists.
- Add regression coverage for trailing garbage after simple and complex custom type strings, plus trailing whitespace.

## Checks

- `rustup run stable cargo fmt --all -- --check`
- `rustup run stable cargo test -p scylla-cql custom_cassandra_type_parser --lib`
- `rustup run stable cargo test -p scylla-cql --lib`
- `rustup run stable cargo test -p scylla-cql-core --lib`
- `rustup run stable cargo clippy -p scylla-cql -p scylla-cql-core --lib -- -D warnings`
- `git diff --check`

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`. Not applicable; this changes an internal parser and error surface only.
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #1661