### PR TITLE
Fix renovate configuration and related issues

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
     - name: Install mdbook
-      uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.2
+      uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
       with:
         tool: mdbook
     - name: Build the book

--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   jira-sync:
-    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@45e7db1ba3b27a2ee342680a563593c5e2df692b
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@45e7db1ba3b27a2ee342680a563593c5e2df692b # main
     with:
       caller_action: ${{ github.event.action }}
     secrets:

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -217,6 +217,40 @@ When reviewing PRs that update the dependencies used in CI,
 ensure the commit comes from the actual release of the action. To do so, open the relevant repository
 and verify that the commit hash on the release page matches the one specified in the action YAML file.
 
+## Dependency updates (Renovate)
+
+Dependency updates - both Cargo crates and GitHub Actions - are managed by
+[Renovate](https://docs.renovatebot.com/). Its configuration lives in
+`renovate.json`. For most dependencies Renovate simply opens a PR when a new
+version is available, and a maintainer reviews and merges it as usual.
+
+However, **not every out-of-date dependency results in a PR**. Some updates are
+intentionally gated and are only visible on the **Dependency Dashboard** - an
+issue that Renovate keeps up to date in the repository (titled "Dependency
+Dashboard"). Maintainers should periodically check that issue to see updates
+that do not have a PR. In particular:
+
+- **Feature-pinned crates.** Some crates are depended on through a
+  "feature-per-version" scheme: each supported major is a separate renamed
+  dependency behind its own Cargo feature (e.g. `num-bigint-03` and
+  `num-bigint-04`, or `secrecy-08` and `secrecy-10`). A plain version bump
+  cannot be applied to these automatically - adopting a new major requires
+  adding a new feature and alias by hand. For the newest supported alias of
+  each such crate, Renovate is configured with `dependencyDashboardApproval`,
+  so a new major (e.g. `num-bigint` 0.5) will appear on the Dependency
+  Dashboard instead of as a PR. When you see such an entry, the action is to
+  introduce a new feature + alias for that version (not to "just bump" the
+  existing one). Approving the dashboard entry would only create the (useless)
+  bump PR, so usually you should leave it and handle the new feature manually.
+- **Superseded aliases.** The older aliases of those crates
+  (e.g. `num-bigint-03`, `secrecy-08`) are frozen at their version and have
+  Renovate disabled entirely (`enabled: false`), so they intentionally produce
+  neither PRs nor Dependency Dashboard entries.
+
+If you add a new feature-pinned crate (or a new supported version of an
+existing one), update `renovate.json` accordingly: the newest alias should get
+`dependencyDashboardApproval`, and the alias it supersedes should be disabled.
+
 ## Writing release notes
 
 PR titles are written for maintainers, but release notes entries are written for users.

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,31 @@
             ],
             "pinDigests": true,
             "minimumReleaseAge": null
+        },
+        {
+            "description": "Newest supported version of feature-pinned crates: surface new majors on the Dependency Dashboard (no PR), as adopting them needs a new feature/alias.",
+            "matchManagers": [
+                "cargo"
+            ],
+            "matchDepNames": [
+                "num-bigint-04",
+                "secrecy-10",
+                "bigdecimal-04",
+                "time-03",
+                "chrono-04"
+            ],
+            "dependencyDashboardApproval": true
+        },
+        {
+            "description": "Superseded versions of feature-pinned crates: frozen at their version, do not notify about newer releases.",
+            "matchManagers": [
+                "cargo"
+            ],
+            "matchDepNames": [
+                "num-bigint-03",
+                "secrecy-08"
+            ],
+            "enabled": false
         }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
             "minimumReleaseAge": "90 days"
         },
         {
+            "description": "Skip wait period for scylladb actions. This is generally a no-op, because minimumReleaseAge doesn't work for pure hashes on branches - it needs releases. Keeping it here in case this changes in the future.",
             "matchManagers": [
                 "github-actions"
             ],
@@ -19,7 +20,6 @@
                 "/^scylladb-actions\\//",
                 "/^scylladb\\//"
             ],
-            "pinDigests": true,
             "minimumReleaseAge": null
         },
         {


### PR DESCRIPTION
Renovate opened some undesirable PRs, and skipped an important change (bumping jira sync).
This PR fixes all of that, with details explained in commits.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
