### PR TITLE
execution: Fix paged request metrics

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -90,10 +90,22 @@ async fn main() -> Result<()> {
     }
 
     let metrics = session.get_metrics();
-    println!("Queries requested: {}", metrics.get_queries_num());
-    println!("Iter queries requested: {}", metrics.get_queries_iter_num());
-    println!("Errors occurred: {}", metrics.get_errors_num());
-    println!("Iter errors occurred: {}", metrics.get_errors_iter_num());
+    println!(
+        "Unpaged queries requested: {}",
+        metrics.get_requests_unpaged_num()
+    );
+    println!(
+        "Automatically paged queries requested: {}",
+        metrics.get_requests_automatically_paged_num()
+    );
+    println!(
+        "Errors occurred in unpaged requests: {}",
+        metrics.get_errors_unpaged_num()
+    );
+    println!(
+        "Errors occurred in automatically paged requests: {}",
+        metrics.get_errors_automatically_paged_num()
+    );
     println!("Average latency: {}", metrics.get_latency_avg_ms()?);
     println!(
         "99.9 latency percentile: {}",

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -133,18 +133,16 @@ impl<'a> RequestExecutionParams<'a> {
     fn inc_total_queries(&self) {
         match self.request_kind {
             RequestPaging::Unpaged => self.metrics.inc_total_nonpaged_queries(),
-            // FIXME: Metrics naming is misleading. Will be fixed in a future commit.
-            RequestPaging::Manual => self.metrics.inc_total_nonpaged_queries(),
-            RequestPaging::Automatic => self.metrics.inc_total_paged_queries(),
+            RequestPaging::Manual => self.metrics.inc_total_manually_paged_queries(),
+            RequestPaging::Automatic => self.metrics.inc_total_automatically_paged_queries(),
         }
     }
 
     fn inc_failed_queries(&self) {
         match self.request_kind {
             RequestPaging::Unpaged => self.metrics.inc_failed_nonpaged_queries(),
-            // FIXME: Metrics naming is misleading. Will be fixed in a future commit.
-            RequestPaging::Manual => self.metrics.inc_failed_nonpaged_queries(),
-            RequestPaging::Automatic => self.metrics.inc_failed_paged_queries(),
+            RequestPaging::Manual => self.metrics.inc_failed_manually_paged_queries(),
+            RequestPaging::Automatic => self.metrics.inc_failed_automatically_paged_queries(),
         }
     }
 

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -23,6 +23,18 @@ pub(crate) enum RunRequestResult<ResT> {
     Completed(ResT),
 }
 
+/// Specifies the mechanism used for query paging.
+///
+/// Currently, only for the purpose of bumping the right metrics counters.
+#[derive(Clone, Debug)]
+pub(crate) enum RequestPaging {
+    Unpaged,
+    #[expect(dead_code)] // Used in the next commit.
+    Manual,
+    #[expect(dead_code)] // Used in the next commit.
+    Automatic,
+}
+
 /// Wraps a request plan in a mutex so that it can be shared between speculative
 /// fibers running concurrently.
 struct SharedPlan<I> {
@@ -67,6 +79,8 @@ pub(crate) struct RequestExecutionParams<'a> {
     pub(crate) request_timeout: Option<Duration>,
     /// History listener, if any.
     pub(crate) history_listener: Option<&'a dyn HistoryListener>,
+    /// Paged vs non-paged, for metrics.
+    pub(crate) request_kind: RequestPaging,
 }
 
 /// History data threaded through a single fiber.
@@ -117,11 +131,21 @@ impl ExecuteRequestContext<'_> {
 
 impl<'a> RequestExecutionParams<'a> {
     fn inc_total_queries(&self) {
-        self.metrics.inc_total_nonpaged_queries();
+        match self.request_kind {
+            RequestPaging::Unpaged => self.metrics.inc_total_nonpaged_queries(),
+            // FIXME: Metrics naming is misleading. Will be fixed in a future commit.
+            RequestPaging::Manual => self.metrics.inc_total_nonpaged_queries(),
+            RequestPaging::Automatic => self.metrics.inc_total_paged_queries(),
+        }
     }
 
     fn inc_failed_queries(&self) {
-        self.metrics.inc_failed_nonpaged_queries();
+        match self.request_kind {
+            RequestPaging::Unpaged => self.metrics.inc_failed_nonpaged_queries(),
+            // FIXME: Metrics naming is misleading. Will be fixed in a future commit.
+            RequestPaging::Manual => self.metrics.inc_failed_nonpaged_queries(),
+            RequestPaging::Automatic => self.metrics.inc_failed_paged_queries(),
+        }
     }
 
     fn inc_retries_num(&self) {

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -29,7 +29,6 @@ pub(crate) enum RunRequestResult<ResT> {
 #[derive(Clone, Debug)]
 pub(crate) enum RequestPaging {
     Unpaged,
-    #[expect(dead_code)] // Used in the next commit.
     Manual,
     #[expect(dead_code)] // Used in the next commit.
     Automatic,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -552,7 +552,7 @@ impl PagerWorker {
         QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
     {
-        self.metrics.inc_total_paged_queries();
+        self.metrics.inc_total_automatically_paged_queries();
         let query_start = std::time::Instant::now();
 
         let connect_address = connection.get_connect_address();
@@ -635,7 +635,7 @@ impl PagerWorker {
                 ))
             }
             Err(err) => {
-                self.metrics.inc_failed_paged_queries();
+                self.metrics.inc_failed_automatically_paged_queries();
                 self.load_balancing_policy
                     .on_request_failure(routing_info, elapsed, node, &err);
                 Err(err)
@@ -700,7 +700,7 @@ impl PagerWorker {
                 ))
             }
             Ok(response) => {
-                self.metrics.inc_failed_paged_queries();
+                self.metrics.inc_failed_automatically_paged_queries();
                 let err =
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
                 self.load_balancing_policy
@@ -770,7 +770,7 @@ impl PagerWorker {
             // This catches all other kinds of responses that are not rows.
             // As this is not the first page, this is certainly an error.
             Ok(response) => {
-                self.metrics.inc_failed_paged_queries();
+                self.metrics.inc_failed_automatically_paged_queries();
                 let err =
                     RequestAttemptError::UnexpectedResponse(response.response.to_response_kind());
                 self.load_balancing_policy
@@ -778,7 +778,7 @@ impl PagerWorker {
                 Err(err)
             }
             Err(err) => {
-                self.metrics.inc_failed_paged_queries();
+                self.metrics.inc_failed_automatically_paged_queries();
                 self.load_balancing_policy
                     .on_request_failure(routing_info, elapsed, node, &err);
                 Err(err)

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -770,7 +770,13 @@ impl Session {
     ) -> Result<QueryResult, ExecutionError> {
         let serialized_values = prepared.serialize_values(&values)?;
         let (result, paging_state) = self
-            .execute(prepared, &serialized_values, None, PagingState::start())
+            .execute(
+                prepared,
+                &serialized_values,
+                None,
+                PagingState::start(),
+                RequestPaging::Unpaged,
+            )
             .await?;
         if !paging_state.finished() {
             error!(
@@ -847,8 +853,14 @@ impl Session {
     ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let serialized_values = prepared.serialize_values(&values)?;
         let page_size = prepared.get_validated_page_size();
-        self.execute(prepared, &serialized_values, Some(page_size), paging_state)
-            .await
+        self.execute(
+            prepared,
+            &serialized_values,
+            Some(page_size),
+            paging_state,
+            RequestPaging::Manual,
+        )
+        .await
     }
 
     /// Execute a prepared statement with paging.\
@@ -1008,6 +1020,8 @@ impl Session {
                 routing_info,
                 &batch.config,
                 execution_profile,
+                // Batch statements are always unpaged, because they can't contain SELECTs.
+                RequestPaging::Unpaged,
                 |connection: Arc<Connection>, consistency: Consistency| async move {
                     connection
                         .batch_with_consistency(batch, values_ref, consistency, serial_consistency)
@@ -1226,7 +1240,13 @@ impl Session {
         values: impl SerializeRow,
     ) -> Result<QueryResult, ExecutionError> {
         let (result, paging_state_response) = self
-            .query(statement, values, None, PagingState::start())
+            .query(
+                statement,
+                values,
+                None,
+                PagingState::start(),
+                RequestPaging::Unpaged,
+            )
             .await?;
         if !paging_state_response.finished() {
             error!(
@@ -1250,6 +1270,7 @@ impl Session {
             values,
             Some(statement.get_validated_page_size()),
             paging_state,
+            RequestPaging::Manual,
         )
         .await
     }
@@ -1271,6 +1292,7 @@ impl Session {
         values: impl SerializeRow,
         page_size: Option<PageSize>,
         paging_state: PagingState,
+        request_paging: RequestPaging,
     ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let execution_profile = statement
             .get_execution_profile_handle()
@@ -1306,6 +1328,7 @@ impl Session {
                 routing_info,
                 &statement.config,
                 execution_profile,
+                request_paging,
                 |connection: Arc<Connection>, consistency: Consistency| {
                     // Needed to avoid moving query and values into async move block
                     let values_ref = &values;
@@ -1659,6 +1682,7 @@ impl Session {
         serialized_values: &SerializedValues,
         page_size: Option<PageSize>,
         paging_state: PagingState,
+        request_paging: RequestPaging,
     ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
         let paging_state_ref = &paging_state;
 
@@ -1718,6 +1742,7 @@ impl Session {
                 routing_info,
                 &prepared.config,
                 execution_profile,
+                request_paging,
                 |connection: Arc<Connection>, consistency: Consistency| async move {
                     connection
                         .execute_raw_with_consistency(
@@ -2032,6 +2057,7 @@ impl Session {
         routing_info: RoutingInfo<'a>,
         statement_config: &'a StatementConfig,
         execution_profile: Arc<ExecutionProfileInner>,
+        request_kind: RequestPaging,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         request_span: &'a RequestSpan,
     ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), ExecutionError>
@@ -2062,7 +2088,7 @@ impl Session {
             speculative_policy: execution_profile.speculative_execution_policy.as_deref(),
             request_timeout,
             history_listener: statement_config.history_listener.as_deref(),
-            request_kind: RequestPaging::Unpaged,
+            request_kind,
         };
 
         let cluster_state = self.cluster.get_state();

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1,6 +1,7 @@
 //! `Session` is the main object used in the driver.\
 //! It manages all connections to the cluster and allows to execute CQL requests.
 
+use super::execution::RequestPaging;
 use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle, ExecutionProfileInner};
 use super::pager::{PreparedPagerConfig, QueryPager};
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
@@ -2061,6 +2062,7 @@ impl Session {
             speculative_policy: execution_profile.speculative_execution_policy.as_deref(),
             request_timeout,
             history_listener: statement_config.history_listener.as_deref(),
+            request_kind: RequestPaging::Unpaged,
         };
 
         let cluster_state = self.cluster.get_state();

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -278,30 +278,48 @@ impl Metrics {
         }
     }
 
-    /// Increments counter for errors that occurred in nonpaged queries.
+    /// Increments counter for errors that occurred in nonpaged execution
+    /// (`Session::{query,execute}_unpaged()` and `Session::batch()`).
     pub(crate) fn inc_failed_nonpaged_queries(&self) {
         self.inner.errors_num.fetch_add(1, ORDER_TYPE);
     }
 
-    /// Increments counter for nonpaged queries.
+    /// Increments counter for nonpaged request execution
+    /// (`Session::{query,execute}_unpaged()` and `Session::batch()`).
     pub(crate) fn inc_total_nonpaged_queries(&self) {
         self.inner.requests_num.fetch_add(1, ORDER_TYPE);
         self.inner.meter.mark();
     }
 
-    /// Increments counter for errors that occurred in paged queries.
-    pub(crate) fn inc_failed_paged_queries(&self) {
+    /// Increments counter for errors that occurred in manually paged execution
+    /// (`Session::{query,execute}_single_page()`).
+    pub(crate) fn inc_failed_manually_paged_queries(&self) {
+        self.inner.errors_num.fetch_add(1, ORDER_TYPE);
+    }
+
+    /// Increments counter for page queries in manually paged execution
+    /// (`Session::{query,execute}_single_page()`).
+    pub(crate) fn inc_total_manually_paged_queries(&self) {
+        self.inner.requests_num.fetch_add(1, ORDER_TYPE);
+        self.inner.meter.mark();
+    }
+
+    /// Increments counter for errors that occurred in automatically paged execution
+    /// (`Session::{query,execute}_iter()`).
+    pub(crate) fn inc_failed_automatically_paged_queries(&self) {
         self.inner.errors_iter_num.fetch_add(1, ORDER_TYPE);
     }
 
-    /// Increments counter for page queries in paged queries.
-    /// If query_iter would return 4 pages then this counter should be incremented 4 times.
-    pub(crate) fn inc_total_paged_queries(&self) {
+    /// Increments counter for page queries in automatically paged execution
+    /// (`Session::{query,execute}_iter()`).
+    /// If `query_iter` would return 4 pages, then this counter should be incremented 4 times.
+    pub(crate) fn inc_total_automatically_paged_queries(&self) {
         self.inner.requests_iter_num.fetch_add(1, ORDER_TYPE);
         self.inner.meter.mark();
     }
 
-    /// Increments counter measuring how many times a retry policy has decided to retry a query
+    /// Increments counter measuring how many times a retry policy has decided
+    /// to retry a request.
     pub(crate) fn inc_retries_num(&self) {
         self.inner.retries_num.fetch_add(1, ORDER_TYPE);
     }
@@ -405,22 +423,22 @@ impl Metrics {
         })
     }
 
-    /// Returns counter for errors occurred in nonpaged queries
+    /// Returns count of errors occurred in **non** `*_iter()` queries (**non** `QueryPager` APIs).
     pub fn get_errors_num(&self) -> u64 {
         self.inner.errors_num.load(ORDER_TYPE)
     }
 
-    /// Returns counter for nonpaged queries
+    /// Returns count of **non** `*_iter()` queries (**non** `QueryPager` APIs).
     pub fn get_queries_num(&self) -> u64 {
         self.inner.requests_num.load(ORDER_TYPE)
     }
 
-    /// Returns counter for errors occurred in paged queries
+    /// Returns counter for errors occurred in `*_iter()` queries (`QueryPager` APIs).
     pub fn get_errors_iter_num(&self) -> u64 {
         self.inner.errors_iter_num.load(ORDER_TYPE)
     }
 
-    /// Returns counter for pages requested in paged queries
+    /// Returns count of `*_iter()` queries (`QueryPager` APIs).
     pub fn get_queries_iter_num(&self) -> u64 {
         self.inner.requests_iter_num.load(ORDER_TYPE)
     }

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -429,25 +429,73 @@ impl Metrics {
         })
     }
 
+    /// Returns count of errors occurred in unpaged execution.
+    pub fn get_errors_unpaged_num(&self) -> u64 {
+        self.inner.errors_unpaged.load(ORDER_TYPE)
+    }
+
+    /// Returns count of errors occurred in manually paged execution.
+    pub fn get_errors_manually_paged_num(&self) -> u64 {
+        self.inner.errors_single_page.load(ORDER_TYPE)
+    }
+
+    #[deprecated(
+        since = "1.8.0",
+        note = "Method's naming is confusing. Call `get_errors_unpaged_num()`
+        and `get_errors_manually_paged_num()` and add their results together instead."
+    )]
     /// Returns count of errors occurred in **non** `*_iter()` queries (**non** `QueryPager` APIs).
     pub fn get_errors_num(&self) -> u64 {
-        self.inner.errors_unpaged.load(ORDER_TYPE) + self.inner.errors_single_page.load(ORDER_TYPE)
+        self.get_errors_unpaged_num() + self.get_errors_manually_paged_num()
     }
 
+    /// Returns count of unpaged requests.
+    pub fn get_requests_unpaged_num(&self) -> u64 {
+        self.inner.requests_unpaged.load(ORDER_TYPE)
+    }
+
+    /// Returns count of manually paged requests.
+    pub fn get_requests_manually_paged_num(&self) -> u64 {
+        self.inner.requests_single_page.load(ORDER_TYPE)
+    }
+
+    #[deprecated(
+        since = "1.8.0",
+        note = "Method's naming is confusing. Call `get_requests_unpaged_num()`
+        and `get_requests_manually_paged_num()` and add their results together instead."
+    )]
     /// Returns count of **non** `*_iter()` queries (**non** `QueryPager` APIs).
     pub fn get_queries_num(&self) -> u64 {
-        self.inner.requests_unpaged.load(ORDER_TYPE)
-            + self.inner.requests_single_page.load(ORDER_TYPE)
+        self.get_requests_unpaged_num() + self.get_requests_manually_paged_num()
     }
 
+    /// Returns count of errors occurred in automatically paged requests
+    /// (`QueryPager` APIs, `*_iter()` execution).
+    pub fn get_errors_automatically_paged_num(&self) -> u64 {
+        self.inner.errors_iter.load(ORDER_TYPE)
+    }
+
+    #[deprecated(
+        since = "1.8.0",
+        note = "Method's naming is confusing. Use `get_errors_automatically_paged_num()` instead."
+    )]
     /// Returns counter for errors occurred in `*_iter()` queries (`QueryPager` APIs).
     pub fn get_errors_iter_num(&self) -> u64 {
         self.inner.errors_iter.load(ORDER_TYPE)
     }
 
+    /// Returns count of automatically paged requests (`QueryPager` APIs, `*_iter()` execution).
+    pub fn get_requests_automatically_paged_num(&self) -> u64 {
+        self.inner.requests_iter.load(ORDER_TYPE)
+    }
+
+    #[deprecated(
+        since = "1.8.0",
+        note = "Method's naming is confusing. Use `get_requests_automatically_paged_num()` instead."
+    )]
     /// Returns count of `*_iter()` queries (`QueryPager` APIs).
     pub fn get_queries_iter_num(&self) -> u64 {
-        self.inner.requests_iter.load(ORDER_TYPE)
+        self.get_requests_automatically_paged_num()
     }
 
     /// Returns counter measuring how many times a retry policy has decided to retry a query

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -230,12 +230,12 @@ pub struct Metrics {
 struct MetricsInner {
     /// Number of errors that occurred in queries executed without `QueryPager`.
     errors_num: AtomicU64,
-    /// Number of queries executed without `QueryPager`.
-    queries_num: AtomicU64,
+    /// Number of requests executed without `QueryPager`.
+    requests_num: AtomicU64,
     /// Number of errors that occurred in queries executed with `QueryPager`.
     errors_iter_num: AtomicU64,
-    /// Number of queries executed with `QueryPager`.
-    queries_iter_num: AtomicU64,
+    /// Number of requests executed with `QueryPager`.
+    requests_iter_num: AtomicU64,
     /// Number of times a retry policy has decided to retry a query.
     retries_num: AtomicU64,
     /// Histogram that collects latencies of queries executed by the driver.
@@ -265,9 +265,9 @@ impl Metrics {
         Self {
             inner: Arc::new(MetricsInner {
                 errors_num: AtomicU64::new(0),
-                queries_num: AtomicU64::new(0),
+                requests_num: AtomicU64::new(0),
                 errors_iter_num: AtomicU64::new(0),
-                queries_iter_num: AtomicU64::new(0),
+                requests_iter_num: AtomicU64::new(0),
                 retries_num: AtomicU64::new(0),
                 histogram: Arc::new(AtomicHistogram::new(grouping_power, max_value_power).unwrap()),
                 meter: Arc::new(RequestRateMeter::new()),
@@ -285,7 +285,7 @@ impl Metrics {
 
     /// Increments counter for nonpaged queries.
     pub(crate) fn inc_total_nonpaged_queries(&self) {
-        self.inner.queries_num.fetch_add(1, ORDER_TYPE);
+        self.inner.requests_num.fetch_add(1, ORDER_TYPE);
         self.inner.meter.mark();
     }
 
@@ -297,7 +297,7 @@ impl Metrics {
     /// Increments counter for page queries in paged queries.
     /// If query_iter would return 4 pages then this counter should be incremented 4 times.
     pub(crate) fn inc_total_paged_queries(&self) {
-        self.inner.queries_iter_num.fetch_add(1, ORDER_TYPE);
+        self.inner.requests_iter_num.fetch_add(1, ORDER_TYPE);
         self.inner.meter.mark();
     }
 
@@ -412,7 +412,7 @@ impl Metrics {
 
     /// Returns counter for nonpaged queries
     pub fn get_queries_num(&self) -> u64 {
-        self.inner.queries_num.load(ORDER_TYPE)
+        self.inner.requests_num.load(ORDER_TYPE)
     }
 
     /// Returns counter for errors occurred in paged queries
@@ -422,7 +422,7 @@ impl Metrics {
 
     /// Returns counter for pages requested in paged queries
     pub fn get_queries_iter_num(&self) -> u64 {
-        self.inner.queries_iter_num.load(ORDER_TYPE)
+        self.inner.requests_iter_num.load(ORDER_TYPE)
     }
 
     /// Returns counter measuring how many times a retry policy has decided to retry a query
@@ -574,9 +574,9 @@ impl std::fmt::Debug for Metrics {
         let h = self.inner.histogram.load();
         f.debug_struct("Metrics")
             .field("errors_num", &self.inner.errors_num)
-            .field("queries_num", &self.inner.queries_num)
+            .field("requests_num", &self.inner.requests_num)
             .field("errors_iter_num", &self.inner.errors_iter_num)
-            .field("queries_iter_num", &self.inner.queries_iter_num)
+            .field("requests_iter_num", &self.inner.requests_iter_num)
             .field("retries_num", &self.inner.retries_num)
             .field("histogram", &h)
             .field("meter", &self.inner.meter)

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -228,14 +228,18 @@ pub struct Metrics {
 
 /// Storage for all metric counters and histograms.
 struct MetricsInner {
-    /// Number of errors that occurred in queries executed without `QueryPager`.
-    errors_num: AtomicU64,
-    /// Number of requests executed without `QueryPager`.
-    requests_num: AtomicU64,
-    /// Number of errors that occurred in queries executed with `QueryPager`.
-    errors_iter_num: AtomicU64,
-    /// Number of requests executed with `QueryPager`.
-    requests_iter_num: AtomicU64,
+    /// Number of errors that occurred in unpaged requests.
+    errors_unpaged: AtomicU64,
+    /// Number of executed unpaged requests.
+    requests_unpaged: AtomicU64,
+    /// Number of errors that occurred in manually paged requests.
+    errors_single_page: AtomicU64,
+    /// Number of executed manually paged requests.
+    requests_single_page: AtomicU64,
+    /// Number of errors that occurred in automatically paged requests.
+    errors_iter: AtomicU64,
+    /// Number of executed automatically paged requests.
+    requests_iter: AtomicU64,
     /// Number of times a retry policy has decided to retry a query.
     retries_num: AtomicU64,
     /// Histogram that collects latencies of queries executed by the driver.
@@ -264,10 +268,12 @@ impl Metrics {
 
         Self {
             inner: Arc::new(MetricsInner {
-                errors_num: AtomicU64::new(0),
-                requests_num: AtomicU64::new(0),
-                errors_iter_num: AtomicU64::new(0),
-                requests_iter_num: AtomicU64::new(0),
+                errors_unpaged: AtomicU64::new(0),
+                requests_unpaged: AtomicU64::new(0),
+                errors_single_page: AtomicU64::new(0),
+                requests_single_page: AtomicU64::new(0),
+                errors_iter: AtomicU64::new(0),
+                requests_iter: AtomicU64::new(0),
                 retries_num: AtomicU64::new(0),
                 histogram: Arc::new(AtomicHistogram::new(grouping_power, max_value_power).unwrap()),
                 meter: Arc::new(RequestRateMeter::new()),
@@ -281,40 +287,40 @@ impl Metrics {
     /// Increments counter for errors that occurred in nonpaged execution
     /// (`Session::{query,execute}_unpaged()` and `Session::batch()`).
     pub(crate) fn inc_failed_nonpaged_queries(&self) {
-        self.inner.errors_num.fetch_add(1, ORDER_TYPE);
+        self.inner.errors_unpaged.fetch_add(1, ORDER_TYPE);
     }
 
     /// Increments counter for nonpaged request execution
     /// (`Session::{query,execute}_unpaged()` and `Session::batch()`).
     pub(crate) fn inc_total_nonpaged_queries(&self) {
-        self.inner.requests_num.fetch_add(1, ORDER_TYPE);
+        self.inner.requests_unpaged.fetch_add(1, ORDER_TYPE);
         self.inner.meter.mark();
     }
 
     /// Increments counter for errors that occurred in manually paged execution
     /// (`Session::{query,execute}_single_page()`).
     pub(crate) fn inc_failed_manually_paged_queries(&self) {
-        self.inner.errors_num.fetch_add(1, ORDER_TYPE);
+        self.inner.errors_single_page.fetch_add(1, ORDER_TYPE);
     }
 
     /// Increments counter for page queries in manually paged execution
     /// (`Session::{query,execute}_single_page()`).
     pub(crate) fn inc_total_manually_paged_queries(&self) {
-        self.inner.requests_num.fetch_add(1, ORDER_TYPE);
+        self.inner.requests_single_page.fetch_add(1, ORDER_TYPE);
         self.inner.meter.mark();
     }
 
     /// Increments counter for errors that occurred in automatically paged execution
     /// (`Session::{query,execute}_iter()`).
     pub(crate) fn inc_failed_automatically_paged_queries(&self) {
-        self.inner.errors_iter_num.fetch_add(1, ORDER_TYPE);
+        self.inner.errors_iter.fetch_add(1, ORDER_TYPE);
     }
 
     /// Increments counter for page queries in automatically paged execution
     /// (`Session::{query,execute}_iter()`).
     /// If `query_iter` would return 4 pages, then this counter should be incremented 4 times.
     pub(crate) fn inc_total_automatically_paged_queries(&self) {
-        self.inner.requests_iter_num.fetch_add(1, ORDER_TYPE);
+        self.inner.requests_iter.fetch_add(1, ORDER_TYPE);
         self.inner.meter.mark();
     }
 
@@ -425,22 +431,23 @@ impl Metrics {
 
     /// Returns count of errors occurred in **non** `*_iter()` queries (**non** `QueryPager` APIs).
     pub fn get_errors_num(&self) -> u64 {
-        self.inner.errors_num.load(ORDER_TYPE)
+        self.inner.errors_unpaged.load(ORDER_TYPE) + self.inner.errors_single_page.load(ORDER_TYPE)
     }
 
     /// Returns count of **non** `*_iter()` queries (**non** `QueryPager` APIs).
     pub fn get_queries_num(&self) -> u64 {
-        self.inner.requests_num.load(ORDER_TYPE)
+        self.inner.requests_unpaged.load(ORDER_TYPE)
+            + self.inner.requests_single_page.load(ORDER_TYPE)
     }
 
     /// Returns counter for errors occurred in `*_iter()` queries (`QueryPager` APIs).
     pub fn get_errors_iter_num(&self) -> u64 {
-        self.inner.errors_iter_num.load(ORDER_TYPE)
+        self.inner.errors_iter.load(ORDER_TYPE)
     }
 
     /// Returns count of `*_iter()` queries (`QueryPager` APIs).
     pub fn get_queries_iter_num(&self) -> u64 {
-        self.inner.requests_iter_num.load(ORDER_TYPE)
+        self.inner.requests_iter.load(ORDER_TYPE)
     }
 
     /// Returns counter measuring how many times a retry policy has decided to retry a query
@@ -591,10 +598,12 @@ impl std::fmt::Debug for Metrics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let h = self.inner.histogram.load();
         f.debug_struct("Metrics")
-            .field("errors_num", &self.inner.errors_num)
-            .field("requests_num", &self.inner.requests_num)
-            .field("errors_iter_num", &self.inner.errors_iter_num)
-            .field("requests_iter_num", &self.inner.requests_iter_num)
+            .field("errors_unpaged", &self.inner.errors_unpaged)
+            .field("requests_unpaged", &self.inner.requests_unpaged)
+            .field("errors_single_page", &self.inner.errors_single_page)
+            .field("requests_single_page", &self.inner.requests_single_page)
+            .field("errors_iter", &self.inner.errors_iter)
+            .field("requests_iter", &self.inner.requests_iter)
             .field("retries_num", &self.inner.retries_num)
             .field("histogram", &h)
             .field("meter", &self.inner.meter)

--- a/scylla/src/observability/metrics_noop.rs
+++ b/scylla/src/observability/metrics_noop.rs
@@ -24,10 +24,16 @@ impl Metrics {
     pub(crate) fn inc_total_nonpaged_queries(&self) {}
 
     #[inline(always)]
-    pub(crate) fn inc_failed_paged_queries(&self) {}
+    pub(crate) fn inc_failed_manually_paged_queries(&self) {}
 
     #[inline(always)]
-    pub(crate) fn inc_total_paged_queries(&self) {}
+    pub(crate) fn inc_total_manually_paged_queries(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_failed_automatically_paged_queries(&self) {}
+
+    #[inline(always)]
+    pub(crate) fn inc_total_automatically_paged_queries(&self) {}
 
     #[inline(always)]
     pub(crate) fn inc_retries_num(&self) {}

--- a/scylla/tests/integration/session/metrics.rs
+++ b/scylla/tests/integration/session/metrics.rs
@@ -1,0 +1,284 @@
+use std::sync::Arc;
+
+use futures::StreamExt as _;
+use scylla::client::execution_profile::ExecutionProfile;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::observability::metrics::Metrics;
+use scylla::policies::retry::FallthroughRetryPolicy;
+use scylla::response::PagingState;
+use scylla_proxy::{
+    Condition, ProxyError, RequestOpcode, RequestReaction, RequestRule, ShardAwareness, WorkerError,
+};
+
+use crate::utils::{setup_tracing, test_with_3_node_cluster};
+
+/// Snapshot of the six per-paging-kind request/error counters.
+///
+/// Call [`RequestMetricsSnapshot::capture`] to take a snapshot, then
+/// [`RequestMetricsSnapshot::assert_only_incremented`] to assert that exactly
+/// one specified counter incremented by 1 since the previous snapshot. The
+/// method updates `self` in place, so it always reflects the last observed
+/// state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RequestMetricsSnapshot {
+    requests_unpaged: u64,
+    requests_manually_paged: u64,
+    requests_automatically_paged: u64,
+    errors_unpaged: u64,
+    errors_manually_paged: u64,
+    errors_automatically_paged: u64,
+}
+
+/// Which of the six per-paging-kind counters is expected to increment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RequestMetricKind {
+    RequestsUnpaged,
+    RequestsManuallyPaged,
+    RequestsAutomaticallyPaged,
+    ErrorsUnpaged,
+    ErrorsManuallyPaged,
+    ErrorsAutomaticallyPaged,
+}
+
+impl RequestMetricsSnapshot {
+    fn capture(m: &Metrics) -> Self {
+        Self {
+            requests_unpaged: m.get_requests_unpaged_num(),
+            requests_manually_paged: m.get_requests_manually_paged_num(),
+            requests_automatically_paged: m.get_requests_automatically_paged_num(),
+            errors_unpaged: m.get_errors_unpaged_num(),
+            errors_manually_paged: m.get_errors_manually_paged_num(),
+            errors_automatically_paged: m.get_errors_automatically_paged_num(),
+        }
+    }
+
+    /// Asserts that exactly the counters listed in `kinds` each incremented by
+    /// 1 since `self`, and all other counters are unchanged. Then updates
+    /// `self` to the current snapshot so the next call uses the fresh baseline.
+    fn assert_only_incremented(&mut self, m: &Metrics, kinds: &[RequestMetricKind]) {
+        let next = Self::capture(m);
+        let inc = |k| kinds.contains(&k) as u64;
+        let expected = RequestMetricsSnapshot {
+            requests_unpaged: self.requests_unpaged + inc(RequestMetricKind::RequestsUnpaged),
+            requests_manually_paged: self.requests_manually_paged
+                + inc(RequestMetricKind::RequestsManuallyPaged),
+            requests_automatically_paged: self.requests_automatically_paged
+                + inc(RequestMetricKind::RequestsAutomaticallyPaged),
+            errors_unpaged: self.errors_unpaged + inc(RequestMetricKind::ErrorsUnpaged),
+            errors_manually_paged: self.errors_manually_paged
+                + inc(RequestMetricKind::ErrorsManuallyPaged),
+            errors_automatically_paged: self.errors_automatically_paged
+                + inc(RequestMetricKind::ErrorsAutomaticallyPaged),
+        };
+        assert_eq!(next, expected, "wrong counters incremented for {kinds:?}");
+        *self = next;
+    }
+}
+
+/// Regression test for the bug where `Session::run_request` always passed
+/// `RequestPaging::Unpaged` to `RequestExecutionParams`, regardless of whether
+/// the caller was a manually-paged (`query_single_page`, `execute_single_page`)
+/// or an unpaged (`query_unpaged`, `execute_unpaged`) method.
+///
+/// As a result, manually-paged requests were incorrectly counted in the
+/// unpaged metrics counter (`requests_unpaged`) rather than in the
+/// manually-paged counter (`requests_manually_paged`).
+///
+/// The test exercises all four non-iter public session methods, as well as
+/// `query_iter` (without bound values) and `execute_iter`, both in the
+/// successful and the failing case, and verifies that after each call exactly
+/// the right per-paging-kind counter is incremented and the other five remain
+/// untouched.
+///
+/// No DDL is needed: all statements target `system.local`, which always exists
+/// and has one row.
+#[tokio::test]
+async fn test_paged_and_unpaged_metrics_are_counted_separately() {
+    setup_tracing();
+
+    const QUERY: &str = "SELECT host_id FROM system.local WHERE key = 'local'";
+
+    // FallthroughRetryPolicy ensures one server error → exactly one error
+    // counter increment (no retries that would inflate the count).
+    let profile = ExecutionProfile::builder()
+        .retry_policy(Arc::new(FallthroughRetryPolicy))
+        .build();
+
+    let query_not_control = Condition::RequestOpcode(RequestOpcode::Query)
+        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent))
+        .and(Condition::BodyContainsCaseSensitive(Box::new(
+            *b"system.local",
+        )));
+    let execute_not_control = Condition::RequestOpcode(RequestOpcode::Execute)
+        .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .default_execution_profile_handle(profile.into_handle())
+                .build()
+                .await
+                .unwrap();
+
+            let metrics = session.get_metrics();
+            let prepared = session.prepare(QUERY).await.unwrap();
+
+            let mut snap = RequestMetricsSnapshot::capture(&metrics);
+
+            // Successful requests: each must increment exactly its own
+            // requests_* counter.
+
+            session.query_unpaged(QUERY, ()).await.unwrap();
+            snap.assert_only_incremented(&metrics, &[RequestMetricKind::RequestsUnpaged]);
+
+            session.execute_unpaged(&prepared, ()).await.unwrap();
+            snap.assert_only_incremented(&metrics, &[RequestMetricKind::RequestsUnpaged]);
+
+            session
+                .query_single_page(QUERY, (), PagingState::start())
+                .await
+                .unwrap();
+            snap.assert_only_incremented(&metrics, &[RequestMetricKind::RequestsManuallyPaged]);
+
+            session
+                .execute_single_page(&prepared, (), PagingState::start())
+                .await
+                .unwrap();
+            snap.assert_only_incremented(&metrics, &[RequestMetricKind::RequestsManuallyPaged]);
+
+            // --- query_iter / execute_iter: must increment
+            //     requests_automatically_paged only.
+            //
+            // The pager fetches the first page eagerly inside the `.await`,
+            // so the counter is already updated by the time the call returns.
+            // `system.local WHERE key = 'local'` returns exactly one row in
+            // one page, so each call increments the counter exactly once.
+            session
+                .query_iter(QUERY, ())
+                .await
+                .unwrap()
+                .rows_stream::<(uuid::Uuid,)>()
+                .unwrap()
+                .for_each(|_| async {})
+                .await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[RequestMetricKind::RequestsAutomaticallyPaged],
+            );
+
+            session
+                .execute_iter(prepared.clone(), ())
+                .await
+                .unwrap()
+                .rows_stream::<(uuid::Uuid,)>()
+                .unwrap()
+                .for_each(|_| async {})
+                .await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[RequestMetricKind::RequestsAutomaticallyPaged],
+            );
+
+            // Failed requests: each must increment exactly its own
+            // errors_* counter (and also its requests_* counter).
+
+            let forge_error_on_query = vec![RequestRule(
+                query_not_control.clone(),
+                RequestReaction::forge().server_error(),
+            )];
+            let forge_error_on_execute = vec![RequestRule(
+                execute_not_control.clone(),
+                RequestReaction::forge().server_error(),
+            )];
+
+            // Forge errors on Query opcode: covers query_unpaged,
+            // query_single_page, and query_iter (empty values → Query opcode).
+            running_proxy
+                .running_nodes
+                .iter_mut()
+                .for_each(|n| n.change_request_rules(Some(forge_error_on_query.clone())));
+            let _ = session.query_unpaged(QUERY, ()).await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[
+                    RequestMetricKind::RequestsUnpaged,
+                    RequestMetricKind::ErrorsUnpaged,
+                ],
+            );
+
+            let _ = session
+                .query_single_page(QUERY, (), PagingState::start())
+                .await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[
+                    RequestMetricKind::RequestsManuallyPaged,
+                    RequestMetricKind::ErrorsManuallyPaged,
+                ],
+            );
+
+            // The first page is fetched eagerly, so the error is returned
+            // directly from the `.await` on the iter call itself.
+            let _ = session.query_iter(QUERY, ()).await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[
+                    RequestMetricKind::RequestsAutomaticallyPaged,
+                    RequestMetricKind::ErrorsAutomaticallyPaged,
+                ],
+            );
+
+            // Forge errors on Execute opcode: covers execute_unpaged,
+            // execute_single_page, and execute_iter.
+            running_proxy
+                .running_nodes
+                .iter_mut()
+                .for_each(|n| n.change_request_rules(Some(forge_error_on_execute.clone())));
+            let _ = session.execute_unpaged(&prepared, ()).await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[
+                    RequestMetricKind::RequestsUnpaged,
+                    RequestMetricKind::ErrorsUnpaged,
+                ],
+            );
+
+            let _ = session
+                .execute_single_page(&prepared, (), PagingState::start())
+                .await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[
+                    RequestMetricKind::RequestsManuallyPaged,
+                    RequestMetricKind::ErrorsManuallyPaged,
+                ],
+            );
+
+            let _ = session.execute_iter(prepared.clone(), ()).await;
+            snap.assert_only_incremented(
+                &metrics,
+                &[
+                    RequestMetricKind::RequestsAutomaticallyPaged,
+                    RequestMetricKind::ErrorsAutomaticallyPaged,
+                ],
+            );
+
+            running_proxy
+                .running_nodes
+                .iter_mut()
+                .for_each(|n| n.change_request_rules(None));
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -3,6 +3,8 @@ mod cluster_reachability;
 mod db_errors;
 mod history;
 mod internal_requests;
+#[cfg(feature = "metrics")]
+mod metrics;
 mod new_session;
 mod pager;
 mod retries;


### PR DESCRIPTION
## Bug Spotted

All executions **not** going through the pager were reported as _unpaged_ requests in metrics.

## The Fix

An enum is added to distinguish unpaged, manually paged, and automatically paged execution, based on the Session API endpoint used (`*_unpaged` vs `*_single_page` vs `_iter`). The enum is propagated to the execution core and respected when bumping requests' metrics.

## Additional Improvements

Previously, there were two pairs of counters (in each pair, one is for all requests and one for errored out requests): one for Pager APIs and one for non-Pager APIs. Now, there are 3 pairs: unpaged, manually paged, automatically paged.
The old public getters (for those old two pairs) were deprecated, and new public getters (for three pairs) were added.

## Testing

A test is added for bumping relevant metrics.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
