### PR TITLE
conditionally publish APIs for C# RS Driver

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -72,7 +72,12 @@ unstable-cpp-rs = []
 # Enables features for use in Node.js-RS Driver.
 unstable-nodejs-rs = ["scylla-cql/unstable-nodejs-rs"]
 # Enables features for use in Python-RS Driver.
-unstable-python-rs = ["scylla-cql/unstable-python-rs", "scylla-cql-core/unstable-python-rs"]
+unstable-python-rs = [
+    "scylla-cql/unstable-python-rs",
+    "scylla-cql-core/unstable-python-rs",
+]
+# Enables features for use in C#-RS Driver.
+unstable-csharp-rs = []
 # Enables HostListener experimental support.
 unstable-host-listener = []
 # Enables unstable reconnection policy configuration.

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -1032,6 +1032,19 @@ impl QueryPager {
         )
     }
 
+    /// This is essentially the same as `next()`, but it is *public* and only available
+    /// when the `unstable-csharp-rs` feature is enabled.
+    /// Rationale: I don't know a way to make a function conditionally public,
+    /// based on a compile-time flag, so I added an new wrapper function
+    /// that is conditionally compiled and is public.
+    #[cfg(all(scylla_unstable, feature = "unstable-csharp-rs"))]
+    #[inline]
+    pub async fn next_column_iterator(
+        &mut self,
+    ) -> Option<Result<(ColumnIterator<'_, '_>, bool), NextRowError>> {
+        self.next().await
+    }
+
     /// Tries to acquire a non-empty page, if current page is exhausted.
     /// Boolean value in `Some(Ok(r))` is true if a new page was fetched.
     fn poll_fill_page(

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1816,6 +1816,27 @@ impl Session {
         .await
     }
 
+    /// This is essentially the same as `execute_iter_nongeneric`, but it is *public*
+    /// and only available when the `unstable-csharp-rs` feature is enabled.
+    /// Rationale: I don't know a way to make a function conditionally public,
+    /// based on a compile-time flag, so I added a new wrapper function
+    /// that is conditionally compiled and is public.
+    ///
+    /// This function is intended to be used by the C#-RS Driver's internals
+    /// and it's potentially a footgun: if a user passes `SerializedValues`
+    /// that don't match the prepared statement, the driver will misbehave
+    /// (potentially leading to data corruption).
+    /// Therefore, this function must not be exposed to end users of the Rust driver.
+    #[cfg(all(scylla_unstable, feature = "unstable-csharp-rs"))]
+    #[inline]
+    pub async fn execute_iter_preserialized(
+        &self,
+        prepared: PreparedStatement,
+        values: SerializedValues,
+    ) -> Result<QueryPager, PagerExecutionError> {
+        self.execute_iter_nongeneric(prepared, values).await
+    }
+
     /// Prepares all statements within the batch and returns a new batch where every
     /// statement is prepared.
     ///

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2449,3 +2449,17 @@ enum SchemaNodeResult {
     Success(Uuid),
     BrokenConnection(BrokenConnectionError),
 }
+
+/// Additional API for interop-based code.
+#[cfg(all(scylla_unstable, feature = "unstable-csharp-rs"))]
+impl Session {
+    /// Needed to bridge C#'s counterpart of `await_schema_agreement`
+    /// which requires a specified host to participate in agreement checking.
+    pub async fn await_schema_agreement_with_required_node_external(
+        &self,
+        required_node: Option<Uuid>,
+    ) -> Result<Uuid, SchemaAgreementError> {
+        self.await_schema_agreement_with_required_node(required_node)
+            .await
+    }
+}

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
-use super::metadata::{Keyspace, Metadata, Strategy};
+use super::metadata::{Keyspace, Metadata, Strategy, Table};
 use super::node::{Node, NodeRef};
 
 /// Represents the state of the cluster, including known nodes, keyspaces, and replica locator.
@@ -319,27 +319,44 @@ impl ClusterState {
         table: &str,
         partition_key: &dyn SerializeRow,
     ) -> Result<Token, ClusterStateTokenError> {
-        let Some(table) = self
-            .keyspaces
-            .get(keyspace)
-            .and_then(|k| k.tables.get(table))
-        else {
-            return Err(ClusterStateTokenError::UnknownTable {
-                keyspace: keyspace.to_owned(),
-                table: table.to_owned(),
-            });
-        };
+        let table_meta = self.lookup_table_meta(keyspace, table)?;
+
         let values = SerializedValues::from_serializable(
-            &RowSerializationContext::from_specs(table.pk_column_specs.as_slice()),
+            &RowSerializationContext::from_specs(table_meta.pk_column_specs.as_slice()),
             partition_key,
         )?;
+
+        // Delegate actual token calculation to centralized helper.
+        self.do_compute_token(table_meta, &values)
+    }
+
+    fn do_compute_token(
+        &self,
+        table: &Table,
+        serialized_partition_key: &SerializedValues,
+    ) -> Result<Token, ClusterStateTokenError> {
         let partitioner = table
             .partitioner
             .as_deref()
             .and_then(PartitionerName::from_str)
             .unwrap_or_default();
-        calculate_token_for_partition_key(&values, &partitioner)
+        calculate_token_for_partition_key(serialized_partition_key, &partitioner)
             .map_err(ClusterStateTokenError::TokenCalculation)
+    }
+
+    /// Helper: lookup table metadata or return `UnknownTable` error.
+    fn lookup_table_meta(
+        &self,
+        keyspace: &str,
+        table: &str,
+    ) -> Result<&Table, ClusterStateTokenError> {
+        self.keyspaces
+            .get(keyspace)
+            .and_then(|k| k.tables.get(table))
+            .ok_or_else(|| ClusterStateTokenError::UnknownTable {
+                keyspace: keyspace.to_string(),
+                table: table.to_string(),
+            })
     }
 
     /// Access to replicas owning a given token
@@ -514,6 +531,86 @@ impl ClusterState {
             };
             self.locator.tablets.add_tablet(table, tablet);
         }
+    }
+}
+
+/// Additional API for interop-based code.
+#[cfg(all(scylla_unstable, feature = "unstable-csharp-rs"))]
+impl ClusterState {
+    /// Compute token for an externally-provided **serialized** partition key.
+    ///
+    /// For typical Rust code that starts from strongly-typed key values, prefer
+    /// [`ClusterState::compute_token`], which takes typed values and handles their
+    /// serialization into [`SerializedValues`] for you.
+    ///
+    /// This is a lower-level variant of [`ClusterState::compute_token`] intended for interop
+    /// and FFI use, when the caller already has a [`SerializedValues`] representing
+    /// the partition key.
+    ///
+    /// # Partition key format
+    ///
+    /// `serialized_partition_key` must contain **exactly** the serialized values of
+    /// the table’s partition key columns:
+    ///
+    /// - Values must be provided in the same order as the partition key columns are
+    ///   defined in the table schema (e.g. `PRIMARY KEY ((k1, k2), ...)` means `k1`,
+    ///   then `k2`).
+    /// - Each value must be serialized using the CQL type of the corresponding
+    ///   partition key column, using the standard CQL binary encoding (including
+    ///   length prefixes for composite keys).
+    /// - Only partition key columns are allowed; clustering or regular columns must
+    ///   not be included.
+    /// - Partition key components must not be null or unset.
+    ///
+    /// This method performs no reordering or validation beyond basic structural
+    /// checks. If the provided values do not exactly match the table’s partition key
+    /// definition in order, type, or encoding, token computation will produce
+    /// incorrect results.
+    ///
+    /// # Usage notes
+    ///
+    /// Use this method when you already have a `SerializedValues` representation of
+    /// the partition key, for example:
+    ///
+    /// - from another language / binding,
+    /// - from code that manually constructs `SerializedValues` using
+    ///   [`RowSerializationContext`] and the [`SerializeRow`] trait.
+    ///
+    /// # Correctness validation
+    ///
+    /// Type validation at this stage would be difficult, as it would likely require deserializing
+    /// each value to check its type against the table schema. Therefore, it is the caller’s
+    /// responsibility to ensure that the provided serialized values are correct for the target
+    /// table’s partition key.
+    pub fn compute_token_preserialized(
+        &self,
+        keyspace: &str,
+        table: &str,
+        serialized_partition_key: &SerializedValues,
+    ) -> Result<Token, ClusterStateTokenError> {
+        let table_meta = self.lookup_table_meta(keyspace, table)?;
+        self.do_compute_token(table_meta, serialized_partition_key)
+    }
+
+    /// Compute token using a specific partitioner, bypassing table metadata lookup.
+    ///
+    /// See [`ClusterState::compute_token_preserialized`] for details on
+    /// the `serialized_partition_key` format.
+    ///
+    /// This is useful when the table metadata is not available but the partitioner
+    /// is known (or default Murmur3 is desired).
+    /// This is the case for the following (Obsolete) C# Driver API:
+    /// ```csharp
+    /// public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey);
+    /// ```
+    /// Once this API is removed, this method can be removed as well.
+    pub fn compute_token_preserialized_with_partitioner(
+        &self,
+        partitioner: &PartitionerName,
+        serialized_partition_key: &SerializedValues,
+    ) -> Result<Token, ClusterStateTokenError> {
+        calculate_token_for_partition_key(serialized_partition_key, partitioner)
+            .map_err(ClusterStateTokenError::TokenCalculation)
     }
 }
 


### PR DESCRIPTION
C# RS Driver needs access to some driver's APIs which are purposely not public. This PR:
- introduces `unstable-csharp-rs` feature, analogous to existing `unstable-nodejs-rs` etc.;
- publishes multiple APIs;
- adds some new APIs, which operate on private internals.

Please note that the last two commits were created by @phalat24.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
