### PR TITLE
Update histogram to 1.0

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -122,7 +122,7 @@ tokio-rustls = { version = "0.26", optional = true }
 # Internal utilities
 ####################
 # Used in metrics.
-histogram = { version = "0.11.1", optional = true }
+histogram = { version = "1", optional = true }
 # Used by authentication and address translation public traits.
 # Technically not part of public API, since it just transforms the
 # trait code, which we could do without it.

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -565,6 +565,31 @@ mod tests {
 
     use super::Metrics;
 
+    // Characterization test for a small, hand-verifiable distribution where
+    // every bucket has width 1 (values are well below 2^(grouping_power + 1)),
+    // so the bucket midpoints equal the inserted values exactly.
+    #[test]
+    fn characterization_known_distribution() {
+        let metrics = Metrics::new();
+        for v in 0..=100u64 {
+            metrics.log_query_latency(v).unwrap();
+        }
+
+        let snapshot = metrics.get_snapshot().unwrap();
+        assert_eq!(snapshot.min, 0);
+        assert_eq!(snapshot.max, 100);
+        assert_eq!(snapshot.mean, 50);
+        assert_eq!(snapshot.stddev, 29);
+        assert_eq!(snapshot.median, 50);
+        assert_eq!(snapshot.percentile_75, 75);
+        assert_eq!(snapshot.percentile_95, 95);
+        assert_eq!(snapshot.percentile_98, 98);
+        assert_eq!(snapshot.percentile_99, 99);
+        assert_eq!(snapshot.percentile_99_9, 100);
+
+        assert_eq!(metrics.get_latency_avg_ms().unwrap(), 50);
+    }
+
     // A regression test for a bug where we would return
     // the number of observations in the bucket for the given percentile.
     #[test]

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -339,14 +339,20 @@ impl Metrics {
     ///
     /// * `percentile` - float value (0.0 - 100.0)
     pub fn get_latency_percentile_ms(&self, percentile: f64) -> Result<u64, MetricsError> {
-        let res = self.histogram.load().percentile(percentile);
+        // `histogram` 1.x uses the 0.0..=1.0 quantile scale, whereas our
+        // public API uses the 0.0..=100.0 percentile scale.
+        let res = self.histogram.load().quantile(percentile / 100.0);
 
         match res {
             Err(err) => Err(MetricsError::HistogramError(Arc::new(err))),
 
             Ok(None) => Err(MetricsError::Empty),
 
-            Ok(Some(p)) => Ok(p.count()),
+            // A single quantile was requested, so there is exactly one entry.
+            Ok(Some(qr)) => match qr.entries().values().next() {
+                Some(bucket) => Ok(bucket.count()),
+                None => Err(MetricsError::Empty),
+            },
         }
     }
 
@@ -359,11 +365,12 @@ impl Metrics {
 
         let (min, max) = Self::minmax(&h)?;
 
-        let percentile_args = [50.0, 75.0, 95.0, 98.0, 99.0, 99.9];
-        let mut percentiles = Self::percentiles(&h, &percentile_args)?;
+        // `histogram` uses the 0.0..=1.0 quantile scale.
+        let quantile_args = [0.50, 0.75, 0.95, 0.98, 0.99, 0.999];
+        let mut percentiles = Self::percentiles(&h, &quantile_args)?;
 
         // SAFETY: `unwrap()`s are OK here, because `Self::percentiles()` returned iterator's length
-        // is equal to number of elements in `percentile_args`.
+        // is equal to number of elements in `quantile_args`.
         let median = percentiles.next().unwrap();
         let percentile_75 = percentiles.next().unwrap();
         let percentile_95 = percentiles.next().unwrap();
@@ -473,21 +480,31 @@ impl Metrics {
             .ok_or(MetricsError::Empty)
     }
 
+    /// Computes the bucket midpoints for the given `quantiles`, which must be
+    /// on the 0.0..=1.0 scale used by the `histogram` crate.
     fn percentiles(
         h: &Histogram,
-        percentiles: &[f64],
+        quantiles: &[f64],
     ) -> Result<impl Iterator<Item = u64> + use<>, MetricsError> {
-        let res = h.percentiles(percentiles);
+        let res = h.quantiles(quantiles);
 
         match res {
             Err(err) => Err(MetricsError::HistogramError(Arc::new(err))),
 
             Ok(None) => Err(MetricsError::Empty),
 
-            Ok(Some(ps)) => Ok(ps
-                .into_iter()
+            // `entries()` is a `BTreeMap` keyed by quantile, so iterating its
+            // values yields buckets in ascending quantile order.
+            Ok(Some(qr)) => Ok(qr
+                .entries()
+                .values()
                 // Get the mean value from the bucket.
-                .map(|(_, bucket)| (bucket.start() + bucket.end()) / 2)),
+                .map(|bucket| (bucket.start() + bucket.end()) / 2)
+                // https://github.com/iopsystems/histogram/issues/23
+                // Until `into_entries` is added, we need this additional Vec.
+                // https://github.com/iopsystems/histogram/pull/24
+                .collect::<Vec<_>>()
+                .into_iter()),
         }
     }
 


### PR DESCRIPTION
This PR bumps histogram dependency version to 1.0.

Replaces https://github.com/scylladb/scylla-rust-driver/pull/1738 - updating to 1.0 is a bit more involved than just bumping the version.



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
