### PR TITLE
Metrics: `cfg` refactor

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -36,7 +36,6 @@ use crate::frame::response::result;
 use crate::network::Connection;
 use crate::observability::driver_tracing::RequestSpan;
 use crate::observability::history::{self, HistoryListener};
-#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
 use crate::policies::retry::{RequestInfo, RetryDecision, RetrySession};
@@ -305,7 +304,6 @@ struct PagerWorker<'a, QueryFunc, SpanCreatorFunc> {
     query_consistency: Consistency,
     retry_session: Box<dyn RetrySession>,
     timeouter: Option<PageQueryTimeouter>,
-    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 
     paging_state: PagingState,
@@ -443,13 +441,11 @@ where
 
                 match retry_decision {
                     RetryDecision::RetrySameTarget(cl) => {
-                        #[cfg(feature = "metrics")]
                         self.metrics.inc_retries_num();
                         current_consistency = cl.unwrap_or(current_consistency);
                         continue 'same_node_retries;
                     }
                     RetryDecision::RetryNextTarget(cl) => {
-                        #[cfg(feature = "metrics")]
                         self.metrics.inc_retries_num();
                         current_consistency = cl.unwrap_or(current_consistency);
                         continue 'nodes_in_plan;
@@ -602,7 +598,6 @@ where
         request_span: &RequestSpan,
     ) -> Result<(Duration, Result<NonErrorQueryResponse, RequestAttemptError>), RequestTimeoutError>
     {
-        #[cfg(feature = "metrics")]
         self.metrics.inc_total_paged_queries();
         let query_start = std::time::Instant::now();
 
@@ -623,7 +618,6 @@ where
                 match tokio::time::timeout_at(timeouter.deadline(), runner).await {
                     Ok(res) => res,
                     Err(_) /* tokio::time::error::Elapsed */ => {
-                        #[cfg(feature = "metrics")]
                         self.metrics.inc_request_timeouts();
                         return Err(RequestTimeoutError(timeouter.timeout_duration()));
                     }
@@ -656,7 +650,6 @@ where
         (RequestAttemptError, ProvingSender<ResultFirstPage>),
     > {
         let mut log_success = || {
-            #[cfg(feature = "metrics")]
             let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
             self.log_attempt_success();
             self.log_request_success();
@@ -708,7 +701,6 @@ where
                 Ok((ControlFlow::Continue(()), proof, next_pages_sender))
             }
             Err(err) => {
-                #[cfg(feature = "metrics")]
                 self.metrics.inc_failed_paged_queries();
                 self.load_balancing_policy.on_request_failure(
                     &self.routing_info,
@@ -786,7 +778,6 @@ where
                 Ok((ControlFlow::Break(()), proof, next_pages_sender))
             }
             Ok(response) => {
-                #[cfg(feature = "metrics")]
                 self.metrics.inc_failed_paged_queries();
                 let err =
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
@@ -819,7 +810,6 @@ where
                 tracing_id,
                 ..
             }) => {
-                #[cfg(feature = "metrics")]
                 let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                 self.log_attempt_success();
                 self.log_request_success();
@@ -860,7 +850,6 @@ where
             // This catches all other kinds of responses that are not rows.
             // As this is not the first page, this is certainly an error.
             Ok(response) => {
-                #[cfg(feature = "metrics")]
                 self.metrics.inc_failed_paged_queries();
                 let err =
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
@@ -873,7 +862,6 @@ where
                 Err(err)
             }
             Err(err) => {
-                #[cfg(feature = "metrics")]
                 self.metrics.inc_failed_paged_queries();
                 self.load_balancing_policy.on_request_failure(
                     &self.routing_info,
@@ -1090,7 +1078,6 @@ pub(crate) struct PreparedPagerConfig {
     pub(crate) values: SerializedValues,
     pub(crate) execution_profile: Arc<ExecutionProfileInner>,
     pub(crate) cluster_state: Arc<ClusterState>,
-    #[cfg(feature = "metrics")]
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) location_preference: Arc<NodeLocationPreference>,
 }
@@ -1221,7 +1208,7 @@ If you are using this API, you are probably doing something wrong."
         statement: Statement,
         execution_profile: Arc<ExecutionProfileInner>,
         cluster_state: Arc<ClusterState>,
-        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
+        metrics: Arc<Metrics>,
         node_location_preference: Arc<NodeLocationPreference>,
     ) -> Result<Self, PagerExecutionError> {
         let (sender, receiver) = oneshot::channel::<ResultFirstPage>();
@@ -1299,7 +1286,6 @@ If you are using this API, you are probably doing something wrong."
                 load_balancing_policy,
                 retry_session,
                 timeouter,
-                #[cfg(feature = "metrics")]
                 metrics,
                 paging_state: PagingState::start(),
                 history_listener: statement.config.history_listener.as_ref().map(Arc::clone),
@@ -1434,7 +1420,6 @@ If you are using this API, you are probably doing something wrong."
                 load_balancing_policy,
                 retry_session,
                 timeouter,
-                #[cfg(feature = "metrics")]
                 metrics: config.metrics,
                 paging_state: PagingState::start(),
                 history_listener: config

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -304,7 +304,7 @@ struct PagerWorker<'a, QueryFunc, SpanCreatorFunc> {
     query_consistency: Consistency,
     retry_session: Box<dyn RetrySession>,
     timeouter: Option<PageQueryTimeouter>,
-    metrics: Arc<Metrics>,
+    metrics: Metrics,
 
     paging_state: PagingState,
 
@@ -1078,7 +1078,7 @@ pub(crate) struct PreparedPagerConfig {
     pub(crate) values: SerializedValues,
     pub(crate) execution_profile: Arc<ExecutionProfileInner>,
     pub(crate) cluster_state: Arc<ClusterState>,
-    pub(crate) metrics: Arc<Metrics>,
+    pub(crate) metrics: Metrics,
     pub(crate) location_preference: Arc<NodeLocationPreference>,
 }
 
@@ -1208,7 +1208,7 @@ If you are using this API, you are probably doing something wrong."
         statement: Statement,
         execution_profile: Arc<ExecutionProfileInner>,
         cluster_state: Arc<ClusterState>,
-        metrics: Arc<Metrics>,
+        metrics: Metrics,
         node_location_preference: Arc<NodeLocationPreference>,
     ) -> Result<Self, PagerExecutionError> {
         let (sender, receiver) = oneshot::channel::<ResultFirstPage>();

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1172,7 +1172,7 @@ impl Session {
             host_listener,
             config.cluster_metadata_refresh_interval,
             tablet_receiver,
-            Arc::clone(&metrics),
+            metrics.as_ref().clone(),
             client_routes_config,
         )
         .await?;
@@ -1474,7 +1474,7 @@ impl Session {
             statement,
             execution_profile,
             self.cluster.get_state(),
-            Arc::clone(&self.metrics),
+            self.metrics.as_ref().clone(),
             Arc::clone(&self.node_location_preference),
         )
         .await
@@ -1800,7 +1800,7 @@ impl Session {
                 values,
                 execution_profile,
                 cluster_state: self.cluster.get_state(),
-                metrics: Arc::clone(&self.metrics),
+                metrics: self.metrics.as_ref().clone(),
                 location_preference: Arc::clone(&self.node_location_preference),
             },
         )

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -22,7 +22,6 @@ use crate::network::{
 };
 use crate::observability::driver_tracing::RequestSpan;
 use crate::observability::history::{self, HistoryListener};
-#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::observability::tracing::TracingInfo;
 use crate::policies::address_translator::AddressTranslator;
@@ -88,7 +87,6 @@ pub struct Session {
     cluster: Cluster,
     default_execution_profile_handle: ExecutionProfileHandle,
     schema_agreement_interval: Duration,
-    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
     schema_agreement_timeout: Duration,
     schema_agreement_automatic_waiting: bool,
@@ -113,7 +111,6 @@ impl std::fmt::Debug for Session {
             )
             .field("schema_agreement_interval", &self.schema_agreement_interval);
 
-        #[cfg(feature = "metrics")]
         d.field("metrics", &self.metrics);
 
         d.field(
@@ -1140,7 +1137,6 @@ impl Session {
             reconnect_policy: Arc::new(ExponentialReconnectPolicy::new()),
         };
 
-        #[cfg(feature = "metrics")]
         let metrics = Arc::new(Metrics::new());
 
         let host_listener = {
@@ -1176,7 +1172,6 @@ impl Session {
             host_listener,
             config.cluster_metadata_refresh_interval,
             tablet_receiver,
-            #[cfg(feature = "metrics")]
             Arc::clone(&metrics),
             client_routes_config,
         )
@@ -1188,7 +1183,6 @@ impl Session {
             cluster,
             default_execution_profile_handle,
             schema_agreement_interval: config.schema_agreement_interval,
-            #[cfg(feature = "metrics")]
             metrics,
             schema_agreement_timeout: config.schema_agreement_timeout,
             schema_agreement_automatic_waiting: config.schema_agreement_automatic_waiting,
@@ -1480,7 +1474,6 @@ impl Session {
             statement,
             execution_profile,
             self.cluster.get_state(),
-            #[cfg(feature = "metrics")]
             Arc::clone(&self.metrics),
             Arc::clone(&self.node_location_preference),
         )
@@ -1807,7 +1800,6 @@ impl Session {
                 values,
                 execution_profile,
                 cluster_state: self.cluster.get_state(),
-                #[cfg(feature = "metrics")]
                 metrics: Arc::clone(&self.metrics),
                 location_preference: Arc::clone(&self.node_location_preference),
             },
@@ -2196,7 +2188,6 @@ impl Session {
         let result = match effective_timeout {
             Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
                 |_: tokio::time::error::Elapsed| {
-                    #[cfg(feature = "metrics")]
                     self.metrics.inc_request_timeouts();
 
                     let timeout_error = RequestError::RequestTimeout(timeout);
@@ -2267,7 +2258,6 @@ impl Session {
                 };
                 context.request_span.record_shard_id(&connection);
 
-                #[cfg(feature = "metrics")]
                 self.metrics.inc_total_nonpaged_queries();
                 let request_start = std::time::Instant::now();
 
@@ -2291,7 +2281,6 @@ impl Session {
                 let request_error: RequestAttemptError = match request_result {
                     Ok(response) => {
                         trace!(parent: &span, "Request succeeded");
-                        #[cfg(feature = "metrics")]
                         let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
                         context.load_balancing_policy.on_request_success(
@@ -2307,7 +2296,6 @@ impl Session {
                             last_error = %e,
                             "Request failed"
                         );
-                        #[cfg(feature = "metrics")]
                         self.metrics.inc_failed_nonpaged_queries();
                         context.load_balancing_policy.on_request_failure(
                             context.query_info,
@@ -2340,13 +2328,11 @@ impl Session {
 
                 match retry_decision {
                     RetryDecision::RetrySameTarget(new_cl) => {
-                        #[cfg(feature = "metrics")]
                         self.metrics.inc_retries_num();
                         current_consistency = new_cl.unwrap_or(current_consistency);
                         continue 'same_node_retries;
                     }
                     RetryDecision::RetryNextTarget(new_cl) => {
-                        #[cfg(feature = "metrics")]
                         self.metrics.inc_retries_num();
                         current_consistency = new_cl.unwrap_or(current_consistency);
                         continue 'nodes_in_plan;

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -7,7 +7,6 @@ use crate::errors::{ConnectionPoolError, DnsLookupError, UseKeyspaceError};
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{Connection, ConnectivityChangeEvent};
 use crate::network::{NodeConnectionPool, PoolConfig};
-#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 /// Node represents a cluster node along with it's data and connections
 use crate::routing::{Shard, Sharder};
@@ -120,7 +119,7 @@ impl Node {
         pool_config: &PoolConfig,
         connectivity_events_sender: tokio::sync::mpsc::UnboundedSender<ConnectivityChangeEvent>,
         keyspace_name: Option<VerifiedKeyspaceName>,
-        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
+        metrics: Arc<Metrics>,
     ) -> Self {
         let host_id = peer.host_id;
         let address = peer.address;
@@ -135,7 +134,6 @@ impl Node {
             Some((host_id, connectivity_events_sender)),
             keyspace_name,
             pool_empty_notifier,
-            #[cfg(feature = "metrics")]
             metrics,
         );
 

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -119,7 +119,7 @@ impl Node {
         pool_config: &PoolConfig,
         connectivity_events_sender: tokio::sync::mpsc::UnboundedSender<ConnectivityChangeEvent>,
         keyspace_name: Option<VerifiedKeyspaceName>,
-        metrics: Arc<Metrics>,
+        metrics: Metrics,
     ) -> Self {
         let host_id = peer.host_id;
         let address = peer.address;

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,6 +1,5 @@
 use crate::errors::{ClusterStateTokenError, ConnectionPoolError};
 use crate::network::{Connection, ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
-#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::host_filter::HostFilter;
 use crate::routing::locator::ReplicaLocator;
@@ -143,7 +142,7 @@ impl ClusterState {
         connectivity_events_sender: &mpsc::UnboundedSender<ConnectivityChangeEvent>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
-        #[cfg(feature = "metrics")] metrics: &Arc<Metrics>,
+        metrics: &Arc<Metrics>,
     ) -> Self {
         // Create new updated known_nodes and ring
         let mut new_known_nodes: HashMap<Uuid, Arc<Node>> =
@@ -194,7 +193,6 @@ impl ClusterState {
                     pool_config,
                     connectivity_events_sender.clone(),
                     used_keyspace.clone(),
-                    #[cfg(feature = "metrics")]
                     Arc::clone(metrics),
                 )),
             };
@@ -601,7 +599,6 @@ mod tests {
             &tx,
             TabletsInfo::new(),
             &HashMap::new(),
-            #[cfg(feature = "metrics")]
             &Default::default(),
         )
         .await

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -142,7 +142,7 @@ impl ClusterState {
         connectivity_events_sender: &mpsc::UnboundedSender<ConnectivityChangeEvent>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
-        metrics: &Arc<Metrics>,
+        metrics: &Metrics,
     ) -> Self {
         // Create new updated known_nodes and ring
         let mut new_known_nodes: HashMap<Uuid, Arc<Node>> =
@@ -193,7 +193,7 @@ impl ClusterState {
                     pool_config,
                     connectivity_events_sender.clone(),
                     used_keyspace.clone(),
-                    Arc::clone(metrics),
+                    metrics.clone(),
                 )),
             };
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -107,7 +107,7 @@ struct ClusterWorker {
     // worker will refresh the cluster metadata
     cluster_metadata_refresh_interval: Duration,
 
-    metrics: Arc<Metrics>,
+    metrics: Metrics,
 }
 
 #[derive(Debug)]
@@ -134,7 +134,7 @@ impl Cluster {
         host_listener: Option<Arc<dyn HostListener>>,
         cluster_metadata_refresh_interval: Duration,
         tablet_receiver: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
-        metrics: Arc<Metrics>,
+        metrics: Metrics,
         client_routes_config: Option<ClientRoutesConfig>,
     ) -> Result<Cluster, NewSessionError> {
         let (refresh_sender, refresh_receiver) = tokio::sync::mpsc::channel(32);

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -7,7 +7,6 @@ use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::frame::response::event::EventV2 as Event;
 use crate::network::{ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
-#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
@@ -108,7 +107,6 @@ struct ClusterWorker {
     // worker will refresh the cluster metadata
     cluster_metadata_refresh_interval: Duration,
 
-    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 }
 
@@ -136,7 +134,7 @@ impl Cluster {
         host_listener: Option<Arc<dyn HostListener>>,
         cluster_metadata_refresh_interval: Duration,
         tablet_receiver: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
-        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
+        metrics: Arc<Metrics>,
         client_routes_config: Option<ClientRoutesConfig>,
     ) -> Result<Cluster, NewSessionError> {
         let (refresh_sender, refresh_receiver) = tokio::sync::mpsc::channel(32);
@@ -195,7 +193,6 @@ impl Cluster {
             &connectivity_events_sender,
             TabletsInfo::new(),
             &HashMap::new(),
-            #[cfg(feature = "metrics")]
             &metrics,
         )
         .await;
@@ -223,7 +220,6 @@ impl Cluster {
             host_listener,
             cluster_metadata_refresh_interval,
 
-            #[cfg(feature = "metrics")]
             metrics,
         };
 
@@ -513,7 +509,6 @@ impl ClusterWorker {
                 &self.connectivity_events_sender,
                 cluster_state.locator.tablets.clone(),
                 &cluster_state.keyspaces,
-                #[cfg(feature = "metrics")]
                 &self.metrics,
             )
             .await,

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -13,7 +13,6 @@ use crate::routing::{Shard, ShardCount, Sharder};
 
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
 
-#[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
 
 use crate::cluster::NodeAddr;
@@ -223,7 +222,7 @@ impl NodeConnectionPool {
         connectivity_events_sender: Option<(Uuid, mpsc::UnboundedSender<ConnectivityChangeEvent>)>,
         current_keyspace: Option<VerifiedKeyspaceName>,
         pool_empty_notifier: mpsc::Sender<()>,
-        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
+        metrics: Arc<Metrics>,
     ) -> Self {
         let (use_keyspace_request_sender, use_keyspace_request_receiver) = mpsc::channel(1);
         let pool_updated_notify = Arc::new(Notify::new());
@@ -241,7 +240,6 @@ impl NodeConnectionPool {
             pool_updated_notify.clone(),
             refill_now_notify.clone(),
             pool_empty_notifier,
-            #[cfg(feature = "metrics")]
             metrics,
             host_reconnect_policy,
         );
@@ -521,7 +519,6 @@ struct PoolRefiller {
     // Signaled when the connection pool becomes empty
     pool_empty_notifier: mpsc::Sender<()>,
 
-    #[cfg(feature = "metrics")]
     metrics: Arc<Metrics>,
 }
 
@@ -532,8 +529,7 @@ struct UseKeyspaceRequest {
 }
 
 impl PoolRefiller {
-    #[allow(clippy::too_many_arguments)] // Not always triggered, because of the metrics, so
-    // I can't use `expect`.
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         endpoint: Arc<RwLock<UntranslatedEndpoint>>,
         pool_config: HostPoolConfig,
@@ -542,7 +538,7 @@ impl PoolRefiller {
         pool_updated_notify: Arc<Notify>,
         refill_now_notify: Arc<Notify>,
         pool_empty_notifier: mpsc::Sender<()>,
-        #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
+        metrics: Arc<Metrics>,
         reconnect_policy: Box<dyn ReconnectPolicySession>,
     ) -> Self {
         // At the beginning, we assume the node does not have any shards
@@ -575,7 +571,6 @@ impl PoolRefiller {
             refill_now_notify,
             pool_empty_notifier,
 
-            #[cfg(feature = "metrics")]
             metrics,
         }
     }
@@ -943,7 +938,6 @@ impl PoolRefiller {
         let cfg = self.pool_config.connection_config.clone();
         let mut endpoint = self.endpoint.read().unwrap().clone();
 
-        #[cfg(feature = "metrics")]
         let count_in_metrics = {
             let metrics = Arc::clone(&self.metrics);
             move |connect_result: &Result<_, ConnectionError>| {
@@ -969,7 +963,6 @@ impl PoolRefiller {
                 )
                 .await;
 
-                #[cfg(feature = "metrics")]
                 count_in_metrics(&result);
 
                 OpenedConnectionEvent {
@@ -983,7 +976,6 @@ impl PoolRefiller {
                 let non_shard_aware_endpoint = endpoint;
                 let result = open_connection(&non_shard_aware_endpoint, None, &cfg).await;
 
-                #[cfg(feature = "metrics")]
                 count_in_metrics(&result);
 
                 OpenedConnectionEvent {
@@ -1128,7 +1120,6 @@ impl PoolRefiller {
             match maybe_idx {
                 Some(idx) => {
                     v.swap_remove(idx);
-                    #[cfg(feature = "metrics")]
                     self.metrics.dec_total_connections();
                     true
                 }

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -222,7 +222,7 @@ impl NodeConnectionPool {
         connectivity_events_sender: Option<(Uuid, mpsc::UnboundedSender<ConnectivityChangeEvent>)>,
         current_keyspace: Option<VerifiedKeyspaceName>,
         pool_empty_notifier: mpsc::Sender<()>,
-        metrics: Arc<Metrics>,
+        metrics: Metrics,
     ) -> Self {
         let (use_keyspace_request_sender, use_keyspace_request_receiver) = mpsc::channel(1);
         let pool_updated_notify = Arc::new(Notify::new());
@@ -519,7 +519,7 @@ struct PoolRefiller {
     // Signaled when the connection pool becomes empty
     pool_empty_notifier: mpsc::Sender<()>,
 
-    metrics: Arc<Metrics>,
+    metrics: Metrics,
 }
 
 #[derive(Debug)]
@@ -538,7 +538,7 @@ impl PoolRefiller {
         pool_updated_notify: Arc<Notify>,
         refill_now_notify: Arc<Notify>,
         pool_empty_notifier: mpsc::Sender<()>,
-        metrics: Arc<Metrics>,
+        metrics: Metrics,
         reconnect_policy: Box<dyn ReconnectPolicySession>,
     ) -> Self {
         // At the beginning, we assume the node does not have any shards
@@ -939,7 +939,7 @@ impl PoolRefiller {
         let mut endpoint = self.endpoint.read().unwrap().clone();
 
         let count_in_metrics = {
-            let metrics = Arc::clone(&self.metrics);
+            let metrics = self.metrics.clone();
             move |connect_result: &Result<_, ConnectionError>| {
                 if connect_result.is_ok() {
                     metrics.inc_total_connections();

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -216,7 +216,18 @@ impl Default for RequestRateMeter {
 }
 
 /// Various metrics collected by the driver.
+///
+/// `Metrics` is cheaply cloneable — all clones share the same underlying
+/// counters and histogram, so recording on any clone is visible through every
+/// other clone.  This is achieved by wrapping the actual data in an `Arc`
+/// internally; cloning `Metrics` costs one atomic reference-count increment.
+#[derive(Clone)]
 pub struct Metrics {
+    inner: Arc<MetricsInner>,
+}
+
+/// Storage for all metric counters and histograms.
+struct MetricsInner {
     /// Number of errors that occurred in queries executed without `QueryPager`.
     errors_num: AtomicU64,
     /// Number of queries executed without `QueryPager`.
@@ -252,67 +263,69 @@ impl Metrics {
         let grouping_power = 12;
 
         Self {
-            errors_num: AtomicU64::new(0),
-            queries_num: AtomicU64::new(0),
-            errors_iter_num: AtomicU64::new(0),
-            queries_iter_num: AtomicU64::new(0),
-            retries_num: AtomicU64::new(0),
-            histogram: Arc::new(AtomicHistogram::new(grouping_power, max_value_power).unwrap()),
-            meter: Arc::new(RequestRateMeter::new()),
-            total_connections: AtomicU64::new(0),
-            connection_timeouts: AtomicU64::new(0),
-            request_timeouts: AtomicU64::new(0),
+            inner: Arc::new(MetricsInner {
+                errors_num: AtomicU64::new(0),
+                queries_num: AtomicU64::new(0),
+                errors_iter_num: AtomicU64::new(0),
+                queries_iter_num: AtomicU64::new(0),
+                retries_num: AtomicU64::new(0),
+                histogram: Arc::new(AtomicHistogram::new(grouping_power, max_value_power).unwrap()),
+                meter: Arc::new(RequestRateMeter::new()),
+                total_connections: AtomicU64::new(0),
+                connection_timeouts: AtomicU64::new(0),
+                request_timeouts: AtomicU64::new(0),
+            }),
         }
     }
 
     /// Increments counter for errors that occurred in nonpaged queries.
     pub(crate) fn inc_failed_nonpaged_queries(&self) {
-        self.errors_num.fetch_add(1, ORDER_TYPE);
+        self.inner.errors_num.fetch_add(1, ORDER_TYPE);
     }
 
     /// Increments counter for nonpaged queries.
     pub(crate) fn inc_total_nonpaged_queries(&self) {
-        self.queries_num.fetch_add(1, ORDER_TYPE);
-        self.meter.mark();
+        self.inner.queries_num.fetch_add(1, ORDER_TYPE);
+        self.inner.meter.mark();
     }
 
     /// Increments counter for errors that occurred in paged queries.
     pub(crate) fn inc_failed_paged_queries(&self) {
-        self.errors_iter_num.fetch_add(1, ORDER_TYPE);
+        self.inner.errors_iter_num.fetch_add(1, ORDER_TYPE);
     }
 
     /// Increments counter for page queries in paged queries.
     /// If query_iter would return 4 pages then this counter should be incremented 4 times.
     pub(crate) fn inc_total_paged_queries(&self) {
-        self.queries_iter_num.fetch_add(1, ORDER_TYPE);
-        self.meter.mark();
+        self.inner.queries_iter_num.fetch_add(1, ORDER_TYPE);
+        self.inner.meter.mark();
     }
 
     /// Increments counter measuring how many times a retry policy has decided to retry a query
     pub(crate) fn inc_retries_num(&self) {
-        self.retries_num.fetch_add(1, ORDER_TYPE);
+        self.inner.retries_num.fetch_add(1, ORDER_TYPE);
     }
 
     /// Increments counter for active number of connections to the cluster.
     /// Should be called when opening new connections, once per connection.
     pub(crate) fn inc_total_connections(&self) {
-        self.total_connections.fetch_add(1, ORDER_TYPE);
+        self.inner.total_connections.fetch_add(1, ORDER_TYPE);
     }
 
     /// Decrements counter for number of active connections to the cluster.
     /// Should be called when closing the connections, once per connection.
     pub(crate) fn dec_total_connections(&self) {
-        self.total_connections.fetch_sub(1, ORDER_TYPE);
+        self.inner.total_connections.fetch_sub(1, ORDER_TYPE);
     }
 
     /// Increments counter for timeouts for new connections to the cluster.
     pub(crate) fn inc_connection_timeouts(&self) {
-        self.connection_timeouts.fetch_add(1, ORDER_TYPE);
+        self.inner.connection_timeouts.fetch_add(1, ORDER_TYPE);
     }
 
     /// Increments counter for client request timeouts.
     pub(crate) fn inc_request_timeouts(&self) {
-        self.request_timeouts.fetch_add(1, ORDER_TYPE);
+        self.inner.request_timeouts.fetch_add(1, ORDER_TYPE);
     }
 
     /// Saves to histogram latency of completing single query.
@@ -322,7 +335,7 @@ impl Metrics {
     ///
     /// * `latency` - time in milliseconds that should be logged
     pub(crate) fn log_query_latency(&self, latency: u64) -> Result<(), MetricsError> {
-        if let Err(err) = self.histogram.increment(latency) {
+        if let Err(err) = self.inner.histogram.increment(latency) {
             Err(MetricsError::HistogramError(Arc::new(err)))
         } else {
             Ok(())
@@ -331,7 +344,7 @@ impl Metrics {
 
     /// Returns average latency in milliseconds
     pub fn get_latency_avg_ms(&self) -> Result<u64, MetricsError> {
-        Self::mean(&self.histogram.load())
+        Self::mean(&self.inner.histogram.load())
     }
 
     /// Returns latency from histogram for a given percentile
@@ -341,7 +354,7 @@ impl Metrics {
     pub fn get_latency_percentile_ms(&self, percentile: f64) -> Result<u64, MetricsError> {
         // `histogram` 1.x uses the 0.0..=1.0 quantile scale, whereas our
         // public API uses the 0.0..=100.0 percentile scale.
-        let res = self.histogram.load().quantile(percentile / 100.0);
+        let res = self.inner.histogram.load().quantile(percentile / 100.0);
 
         match res {
             Err(err) => Err(MetricsError::HistogramError(Arc::new(err))),
@@ -361,7 +374,7 @@ impl Metrics {
     ///                    percentile_75, percentile_95, percentile_98,
     ///                    percentile_99, and percentile_99_9.
     pub fn get_snapshot(&self) -> Result<Snapshot, MetricsError> {
-        let h = self.histogram.load();
+        let h = self.inner.histogram.load();
 
         let (min, max) = Self::minmax(&h)?;
 
@@ -394,62 +407,62 @@ impl Metrics {
 
     /// Returns counter for errors occurred in nonpaged queries
     pub fn get_errors_num(&self) -> u64 {
-        self.errors_num.load(ORDER_TYPE)
+        self.inner.errors_num.load(ORDER_TYPE)
     }
 
     /// Returns counter for nonpaged queries
     pub fn get_queries_num(&self) -> u64 {
-        self.queries_num.load(ORDER_TYPE)
+        self.inner.queries_num.load(ORDER_TYPE)
     }
 
     /// Returns counter for errors occurred in paged queries
     pub fn get_errors_iter_num(&self) -> u64 {
-        self.errors_iter_num.load(ORDER_TYPE)
+        self.inner.errors_iter_num.load(ORDER_TYPE)
     }
 
     /// Returns counter for pages requested in paged queries
     pub fn get_queries_iter_num(&self) -> u64 {
-        self.queries_iter_num.load(ORDER_TYPE)
+        self.inner.queries_iter_num.load(ORDER_TYPE)
     }
 
     /// Returns counter measuring how many times a retry policy has decided to retry a query
     pub fn get_retries_num(&self) -> u64 {
-        self.retries_num.load(ORDER_TYPE)
+        self.inner.retries_num.load(ORDER_TYPE)
     }
 
     /// Returns mean rate of queries per second
     pub fn get_mean_rate(&self) -> f64 {
-        self.meter.mean_rate()
+        self.inner.meter.mean_rate()
     }
 
     /// Returns one-minute rate of queries per second
     pub fn get_one_minute_rate(&self) -> f64 {
-        self.meter.one_minute_rate()
+        self.inner.meter.one_minute_rate()
     }
 
     /// Returns five-minute rate of queries per second
     pub fn get_five_minute_rate(&self) -> f64 {
-        self.meter.five_minute_rate()
+        self.inner.meter.five_minute_rate()
     }
 
     /// Returns fifteen-minute rate of queries per second
     pub fn get_fifteen_minute_rate(&self) -> f64 {
-        self.meter.fifteen_minute_rate()
+        self.inner.meter.fifteen_minute_rate()
     }
 
     /// Returns total number of active connections
     pub fn get_total_connections(&self) -> u64 {
-        self.total_connections.load(ORDER_TYPE)
+        self.inner.total_connections.load(ORDER_TYPE)
     }
 
     /// Returns counter for connection timeouts
     pub fn get_connection_timeouts(&self) -> u64 {
-        self.connection_timeouts.load(ORDER_TYPE)
+        self.inner.connection_timeouts.load(ORDER_TYPE)
     }
 
     /// Returns counter for request timeouts
     pub fn get_request_timeouts(&self) -> u64 {
-        self.request_timeouts.load(ORDER_TYPE)
+        self.inner.request_timeouts.load(ORDER_TYPE)
     }
 
     // Metric implementations
@@ -558,18 +571,18 @@ impl Default for Metrics {
 
 impl std::fmt::Debug for Metrics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let h = self.histogram.load();
+        let h = self.inner.histogram.load();
         f.debug_struct("Metrics")
-            .field("errors_num", &self.errors_num)
-            .field("queries_num", &self.queries_num)
-            .field("errors_iter_num", &self.errors_iter_num)
-            .field("queries_iter_num", &self.queries_iter_num)
-            .field("retries_num", &self.retries_num)
+            .field("errors_num", &self.inner.errors_num)
+            .field("queries_num", &self.inner.queries_num)
+            .field("errors_iter_num", &self.inner.errors_iter_num)
+            .field("queries_iter_num", &self.inner.queries_iter_num)
+            .field("retries_num", &self.inner.retries_num)
             .field("histogram", &h)
-            .field("meter", &self.meter)
-            .field("total_connections", &self.total_connections)
-            .field("connection_timeouts", &self.connection_timeouts)
-            .field("request_timeouts", &self.request_timeouts)
+            .field("meter", &self.inner.meter)
+            .field("total_connections", &self.inner.total_connections)
+            .field("connection_timeouts", &self.inner.connection_timeouts)
+            .field("request_timeouts", &self.inner.request_timeouts)
             .finish()
     }
 }

--- a/scylla/src/observability/metrics_noop.rs
+++ b/scylla/src/observability/metrics_noop.rs
@@ -1,0 +1,58 @@
+//! No-op metrics module used when the `metrics` feature is disabled.
+//!
+//! All recording methods are zero-cost no-ops;
+//! Nothing is public, to make sure we don't expose those no-op structs to the user.
+//! Query methods are removed to make sure we don't use non-functioning methods by accident.
+
+/// Error that occurred upon a metrics operation.
+pub(crate) enum MetricsError {}
+
+/// No-op metrics object used when the `metrics` feature is disabled.
+#[derive(Debug)]
+pub(crate) struct Metrics;
+
+impl Metrics {
+    #[inline(always)]
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    #[inline(always)]
+    pub(crate) fn inc_failed_nonpaged_queries(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_total_nonpaged_queries(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_failed_paged_queries(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_total_paged_queries(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_retries_num(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_total_connections(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn dec_total_connections(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_connection_timeouts(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_request_timeouts(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn log_query_latency(&self, _latency: u64) -> Result<(), MetricsError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl Default for Metrics {
+    fn default() -> Self {
+        Self
+    }
+}

--- a/scylla/src/observability/metrics_noop.rs
+++ b/scylla/src/observability/metrics_noop.rs
@@ -8,7 +8,7 @@
 pub(crate) enum MetricsError {}
 
 /// No-op metrics object used when the `metrics` feature is disabled.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Metrics;
 
 impl Metrics {

--- a/scylla/src/observability/mod.rs
+++ b/scylla/src/observability/mod.rs
@@ -7,6 +7,14 @@
 
 pub(crate) mod driver_tracing;
 pub mod history;
+// When the `metrics` feature is enabled, compile and expose the real metrics
+// implementation as a public module.  When disabled, compile the zero-cost
+// no-op implementation as a crate-internal module so that internal code can
+// use it without any `#[cfg]` guards, while keeping the no-op hidden from
+// library users.
 #[cfg(feature = "metrics")]
 pub mod metrics;
+#[cfg(not(feature = "metrics"))]
+#[path = "metrics_noop.rs"]
+pub(crate) mod metrics;
 pub mod tracing;

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1434,7 +1434,6 @@ mod tests {
                 &connectivity_events_sender,
                 TabletsInfo::new(),
                 &HashMap::new(),
-                #[cfg(feature = "metrics")]
                 &Default::default(),
             )
             .await;
@@ -1478,7 +1477,6 @@ mod tests {
                 &connectivity_events_sender,
                 TabletsInfo::new(),
                 &HashMap::new(),
-                #[cfg(feature = "metrics")]
                 &Default::default(),
             )
             .await;
@@ -2628,7 +2626,6 @@ mod tests {
             &connectivity_events_sender,
             TabletsInfo::new(),
             &HashMap::new(),
-            #[cfg(feature = "metrics")]
             &Default::default(),
         )
         .await;

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -196,7 +196,6 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
             &pool_config,
             connectivity_events_sender.clone(),
             None,
-            #[cfg(feature = "metrics")]
             Default::default(),
         ));
 


### PR DESCRIPTION
Metrics are guarded by `metrics` feature. Unfortunately, they need to be passed around in many places in our codebase, leading to sprawl of `cfg` directives. I really don't like having this amount of conditional compilation, so here I implement a solution that is in my opinion cleaner: having compile-time backends for metrics.

In other words, when `metrics` feature is disabled we use a small no-op Metrics implementation, and when it is enabled we use the real one.
No-op backend has no public items, and only 0-sized, or uninhabited items, with empty methods, so it should have 0 performance overhead.
It has no public items, and no querying methods, so there is no way to accidently misuse it and get wrong results.

Public metrics-dependent stuff is still guarded by cfg: `metrics` field in `Context`, `Session::get_metrics`, `PercentileSpeculativeExecutionPolicy`.

I saw one posssible undesirable behavior: we pass around `Arc<Metrics>`, not just `Metrics`. This could cause some overhead even when feature is disabled. I fixed that by moving to just `Metrics` wherever possible, and storing the `Arc` inside.


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1268

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
