### PR TITLE
session: small fixes & refactors

### DIFF
--- a/scylla/src/client/mod.rs
+++ b/scylla/src/client/mod.rs
@@ -8,7 +8,7 @@
 //! - [SessionBuilder](session_builder::SessionBuilder) - just a convenient builder for a `Session`.
 //! - [CachingSession](caching_session::CachingSession) - a wrapper over a [Session](session::Session)
 //!   that keeps and manages a cache of prepared statements, so that a user can be free of such considerations.
-//! - [SelfIdentity] - configuresd driver and application self-identifying information,
+//! - [SelfIdentity] - configures driver and application self-identifying information,
 //!   to be sent in STARTUP message.
 //! - [ExecutionProfile](execution_profile::ExecutionProfile) - a profile that groups various configuration
 //!   options relevant when executing a request against the DB.

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1016,11 +1016,7 @@ impl Session {
                 execution_profile,
                 |connection: Arc<Connection>,
                  consistency: Consistency,
-                 execution_profile: &ExecutionProfileInner| {
-                    let serial_consistency = batch
-                        .config
-                        .serial_consistency
-                        .unwrap_or(execution_profile.serial_consistency);
+                 _execution_profile: &ExecutionProfileInner| {
                     async move {
                         connection
                             .batch_with_consistency(
@@ -1296,15 +1292,19 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
+        let consistency = statement
+            .config
+            .consistency
+            .unwrap_or(execution_profile.consistency);
+
+        let serial_consistency = statement
+            .config
+            .serial_consistency
+            .unwrap_or(execution_profile.serial_consistency);
+
         let routing_info = RoutingInfo {
-            consistency: statement
-                .config
-                .consistency
-                .unwrap_or(execution_profile.consistency),
-            serial_consistency: statement
-                .config
-                .serial_consistency
-                .unwrap_or(execution_profile.serial_consistency),
+            consistency,
+            serial_consistency,
             token: None,
             table: None,
             is_confirmed_lwt: false,
@@ -1323,11 +1323,7 @@ impl Session {
                 execution_profile,
                 |connection: Arc<Connection>,
                  consistency: Consistency,
-                 execution_profile: &ExecutionProfileInner| {
-                    let serial_consistency = statement
-                        .config
-                        .serial_consistency
-                        .unwrap_or(execution_profile.serial_consistency);
+                 _execution_profile: &ExecutionProfileInner| {
                     // Needed to avoid moving query and values into async move block
                     let values_ref = &values;
                     let paging_state_ref = &paging_state;
@@ -1696,17 +1692,21 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
+        let consistency = prepared
+            .config
+            .consistency
+            .unwrap_or(execution_profile.consistency);
+
+        let serial_consistency = prepared
+            .config
+            .serial_consistency
+            .unwrap_or(execution_profile.serial_consistency);
+
         let table_spec = prepared.get_table_spec();
 
         let routing_info = RoutingInfo {
-            consistency: prepared
-                .config
-                .consistency
-                .unwrap_or(execution_profile.consistency),
-            serial_consistency: prepared
-                .config
-                .serial_consistency
-                .unwrap_or(execution_profile.serial_consistency),
+            consistency,
+            serial_consistency,
             token,
             table: table_spec,
             is_confirmed_lwt: prepared.is_confirmed_lwt(),
@@ -1737,11 +1737,7 @@ impl Session {
                 execution_profile,
                 |connection: Arc<Connection>,
                  consistency: Consistency,
-                 execution_profile: &ExecutionProfileInner| {
-                    let serial_consistency = prepared
-                        .config
-                        .serial_consistency
-                        .unwrap_or(execution_profile.serial_consistency);
+                 _execution_profile: &ExecutionProfileInner| {
                     async move {
                         connection
                             .execute_raw_with_consistency(

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -995,7 +995,7 @@ impl Session {
                 None
             };
 
-        let statement_info = RoutingInfo {
+        let routing_info = RoutingInfo {
             consistency,
             serial_consistency,
             token: first_value_token,
@@ -1011,7 +1011,7 @@ impl Session {
             Coordinator,
         ) = self
             .run_request(
-                statement_info,
+                routing_info,
                 &batch.config,
                 execution_profile,
                 |connection: Arc<Connection>,
@@ -1296,7 +1296,7 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        let statement_info = RoutingInfo {
+        let routing_info = RoutingInfo {
             consistency: statement
                 .config
                 .consistency
@@ -1318,7 +1318,7 @@ impl Session {
             Coordinator,
         ) = self
             .run_request(
-                statement_info,
+                routing_info,
                 &statement.config,
                 execution_profile,
                 |connection: Arc<Connection>,
@@ -1698,7 +1698,7 @@ impl Session {
 
         let table_spec = prepared.get_table_spec();
 
-        let statement_info = RoutingInfo {
+        let routing_info = RoutingInfo {
             consistency: prepared
                 .config
                 .consistency
@@ -1720,7 +1720,7 @@ impl Session {
         );
 
         if !span.span().is_disabled()
-            && let (Some(table_spec), Some(token)) = (statement_info.table, token)
+            && let (Some(table_spec), Some(token)) = (routing_info.table, token)
         {
             let cluster_state = self.get_cluster_state();
             let replicas = cluster_state.get_token_endpoints_iter(table_spec, token);
@@ -1732,7 +1732,7 @@ impl Session {
             Coordinator,
         ) = self
             .run_request(
-                statement_info,
+                routing_info,
                 &prepared.config,
                 execution_profile,
                 |connection: Arc<Connection>,
@@ -2052,7 +2052,7 @@ impl Session {
     // maybe once async closures get stabilized this can be fixed
     async fn run_request<'a, QueryFut>(
         &'a self,
-        statement_info: RoutingInfo<'a>,
+        routing_info: RoutingInfo<'a>,
         statement_config: &'a StatementConfig,
         execution_profile: Arc<ExecutionProfileInner>,
         run_request_once: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
@@ -2075,7 +2075,7 @@ impl Session {
         let runner = async {
             let cluster_state = self.cluster.get_state();
             let request_plan =
-                load_balancing::Plan::new(load_balancer, &statement_info, &cluster_state);
+                load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
 
             // If a speculative execution policy is used to run request, request_plan has to be shared
             // between different async functions. This struct helps to wrap request_plan in mutex so it
@@ -2144,7 +2144,7 @@ impl Session {
                                 retry_session: retry_policy.new_session(),
                                 history_data,
                                 load_balancing_policy: load_balancer,
-                                query_info: &statement_info,
+                                routing_info: &routing_info,
                                 request_span,
                             },
                         )
@@ -2181,7 +2181,7 @@ impl Session {
                             retry_session: retry_policy.new_session(),
                             history_data,
                             load_balancing_policy: load_balancer,
-                            query_info: &statement_info,
+                            routing_info: &routing_info,
                             request_span,
                         },
                     )
@@ -2292,7 +2292,7 @@ impl Session {
                         let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
                         context.load_balancing_policy.on_request_success(
-                            context.query_info,
+                            context.routing_info,
                             elapsed,
                             node,
                         );
@@ -2306,7 +2306,7 @@ impl Session {
                         );
                         self.metrics.inc_failed_nonpaged_queries();
                         context.load_balancing_policy.on_request_failure(
-                            context.query_info,
+                            context.routing_info,
                             elapsed,
                             node,
                             &e,
@@ -2670,7 +2670,7 @@ struct ExecuteRequestContext<'a> {
     retry_session: Box<dyn RetrySession>,
     history_data: Option<HistoryData<'a>>,
     load_balancing_policy: &'a dyn load_balancing::LoadBalancingPolicy,
-    query_info: &'a load_balancing::RoutingInfo<'a>,
+    routing_info: &'a load_balancing::RoutingInfo<'a>,
     request_span: &'a RequestSpan,
 }
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2319,9 +2319,7 @@ impl Session {
                 let request_info = RequestInfo {
                     error: &request_error,
                     is_idempotent: context.is_idempotent,
-                    consistency: context
-                        .consistency_set_on_statement
-                        .unwrap_or(execution_profile.consistency),
+                    consistency: current_consistency,
                 };
 
                 let retry_decision = context.retry_session.decide_should_retry(request_info);

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1014,20 +1014,11 @@ impl Session {
                 routing_info,
                 &batch.config,
                 execution_profile,
-                |connection: Arc<Connection>,
-                 consistency: Consistency,
-                 _execution_profile: &ExecutionProfileInner| {
-                    async move {
-                        connection
-                            .batch_with_consistency(
-                                batch,
-                                values_ref,
-                                consistency,
-                                serial_consistency,
-                            )
-                            .await
-                            .and_then(QueryResponse::into_non_error_query_response)
-                    }
+                |connection: Arc<Connection>, consistency: Consistency| async move {
+                    connection
+                        .batch_with_consistency(batch, values_ref, consistency, serial_consistency)
+                        .await
+                        .and_then(QueryResponse::into_non_error_query_response)
                 },
                 &span,
             )
@@ -1321,9 +1312,7 @@ impl Session {
                 routing_info,
                 &statement.config,
                 execution_profile,
-                |connection: Arc<Connection>,
-                 consistency: Consistency,
-                 _execution_profile: &ExecutionProfileInner| {
+                |connection: Arc<Connection>, consistency: Consistency| {
                     // Needed to avoid moving query and values into async move block
                     let values_ref = &values;
                     let paging_state_ref = &paging_state;
@@ -1735,22 +1724,18 @@ impl Session {
                 routing_info,
                 &prepared.config,
                 execution_profile,
-                |connection: Arc<Connection>,
-                 consistency: Consistency,
-                 _execution_profile: &ExecutionProfileInner| {
-                    async move {
-                        connection
-                            .execute_raw_with_consistency(
-                                prepared,
-                                serialized_values,
-                                consistency,
-                                serial_consistency,
-                                page_size,
-                                paging_state_ref.clone(),
-                            )
-                            .await
-                            .and_then(QueryResponse::into_non_error_query_response)
-                    }
+                |connection: Arc<Connection>, consistency: Consistency| async move {
+                    connection
+                        .execute_raw_with_consistency(
+                            prepared,
+                            serialized_values,
+                            consistency,
+                            serial_consistency,
+                            page_size,
+                            paging_state_ref.clone(),
+                        )
+                        .await
+                        .and_then(QueryResponse::into_non_error_query_response)
                 },
                 &span,
             )
@@ -2051,7 +2036,7 @@ impl Session {
         routing_info: RoutingInfo<'a>,
         statement_config: &'a StatementConfig,
         execution_profile: Arc<ExecutionProfileInner>,
-        run_request_once: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
+        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         request_span: &'a RequestSpan,
     ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), ExecutionError>
     where
@@ -2232,7 +2217,7 @@ impl Session {
     async fn run_request_speculative_fiber<'a, QueryFut>(
         &'a self,
         request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
-        run_request_once: impl Fn(Arc<Connection>, Consistency, &ExecutionProfileInner) -> QueryFut,
+        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         execution_profile: &ExecutionProfileInner,
         mut context: ExecuteRequestContext<'a>,
     ) -> Option<Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>>
@@ -2277,7 +2262,7 @@ impl Session {
                 let attempt_id: Option<history::AttemptId> =
                     context.log_attempt_start(connect_address);
                 let request_result: Result<NonErrorQueryResponse, RequestAttemptError> =
-                    run_request_once(connection, current_consistency, execution_profile)
+                    run_request_once(connection, current_consistency)
                         .instrument(span.clone())
                         .await;
 

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -15,7 +15,6 @@ use tracing::{Instrument, trace_span};
 use crate::errors::{RequestAttemptError, RequestError};
 #[cfg(feature = "metrics")]
 use crate::observability::metrics::Metrics;
-use crate::response::Coordinator;
 
 /// [`Context`] is passed as an argument to [`SpeculativeExecutionPolicy`] methods.
 #[non_exhaustive]
@@ -157,13 +156,13 @@ fn can_be_ignored<ResT>(result: &Result<ResT, RequestError>) -> bool {
 
 const EMPTY_PLAN_ERROR: RequestError = RequestError::EmptyPlan;
 
-pub(crate) async fn execute<QueryFut, ResT>(
+pub(crate) async fn execute<QueryFut, T>(
     policy: &dyn SpeculativeExecutionPolicy,
     context: &Context,
     mut query_runner_generator: impl FnMut(bool) -> QueryFut,
-) -> Result<(ResT, Coordinator), RequestError>
+) -> Result<T, RequestError>
 where
-    QueryFut: Future<Output = Option<Result<(ResT, Coordinator), RequestError>>>,
+    QueryFut: Future<Output = Option<Result<T, RequestError>>>,
 {
     let mut retries_remaining = policy.max_retry_count(context);
     let retry_interval = policy.retry_interval(context);

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -32,7 +32,7 @@ use scylla_proxy::{
 use tracing::info;
 
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, fetch_negotiated_features,
+    CapturingRetryPolicy, PerformDDL as _, create_new_session_builder, fetch_negotiated_features,
     scylla_supports_tablets, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
 };
 
@@ -558,45 +558,6 @@ async fn test_pager_timeouts() {
 #[tokio::test]
 async fn test_pager_retry_receives_current_consistency() {
     setup_tracing();
-
-    /// On the first call: downgrade CL from `All` to `Two`.
-    /// On the second call: send the observed consistency and stop.
-    /// Resets `call_count` between pages (via `reset()`).
-    #[derive(Debug)]
-    struct CapturingRetryPolicy(mpsc::UnboundedSender<Consistency>);
-
-    impl RetryPolicy for CapturingRetryPolicy {
-        fn new_session(&self) -> Box<dyn RetrySession> {
-            Box::new(CapturingRetrySession {
-                tx: self.0.clone(),
-                call_count: 0,
-            })
-        }
-    }
-
-    struct CapturingRetrySession {
-        tx: mpsc::UnboundedSender<Consistency>,
-        call_count: u32,
-    }
-
-    impl RetrySession for CapturingRetrySession {
-        fn decide_should_retry(&mut self, request_info: RequestInfo) -> RetryDecision {
-            self.call_count += 1;
-            match self.call_count {
-                // First failure: simulate a consistency downgrade (All → Two).
-                1 => RetryDecision::RetrySameTarget(Some(Consistency::Two)),
-                // Second failure: record what consistency was reported.
-                _ => {
-                    let _ = self.tx.send(request_info.consistency);
-                    RetryDecision::DontRetry
-                }
-            }
-        }
-
-        fn reset(&mut self) {
-            self.call_count = 0;
-        }
-    }
 
     let execute_not_control = Condition::RequestOpcode(RequestOpcode::Execute)
         .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));

--- a/scylla/tests/integration/session/retries.rs
+++ b/scylla/tests/integration/session/retries.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    PerformDDL, fetch_negotiated_features, setup_tracing, test_with_3_node_cluster,
-    unique_keyspace_name,
+    CapturingRetryPolicy, PerformDDL, fetch_negotiated_features, setup_tracing,
+    test_with_3_node_cluster, unique_keyspace_name,
 };
 use assert_matches::assert_matches;
 use scylla::client::execution_profile::ExecutionProfile;
@@ -348,6 +348,132 @@ async fn downgrading_consistency_policy_downgrades_on_unavailable() {
         Ok(()) => (),
         Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
         Err(err) => panic!("{}", err),
+    }
+}
+
+/// Regression test for the bug where `Session::run_request_speculative_fiber`
+/// passed the original query consistency instead of `current_consistency` to
+/// `RequestInfo` in the retry loop.
+///
+/// A custom retry policy:
+/// 1. On the first failure: returns `RetrySameTarget(Some(Consistency::Two))`
+///    (simulating a downgrade from `All`).
+/// 2. On the second failure: sends the observed `RequestInfo::consistency`
+///    to a channel and returns `DontRetry`.
+///
+/// Both `query_unpaged` (unprepared) and `execute_unpaged` (prepared) paths
+/// are exercised, since both go through the same retry loop.
+///
+/// Before the fix, `current_consistency` was not passed to `RequestInfo`;
+/// the original query consistency (`All`) was used instead. After the fix
+/// the downgraded value (`Two`) is correctly forwarded.
+#[tokio::test]
+async fn test_session_retry_receives_current_consistency() {
+    setup_tracing();
+
+    let execute_not_control = Condition::RequestOpcode(RequestOpcode::Execute)
+        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+    let query_not_control = Condition::RequestOpcode(RequestOpcode::Query)
+        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+
+    // Case 1: unprepared query via `query_unpaged`.
+    let (tx1, mut rx1) = mpsc::unbounded_channel::<Consistency>();
+    let profile1 = ExecutionProfile::builder()
+        .consistency(Consistency::All)
+        .retry_policy(Arc::new(CapturingRetryPolicy(tx1)))
+        .build();
+
+    // Case 2: prepared statement via `execute_unpaged`.
+    let (tx2, mut rx2) = mpsc::unbounded_channel::<Consistency>();
+    let profile2 = ExecutionProfile::builder()
+        .consistency(Consistency::All)
+        .retry_policy(Arc::new(CapturingRetryPolicy(tx2)))
+        .build();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            // No DDL needed: both queries target system tables that always
+            // exist.
+
+            // --- Case 1: unprepared query ---
+            // Forge server errors on all Query requests whose body contains
+            // "system_schema.tables" (i.e. our specific statement, not
+            // driver-internal queries).
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![RequestRule(
+                    query_not_control
+                        .clone()
+                        .and(Condition::BodyContainsCaseSensitive(Box::new(
+                            *b"system_schema.tables",
+                        ))),
+                    RequestReaction::forge().server_error(),
+                )]));
+            });
+            let mut stmt =
+                Statement::from("SELECT keyspace_name FROM system_schema.tables LIMIT 7");
+            stmt.set_is_idempotent(true);
+            stmt.set_execution_profile_handle(Some(profile1.into_handle()));
+            let _ = session.query_unpaged(stmt, ()).await;
+
+            running_proxy
+                .running_nodes
+                .iter_mut()
+                .for_each(|node| node.change_request_rules(None));
+
+            // --- Case 2: prepared statement ---
+            // Forge server errors on all Execute requests (Execute opcode is
+            // only used for prepared statements, so no further filtering is
+            // needed).
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![RequestRule(
+                    execute_not_control.clone(),
+                    RequestReaction::forge().server_error(),
+                )]));
+            });
+            let mut prepared = session
+                .prepare("SELECT keyspace_name FROM system_schema.tables LIMIT 7")
+                .await
+                .unwrap();
+            prepared.set_is_idempotent(true);
+            prepared.set_execution_profile_handle(Some(profile2.into_handle()));
+            let _ = session.execute_unpaged(&prepared, ()).await;
+
+            running_proxy
+                .running_nodes
+                .iter_mut()
+                .for_each(|node| node.change_request_rules(None));
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+
+    // Both retry sessions must have observed Consistency::Two (the downgraded
+    // CL), not Consistency::All (the original query CL).
+    for (label, rx) in [("query_unpaged", &mut rx1), ("execute_unpaged", &mut rx2)] {
+        let observed = rx.recv().await.unwrap_or_else(|| {
+            panic!("[{label}] retry policy did not send an observed consistency")
+        });
+        assert_eq!(
+            observed,
+            Consistency::Two,
+            "[{label}] session must pass the downgraded consistency (Two) to \
+             RequestInfo, not the original query consistency (All)"
+        );
     }
 }
 

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -10,6 +10,7 @@ use scylla::cluster::NodeRef;
 use scylla::cluster::metadata::ColumnType;
 use scylla::deserialize::value::DeserializeValue;
 use scylla::errors::{DbError, ExecutionError, RequestAttemptError};
+use scylla::frame::types::Consistency;
 use scylla::policies::host_filter::AllowListHostFilter;
 use scylla::policies::load_balancing::{
     FallbackPlan, LoadBalancingPolicy, NodeIdentifier, RoutingInfo, SingleTargetLoadBalancingPolicy,
@@ -601,4 +602,50 @@ pub(crate) async fn fetch_negotiated_features(server: Option<String>) -> Protoco
     running_proxy.finish().await.unwrap();
 
     ProtocolFeatures::parse_from_supported(&supported)
+}
+
+/// A retry policy that captures the consistency seen on the second failure.
+///
+/// On the first `decide_should_retry` call it returns
+/// `RetrySameTarget(Some(Consistency::Two))`, simulating a consistency
+/// downgrade to `Two`.  On every subsequent call it sends
+/// `request_info.consistency` to the channel and returns `DontRetry`.
+///
+/// This is used by regression tests for the bug where the session/pager
+/// passed the original query consistency instead of `current_consistency`
+/// to `RequestInfo`.
+#[derive(Debug)]
+pub(crate) struct CapturingRetryPolicy(pub(crate) mpsc::UnboundedSender<Consistency>);
+
+impl RetryPolicy for CapturingRetryPolicy {
+    fn new_session(&self) -> Box<dyn RetrySession> {
+        Box::new(CapturingRetrySession {
+            tx: self.0.clone(),
+            call_count: 0,
+        })
+    }
+}
+
+pub(crate) struct CapturingRetrySession {
+    tx: mpsc::UnboundedSender<Consistency>,
+    call_count: u32,
+}
+
+impl RetrySession for CapturingRetrySession {
+    fn decide_should_retry(&mut self, request_info: RequestInfo) -> RetryDecision {
+        self.call_count += 1;
+        match self.call_count {
+            // First failure: simulate a consistency downgrade (All → Two).
+            1 => RetryDecision::RetrySameTarget(Some(Consistency::Two)),
+            // Second failure: record what consistency was reported.
+            _ => {
+                let _ = self.tx.send(request_info.consistency);
+                RetryDecision::DontRetry
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.call_count = 0;
+    }
 }


### PR DESCRIPTION
Refs: #1549

## Motivation

While working on #1549, I decide to extract some noncontroversial prefix of the work to a separate PR, so here it is.

## Contents

- Fixes bug that `retry_policy::RequestInfo` was populated with the original consistency instead of the (possibly different) actual consistency used for the request. Added a regression test analogous to one already present in `pager.rs`.
- Updates obsolete naming, moves some code, fixes typo.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
