### PR TITLE
Reject zero keepalive interval during session creation

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -523,6 +523,12 @@ impl SessionConfig {
             return Err(NewSessionError::EmptyKnownNodesList);
         }
 
+        if self.keepalive_interval == Some(Duration::ZERO) {
+            return Err(NewSessionError::IllegalConfig(
+                "Keepalive interval must be non-zero".into(),
+            ));
+        }
+
         // Ensure no illegal configuration with Client Routes
         #[cfg(feature = "unstable-client-routes")]
         if self.client_routes_config.is_some() {

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1027,6 +1027,7 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// Set the keepalive interval.
     /// The default is `Some(Duration::from_secs(30))`, which corresponds
     /// to keepalive CQL messages being sent every 30 seconds.
+    /// Zero intervals are rejected during session creation.
     /// Note: this configures CQL-layer keepalives. See also:
     /// `Self::tcp_keepalive_interval`.
     ///
@@ -1421,6 +1422,7 @@ mod tests {
     use super::SessionBuilder;
     use crate::client::execution_profile::{ExecutionProfile, defaults};
     use crate::cluster::node::KnownNode;
+    use crate::errors::NewSessionError;
     use crate::test_utils::setup_tracing;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::time::Duration;
@@ -1552,6 +1554,24 @@ mod tests {
         assert_eq!(
             builder.config.connect_timeout,
             std::time::Duration::from_secs(10)
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_keepalive_interval_is_rejected() {
+        setup_tracing();
+        let error = SessionBuilder::new()
+            .known_node("127.0.0.1:9042")
+            .keepalive_interval(Duration::ZERO)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, NewSessionError::IllegalConfig(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("Keepalive interval must be non-zero")
         );
     }
 


### PR DESCRIPTION
## Summary
- Reject `Duration::ZERO` CQL keepalive intervals during session config validation.
- Document that zero keepalive intervals are rejected during session creation.
- Add a regression test covering `SessionBuilder::build()` returning `NewSessionError::IllegalConfig`.

## Checks
- `cargo +stable test -p scylla zero_keepalive_interval_is_rejected`
- `cargo +stable test -p scylla client::session_builder --lib`
- `cargo +stable check -p scylla --all-features`
- `cargo +stable fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings --cfg scylla_unstable' cargo +stable clippy --all-targets --all-features`
- `RUSTFLAGS='-Dwarnings' cargo +stable clippy --all-features --tests --examples`
- `git diff --check`

## Not run
- Full live-cluster suite / `make test`: no local Scylla cluster is available. An attempted full `cargo +stable test -p scylla --lib` passed the new and adjacent builder tests, then timed out in existing live-node tests connecting to `172.42.0.2:9042`.

Fixes: #1695