### PR TITLE
pager: fix reported retry consistency and improve test coverage

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -426,7 +426,7 @@ where
                 let request_info = RequestInfo {
                     error: &request_error,
                     is_idempotent: self.query_is_idempotent,
-                    consistency: self.query_consistency,
+                    consistency: current_consistency,
                 };
 
                 let retry_decision = self.retry_session.decide_should_retry(request_info);

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -701,3 +701,117 @@ async fn test_pager_retry_receives_current_consistency() {
         );
     }
 }
+
+/// Regression test: `execute_iter` and `query_iter` must not return a spurious
+/// `PartitionKeyError` for token-unaware queries.
+///
+/// The bug was in `new_for_prepared_statement`: it called
+/// `extract_partition_key_and_calculate_token` unconditionally, whereas
+/// previously (before the "fetch first page without spawning" refactor) that
+/// call was only reached inside the spawned worker task, which was guarded by
+/// `is_token_aware()`. For non-token-aware statements the call returns
+/// `Ok(None)` today, so there is no actual failure — but this test locks in
+/// the correct behaviour and will catch any future regression.
+///
+/// Three cases are exercised:
+///
+/// 1. Unprepared `Statement` + `query_iter` (token is always `None` here;
+///    baseline sanity check).
+/// 2. Token-unaware `PreparedStatement` with **no bind markers**
+///    (`SELECT peer FROM system.peers` — the PK column `peer` never appears
+///    as `?`, so the server returns `pk_indexes = []`).
+/// 3. Token-unaware `PreparedStatement` with **bind markers on non-PK
+///    columns** (`system_schema.columns WHERE keyspace_name = 'system' AND
+///    position >= ?` — the PK `keyspace_name` is a hardcoded literal, so
+///    again `pk_indexes = []`).
+///
+/// All three cases must succeed end-to-end and return at least one row, using
+/// `page_size = 1` to force the multi-page `work()` code path.
+#[tokio::test]
+async fn test_token_unaware_pager() {
+    setup_tracing();
+
+    let session = create_new_session_builder().build().await.unwrap();
+
+    // Drain a pager and assert it yields at least one row without error.
+    async fn assert_pager_succeeds(
+        mut stream: impl futures::Stream<Item = Result<Row, impl std::error::Error>> + Unpin,
+        label: &str,
+    ) {
+        let mut count = 0_usize;
+        while let Some(row) = stream.next().await {
+            row.unwrap_or_else(|e| panic!("[{label}] unexpected stream error: {e:?}"));
+            count += 1;
+        }
+        assert!(count >= 1, "[{label}] expected at least one row, got none");
+    }
+
+    // Case 1: unprepared Statement + query_iter.
+    // new_for_query always sets token = None; no partition-key extraction is attempted.
+    {
+        let label = "case 1: unprepared Statement";
+        let mut stmt = Statement::from("SELECT peer FROM system.peers");
+        stmt.set_page_size(1);
+        let stream = session
+            .query_iter(stmt, ())
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] query_iter failed: {e}"))
+            .rows_stream::<Row>()
+            .unwrap();
+        assert_pager_succeeds(stream, label).await;
+    }
+
+    // Case 2: token-unaware PreparedStatement, no bind markers.
+    // `SELECT peer FROM system.peers` has no `?` at all, so the server returns
+    // pk_indexes = [] and is_token_aware() is false.
+    {
+        let label = "case 2: prepared, no bind markers";
+        let mut prepared = session
+            .prepare("SELECT peer FROM system.peers")
+            .await
+            .unwrap();
+        assert!(
+            !prepared.is_token_aware(),
+            "[{label}] expected non-token-aware statement"
+        );
+        prepared.set_page_size(1);
+        let stream = session
+            .execute_iter(prepared, ())
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] execute_iter failed: {e}"))
+            .rows_stream::<Row>()
+            .unwrap();
+        assert_pager_succeeds(stream, label).await;
+    }
+
+    // Case 3: token-unaware PreparedStatement, bind markers on non-PK columns.
+    // `keyspace_name = 'system'` is the partition key as a hardcoded literal,
+    // so it does not appear in pk_indexes. `position >= ?` is a bind marker on
+    // a regular (non-PK) column. The server therefore returns pk_indexes = []
+    // and is_token_aware() is false, even though the statement has bind values.
+    // The query returns many rows (all columns of all system tables), ensuring
+    // the multi-page `work()` code path is exercised.
+    {
+        let label = "case 3: prepared, non-PK bind markers";
+        let mut prepared = session
+            .prepare(
+                "SELECT column_name FROM system_schema.columns \
+                 WHERE keyspace_name = 'system' AND position >= ? \
+                 ALLOW FILTERING",
+            )
+            .await
+            .unwrap();
+        assert!(
+            !prepared.is_token_aware(),
+            "[{label}] expected non-token-aware statement"
+        );
+        prepared.set_page_size(1);
+        let stream = session
+            .execute_iter(prepared, (0_i32,))
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] execute_iter failed: {e}"))
+            .rows_stream::<Row>()
+            .unwrap();
+        assert_pager_succeeds(stream, label).await;
+    }
+}

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -5,6 +5,7 @@ use std::{
     },
     time::Duration,
 };
+use tokio::sync::mpsc;
 
 use assert_matches::assert_matches;
 use futures::{StreamExt as _, TryStreamExt as _};
@@ -533,5 +534,170 @@ async fn test_pager_timeouts() {
         Ok(()) => (),
         Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
         Err(err) => panic!("{}", err),
+    }
+}
+
+/// Regression test for the bug where `PagerWorker` passed the original
+/// `query_consistency` instead of `current_consistency` to `RequestInfo`
+/// in the retry loop.
+///
+/// Two cases are tested here. In each case a custom retry policy:
+/// 1. On the first failure: returns `RetrySameTarget(Some(Consistency::Two))`
+///    (simulating a downgrade from `All`).
+/// 2. On the second failure: sends the observed `RequestInfo::consistency`
+///    to a channel and returns `DontRetry`.
+///
+/// Before the fix, `current_consistency` was not passed to `RequestInfo`;
+/// the original `query_consistency` (`All`) was used instead. After the
+/// fix the downgraded value (`Two`) is correctly forwarded.
+#[tokio::test]
+async fn test_pager_retry_receives_current_consistency() {
+    setup_tracing();
+
+    /// On the first call: downgrade CL from `All` to `Two`.
+    /// On the second call: send the observed consistency and stop.
+    /// Resets `call_count` between pages (via `reset()`).
+    #[derive(Debug)]
+    struct CapturingRetryPolicy(mpsc::UnboundedSender<Consistency>);
+
+    impl RetryPolicy for CapturingRetryPolicy {
+        fn new_session(&self) -> Box<dyn RetrySession> {
+            Box::new(CapturingRetrySession {
+                tx: self.0.clone(),
+                call_count: 0,
+            })
+        }
+    }
+
+    struct CapturingRetrySession {
+        tx: mpsc::UnboundedSender<Consistency>,
+        call_count: u32,
+    }
+
+    impl RetrySession for CapturingRetrySession {
+        fn decide_should_retry(&mut self, request_info: RequestInfo) -> RetryDecision {
+            self.call_count += 1;
+            match self.call_count {
+                // First failure: simulate a consistency downgrade (All → Two).
+                1 => RetryDecision::RetrySameTarget(Some(Consistency::Two)),
+                // Second failure: record what consistency was reported.
+                _ => {
+                    let _ = self.tx.send(request_info.consistency);
+                    RetryDecision::DontRetry
+                }
+            }
+        }
+
+        fn reset(&mut self) {
+            self.call_count = 0;
+        }
+    }
+
+    let execute_not_control = Condition::RequestOpcode(RequestOpcode::Execute)
+        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+
+    // Case 1: first page fetch.
+    // All Execute requests are forged to fail immediately.
+    let (tx1, mut rx1) = mpsc::unbounded_channel::<Consistency>();
+    let profile1 = ExecutionProfile::builder()
+        .consistency(Consistency::All)
+        .retry_policy(Arc::new(CapturingRetryPolicy(tx1)))
+        .build();
+
+    // Case 2: second and further page fetches.
+    // The first Execute is passed through (first page succeeds), all subsequent
+    // ones are forged to fail.
+    let (tx2, mut rx2) = mpsc::unbounded_channel::<Consistency>();
+    let profile2 = ExecutionProfile::builder()
+        .consistency(Consistency::All)
+        .retry_policy(Arc::new(CapturingRetryPolicy(tx2)))
+        .build();
+
+    let res = test_with_3_node_cluster(
+        scylla_proxy::ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            let mut prepared = session
+                .prepare("SELECT peer FROM system.peers")
+                .await
+                .unwrap();
+            prepared.set_is_idempotent(true);
+
+            // --- Case 1: first page ---
+            // Forge errors on all Execute requests.
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![RequestRule(
+                    execute_not_control.clone(),
+                    RequestReaction::forge().server_error(),
+                )]));
+            });
+            prepared.set_execution_profile_handle(Some(profile1.into_handle()));
+            let _ = session.execute_iter(prepared.clone(), ()).await;
+
+            // --- Case 2: second page ---
+            // system.peers has 2 rows in a 3-node cluster. With page_size=1,
+            // the first page always returns HasMorePages on both ScyllaDB and
+            // Cassandra (1 row returned, 1 still remaining), so the worker
+            // is always spawned and the second Execute is reliably issued.
+            //
+            // Curiously, ScyllaDB returns HasMorePages on the second page as well
+            // (1 row returned, 0 remaining, but HasMorePages=true since the server
+            // hasn't yet tried to consume non-existing rows), while Cassandra returns
+            // HasMorePages=false (the check `remaining_rows == 0` seems to happen eagerly).
+            //
+            // Pass the first Execute through (first page succeeds), then forge
+            // errors on all subsequent Execute requests.
+            prepared.set_page_size(1);
+            prepared.set_execution_profile_handle(Some(profile2.into_handle()));
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![
+                    // 1st Execute per node: pass through.
+                    RequestRule(
+                        execute_not_control
+                            .clone()
+                            .and(Condition::TrueForLimitedTimes(1)),
+                        RequestReaction::noop(),
+                    ),
+                    // All subsequent Executes: forge error.
+                    RequestRule(
+                        execute_not_control.clone(),
+                        RequestReaction::forge().server_error(),
+                    ),
+                ]));
+            });
+            let pager = session.execute_iter(prepared, ()).await.unwrap();
+            // Drive the stream until it errors (triggering worker spawn).
+            let mut stream = pager.rows_stream::<Row>().unwrap();
+            while stream.next().await.transpose().is_ok_and(|r| r.is_some()) {}
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+
+    // Both retry sessions must have observed Consistency::Two (the downgraded
+    // CL), not Consistency::All (the original query CL).
+    for (label, rx) in [("first page", &mut rx1), ("second page", &mut rx2)] {
+        let observed = rx.recv().await.unwrap_or_else(|| {
+            panic!("[{label}] retry policy did not send an observed consistency")
+        });
+        assert_eq!(
+            observed,
+            Consistency::Two,
+            "[{label}] pager must pass the downgraded consistency (Two) to \
+             RequestInfo, not the original query consistency (All)"
+        );
     }
 }


### PR DESCRIPTION
This PR improves test coverage of the `QueryPager` by introducing two regression tests.

One guards against a pre-existing bug - reporting a wrong consistency to `RetryPolicy` (the original consistency instead of the actual consistency) - and fixes the bug.

Another guards against a bug that I've introduced during my refactor (it has never landed on main). The bug involved an error thrown when executing token-unaware prepared statements.

I paid attention to keeping the tests lightweight: they execute no DDLs. Bows to @Lorak-mmk.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
