### PR TITLE
Renovate: fix milestone sync & ping digests to semver

### DIFF
--- a/.github/workflows/milestone-sync.yml
+++ b/.github/workflows/milestone-sync.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   sync-manual:
     if: github.event_name == 'workflow_dispatch'
-    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@80b35e1904224052222a4f876fbe33d8a867e50e
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@80b35e1904224052222a4f876fbe33d8a867e50e # main
     with:
       milestone: ${{ inputs.milestone }}
       config-path: milestone-sync/config.yaml
@@ -29,7 +29,7 @@ jobs:
 
   sync-automatic:
     if: github.event_name != 'workflow_dispatch'
-    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@80b35e1904224052222a4f876fbe33d8a867e50e
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@80b35e1904224052222a4f876fbe33d8a867e50e # main
     with:
       config-path: milestone-sync/config.yaml
       github-event-name: ${{ github.event_name }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,10 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended"
+        "config:recommended",
+        "helpers:pinGitHubActionDigestsToSemver"
     ],
+    "commitBodyTable": true,
     "packageRules": [
         {
             "matchManagers": [


### PR DESCRIPTION
Another round of improvements to Renovate.
- Milestone sync workflows gets the same branch comments as jira sync, which should make it update
- Started using `helpers:pinGitHubActionDigestsToSemver` to get updates version numbers in PRs - it should be a bit more useful than just hashes. It mirrors https://github.com/scylladb/cassandra-stress/pull/160


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [ ] ~~All commits compile, pass static checks and pass test.~~
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
