### PR TITLE
scylla-cql-core: document CqlTimeuuid::lsb_signed and harden test_timeuuid_ordering

### DIFF
--- a/scylla-cql-core/src/value.rs
+++ b/scylla-cql-core/src/value.rs
@@ -239,16 +239,19 @@ impl CqlTimeuuid {
         ])
     }
 
-    /// Returns the least significant bytes of the timeuuid transformed so that
-    /// an unsigned comparison of the result orders the values the same way a
-    /// signed (two's-complement `i64`) comparison of [`Self::lsb`] would.
+    /// Returns the least significant bytes transformed so that an unsigned
+    /// comparison of the result reproduces Scylla/Cassandra's ordering of those
+    /// bytes for two timeuuids with equal `msb` (used by the [`Ord`] impl).
     ///
-    /// Cassandra/Scylla compare the low 64 bits of a timeuuid as a signed
-    /// integer (see the [`Ord`] impl). Flipping the sign bit maps the signed
-    /// range onto the unsigned range while preserving order, which lets `cmp`
-    /// use a plain `u64` comparison.
+    /// Cassandra legacy compares the 8 low bytes as *signed bytes* — each byte
+    /// independently, most-significant byte first — not as one signed 64-bit
+    /// integer. Scylla implements this in `timeuuid_tri_compare` (utils/UUID.hh)
+    /// as `lsb ^ 0x8080808080808080` followed by an unsigned compare: flipping
+    /// the top bit of every byte maps each byte's signed order onto its unsigned
+    /// order, so a big-endian `u64` comparison of the XORed value matches the
+    /// byte-wise signed ordering.
     fn lsb_signed(&self) -> u64 {
-        self.lsb() ^ 0x8000000000000000
+        self.lsb() ^ 0x8080808080808080
     }
 }
 
@@ -1419,30 +1422,6 @@ mod tests {
         let uuid = CqlTimeuuid::from_str("ffffffff-ffff-ffff-ffff-ffffffffffff").unwrap();
 
         assert_eq!(0xffffffffffffffff, uuid.lsb());
-    }
-
-    // Regression test for #1637: the low 64 bits of a timeuuid are compared as a
-    // signed integer, so timeuuids with equal `msb` must order by the signed
-    // value of their `lsb`. A byte-wise sign transform gets these backwards.
-    #[test]
-    fn timeuuid_lsb_signed_ordering() {
-        // Reported case: same msb, lsb differs only in the last byte.
-        let x = CqlTimeuuid::from_str("00000000-0000-1000-8000-00000000007f").unwrap();
-        let y = CqlTimeuuid::from_str("00000000-0000-1000-8000-000000000080").unwrap();
-        assert!(x < y);
-        assert!(y > x);
-
-        // Same msb; as signed i64, lsb 0x0000_0000_0000_0100 (256) < 0x0000_0000_0000_8000
-        // (32768), so `a` sorts before `b`.
-        let a = CqlTimeuuid::from_str("00000000-0000-1000-0000-000000000100").unwrap();
-        let b = CqlTimeuuid::from_str("00000000-0000-1000-0000-000000008000").unwrap();
-        assert!(a < b);
-
-        // A timeuuid whose lsb has the sign bit set (negative as i64) sorts before
-        // one whose lsb is positive, when msb is equal.
-        let neg = CqlTimeuuid::from_str("00000000-0000-1000-8000-000000000000").unwrap();
-        let pos = CqlTimeuuid::from_str("00000000-0000-1000-0000-000000000001").unwrap();
-        assert!(neg < pos);
     }
 
     #[test]

--- a/scylla-cql-core/src/value.rs
+++ b/scylla-cql-core/src/value.rs
@@ -239,8 +239,16 @@ impl CqlTimeuuid {
         ])
     }
 
+    /// Returns the least significant bytes of the timeuuid transformed so that
+    /// an unsigned comparison of the result orders the values the same way a
+    /// signed (two's-complement `i64`) comparison of [`Self::lsb`] would.
+    ///
+    /// Cassandra/Scylla compare the low 64 bits of a timeuuid as a signed
+    /// integer (see the [`Ord`] impl). Flipping the sign bit maps the signed
+    /// range onto the unsigned range while preserving order, which lets `cmp`
+    /// use a plain `u64` comparison.
     fn lsb_signed(&self) -> u64 {
-        self.lsb() ^ 0x8080808080808080
+        self.lsb() ^ 0x8000000000000000
     }
 }
 
@@ -1411,6 +1419,30 @@ mod tests {
         let uuid = CqlTimeuuid::from_str("ffffffff-ffff-ffff-ffff-ffffffffffff").unwrap();
 
         assert_eq!(0xffffffffffffffff, uuid.lsb());
+    }
+
+    // Regression test for #1637: the low 64 bits of a timeuuid are compared as a
+    // signed integer, so timeuuids with equal `msb` must order by the signed
+    // value of their `lsb`. A byte-wise sign transform gets these backwards.
+    #[test]
+    fn timeuuid_lsb_signed_ordering() {
+        // Reported case: same msb, lsb differs only in the last byte.
+        let x = CqlTimeuuid::from_str("00000000-0000-1000-8000-00000000007f").unwrap();
+        let y = CqlTimeuuid::from_str("00000000-0000-1000-8000-000000000080").unwrap();
+        assert!(x < y);
+        assert!(y > x);
+
+        // Same msb; as signed i64, lsb 0x0000_0000_0000_0100 (256) < 0x0000_0000_0000_8000
+        // (32768), so `a` sorts before `b`.
+        let a = CqlTimeuuid::from_str("00000000-0000-1000-0000-000000000100").unwrap();
+        let b = CqlTimeuuid::from_str("00000000-0000-1000-0000-000000008000").unwrap();
+        assert!(a < b);
+
+        // A timeuuid whose lsb has the sign bit set (negative as i64) sorts before
+        // one whose lsb is positive, when msb is equal.
+        let neg = CqlTimeuuid::from_str("00000000-0000-1000-8000-000000000000").unwrap();
+        let pos = CqlTimeuuid::from_str("00000000-0000-1000-0000-000000000001").unwrap();
+        assert!(neg < pos);
     }
 
     #[test]

--- a/scylla/tests/integration/types/cql_types.rs
+++ b/scylla/tests/integration/types/cql_types.rs
@@ -1314,8 +1314,16 @@ async fn test_timeuuid_ordering() {
 
     // Timeuuid values, sorted in the same order as Scylla/Cassandra sorts them.
     let sorted_timeuuid_vals: Vec<CqlTimeuuid> = vec![
-        CqlTimeuuid::from_str("00000000-0000-1000-8080-808080808080").unwrap(),
-        CqlTimeuuid::from_str("00000000-0000-1000-ffff-ffffffffffff").unwrap(),
+        // These three share the same msb, so the byte-wise signed comparison of
+        // the low 64 bits decides their order (Cassandra legacy `^ 0x8080...`,
+        // see CqlTimeuuid::lsb_signed). The first two differ only in the low
+        // byte and sort `...080` before `...07f`; comparing the low bits as a
+        // single 64-bit signed integer (`^ 0x8000...`) would order them the
+        // other way, so this pair guards against that mistake. The values that
+        // used to be here sorted the same under either transform, so they never
+        // caught it.
+        CqlTimeuuid::from_str("00000000-0000-1000-8000-000000000080").unwrap(),
+        CqlTimeuuid::from_str("00000000-0000-1000-8000-00000000007f").unwrap(),
         CqlTimeuuid::from_str("00000000-0000-1000-0000-000000000000").unwrap(),
         CqlTimeuuid::from_str("fed35080-0efb-11ee-a1ca-00006490e9a4").unwrap(),
         CqlTimeuuid::from_str("00000257-0efc-11ee-9547-00006490e9a6").unwrap(),


### PR DESCRIPTION
## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Refs:`/`Fixes:` annotations to PR description.

## Description

`CqlTimeuuid`'s `Ord` compares `msb()` and then `lsb_signed()`. The low 64 bits are compared as **signed bytes** — each of the 8 bytes independently, most-significant first — which Scylla/Cassandra implement as `lsb ^ 0x8080808080808080` followed by an unsigned compare (`timeuuid_tri_compare` in `utils/UUID.hh`). This is **not** the same as comparing the low bits as one signed 64-bit integer.

The existing behavior is correct (it matches Scylla). This PR only makes it harder to break by accident — there is **no functional change**:

- Adds a doc comment on `lsb_signed` explaining the byte-wise signed comparison and why the `^ 0x8080...` transform reproduces it.
- Strengthens `test_timeuuid_ordering`. Its previous values sorted the same whether the low bits were compared byte-wise-signed or as a single 64-bit signed integer, so the test could not catch a regression to the latter. It now includes `00000000-0000-1000-8000-000000000080` and `00000000-0000-1000-8000-00000000007f` (equal `msb`, differing only in the low byte), which sort `...080` before `...07f` **only** under the byte-wise comparison; a 64-bit signed compare would order them the other way.

Refs #1637 — after investigation this turned out not to be a bug: the reported ordering matches how Scylla sorts timeuuids.
