### PR TITLE
More robust Scylla recognition

### DIFF
--- a/scylla-cql-core/src/frame/protocol_features.rs
+++ b/scylla-cql-core/src/frame/protocol_features.rs
@@ -29,6 +29,9 @@ const SCYLLA_USE_METADATA_ID_KEY: &str = "SCYLLA_USE_METADATA_ID";
 ///   e.g. whether to expect a rate limit error or how to handle LWT operations;
 /// - client also adds the features it supports to the `STARTUP` frame and sends it to
 ///   the server, which finishes the extensions negotiation process.
+//
+// FOR CONTRIBUTORS:
+// When adding new features, remember to adjust `is_to_scylladb` method on `Connection`.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ProtocolFeatures {

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -61,7 +61,7 @@ impl ControlConnection {
 
     /// Returns true iff the target node is a ScyllaDB node (and not a, e.g., Cassandra node).
     pub(super) fn is_to_scylladb(&self) -> bool {
-        self.conn.get_shard_info().is_some()
+        self.conn.is_to_scylladb()
     }
 
     /// Appends the custom server-side timeout to the statement string, if such custom timeout

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1898,6 +1898,17 @@ impl Connection {
         self.features = features;
     }
 
+    pub(crate) fn is_to_scylladb(&self) -> bool {
+        let features = &self.features;
+        let proto_features = &features.protocol_features;
+        proto_features.lwt_optimization_meta_bit_mask.is_some()
+            || features.shard_info.is_some()
+            || features.shard_aware_port.is_some()
+            || proto_features.rate_limit_error.is_some()
+            || proto_features.tablets_v1_supported
+            || proto_features.scylla_metadata_id_supported
+    }
+
     pub(crate) fn get_connect_address(&self) -> SocketAddr {
         self.connect_address
     }

--- a/scylla/tests/integration/ccm/mod.rs
+++ b/scylla/tests/integration/ccm/mod.rs
@@ -11,3 +11,4 @@ mod host_listener;
 mod tls;
 
 mod result_metadata_extension;
+mod using_timeout;

--- a/scylla/tests/integration/ccm/using_timeout.rs
+++ b/scylla/tests/integration/ccm/using_timeout.rs
@@ -1,0 +1,172 @@
+//! CCM test verifying that the control connection still appends a
+//! `USING TIMEOUT` directive to its metadata queries even when ScyllaDB is
+//! started with `allow_shard_aware_drivers: false`.
+//!
+//! Rationale: the driver only appends `USING TIMEOUT` (a ScyllaDB-only
+//! extension) to control-connection queries when it recognizes the peer as a
+//! ScyllaDB node. That recognition (`Connection::is_to_scylladb`) is based on
+//! several advertised features, one of which is shard awareness. With
+//! `allow_shard_aware_drivers: false`, ScyllaDB stops advertising shard
+//! awareness, so this test guards against a regression where the driver would
+//! then fail to recognize the node as ScyllaDB and stop sending `USING
+//! TIMEOUT` (the other ScyllaDB feature flags should keep `is_to_scylladb`
+//! returning `true`).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla_proxy::{
+    Condition, Node, Proxy, ProxyError, Reaction as _, RequestOpcode, RequestReaction, RequestRule,
+    ShardAwareness, WorkerError,
+};
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TryRecvError;
+use tracing::info;
+
+use crate::ccm::lib::cluster::{Cluster, ClusterOptions};
+use crate::ccm::lib::{CLUSTER_VERSION, run_ccm_test_with_configuration};
+use crate::utils::setup_tracing;
+
+/// Custom server-side metadata timeout we force the driver to use, so that the
+/// `USING TIMEOUT` clause is deterministic and easy to assert on.
+const CUSTOM_TIMEOUT: Duration = Duration::from_millis(2137);
+
+fn cluster_1_node() -> ClusterOptions {
+    ClusterOptions {
+        name: "using_timeout_no_shard_aware".to_string(),
+        version: CLUSTER_VERSION.clone(),
+        nodes_per_dc: vec![1],
+        ..ClusterOptions::default()
+    }
+}
+
+fn contains_subslice(slice: &[u8], subslice: &[u8]) -> bool {
+    slice
+        .windows(subslice.len())
+        .any(|window| window == subslice)
+}
+
+/// Verifies that the control connection keeps sending `USING TIMEOUT` in its
+/// metadata queries when ScyllaDB does not advertise shard awareness.
+#[tokio::test]
+async fn test_control_connection_using_timeout_without_shard_awareness() {
+    setup_tracing();
+
+    async fn test(cluster: &mut Cluster) {
+        // Put a proxy in front of the single node so we can inspect the
+        // wire-level frames sent on the control connection.
+        let node = cluster.nodes().iter().next().expect("No nodes in cluster");
+        let real_addr = SocketAddr::new(node.broadcast_rpc_address(), node.native_transport_port());
+        let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
+
+        let proxy = Proxy::new([Node::builder()
+            .real_address(real_addr)
+            .proxy_address(proxy_addr)
+            // Faithfully forward whatever the node advertises about shard
+            // awareness. With `allow_shard_aware_drivers: false` the node
+            // advertises nothing, so QueryNode transparently falls back to
+            // shard-unaware behavior.
+            .shard_awareness(ShardAwareness::QueryNode)
+            .build()]);
+
+        let translation_map = proxy.translation_map();
+        let mut running_proxy = proxy.run().await.unwrap();
+
+        // Feedback rule: capture every QUERY/PREPARE issued on the control
+        // connection (i.e. the connection that registered for events).
+        let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel();
+        running_proxy.running_nodes[0].change_request_rules(Some(vec![RequestRule(
+            Condition::and(
+                Condition::ConnectionRegisteredAnyEvent,
+                Condition::or(
+                    Condition::RequestOpcode(RequestOpcode::Query),
+                    Condition::RequestOpcode(RequestOpcode::Prepare),
+                ),
+            ),
+            RequestReaction::noop().with_feedback_when_performed(feedback_tx),
+        )]));
+
+        // Build the session through the proxy, forcing a known custom
+        // server-side metadata timeout. The session build performs the initial
+        // metadata fetch, which prepares the metadata queries on the control
+        // connection (with the `USING TIMEOUT` clause baked into the PREPARE).
+        let session: Session = SessionBuilder::new()
+            .known_node(format!("{}", proxy_addr))
+            .address_translator(Arc::new(translation_map))
+            .metadata_request_serverside_timeout(CUSTOM_TIMEOUT)
+            .build()
+            .await
+            .unwrap();
+
+        // Sanity check: confirm that `allow_shard_aware_drivers: false` took
+        // effect, i.e. the driver does NOT see the node as shard-aware. This is
+        // the precondition that makes the test meaningful: despite the missing
+        // shard awareness, `USING TIMEOUT` must still be sent.
+        let sharder = session
+            .get_cluster_state()
+            .get_nodes_info()
+            .first()
+            .and_then(|node| node.sharder());
+        assert!(
+            sharder.is_none(),
+            "Expected node to NOT be shard-aware (allow_shard_aware_drivers: false), \
+             but a sharder was found: {sharder:?}"
+        );
+
+        // Stop the rules so that no further frames race into the channel after
+        // we start draining it.
+        running_proxy.turn_off_rules();
+
+        // Every metadata query issued on the control connection must carry the
+        // custom `USING TIMEOUT` clause.
+        let expected = format!("USING TIMEOUT {}ms", CUSTOM_TIMEOUT.as_millis());
+        let mut total = 0usize;
+        loop {
+            match feedback_rx.try_recv() {
+                Ok((frame, _shard)) => {
+                    total += 1;
+                    assert!(
+                        contains_subslice(&frame.body, expected.as_bytes()),
+                        "Control connection query did not contain `{}`. Frame body: {:?}",
+                        expected,
+                        frame.body,
+                    );
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
+
+        assert!(
+            total > 0,
+            "No control connection QUERY/PREPARE frames were captured — \
+             cannot verify that USING TIMEOUT is sent"
+        );
+        info!(
+            "Verified {} control connection metadata queries all contained `{}`",
+            total, expected
+        );
+
+        match running_proxy.finish().await {
+            Ok(()) => (),
+            Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+            Err(err) => panic!("{}", err),
+        }
+    }
+
+    run_ccm_test_with_configuration(
+        cluster_1_node,
+        |mut cluster: Cluster| async move {
+            cluster
+                .updateconf([("enable_shard_aware_drivers", "false")])
+                .await
+                .expect("Failed to set allow_shard_aware_drivers: false");
+            cluster
+        },
+        test,
+    )
+    .await;
+}


### PR DESCRIPTION
Until now we recognized Scylla server by the presence of sharding info. This is perfectly find for connection pool, because sharding info is what we care about there. In CC (`is_to_scylladb`) we actually care if its Scylla or not, because we append `USING TIMEOUT` to requests based on that.
Turns out that sharding-based recognition is not enough, because it is possible to start Scylla with shard-awareness disabled! In that case, it will not send any sharding-related keys in SUPPORTED.

This PR changes the recognition method to check any Scylla-specific feature, and adds regression CCM test.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1718

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
