### PR TITLE
Release 1.7.0

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sphinx-docs"
-version = "1.6"
+version = "1.7"
 description = "ScyllaDB Documentation"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,22 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0", "v1.6.0"]
+TAGS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0", "v1.6.0", "v1.7.0"]
 BRANCHES = ["main"]
 # Set the latest version.
-LATEST_VERSION = "v1.6.0"
+LATEST_VERSION = "v1.7.0"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["main"]
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0"]
+DEPRECATED_VERSIONS = [
+    "v1.2.0",
+    "v1.3.0",
+    "v1.3.1",
+    "v1.4.0",
+    "v1.4.1",
+    "v1.5.0",
+    "v1.6.0",
+]
 
 # -- General configuration
 

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "1.6"
+scylla = "1.7"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-cql-core/Cargo.toml
+++ b/scylla-cql-core/Cargo.toml
@@ -55,7 +55,7 @@ full-serialization = [
 # Important: We use precise version of scylla-macros. This enables
 # us to make breaking changes in the doc(hidden) interfaces that are
 # used by macros.
-scylla-macros = { version = "=1.6.0", path = "../scylla-macros" }
+scylla-macros = { version = "=1.7.0", path = "../scylla-macros" }
 # FrameSlice and other parts of public API (impl SerializeValue for Bytes, BufMut in vint_encode)
 bytes = "1.0.1"
 # CqlTimeuuid, ser/deser of CQL UUID

--- a/scylla-cql-core/Cargo.toml
+++ b/scylla-cql-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql-core"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "CQL data types and primitives that form the stable public API of the ScyllaDB Rust driver."

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -66,7 +66,7 @@ unstable-nodejs-rs = []
 ###########################
 # Main, public dependencies
 ###########################
-scylla-cql-core = { version = "1.6.0", path = "../scylla-cql-core" }
+scylla-cql-core = { version = "1.7.0", path = "../scylla-cql-core" }
 # AsyncRead trait used in read_response_frame
 tokio = { version = "1.40", features = ["io-util"] }
 # FrameSlice and other parts of public API

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "CQL data types and primitives, for interacting with ScyllaDB."

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "proc macros for the ScyllaDB async CQL driver"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "1.6.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.7.0", path = "../scylla-cql" }
 byteorder = "1.3.4"
 bytes = "1.10"
 futures = "0.3.6"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Async CQL driver for Rust, optimized for ScyllaDB, fully compatible with Apache Cassandra™"

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -84,7 +84,7 @@ unstable-client-routes = []
 ###########################
 # Main, public dependencies
 ###########################
-scylla-cql = { version = "=1.6.0", path = "../scylla-cql" }
+scylla-cql = { version = "=1.7.0", path = "../scylla-cql" }
 scylla-cql-core = { version = "=1.7.0", path = "../scylla-cql-core" }
 tokio = { version = "1.40", features = [
     "net",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -85,7 +85,7 @@ unstable-client-routes = []
 # Main, public dependencies
 ###########################
 scylla-cql = { version = "=1.6.0", path = "../scylla-cql" }
-scylla-cql-core = { version = "=1.6.0", path = "../scylla-cql-core" }
+scylla-cql-core = { version = "=1.7.0", path = "../scylla-cql-core" }
 tokio = { version = "1.40", features = [
     "net",
     "time",


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 1.7.0,
an asynchronous CQL driver for Rust, optimized for ScyllaDB, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 7.2M downloads on crates.io!
- over 674 GitHub stars!

## Changes

**New features / enhancements:**
- Preferred DC and rack can now be configured on `Session` directly ([#1658](https://github.com/scylladb/scylla-rust-driver/pull/1658)).
- Introduced refill trigger in connection pool. Now a refill is triggered automatically upon two kinds of events: 1) client routes change 2) node status changes to UP, which decreases reconnection delay in those situations ([#1630](https://github.com/scylladb/scylla-rust-driver/pull/1630)).
- Added method to `ClusterState` to get node by host id ([#1646](https://github.com/scylladb/scylla-rust-driver/pull/1646)).
- Exposed cluster name in `ClusterState` ([#1666](https://github.com/scylladb/scylla-rust-driver/pull/1666)).
- Re-exported in `scylla` crate `VectorIterator` and other Vector-related types ([#1650](https://github.com/scylladb/scylla-rust-driver/pull/1650)).
- `get_tracing_info` now waits for the request duration to be available ([#1652](https://github.com/scylladb/scylla-rust-driver/pull/1652)).
- Implemented / fixed / optimized optional methods (`size_hint`) and traits (`ExactSizeIterator`) for our iterators ([#1664](https://github.com/scylladb/scylla-rust-driver/pull/1664)).
- Added Vec accessor support for `CqlValue::Vector` ([#1705](https://github.com/scylladb/scylla-rust-driver/pull/1705)).
- Made TCP options use dedicated tokio helpers ([#1618](https://github.com/scylladb/scylla-rust-driver/pull/1618)).

**Bug fixes:**
- Statements executed with `SERIAL`/`LOCAL_SERIAL` consistency are now treated as LWT for routing, reducing Paxos contention ([#1647](https://github.com/scylladb/scylla-rust-driver/pull/1647)).
- Fixed panic in `metadata/reader` occurring on runtime shutdown ([#1644](https://github.com/scylladb/scylla-rust-driver/pull/1644)).
- Node attribute changes are now handled correctly w.r.t. `HostFilter` ([#1654](https://github.com/scylladb/scylla-rust-driver/pull/1654)).
- Fixed shard-awareness port iteration logic when `REUSEADDR` is used ([#1622](https://github.com/scylladb/scylla-rust-driver/pull/1622)).
- Made driver reject lz4 frame bodies shorter than the 4-byte size prefix ([#1642](https://github.com/scylladb/scylla-rust-driver/pull/1642)).
- Fixed `read_inet` port conversion ([#1649](https://github.com/scylladb/scylla-rust-driver/pull/1649)).
- Fixed panic in connection pool on out-of-range shard ([#1656](https://github.com/scylladb/scylla-rust-driver/pull/1656)).
- Fixed shard aware port range crash (and other problems) ([#1657](https://github.com/scylladb/scylla-rust-driver/pull/1657)).
- Require `first_tablet < last_tablet` when parsing tablet hint from the server ([#1660](https://github.com/scylladb/scylla-rust-driver/pull/1660)).
- Fixed tracing diagnostics to reference `system_traces.sessions` ([#1698](https://github.com/scylladb/scylla-rust-driver/pull/1698)).
- Fixed `RequiredHostAbsent` error, which always displayed host id `0` ([#1700](https://github.com/scylladb/scylla-rust-driver/pull/1700)).
- Hex prefix validation error is now propagated in custom type parser ([#1701](https://github.com/scylladb/scylla-rust-driver/pull/1701)).
- Zero prepared-statement cache capacity is now rejected to prevent infinite looping ([#1702](https://github.com/scylladb/scylla-rust-driver/pull/1702)).
- Exposed inner error in TracingError row-conversion variants ([#1703](https://github.com/scylladb/scylla-rust-driver/pull/1703)).
- Zero latency scale in the default load-balancing policy is now rejected ([#1704](https://github.com/scylladb/scylla-rust-driver/pull/1704)).
- Fixed (again) ser/deser of tuples that are shorter than the metadata says ([#1708](https://github.com/scylladb/scylla-rust-driver/pull/1708)).
- Zero keepalive interval is now rejected during session creation ([#1711](https://github.com/scylladb/scylla-rust-driver/pull/1711)).

**Internal refactors**:
- Extracted part of `scylla-cql` crate that is exposed in `scylla` crate's public API into a new `scylla-cql-core` crate, which is now a dependency of `scylla-cql`. This allows us to make breaking changes in `scylla-cql` from now on, without affecting the `scylla` crate's public API. ([#1604](https://github.com/scylladb/scylla-rust-driver/pull/1604), [#1609](https://github.com/scylladb/scylla-rust-driver/pull/1609), [#1593](https://github.com/scylladb/scylla-rust-driver/pull/1593)).
- Pinned `scylla` crate's dependencies (`scylla-cql-core`, `scylla-cql`) to specific versions, to prevent resolving incompatible dependencies. Now users will no longer suffer from incompability of `scylla` with `scylla-cql[-core]` ([#1715](https://github.com/scylladb/scylla-rust-driver/pull/1715)).

**Documentation:**
- Described interaction of statement idempotence and `DefaultRetryPolicy` decision matrix ([#1633](https://github.com/scylladb/scylla-rust-driver/pull/1633)).
- Updated actions ([#1635](https://github.com/scylladb/scylla-rust-driver/pull/1635)).
- Clarified `connection_address` semantics in `Coordinator` ([#1651](https://github.com/scylladb/scylla-rust-driver/pull/1651)).
- Fixed broken links ([#1663](https://github.com/scylladb/scylla-rust-driver/pull/1663)).

**CI / developer tool improvements:**
- Improved client routes testing ([#1615](https://github.com/scylladb/scylla-rust-driver/pull/1615), [#1631](https://github.com/scylladb/scylla-rust-driver/pull/1631)).
- Decreased number of connections in `many_connections` test to prevent file descriptor exhaustion ([#1621](https://github.com/scylladb/scylla-rust-driver/pull/1621)).
- Fixed client-routes tests flakiness upon node decommission ([#1653](https://github.com/scylladb/scylla-rust-driver/pull/1653)).
- Fixed swapped arguments in result metadata serialize test helper ([#1699](https://github.com/scylladb/scylla-rust-driver/pull/1699)).
- Fixed flaky `test_schema_await_required_host_absent` ([#1709](https://github.com/scylladb/scylla-rust-driver/pull/1709)).

**Others:**
- Updated used dependencies ([#1617](https://github.com/scylladb/scylla-rust-driver/pull/1617)).

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

| commits | author                 |
|---------|------------------------|
|  155    | Karol Baryła           |
|   26    | Wojciech Przytuła      |
|    5    | Copilot                |
|    4    | Stanisław Czech        |
|    2    | copilot-swe-agent[bot] |
|    1    | David Garcia           |
|    1    | Lukasz Sojka           |
|    1    | Matt Van Horn          |
|    1    | Photon101              |
|    1    | Sai Asish Y            |
|    1    | conorbros              |
