### PR TITLE
Add public methods required for python-rs driver

### DIFF
--- a/scylla-cql-core/Cargo.toml
+++ b/scylla-cql-core/Cargo.toml
@@ -50,6 +50,10 @@ full-serialization = [
     "bigdecimal-04",
 ]
 
+### UNSTABLE FEATURES ###
+# Enables features for use in Python-RS Driver.
+unstable-python-rs = []
+
 
 [dependencies]
 # Important: We use precise version of scylla-macros. This enables

--- a/scylla-cql-core/src/deserialize/frame_slice.rs
+++ b/scylla-cql-core/src/deserialize/frame_slice.rs
@@ -2,7 +2,10 @@
 
 use bytes::Bytes;
 
+use crate::deserialize::value::DeserializeValue;
+use crate::deserialize::{DeserializationError, TypeCheckError};
 use crate::frame::frame_errors::LowLevelDeserializationError;
+use crate::frame::response::result::ColumnType;
 use crate::frame::types;
 
 /// A borrowed reference to a part of the frame.
@@ -189,6 +192,23 @@ impl<'frame> FrameSlice<'frame> {
             frame_subslice: cql_bytes,
             original_frame: self.original_frame,
         }))
+    }
+}
+
+// What is the purpose of implementing DeserializeValue for Option<FrameSlice<'_>>?
+//
+// Sometimes users might be interested in operating on Option<FrameSlice<'_>> directly.
+// Implementing DeserializeValue for it allows us to simplify our interface.
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for Option<FrameSlice<'frame>> {
+    fn type_check(_typ: &ColumnType) -> Result<(), TypeCheckError> {
+        Ok(())
+    }
+
+    fn deserialize(
+        _typ: &'metadata ColumnType<'metadata>,
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
+        Ok(v)
     }
 }
 

--- a/scylla-cql-core/src/deserialize/value.rs
+++ b/scylla-cql-core/src/deserialize/value.rs
@@ -1592,6 +1592,39 @@ where
     }
 }
 
+/// A type that pairs a frame slice with its column metadata during deserialization.
+/// This is useful when you need both the raw serialized data and the type information
+/// to properly interpret or further deserialize the value.
+pub struct FrameSliceWithMetadata<'frame, 'metadata> {
+    pub frame_slice: Option<FrameSlice<'frame>>,
+    pub column_type: &'metadata ColumnType<'metadata>,
+}
+
+/// What is the purpose of implementing DeserializeValue for FrameSliceWithMetadata<'_, '_>?
+///
+/// Sometimes users might be interested in getting both the raw frame slice and the column
+/// metadata together during deserialization. This allows deferred or custom deserialization
+/// where the user needs access to the type information alongside the serialized bytes.
+/// Implementing DeserializeValue for FrameSliceWithMetadata<'_, '_> allows us to
+/// simplify our interface and provide this capability directly.
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata>
+    for FrameSliceWithMetadata<'frame, 'metadata>
+{
+    fn type_check(_typ: &ColumnType) -> Result<(), TypeCheckError> {
+        Ok(())
+    }
+
+    fn deserialize(
+        typ: &'metadata ColumnType<'metadata>,
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
+        Ok(FrameSliceWithMetadata {
+            frame_slice: v,
+            column_type: typ,
+        })
+    }
+}
+
 // tuples
 
 // Implements tuple deserialization.

--- a/scylla-cql-core/src/serialize/value.rs
+++ b/scylla-cql-core/src/serialize/value.rs
@@ -980,7 +980,19 @@ fn serialize_sequence<'t, 'b, T: SerializeValue + 't>(
         .map_err(|_| mk_ser_err_named(rust_name, typ, BuiltinSerializationErrorKind::SizeOverflow))
 }
 
-fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
+/// Serializes an element with constant-length encoding
+#[cfg(all(scylla_unstable, feature = "unstable-python-rs"))]
+pub fn serialize_next_constant_length_elem_unstable<'t, T: SerializeValue + 't>(
+    rust_name: &'static str,
+    element_type: &ColumnType,
+    typ: &ColumnType,
+    builder: &mut CellValueBuilder,
+    element: &'t T,
+) -> Result<(), SerializationError> {
+    serialize_next_constant_length_elem(rust_name, element_type, typ, builder, element)
+}
+
+pub(crate) fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
     rust_name: &'static str,
     element_type: &ColumnType,
     typ: &ColumnType,

--- a/scylla-cql-core/src/serialize/value.rs
+++ b/scylla-cql-core/src/serialize/value.rs
@@ -1002,7 +1002,19 @@ fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
     Ok(())
 }
 
-fn serialize_next_variable_length_elem<'t, T: SerializeValue + 't>(
+/// Serializes an element with variable-length encoding (vint length prefix + data).
+#[cfg(all(scylla_unstable, feature = "unstable-python-rs"))]
+pub fn serialize_next_variable_length_elem_unstable<'t, T: SerializeValue + 't>(
+    rust_name: &'static str,
+    element_type: &ColumnType,
+    typ: &ColumnType,
+    builder: &mut CellValueBuilder,
+    element: &'t T,
+) -> Result<(), SerializationError> {
+    serialize_next_variable_length_elem(rust_name, element_type, typ, builder, element)
+}
+
+pub(crate) fn serialize_next_variable_length_elem<'t, T: SerializeValue + 't>(
     rust_name: &'static str,
     element_type: &ColumnType,
     typ: &ColumnType,

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -60,6 +60,8 @@ full-serialization = [
 ### UNSTABLE FEATURES ###
 # Enables features for use in Node.js-RS Driver.
 unstable-nodejs-rs = []
+# Enables features for use in Python-RS Driver.
+unstable-python-rs = ["scylla-cql-core/unstable-python-rs"]
 
 
 [dependencies]

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -449,9 +449,7 @@ impl DeserializedMetadataAndRawRows {
         TypedRowIterator::new(raw)
     }
 
-    /// Allows to retrieve raw rows, without the need for deserialization
-    /// Intended to be used only in nodejs-rs driver only.
-    #[cfg(all(scylla_unstable, feature = "unstable-nodejs-rs"))]
+    /// Allows to retrieve raw rows, without the need for deserialization.
     pub fn raw_rows(&self) -> &Bytes {
         &self.raw_rows
     }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -71,6 +71,8 @@ unstable-testing = []
 unstable-cpp-rs = []
 # Enables features for use in Node.js-RS Driver.
 unstable-nodejs-rs = ["scylla-cql/unstable-nodejs-rs"]
+# Enables features for use in Python-RS Driver.
+unstable-python-rs = ["scylla-cql/unstable-python-rs", "scylla-cql-core/unstable-python-rs"]
 # Enables HostListener experimental support.
 unstable-host-listener = []
 # Enables unstable reconnection policy configuration.

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -61,6 +61,7 @@ pub(crate) struct Metadata {
 }
 
 /// Represents a node in the cluster, as fetched from the `system.{peers,local}` tables.
+#[cfg_attr(all(scylla_unstable, feature = "unstable-python-rs"), derive(Clone))] // <- for python-rs HostFilter wrapper to store Peer and reconstruct it from &Peer in accept()
 #[non_exhaustive] // <- so that we can add more fields in a backwards-compatible way
 pub struct Peer {
     /// Unique identifier of the node.

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -53,13 +53,8 @@ pub struct ClusterState {
     pub(crate) cluster_name: Option<String>,
 }
 
-/// Enables printing [ClusterState] struct in a neat way, skipping the clutter involved by
-/// [ClusterState::ring] being large and [Self::keyspaces] debug print being very verbose by default.
-pub(crate) struct ClusterStateNeatDebug<'a>(pub(crate) &'a Arc<ClusterState>);
-impl std::fmt::Debug for ClusterStateNeatDebug<'_> {
+impl std::fmt::Debug for ClusterState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let cluster_state = &self.0;
-
         let ring_printer = {
             struct RingSizePrinter(usize);
             impl std::fmt::Debug for RingSizePrinter {
@@ -67,13 +62,13 @@ impl std::fmt::Debug for ClusterStateNeatDebug<'_> {
                     write!(f, "<size={}>", self.0)
                 }
             }
-            RingSizePrinter(cluster_state.locator.ring().len())
+            RingSizePrinter(self.locator.ring().len())
         };
 
         f.debug_struct("ClusterState")
-            .field("known_nodes", &cluster_state.known_nodes)
+            .field("known_nodes", &self.known_nodes)
             .field("ring", &ring_printer)
-            .field("keyspaces", &cluster_state.keyspaces.keys())
+            .field("keyspaces", &self.keyspaces.keys())
             .finish_non_exhaustive()
     }
 }

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
 use super::metadata::reader::MetadataReader;
-use super::state::{ClusterState, ClusterStateNeatDebug};
+use super::state::ClusterState;
 
 /// Cluster manages up to date information and connections to database nodes.
 /// All state can be accessed by cloning Arc<ClusterState> in the `state` field
@@ -48,7 +48,7 @@ impl std::fmt::Debug for ClusterNeatDebug<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let cluster = self.0;
         f.debug_struct("Cluster")
-            .field("data", &ClusterStateNeatDebug(&cluster.state.load()))
+            .field("data", &cluster.state.load())
             .finish_non_exhaustive()
     }
 }

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -240,7 +240,7 @@ pub mod deserialize {
     pub mod value {
         pub use scylla_cql_core::deserialize::value::{
             BuiltinDeserializationError, BuiltinDeserializationErrorKind, BuiltinTypeCheckError,
-            BuiltinTypeCheckErrorKind, DeserializeValue, ListlikeIterator,
+            BuiltinTypeCheckErrorKind, DeserializeValue, FrameSliceWithMetadata, ListlikeIterator,
             MapDeserializationErrorKind, MapIterator, MapTypeCheckErrorKind,
             SetOrListDeserializationErrorKind, SetOrListTypeCheckErrorKind,
             TupleDeserializationErrorKind, TupleTypeCheckErrorKind, UdtIterator,

--- a/scylla/src/policies/address_translator.rs
+++ b/scylla/src/policies/address_translator.rs
@@ -24,7 +24,7 @@ pub struct UntranslatedPeer<'a> {
     pub(crate) rack: Option<&'a str>,
 }
 
-impl UntranslatedPeer<'_> {
+impl<'a> UntranslatedPeer<'a> {
     /// The unique identifier of the node in the cluster.
     #[inline]
     pub fn host_id(&self) -> Uuid {
@@ -48,6 +48,40 @@ impl UntranslatedPeer<'_> {
     #[inline]
     pub fn rack(&self) -> Option<&str> {
         self.rack
+    }
+
+    /// Creates a new `UntranslatedPeer` from its fields.
+    ///
+    /// This constructor is intended to be used only by the python-rs driver.
+    ///
+    /// In the python-rs driver we need to expose built-in `AddressTranslator`
+    /// implementations to Python users. This means that their `translate`
+    /// methods must also be callable from Python.
+    ///
+    /// When Rust calls a Python-provided `AddressTranslator`, we convert the
+    /// Rust `UntranslatedPeer` into the corresponding Python wrapper and pass it
+    /// to the Python `translate` method. However, a Python user may also call
+    /// `translate` on one of our exposed built-in translators and pass that same
+    /// Python wrapper back to us. In that case, to call the internal Rust
+    /// implementation of the `AddressTranslator` trait, we need to reconstruct
+    /// the Rust `UntranslatedPeer` from the Python wrapper.
+    ///
+    /// Since `UntranslatedPeer` contains a lifetime, it cannot be stored directly
+    /// inside the Python wrapper, so the wrapper stores its fields instead and
+    /// uses this constructor to rebuild the Rust value when needed.
+    #[cfg(all(scylla_unstable, feature = "unstable-python-rs"))]
+    pub fn from_fields(
+        host_id: Uuid,
+        untranslated_address: SocketAddr,
+        datacenter: Option<&'a str>,
+        rack: Option<&'a str>,
+    ) -> Self {
+        UntranslatedPeer {
+            host_id,
+            untranslated_address,
+            datacenter,
+            rack,
+        }
     }
 
     /// Creates a new untranslated peer. Intended to be used only in nodejs-rs driver only.

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -97,6 +97,32 @@ impl RoutingInfo<'_> {
     }
 }
 
+impl<'a> RoutingInfo<'a> {
+    /// Creates a new `RoutingInfo` instance with the specified parameters.
+    ///
+    /// This constructor should be used only by the Python RS Driver to construct
+    /// routing metadata, enabling built-in driver components—such as the
+    /// default load balancing policy to be exposed to Python.
+    #[cfg(all(scylla_unstable, feature = "unstable-python-rs"))]
+    pub fn new(
+        consistency: types::Consistency,
+        serial_consistency: Option<types::SerialConsistency>,
+        token: Option<Token>,
+        table: Option<&'a TableSpec<'a>>,
+        is_confirmed_lwt: bool,
+        node_location_preference: &'a NodeLocationPreference,
+    ) -> Self {
+        Self {
+            consistency,
+            serial_consistency,
+            token,
+            table,
+            is_confirmed_lwt,
+            node_location_preference,
+        }
+    }
+}
+
 /// The fallback list of nodes in the request plan.
 ///
 /// It is computed on-demand, only if querying the most preferred node fails

--- a/scylla/src/policies/retry/retry_policy.rs
+++ b/scylla/src/policies/retry/retry_policy.rs
@@ -18,6 +18,22 @@ pub struct RequestInfo<'a> {
     pub consistency: Consistency,
 }
 
+impl<'a> RequestInfo<'a> {
+    /// Creates a new `RequestInfo` instance.
+    #[cfg(all(scylla_unstable, feature = "unstable-python-rs"))]
+    pub fn new(
+        error: &'a RequestAttemptError,
+        is_idempotent: bool,
+        consistency: Consistency,
+    ) -> Self {
+        Self {
+            error,
+            is_idempotent,
+            consistency,
+        }
+    }
+}
+
 /// Returned by implementations of RetryPolicy. Instructs the driver on what
 /// to do about the request after it failed.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -127,6 +127,14 @@ impl QueryResult {
         }
     }
 
+    /// Returns the deserialized metadata and raw rows.
+    /// Public only when the `unstable-python-rs` feature is enabled.
+    #[cfg(all(scylla_unstable, feature = "unstable-python-rs"))]
+    pub fn deserialized_metadata_and_rows(&self) -> Option<&DeserializedMetadataAndRawRows> {
+        self.deserialized_metadata_and_rows.as_ref()
+    }
+
+    #[cfg(not(all(scylla_unstable, feature = "unstable-python-rs")))]
     pub(crate) fn deserialized_metadata_and_rows(&self) -> Option<&DeserializedMetadataAndRawRows> {
         self.deserialized_metadata_and_rows.as_ref()
     }


### PR DESCRIPTION
## Summary
Introduces a python-rs feature flag to conditionally expose internal methods required exclusively by the python-rs driver.
## Changes
-  Added python-rs feature flag.
- Applied #[cfg(feature = "python-rs")] to methods needed by the python-rs driver
- Made serialize_next_variable_length_elem public for python-rs.
- Made serialize_next_constant_length_elem public for python-rs.
- Made raw_rows() public
- Implement constructors for UntranslatedPeer, RequestInfo, RoutingInfo
- Add clone to Peer

## Pre-review checklist


- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
