### PR TITLE
Fix bug in `Metrics::get_latency_percentile_ms`

### DIFF
--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -337,7 +337,7 @@ impl Metrics {
     /// Returns latency from histogram for a given percentile
     /// # Arguments
     ///
-    /// * `percentile` - float value (0.0 - 100.0)
+    /// * `percentile` - float value (0.0..=100.0)
     pub fn get_latency_percentile_ms(&self, percentile: f64) -> Result<u64, MetricsError> {
         // `histogram` 1.x uses the 0.0..=1.0 quantile scale, whereas our
         // public API uses the 0.0..=100.0 percentile scale.

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -350,7 +350,7 @@ impl Metrics {
 
             // A single quantile was requested, so there is exactly one entry.
             Ok(Some(qr)) => match qr.entries().values().next() {
-                Some(bucket) => Ok(bucket.count()),
+                Some(bucket) => Ok((bucket.start() + bucket.end()) / 2),
                 None => Err(MetricsError::Empty),
             },
         }
@@ -605,6 +605,29 @@ mod tests {
         assert_eq!(snapshot.percentile_99_9, 100);
 
         assert_eq!(metrics.get_latency_avg_ms().unwrap(), 50);
+    }
+
+    #[test]
+    fn regression_get_latency_percentile_ms() {
+        let metrics = Metrics::new();
+        // One bucket (value 5) with 10 observations, another (value 1000) with 1.
+        for _ in 0..10 {
+            metrics.log_query_latency(5).unwrap();
+        }
+        metrics.log_query_latency(1000).unwrap();
+
+        // The public API uses the 0.0..=100.0 percentile scale.
+        assert_eq!(metrics.get_latency_percentile_ms(0.0).unwrap(), 5);
+        assert_eq!(metrics.get_latency_percentile_ms(50.0).unwrap(), 5);
+        assert_eq!(metrics.get_latency_percentile_ms(90.0).unwrap(), 5);
+        assert_eq!(metrics.get_latency_percentile_ms(100.0).unwrap(), 1000);
+
+        // Empty histogram yields the `Empty` error.
+        let empty = Metrics::new();
+        assert!(matches!(
+            empty.get_latency_percentile_ms(50.0),
+            Err(super::MetricsError::Empty)
+        ));
     }
 
     // A regression test for a bug where we would return


### PR DESCRIPTION
It was returning bucket count, instead of median value.
This is the exact same bug that was fixed in https://github.com/scylladb/scylla-rust-driver/pull/1327 , but this time
in get_latency_percentile_ms.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1745

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
