### PR TITLE
session: Extract execution core

### DIFF
--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -1,0 +1,383 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::{Instrument as _, trace, trace_span};
+
+use crate::errors::{RequestAttemptError, RequestError};
+use crate::frame::types::Consistency;
+
+use crate::network::Connection;
+use crate::observability::driver_tracing::RequestSpan;
+use crate::observability::history::{self, HistoryListener};
+use crate::observability::metrics::Metrics;
+use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
+use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy};
+use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
+use crate::response::{Coordinator, NonErrorQueryResponse};
+use crate::{cluster::NodeRef, routing::Shard};
+
+pub(crate) enum RunRequestResult<ResT> {
+    IgnoredWriteError,
+    Completed(ResT),
+}
+
+// If a speculative execution policy is used to run request, request_plan has to be shared
+// between different async functions. This struct helps to wrap request_plan in mutex so it
+// can be shared safely.
+struct SharedPlan<'a, I>
+where
+    I: Iterator<Item = (NodeRef<'a>, Shard)>,
+{
+    iter: std::sync::Mutex<I>,
+}
+
+impl<'a, I> Iterator for &SharedPlan<'a, I>
+where
+    I: Iterator<Item = (NodeRef<'a>, Shard)>,
+{
+    type Item = (NodeRef<'a>, Shard);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.lock().unwrap().next()
+    }
+}
+
+/// All resolved per-request configuration needed to execute a request,
+/// independent of any `Session`.
+///
+/// The two-level fallback between per-statement config and the execution
+/// profile is resolved *before* constructing this struct.
+pub(crate) struct RequestExecutionParams<'a> {
+    /// Whether the request is idempotent (gates speculative execution and is
+    /// passed to the retry policy).
+    pub(crate) is_idempotent: bool,
+    /// Consistency explicitly set on the statement, if any. When `None`,
+    /// [`Self::default_consistency`] is used.
+    pub(crate) consistency_set_on_statement: Option<Consistency>,
+    /// Consistency to use when the statement does not set one explicitly
+    /// (i.e. the execution profile's consistency).
+    pub(crate) default_consistency: Consistency,
+    /// Retry policy used to start a fresh retry session per fiber.
+    pub(crate) retry_policy: &'a dyn RetryPolicy,
+    /// Load balancing policy used to order targets for the execution.
+    pub(crate) load_balancing_policy: &'a dyn LoadBalancingPolicy,
+    /// Metrics sink.
+    pub(crate) metrics: &'a Arc<Metrics>,
+    /// Speculative execution policy, if any.
+    pub(crate) speculative_policy: Option<&'a dyn SpeculativeExecutionPolicy>,
+    /// Client-side request timeout, if any.
+    pub(crate) request_timeout: Option<Duration>,
+    /// History listener, if any.
+    pub(crate) history_listener: Option<&'a dyn HistoryListener>,
+}
+
+struct HistoryData<'a> {
+    listener: &'a dyn HistoryListener,
+    request_id: history::RequestId,
+    speculative_id: Option<history::SpeculativeId>,
+}
+
+struct ExecuteRequestContext<'a> {
+    history_data: Option<HistoryData<'a>>,
+    routing_info: &'a load_balancing::RoutingInfo<'a>,
+    request_span: &'a RequestSpan,
+}
+
+impl ExecuteRequestContext<'_> {
+    fn log_attempt_start(&self, node_addr: SocketAddr) -> Option<history::AttemptId> {
+        self.history_data.as_ref().map(|hd| {
+            hd.listener
+                .log_attempt_start(hd.request_id, hd.speculative_id, node_addr)
+        })
+    }
+
+    fn log_attempt_success(&self, attempt_id_opt: &Option<history::AttemptId>) {
+        let attempt_id: &history::AttemptId = match attempt_id_opt {
+            Some(id) => id,
+            None => return,
+        };
+
+        let history_data: &HistoryData = match &self.history_data {
+            Some(data) => data,
+            None => return,
+        };
+
+        history_data.listener.log_attempt_success(*attempt_id);
+    }
+
+    fn log_attempt_error(
+        &self,
+        attempt_id_opt: &Option<history::AttemptId>,
+        error: &RequestAttemptError,
+        retry_decision: &RetryDecision,
+    ) {
+        let attempt_id: &history::AttemptId = match attempt_id_opt {
+            Some(id) => id,
+            None => return,
+        };
+
+        let history_data: &HistoryData = match &self.history_data {
+            Some(data) => data,
+            None => return,
+        };
+
+        history_data
+            .listener
+            .log_attempt_error(*attempt_id, error, retry_decision);
+    }
+}
+
+impl<'a> RequestExecutionParams<'a> {
+    /// Executes a request without handling side effects and without
+    /// needing a `Session`.
+    ///
+    /// Applies the client-side timeout and, for idempotent requests with a
+    /// speculative execution policy, runs potentially multiple
+    /// [`run_request_speculative_fiber`] fibers; otherwise runs a single fiber.
+    ///
+    /// `request_plan` is an iterator of targets. `run_request_once`
+    /// performs a single attempt against a chosen connection and consistency.
+    pub(crate) async fn run_request_no_side_effects<QueryFut>(
+        &'a self,
+        routing_info: &'a RoutingInfo<'a>,
+        request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
+        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
+        request_span: &'a RequestSpan,
+    ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>
+    where
+        QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
+    {
+        let history_listener_and_id: Option<(&dyn HistoryListener, history::RequestId)> =
+            self.history_listener.map(|hl| (hl, hl.log_request_start()));
+
+        let runner = async {
+            match self.speculative_policy {
+                Some(speculative) if self.is_idempotent => {
+                    let shared_request_plan = SharedPlan {
+                        iter: std::sync::Mutex::new(request_plan),
+                    };
+
+                    let request_runner_generator = |is_speculative: bool| {
+                        let history_data: Option<HistoryData> = history_listener_and_id
+                            .as_ref()
+                            .map(|(history_listener, request_id)| {
+                                let speculative_id: Option<history::SpeculativeId> =
+                                    if is_speculative {
+                                        Some(
+                                            history_listener.log_new_speculative_fiber(*request_id),
+                                        )
+                                    } else {
+                                        None
+                                    };
+                                HistoryData {
+                                    listener: *history_listener,
+                                    request_id: *request_id,
+                                    speculative_id,
+                                }
+                            });
+
+                        if is_speculative {
+                            request_span.inc_speculative_executions();
+                        }
+
+                        self.run_request_speculative_fiber(
+                            &shared_request_plan,
+                            &run_request_once,
+                            ExecuteRequestContext {
+                                history_data,
+                                routing_info,
+                                request_span,
+                            },
+                        )
+                    };
+
+                    let context = speculative_execution::Context {
+                        #[cfg(feature = "metrics")]
+                        metrics: Arc::clone(self.metrics),
+                    };
+
+                    speculative_execution::execute(speculative, &context, request_runner_generator)
+                        .await
+                }
+                _ => {
+                    let history_data: Option<HistoryData> =
+                        history_listener_and_id
+                            .as_ref()
+                            .map(|(history_listener, request_id)| HistoryData {
+                                listener: *history_listener,
+                                request_id: *request_id,
+                                speculative_id: None,
+                            });
+                    self.run_request_speculative_fiber(
+                        request_plan,
+                        &run_request_once,
+                        ExecuteRequestContext {
+                            history_data,
+                            routing_info,
+                            request_span,
+                        },
+                    )
+                    .await
+                    .unwrap_or(Err(RequestError::EmptyPlan))
+                }
+            }
+        };
+
+        let result = match self.request_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
+                |_: tokio::time::error::Elapsed| {
+                    self.metrics.inc_request_timeouts();
+
+                    let timeout_error = RequestError::RequestTimeout(timeout);
+                    trace!(
+                        parent: request_span.span(),
+                        error = %timeout_error,
+                        "Request timed out"
+                    );
+                    Err(timeout_error)
+                },
+            ),
+            None => runner.await,
+        };
+
+        if let Some((history_listener, request_id)) = history_listener_and_id {
+            match &result {
+                Ok(_) => history_listener.log_request_success(request_id),
+                Err(e) => history_listener.log_request_error(request_id, e),
+            }
+        }
+
+        result
+    }
+}
+
+impl<'a> RequestExecutionParams<'a> {
+    /// A single execution fiber.
+    ///
+    /// Iterates the execution plan, picking a connection for each target and attempt,
+    /// running `run_request_once` and consulting the retry policy on failure.
+    ///
+    /// Returns `None` only if the plan was empty.
+    async fn run_request_speculative_fiber<QueryFut>(
+        &self,
+        request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
+        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
+        context: ExecuteRequestContext<'a>,
+    ) -> Option<Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>>
+    where
+        QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
+    {
+        let mut retry_session = self.retry_policy.new_session();
+        let mut last_error: Option<RequestError> = None;
+        let mut current_consistency: Consistency = self
+            .consistency_set_on_statement
+            .unwrap_or(self.default_consistency);
+
+        'nodes_in_plan: for (node, shard) in request_plan {
+            let span = trace_span!("Executing request", node = %node.address, shard = %shard);
+            'same_node_retries: loop {
+                trace!(parent: &span, "Execution started");
+                let connection = match node.connection_for_shard(shard).await {
+                    Ok(connection) => connection,
+                    Err(e) => {
+                        trace!(
+                            parent: &span,
+                            error = %e,
+                            "Choosing connection failed"
+                        );
+                        last_error = Some(e.into());
+                        // Broken connection doesn't count as a failed request, don't log in metrics
+                        continue 'nodes_in_plan;
+                    }
+                };
+                context.request_span.record_shard_id(&connection);
+
+                self.metrics.inc_total_nonpaged_queries();
+                let request_start = std::time::Instant::now();
+
+                let connect_address = connection.get_connect_address();
+                trace!(
+                    parent: &span,
+                    connection = %connect_address,
+                    "Sending"
+                );
+                let coordinator = Coordinator::new(node, &connection);
+
+                let attempt_id: Option<history::AttemptId> =
+                    context.log_attempt_start(connect_address);
+                let request_result: Result<NonErrorQueryResponse, RequestAttemptError> =
+                    run_request_once(connection, current_consistency)
+                        .instrument(span.clone())
+                        .await;
+
+                let elapsed = request_start.elapsed();
+                let request_error: RequestAttemptError = match request_result {
+                    Ok(response) => {
+                        trace!(parent: &span, "Request succeeded");
+                        let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
+                        context.log_attempt_success(&attempt_id);
+                        self.load_balancing_policy.on_request_success(
+                            context.routing_info,
+                            elapsed,
+                            node,
+                        );
+                        return Some(Ok((RunRequestResult::Completed(response), coordinator)));
+                    }
+                    Err(e) => {
+                        trace!(
+                            parent: &span,
+                            last_error = %e,
+                            "Request failed"
+                        );
+                        self.metrics.inc_failed_nonpaged_queries();
+                        self.load_balancing_policy.on_request_failure(
+                            context.routing_info,
+                            elapsed,
+                            node,
+                            &e,
+                        );
+                        e
+                    }
+                };
+
+                // Use retry policy to decide what to do next
+                let request_info = RequestInfo {
+                    error: &request_error,
+                    is_idempotent: self.is_idempotent,
+                    consistency: current_consistency,
+                };
+
+                let retry_decision = retry_session.decide_should_retry(request_info);
+                trace!(
+                    parent: &span,
+                    retry_decision = ?retry_decision
+                );
+
+                context.log_attempt_error(&attempt_id, &request_error, &retry_decision);
+
+                last_error = Some(request_error.into());
+
+                match retry_decision {
+                    RetryDecision::RetrySameTarget(new_cl) => {
+                        self.metrics.inc_retries_num();
+                        current_consistency = new_cl.unwrap_or(current_consistency);
+                        continue 'same_node_retries;
+                    }
+                    RetryDecision::RetryNextTarget(new_cl) => {
+                        self.metrics.inc_retries_num();
+                        current_consistency = new_cl.unwrap_or(current_consistency);
+                        continue 'nodes_in_plan;
+                    }
+                    RetryDecision::DontRetry => break 'nodes_in_plan,
+
+                    RetryDecision::IgnoreWriteError => {
+                        return Some(Ok((RunRequestResult::IgnoredWriteError, coordinator)));
+                    }
+                };
+            }
+        }
+
+        last_error.map(Result::Err)
+    }
+}

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -125,6 +125,26 @@ impl ExecuteRequestContext<'_> {
 }
 
 impl<'a> RequestExecutionParams<'a> {
+    fn inc_total_queries(&self) {
+        self.metrics.inc_total_nonpaged_queries();
+    }
+
+    fn inc_failed_queries(&self) {
+        self.metrics.inc_failed_nonpaged_queries();
+    }
+
+    fn inc_retries_num(&self) {
+        self.metrics.inc_retries_num();
+    }
+
+    fn inc_request_timeouts(&self) {
+        self.metrics.inc_request_timeouts();
+    }
+
+    fn log_query_latency(&self, latency_ms: u64) {
+        let _ = self.metrics.log_query_latency(latency_ms);
+    }
+
     /// Executes a request without handling side effects and without
     /// needing a `Session`.
     ///
@@ -223,7 +243,7 @@ impl<'a> RequestExecutionParams<'a> {
         let result = match self.request_timeout {
             Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
                 |_: tokio::time::error::Elapsed| {
-                    self.metrics.inc_request_timeouts();
+                    self.inc_request_timeouts();
 
                     let timeout_error = RequestError::RequestTimeout(timeout);
                     trace!(
@@ -289,7 +309,7 @@ impl<'a> RequestExecutionParams<'a> {
                 };
                 context.request_span.record_shard_id(&connection);
 
-                self.metrics.inc_total_nonpaged_queries();
+                self.inc_total_queries();
                 let request_start = std::time::Instant::now();
 
                 let connect_address = connection.get_connect_address();
@@ -311,7 +331,7 @@ impl<'a> RequestExecutionParams<'a> {
                 let request_error: RequestAttemptError = match request_result {
                     Ok(response) => {
                         trace!(parent: &span, "Request succeeded");
-                        let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
+                        self.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
                         self.load_balancing_policy.on_request_success(
                             context.routing_info,
@@ -326,7 +346,7 @@ impl<'a> RequestExecutionParams<'a> {
                             last_error = %e,
                             "Request failed"
                         );
-                        self.metrics.inc_failed_nonpaged_queries();
+                        self.inc_failed_queries();
                         self.load_balancing_policy.on_request_failure(
                             context.routing_info,
                             elapsed,
@@ -356,12 +376,12 @@ impl<'a> RequestExecutionParams<'a> {
 
                 match retry_decision {
                     RetryDecision::RetrySameTarget(new_cl) => {
-                        self.metrics.inc_retries_num();
+                        self.inc_retries_num();
                         current_consistency = new_cl.unwrap_or(current_consistency);
                         continue 'same_node_retries;
                     }
                     RetryDecision::RetryNextTarget(new_cl) => {
-                        self.metrics.inc_retries_num();
+                        self.inc_retries_num();
                         current_consistency = new_cl.unwrap_or(current_consistency);
                         continue 'nodes_in_plan;
                     }

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -17,6 +17,7 @@ use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
 use crate::response::{Coordinator, NonErrorQueryResponse};
 use crate::{cluster::NodeRef, routing::Shard};
 
+/// Result of running a request, before side effects are handled.
 pub(crate) enum RunRequestResult<ResT> {
     IgnoredWriteError,
     Completed(ResT),
@@ -68,12 +69,14 @@ pub(crate) struct RequestExecutionParams<'a> {
     pub(crate) history_listener: Option<&'a dyn HistoryListener>,
 }
 
+/// History data threaded through a single fiber.
 struct HistoryData<'a> {
     listener: &'a dyn HistoryListener,
     request_id: history::RequestId,
     speculative_id: Option<history::SpeculativeId>,
 }
 
+/// Per-fiber execution context.
 struct ExecuteRequestContext<'a> {
     history_data: Option<HistoryData<'a>>,
     routing_info: &'a load_balancing::RoutingInfo<'a>,

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -22,21 +22,17 @@ pub(crate) enum RunRequestResult<ResT> {
     Completed(ResT),
 }
 
-// If a speculative execution policy is used to run request, request_plan has to be shared
-// between different async functions. This struct helps to wrap request_plan in mutex so it
-// can be shared safely.
-struct SharedPlan<'a, I>
-where
-    I: Iterator<Item = (NodeRef<'a>, Shard)>,
-{
+/// Wraps a request plan in a mutex so that it can be shared between speculative
+/// fibers running concurrently.
+struct SharedPlan<I> {
     iter: std::sync::Mutex<I>,
 }
 
-impl<'a, I> Iterator for &SharedPlan<'a, I>
+impl<Target, I> Iterator for &SharedPlan<I>
 where
-    I: Iterator<Item = (NodeRef<'a>, Shard)>,
+    I: Iterator<Item = Target>,
 {
-    type Item = (NodeRef<'a>, Shard);
+    type Item = Target;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.lock().unwrap().next()

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -92,14 +92,8 @@ impl ExecuteRequestContext<'_> {
     }
 
     fn log_attempt_success(&self, attempt_id_opt: &Option<history::AttemptId>) {
-        let attempt_id: &history::AttemptId = match attempt_id_opt {
-            Some(id) => id,
-            None => return,
-        };
-
-        let history_data: &HistoryData = match &self.history_data {
-            Some(data) => data,
-            None => return,
+        let (Some(history_data), Some(attempt_id)) = (&self.history_data, attempt_id_opt) else {
+            return;
         };
 
         history_data.listener.log_attempt_success(*attempt_id);
@@ -111,14 +105,8 @@ impl ExecuteRequestContext<'_> {
         error: &RequestAttemptError,
         retry_decision: &RetryDecision,
     ) {
-        let attempt_id: &history::AttemptId = match attempt_id_opt {
-            Some(id) => id,
-            None => return,
-        };
-
-        let history_data: &HistoryData = match &self.history_data {
-            Some(data) => data,
-            None => return,
+        let (Some(history_data), Some(attempt_id)) = (&self.history_data, attempt_id_opt) else {
+            return;
         };
 
         history_data

--- a/scylla/src/client/mod.rs
+++ b/scylla/src/client/mod.rs
@@ -17,6 +17,8 @@
 
 pub mod execution_profile;
 
+mod execution;
+
 pub mod pager;
 
 pub mod client_routes;

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2094,14 +2094,53 @@ impl Session {
         let cluster_state = self.cluster.get_state();
         let request_plan = load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
 
-        let history_listener_and_id: Option<(&'_ dyn HistoryListener, history::RequestId)> =
-            exec_params
-                .history_listener
-                .map(|hl| (hl, hl.log_request_start()));
+        let result = exec_params
+            .run_request_no_side_effects(
+                &routing_info,
+                request_plan,
+                run_request_once,
+                request_span,
+            )
+            .await
+            .map_err(RequestError::into_execution_error)?;
+
+        // Automatically handle meaningful responses.
+        if let (RunRequestResult::Completed(ref response), ref coordinator) = result {
+            self.handle_set_keyspace_response(response).await?;
+            self.handle_auto_await_schema_agreement(response, coordinator.node().host_id)
+                .await?;
+        }
+
+        Ok(result)
+    }
+}
+
+impl<'a> RequestExecutionParams<'a> {
+    /// Executes a request without handling side effects and without
+    /// needing a `Session`.
+    ///
+    /// Applies the client-side timeout and, for idempotent requests with a
+    /// speculative execution policy, runs potentially multiple
+    /// [`run_request_speculative_fiber`] fibers; otherwise runs a single fiber.
+    ///
+    /// `request_plan` is an iterator of targets. `run_request_once`
+    /// performs a single attempt against a chosen connection and consistency.
+    pub(crate) async fn run_request_no_side_effects<QueryFut>(
+        &'a self,
+        routing_info: &'a RoutingInfo<'a>,
+        request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
+        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
+        request_span: &'a RequestSpan,
+    ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>
+    where
+        QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
+    {
+        let history_listener_and_id: Option<(&dyn HistoryListener, history::RequestId)> =
+            self.history_listener.map(|hl| (hl, hl.log_request_start()));
 
         let runner = async {
-            match exec_params.speculative_policy {
-                Some(speculative) if statement_config.is_idempotent => {
+            match self.speculative_policy {
+                Some(speculative) if self.is_idempotent => {
                     let shared_request_plan = SharedPlan {
                         iter: std::sync::Mutex::new(request_plan),
                     };
@@ -2129,12 +2168,12 @@ impl Session {
                             request_span.inc_speculative_executions();
                         }
 
-                        exec_params.run_request_speculative_fiber(
+                        self.run_request_speculative_fiber(
                             &shared_request_plan,
                             &run_request_once,
                             ExecuteRequestContext {
                                 history_data,
-                                routing_info: &routing_info,
+                                routing_info,
                                 request_span,
                             },
                         )
@@ -2142,7 +2181,7 @@ impl Session {
 
                     let context = speculative_execution::Context {
                         #[cfg(feature = "metrics")]
-                        metrics: Arc::clone(&self.metrics),
+                        metrics: Arc::clone(self.metrics),
                     };
 
                     speculative_execution::execute(speculative, &context, request_runner_generator)
@@ -2157,23 +2196,22 @@ impl Session {
                                 request_id: *request_id,
                                 speculative_id: None,
                             });
-                    exec_params
-                        .run_request_speculative_fiber(
-                            request_plan,
-                            &run_request_once,
-                            ExecuteRequestContext {
-                                history_data,
-                                routing_info: &routing_info,
-                                request_span,
-                            },
-                        )
-                        .await
-                        .unwrap_or(Err(RequestError::EmptyPlan))
+                    self.run_request_speculative_fiber(
+                        request_plan,
+                        &run_request_once,
+                        ExecuteRequestContext {
+                            history_data,
+                            routing_info,
+                            request_span,
+                        },
+                    )
+                    .await
+                    .unwrap_or(Err(RequestError::EmptyPlan))
                 }
             }
         };
 
-        let result = match exec_params.request_timeout {
+        let result = match self.request_timeout {
             Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
                 |_: tokio::time::error::Elapsed| {
                     self.metrics.inc_request_timeouts();
@@ -2197,16 +2235,7 @@ impl Session {
             }
         }
 
-        let result = result.map_err(RequestError::into_execution_error)?;
-
-        // Automatically handle meaningful responses.
-        if let (RunRequestResult::Completed(ref response), ref coordinator) = result {
-            self.handle_set_keyspace_response(response).await?;
-            self.handle_auto_await_schema_agreement(response, coordinator.node().host_id)
-                .await?;
-        }
-
-        Ok(result)
+        result
     }
 }
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -6,7 +6,8 @@ use super::pager::{PreparedPagerConfig, QueryPager};
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
 use crate::client::client_routes::ClientRoutesConfig;
-use crate::cluster::node::{KnownNode, NodeRef};
+use crate::client::execution::{RequestExecutionParams, RunRequestResult};
+use crate::cluster::node::KnownNode;
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::DbError;
 use crate::errors::{
@@ -21,25 +22,22 @@ use crate::network::{
     Connection, ConnectionConfig, PoolConfig, TcpSocketOptions, VerifiedKeyspaceName,
 };
 use crate::observability::driver_tracing::RequestSpan;
-use crate::observability::history::{self, HistoryListener};
 use crate::observability::metrics::Metrics;
 use crate::observability::tracing::TracingInfo;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
-use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
+use crate::policies::load_balancing::{self, RoutingInfo};
 use crate::policies::reconnect::ExponentialReconnectPolicy;
 #[cfg(all(scylla_unstable, feature = "unstable-reconnect-policy"))]
 use crate::policies::reconnect::ReconnectPolicy;
-use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy};
-use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::response::query_result::{MaybeFirstRowError, QueryResult, RowsError};
 use crate::response::{
     Coordinator, NonErrorQueryResponse, PagingState, PagingStateResponse, QueryResponse,
 };
 use crate::routing::NodeLocationPreference;
+use crate::routing::ShardAwarePortRange;
 use crate::routing::partitioner::PartitionerName;
-use crate::routing::{Shard, ShardAwarePortRange};
 use crate::serialize::batch::BatchValues;
 use crate::serialize::row::{SerializeRow, SerializedValues};
 use crate::statement::batch::batch_values;
@@ -60,7 +58,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use thiserror::Error;
 use tokio::time::timeout;
-use tracing::{Instrument, debug, error, trace, trace_span};
+use tracing::{Instrument, debug, error};
 use uuid::Uuid;
 
 pub(crate) const TABLET_CHANNEL_SIZE: usize = 8192;
@@ -547,11 +545,6 @@ impl SessionConfig {
 
         Ok(())
     }
-}
-
-pub(crate) enum RunRequestResult<ResT> {
-    IgnoredWriteError,
-    Completed(ResT),
 }
 
 /// Represents a CQL session, which can be used to communicate
@@ -2022,27 +2015,6 @@ impl Session {
     }
 }
 
-// If a speculative execution policy is used to run request, request_plan has to be shared
-// between different async functions. This struct helps to wrap request_plan in mutex so it
-// can be shared safely.
-struct SharedPlan<'a, I>
-where
-    I: Iterator<Item = (NodeRef<'a>, Shard)>,
-{
-    iter: std::sync::Mutex<I>,
-}
-
-impl<'a, I> Iterator for &SharedPlan<'a, I>
-where
-    I: Iterator<Item = (NodeRef<'a>, Shard)>,
-{
-    type Item = (NodeRef<'a>, Shard);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.lock().unwrap().next()
-    }
-}
-
 impl Session {
     /// This method allows to easily run a request using load balancing, retry policy etc.
     /// Requires some information about the request and a closure.
@@ -2112,289 +2084,6 @@ impl Session {
         }
 
         Ok(result)
-    }
-}
-
-impl<'a> RequestExecutionParams<'a> {
-    /// Executes a request without handling side effects and without
-    /// needing a `Session`.
-    ///
-    /// Applies the client-side timeout and, for idempotent requests with a
-    /// speculative execution policy, runs potentially multiple
-    /// [`run_request_speculative_fiber`] fibers; otherwise runs a single fiber.
-    ///
-    /// `request_plan` is an iterator of targets. `run_request_once`
-    /// performs a single attempt against a chosen connection and consistency.
-    pub(crate) async fn run_request_no_side_effects<QueryFut>(
-        &'a self,
-        routing_info: &'a RoutingInfo<'a>,
-        request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
-        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
-        request_span: &'a RequestSpan,
-    ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>
-    where
-        QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
-    {
-        let history_listener_and_id: Option<(&dyn HistoryListener, history::RequestId)> =
-            self.history_listener.map(|hl| (hl, hl.log_request_start()));
-
-        let runner = async {
-            match self.speculative_policy {
-                Some(speculative) if self.is_idempotent => {
-                    let shared_request_plan = SharedPlan {
-                        iter: std::sync::Mutex::new(request_plan),
-                    };
-
-                    let request_runner_generator = |is_speculative: bool| {
-                        let history_data: Option<HistoryData> = history_listener_and_id
-                            .as_ref()
-                            .map(|(history_listener, request_id)| {
-                                let speculative_id: Option<history::SpeculativeId> =
-                                    if is_speculative {
-                                        Some(
-                                            history_listener.log_new_speculative_fiber(*request_id),
-                                        )
-                                    } else {
-                                        None
-                                    };
-                                HistoryData {
-                                    listener: *history_listener,
-                                    request_id: *request_id,
-                                    speculative_id,
-                                }
-                            });
-
-                        if is_speculative {
-                            request_span.inc_speculative_executions();
-                        }
-
-                        self.run_request_speculative_fiber(
-                            &shared_request_plan,
-                            &run_request_once,
-                            ExecuteRequestContext {
-                                history_data,
-                                routing_info,
-                                request_span,
-                            },
-                        )
-                    };
-
-                    let context = speculative_execution::Context {
-                        #[cfg(feature = "metrics")]
-                        metrics: Arc::clone(self.metrics),
-                    };
-
-                    speculative_execution::execute(speculative, &context, request_runner_generator)
-                        .await
-                }
-                _ => {
-                    let history_data: Option<HistoryData> =
-                        history_listener_and_id
-                            .as_ref()
-                            .map(|(history_listener, request_id)| HistoryData {
-                                listener: *history_listener,
-                                request_id: *request_id,
-                                speculative_id: None,
-                            });
-                    self.run_request_speculative_fiber(
-                        request_plan,
-                        &run_request_once,
-                        ExecuteRequestContext {
-                            history_data,
-                            routing_info,
-                            request_span,
-                        },
-                    )
-                    .await
-                    .unwrap_or(Err(RequestError::EmptyPlan))
-                }
-            }
-        };
-
-        let result = match self.request_timeout {
-            Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
-                |_: tokio::time::error::Elapsed| {
-                    self.metrics.inc_request_timeouts();
-
-                    let timeout_error = RequestError::RequestTimeout(timeout);
-                    trace!(
-                        parent: request_span.span(),
-                        error = %timeout_error,
-                        "Request timed out"
-                    );
-                    Err(timeout_error)
-                },
-            ),
-            None => runner.await,
-        };
-
-        if let Some((history_listener, request_id)) = history_listener_and_id {
-            match &result {
-                Ok(_) => history_listener.log_request_success(request_id),
-                Err(e) => history_listener.log_request_error(request_id, e),
-            }
-        }
-
-        result
-    }
-}
-
-/// All resolved per-request configuration needed to execute a request,
-/// independent of any `Session`.
-///
-/// The two-level fallback between per-statement config and the execution
-/// profile is resolved *before* constructing this struct.
-pub(crate) struct RequestExecutionParams<'a> {
-    /// Whether the request is idempotent (gates speculative execution and is
-    /// passed to the retry policy).
-    pub(crate) is_idempotent: bool,
-    /// Consistency explicitly set on the statement, if any. When `None`,
-    /// [`Self::default_consistency`] is used.
-    pub(crate) consistency_set_on_statement: Option<Consistency>,
-    /// Consistency to use when the statement does not set one explicitly
-    /// (i.e. the execution profile's consistency).
-    pub(crate) default_consistency: Consistency,
-    /// Retry policy used to start a fresh retry session per fiber.
-    pub(crate) retry_policy: &'a dyn RetryPolicy,
-    /// Load balancing policy used to order targets for the execution.
-    pub(crate) load_balancing_policy: &'a dyn LoadBalancingPolicy,
-    /// Metrics sink.
-    pub(crate) metrics: &'a Arc<Metrics>,
-    /// Speculative execution policy, if any.
-    pub(crate) speculative_policy: Option<&'a dyn SpeculativeExecutionPolicy>,
-    /// Client-side request timeout, if any.
-    pub(crate) request_timeout: Option<Duration>,
-    /// History listener, if any.
-    pub(crate) history_listener: Option<&'a dyn HistoryListener>,
-}
-
-impl<'a> RequestExecutionParams<'a> {
-    /// A single execution fiber.
-    ///
-    /// Iterates the execution plan, picking a connection for each target and each attempt,
-    /// running `run_request_once` and consulting the retry policy on failure.
-    ///
-    /// Returns `None` only if the plan was empty.
-    async fn run_request_speculative_fiber<QueryFut>(
-        &self,
-        request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
-        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
-        context: ExecuteRequestContext<'a>,
-    ) -> Option<Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>>
-    where
-        QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
-    {
-        let mut retry_session = self.retry_policy.new_session();
-        let mut last_error: Option<RequestError> = None;
-        let mut current_consistency: Consistency = self
-            .consistency_set_on_statement
-            .unwrap_or(self.default_consistency);
-
-        'nodes_in_plan: for (node, shard) in request_plan {
-            let span = trace_span!("Executing request", node = %node.address, shard = %shard);
-            'same_node_retries: loop {
-                trace!(parent: &span, "Execution started");
-                let connection = match node.connection_for_shard(shard).await {
-                    Ok(connection) => connection,
-                    Err(e) => {
-                        trace!(
-                            parent: &span,
-                            error = %e,
-                            "Choosing connection failed"
-                        );
-                        last_error = Some(e.into());
-                        // Broken connection doesn't count as a failed request, don't log in metrics
-                        continue 'nodes_in_plan;
-                    }
-                };
-                context.request_span.record_shard_id(&connection);
-
-                self.metrics.inc_total_nonpaged_queries();
-                let request_start = std::time::Instant::now();
-
-                let connect_address = connection.get_connect_address();
-                trace!(
-                    parent: &span,
-                    connection = %connect_address,
-                    "Sending"
-                );
-                let coordinator = Coordinator::new(node, &connection);
-
-                let attempt_id: Option<history::AttemptId> =
-                    context.log_attempt_start(connect_address);
-                let request_result: Result<NonErrorQueryResponse, RequestAttemptError> =
-                    run_request_once(connection, current_consistency)
-                        .instrument(span.clone())
-                        .await;
-
-                let elapsed = request_start.elapsed();
-                let request_error: RequestAttemptError = match request_result {
-                    Ok(response) => {
-                        trace!(parent: &span, "Request succeeded");
-                        let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
-                        context.log_attempt_success(&attempt_id);
-                        self.load_balancing_policy.on_request_success(
-                            context.routing_info,
-                            elapsed,
-                            node,
-                        );
-                        return Some(Ok((RunRequestResult::Completed(response), coordinator)));
-                    }
-                    Err(e) => {
-                        trace!(
-                            parent: &span,
-                            last_error = %e,
-                            "Request failed"
-                        );
-                        self.metrics.inc_failed_nonpaged_queries();
-                        self.load_balancing_policy.on_request_failure(
-                            context.routing_info,
-                            elapsed,
-                            node,
-                            &e,
-                        );
-                        e
-                    }
-                };
-
-                // Use retry policy to decide what to do next
-                let request_info = RequestInfo {
-                    error: &request_error,
-                    is_idempotent: self.is_idempotent,
-                    consistency: current_consistency,
-                };
-
-                let retry_decision = retry_session.decide_should_retry(request_info);
-                trace!(
-                    parent: &span,
-                    retry_decision = ?retry_decision
-                );
-
-                context.log_attempt_error(&attempt_id, &request_error, &retry_decision);
-
-                last_error = Some(request_error.into());
-
-                match retry_decision {
-                    RetryDecision::RetrySameTarget(new_cl) => {
-                        self.metrics.inc_retries_num();
-                        current_consistency = new_cl.unwrap_or(current_consistency);
-                        continue 'same_node_retries;
-                    }
-                    RetryDecision::RetryNextTarget(new_cl) => {
-                        self.metrics.inc_retries_num();
-                        current_consistency = new_cl.unwrap_or(current_consistency);
-                        continue 'nodes_in_plan;
-                    }
-                    RetryDecision::DontRetry => break 'nodes_in_plan,
-
-                    RetryDecision::IgnoreWriteError => {
-                        return Some(Ok((RunRequestResult::IgnoredWriteError, coordinator)));
-                    }
-                };
-            }
-        }
-
-        last_error.map(Result::Err)
     }
 }
 
@@ -2703,62 +2392,6 @@ impl Session {
     /// by default, i.e. when an executed statement does not define its own handle.
     pub fn get_default_execution_profile_handle(&self) -> &ExecutionProfileHandle {
         &self.default_execution_profile_handle
-    }
-}
-
-struct ExecuteRequestContext<'a> {
-    history_data: Option<HistoryData<'a>>,
-    routing_info: &'a load_balancing::RoutingInfo<'a>,
-    request_span: &'a RequestSpan,
-}
-
-struct HistoryData<'a> {
-    listener: &'a dyn HistoryListener,
-    request_id: history::RequestId,
-    speculative_id: Option<history::SpeculativeId>,
-}
-
-impl ExecuteRequestContext<'_> {
-    fn log_attempt_start(&self, node_addr: SocketAddr) -> Option<history::AttemptId> {
-        self.history_data.as_ref().map(|hd| {
-            hd.listener
-                .log_attempt_start(hd.request_id, hd.speculative_id, node_addr)
-        })
-    }
-
-    fn log_attempt_success(&self, attempt_id_opt: &Option<history::AttemptId>) {
-        let attempt_id: &history::AttemptId = match attempt_id_opt {
-            Some(id) => id,
-            None => return,
-        };
-
-        let history_data: &HistoryData = match &self.history_data {
-            Some(data) => data,
-            None => return,
-        };
-
-        history_data.listener.log_attempt_success(*attempt_id);
-    }
-
-    fn log_attempt_error(
-        &self,
-        attempt_id_opt: &Option<history::AttemptId>,
-        error: &RequestAttemptError,
-        retry_decision: &RetryDecision,
-    ) {
-        let attempt_id: &history::AttemptId = match attempt_id_opt {
-            Some(id) => id,
-            None => return,
-        };
-
-        let history_data: &HistoryData = match &self.history_data {
-            Some(data) => data,
-            None => return,
-        };
-
-        history_data
-            .listener
-            .log_attempt_error(*attempt_id, error, retry_decision);
     }
 }
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2084,6 +2084,9 @@ impl Session {
             metrics: &self.metrics,
         };
 
+        let cluster_state = self.cluster.get_state();
+        let request_plan = load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
+
         let history_listener_and_id: Option<(&'a dyn HistoryListener, history::RequestId)> =
             statement_config
                 .history_listener
@@ -2091,10 +2094,6 @@ impl Session {
                 .map(|hl| (&**hl, hl.log_request_start()));
 
         let runner = async {
-            let cluster_state = self.cluster.get_state();
-            let request_plan =
-                load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
-
             let speculative_policy = execution_profile.speculative_execution_policy.as_deref();
 
             match speculative_policy {

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2020,7 +2020,30 @@ impl Session {
 
         Ok(Some(tracing_info))
     }
+}
 
+// If a speculative execution policy is used to run request, request_plan has to be shared
+// between different async functions. This struct helps to wrap request_plan in mutex so it
+// can be shared safely.
+struct SharedPlan<'a, I>
+where
+    I: Iterator<Item = (NodeRef<'a>, Shard)>,
+{
+    iter: std::sync::Mutex<I>,
+}
+
+impl<'a, I> Iterator for &SharedPlan<'a, I>
+where
+    I: Iterator<Item = (NodeRef<'a>, Shard)>,
+{
+    type Item = (NodeRef<'a>, Shard);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.lock().unwrap().next()
+    }
+}
+
+impl Session {
     /// This method allows to easily run a request using load balancing, retry policy etc.
     /// Requires some information about the request and a closure.
     /// The closure is used to execute the request once on a chosen connection.
@@ -2057,27 +2080,6 @@ impl Session {
             let cluster_state = self.cluster.get_state();
             let request_plan =
                 load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
-
-            // If a speculative execution policy is used to run request, request_plan has to be shared
-            // between different async functions. This struct helps to wrap request_plan in mutex so it
-            // can be shared safely.
-            struct SharedPlan<'a, I>
-            where
-                I: Iterator<Item = (NodeRef<'a>, Shard)>,
-            {
-                iter: std::sync::Mutex<I>,
-            }
-
-            impl<'a, I> Iterator for &SharedPlan<'a, I>
-            where
-                I: Iterator<Item = (NodeRef<'a>, Shard)>,
-            {
-                type Item = (NodeRef<'a>, Shard);
-
-                fn next(&mut self) -> Option<Self::Item> {
-                    self.iter.lock().unwrap().next()
-                }
-            }
 
             let retry_policy = statement_config
                 .retry_policy

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2086,16 +2086,17 @@ impl Session {
             retry_policy,
             load_balancing_policy: load_balancer,
             metrics: &self.metrics,
+            request_timeout,
+            history_listener: statement_config.history_listener.as_deref(),
         };
 
         let cluster_state = self.cluster.get_state();
         let request_plan = load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
 
-        let history_listener_and_id: Option<(&'a dyn HistoryListener, history::RequestId)> =
-            statement_config
+        let history_listener_and_id: Option<(&'_ dyn HistoryListener, history::RequestId)> =
+            exec_params
                 .history_listener
-                .as_ref()
-                .map(|hl| (&**hl, hl.log_request_start()));
+                .map(|hl| (hl, hl.log_request_start()));
 
         let runner = async {
             let speculative_policy = execution_profile.speculative_execution_policy.as_deref();
@@ -2173,7 +2174,7 @@ impl Session {
             }
         };
 
-        let result = match request_timeout {
+        let result = match exec_params.request_timeout {
             Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
                 |_: tokio::time::error::Elapsed| {
                     self.metrics.inc_request_timeouts();
@@ -2231,6 +2232,10 @@ pub(crate) struct RequestExecutionParams<'a> {
     pub(crate) load_balancing_policy: &'a dyn LoadBalancingPolicy,
     /// Metrics sink.
     pub(crate) metrics: &'a Arc<Metrics>,
+    /// Client-side request timeout, if any.
+    pub(crate) request_timeout: Option<Duration>,
+    /// History listener, if any.
+    pub(crate) history_listener: Option<&'a dyn HistoryListener>,
 }
 
 impl<'a> RequestExecutionParams<'a> {

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2199,14 +2199,16 @@ impl Session {
             }
         }
 
+        let result = result.map_err(RequestError::into_execution_error)?;
+
         // Automatically handle meaningful responses.
-        if let Ok((RunRequestResult::Completed(ref response), ref coordinator)) = result {
+        if let (RunRequestResult::Completed(ref response), ref coordinator) = result {
             self.handle_set_keyspace_response(response).await?;
             self.handle_auto_await_schema_agreement(response, coordinator.node().host_id)
                 .await?;
         }
 
-        result.map_err(RequestError::into_execution_error)
+        Ok(result)
     }
 
     /// Executes the closure `run_request_once`, provided the load balancing plan and some information

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2076,15 +2076,15 @@ impl Session {
             .as_deref()
             .unwrap_or(execution_profile.load_balancing_policy.as_ref());
 
+        let retry_policy = statement_config
+            .retry_policy
+            .as_deref()
+            .unwrap_or(&*execution_profile.retry_policy);
+
         let runner = async {
             let cluster_state = self.cluster.get_state();
             let request_plan =
                 load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
-
-            let retry_policy = statement_config
-                .retry_policy
-                .as_deref()
-                .unwrap_or(&*execution_profile.retry_policy);
 
             let speculative_policy = execution_profile.speculative_execution_policy.as_ref();
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2075,6 +2075,10 @@ impl Session {
             .as_deref()
             .unwrap_or(&*execution_profile.retry_policy);
 
+        let request_timeout = statement_config
+            .request_timeout
+            .or(execution_profile.request_timeout);
+
         let exec_params = RequestExecutionParams {
             is_idempotent: statement_config.is_idempotent,
             consistency_set_on_statement: statement_config.consistency,
@@ -2169,10 +2173,7 @@ impl Session {
             }
         };
 
-        let effective_timeout = statement_config
-            .request_timeout
-            .or(execution_profile.request_timeout);
-        let result = match effective_timeout {
+        let result = match request_timeout {
             Some(timeout) => tokio::time::timeout(timeout, runner).await.unwrap_or_else(
                 |_: tokio::time::error::Elapsed| {
                     self.metrics.inc_request_timeouts();

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2086,7 +2086,7 @@ impl Session {
             let request_plan =
                 load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
 
-            let speculative_policy = execution_profile.speculative_execution_policy.as_ref();
+            let speculative_policy = execution_profile.speculative_execution_policy.as_deref();
 
             match speculative_policy {
                 Some(speculative) if statement_config.is_idempotent => {
@@ -2138,12 +2138,8 @@ impl Session {
                         metrics: Arc::clone(&self.metrics),
                     };
 
-                    speculative_execution::execute(
-                        speculative.as_ref(),
-                        &context,
-                        request_runner_generator,
-                    )
-                    .await
+                    speculative_execution::execute(speculative, &context, request_runner_generator)
+                        .await
                 }
                 _ => {
                     let history_data: Option<HistoryData> =

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2065,12 +2065,6 @@ impl Session {
     where
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
-        let history_listener_and_id: Option<(&'a dyn HistoryListener, history::RequestId)> =
-            statement_config
-                .history_listener
-                .as_ref()
-                .map(|hl| (&**hl, hl.log_request_start()));
-
         let load_balancer = statement_config
             .load_balancing_policy
             .as_deref()
@@ -2089,6 +2083,12 @@ impl Session {
             load_balancing_policy: load_balancer,
             metrics: &self.metrics,
         };
+
+        let history_listener_and_id: Option<(&'a dyn HistoryListener, history::RequestId)> =
+            statement_config
+                .history_listener
+                .as_ref()
+                .map(|hl| (&**hl, hl.log_request_start()));
 
         let runner = async {
             let cluster_state = self.cluster.get_state();

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2081,6 +2081,10 @@ impl Session {
             .as_deref()
             .unwrap_or(&*execution_profile.retry_policy);
 
+        let exec_params = RequestExecutionParams {
+            metrics: &self.metrics,
+        };
+
         let runner = async {
             let cluster_state = self.cluster.get_state();
             let request_plan =
@@ -2117,7 +2121,7 @@ impl Session {
                             request_span.inc_speculative_executions();
                         }
 
-                        self.run_request_speculative_fiber(
+                        exec_params.run_request_speculative_fiber(
                             &shared_request_plan,
                             &run_request_once,
                             &execution_profile,
@@ -2150,22 +2154,23 @@ impl Session {
                                 request_id: *request_id,
                                 speculative_id: None,
                             });
-                    self.run_request_speculative_fiber(
-                        request_plan,
-                        &run_request_once,
-                        &execution_profile,
-                        ExecuteRequestContext {
-                            is_idempotent: statement_config.is_idempotent,
-                            consistency_set_on_statement: statement_config.consistency,
-                            retry_session: retry_policy.new_session(),
-                            history_data,
-                            load_balancing_policy: load_balancer,
-                            routing_info: &routing_info,
-                            request_span,
-                        },
-                    )
-                    .await
-                    .unwrap_or(Err(RequestError::EmptyPlan))
+                    exec_params
+                        .run_request_speculative_fiber(
+                            request_plan,
+                            &run_request_once,
+                            &execution_profile,
+                            ExecuteRequestContext {
+                                is_idempotent: statement_config.is_idempotent,
+                                consistency_set_on_statement: statement_config.consistency,
+                                retry_session: retry_policy.new_session(),
+                                history_data,
+                                load_balancing_policy: load_balancer,
+                                routing_info: &routing_info,
+                                request_span,
+                            },
+                        )
+                        .await
+                        .unwrap_or(Err(RequestError::EmptyPlan))
                 }
             }
         };
@@ -2208,14 +2213,27 @@ impl Session {
 
         Ok(result)
     }
+}
 
-    /// Executes the closure `run_request_once`, provided the load balancing plan and some information
-    /// about the request, including retry session.
-    /// If request fails, retry session is used to perform retries.
+/// All resolved per-request configuration needed to execute a request,
+/// independent of any `Session`.
+///
+/// The two-level fallback between per-statement config and the execution
+/// profile is resolved *before* constructing this struct.
+pub(crate) struct RequestExecutionParams<'a> {
+    /// Metrics sink.
+    pub(crate) metrics: &'a Arc<Metrics>,
+}
+
+impl<'a> RequestExecutionParams<'a> {
+    /// A single execution fiber.
     ///
-    /// Returns None, if provided plan is empty.
-    async fn run_request_speculative_fiber<'a, QueryFut>(
-        &'a self,
+    /// Iterates the execution plan, picking a connection for each target and each attempt,
+    /// running `run_request_once` and consulting the retry policy on failure.
+    ///
+    /// Returns `None` only if the plan was empty.
+    async fn run_request_speculative_fiber<QueryFut>(
+        &self,
         request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         execution_profile: &ExecutionProfileInner,
@@ -2335,7 +2353,9 @@ impl Session {
 
         last_error.map(Result::Err)
     }
+}
 
+impl Session {
     /// Awaits schema agreement among all reachable nodes.
     ///
     /// Issues an agreement check each `Session::schema_agreement_interval`.

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -31,7 +31,7 @@ use crate::policies::reconnect::ExponentialReconnectPolicy;
 #[cfg(all(scylla_unstable, feature = "unstable-reconnect-policy"))]
 use crate::policies::reconnect::ReconnectPolicy;
 use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy};
-use crate::policies::speculative_execution;
+use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::response::query_result::{MaybeFirstRowError, QueryResult, RowsError};
 use crate::response::{
@@ -2086,6 +2086,7 @@ impl Session {
             retry_policy,
             load_balancing_policy: load_balancer,
             metrics: &self.metrics,
+            speculative_policy: execution_profile.speculative_execution_policy.as_deref(),
             request_timeout,
             history_listener: statement_config.history_listener.as_deref(),
         };
@@ -2099,9 +2100,7 @@ impl Session {
                 .map(|hl| (hl, hl.log_request_start()));
 
         let runner = async {
-            let speculative_policy = execution_profile.speculative_execution_policy.as_deref();
-
-            match speculative_policy {
+            match exec_params.speculative_policy {
                 Some(speculative) if statement_config.is_idempotent => {
                     let shared_request_plan = SharedPlan {
                         iter: std::sync::Mutex::new(request_plan),
@@ -2232,6 +2231,8 @@ pub(crate) struct RequestExecutionParams<'a> {
     pub(crate) load_balancing_policy: &'a dyn LoadBalancingPolicy,
     /// Metrics sink.
     pub(crate) metrics: &'a Arc<Metrics>,
+    /// Speculative execution policy, if any.
+    pub(crate) speculative_policy: Option<&'a dyn SpeculativeExecutionPolicy>,
     /// Client-side request timeout, if any.
     pub(crate) request_timeout: Option<Duration>,
     /// History listener, if any.

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -26,11 +26,11 @@ use crate::observability::metrics::Metrics;
 use crate::observability::tracing::TracingInfo;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
-use crate::policies::load_balancing::{self, RoutingInfo};
+use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
 use crate::policies::reconnect::ExponentialReconnectPolicy;
 #[cfg(all(scylla_unstable, feature = "unstable-reconnect-policy"))]
 use crate::policies::reconnect::ReconnectPolicy;
-use crate::policies::retry::{RequestInfo, RetryDecision, RetrySession};
+use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy};
 use crate::policies::speculative_execution;
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::response::query_result::{MaybeFirstRowError, QueryResult, RowsError};
@@ -2082,6 +2082,11 @@ impl Session {
             .unwrap_or(&*execution_profile.retry_policy);
 
         let exec_params = RequestExecutionParams {
+            is_idempotent: statement_config.is_idempotent,
+            consistency_set_on_statement: statement_config.consistency,
+            default_consistency: execution_profile.consistency,
+            retry_policy,
+            load_balancing_policy: load_balancer,
             metrics: &self.metrics,
         };
 
@@ -2124,13 +2129,8 @@ impl Session {
                         exec_params.run_request_speculative_fiber(
                             &shared_request_plan,
                             &run_request_once,
-                            &execution_profile,
                             ExecuteRequestContext {
-                                is_idempotent: statement_config.is_idempotent,
-                                consistency_set_on_statement: statement_config.consistency,
-                                retry_session: retry_policy.new_session(),
                                 history_data,
-                                load_balancing_policy: load_balancer,
                                 routing_info: &routing_info,
                                 request_span,
                             },
@@ -2158,13 +2158,8 @@ impl Session {
                         .run_request_speculative_fiber(
                             request_plan,
                             &run_request_once,
-                            &execution_profile,
                             ExecuteRequestContext {
-                                is_idempotent: statement_config.is_idempotent,
-                                consistency_set_on_statement: statement_config.consistency,
-                                retry_session: retry_policy.new_session(),
                                 history_data,
-                                load_balancing_policy: load_balancer,
                                 routing_info: &routing_info,
                                 request_span,
                             },
@@ -2221,6 +2216,19 @@ impl Session {
 /// The two-level fallback between per-statement config and the execution
 /// profile is resolved *before* constructing this struct.
 pub(crate) struct RequestExecutionParams<'a> {
+    /// Whether the request is idempotent (gates speculative execution and is
+    /// passed to the retry policy).
+    pub(crate) is_idempotent: bool,
+    /// Consistency explicitly set on the statement, if any. When `None`,
+    /// [`Self::default_consistency`] is used.
+    pub(crate) consistency_set_on_statement: Option<Consistency>,
+    /// Consistency to use when the statement does not set one explicitly
+    /// (i.e. the execution profile's consistency).
+    pub(crate) default_consistency: Consistency,
+    /// Retry policy used to start a fresh retry session per fiber.
+    pub(crate) retry_policy: &'a dyn RetryPolicy,
+    /// Load balancing policy used to order targets for the execution.
+    pub(crate) load_balancing_policy: &'a dyn LoadBalancingPolicy,
     /// Metrics sink.
     pub(crate) metrics: &'a Arc<Metrics>,
 }
@@ -2236,16 +2244,16 @@ impl<'a> RequestExecutionParams<'a> {
         &self,
         request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
-        execution_profile: &ExecutionProfileInner,
-        mut context: ExecuteRequestContext<'a>,
+        context: ExecuteRequestContext<'a>,
     ) -> Option<Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>>
     where
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
+        let mut retry_session = self.retry_policy.new_session();
         let mut last_error: Option<RequestError> = None;
-        let mut current_consistency: Consistency = context
+        let mut current_consistency: Consistency = self
             .consistency_set_on_statement
-            .unwrap_or(execution_profile.consistency);
+            .unwrap_or(self.default_consistency);
 
         'nodes_in_plan: for (node, shard) in request_plan {
             let span = trace_span!("Executing request", node = %node.address, shard = %shard);
@@ -2290,7 +2298,7 @@ impl<'a> RequestExecutionParams<'a> {
                         trace!(parent: &span, "Request succeeded");
                         let _ = self.metrics.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
-                        context.load_balancing_policy.on_request_success(
+                        self.load_balancing_policy.on_request_success(
                             context.routing_info,
                             elapsed,
                             node,
@@ -2304,7 +2312,7 @@ impl<'a> RequestExecutionParams<'a> {
                             "Request failed"
                         );
                         self.metrics.inc_failed_nonpaged_queries();
-                        context.load_balancing_policy.on_request_failure(
+                        self.load_balancing_policy.on_request_failure(
                             context.routing_info,
                             elapsed,
                             node,
@@ -2317,11 +2325,11 @@ impl<'a> RequestExecutionParams<'a> {
                 // Use retry policy to decide what to do next
                 let request_info = RequestInfo {
                     error: &request_error,
-                    is_idempotent: context.is_idempotent,
+                    is_idempotent: self.is_idempotent,
                     consistency: current_consistency,
                 };
 
-                let retry_decision = context.retry_session.decide_should_retry(request_info);
+                let retry_decision = retry_session.decide_should_retry(request_info);
                 trace!(
                     parent: &span,
                     retry_decision = ?retry_decision
@@ -2664,11 +2672,7 @@ impl Session {
 }
 
 struct ExecuteRequestContext<'a> {
-    is_idempotent: bool,
-    consistency_set_on_statement: Option<Consistency>,
-    retry_session: Box<dyn RetrySession>,
     history_data: Option<HistoryData<'a>>,
-    load_balancing_policy: &'a dyn load_balancing::LoadBalancingPolicy,
     routing_info: &'a load_balancing::RoutingInfo<'a>,
     request_span: &'a RequestSpan,
 }


### PR DESCRIPTION
Refs: #1549

This is another important step on the way to deduplicate request execution paths (currently split between `session.rs` and `pager.rs`).

The PR extracts the execution core from `session.rs` to the newly created `execution.rs`. To ensure that the extraction is correct and absolutely 0 logical changes happen by accident, the changes are put in very small commits, which are carefully crafted as non-controversial no-brainers. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
