### PR TITLE
Enhance `QueryPager`: optimise for single-page results and prevent plan exhaustion

### DIFF
--- a/docs/source/statements/paged.md
+++ b/docs/source/statements/paged.md
@@ -21,11 +21,6 @@ Stay safe. Page your SELECTs.
 The automated way to achieve that is `QueryPager`. It always fetches and enables access to one page,
 while prefetching the next one. This limits latency and is a convenient abstraction.
 
-> ***Note***\
-> `QueryPager` is quite heavy machinery, introducing considerable overhead. Therefore,
-> don't use it for statements that do not benefit from paging. In particular, avoid using it
-> for non-SELECTs.
-
 On API level, `Session::query_iter` and `Session::execute_iter` take a [unprepared statement](unprepared.md)
 or a [prepared statement](prepared.md), respectively, and return a `QueryPager`. `QueryPager` needs
 to be converted into typed `Stream` (by calling `QueryPager::rows_stream::<RowT>`) in order to

--- a/docs/source/statements/result.md
+++ b/docs/source/statements/result.md
@@ -1,7 +1,7 @@
 # Query result
 
 `Session::query_unpaged`, `Session::query_single_page`, `Session::execute_unpaged` and `Session::execute_single_page`
-return a `QueryResult` with rows represented as `Option<Vec<Row>>`.
+return a `QueryResult` with rows in a raw form, yet-to-be lazily deserialized.
 
 > ***Note***\
 > Using unpaged queries for SELECTs is discouraged in general.

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -102,7 +102,7 @@ enum FirstPageContent {
 struct FirstReceivedPage {
     content: FirstPageContent,
     tracing_id: Option<Uuid>,
-    request_coordinator: Option<Coordinator>,
+    request_coordinator: Coordinator,
 }
 
 type ResultNextPage = Result<NextReceivedPage, NextPageError>;
@@ -479,7 +479,7 @@ impl PagerWorker {
                                     rows: DeserializedMetadataAndRawRows::mock_empty(),
                                 },
                                 tracing_id: None,
-                                request_coordinator: Some(coordinator),
+                                request_coordinator: coordinator,
                             },
                             PagingStateResponse::NoMorePages,
                         ));
@@ -580,7 +580,7 @@ impl PagerWorker {
                     FirstReceivedPage {
                         content: FirstPageContent::Rows { rows },
                         tracing_id,
-                        request_coordinator: Some(coordinator),
+                        request_coordinator: coordinator,
                     },
                     paging_state_response,
                 ))
@@ -605,7 +605,7 @@ impl PagerWorker {
                     FirstReceivedPage {
                         content: FirstPageContent::SetKeyspace { set_keyspace },
                         tracing_id,
-                        request_coordinator: Some(coordinator),
+                        request_coordinator: coordinator,
                     },
                     PagingStateResponse::NoMorePages,
                 ))
@@ -624,7 +624,7 @@ impl PagerWorker {
                     FirstReceivedPage {
                         content: FirstPageContent::SchemaChange { schema_change },
                         tracing_id,
-                        request_coordinator: Some(coordinator),
+                        request_coordinator: coordinator,
                     },
                     PagingStateResponse::NoMorePages,
                 ))
@@ -645,7 +645,7 @@ impl PagerWorker {
                             rows: DeserializedMetadataAndRawRows::mock_empty(),
                         },
                         tracing_id,
-                        request_coordinator: Some(coordinator),
+                        request_coordinator: coordinator,
                     },
                     PagingStateResponse::NoMorePages,
                 ))
@@ -1505,11 +1505,8 @@ If you are using this API, you are probably doing something wrong."
         session: &Session,
     ) -> Result<Self, PagerExecutionError> {
         let tracing_ids = Vec::from_iter(first_page.tracing_id);
-        let coordinator_id = first_page
-            .request_coordinator
-            .as_ref()
-            .map(|coordinator| coordinator.node().host_id);
-        let request_coordinators = Vec::from_iter(first_page.request_coordinator);
+        let coordinator_id = first_page.request_coordinator.node().host_id;
+        let request_coordinators = vec![first_page.request_coordinator];
 
         let first_page = match first_page.content {
             FirstPageContent::Rows { rows } => RawRowLendingIterator::new(rows),
@@ -1548,20 +1545,7 @@ If you are using this API, you are probably doing something wrong."
                     warnings: Vec::new(),
                 };
                 session
-                    .handle_auto_await_schema_agreement(
-                        &response,
-                        // Making it impossible to pass None here on the type level would be possible,
-                        // but it would require heavy restructuring. The culprit is SingleConnectionPagerWorker,
-                        // which is used for ControlConnection::execute_iter, and which doesn't have enough
-                        // data to provide a Coordinator in its proof of sending the first page.
-                        //
-                        // I could duplicate data types and the proving sender with Coordinator for PagerWorker
-                        // and no Coordinator for SingleConnectionPagerWorker, but it's not worth it given that
-                        // this None here is an erroneous situation that can only happen due to a bug in the driver.
-                        //
-                        // Also, we hope to refactor the Pager soon [#1549](https://github.com/scylladb/scylla-rust-driver/issues/1549).
-                        coordinator_id.expect("PagerWorker always has Coordinator specified"),
-                    )
+                    .handle_auto_await_schema_agreement(&response, coordinator_id)
                     .await?;
                 // The stream will be empty.
                 RawRowLendingIterator::new(DeserializedMetadataAndRawRows::mock_empty())

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -293,13 +293,8 @@ impl PageSender {
 
 // PagerWorker works in the background to fetch pages
 // QueryPager receives them through a channel
-struct PagerWorker<'a, QueryFunc, SpanCreatorFunc> {
-    // Closure used to perform a single page query
-    // AsyncFn(Arc<Connection>, Option<Arc<[u8]>>) -> Result<QueryResponse, RequestAttemptError>
-    page_query: QueryFunc,
-
+struct PagerWorker {
     load_balancing_policy: Arc<dyn LoadBalancingPolicy>,
-    routing_info: RoutingInfo<'a>,
     query_is_idempotent: bool,
     query_consistency: Consistency,
     retry_session: Box<dyn RetrySession>,
@@ -313,23 +308,24 @@ struct PagerWorker<'a, QueryFunc, SpanCreatorFunc> {
     current_attempt_id: Option<history::AttemptId>,
 
     parent_span: tracing::Span,
-    span_creator: SpanCreatorFunc,
 }
 
-impl<QueryFunc, QueryFut, SpanCreator> PagerWorker<'_, QueryFunc, SpanCreator>
-where
-    QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
-    QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
-    SpanCreator: Fn() -> RequestSpan,
-{
+impl PagerWorker {
     // Contract: this function MUST send at least one item through first_page_sender.
-    async fn work(
+    async fn work<QueryFunc, QueryFut, SpanCreator>(
         mut self,
         cluster_state: Arc<ClusterState>,
         first_page_sender: ProvingSender<ResultFirstPage>,
-    ) -> FirstPageSendAttemptedProof {
+        page_query: QueryFunc,
+        routing_info: RoutingInfo<'_>,
+        span_creator: SpanCreator,
+    ) -> FirstPageSendAttemptedProof
+    where
+        QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
+        QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
+        SpanCreator: Fn() -> RequestSpan,
+    {
         let load_balancer = Arc::clone(&self.load_balancing_policy);
-        let routing_info = self.routing_info.clone();
         let query_plan =
             load_balancing::Plan::new(load_balancer.as_ref(), &routing_info, &cluster_state);
 
@@ -379,11 +375,14 @@ where
                     PageSender,
                 ) = self
                     .query_pages(
+                        &routing_info,
+                        &span_creator,
                         &connection,
                         current_consistency,
                         node,
                         coordinator.clone(),
                         sender,
+                        &page_query,
                     )
                     .instrument(span.clone())
                     .await;
@@ -482,27 +481,38 @@ where
     // Contract: this function must either:
     // - Return an error
     // - Return Ok but have attempted to send a page via self.sender
-    async fn query_pages(
+    #[expect(clippy::too_many_arguments)]
+    async fn query_pages<QueryFunc, QueryFut, SpanCreator>(
         &mut self,
+        routing_info: &RoutingInfo<'_>,
+        span_creator: SpanCreator,
         connection: &Arc<Connection>,
         consistency: Consistency,
         node: NodeRef<'_>,
         coordinator: Coordinator,
         mut sender: PageSender,
+        page_query: &QueryFunc,
     ) -> (
         Result<Result<FirstPageSendAttemptedProof, RequestAttemptError>, RequestTimeoutError>,
         PageSender,
-    ) {
+    )
+    where
+        QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
+        QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
+        SpanCreator: Fn() -> RequestSpan,
+    {
         loop {
-            let request_span = (self.span_creator)();
+            let request_span = span_creator();
             let (res, new_sender) = self
                 .query_one_page(
+                    routing_info,
                     connection,
                     consistency,
                     node,
                     coordinator.clone(),
                     &request_span,
                     sender,
+                    page_query,
                 )
                 .instrument(request_span.span().clone())
                 .await;
@@ -529,23 +539,30 @@ where
         }
     }
 
-    async fn query_one_page(
+    #[expect(clippy::too_many_arguments)]
+    async fn query_one_page<QueryFunc, QueryFut>(
         &mut self,
+        routing_info: &RoutingInfo<'_>,
         connection: &Arc<Connection>,
         consistency: Consistency,
         node: NodeRef<'_>,
         coordinator: Coordinator,
         request_span: &RequestSpan,
         mut sender: PageSender,
+        page_query: &QueryFunc,
     ) -> (
         Result<
             Result<ControlFlow<FirstPageSendAttemptedProof, ()>, RequestAttemptError>,
             RequestTimeoutError,
         >,
         PageSender,
-    ) {
+    )
+    where
+        QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
+        QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
+    {
         let (elapsed, page_result) = match self
-            .fetch_one_page(connection, consistency, request_span)
+            .fetch_one_page(connection, consistency, request_span, page_query)
             .await
         {
             Err(timeout_err) => return (Err(timeout_err), sender),
@@ -556,6 +573,7 @@ where
             PageSender::FirstPage(first_page_sender) => {
                 let res = self
                     .process_first_page(
+                        routing_info,
                         node,
                         coordinator,
                         request_span,
@@ -579,6 +597,7 @@ where
             PageSender::NextPages(ref proof, ref next_pages_sender) => {
                 let res = self
                     .process_next_page(
+                        routing_info,
                         node,
                         coordinator,
                         request_span,
@@ -593,12 +612,16 @@ where
         (Ok(res), sender)
     }
 
-    async fn fetch_one_page(
+    async fn fetch_one_page<QueryFunc, QueryFut>(
         &mut self,
         connection: &Arc<Connection>,
         consistency: Consistency,
         request_span: &RequestSpan,
+        page_query: &QueryFunc,
     ) -> Result<(Duration, Result<NonErrorQueryResponse, RequestAttemptError>), RequestTimeoutError>
+    where
+        QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
+        QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
     {
         self.metrics.inc_total_paged_queries();
         let query_start = std::time::Instant::now();
@@ -611,7 +634,7 @@ where
         self.log_attempt_start(connect_address);
 
         let runner = async {
-            (self.page_query)(connection.clone(), consistency, self.paging_state.clone())
+            page_query(connection.clone(), consistency, self.paging_state.clone())
                 .await
                 .and_then(QueryResponse::into_non_error_query_response)
         };
@@ -635,8 +658,10 @@ where
         Ok((elapsed, query_response))
     }
 
+    #[expect(clippy::too_many_arguments)]
     async fn process_first_page(
         &mut self,
+        routing_info: &RoutingInfo<'_>,
         node: NodeRef<'_>,
         coordinator: Coordinator,
         request_span: &RequestSpan,
@@ -656,7 +681,7 @@ where
             self.log_attempt_success();
             self.log_request_success();
             self.load_balancing_policy
-                .on_request_success(&self.routing_info, elapsed, node);
+                .on_request_success(routing_info, elapsed, node);
         };
 
         match query_response {
@@ -704,12 +729,8 @@ where
             }
             Err(err) => {
                 self.metrics.inc_failed_paged_queries();
-                self.load_balancing_policy.on_request_failure(
-                    &self.routing_info,
-                    elapsed,
-                    node,
-                    &err,
-                );
+                self.load_balancing_policy
+                    .on_request_failure(routing_info, elapsed, node, &err);
                 Err((err, sender))
             }
             Ok(NonErrorQueryResponse {
@@ -783,19 +804,17 @@ where
                 self.metrics.inc_failed_paged_queries();
                 let err =
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
-                self.load_balancing_policy.on_request_failure(
-                    &self.routing_info,
-                    elapsed,
-                    node,
-                    &err,
-                );
+                self.load_balancing_policy
+                    .on_request_failure(routing_info, elapsed, node, &err);
                 Err((err, sender))
             }
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     async fn process_next_page(
         &mut self,
+        routing_info: &RoutingInfo<'_>,
         node: NodeRef<'_>,
         coordinator: Coordinator,
         request_span: &RequestSpan,
@@ -816,7 +835,7 @@ where
                 self.log_attempt_success();
                 self.log_request_success();
                 self.load_balancing_policy
-                    .on_request_success(&self.routing_info, elapsed, node);
+                    .on_request_success(routing_info, elapsed, node);
 
                 request_span.record_raw_rows_fields(&rows);
 
@@ -855,22 +874,14 @@ where
                 self.metrics.inc_failed_paged_queries();
                 let err =
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
-                self.load_balancing_policy.on_request_failure(
-                    &self.routing_info,
-                    elapsed,
-                    node,
-                    &err,
-                );
+                self.load_balancing_policy
+                    .on_request_failure(routing_info, elapsed, node, &err);
                 Err(err)
             }
             Err(err) => {
                 self.metrics.inc_failed_paged_queries();
-                self.load_balancing_policy.on_request_failure(
-                    &self.routing_info,
-                    elapsed,
-                    node,
-                    &err,
-                );
+                self.load_balancing_policy
+                    .on_request_failure(routing_info, elapsed, node, &err);
                 Err(err)
             }
         }
@@ -1272,17 +1283,15 @@ If you are using this API, you are probably doing something wrong."
                 node_location_preference: &node_location_preference,
             };
 
-            let statement_ref = &statement;
+            let statement_contents = &statement.contents;
 
             let span_creator = move || {
-                let span = RequestSpan::new_query(&statement_ref.contents);
+                let span = RequestSpan::new_query(statement_contents);
                 span.record_request_size(0);
                 span
             };
 
             let worker = PagerWorker {
-                page_query,
-                routing_info,
                 query_is_idempotent: statement.config.is_idempotent,
                 query_consistency: consistency,
                 load_balancing_policy,
@@ -1294,10 +1303,17 @@ If you are using this API, you are probably doing something wrong."
                 current_request_id: None,
                 current_attempt_id: None,
                 parent_span,
-                span_creator,
             };
 
-            worker.work(cluster_state, sender.into()).await
+            worker
+                .work(
+                    cluster_state,
+                    sender.into(),
+                    page_query,
+                    routing_info,
+                    span_creator,
+                )
+                .await
         };
 
         Self::new_from_worker_future(worker_task, receiver, Some(session))
@@ -1415,8 +1431,6 @@ If you are using this API, you are probably doing something wrong."
             };
 
             let worker = PagerWorker {
-                page_query,
-                routing_info,
                 query_is_idempotent: config.prepared.config.is_idempotent,
                 query_consistency: consistency,
                 load_balancing_policy,
@@ -1433,10 +1447,17 @@ If you are using this API, you are probably doing something wrong."
                 current_request_id: None,
                 current_attempt_id: None,
                 parent_span,
-                span_creator,
             };
 
-            worker.work(config.cluster_state, sender.into()).await
+            worker
+                .work(
+                    config.cluster_state,
+                    sender.into(),
+                    page_query,
+                    routing_info,
+                    span_creator,
+                )
+                .await
         };
 
         Self::new_from_worker_future(worker_task, receiver, Some(session))

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -151,6 +151,11 @@ mod timeouter {
 }
 use timeouter::PageQueryTimeouter;
 
+enum ShouldFetchMorePages {
+    NoMorePages,
+    MorePages { first_page_coordinator: Coordinator },
+}
+
 // PagerWorker works in the background to fetch pages
 // QueryPager receives them through a channel
 struct PagerWorker {
@@ -176,6 +181,10 @@ impl PagerWorker {
     ///
     /// A fresh query plan is constructed for each page, preventing plan
     /// exhaustion for long-running multi-page queries.
+    ///
+    /// The last successful coordinator is preferred for the next page
+    /// (coordinator stability), but all other nodes remain available
+    /// for retry.
     async fn work<QueryFunc, QueryFut, SpanCreator>(
         mut self,
         cluster_state: Arc<ClusterState>,
@@ -183,6 +192,7 @@ impl PagerWorker {
         page_query: QueryFunc,
         routing_info: RoutingInfo<'_>,
         span_creator: SpanCreator,
+        mut last_successful_page_coordinator: Coordinator,
     ) where
         QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
@@ -199,9 +209,36 @@ impl PagerWorker {
 
             self.timeouter.as_mut().map(PageQueryTimeouter::reset);
 
+            let parent_span = self.parent_span.clone();
+
+            // Prefix the plan with the last successful coordinator (coordinator
+            // stability), then chain the remaining nodes from the fresh plan.
+            let mut query_plan = std::iter::once((
+                last_successful_page_coordinator.node(),
+                // `Coordinator` gets its shard from `Connection`. If `Connection` believes it has `Shard` `None`,
+                // then it means that the connection pool to that connection is not sharded.
+                // In such case, shard is ignored in `connection_for_shard()`.
+                // We must provide a shard to `connection_for_shard()` anyway.
+                // Therefore, let's pass an arbitrarily big shard to catch regressions in this logic earlier.
+                last_successful_page_coordinator.shard().unwrap_or(2137),
+            ))
+            .chain(
+                query_plan
+                    // We filter out the last successful page coordinator, because it's tried out first.
+                    .filter(|&(node, shard)| {
+                        !(Arc::ptr_eq(node, last_successful_page_coordinator.node())
+                            && last_successful_page_coordinator
+                                .shard()
+                                // If we targeted an unsharded node (such as Cassandra) previously,
+                                // we should now repeat it as unsharded and at the same time filter out
+                                // all targets to that node, with any shard.
+                                .is_none_or(|last_shard| last_shard == shard))
+                    }),
+            );
+
             // Iterates over nodes in the query plan, trying to fetch the next page.
-            'nodes_in_plan: for (node, shard) in query_plan {
-                let per_target_span = trace_span!(parent: &self.parent_span, "Executing query", node = %node.address, shard = %shard);
+            'nodes_in_plan: while let Some((node, shard)) = query_plan.next() {
+                let per_target_span = trace_span!(parent: &parent_span, "Executing query", node = %node.address, shard = ?shard);
                 // For each node in the plan choose a connection to use
                 // This connection will be reused for same node retries to preserve paging cache on the shard
                 let connection: Arc<Connection> = match node
@@ -274,6 +311,12 @@ impl PagerWorker {
                             // Successfully queried one page, and there are more to fetch.
                             // Reset the timeout_instant for the next page fetch.
                             self.timeouter.as_mut().map(PageQueryTimeouter::reset);
+
+                            // Prioritize the successful coordinator for the next page fetch.
+
+                            std::mem::drop(query_plan);
+                            last_successful_page_coordinator = coordinator;
+
                             // Continue with a fresh plan for the next page.
                             continue 'paging;
                         }
@@ -337,14 +380,14 @@ impl PagerWorker {
     }
 
     /// Fetches the first page on the caller task (no spawning).
-    /// Returns the first page and its paging state response.
+    /// Returns the first page and whether more pages should be fetched.
     async fn query_first_page<QueryFunc, QueryFut, SpanCreator>(
         &mut self,
         cluster_state: &ClusterState,
         span_creator: SpanCreator,
         routing_info: &RoutingInfo<'_>,
         page_query: QueryFunc,
-    ) -> Result<(FirstReceivedPage, PagingStateResponse), NextPageError>
+    ) -> Result<(FirstReceivedPage, ShouldFetchMorePages), NextPageError>
     where
         QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
@@ -412,9 +455,17 @@ impl PagerWorker {
                 };
 
                 let request_error: RequestAttemptError = match query_result {
-                    Ok(Ok(response)) => {
+                    Ok(Ok((first_page, paging_state_response))) => {
                         trace!(parent: &per_target_span, "Request succeeded");
-                        return Ok(response);
+                        let should_fetch_more_pages = match paging_state_response {
+                            PagingStateResponse::HasMorePages { .. } => {
+                                ShouldFetchMorePages::MorePages {
+                                    first_page_coordinator: coordinator,
+                                }
+                            }
+                            PagingStateResponse::NoMorePages => ShouldFetchMorePages::NoMorePages,
+                        };
+                        return Ok((first_page, should_fetch_more_pages));
                     }
                     Ok(Err(error)) => {
                         trace!(
@@ -479,7 +530,7 @@ impl PagerWorker {
                                 tracing_id: None,
                                 request_coordinator: coordinator,
                             },
-                            PagingStateResponse::NoMorePages,
+                            ShouldFetchMorePages::NoMorePages,
                         ));
                     }
                 };
@@ -1129,7 +1180,7 @@ If you are using this API, you are probably doing something wrong."
             parent_span,
         };
 
-        let (first_page, paging_state_response) = {
+        let (first_page, should_fetch_more_pages) = {
             let routing_info = RoutingInfo {
                 consistency,
                 serial_consistency,
@@ -1148,12 +1199,14 @@ If you are using this API, you are probably doing something wrong."
 
         /* PROCESS FIRST PAGE */
         let (sender, receiver) = mpsc::channel::<ResultNextPage>(1);
-        match paging_state_response {
-            PagingStateResponse::NoMorePages => {
+        match should_fetch_more_pages {
+            ShouldFetchMorePages::NoMorePages => {
                 // No more pages - we are done, return the first page and an empty receiver.
                 std::mem::drop(sender);
             }
-            PagingStateResponse::HasMorePages { .. } => {
+            ShouldFetchMorePages::MorePages {
+                first_page_coordinator,
+            } => {
                 /* REMAINING PAGES */
                 let worker_task = async move {
                     let routing_info = RoutingInfo {
@@ -1190,6 +1243,7 @@ If you are using this API, you are probably doing something wrong."
                             page_query,
                             routing_info,
                             span_creator,
+                            first_page_coordinator,
                         )
                         .await;
                 };
@@ -1336,7 +1390,7 @@ If you are using this API, you are probably doing something wrong."
             parent_span,
         };
 
-        let (first_page, paging_state_response) = worker
+        let (first_page, should_fetch_more_pages) = worker
             .query_first_page(
                 &config.cluster_state,
                 &span_creator,
@@ -1350,12 +1404,14 @@ If you are using this API, you are probably doing something wrong."
 
         /* PROCESS FIRST PAGE */
         let (sender, receiver) = mpsc::channel::<ResultNextPage>(1);
-        match paging_state_response {
-            PagingStateResponse::NoMorePages => {
+        match should_fetch_more_pages {
+            ShouldFetchMorePages::NoMorePages => {
                 // No more pages - we are done, return the first page and an empty receiver.
                 std::mem::drop(sender);
             }
-            PagingStateResponse::HasMorePages { .. } => {
+            ShouldFetchMorePages::MorePages {
+                first_page_coordinator,
+            } => {
                 /* REMAINING PAGES */
                 let worker_task = async move {
                     let partition_key = if config.prepared.is_token_aware() {
@@ -1418,6 +1474,7 @@ If you are using this API, you are probably doing something wrong."
                             page_query,
                             routing_info,
                             span_creator,
+                            first_page_coordinator,
                         )
                         .await;
                 };

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -199,13 +199,13 @@ impl PagerWorker {
         SpanCreator: Fn() -> RequestSpan,
     {
         let mut last_error: RequestError = RequestError::EmptyPlan;
-        let mut current_consistency: Consistency = self.query_consistency;
         let load_balancer = Arc::clone(&self.load_balancing_policy);
 
         // Iterates over pages until exhaustion or non-retriable error.
         'paging: loop {
             let query_plan =
                 load_balancing::Plan::new(load_balancer.as_ref(), &routing_info, &cluster_state);
+            let mut current_consistency: Consistency = self.query_consistency;
 
             self.timeouter.as_mut().map(PageQueryTimeouter::reset);
 

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -26,7 +26,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::client::execution_profile::ExecutionProfileInner;
 use crate::client::session::{AutoSchemaAwaitingError, Session};
-use crate::cluster::{ClusterState, NodeRef};
+use crate::cluster::{ClusterState, Node, NodeRef};
 use crate::deserialize::DeserializeOwnedRow;
 use crate::errors::{
     MetadataError, PagerExecutionError, RequestAttemptError, RequestError, SchemaAgreementError,
@@ -41,8 +41,8 @@ use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
 use crate::policies::retry::{RequestInfo, RetryDecision, RetrySession};
 use crate::response::query_result::ColumnSpecs;
 use crate::response::{Coordinator, NonErrorQueryResponse, QueryResponse};
-use crate::routing::NodeLocationPreference;
-use crate::statement::prepared::{PartitionKeyError, PreparedStatement};
+use crate::routing::{NodeLocationPreference, Shard, Token};
+use crate::statement::prepared::{PartitionKey, PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
 use tracing::{Instrument, error, trace, trace_span, warn};
 use uuid::Uuid;
@@ -1190,6 +1190,13 @@ If you are using this API, you are probably doing something wrong."
             .new_session();
 
         let parent_span = tracing::Span::current();
+
+        fn create_span(statement_contents: &str) -> RequestSpan {
+            let span = RequestSpan::new_query(statement_contents);
+            span.record_request_size(0);
+            span
+        }
+
         let worker_task = async move {
             let statement_ref = &statement;
 
@@ -1218,13 +1225,7 @@ If you are using this API, you are probably doing something wrong."
                 node_location_preference: &node_location_preference,
             };
 
-            let statement_contents = &statement.contents;
-
-            let span_creator = move || {
-                let span = RequestSpan::new_query(statement_contents);
-                span.record_request_size(0);
-                span
-            };
+            let span_creator = || create_span(&statement.contents);
 
             let worker = PagerWorker {
                 query_is_idempotent: statement.config.is_idempotent,
@@ -1295,7 +1296,26 @@ If you are using this API, you are probably doing something wrong."
             .unwrap_or(&*config.execution_profile.retry_policy)
             .new_session();
 
+        type Replicas = smallvec::SmallVec<[(Arc<Node>, Shard); 8]>;
+
         let parent_span = tracing::Span::current();
+        fn create_span(
+            partition_key: &Option<PartitionKey>,
+            token: Option<Token>,
+            serialized_values_size: usize,
+            replicas: Option<&Replicas>,
+        ) -> RequestSpan {
+            let span = RequestSpan::new_prepared(
+                partition_key.as_ref().map(|pk| pk.iter()),
+                token,
+                serialized_values_size,
+            );
+            if let Some(replicas) = replicas {
+                span.record_replicas(replicas.iter().map(|(node, shard)| (node, *shard)));
+            }
+            span
+        }
+
         let worker_task = async move {
             let prepared_ref = &config.prepared;
             let values_ref = &config.values;
@@ -1340,29 +1360,22 @@ If you are using this API, you are probably doing something wrong."
 
             let serialized_values_size = config.values.buffer_size();
 
-            let replicas: Option<smallvec::SmallVec<[_; 8]>> =
-                if let (Some(table_spec), Some(token)) = (routing_info.table, routing_info.token) {
-                    Some(
-                        config
-                            .cluster_state
-                            .get_token_endpoints_iter(table_spec, token)
-                            .map(|(node, shard)| (node.clone(), shard))
-                            .collect(),
-                    )
-                } else {
-                    None
-                };
+            let replicas: Option<Replicas> = Option::zip(routing_info.table, routing_info.token)
+                .map(|(table_spec, token)| {
+                    config
+                        .cluster_state
+                        .get_token_endpoints_iter(table_spec, token)
+                        .map(|(node, shard)| (node.clone(), shard))
+                        .collect()
+                });
 
             let span_creator = move || {
-                let span = RequestSpan::new_prepared(
-                    partition_key.as_ref().map(|pk| pk.iter()),
+                create_span(
+                    &partition_key,
                     token,
                     serialized_values_size,
-                );
-                if let Some(replicas) = replicas.as_ref() {
-                    span.record_replicas(replicas.iter().map(|(node, shard)| (node, *shard)));
-                }
-                span
+                    replicas.as_ref(),
+                )
             };
 
             let worker = PagerWorker {

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -173,6 +173,9 @@ struct PagerWorker {
 impl PagerWorker {
     /// Fetches remaining pages (pages 2+) in a background task.
     /// Sends each page through the mpsc channel.
+    ///
+    /// A fresh query plan is constructed for each page, preventing plan
+    /// exhaustion for long-running multi-page queries.
     async fn work<QueryFunc, QueryFut, SpanCreator>(
         mut self,
         cluster_state: Arc<ClusterState>,
@@ -185,46 +188,46 @@ impl PagerWorker {
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
         SpanCreator: Fn() -> RequestSpan,
     {
-        let load_balancer = Arc::clone(&self.load_balancing_policy);
-        let query_plan =
-            load_balancing::Plan::new(load_balancer.as_ref(), &routing_info, &cluster_state);
-
         let mut last_error: RequestError = RequestError::EmptyPlan;
         let mut current_consistency: Consistency = self.query_consistency;
+        let load_balancer = Arc::clone(&self.load_balancing_policy);
 
-        self.timeouter.as_mut().map(PageQueryTimeouter::reset);
+        // Iterates over pages until exhaustion or non-retriable error.
+        'paging: loop {
+            let query_plan =
+                load_balancing::Plan::new(load_balancer.as_ref(), &routing_info, &cluster_state);
 
-        // Iterates over nodes in the query plan, trying to fetch the next page.
-        'nodes_in_plan: for (node, shard) in query_plan {
-            let per_target_span = trace_span!(parent: &self.parent_span, "Executing query", node = %node.address, shard = %shard);
-            // For each node in the plan choose a connection to use
-            // This connection will be reused for same node retries to preserve paging cache on the shard
-            let connection: Arc<Connection> = match node
-                .connection_for_shard(shard)
-                .instrument(per_target_span.clone())
-                .await
-            {
-                Ok(connection) => connection,
-                Err(e) => {
-                    trace!(
-                        parent: &per_target_span,
-                        error = %e,
-                        "Choosing connection failed"
-                    );
-                    last_error = e.into();
-                    // Broken connection doesn't count as a failed query, don't log in metrics
-                    continue 'nodes_in_plan;
-                }
-            };
+            self.timeouter.as_mut().map(PageQueryTimeouter::reset);
 
-            let coordinator = Coordinator::new(node, &connection);
+            // Iterates over nodes in the query plan, trying to fetch the next page.
+            'nodes_in_plan: for (node, shard) in query_plan {
+                let per_target_span = trace_span!(parent: &self.parent_span, "Executing query", node = %node.address, shard = %shard);
+                // For each node in the plan choose a connection to use
+                // This connection will be reused for same node retries to preserve paging cache on the shard
+                let connection: Arc<Connection> = match node
+                    .connection_for_shard(shard)
+                    .instrument(per_target_span.clone())
+                    .await
+                {
+                    Ok(connection) => connection,
+                    Err(e) => {
+                        trace!(
+                            parent: &per_target_span,
+                            error = %e,
+                            "Choosing connection failed"
+                        );
+                        last_error = e.into();
+                        // Broken connection doesn't count as a failed query, don't log in metrics.
+                        continue 'nodes_in_plan;
+                    }
+                };
 
-            // Retries on the same node as long as RetrySession decides so.
-            'same_node_retries: loop {
-                trace!(parent: &per_target_span, "Execution started");
+                let coordinator = Coordinator::new(node, &connection);
 
-                // Fetch pages from this connection until an error occurs.
-                'same_node_pages: loop {
+                // Retries on the same node as long as RetrySession decides so.
+                'same_node_retries: loop {
+                    trace!(parent: &per_target_span, "Execution started");
+
                     let request_span = span_creator();
 
                     let fetch_result = self
@@ -238,18 +241,14 @@ impl PagerWorker {
                         .await;
                     let query_result = match fetch_result {
                         Err(RequestTimeoutError(timeout)) => {
-                            let request_error = RequestError::RequestTimeout(timeout);
-                            self.log_request_error(&request_error);
+                            last_error = RequestError::RequestTimeout(timeout);
                             trace!(
                                 parent: &per_target_span,
-                                error = %request_error,
+                                error = %last_error,
                                 "Request timed out"
                             );
                             // This means that we failed all attempts - in this case, due to a timeout.
-                            let _ = sender
-                                .send(Err(NextPageError::RequestFailure(request_error)))
-                                .await;
-                            return;
+                            break 'nodes_in_plan;
                         }
                         Ok((elapsed, result)) => {
                             self.process_next_page(
@@ -265,7 +264,7 @@ impl PagerWorker {
                         }
                     };
 
-                    match query_result {
+                    let request_error: RequestAttemptError = match query_result {
                         Ok(ControlFlow::Break(())) => {
                             // Successfully queried the last remaining page.
                             trace!(parent: &per_target_span, "Request succeeded");
@@ -275,67 +274,66 @@ impl PagerWorker {
                             // Successfully queried one page, and there are more to fetch.
                             // Reset the timeout_instant for the next page fetch.
                             self.timeouter.as_mut().map(PageQueryTimeouter::reset);
-                            continue 'same_node_pages;
+                            // Continue with a fresh plan for the next page.
+                            continue 'paging;
                         }
-                        Err(request_error) => {
+                        Err(error) => {
                             trace!(
                                 parent: &per_target_span,
-                                error = %request_error,
+                                error = %error,
                                 "Request failed"
                             );
-
-                            // Break out of the inner page-fetching loop to retry logic.
-                            let request_info = RequestInfo {
-                                error: &request_error,
-                                is_idempotent: self.query_is_idempotent,
-                                consistency: current_consistency,
-                            };
-
-                            let retry_decision =
-                                self.retry_session.decide_should_retry(request_info);
-                            trace!(
-                                parent: &per_target_span,
-                                retry_decision = ?retry_decision
-                            );
-
-                            self.log_attempt_error(&request_error, &retry_decision);
-
-                            last_error = request_error.into();
-
-                            match retry_decision {
-                                RetryDecision::RetrySameTarget(cl) => {
-                                    self.metrics.inc_retries_num();
-                                    current_consistency = cl.unwrap_or(current_consistency);
-                                    continue 'same_node_retries;
-                                }
-                                RetryDecision::RetryNextTarget(cl) => {
-                                    self.metrics.inc_retries_num();
-                                    current_consistency = cl.unwrap_or(current_consistency);
-                                    continue 'nodes_in_plan;
-                                }
-                                RetryDecision::DontRetry => break 'nodes_in_plan,
-                                RetryDecision::IgnoreWriteError => {
-                                    self.log_request_success();
-                                    self.retry_session.reset();
-
-                                    warn!(
-                                        "Ignoring error during fetching pages; stopping fetching."
-                                    );
-                                    return;
-                                }
-                            };
+                            error
                         }
-                    }
+                    };
+
+                    let request_info = RequestInfo {
+                        error: &request_error,
+                        is_idempotent: self.query_is_idempotent,
+                        consistency: current_consistency,
+                    };
+
+                    let retry_decision = self.retry_session.decide_should_retry(request_info);
+                    trace!(
+                        parent: &per_target_span,
+                        retry_decision = ?retry_decision
+                    );
+
+                    self.log_attempt_error(&request_error, &retry_decision);
+
+                    last_error = request_error.into();
+
+                    match retry_decision {
+                        RetryDecision::RetrySameTarget(cl) => {
+                            self.metrics.inc_retries_num();
+                            current_consistency = cl.unwrap_or(current_consistency);
+                            continue 'same_node_retries;
+                        }
+                        RetryDecision::RetryNextTarget(cl) => {
+                            self.metrics.inc_retries_num();
+                            current_consistency = cl.unwrap_or(current_consistency);
+                            continue 'nodes_in_plan;
+                        }
+                        RetryDecision::DontRetry => break 'nodes_in_plan,
+                        RetryDecision::IgnoreWriteError => {
+                            self.log_request_success();
+                            self.retry_session.reset();
+
+                            warn!("Ignoring error during fetching pages; stopping fetching.");
+                            return;
+                        }
+                    };
                 }
             }
-        }
 
-        // If we are here, it means we failed to fetch next page on any node from the plan.
-        // The plan is exhausted, so we send the last error and finish.
-        self.log_request_error(&last_error);
-        let _ = sender
-            .send(Err(NextPageError::RequestFailure(last_error)))
-            .await;
+            // If we are here, it means we failed to fetch next page on any node from the plan.
+            // The plan is exhausted, so we send the last error and finish.
+            self.log_request_error(&last_error);
+            let _ = sender
+                .send(Err(NextPageError::RequestFailure(last_error)))
+                .await;
+            return;
+        }
     }
 
     /// Fetches the first page on the caller task (no spawning).

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -367,26 +367,43 @@ impl PagerWorker {
                 trace!(parent: &span, "Execution started");
 
                 // Fetch pages from this connection until an error occurs.
-                let (queries_result, new_sender): (
-                    Result<
-                        Result<FirstPageSendAttemptedProof, RequestAttemptError>,
-                        RequestTimeoutError,
-                    >,
-                    PageSender,
-                ) = self
-                    .query_pages(
-                        &routing_info,
-                        &span_creator,
-                        &connection,
-                        current_consistency,
-                        node,
-                        coordinator.clone(),
-                        sender,
-                        &page_query,
-                    )
-                    .instrument(span.clone())
-                    .await;
-                sender = new_sender;
+                let queries_result = 'same_node_pages: loop {
+                    let request_span = span_creator();
+                    let (res, new_sender) = self
+                        .query_one_page(
+                            &routing_info,
+                            &connection,
+                            current_consistency,
+                            node,
+                            coordinator.clone(),
+                            &request_span,
+                            sender,
+                            &page_query,
+                        )
+                        .instrument(request_span.span().clone())
+                        .await;
+                    sender = new_sender;
+
+                    match res {
+                        Ok(Ok(ControlFlow::Break(proof))) => {
+                            // Successfully queried the last remaining page.
+                            break Ok(Ok(proof));
+                        }
+
+                        Ok(Ok(ControlFlow::Continue(()))) => {
+                            // Successfully queried one page, and there are more to fetch.
+                            // Reset the timeout_instant for the next page fetch.
+                            self.timeouter.as_mut().map(PageQueryTimeouter::reset);
+                            continue 'same_node_pages;
+                        }
+                        Ok(Err(request_attempt_error)) => {
+                            break Ok(Err(request_attempt_error));
+                        }
+                        Err(request_timeout_error) => {
+                            break Err(request_timeout_error);
+                        }
+                    };
+                };
 
                 let request_error: RequestAttemptError = match queries_result {
                     Ok(Ok(proof)) => {
@@ -474,69 +491,6 @@ impl PagerWorker {
         sender
             .send_err(NextPageError::RequestFailure(last_error))
             .await
-    }
-
-    // Given a working connection query as many pages as possible until the first error.
-    //
-    // Contract: this function must either:
-    // - Return an error
-    // - Return Ok but have attempted to send a page via self.sender
-    #[expect(clippy::too_many_arguments)]
-    async fn query_pages<QueryFunc, QueryFut, SpanCreator>(
-        &mut self,
-        routing_info: &RoutingInfo<'_>,
-        span_creator: SpanCreator,
-        connection: &Arc<Connection>,
-        consistency: Consistency,
-        node: NodeRef<'_>,
-        coordinator: Coordinator,
-        mut sender: PageSender,
-        page_query: &QueryFunc,
-    ) -> (
-        Result<Result<FirstPageSendAttemptedProof, RequestAttemptError>, RequestTimeoutError>,
-        PageSender,
-    )
-    where
-        QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
-        QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
-        SpanCreator: Fn() -> RequestSpan,
-    {
-        loop {
-            let request_span = span_creator();
-            let (res, new_sender) = self
-                .query_one_page(
-                    routing_info,
-                    connection,
-                    consistency,
-                    node,
-                    coordinator.clone(),
-                    &request_span,
-                    sender,
-                    page_query,
-                )
-                .instrument(request_span.span().clone())
-                .await;
-            sender = new_sender;
-
-            match res {
-                Ok(Ok(ControlFlow::Break(proof))) => {
-                    // Successfully queried the last remaining page.
-                    return (Ok(Ok(proof)), sender);
-                }
-
-                Ok(Ok(ControlFlow::Continue(()))) => {
-                    // Successfully queried one page, and there are more to fetch.
-                    // Reset the timeout_instant for the next page fetch.
-                    self.timeouter.as_mut().map(PageQueryTimeouter::reset);
-                }
-                Ok(Err(request_attempt_error)) => {
-                    return (Ok(Err(request_attempt_error)), sender);
-                }
-                Err(request_timeout_error) => {
-                    return (Err(request_timeout_error), sender);
-                }
-            };
-        }
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -22,7 +22,7 @@ use crate::serialize::row::SerializedValues;
 use futures::Stream;
 use std::result::Result;
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 use crate::client::execution_profile::ExecutionProfileInner;
 use crate::client::session::{AutoSchemaAwaitingError, Session};
@@ -44,7 +44,7 @@ use crate::response::{Coordinator, NonErrorQueryResponse, QueryResponse};
 use crate::routing::{NodeLocationPreference, Shard, Token};
 use crate::statement::prepared::{PartitionKey, PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
-use tracing::{Instrument, error, trace, trace_span, warn};
+use tracing::{Instrument, trace, trace_span, warn};
 use uuid::Uuid;
 
 // Like std::task::ready!, but handles the whole stack of Poll<Option<Result<>>>.
@@ -108,46 +108,7 @@ struct FirstReceivedPage {
     request_coordinator: Option<Coordinator>,
 }
 
-type ResultFirstPage = Result<(FirstReceivedPage, mpsc::Receiver<ResultNextPage>), NextPageError>;
 type ResultNextPage = Result<NextReceivedPage, NextPageError>;
-
-// A separate module is used here so that the parent module cannot construct
-// SendAttemptedProof directly.
-mod checked_oneshot_sender {
-    use std::marker::PhantomData;
-    use tokio::sync::oneshot;
-
-    /// A value whose existence proves that there was an attempt
-    /// to send an item of type T through a oneshot.
-    /// Can only be constructed by ProvingSender::send.
-    pub(crate) struct SendAttemptedProof<T>(PhantomData<T>);
-
-    impl<T> Clone for SendAttemptedProof<T> {
-        fn clone(&self) -> Self {
-            SendAttemptedProof(PhantomData)
-        }
-    }
-
-    /// An oneshot::Sender which returns proof that it attempted to send an item.
-    pub(crate) struct ProvingSender<T>(oneshot::Sender<T>);
-
-    impl<T> From<oneshot::Sender<T>> for ProvingSender<T> {
-        fn from(s: oneshot::Sender<T>) -> Self {
-            Self(s)
-        }
-    }
-
-    impl<T> ProvingSender<T> {
-        pub(crate) fn send(self, value: T) -> (SendAttemptedProof<T>, Result<(), T>) {
-            let res = self.0.send(value);
-            (SendAttemptedProof(PhantomData), res)
-        }
-    }
-}
-
-use checked_oneshot_sender::{ProvingSender, SendAttemptedProof};
-
-type FirstPageSendAttemptedProof = SendAttemptedProof<ResultFirstPage>;
 
 mod timeouter {
     use std::time::Duration;
@@ -192,53 +153,6 @@ mod timeouter {
     }
 }
 use timeouter::PageQueryTimeouter;
-
-enum PageSender {
-    FirstPage(ProvingSender<ResultFirstPage>),
-    NextPages(FirstPageSendAttemptedProof, mpsc::Sender<ResultNextPage>),
-}
-
-impl PageSender {
-    async fn send_err(self, err: NextPageError) -> FirstPageSendAttemptedProof {
-        match self {
-            PageSender::FirstPage(sender) => {
-                let (proof, _) = sender.send(Err(err));
-                proof
-            }
-            PageSender::NextPages(proof, sender) => {
-                let _ = sender.send(Err(err)).await;
-                proof
-            }
-        }
-    }
-
-    async fn send(
-        self,
-        page: NextReceivedPage,
-    ) -> (FirstPageSendAttemptedProof, Self, Result<(), ()>) {
-        match self {
-            PageSender::FirstPage(sender) => {
-                // This conversion from NextReceivedPage to FirstReceivedPage is correct as long as we assume
-                // that NextReceivedPage is a logical subset of FirstReceivedPage. This is true because
-                // currently FirstReceivedPage can contain either Rows, SetKeyspace or SchemaChange,
-                // while NextReceivedPage can only contain Rows.
-                let first_page = FirstReceivedPage {
-                    content: FirstPageContent::Rows { rows: page.rows },
-                    tracing_id: page.tracing_id,
-                    request_coordinator: page.request_coordinator,
-                };
-                let (next_pages_sender, next_pages_receiver) = mpsc::channel::<ResultNextPage>(1);
-                let (proof, res) = sender.send(Ok((first_page, next_pages_receiver)));
-                let sender = PageSender::NextPages(proof.clone(), next_pages_sender);
-                (proof, sender, res.map_err(|_| ()))
-            }
-            PageSender::NextPages(ref proof, ref next_pages_sender) => {
-                let res = next_pages_sender.send(Ok(page)).await;
-                (proof.clone(), self, res.map_err(|_| ()))
-            }
-        }
-    }
-}
 
 // PagerWorker works in the background to fetch pages
 // QueryPager receives them through a channel
@@ -919,87 +833,85 @@ struct SingleConnectionPagerWorker<Fetcher> {
     timeout: Option<Duration>,
 }
 
-impl<Fetcher, FetchFut> SingleConnectionPagerWorker<Fetcher>
+impl<Fetcher> SingleConnectionPagerWorker<Fetcher>
 where
-    Fetcher: Fn(PagingState) -> FetchFut + Send + Sync,
-    FetchFut: Future<Output = Result<QueryResponse, RequestAttemptError>> + Send,
+    Fetcher: AsyncFn(PagingState) -> Result<QueryResponse, RequestAttemptError> + Send + Sync,
 {
-    async fn work(
-        mut self,
-        first_page_sender: ProvingSender<ResultFirstPage>,
-    ) -> FirstPageSendAttemptedProof {
-        let sender = PageSender::FirstPage(first_page_sender);
+    /// Fetches a single page. Returns the page and paging state response.
+    async fn query_one_page(
+        &mut self,
+        paging_state: PagingState,
+    ) -> Result<
+        Result<(NextReceivedPage, PagingStateResponse), RequestAttemptError>,
+        RequestTimeoutError,
+    > {
+        let runner = async {
+            (self.fetcher)(paging_state)
+                .await
+                .and_then(QueryResponse::into_non_error_query_response)
+        };
+        let response_res = match self.timeout {
+            Some(timeout) => {
+                match tokio::time::timeout(timeout, runner).await {
+                    Ok(res) => res,
+                    Err(_) /* tokio::time::error::Elapsed */ => {
+                        return Err(RequestTimeoutError(timeout));
+                    }
+                }
+            }
+            None => runner.await,
+        };
+        let response = match response_res {
+            Ok(resp) => resp,
+            Err(err) => {
+                return Ok(Err(err));
+            }
+        };
 
-        let (res, sender) = self.do_work(sender).await;
-        match res {
-            Ok(Ok(proof)) => proof,
-            Ok(Err(err)) => {
-                sender
-                    .send_err(NextPageError::RequestFailure(
-                        RequestError::LastAttemptError(err),
-                    ))
-                    .await
+        match response.response {
+            NonErrorResponseWithDeserializedMetadata::Result(
+                result::ResultWithDeserializedMetadata::Rows((rows, paging_state_response)),
+            ) => {
+                let page = NextReceivedPage {
+                    rows,
+                    tracing_id: response.tracing_id,
+                    request_coordinator: None,
+                };
+                Ok(Ok((page, paging_state_response)))
             }
-            Err(RequestTimeoutError(timeout)) => {
-                sender
-                    .send_err(NextPageError::RequestFailure(RequestError::RequestTimeout(
-                        timeout,
-                    )))
-                    .await
-            }
+            _ => Ok(Err(RequestAttemptError::UnexpectedResponse(
+                response.response.to_response_kind(),
+            ))),
         }
     }
 
-    async fn do_work(
-        &mut self,
-        mut sender: PageSender,
-    ) -> (
-        Result<Result<FirstPageSendAttemptedProof, RequestAttemptError>, RequestTimeoutError>,
-        PageSender,
-    ) {
-        let mut paging_state = PagingState::start();
-
+    /// Fetches remaining pages (pages 2+) and sends them through the channel.
+    async fn work(mut self, paging_state: PagingState, sender: mpsc::Sender<ResultNextPage>) {
+        let mut paging_state = paging_state;
         loop {
-            let runner = async {
-                (self.fetcher)(paging_state)
-                    .await
-                    .and_then(QueryResponse::into_non_error_query_response)
-            };
-            let response_res = match self.timeout {
-                Some(timeout) => {
-                    match tokio::time::timeout(timeout, runner).await {
-                        Ok(res) => res,
-                        Err(_) /* tokio::time::error::Elapsed */ => {
-                            return (Err(RequestTimeoutError(timeout)), sender);
-                        }
-                    }
-                }
-
-                None => runner.await,
-            };
-            let response = match response_res {
-                Ok(resp) => resp,
-                Err(err) => {
-                    return (Ok(Err(err)), sender);
-                }
-            };
-
-            match response.response {
-                NonErrorResponseWithDeserializedMetadata::Result(
-                    result::ResultWithDeserializedMetadata::Rows((rows, paging_state_response)),
-                ) => {
-                    let (proof, new_sender, send_result) = sender
-                        .send(NextReceivedPage {
-                            rows,
-                            tracing_id: response.tracing_id,
-                            request_coordinator: None,
-                        })
+            let result = self.query_one_page(paging_state).await;
+            match result {
+                Err(RequestTimeoutError(timeout)) => {
+                    let _ = sender
+                        .send(Err(NextPageError::RequestFailure(
+                            RequestError::RequestTimeout(timeout),
+                        )))
                         .await;
-                    sender = new_sender;
-
+                    return;
+                }
+                Ok(Err(err)) => {
+                    let _ = sender
+                        .send(Err(NextPageError::RequestFailure(
+                            RequestError::LastAttemptError(err),
+                        )))
+                        .await;
+                    return;
+                }
+                Ok(Ok((page, paging_state_response))) => {
+                    let send_result = sender.send(Ok(page)).await;
                     if send_result.is_err() {
                         // channel was closed, QueryPager was dropped - should shutdown
-                        return (Ok(Ok(proof)), sender);
+                        return;
                     }
 
                     match paging_state_response.into_paging_control_flow() {
@@ -1008,17 +920,9 @@ where
                         }
                         ControlFlow::Break(()) => {
                             // Reached the last query, shutdown
-                            return (Ok(Ok(proof)), sender);
+                            return;
                         }
                     }
-                }
-                _ => {
-                    return (
-                        Ok(Err(RequestAttemptError::UnexpectedResponse(
-                            response.response.to_response_kind(),
-                        ))),
-                        sender,
-                    );
                 }
             }
         }
@@ -1540,8 +1444,6 @@ If you are using this API, you are probably doing something wrong."
         consistency: Consistency,
         serial_consistency: Option<SerialConsistency>,
     ) -> Result<Self, NextPageError> {
-        let (sender, receiver) = oneshot::channel::<ResultFirstPage>();
-
         let page_size = prepared.get_validated_page_size();
         let timeout = prepared.get_request_timeout().or_else(|| {
             prepared
@@ -1550,10 +1452,10 @@ If you are using this API, you are probably doing something wrong."
                 .request_timeout
         });
 
-        let worker_task = async move {
-            let worker = SingleConnectionPagerWorker {
-                fetcher: |paging_state| {
-                    connection.execute_raw_with_consistency(
+        let mut worker = SingleConnectionPagerWorker {
+            fetcher: async move |paging_state: PagingState| {
+                connection
+                    .execute_raw_with_consistency(
                         &prepared,
                         &values,
                         consistency,
@@ -1561,29 +1463,47 @@ If you are using this API, you are probably doing something wrong."
                         Some(page_size),
                         paging_state,
                     )
-                },
-                timeout,
-            };
-            worker.work(sender.into()).await
+                    .await
+            },
+            timeout,
         };
 
-        Self::new_from_worker_future(worker_task, receiver, None)
+        let (first_page, paging_state_response) = worker
+            .query_one_page(PagingState::start())
             .await
-            .map_err(|e| match e {
-                PagerConstructionError::NextPage(next_page_error) => next_page_error,
-                PagerConstructionError::SchemaAgreement(schema_agreement_error) => panic!(
-                    "A DDL statement executed via Connection::execute_iter(), which is unsupported and a bug in the driver! Triggered error: {:?}",
-                    schema_agreement_error
-                ),
-                PagerConstructionError::MetadataRefresh(metadata_error) => panic!(
-                    "A DDL statement executed via Connection::execute_iter(), which is unsupported and a bug in the driver! Triggered error: {:?}",
-                    metadata_error
-                ),
-                PagerConstructionError::UseKeyspace(use_keyspace_error) => panic!(
-                    "A \"USE <keyspace>\" statement executed via Connection::execute_iter(), which is unsupported and a bug in the driver! Triggered error: {:?}",
-                    use_keyspace_error
-                ),
-            })
+            .map_err(|RequestTimeoutError(timeout)| {
+                NextPageError::RequestFailure(RequestError::RequestTimeout(timeout))
+            })?
+            .map_err(|attempt_error| {
+                NextPageError::RequestFailure(RequestError::LastAttemptError(attempt_error))
+            })?;
+
+        /* PROCESS FIRST PAGE */
+        let (sender, receiver) = mpsc::channel::<ResultNextPage>(1);
+        match paging_state_response {
+            PagingStateResponse::NoMorePages => {
+                // No more pages - we are done, return the first page and an empty receiver.
+                std::mem::drop(sender);
+            }
+            PagingStateResponse::HasMorePages { state } => {
+                /* REMAINING PAGES */
+                let worker_task = async move { worker.work(state, sender).await };
+                let _worker_handle = tokio::task::spawn(worker_task);
+            }
+        }
+
+        let NextReceivedPage {
+            rows,
+            tracing_id,
+            request_coordinator,
+        } = first_page;
+
+        Ok(Self {
+            current_page: RawRowLendingIterator::new(rows),
+            page_receiver: receiver,
+            tracing_ids: Vec::from_iter(tracing_id),
+            request_coordinators: Vec::from_iter(request_coordinator),
+        })
     }
 
     async fn new_from_first_page(
@@ -1658,150 +1578,6 @@ If you are using this API, you are probably doing something wrong."
         Ok(Self {
             current_page: first_page,
             page_receiver: receiver,
-            tracing_ids,
-            request_coordinators,
-        })
-    }
-
-    async fn new_from_worker_future(
-        worker_task: impl Future<Output = FirstPageSendAttemptedProof> + Send + 'static,
-        first_page_receiver: oneshot::Receiver<ResultFirstPage>,
-        session: Option<&Session>,
-    ) -> Result<Self, PagerConstructionError> {
-        let worker_handle = tokio::task::spawn(worker_task);
-
-        let Ok(first_page_res) = first_page_receiver.await else {
-            // - The future returned by worker.work sends at least one item
-            //   to the channel (the PageSendAttemptedProof helps enforce this);
-            // - That future is polled in a tokio::task which isn't going to be
-            //   cancelled, **unless** the runtime is being shut down.
-            // - Another way for the worker task to terminate without sending
-            //   anything could be panic.
-            // Therefore, there are two possible reasons for recv() to return None:
-            // 1. The runtime is being shut down.
-            // 2. The worker task panicked.
-            //
-            // Both cases are handled below, and in both cases we do not return
-            // from this function, but rather either propagate the panic,
-            // or hang indefinitely to avoid returning from here during runtime shutdown.
-            let worker_result = worker_handle.await;
-            match worker_result {
-                Ok(_send_attempted_proof) => {
-                    unreachable!(
-                        "Worker task completed without sending any page, despite having returned proof of having sent some"
-                    )
-                }
-                Err(join_error) => {
-                    let is_cancelled = join_error.is_cancelled();
-                    if let Ok(panic_payload) = join_error.try_into_panic() {
-                        // Worker task panicked. Propagate the panic.
-                        std::panic::resume_unwind(panic_payload);
-                    } else {
-                        // This is not a panic, so it must be runtime shutdown.
-                        assert!(
-                            is_cancelled,
-                            "PagerWorker task join error is neither a panic nor cancellation, which should be impossible"
-                        );
-                        // Let's await a never-ending future to avoid returning from here.
-                        // But before, let's emit a message to indicate that we're in such a situation.
-                        tracing::info!(
-                            "Runtime is being shut down while QueryPager is being constructed; hanging the future indefinitely"
-                        );
-                        return futures::future::pending().await;
-                    }
-                }
-            }
-        };
-
-        let (first_page, remaining_pages_receiver) = first_page_res?;
-
-        let tracing_ids = Vec::from_iter(first_page.tracing_id);
-        let coordinator_id = first_page
-            .request_coordinator
-            .as_ref()
-            .map(|coordinator| coordinator.node().host_id);
-        let request_coordinators = Vec::from_iter(first_page.request_coordinator);
-
-        let current_page = match first_page.content {
-            FirstPageContent::Rows { rows } => RawRowLendingIterator::new(rows),
-            FirstPageContent::SetKeyspace { set_keyspace } => {
-                if let Some(session) = session {
-                    // If we are here, this means that we received a SET_KEYSPACE response as a first page.
-                    // This can happen when the user executes a "USE <keyspace>" statement.
-                    // Although it makes little sense to page over such a statement,
-                    // we must handle it gracefully. Especially that there may be users who execute
-                    // all statements in a paged manner (e.g., C#-RS Driver).
-                    //
-                    // Let's set the keyspace on the session.
-                    let response = NonErrorQueryResponse {
-                        response: NonErrorResponseWithDeserializedMetadata::Result(
-                            result::ResultWithDeserializedMetadata::SetKeyspace(set_keyspace),
-                        ),
-                        tracing_id: None,
-                        warnings: Vec::new(),
-                    };
-                    session.handle_set_keyspace_response(&response).await?;
-                } else {
-                    // We don't have a session to set the keyspace on.
-                    // Let's just log an erroneous situation.
-                    error!(
-                    "BUG: Received SET_KEYSPACE response as a first page in QueryPager without a Session.
-                    This should be impossible, because it means that we executed USE KEYSPACE statement with `Connection::execute_iter()`.
-                    The response may not be handled by setting the keyspace on the Session."
-                );
-                }
-                // The stream will be empty.
-                RawRowLendingIterator::new(DeserializedMetadataAndRawRows::mock_empty())
-            }
-            FirstPageContent::SchemaChange { schema_change } => {
-                if let Some(session) = session {
-                    // If we are here, this means that we received a SCHEMA_CHANGE response as a first page.
-                    // This can happen when the user executes a DDL statement.
-                    // Although it makes little sense to page over such a statement,
-                    // we must handle it gracefully. Especially that there may be users who execute
-                    // all statements in a paged manner (e.g., C#-RS Driver).
-                    //
-                    // Let's await schema agreement, if Session is configured to do so.
-                    let response = NonErrorQueryResponse {
-                        response: NonErrorResponseWithDeserializedMetadata::Result(
-                            result::ResultWithDeserializedMetadata::SchemaChange(schema_change),
-                        ),
-                        tracing_id: None,
-                        warnings: Vec::new(),
-                    };
-                    session
-                        .handle_auto_await_schema_agreement(
-                            &response,
-                            // Making it impossible to pass None here on the type level would be possible,
-                            // but it would require heavy restructuring. The culprit is SingleConnectionPagerWorker,
-                            // which is used for ControlConnection::execute_iter, and which doesn't have enough
-                            // data to provide a Coordinator in its proof of sending the first page.
-                            //
-                            // I could duplicate data types and the proving sender with Coordinator for PagerWorker
-                            // and no Coordinator for SingleConnectionPagerWorker, but it's not worth it given that
-                            // this None here is an erroneous situation that can only happen due to a bug in the driver.
-                            //
-                            // Also, we hope to refactor the Pager soon [#1549](https://github.com/scylladb/scylla-rust-driver/issues/1549).
-                            coordinator_id.expect("PagerWorker always has Coordinator specified"),
-                        )
-                        .await?;
-                } else {
-                    // We don't have a session to await schema agreement with.
-                    // Let's just log an erroneous situation.
-                    error!(
-                        "BUG: Received SCHEMA_CHANGE response as a first page in QueryPager without a Session.
-                        This should be impossible, because it means that we executed a DDL statement with `Connection::execute_iter()`.
-                        Without Session, the response may not be handled by awaiting schema agreement."
-                    );
-                }
-                // The stream will be empty.
-                RawRowLendingIterator::new(DeserializedMetadataAndRawRows::mock_empty())
-            }
-        };
-
-        Ok(Self {
-            current_page,
-            page_receiver: remaining_pages_receiver,
             tracing_ids,
             request_coordinators,
         })

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -339,18 +339,18 @@ impl PagerWorker {
 
         // Iterates over nodes in the query plan, trying to fetch the next page.
         'nodes_in_plan: for (node, shard) in query_plan {
-            let span = trace_span!(parent: &self.parent_span, "Executing query", node = %node.address, shard = %shard);
+            let per_target_span = trace_span!(parent: &self.parent_span, "Executing query", node = %node.address, shard = %shard);
             // For each node in the plan choose a connection to use
             // This connection will be reused for same node retries to preserve paging cache on the shard
             let connection: Arc<Connection> = match node
                 .connection_for_shard(shard)
-                .instrument(span.clone())
+                .instrument(per_target_span.clone())
                 .await
             {
                 Ok(connection) => connection,
                 Err(e) => {
                     trace!(
-                        parent: &span,
+                        parent: &per_target_span,
                         error = %e,
                         "Choosing connection failed"
                     );
@@ -364,7 +364,7 @@ impl PagerWorker {
 
             // Retries on the same node as long as RetrySession decides so.
             'same_node_retries: loop {
-                trace!(parent: &span, "Execution started");
+                trace!(parent: &per_target_span, "Execution started");
 
                 // Fetch pages from this connection until an error occurs.
                 let queries_result = 'same_node_pages: loop {
@@ -407,7 +407,7 @@ impl PagerWorker {
 
                 let request_error: RequestAttemptError = match queries_result {
                     Ok(Ok(proof)) => {
-                        trace!(parent: &span, "Request succeeded");
+                        trace!(parent: &per_target_span, "Request succeeded");
                         // query_pages returned Ok, so we are guaranteed
                         // that it attempted to send at least one page
                         // through sender and we can safely return now.
@@ -415,7 +415,7 @@ impl PagerWorker {
                     }
                     Ok(Err(error)) => {
                         trace!(
-                            parent: &span,
+                            parent: &per_target_span,
                             error = %error,
                             "Request failed"
                         );
@@ -425,7 +425,7 @@ impl PagerWorker {
                         let request_error = RequestError::RequestTimeout(timeout);
                         self.log_request_error(&request_error);
                         trace!(
-                            parent: &span,
+                            parent: &per_target_span,
                             error = %request_error,
                             "Request timed out"
                         );
@@ -446,7 +446,7 @@ impl PagerWorker {
 
                 let retry_decision = self.retry_session.decide_should_retry(request_info);
                 trace!(
-                    parent: &span,
+                    parent: &per_target_span,
                     retry_decision = ?retry_decision
                 );
 

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -14,7 +14,7 @@ use crate::deserialize::result::RawRowLendingIterator;
 use crate::deserialize::row::{ColumnIterator, DeserializeRow};
 use crate::deserialize::{DeserializationError, TypeCheckError};
 use crate::frame::frame_errors::ResultMetadataAndRowsCountParseError;
-use crate::frame::request::query::PagingState;
+use crate::frame::request::query::{PagingState, PagingStateResponse};
 use crate::frame::response::NonErrorResponseWithDeserializedMetadataV2 as NonErrorResponseWithDeserializedMetadata;
 use crate::frame::response::result::{DeserializedMetadataAndRawRows, SchemaChange, SetKeyspace};
 use crate::frame::types::{Consistency, SerialConsistency};
@@ -571,28 +571,39 @@ impl PagerWorker {
 
         let res = match sender {
             PageSender::FirstPage(first_page_sender) => {
-                let res = self
+                let result = self
                     .process_first_page(
                         routing_info,
                         node,
                         coordinator,
                         request_span,
-                        first_page_sender,
                         elapsed,
                         page_result,
                     )
                     .await;
-                let (res, new_sender) = match res {
-                    Ok((cf, proof, next_pages_sender)) => {
-                        let new_sender = PageSender::NextPages(proof.clone(), next_pages_sender);
-                        (Ok(cf.map_break(|()| proof)), new_sender)
+                match result {
+                    Ok((first_page, paging_state_response)) => {
+                        let (next_pages_sender, next_pages_receiver) = mpsc::channel(1);
+                        let (proof, res) =
+                            first_page_sender.send(Ok((first_page, next_pages_receiver)));
+                        sender = PageSender::NextPages(proof.clone(), next_pages_sender);
+                        if res.is_err() {
+                            // channel was closed, QueryPager was dropped - should shutdown
+                            Ok(ControlFlow::Break(proof))
+                        } else {
+                            match paging_state_response {
+                                PagingStateResponse::NoMorePages => Ok(ControlFlow::Break(proof)),
+                                PagingStateResponse::HasMorePages { .. } => {
+                                    Ok(ControlFlow::Continue(()))
+                                }
+                            }
+                        }
                     }
-                    Err((attempt_err, proving_sender)) => {
-                        (Err(attempt_err), PageSender::FirstPage(proving_sender))
+                    Err(attempt_err) => {
+                        sender = PageSender::FirstPage(first_page_sender);
+                        Err(attempt_err)
                     }
-                };
-                sender = new_sender;
-                res
+                }
             }
             PageSender::NextPages(ref proof, ref next_pages_sender) => {
                 let res = self
@@ -658,24 +669,15 @@ impl PagerWorker {
         Ok((elapsed, query_response))
     }
 
-    #[expect(clippy::too_many_arguments)]
     async fn process_first_page(
         &mut self,
         routing_info: &RoutingInfo<'_>,
         node: NodeRef<'_>,
         coordinator: Coordinator,
         request_span: &RequestSpan,
-        sender: ProvingSender<ResultFirstPage>,
         elapsed: Duration,
         query_response: Result<NonErrorQueryResponse, RequestAttemptError>,
-    ) -> Result<
-        (
-            ControlFlow<(), ()>,
-            FirstPageSendAttemptedProof,
-            mpsc::Sender<ResultNextPage>,
-        ),
-        (RequestAttemptError, ProvingSender<ResultFirstPage>),
-    > {
+    ) -> Result<(FirstReceivedPage, PagingStateResponse), RequestAttemptError> {
         let mut log_success = || {
             let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
             self.log_attempt_success();
@@ -696,42 +698,29 @@ impl PagerWorker {
                 log_success();
                 request_span.record_raw_rows_fields(&rows);
 
-                let received_page = FirstReceivedPage {
-                    content: FirstPageContent::Rows { rows },
-                    tracing_id,
-                    request_coordinator: Some(coordinator),
-                };
-
-                let (next_pages_sender, next_pages_receiver) = mpsc::channel(1);
-
-                // Send the first page to QueryPager
-                let (proof, res) = sender.send(Ok((received_page, next_pages_receiver)));
-                if res.is_err() {
-                    // channel was closed, QueryPager was dropped - should shutdown
-                    return Ok((ControlFlow::Break(()), proof, next_pages_sender));
-                }
-
-                match paging_state_response.into_paging_control_flow() {
-                    ControlFlow::Continue(paging_state) => {
-                        self.paging_state = paging_state;
-                    }
-                    ControlFlow::Break(()) => {
-                        // Reached the last query, shutdown
-                        return Ok((ControlFlow::Break(()), proof, next_pages_sender));
-                    }
+                if let PagingStateResponse::HasMorePages { state } = &paging_state_response {
+                    self.paging_state = state.clone();
+                    // Log the next page fetch in advance.
+                    self.log_request_start();
                 }
 
                 // Query succeeded, reset retry policy for future retries
                 self.retry_session.reset();
-                self.log_request_start();
 
-                Ok((ControlFlow::Continue(()), proof, next_pages_sender))
+                Ok((
+                    FirstReceivedPage {
+                        content: FirstPageContent::Rows { rows },
+                        tracing_id,
+                        request_coordinator: Some(coordinator),
+                    },
+                    paging_state_response,
+                ))
             }
             Err(err) => {
                 self.metrics.inc_failed_paged_queries();
                 self.load_balancing_policy
                     .on_request_failure(routing_info, elapsed, node, &err);
-                Err((err, sender))
+                Err(err)
             }
             Ok(NonErrorQueryResponse {
                 response:
@@ -741,23 +730,16 @@ impl PagerWorker {
                 tracing_id,
                 ..
             }) => {
-                // It seems we executed a USE <keyspace> statement.
-                // Although it makes little sense to page over such a statement,
-                // we must handle it gracefully. Especially that there may be users who execute
-                // all statements in a paged manner (e.g., C#-RS Driver).
-
                 log_success();
 
-                let (next_pages_sender, next_pages_receiver) = mpsc::channel(1);
-                let (proof, _) = sender.send(Ok((
-                    (FirstReceivedPage {
+                Ok((
+                    FirstReceivedPage {
+                        content: FirstPageContent::SetKeyspace { set_keyspace },
                         tracing_id,
                         request_coordinator: Some(coordinator),
-                        content: FirstPageContent::SetKeyspace { set_keyspace },
-                    }),
-                    next_pages_receiver,
-                )));
-                Ok((ControlFlow::Break(()), proof, next_pages_sender))
+                    },
+                    PagingStateResponse::NoMorePages,
+                ))
             }
             Ok(NonErrorQueryResponse {
                 response:
@@ -767,23 +749,16 @@ impl PagerWorker {
                 tracing_id,
                 ..
             }) => {
-                // It seems we executed a DDL statement.
-                // Although it makes little sense to page over such a statement,
-                // we must handle it gracefully. Especially that there may be users who execute
-                // all statements in a paged manner (e.g., C#-RS Driver).
-
                 log_success();
 
-                let (next_pages_sender, next_pages_receiver) = mpsc::channel(1);
-                let (proof, _) = sender.send(Ok((
+                Ok((
                     FirstReceivedPage {
+                        content: FirstPageContent::SchemaChange { schema_change },
                         tracing_id,
                         request_coordinator: Some(coordinator),
-                        content: FirstPageContent::SchemaChange { schema_change },
                     },
-                    next_pages_receiver,
-                )));
-                Ok((ControlFlow::Break(()), proof, next_pages_sender))
+                    PagingStateResponse::NoMorePages,
+                ))
             }
             Ok(NonErrorQueryResponse {
                 response: NonErrorResponseWithDeserializedMetadata::Result(_),
@@ -795,10 +770,16 @@ impl PagerWorker {
 
                 log_success();
 
-                // We must attempt to send something because the pager expects it.
-                let (next_pages_sender, _) = mpsc::channel(1);
-                let (proof, _) = sender.send_empty_page(tracing_id, Some(coordinator));
-                Ok((ControlFlow::Break(()), proof, next_pages_sender))
+                Ok((
+                    FirstReceivedPage {
+                        content: FirstPageContent::Rows {
+                            rows: DeserializedMetadataAndRawRows::mock_empty(),
+                        },
+                        tracing_id,
+                        request_coordinator: Some(coordinator),
+                    },
+                    PagingStateResponse::NoMorePages,
+                ))
             }
             Ok(response) => {
                 self.metrics.inc_failed_paged_queries();
@@ -806,7 +787,7 @@ impl PagerWorker {
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
                 self.load_balancing_policy
                     .on_request_failure(routing_info, elapsed, node, &err);
-                Err((err, sender))
+                Err(err)
             }
         }
     }

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -114,14 +114,8 @@ type ResultNextPage = Result<NextReceivedPage, NextPageError>;
 // A separate module is used here so that the parent module cannot construct
 // SendAttemptedProof directly.
 mod checked_oneshot_sender {
-    use crate::frame::response::result::DeserializedMetadataAndRawRows;
     use std::marker::PhantomData;
-    use tokio::sync::{mpsc, oneshot};
-    use uuid::Uuid;
-
-    use crate::response::Coordinator;
-
-    use super::{FirstPageContent, FirstReceivedPage, ResultFirstPage, ResultNextPage};
+    use tokio::sync::oneshot;
 
     /// A value whose existence proves that there was an attempt
     /// to send an item of type T through a oneshot.
@@ -147,29 +141,6 @@ mod checked_oneshot_sender {
         pub(crate) fn send(self, value: T) -> (SendAttemptedProof<T>, Result<(), T>) {
             let res = self.0.send(value);
             (SendAttemptedProof(PhantomData), res)
-        }
-    }
-
-    impl ProvingSender<ResultFirstPage> {
-        pub(crate) fn send_empty_page(
-            self,
-            tracing_id: Option<Uuid>,
-            request_coordinator: Option<Coordinator>,
-        ) -> (
-            SendAttemptedProof<ResultFirstPage>,
-            Result<(), ResultFirstPage>,
-        ) {
-            let empty_page = FirstReceivedPage {
-                content: FirstPageContent::Rows {
-                    rows: DeserializedMetadataAndRawRows::mock_empty(),
-                },
-                tracing_id,
-                request_coordinator,
-            };
-            // No more pages to follow.
-            let (_, next_pages_receiver) = mpsc::channel::<ResultNextPage>(1);
-
-            self.send(Ok((empty_page, next_pages_receiver)))
         }
     }
 }
@@ -241,28 +212,6 @@ impl PageSender {
         }
     }
 
-    async fn send_empty_page(
-        self,
-        tracing_id: Option<Uuid>,
-        request_coordinator: Option<Coordinator>,
-    ) -> FirstPageSendAttemptedProof {
-        match self {
-            PageSender::FirstPage(sender) => {
-                let (proof, _) = sender.send_empty_page(tracing_id, request_coordinator);
-                proof
-            }
-            PageSender::NextPages(proof, sender) => {
-                let empty_page = NextReceivedPage {
-                    rows: DeserializedMetadataAndRawRows::mock_empty(),
-                    tracing_id,
-                    request_coordinator,
-                };
-                let _ = sender.send(Ok(empty_page)).await;
-                proof
-            }
-        }
-    }
-
     async fn send(
         self,
         page: NextReceivedPage,
@@ -311,16 +260,16 @@ struct PagerWorker {
 }
 
 impl PagerWorker {
-    // Contract: this function MUST send at least one item through first_page_sender.
+    /// Fetches remaining pages (pages 2+) in a background task.
+    /// Sends each page through the mpsc channel.
     async fn work<QueryFunc, QueryFut, SpanCreator>(
         mut self,
         cluster_state: Arc<ClusterState>,
-        first_page_sender: ProvingSender<ResultFirstPage>,
+        sender: mpsc::Sender<ResultNextPage>,
         page_query: QueryFunc,
         routing_info: RoutingInfo<'_>,
         span_creator: SpanCreator,
-    ) -> FirstPageSendAttemptedProof
-    where
+    ) where
         QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
         SpanCreator: Fn() -> RequestSpan,
@@ -332,9 +281,6 @@ impl PagerWorker {
         let mut last_error: RequestError = RequestError::EmptyPlan;
         let mut current_consistency: Consistency = self.query_consistency;
 
-        let mut sender = PageSender::FirstPage(first_page_sender);
-
-        self.log_request_start();
         self.timeouter.as_mut().map(PageQueryTimeouter::reset);
 
         // Iterates over nodes in the query plan, trying to fetch the next page.
@@ -367,51 +313,199 @@ impl PagerWorker {
                 trace!(parent: &per_target_span, "Execution started");
 
                 // Fetch pages from this connection until an error occurs.
-                let queries_result = 'same_node_pages: loop {
+                'same_node_pages: loop {
                     let request_span = span_creator();
-                    let (res, new_sender) = self
-                        .query_one_page(
-                            &routing_info,
+
+                    let fetch_result = self
+                        .fetch_one_page(
                             &connection,
                             current_consistency,
-                            node,
-                            coordinator.clone(),
                             &request_span,
-                            sender,
                             &page_query,
                         )
                         .instrument(request_span.span().clone())
                         .await;
-                    sender = new_sender;
-
-                    match res {
-                        Ok(Ok(ControlFlow::Break(proof))) => {
-                            // Successfully queried the last remaining page.
-                            break Ok(Ok(proof));
+                    let query_result = match fetch_result {
+                        Err(RequestTimeoutError(timeout)) => {
+                            let request_error = RequestError::RequestTimeout(timeout);
+                            self.log_request_error(&request_error);
+                            trace!(
+                                parent: &per_target_span,
+                                error = %request_error,
+                                "Request timed out"
+                            );
+                            // This means that we failed all attempts - in this case, due to a timeout.
+                            let _ = sender
+                                .send(Err(NextPageError::RequestFailure(request_error)))
+                                .await;
+                            return;
                         }
+                        Ok((elapsed, result)) => {
+                            self.process_next_page(
+                                &routing_info,
+                                node,
+                                coordinator.clone(),
+                                &request_span,
+                                &sender,
+                                elapsed,
+                                result,
+                            )
+                            .await
+                        }
+                    };
 
-                        Ok(Ok(ControlFlow::Continue(()))) => {
+                    match query_result {
+                        Ok(ControlFlow::Break(())) => {
+                            // Successfully queried the last remaining page.
+                            trace!(parent: &per_target_span, "Request succeeded");
+                            return;
+                        }
+                        Ok(ControlFlow::Continue(())) => {
                             // Successfully queried one page, and there are more to fetch.
                             // Reset the timeout_instant for the next page fetch.
                             self.timeouter.as_mut().map(PageQueryTimeouter::reset);
                             continue 'same_node_pages;
                         }
-                        Ok(Err(request_attempt_error)) => {
-                            break Ok(Err(request_attempt_error));
+                        Err(request_error) => {
+                            trace!(
+                                parent: &per_target_span,
+                                error = %request_error,
+                                "Request failed"
+                            );
+
+                            // Break out of the inner page-fetching loop to retry logic.
+                            let request_info = RequestInfo {
+                                error: &request_error,
+                                is_idempotent: self.query_is_idempotent,
+                                consistency: current_consistency,
+                            };
+
+                            let retry_decision =
+                                self.retry_session.decide_should_retry(request_info);
+                            trace!(
+                                parent: &per_target_span,
+                                retry_decision = ?retry_decision
+                            );
+
+                            self.log_attempt_error(&request_error, &retry_decision);
+
+                            last_error = request_error.into();
+
+                            match retry_decision {
+                                RetryDecision::RetrySameTarget(cl) => {
+                                    self.metrics.inc_retries_num();
+                                    current_consistency = cl.unwrap_or(current_consistency);
+                                    continue 'same_node_retries;
+                                }
+                                RetryDecision::RetryNextTarget(cl) => {
+                                    self.metrics.inc_retries_num();
+                                    current_consistency = cl.unwrap_or(current_consistency);
+                                    continue 'nodes_in_plan;
+                                }
+                                RetryDecision::DontRetry => break 'nodes_in_plan,
+                                RetryDecision::IgnoreWriteError => {
+                                    self.log_request_success();
+                                    self.retry_session.reset();
+
+                                    warn!(
+                                        "Ignoring error during fetching pages; stopping fetching."
+                                    );
+                                    return;
+                                }
+                            };
                         }
-                        Err(request_timeout_error) => {
-                            break Err(request_timeout_error);
-                        }
-                    };
+                    }
+                }
+            }
+        }
+
+        // If we are here, it means we failed to fetch next page on any node from the plan.
+        // The plan is exhausted, so we send the last error and finish.
+        self.log_request_error(&last_error);
+        let _ = sender
+            .send(Err(NextPageError::RequestFailure(last_error)))
+            .await;
+    }
+
+    /// Fetches the first page on the caller task (no spawning).
+    /// Returns the first page and its paging state response.
+    async fn query_first_page<QueryFunc, QueryFut, SpanCreator>(
+        &mut self,
+        cluster_state: &ClusterState,
+        span_creator: SpanCreator,
+        routing_info: &RoutingInfo<'_>,
+        page_query: QueryFunc,
+    ) -> Result<(FirstReceivedPage, PagingStateResponse), NextPageError>
+    where
+        QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
+        QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
+        SpanCreator: Fn() -> RequestSpan,
+    {
+        let load_balancer = Arc::clone(&self.load_balancing_policy);
+        let query_plan =
+            load_balancing::Plan::new(load_balancer.as_ref(), routing_info, cluster_state);
+
+        let mut last_error: RequestError = RequestError::EmptyPlan;
+        let mut current_consistency: Consistency = self.query_consistency;
+
+        self.log_request_start();
+        self.timeouter.as_mut().map(PageQueryTimeouter::reset);
+
+        // Iterates over nodes in the query plan, trying to fetch the next page.
+        'nodes_in_plan: for (node, shard) in query_plan {
+            let per_target_span = trace_span!(parent: &self.parent_span, "Executing query", node = %node.address, shard = %shard);
+            // For each node in the plan choose a connection to use
+            // This connection will be reused for same node retries to preserve paging cache on the shard
+            let connection: Arc<Connection> = match node
+                .connection_for_shard(shard)
+                .instrument(per_target_span.clone())
+                .await
+            {
+                Ok(connection) => connection,
+                Err(e) => {
+                    trace!(
+                        parent: &per_target_span,
+                        error = %e,
+                        "Choosing connection failed"
+                    );
+                    last_error = e.into();
+                    // Broken connection doesn't count as a failed query, don't log in metrics
+                    continue 'nodes_in_plan;
+                }
+            };
+
+            let coordinator = Coordinator::new(node, &connection);
+
+            // Retries on the same node as long as RetrySession decides so.
+            'same_node_retries: loop {
+                trace!(parent: &per_target_span, "Execution started");
+                let request_span = span_creator();
+
+                let fetch_result = self
+                    .fetch_one_page(&connection, current_consistency, &request_span, &page_query)
+                    .instrument(request_span.span().clone())
+                    .await;
+                let query_result = match fetch_result {
+                    Err(e) => Err(e),
+                    Ok((elapsed, result)) => {
+                        let result = self
+                            .process_first_page(
+                                routing_info,
+                                node,
+                                coordinator.clone(),
+                                &request_span,
+                                elapsed,
+                                result,
+                            )
+                            .await;
+                        Ok(result)
+                    }
                 };
 
-                let request_error: RequestAttemptError = match queries_result {
-                    Ok(Ok(proof)) => {
+                let request_error: RequestAttemptError = match query_result {
+                    Ok(Ok(response)) => {
                         trace!(parent: &per_target_span, "Request succeeded");
-                        // query_pages returned Ok, so we are guaranteed
-                        // that it attempted to send at least one page
-                        // through sender and we can safely return now.
-                        return proof;
+                        return Ok(response);
                     }
                     Ok(Err(error)) => {
                         trace!(
@@ -430,10 +524,7 @@ impl PagerWorker {
                             "Request timed out"
                         );
                         // This means that we failed all attempts - in this case, due to a timeout.
-                        let proof = sender
-                            .send_err(NextPageError::RequestFailure(request_error))
-                            .await;
-                        return proof;
+                        return Err(NextPageError::RequestFailure(request_error));
                     }
                 };
 
@@ -452,7 +543,7 @@ impl PagerWorker {
 
                 self.log_attempt_error(&request_error, &retry_decision);
 
-                last_error = request_error.into();
+                last_error = RequestError::LastAttemptError(request_error);
 
                 match retry_decision {
                     RetryDecision::RetrySameTarget(cl) => {
@@ -471,110 +562,23 @@ impl PagerWorker {
                         self.retry_session.reset();
 
                         warn!("Ignoring error during fetching pages; stopping fetching.");
-                        // If we are here then, most likely, we didn't send
-                        // anything through the self.sender channel.
-                        // Although we are in an awkward situation (_iter
-                        // interface isn't meant for sending writes),
-                        // we must attempt to send something because
-                        // QueryPager expects it.
-                        return sender
-                            .send_empty_page(None, Some(coordinator.clone()))
-                            .await;
+                        return Ok((
+                            FirstReceivedPage {
+                                content: FirstPageContent::Rows {
+                                    rows: DeserializedMetadataAndRawRows::mock_empty(),
+                                },
+                                tracing_id: None,
+                                request_coordinator: Some(coordinator),
+                            },
+                            PagingStateResponse::NoMorePages,
+                        ));
                     }
                 };
             }
         }
 
-        // If we are here, it means we failed to fetch next page on any node from the plan.
-        // The plan is exhausted, so we send the last error and finish.
         self.log_request_error(&last_error);
-        sender
-            .send_err(NextPageError::RequestFailure(last_error))
-            .await
-    }
-
-    #[expect(clippy::too_many_arguments)]
-    async fn query_one_page<QueryFunc, QueryFut>(
-        &mut self,
-        routing_info: &RoutingInfo<'_>,
-        connection: &Arc<Connection>,
-        consistency: Consistency,
-        node: NodeRef<'_>,
-        coordinator: Coordinator,
-        request_span: &RequestSpan,
-        mut sender: PageSender,
-        page_query: &QueryFunc,
-    ) -> (
-        Result<
-            Result<ControlFlow<FirstPageSendAttemptedProof, ()>, RequestAttemptError>,
-            RequestTimeoutError,
-        >,
-        PageSender,
-    )
-    where
-        QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
-        QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
-    {
-        let (elapsed, page_result) = match self
-            .fetch_one_page(connection, consistency, request_span, page_query)
-            .await
-        {
-            Err(timeout_err) => return (Err(timeout_err), sender),
-            Ok((elapsed, resp)) => (elapsed, resp),
-        };
-
-        let res = match sender {
-            PageSender::FirstPage(first_page_sender) => {
-                let result = self
-                    .process_first_page(
-                        routing_info,
-                        node,
-                        coordinator,
-                        request_span,
-                        elapsed,
-                        page_result,
-                    )
-                    .await;
-                match result {
-                    Ok((first_page, paging_state_response)) => {
-                        let (next_pages_sender, next_pages_receiver) = mpsc::channel(1);
-                        let (proof, res) =
-                            first_page_sender.send(Ok((first_page, next_pages_receiver)));
-                        sender = PageSender::NextPages(proof.clone(), next_pages_sender);
-                        if res.is_err() {
-                            // channel was closed, QueryPager was dropped - should shutdown
-                            Ok(ControlFlow::Break(proof))
-                        } else {
-                            match paging_state_response {
-                                PagingStateResponse::NoMorePages => Ok(ControlFlow::Break(proof)),
-                                PagingStateResponse::HasMorePages { .. } => {
-                                    Ok(ControlFlow::Continue(()))
-                                }
-                            }
-                        }
-                    }
-                    Err(attempt_err) => {
-                        sender = PageSender::FirstPage(first_page_sender);
-                        Err(attempt_err)
-                    }
-                }
-            }
-            PageSender::NextPages(ref proof, ref next_pages_sender) => {
-                let res = self
-                    .process_next_page(
-                        routing_info,
-                        node,
-                        coordinator,
-                        request_span,
-                        next_pages_sender,
-                        elapsed,
-                        page_result,
-                    )
-                    .await;
-                res.map(|cf| cf.map_break(|()| proof.clone()))
-            }
-        };
-        (Ok(res), sender)
+        Err(NextPageError::RequestFailure(last_error))
     }
 
     async fn fetch_one_page<QueryFunc, QueryFut>(
@@ -1159,8 +1163,6 @@ If you are using this API, you are probably doing something wrong."
         metrics: Metrics,
         node_location_preference: Arc<NodeLocationPreference>,
     ) -> Result<Self, PagerExecutionError> {
-        let (sender, receiver) = oneshot::channel::<ResultFirstPage>();
-
         let consistency = statement
             .config
             .consistency
@@ -1197,25 +1199,38 @@ If you are using this API, you are probably doing something wrong."
             span
         }
 
-        let worker_task = async move {
-            let statement_ref = &statement;
+        let statement_ref = &statement;
+        let page_query = |connection: Arc<Connection>,
+                          consistency: Consistency,
+                          paging_state: PagingState| {
+            async move {
+                connection
+                    .query_raw_with_consistency(
+                        statement_ref,
+                        consistency,
+                        serial_consistency,
+                        Some(page_size),
+                        paging_state,
+                    )
+                    .await
+            }
+        };
 
-            let page_query = |connection: Arc<Connection>,
-                              consistency: Consistency,
-                              paging_state: PagingState| {
-                async move {
-                    connection
-                        .query_raw_with_consistency(
-                            statement_ref,
-                            consistency,
-                            serial_consistency,
-                            Some(page_size),
-                            paging_state,
-                        )
-                        .await
-                }
-            };
+        let mut worker = PagerWorker {
+            query_is_idempotent: statement.config.is_idempotent,
+            query_consistency: consistency,
+            load_balancing_policy,
+            retry_session,
+            timeouter,
+            metrics,
+            paging_state: PagingState::start(),
+            history_listener: statement.config.history_listener.as_ref().map(Arc::clone),
+            current_request_id: None,
+            current_attempt_id: None,
+            parent_span,
+        };
 
+        let (first_page, paging_state_response) = {
             let routing_info = RoutingInfo {
                 consistency,
                 serial_consistency,
@@ -1227,32 +1242,63 @@ If you are using this API, you are probably doing something wrong."
 
             let span_creator = || create_span(&statement.contents);
 
-            let worker = PagerWorker {
-                query_is_idempotent: statement.config.is_idempotent,
-                query_consistency: consistency,
-                load_balancing_policy,
-                retry_session,
-                timeouter,
-                metrics,
-                paging_state: PagingState::start(),
-                history_listener: statement.config.history_listener.as_ref().map(Arc::clone),
-                current_request_id: None,
-                current_attempt_id: None,
-                parent_span,
-            };
-
             worker
-                .work(
-                    cluster_state,
-                    sender.into(),
-                    page_query,
-                    routing_info,
-                    span_creator,
-                )
-                .await
+                .query_first_page(&cluster_state, span_creator, &routing_info, page_query)
+                .await?
         };
 
-        Self::new_from_worker_future(worker_task, receiver, Some(session))
+        /* PROCESS FIRST PAGE */
+        let (sender, receiver) = mpsc::channel::<ResultNextPage>(1);
+        match paging_state_response {
+            PagingStateResponse::NoMorePages => {
+                // No more pages - we are done, return the first page and an empty receiver.
+                std::mem::drop(sender);
+            }
+            PagingStateResponse::HasMorePages { .. } => {
+                /* REMAINING PAGES */
+                let worker_task = async move {
+                    let routing_info = RoutingInfo {
+                        consistency,
+                        serial_consistency,
+                        token: None,
+                        table: None,
+                        is_confirmed_lwt: false,
+                        node_location_preference: &node_location_preference,
+                    };
+
+                    let statement_ref = &statement;
+                    let page_query =
+                        |connection: Arc<Connection>,
+                         consistency: Consistency,
+                         paging_state: PagingState| async move {
+                            connection
+                                .query_raw_with_consistency(
+                                    statement_ref,
+                                    consistency,
+                                    serial_consistency,
+                                    Some(page_size),
+                                    paging_state,
+                                )
+                                .await
+                        };
+
+                    let span_creator = move || create_span(&statement_ref.contents);
+
+                    worker
+                        .work(
+                            cluster_state,
+                            sender,
+                            page_query,
+                            routing_info,
+                            span_creator,
+                        )
+                        .await;
+                };
+                let _worker_handle = tokio::task::spawn(worker_task);
+            }
+        }
+
+        Self::new_from_first_page(first_page, receiver, session)
             .await
             .map_err(PagerExecutionError::from)
     }
@@ -1261,8 +1307,6 @@ If you are using this API, you are probably doing something wrong."
         session: &Session,
         config: PreparedPagerConfig,
     ) -> Result<Self, PagerExecutionError> {
-        let (sender, receiver) = oneshot::channel::<ResultFirstPage>();
-
         let consistency = config
             .prepared
             .config
@@ -1316,99 +1360,175 @@ If you are using this API, you are probably doing something wrong."
             span
         }
 
-        let worker_task = async move {
-            let prepared_ref = &config.prepared;
-            let values_ref = &config.values;
-
-            let (partition_key, token) = match prepared_ref
-                .extract_partition_key_and_calculate_token(
-                    prepared_ref.get_partitioner_name(),
-                    values_ref,
-                ) {
+        let (partition_key, token) =
+            match config.prepared.extract_partition_key_and_calculate_token(
+                config.prepared.get_partitioner_name(),
+                &config.values,
+            ) {
                 Ok(res) => res.unzip(),
                 Err(err) => {
-                    let (proof, _res) = ProvingSender::from(sender)
-                        .send(Err(NextPageError::PartitionKeyError(err)));
-                    return proof;
+                    return Err(PagerExecutionError::NextPageError(
+                        NextPageError::PartitionKeyError(err),
+                    ));
                 }
             };
 
-            let table_spec = config.prepared.get_table_spec();
-            let routing_info = RoutingInfo {
-                consistency,
-                serial_consistency,
-                token,
-                table: table_spec,
-                is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
-                node_location_preference: &config.location_preference,
-            };
+        let table_spec = config.prepared.get_table_spec();
+        let routing_info = RoutingInfo {
+            consistency,
+            serial_consistency,
+            token,
+            table: table_spec,
+            is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
+            node_location_preference: &config.location_preference,
+        };
 
-            let page_query = |connection: Arc<Connection>,
-                              consistency: Consistency,
-                              paging_state: PagingState| async move {
-                connection
-                    .execute_raw_with_consistency(
-                        prepared_ref,
-                        values_ref,
-                        consistency,
-                        serial_consistency,
-                        Some(page_size),
-                        paging_state,
-                    )
-                    .await
-            };
-
-            let serialized_values_size = config.values.buffer_size();
-
-            let replicas: Option<Replicas> = Option::zip(routing_info.table, routing_info.token)
-                .map(|(table_spec, token)| {
-                    config
-                        .cluster_state
-                        .get_token_endpoints_iter(table_spec, token)
-                        .map(|(node, shard)| (node.clone(), shard))
-                        .collect()
-                });
-
-            let span_creator = move || {
-                create_span(
-                    &partition_key,
-                    token,
-                    serialized_values_size,
-                    replicas.as_ref(),
-                )
-            };
-
-            let worker = PagerWorker {
-                query_is_idempotent: config.prepared.config.is_idempotent,
-                query_consistency: consistency,
-                load_balancing_policy,
-                retry_session,
-                timeouter,
-                metrics: config.metrics,
-                paging_state: PagingState::start(),
-                history_listener: config
-                    .prepared
-                    .config
-                    .history_listener
-                    .as_ref()
-                    .map(Arc::clone),
-                current_request_id: None,
-                current_attempt_id: None,
-                parent_span,
-            };
-
-            worker
-                .work(
-                    config.cluster_state,
-                    sender.into(),
-                    page_query,
-                    routing_info,
-                    span_creator,
+        let prepared_ref = &config.prepared;
+        let values_ref = &config.values;
+        let page_query = |connection: Arc<Connection>,
+                          consistency: Consistency,
+                          paging_state: PagingState| async move {
+            connection
+                .execute_raw_with_consistency(
+                    prepared_ref,
+                    values_ref,
+                    consistency,
+                    serial_consistency,
+                    Some(page_size),
+                    paging_state,
                 )
                 .await
         };
 
-        Self::new_from_worker_future(worker_task, receiver, Some(session))
+        let serialized_values_size = config.values.buffer_size();
+
+        let replicas: Option<Replicas> =
+            Option::zip(routing_info.table, routing_info.token).map(|(table_spec, token)| {
+                config
+                    .cluster_state
+                    .get_token_endpoints_iter(table_spec, token)
+                    .map(|(node, shard)| (node.clone(), shard))
+                    .collect()
+            });
+
+        let span_creator = || {
+            create_span(
+                &partition_key,
+                token,
+                serialized_values_size,
+                replicas.as_ref(),
+            )
+        };
+
+        let mut worker = PagerWorker {
+            query_is_idempotent: config.prepared.config.is_idempotent,
+            query_consistency: consistency,
+            load_balancing_policy,
+            retry_session,
+            timeouter,
+            metrics: config.metrics,
+            paging_state: PagingState::start(),
+            history_listener: config
+                .prepared
+                .config
+                .history_listener
+                .as_ref()
+                .map(Arc::clone),
+            current_request_id: None,
+            current_attempt_id: None,
+            parent_span,
+        };
+
+        let (first_page, paging_state_response) = worker
+            .query_first_page(
+                &config.cluster_state,
+                &span_creator,
+                &routing_info,
+                page_query,
+            )
+            .await?;
+
+        // Required to end the borrow of `partition_key`, so `config` can be moved into the worker task.
+        std::mem::drop(partition_key);
+
+        /* PROCESS FIRST PAGE */
+        let (sender, receiver) = mpsc::channel::<ResultNextPage>(1);
+        match paging_state_response {
+            PagingStateResponse::NoMorePages => {
+                // No more pages - we are done, return the first page and an empty receiver.
+                std::mem::drop(sender);
+            }
+            PagingStateResponse::HasMorePages { .. } => {
+                /* REMAINING PAGES */
+                let worker_task = async move {
+                    let partition_key = if config.prepared.is_token_aware() {
+                        match config.prepared.extract_partition_key(&config.values) {
+                            Ok(res) => Some(res),
+                            Err(err) => {
+                                let _ = sender
+                                    .send(Err(NextPageError::PartitionKeyError(
+                                        PartitionKeyError::PartitionKeyExtraction(err),
+                                    )))
+                                    .await;
+                                return;
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    let table_spec = config.prepared.get_table_spec();
+                    let routing_info = RoutingInfo {
+                        consistency,
+                        serial_consistency,
+                        token,
+                        table: table_spec,
+                        is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
+                        node_location_preference: &config.location_preference,
+                    };
+
+                    let prepared = &config.prepared;
+                    let values_ref = &config.values;
+                    let page_query =
+                        |connection: Arc<Connection>,
+                         consistency: Consistency,
+                         paging_state: PagingState| async move {
+                            connection
+                                .execute_raw_with_consistency(
+                                    prepared,
+                                    values_ref,
+                                    consistency,
+                                    serial_consistency,
+                                    Some(page_size),
+                                    paging_state,
+                                )
+                                .await
+                        };
+
+                    let span_creator = move || {
+                        create_span(
+                            &partition_key,
+                            token,
+                            serialized_values_size,
+                            replicas.as_ref(),
+                        )
+                    };
+
+                    worker
+                        .work(
+                            config.cluster_state,
+                            sender,
+                            page_query,
+                            routing_info,
+                            span_creator,
+                        )
+                        .await;
+                };
+                let _worker_handle = tokio::task::spawn(worker_task);
+            }
+        };
+
+        Self::new_from_first_page(first_page, receiver, session)
             .await
             .map_err(PagerExecutionError::from)
     }
@@ -1464,6 +1584,83 @@ If you are using this API, you are probably doing something wrong."
                     use_keyspace_error
                 ),
             })
+    }
+
+    async fn new_from_first_page(
+        first_page: FirstReceivedPage,
+        receiver: mpsc::Receiver<ResultNextPage>,
+        session: &Session,
+    ) -> Result<Self, PagerConstructionError> {
+        let tracing_ids = Vec::from_iter(first_page.tracing_id);
+        let coordinator_id = first_page
+            .request_coordinator
+            .as_ref()
+            .map(|coordinator| coordinator.node().host_id);
+        let request_coordinators = Vec::from_iter(first_page.request_coordinator);
+
+        let first_page = match first_page.content {
+            FirstPageContent::Rows { rows } => RawRowLendingIterator::new(rows),
+            FirstPageContent::SetKeyspace { set_keyspace } => {
+                // If we are here, this means that we received a SET_KEYSPACE response as a first page.
+                // This can happen when the user executes a "USE <keyspace>" statement.
+                // Although it makes little sense to page over such a statement,
+                // we must handle it gracefully. Especially that there may be users who execute
+                // all statements in a paged manner (e.g., C# RS Driver).
+                //
+                // Let's set the keyspace on the session.
+                let response = NonErrorQueryResponse {
+                    response: NonErrorResponseWithDeserializedMetadata::Result(
+                        result::ResultWithDeserializedMetadata::SetKeyspace(set_keyspace),
+                    ),
+                    tracing_id: None,
+                    warnings: Vec::new(),
+                };
+                session.handle_set_keyspace_response(&response).await?;
+                // The stream will be empty.
+                RawRowLendingIterator::new(DeserializedMetadataAndRawRows::mock_empty())
+            }
+            FirstPageContent::SchemaChange { schema_change } => {
+                // If we are here, this means that we received a SCHEMA_CHANGE response as a first page.
+                // This can happen when the user executes a DDL statement.
+                // Although it makes little sense to page over such a statement,
+                // we must handle it gracefully. Especially that there may be users who execute
+                // all statements in a paged manner (e.g., C#-RS Driver).
+                //
+                // Let's await schema agreement, if Session is configured to do so.
+                let response = NonErrorQueryResponse {
+                    response: NonErrorResponseWithDeserializedMetadata::Result(
+                        result::ResultWithDeserializedMetadata::SchemaChange(schema_change),
+                    ),
+                    tracing_id: None,
+                    warnings: Vec::new(),
+                };
+                session
+                    .handle_auto_await_schema_agreement(
+                        &response,
+                        // Making it impossible to pass None here on the type level would be possible,
+                        // but it would require heavy restructuring. The culprit is SingleConnectionPagerWorker,
+                        // which is used for ControlConnection::execute_iter, and which doesn't have enough
+                        // data to provide a Coordinator in its proof of sending the first page.
+                        //
+                        // I could duplicate data types and the proving sender with Coordinator for PagerWorker
+                        // and no Coordinator for SingleConnectionPagerWorker, but it's not worth it given that
+                        // this None here is an erroneous situation that can only happen due to a bug in the driver.
+                        //
+                        // Also, we hope to refactor the Pager soon [#1549](https://github.com/scylladb/scylla-rust-driver/issues/1549).
+                        coordinator_id.expect("PagerWorker always has Coordinator specified"),
+                    )
+                    .await?;
+                // The stream will be empty.
+                RawRowLendingIterator::new(DeserializedMetadataAndRawRows::mock_empty())
+            }
+        };
+
+        Ok(Self {
+            current_page: first_page,
+            page_receiver: receiver,
+            tracing_ids,
+            request_coordinators,
+        })
     }
 
     async fn new_from_worker_future(

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -25,13 +25,10 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 
 use crate::client::execution_profile::ExecutionProfileInner;
-use crate::client::session::{AutoSchemaAwaitingError, Session};
+use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node, NodeRef};
 use crate::deserialize::DeserializeOwnedRow;
-use crate::errors::{
-    MetadataError, PagerExecutionError, RequestAttemptError, RequestError, SchemaAgreementError,
-    UseKeyspaceError,
-};
+use crate::errors::{PagerExecutionError, RequestAttemptError, RequestError};
 use crate::frame::response::result;
 use crate::network::Connection;
 use crate::observability::driver_tracing::RequestSpan;
@@ -1202,9 +1199,7 @@ If you are using this API, you are probably doing something wrong."
             }
         }
 
-        Self::new_from_first_page(first_page, receiver, session)
-            .await
-            .map_err(PagerExecutionError::from)
+        Self::new_from_first_page(first_page, receiver, session).await
     }
 
     pub(crate) async fn new_for_prepared_statement(
@@ -1432,9 +1427,7 @@ If you are using this API, you are probably doing something wrong."
             }
         };
 
-        Self::new_from_first_page(first_page, receiver, session)
-            .await
-            .map_err(PagerExecutionError::from)
+        Self::new_from_first_page(first_page, receiver, session).await
     }
 
     pub(crate) async fn new_for_connection_execute_iter(
@@ -1510,7 +1503,7 @@ If you are using this API, you are probably doing something wrong."
         first_page: FirstReceivedPage,
         receiver: mpsc::Receiver<ResultNextPage>,
         session: &Session,
-    ) -> Result<Self, PagerConstructionError> {
+    ) -> Result<Self, PagerExecutionError> {
         let tracing_ids = Vec::from_iter(first_page.tracing_id);
         let coordinator_id = first_page
             .request_coordinator
@@ -1740,84 +1733,4 @@ pub enum NextRowError {
     /// An error occurred during row deserialization.
     #[error("Row deserialization error: {0}")]
     RowDeserializationError(#[from] DeserializationError),
-}
-
-/// An error that occurred during construction of [QueryPager].
-/// A temporary error type that is introduced to support proper error handling
-/// when the first page is received and processed.
-///
-/// Rationale:
-/// - `new_from_worker_future` function is used both by Session-based QueryPager constructors
-///   (`QueryPager::new_for_query` and `QueryPager::new_for_prepared_statement`,
-///   used by `Session::query_iter` and `Session::execute_iter`, respectively)
-///   and by connection-based QueryPager constructor (QueryPager::new_for_connection_execute_iter,
-///   used by `Connection::execute_iter`).
-/// - In the Session-based constructors, we have a Session available, so we can handle
-///   SET_KEYSPACE and SCHEMA_CHANGE responses properly (by setting the keyspace on the Session,
-///   or awaiting schema agreement, respectively).
-/// - In the connection-based constructor, we do not have a Session available, so we cannot handle
-///   those responses properly. We can only log an error message. Note that those responses
-///   should never be received in that case, because USE KEYSPACE statements and DDL statements
-///   should not be executed via `Connection::execute_iter()`.
-/// - Therefore, we need to distinguish between errors that can occur during handling
-///   of those responses, so that we can propagate them only in the Session-based constructors.
-///   Specifically, we need to propagate UseKeyspaceError and SchemaAgreementError
-///   only in the Session-based constructors, and assert that they never occur in the connection-based constructor.
-/// - We don't want to pollute NextPageError or NextRowError with those variants,
-///   because they are not relevant for normal paging operation (only for construction and the first received page).
-enum PagerConstructionError {
-    NextPage(NextPageError),
-    SchemaAgreement(SchemaAgreementError),
-    MetadataRefresh(MetadataError),
-    UseKeyspace(UseKeyspaceError),
-}
-
-impl From<NextPageError> for PagerConstructionError {
-    fn from(err: NextPageError) -> Self {
-        PagerConstructionError::NextPage(err)
-    }
-}
-
-impl From<SchemaAgreementError> for PagerConstructionError {
-    fn from(err: SchemaAgreementError) -> Self {
-        PagerConstructionError::SchemaAgreement(err)
-    }
-}
-
-impl From<UseKeyspaceError> for PagerConstructionError {
-    fn from(err: UseKeyspaceError) -> Self {
-        PagerConstructionError::UseKeyspace(err)
-    }
-}
-
-impl From<AutoSchemaAwaitingError> for PagerConstructionError {
-    fn from(err: AutoSchemaAwaitingError) -> Self {
-        match err {
-            AutoSchemaAwaitingError::SchemaAgreement(err) => {
-                PagerConstructionError::SchemaAgreement(err)
-            }
-            AutoSchemaAwaitingError::MetadataRefresh(err) => {
-                PagerConstructionError::MetadataRefresh(err)
-            }
-        }
-    }
-}
-
-impl From<PagerConstructionError> for PagerExecutionError {
-    fn from(err: PagerConstructionError) -> Self {
-        match err {
-            PagerConstructionError::NextPage(next_page_err) => {
-                PagerExecutionError::NextPageError(next_page_err)
-            }
-            PagerConstructionError::SchemaAgreement(schema_agreement_err) => {
-                PagerExecutionError::SchemaAgreementError(schema_agreement_err)
-            }
-            PagerConstructionError::MetadataRefresh(metadata_err) => {
-                PagerExecutionError::MetadataError(metadata_err)
-            }
-            PagerConstructionError::UseKeyspace(use_keyspace_err) => {
-                PagerExecutionError::UseKeyspaceError(use_keyspace_err)
-            }
-        }
-    }
 }

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -364,11 +364,11 @@ where
                 }
             };
 
+            let coordinator = Coordinator::new(node, &connection);
+
             // Retries on the same node as long as RetrySession decides so.
             'same_node_retries: loop {
                 trace!(parent: &span, "Execution started");
-
-                let coordinator = Coordinator::new(node, &connection);
 
                 // Fetch pages from this connection until an error occurs.
                 let (queries_result, new_sender): (

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1422,6 +1422,15 @@ impl From<AutoSchemaAwaitingError> for ExecutionError {
     }
 }
 
+impl From<AutoSchemaAwaitingError> for PagerExecutionError {
+    fn from(err: AutoSchemaAwaitingError) -> Self {
+        match err {
+            AutoSchemaAwaitingError::SchemaAgreement(e) => e.into(),
+            AutoSchemaAwaitingError::MetadataRefresh(e) => e.into(),
+        }
+    }
+}
+
 impl Session {
     pub(crate) async fn handle_auto_await_schema_agreement(
         &self,

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -354,6 +354,9 @@ async fn test_iter_methods_when_altering_table() {
 }
 
 #[tokio::test]
+#[ignore = "This test required coordinator stickiness in the pager,
+    which is temporarily not implemented in the middle of the undergoing refactor.
+    The next commit will reintroduce it and reenable this test."]
 async fn test_pager_timeouts() {
     setup_tracing();
 

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -354,9 +354,6 @@ async fn test_iter_methods_when_altering_table() {
 }
 
 #[tokio::test]
-#[ignore = "This test required coordinator stickiness in the pager,
-    which is temporarily not implemented in the middle of the undergoing refactor.
-    The next commit will reintroduce it and reenable this test."]
 async fn test_pager_timeouts() {
     setup_tracing();
 

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -32,8 +32,8 @@ use scylla_proxy::{
 use tracing::info;
 
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, scylla_supports_tablets, setup_tracing,
-    test_with_3_node_cluster, unique_keyspace_name,
+    PerformDDL as _, create_new_session_builder, fetch_negotiated_features,
+    scylla_supports_tablets, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
 };
 
 /// Basic pager functionality test
@@ -705,6 +705,179 @@ async fn test_pager_retry_receives_current_consistency() {
              RequestInfo, not the original query consistency (All)"
         );
     }
+}
+
+/// Regression test: consistency must be reset to the original query value at
+/// the start of each new page, even if a retry during a previous page
+/// downgraded it.
+///
+/// The bug: `current_consistency` not reset before starting the first query attempt
+/// for each page, so a downgrade performed during page N's retry
+/// sequence persisted into page N+1's first attempt.
+///
+/// This test observes the consistency of each Execute frame **on the wire**
+/// using proxy feedback channels, rather than inspecting what the retry policy
+/// receives. This keeps the two concerns separate:
+/// - `test_pager_retry_receives_current_consistency` verifies that the pager
+///   correctly reports `current_consistency` (not `query_consistency`) to the
+///   retry policy within a single page's retry loop.
+/// - This test verifies that `current_consistency` is reset to `query_consistency`
+///   at the start of each new page.
+///
+/// Execute sequence (all on the same node via coordinator stability):
+///
+/// | Execute # | Rule      | Consistency | Event                                       |
+/// |-----------|-----------|-------------|---------------------------------------------|
+/// | 1         | noop      | All         | Page 1 → success                            |
+/// | 2         | forge+cap | All         | Page 2, att.1 → error → downgrade All → One |
+/// | 3         | noop+cap  | One         | Page 2, att.2 → success                     |
+/// | 4         | forge+cap | All         | Page 3, att.1 → error → stop                |
+///
+/// The key assertion: Execute #4 uses `All`, not `One` — proving the reset.
+#[tokio::test]
+async fn test_pager_consistency_reset_between_pages() {
+    setup_tracing();
+
+    // The retry policy only needs to downgrade on the first failure (page 2,
+    // attempt 1) and give up on the second (page 3, attempt 1).
+    #[derive(Debug)]
+    struct DowngradeOnceThenStopPolicy;
+
+    impl RetryPolicy for DowngradeOnceThenStopPolicy {
+        fn new_session(&self) -> Box<dyn RetrySession> {
+            Box::new(DowngradeOnceThenStopSession { retried: false })
+        }
+    }
+
+    struct DowngradeOnceThenStopSession {
+        retried: bool,
+    }
+
+    impl RetrySession for DowngradeOnceThenStopSession {
+        fn decide_should_retry(&mut self, _: RequestInfo) -> RetryDecision {
+            if !self.retried {
+                self.retried = true;
+                RetryDecision::RetrySameTarget(Some(Consistency::One))
+            } else {
+                RetryDecision::DontRetry
+            }
+        }
+
+        fn reset(&mut self) {
+            self.retried = false;
+        }
+    }
+
+    let profile = ExecutionProfile::builder()
+        .consistency(Consistency::All)
+        .retry_policy(Arc::new(DowngradeOnceThenStopPolicy))
+        .build();
+
+    let features = fetch_negotiated_features(None).await;
+
+    let execute_not_control = Condition::RequestOpcode(RequestOpcode::Execute)
+        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+
+    // Feedback channels: the proxy sends each matched frame here so we can
+    // inspect its wire consistency after the test completes.
+    let (forged_tx, mut forged_rx) = mpsc::unbounded_channel();
+    let (passed_tx, mut passed_rx) = mpsc::unbounded_channel();
+
+    let res = test_with_3_node_cluster(
+        scylla_proxy::ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .default_execution_profile_handle(profile.into_handle())
+                .build()
+                .await
+                .unwrap();
+
+            // system_schema.tables has many built-in tables on both ScyllaDB
+            // and Cassandra, giving us at least 5 pages regardless of
+            // cluster size or backend.
+            let mut prepared = session
+                .prepare("SELECT keyspace_name FROM system_schema.tables LIMIT 5")
+                .await
+                .unwrap();
+            prepared.set_page_size(1);
+            prepared.set_is_idempotent(true);
+
+            // Rule 1: pass page 1 through silently (no feedback needed).
+            // Rule 2: forge server_error for every CL=All attempt; capture frame.
+            // Rule 3: pass everything else (CL=One retries) through; capture frame.
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![
+                    RequestRule(
+                        execute_not_control
+                            .clone()
+                            .and(Condition::TrueForLimitedTimes(1)),
+                        RequestReaction::noop(),
+                    ),
+                    RequestRule(
+                        execute_not_control
+                            .clone()
+                            .and(Condition::RequestConsistency(Consistency::All, features)),
+                        RequestReaction::forge()
+                            .server_error()
+                            .with_feedback_when_performed(forged_tx.clone()),
+                    ),
+                    RequestRule(
+                        execute_not_control.clone(),
+                        RequestReaction::noop().with_feedback_when_performed(passed_tx.clone()),
+                    ),
+                ]));
+            });
+
+            let pager = session.execute_iter(prepared, ()).await.unwrap();
+            let mut stream = pager.rows_stream::<Row>().unwrap();
+            while stream.next().await.transpose().is_ok_and(|r| r.is_some()) {}
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+
+    // Helper: extract the wire consistency from a captured frame.
+    let cl = |frame: scylla_proxy::RequestFrame| {
+        frame
+            .deserialize(&features)
+            .unwrap()
+            .get_consistency()
+            .unwrap()
+    };
+
+    // Execute 2 (page 2, attempt 1): must have been sent at All.
+    let (page2_att1, _) = forged_rx.recv().await.expect("page 2 att.1 frame missing");
+    assert_eq!(
+        cl(page2_att1),
+        Consistency::All,
+        "page 2 att.1 must use All"
+    );
+
+    // Execute 3 (page 2, attempt 2): downgraded to One by the retry policy.
+    let (page2_att2, _) = passed_rx.recv().await.expect("page 2 att.2 frame missing");
+    assert_eq!(
+        cl(page2_att2),
+        Consistency::One,
+        "page 2 att.2 must use One"
+    );
+
+    // Execute 4 (page 3, attempt 1): must be reset to All, not leaked One.
+    let (page3_att1, _) = forged_rx.recv().await.expect("page 3 att.1 frame missing");
+    assert_eq!(
+        cl(page3_att1),
+        Consistency::All,
+        "page 3 att.1 must use All (reset to query_consistency), not One \
+         (leaked from page 2 downgrade)"
+    );
 }
 
 /// Regression test: `execute_iter` and `query_iter` must not return a spurious

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -11,7 +11,12 @@ use assert_matches::assert_matches;
 use futures::{StreamExt as _, TryStreamExt as _};
 use scylla::{
     client::execution_profile::ExecutionProfile,
-    policies::retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySession},
+    cluster::{ClusterState, NodeRef},
+    policies::{
+        load_balancing::{FallbackPlan, LoadBalancingPolicy, RoutingInfo},
+        retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySession},
+    },
+    routing::Shard,
     statement::Statement,
     value::Row,
 };
@@ -813,5 +818,395 @@ async fn test_token_unaware_pager() {
             .rows_stream::<Row>()
             .unwrap();
         assert_pager_succeeds(stream, label).await;
+    }
+}
+
+// ---------- Shared infrastructure for pager plan tests ----------
+
+/// Retry policy that always retries on the next target in the query plan.
+#[derive(Debug)]
+struct AlwaysRetryNextTargetPolicy;
+
+impl RetryPolicy for AlwaysRetryNextTargetPolicy {
+    fn new_session(&self) -> Box<dyn RetrySession> {
+        Box::new(AlwaysRetryNextTargetSession)
+    }
+}
+
+struct AlwaysRetryNextTargetSession;
+
+impl RetrySession for AlwaysRetryNextTargetSession {
+    fn decide_should_retry(&mut self, _: RequestInfo) -> RetryDecision {
+        RetryDecision::RetryNextTarget(None)
+    }
+    fn reset(&mut self) {}
+}
+
+/// Load balancing policy that always returns nodes in get_nodes_info() order.
+#[derive(Debug)]
+struct FixedOrderLBP;
+
+impl LoadBalancingPolicy for FixedOrderLBP {
+    fn pick<'a>(
+        &'a self,
+        _query: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+    ) -> Option<(NodeRef<'a>, Option<Shard>)> {
+        cluster.get_nodes_info().first().map(|node| (node, Some(0)))
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        _query: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+    ) -> FallbackPlan<'a> {
+        Box::new(cluster.get_nodes_info().iter().map(|node| (node, Some(0))))
+    }
+
+    fn name(&self) -> String {
+        "FixedOrderLBP".to_owned()
+    }
+}
+
+/// Load balancing policy that rotates which node is picked first on each call.
+/// This is used to prove that coordinator stability overrides LBP preference.
+#[derive(Debug)]
+struct RotatingLBP {
+    counter: AtomicUsize,
+}
+
+impl LoadBalancingPolicy for RotatingLBP {
+    fn pick<'a>(
+        &'a self,
+        _query: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+    ) -> Option<(NodeRef<'a>, Option<Shard>)> {
+        let nodes = cluster.get_nodes_info();
+        let idx = self.counter.fetch_add(1, Ordering::Relaxed) % nodes.len();
+        Some((&nodes[idx], Some(0)))
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        _query: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+    ) -> FallbackPlan<'a> {
+        Box::new(cluster.get_nodes_info().iter().map(|node| (node, Some(0))))
+    }
+
+    fn name(&self) -> String {
+        "RotatingLBP".to_owned()
+    }
+}
+
+// ---------- Tests ----------
+
+/// Tests that per-page query plan creation prevents plan exhaustion across pages.
+///
+/// Each node allows the 1st request, errors on the 2nd, then recovers (3rd+ succeed).
+/// With the old single-plan approach, after each node errors once, the plan is exhausted
+/// and the query fails. With per-page plans, recovered nodes are retried on subsequent pages.
+#[tokio::test]
+async fn test_pager_per_page_plan_prevents_exhaustion() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        scylla_proxy::ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            // Set up proxy rules: per node, 1st request ok, 2nd request error, 3rd+ ok.
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![
+                    // 1st Execute request: pass through.
+                    RequestRule(
+                        Condition::RequestOpcode(RequestOpcode::Execute)
+                            .and(Condition::not(Condition::ConnectionRegisteredAnyEvent))
+                            .and(Condition::TrueForLimitedTimes(1)),
+                        RequestReaction::noop(),
+                    ),
+                    // 2nd Execute request: return Overloaded error.
+                    RequestRule(
+                        Condition::RequestOpcode(RequestOpcode::Execute)
+                            .and(Condition::not(Condition::ConnectionRegisteredAnyEvent))
+                            .and(Condition::TrueForLimitedTimes(1)),
+                        RequestReaction::forge_with_error(example_db_errors::overloaded()),
+                    ),
+                    // 3rd+ Execute requests: pass through (node recovered).
+                    RequestRule(
+                        Condition::RequestOpcode(RequestOpcode::Execute)
+                            .and(Condition::not(Condition::ConnectionRegisteredAnyEvent)),
+                        RequestReaction::noop(),
+                    ),
+                ]));
+            });
+
+            let profile = ExecutionProfile::builder()
+                .load_balancing_policy(Arc::new(FixedOrderLBP))
+                .retry_policy(Arc::new(AlwaysRetryNextTargetPolicy))
+                .build()
+                .into_handle();
+
+            // system_schema.tables has many built-in tables on both ScyllaDB
+            // and Cassandra, giving us at least 5 pages regardless of
+            // cluster size or backend.
+            let mut prepared = session
+                .prepare("SELECT keyspace_name FROM system_schema.tables LIMIT 5")
+                .await
+                .unwrap();
+            prepared.set_page_size(1);
+            prepared.set_is_idempotent(true);
+            prepared.set_execution_profile_handle(Some(profile));
+
+            // With the old single-plan approach, this would fail at page 4
+            // because the plan [A, B, C] gets exhausted after each node errors once.
+            // With per-page plans, recovered nodes are retried successfully.
+            let row_stream = session
+                .execute_iter(prepared, ())
+                .await
+                .unwrap()
+                .rows_stream::<(String,)>()
+                .unwrap();
+
+            let count = row_stream.map(|row| row.unwrap()).count().await;
+            assert_eq!(count, 5, "All 5 rows must be consumed successfully");
+            info!("test_pager_per_page_plan_prevents_exhaustion passed.");
+
+            running_proxy.turn_off_rules();
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Tests coordinator stability: once a node successfully serves a page, it is
+/// tried first for subsequent pages, regardless of what the LBP would prefer.
+///
+/// Uses a rotating LBP that picks a different node each time. Without coordinator
+/// stability, each page would go to a different node. With coordinator stability,
+/// all pages after the first go to the same node that served the first page.
+#[tokio::test]
+async fn test_pager_coordinator_stability() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        scylla_proxy::ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            // All nodes always succeed (no proxy rules needed beyond noop).
+            // Proxy rules are off by default (pass through), which is what we want.
+            running_proxy.turn_off_rules();
+
+            let profile = ExecutionProfile::builder()
+                .load_balancing_policy(Arc::new(RotatingLBP {
+                    counter: AtomicUsize::new(0),
+                }))
+                .build()
+                .into_handle();
+
+            let mut prepared = session
+                .prepare("SELECT keyspace_name FROM system_schema.tables LIMIT 5")
+                .await
+                .unwrap();
+            prepared.set_page_size(1);
+            prepared.set_is_idempotent(true);
+            prepared.set_execution_profile_handle(Some(profile));
+
+            let mut row_stream = session
+                .execute_iter(prepared, ())
+                .await
+                .unwrap()
+                .rows_stream::<(String,)>()
+                .unwrap();
+
+            // Consume all rows.
+            while let Some(row) = row_stream.next().await {
+                row.unwrap();
+            }
+
+            // Verify coordinator stability: all pages must have been served by
+            // the same node, despite the rotating LBP preferring different nodes.
+            let coordinators: Vec<_> = row_stream
+                .request_coordinators()
+                .map(|c| c.node().host_id)
+                .collect();
+            assert!(
+                coordinators.len() >= 2,
+                "Expected at least 2 pages, got {}",
+                coordinators.len()
+            );
+            let first = coordinators[0];
+            assert!(
+                coordinators.iter().all(|&id| id == first),
+                "Coordinator stability violated: expected all pages to be served by \
+                 the same node {:?}, but got {:?}",
+                first,
+                coordinators
+            );
+            info!("test_pager_coordinator_stability passed.");
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Tests that coordinator stability correctly switches to a new node when the
+/// current coordinator starts erroring, and then remains stable on the new one.
+///
+/// Each node allows exactly 3 successful requests, then errors forever.
+/// Expected coordinator pattern (with page_size=1, 7 rows = 7 pages):
+///
+/// - Page 1: node A, req 1 → ok (A: 1/3 used)
+/// - Page 2: node A (coordinator stability), req 2 → ok (A: 2/3 used)
+/// - Page 3: node A (coordinator stability), req 3 → ok (A: 3/3 used)
+/// - Page 4: node A (coordinator stability), req 4 → error (A exhausted)
+///   → RetryNextTarget → node B, req 1 → ok (B: 1/3 used)
+/// - Page 5: node B (coordinator stability), req 2 → ok (B: 2/3 used)
+/// - Page 6: node B (coordinator stability), req 3 → ok (B: 3/3 used)
+/// - Page 7: node B (coordinator stability), req 4 → error (B exhausted)
+///   → RetryNextTarget → node C, req 1 → ok (C: 1/3 used)
+///
+/// Coordinator pattern: [A, A, A, B, B, B, C] — stable within each tenure,
+/// switches are one-directional.
+#[tokio::test]
+async fn test_pager_coordinator_switches_on_error() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        scylla_proxy::ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            const N_ROWS: usize = 7;
+
+            // Each node allows 3 Execute requests, then errors forever.
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![
+                    RequestRule(
+                        Condition::RequestOpcode(RequestOpcode::Execute)
+                            .and(Condition::not(Condition::ConnectionRegisteredAnyEvent))
+                            .and(Condition::TrueForLimitedTimes(3)),
+                        RequestReaction::noop(),
+                    ),
+                    RequestRule(
+                        Condition::RequestOpcode(RequestOpcode::Execute)
+                            .and(Condition::not(Condition::ConnectionRegisteredAnyEvent)),
+                        RequestReaction::forge_with_error(example_db_errors::overloaded()),
+                    ),
+                ]));
+            });
+
+            let profile = ExecutionProfile::builder()
+                .load_balancing_policy(Arc::new(FixedOrderLBP))
+                .retry_policy(Arc::new(AlwaysRetryNextTargetPolicy))
+                .build()
+                .into_handle();
+
+            // system_schema.tables has many built-in tables on both ScyllaDB
+            // and Cassandra, giving us at least 7 pages regardless of
+            // cluster size or backend.
+            let mut prepared = session
+                .prepare("SELECT keyspace_name FROM system_schema.tables LIMIT 7")
+                .await
+                .unwrap();
+            prepared.set_page_size(1);
+            prepared.set_is_idempotent(true);
+            prepared.set_execution_profile_handle(Some(profile));
+
+            let mut row_stream = session
+                .execute_iter(prepared, ())
+                .await
+                .unwrap()
+                .rows_stream::<(String,)>()
+                .unwrap();
+
+            let mut count = 0;
+            while let Some(row) = row_stream.next().await {
+                row.unwrap();
+                count += 1;
+            }
+            assert_eq!(
+                count, N_ROWS,
+                "All {} rows must be consumed successfully",
+                N_ROWS
+            );
+
+            // Verify the coordinator pattern: stable within each "tenure",
+            // switches are one-directional (exhausted nodes never recover).
+            let coordinators: Vec<_> = row_stream
+                .request_coordinators()
+                .map(|c| c.node().host_id)
+                .collect();
+
+            // At least 2 distinct coordinators (proving a switch happened).
+            let distinct: std::collections::HashSet<_> = coordinators.iter().collect();
+            assert!(
+                distinct.len() >= 2,
+                "Expected at least 2 distinct coordinators (switch must happen), \
+                 but got {:?}",
+                coordinators
+            );
+
+            // Verify one-directional switches: once we leave a coordinator, we
+            // never go back (since exhausted nodes don't recover in this test).
+            let mut seen_coordinators = Vec::new();
+            for &coord in &coordinators {
+                if seen_coordinators.last() != Some(&coord) {
+                    assert!(
+                        !seen_coordinators.contains(&coord),
+                        "Coordinator {:?} re-appeared after being abandoned. \
+                         Pattern: {:?}",
+                        coord,
+                        coordinators
+                    );
+                    seen_coordinators.push(coord);
+                }
+            }
+
+            info!(
+                "test_pager_coordinator_switches_on_error passed. \
+                 Coordinator pattern: {:?}",
+                coordinators
+            );
+
+            running_proxy.turn_off_rules();
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
     }
 }


### PR DESCRIPTION
Fixes: #1736
Fixes: #1737 (for now, every successful coordinator is _sticky_, no matter if it's replica or not)

## What's Done

### Behavioral changes

1. Before, one `Plan` was used for all pages. Now, a fresh new `Plan` is produced for each page. This fixes #1737.
2. Before, the same target was queried until the pages are exhausted or the `RetrySession` decides to move on to the next target. Now, the previous target is reused if it has served the last page query successfully (_I've coined a term for this mechanism: **coordinator stickiness**_).
    - **TODO:** only apply _coordinator stickiness_ when the coordinator is a preferred target for the LBP. See [#1737](https://github.com/scylladb/scylla-rust-driver/issues/1737#issuecomment-4767346928) for the idea.
3. Before, the consistency would be stable across page queries. This meant that if the `RetrySession` decided to downgrade the consistency for one query, it would stay downgraded for the remaining page queries too. Now, the consistency is reset to the original one for each page.

### Performance changes

Before, the `PagerWorker` (for `Session::{query,execute}_iter()`) and `SingleConnectionPagerWorker` (for `ControlConnection::execute_iter()`) were spawned on a separate tokio task unconditionally. Now, they are spawned only for fetching second page and further pages, and only if the first page query returns `PagingStateResponse::HasMorePages`. This reduces overhead of single-paged queries, which are likely a common scenario.

### Internal refactors

- `PagerWorker` is now `'static`, allowing `Send`ing it from the main task to the new spawned task.
- `PagerConstructionError` is removed.
- `Coordinator` is no longer an `Option` in `FirstReceivedPage`, which removed the `expect()` and replaced that runtime assertion with type-system compile-time non-nullity assertion.
- The whole `ProvingSender` abstraction is removed, as the first page is no longer sent through the channel, but returned directly instead. 

### Testing

Tests are added for the new behaviour:
1. Verifies that a new Plan is created for each page.
2. Verifies that _coordinator stickiness_ is applied correctly (for now, for any target that responded successfully).
3. Verifies that consistency is reset for each page to the original value.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
