### PR TITLE
Reject out-of-range shard ids in sharding info

### DIFF
--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -859,11 +859,16 @@ impl PoolRefiller {
                     return;
                 }
 
+                let active_connection_count = self.active_connection_count();
+                // `ShardInfo::new` rejects out-of-range shard IDs; without shard info
+                // we use shard 0. `maybe_reshard` has sized `self.conns` accordingly.
+                let shard_conns = &mut self.conns[shard_id];
+
                 // Decide if the connection can be accepted, according to
                 // the pool filling strategy
                 let can_be_accepted = match self.pool_config.pool_size {
-                    PoolSize::PerHost(target) => self.active_connection_count() < target.get(),
-                    PoolSize::PerShard(target) => self.conns[shard_id].len() < target.get(),
+                    PoolSize::PerHost(target) => active_connection_count < target.get(),
+                    PoolSize::PerShard(target) => shard_conns.len() < target.get(),
                 };
 
                 if can_be_accepted {
@@ -877,13 +882,13 @@ impl PoolRefiller {
                         endpoint,
                         Arc::as_ptr(&conn),
                         shard_id,
-                        self.conns[shard_id].len() + 1,
-                        self.active_connection_count() + 1,
+                        shard_conns.len() + 1,
+                        active_connection_count + 1,
                     );
 
                     self.connection_errors
                         .push(wait_for_error(Arc::downgrade(&conn), error_receiver).boxed());
-                    self.conns[shard_id].push(conn);
+                    shard_conns.push(conn);
 
                     self.update_shared_conns(None);
                 } else if evt.requested_shard.is_some() {

--- a/scylla/src/routing/sharding.rs
+++ b/scylla/src/routing/sharding.rs
@@ -83,12 +83,23 @@ impl std::str::FromStr for Token {
 }
 
 impl ShardInfo {
-    pub(crate) fn new(shard: u16, nr_shards: ShardCount, msb_ignore: u8) -> Self {
-        ShardInfo {
+    pub(crate) fn new(
+        shard: u16,
+        nr_shards: ShardCount,
+        msb_ignore: u8,
+    ) -> Result<Self, ShardingError> {
+        if shard >= nr_shards.get() {
+            return Err(ShardingError::ShardIdOutOfRange {
+                shard,
+                nr_shards: nr_shards.get(),
+            });
+        }
+
+        Ok(ShardInfo {
             shard,
             nr_shards,
             msb_ignore,
-        }
+        })
     }
 
     pub(crate) fn get_sharder(&self) -> Sharder {
@@ -245,6 +256,12 @@ pub(crate) enum ShardingError {
     #[error("Sharding info contains an invalid number of shards (0)")]
     ZeroShards,
 
+    /// A bug in Scylla. Shard IDs must be lower than the total number of shards.
+    #[error(
+        "Sharding info contains an invalid shard id ({shard}); it must be lower than the number of shards ({nr_shards})"
+    )]
+    ShardIdOutOfRange { shard: u16, nr_shards: u16 },
+
     /// A bug in Scylla. Failed to parse string to number.
     #[error("Failed to parse a sharding info parameter's value: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
@@ -286,7 +303,7 @@ impl<'a> TryFrom<&'a HashMap<String, Vec<String>>> for ShardInfo {
         let nr_shards = nr_shards_entry.parse::<u16>()?;
         let nr_shards = ShardCount::new(nr_shards).ok_or(ShardingError::ZeroShards)?;
         let msb_ignore = msb_ignore_entry.parse::<u8>()?;
-        Ok(ShardInfo::new(shard, nr_shards, msb_ignore))
+        ShardInfo::new(shard, nr_shards, msb_ignore)
     }
 }
 
@@ -309,8 +326,9 @@ mod tests {
     use crate::test_utils::setup_tracing;
 
     use super::Token;
-    use super::{ShardCount, Sharder};
-    use std::collections::HashSet;
+    use super::{MSB_IGNORE_ENTRY, NR_SHARDS_ENTRY, SHARD_ENTRY};
+    use super::{ShardCount, ShardInfo, Sharder, ShardingError};
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn test_shard_aware_port_range_constructor() {
@@ -346,6 +364,61 @@ mod tests {
             }),
             3
         );
+    }
+
+    fn sharding_options(shard: u16, nr_shards: u16) -> HashMap<String, Vec<String>> {
+        [
+            (SHARD_ENTRY.to_owned(), vec![shard.to_string()]),
+            (NR_SHARDS_ENTRY.to_owned(), vec![nr_shards.to_string()]),
+            (MSB_IGNORE_ENTRY.to_owned(), vec!["12".to_owned()]),
+        ]
+        .into()
+    }
+
+    #[test]
+    fn shard_info_rejects_out_of_range_shard_ids() {
+        setup_tracing();
+
+        for shard in [4, 5] {
+            let options = sharding_options(shard, 4);
+            let error = ShardInfo::try_from(&options).unwrap_err();
+
+            assert!(matches!(
+                error,
+                ShardingError::ShardIdOutOfRange {
+                    shard: rejected_shard,
+                    nr_shards: 4,
+                } if rejected_shard == shard
+            ));
+        }
+    }
+
+    #[test]
+    fn shard_info_constructor_rejects_out_of_range_shard_ids() {
+        setup_tracing();
+
+        let nr_shards = ShardCount::new(4).unwrap();
+        let error = ShardInfo::new(4, nr_shards, 12).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ShardingError::ShardIdOutOfRange {
+                shard: 4,
+                nr_shards: 4,
+            }
+        ));
+    }
+
+    #[test]
+    fn shard_info_accepts_highest_valid_shard_id() {
+        setup_tracing();
+
+        let options = sharding_options(3, 4);
+        let shard_info = ShardInfo::try_from(&options).unwrap();
+
+        assert_eq!(shard_info.shard, 3);
+        assert_eq!(shard_info.nr_shards, ShardCount::new(4).unwrap());
+        assert_eq!(shard_info.msb_ignore, 12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reject server-reported shard IDs that are not lower than `SCYLLA_NR_SHARDS` while parsing sharding info.
- Preserve acceptance of the highest valid shard ID.
- Add regression coverage for `shard == nr_shards` and `shard > nr_shards`.

## Checks

- `rustup run stable cargo test -p scylla shard_info --lib`
- `rustup run stable cargo test -p scylla routing::sharding --lib`
- `rustup run stable cargo fmt --all -- --check`
- `rustup run stable cargo check -p scylla --all-features`
- `RUSTFLAGS='-Dwarnings --cfg scylla_unstable' rustup run stable cargo clippy --all-targets --all-features`
- `RUSTFLAGS='-Dwarnings' rustup run stable cargo clippy --all-features --tests --examples`
- `git diff --check`

## Not run

- `make test` / live-cluster and ccm suites; this change is covered by parser unit tests and I did not use a local Scylla/ccm cluster.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #1696
