### PR TITLE
Draft: [DRIVER-783] Validate SELECT without FROM support

### DIFF
--- a/scylla/tests/integration/statements/mod.rs
+++ b/scylla/tests/integration/statements/mod.rs
@@ -6,6 +6,7 @@ mod named_bind_markers;
 mod prepared;
 mod request_timeout;
 mod result_metadata_extension;
+mod select_without_from;
 mod timestamps;
 mod transparent_reprepare;
 mod unprepared;

--- a/scylla/tests/integration/statements/select_without_from.rs
+++ b/scylla/tests/integration/statements/select_without_from.rs
@@ -1,0 +1,63 @@
+use crate::utils::{create_new_session_builder, setup_tracing};
+use scylla::errors::{DbError, ExecutionError, RequestAttemptError};
+use scylla_cql::value::CqlTimeuuid;
+
+fn is_select_without_from_unsupported(err: &ExecutionError) -> bool {
+    matches!(
+        err,
+        ExecutionError::LastAttemptError(RequestAttemptError::DbError(
+            DbError::SyntaxError | DbError::Invalid,
+            _
+        ))
+    )
+}
+
+#[tokio::test]
+async fn test_select_without_from() {
+    setup_tracing();
+    let session = create_new_session_builder().build().await.unwrap();
+
+    let rows = match session.query_unpaged("SELECT 1", &[]).await {
+        Ok(result) => result.into_rows_result().unwrap(),
+        Err(err) if is_select_without_from_unsupported(&err) => return,
+        Err(err) => panic!("SELECT without FROM failed unexpectedly: {err}"),
+    };
+
+    assert_eq!(rows.column_specs().len(), 1);
+    assert_eq!(rows.column_specs().get_by_index(0).unwrap().name(), "1");
+    let (value,): (i32,) = rows.single_row::<(i32,)>().unwrap();
+    assert_eq!(value, 1);
+
+    let rows = session
+        .query_unpaged("SELECT now()", &[])
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap();
+    assert_eq!(rows.column_specs().len(), 1);
+    assert_eq!(rows.column_specs().get_by_index(0).unwrap().name(), "now()");
+    let (_value,): (CqlTimeuuid,) = rows.single_row::<(CqlTimeuuid,)>().unwrap();
+
+    let prepared = session.prepare("SELECT 1").await.unwrap();
+    let rows = session
+        .execute_unpaged(&prepared, &[])
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap();
+    assert_eq!(rows.column_specs().len(), 1);
+    assert_eq!(rows.column_specs().get_by_index(0).unwrap().name(), "1");
+    let (value,): (i32,) = rows.single_row::<(i32,)>().unwrap();
+    assert_eq!(value, 1);
+
+    let prepared = session.prepare("SELECT now()").await.unwrap();
+    let rows = session
+        .execute_unpaged(&prepared, &[])
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap();
+    assert_eq!(rows.column_specs().len(), 1);
+    assert_eq!(rows.column_specs().get_by_index(0).unwrap().name(), "now()");
+    let (_value,): (CqlTimeuuid,) = rows.single_row::<(CqlTimeuuid,)>().unwrap();
+}


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-783
GitHub issue: https://github.com/scylladb/scylla-rust-driver/issues/1781
Parent epic: https://scylladb.atlassian.net/browse/DRIVER-782

Draft PR for validating SELECT without FROM support in this driver.

Refs #1781.

Scope:
- Add or update integration tests for SELECT 1.
- Add or update integration tests for SELECT now().
- Cover prepared and non-prepared execution paths where relevant.
- Feature-detect or skip cleanly against servers that do not support SELECT without FROM.
- Document any driver-specific limitation found during implementation.

This draft currently contains an empty setup commit so work can start from a linked branch without adding placeholder source changes.