### PR TITLE
pager: deduplicate `QueryPager`/`PagingExecutor` creation

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -548,15 +548,6 @@ where
     }
 }
 
-pub(crate) struct PreparedPagerConfig {
-    pub(crate) prepared: PreparedStatement,
-    pub(crate) values: SerializedValues,
-    pub(crate) execution_profile: Arc<ExecutionProfileInner>,
-    pub(crate) cluster_state: Arc<ClusterState>,
-    pub(crate) metrics: Arc<Metrics>,
-    pub(crate) location_preference: Arc<NodeLocationPreference>,
-}
-
 /// An intermediate object that allows to construct a stream over a query
 /// that is asynchronously paged in the background.
 ///
@@ -836,45 +827,48 @@ If you are using this API, you are probably doing something wrong."
 
     pub(crate) async fn new_for_prepared_statement(
         session: &Session,
-        config: PreparedPagerConfig,
+        prepared: PreparedStatement,
+        values: SerializedValues,
     ) -> Result<Self, PagerExecutionError> {
-        let consistency = config
-            .prepared
+        let execution_profile = prepared
+            .get_execution_profile_handle()
+            .unwrap_or_else(|| session.get_default_execution_profile_handle())
+            .access();
+
+        let consistency = prepared
             .config
             .consistency
-            .unwrap_or(config.execution_profile.consistency);
-        let serial_consistency = config
-            .prepared
+            .unwrap_or(execution_profile.consistency);
+        let serial_consistency = prepared
             .config
             .serial_consistency
-            .unwrap_or(config.execution_profile.serial_consistency);
+            .unwrap_or(execution_profile.serial_consistency);
 
-        let request_timeout = config
-            .prepared
+        let request_timeout = prepared
             .get_request_timeout()
-            .or(config.execution_profile.request_timeout);
+            .or(execution_profile.request_timeout);
 
-        let page_size = config.prepared.get_validated_page_size();
+        let page_size = prepared.get_validated_page_size();
 
         let load_balancing_policy = Arc::clone(
-            config
-                .prepared
+            prepared
                 .get_load_balancing_policy()
-                .unwrap_or(&config.execution_profile.load_balancing_policy),
+                .unwrap_or(&execution_profile.load_balancing_policy),
         );
 
         let retry_policy = Arc::clone(
-            config
-                .prepared
+            prepared
                 .get_retry_policy()
-                .unwrap_or(&config.execution_profile.retry_policy),
+                .unwrap_or(&execution_profile.retry_policy),
         );
 
-        let speculative_policy = config
-            .execution_profile
+        let speculative_policy = execution_profile
             .speculative_execution_policy
             .as_ref()
             .map(Arc::clone);
+
+        let metrics = session.get_metrics_priv();
+        let cluster_state = session.get_cluster_state();
 
         type Replicas = smallvec::SmallVec<[(Arc<Node>, Shard); 8]>;
 
@@ -895,31 +889,29 @@ If you are using this API, you are probably doing something wrong."
             span
         }
 
-        let (partition_key, token) =
-            match config.prepared.extract_partition_key_and_calculate_token(
-                config.prepared.get_partitioner_name(),
-                &config.values,
-            ) {
-                Ok(res) => res.unzip(),
-                Err(err) => {
-                    return Err(PagerExecutionError::NextPageError(
-                        NextPageError::PartitionKeyError(err),
-                    ));
-                }
-            };
+        let (partition_key, token) = match prepared
+            .extract_partition_key_and_calculate_token(prepared.get_partitioner_name(), &values)
+        {
+            Ok(res) => res.unzip(),
+            Err(err) => {
+                return Err(PagerExecutionError::NextPageError(
+                    NextPageError::PartitionKeyError(err),
+                ));
+            }
+        };
 
-        let table_spec = config.prepared.get_table_spec();
+        let table_spec = prepared.get_table_spec();
         let routing_info = RoutingInfo {
             consistency,
             serial_consistency,
             token,
             table: table_spec,
-            is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
-            node_location_preference: &config.location_preference,
+            is_confirmed_lwt: prepared.is_confirmed_lwt(),
+            node_location_preference: session.get_node_location_preference(),
         };
 
-        let prepared_ref = &config.prepared;
-        let values_ref = &config.values;
+        let prepared_ref = &prepared;
+        let values_ref = &values;
         let page_query = |connection: Arc<Connection>,
                           consistency: Consistency,
                           paging_state: PagingState| async move {
@@ -935,12 +927,11 @@ If you are using this API, you are probably doing something wrong."
                 .await
         };
 
-        let serialized_values_size = config.values.buffer_size();
+        let serialized_values_size = values.buffer_size();
 
         let replicas: Option<Replicas> =
             Option::zip(routing_info.table, routing_info.token).map(|(table_spec, token)| {
-                config
-                    .cluster_state
+                cluster_state
                     .get_token_endpoints_iter(table_spec, token)
                     .map(|(node, shard)| (node.clone(), shard))
                     .collect()
@@ -954,20 +945,15 @@ If you are using this API, you are probably doing something wrong."
         );
 
         let mut executor = PagingExecutor {
-            cluster_state: config.cluster_state,
+            cluster_state,
             load_balancing_policy,
             retry_policy,
             speculative_policy,
             request_timeout,
-            is_idempotent: config.prepared.config.is_idempotent,
+            is_idempotent: prepared.config.is_idempotent,
             consistency,
-            metrics: config.metrics,
-            history_listener: config
-                .prepared
-                .config
-                .history_listener
-                .as_ref()
-                .map(Arc::clone),
+            metrics,
+            history_listener: prepared.config.history_listener.as_ref().map(Arc::clone),
             paging_state: PagingState::start(),
             stable_coordinator: None,
         };
@@ -989,9 +975,10 @@ If you are using this API, you are probably doing something wrong."
             }
             ShouldFetchMorePages::MorePages => {
                 /* REMAINING PAGES */
+                let node_location_preference = Arc::clone(session.get_node_location_preference());
                 let worker_task = async move {
-                    let partition_key = if config.prepared.is_token_aware() {
-                        match config.prepared.extract_partition_key(&config.values) {
+                    let partition_key = if prepared.is_token_aware() {
+                        match prepared.extract_partition_key(&values) {
                             Ok(res) => Some(res),
                             Err(err) => {
                                 let _ = sender
@@ -1006,18 +993,18 @@ If you are using this API, you are probably doing something wrong."
                         None
                     };
 
-                    let table_spec = config.prepared.get_table_spec();
+                    let table_spec = prepared.get_table_spec();
                     let routing_info = RoutingInfo {
                         consistency,
                         serial_consistency,
                         token,
                         table: table_spec,
-                        is_confirmed_lwt: config.prepared.is_confirmed_lwt(),
-                        node_location_preference: &config.location_preference,
+                        is_confirmed_lwt: prepared.is_confirmed_lwt(),
+                        node_location_preference: &node_location_preference,
                     };
 
-                    let prepared = &config.prepared;
-                    let values_ref = &config.values;
+                    let prepared = &prepared;
+                    let values_ref = &values;
                     let page_query =
                         |connection: Arc<Connection>,
                          consistency: Consistency,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -17,7 +17,6 @@ use tracing::{Instrument, warn};
 use uuid::Uuid;
 
 use crate::client::execution::{RequestExecutionParams, RequestPaging, RunRequestResult};
-use crate::client::execution_profile::ExecutionProfileInner;
 use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node};
 use crate::deserialize::DeserializeOwnedRow;
@@ -40,7 +39,7 @@ use crate::policies::retry::RetryPolicy;
 use crate::policies::speculative_execution::SpeculativeExecutionPolicy;
 use crate::response::query_result::ColumnSpecs;
 use crate::response::{Coordinator, NonErrorQueryResponse, QueryResponse};
-use crate::routing::{NodeLocationPreference, Shard, Token};
+use crate::routing::{Shard, Token};
 use crate::serialize::row::SerializedValues;
 use crate::statement::prepared::{PartitionKey, PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
@@ -685,11 +684,12 @@ If you are using this API, you are probably doing something wrong."
     pub(crate) async fn new_for_query(
         session: &Session,
         statement: Statement,
-        execution_profile: Arc<ExecutionProfileInner>,
-        cluster_state: Arc<ClusterState>,
-        metrics: Arc<Metrics>,
-        node_location_preference: Arc<NodeLocationPreference>,
     ) -> Result<Self, PagerExecutionError> {
+        let execution_profile = statement
+            .get_execution_profile_handle()
+            .unwrap_or_else(|| session.get_default_execution_profile_handle())
+            .access();
+
         let consistency = statement
             .config
             .consistency
@@ -721,6 +721,9 @@ If you are using this API, you are probably doing something wrong."
             .speculative_execution_policy
             .as_ref()
             .map(Arc::clone);
+
+        let cluster_state = session.get_cluster_state();
+        let metrics = session.get_metrics_priv();
 
         fn create_span(statement_contents: &str) -> RequestSpan {
             let span = RequestSpan::new_query(statement_contents);
@@ -766,7 +769,7 @@ If you are using this API, you are probably doing something wrong."
                 token: None,
                 table: None,
                 is_confirmed_lwt: false,
-                node_location_preference: &node_location_preference,
+                node_location_preference: session.get_node_location_preference(),
             };
 
             let request_span = create_span(&statement.contents);
@@ -786,6 +789,7 @@ If you are using this API, you are probably doing something wrong."
             }
             ShouldFetchMorePages::MorePages => {
                 /* REMAINING PAGES */
+                let node_location_preference = Arc::clone(session.get_node_location_preference());
                 let worker_task = async move {
                     let routing_info = RoutingInfo {
                         consistency,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -17,7 +17,6 @@ use tracing::{Instrument, warn};
 use uuid::Uuid;
 
 use crate::client::execution::{RequestExecutionParams, RequestPaging, RunRequestResult};
-use crate::client::execution_profile::ExecutionProfileInner;
 use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node};
 use crate::deserialize::DeserializeOwnedRow;
@@ -141,11 +140,13 @@ struct PagingExecutor {
 }
 
 impl PagingExecutor {
-    fn new(
-        session: &Session,
-        statement: &StatementConfig,
-        execution_profile: &ExecutionProfileInner,
-    ) -> Self {
+    fn new(session: &Session, statement: &StatementConfig) -> Self {
+        let execution_profile = statement
+            .execution_profile_handle
+            .as_ref()
+            .unwrap_or_else(|| session.get_default_execution_profile_handle())
+            .access();
+
         Self {
             cluster_state: session.get_cluster_state(),
             load_balancing_policy: Arc::clone(
@@ -729,12 +730,7 @@ If you are using this API, you are probably doing something wrong."
         session: &Session,
         statement: Statement,
     ) -> Result<Self, PagerExecutionError> {
-        let execution_profile = statement
-            .get_execution_profile_handle()
-            .unwrap_or_else(|| session.get_default_execution_profile_handle())
-            .access();
-
-        let mut executor = PagingExecutor::new(session, &statement.config, &execution_profile);
+        let mut executor = PagingExecutor::new(session, &statement.config);
         let consistency = executor.consistency;
         let serial_consistency = executor.serial_consistency;
 
@@ -834,12 +830,7 @@ If you are using this API, you are probably doing something wrong."
         prepared: PreparedStatement,
         values: SerializedValues,
     ) -> Result<Self, PagerExecutionError> {
-        let execution_profile = prepared
-            .get_execution_profile_handle()
-            .unwrap_or_else(|| session.get_default_execution_profile_handle())
-            .access();
-
-        let mut executor = PagingExecutor::new(session, &prepared.config, &execution_profile);
+        let mut executor = PagingExecutor::new(session, &prepared.config);
 
         let consistency = executor.consistency;
         let serial_consistency = executor.serial_consistency;

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -110,7 +110,7 @@ type ResultNextPage = Result<NextReceivedPage, NextPageError>;
 
 enum ShouldFetchMorePages {
     NoMorePages,
-    MorePages { successful_coordinator: Coordinator },
+    MorePages,
 }
 
 /// Drives paged execution by repeatedly invoking the unified request-execution
@@ -134,6 +134,7 @@ struct PagingExecutor {
     metrics: Arc<Metrics>,
     history_listener: Option<Arc<dyn HistoryListener>>,
     paging_state: PagingState,
+    stable_coordinator: Option<Coordinator>,
 }
 
 impl PagingExecutor {
@@ -153,7 +154,6 @@ impl PagingExecutor {
         page_query: QueryFunc,
         routing_info: RoutingInfo<'_>,
         span_creator: SpanCreator,
-        mut last_successful_page_coordinator: Coordinator,
     ) where
         QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
@@ -164,13 +164,7 @@ impl PagingExecutor {
             let page_span = span_creator();
 
             let page_res = self
-                .fetch_one_page(
-                    &cluster_state,
-                    &routing_info,
-                    Some(&last_successful_page_coordinator),
-                    &page_span,
-                    &page_query,
-                )
+                .fetch_one_page(&cluster_state, &routing_info, &page_span, &page_query)
                 .instrument(page_span.span().clone())
                 .await;
 
@@ -195,11 +189,7 @@ impl PagingExecutor {
                             // Reached the last page, shutdown.
                             return;
                         }
-                        ShouldFetchMorePages::MorePages {
-                            successful_coordinator,
-                        } => {
-                            last_successful_page_coordinator = successful_coordinator;
-                        }
+                        ShouldFetchMorePages::MorePages => {}
                     }
                 }
                 Err(err) => {
@@ -224,7 +214,7 @@ impl PagingExecutor {
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
     {
         let fetch_result = self
-            .fetch_one_page(cluster_state, routing_info, None, request_span, &page_query)
+            .fetch_one_page(cluster_state, routing_info, request_span, &page_query)
             .instrument(request_span.span().clone())
             .await;
 
@@ -253,14 +243,13 @@ impl PagingExecutor {
 
     /// Fetches exactly one page by delegating to [`run_request_no_side_effects`].
     ///
-    /// `paging_state` is injected into each attempt. If `stability` is set, the
-    /// given coordinator is tried first (and filtered out of the
-    /// fresh load balancing plan so it is not attempted twice).
+    /// `self.paging_state` is injected into each attempt.
+    /// If `self.stable_coordinator` is set, it is tried first (and filtered out
+    /// of the fresh load balancing plan so it is not attempted twice).
     async fn fetch_one_page<PageQuery, QueryFut>(
         &self,
         cluster_state: &ClusterState,
         routing_info: &RoutingInfo<'_>,
-        stable_coordinator: Option<&Coordinator>,
         page_span: &RequestSpan,
         page_query: &PageQuery,
     ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>
@@ -294,7 +283,7 @@ impl PagingExecutor {
             load_balancing::Plan::new(load_balancing_policy, routing_info, cluster_state);
 
         // Coordinator stability: try the previous page's coordinator first.
-        let stability_target = stable_coordinator.map(|coordinator| {
+        let stability_target = self.stable_coordinator.as_ref().map(|coordinator| {
             // `Coordinator` gets its shard from `Connection`. If `Connection` believes it has `Shard` `None`,
             // then it means that the connection pool to that connection is not sharded.
             // In such case, shard is ignored in `connection_for_shard()`.
@@ -307,7 +296,7 @@ impl PagingExecutor {
             .into_iter()
             .chain(base_plan.filter(|&(node, shard)| {
                 // Filter out the preselected coordinator - it is tried first.
-                stable_coordinator.is_none_or(|coordinator| {
+                self.stable_coordinator.as_ref().is_none_or(|coordinator| {
                     // If the previous attempt targeted an unsharded node (such as
                     // Cassandra), filter out all targets to that node regardless
                     // of shard.
@@ -343,9 +332,8 @@ impl PagingExecutor {
                 let should_fetch_more_pages = match paging_state_response {
                     PagingStateResponse::HasMorePages { state } => {
                         self.paging_state = state;
-                        ShouldFetchMorePages::MorePages {
-                            successful_coordinator: coordinator.clone(),
-                        }
+                        self.stable_coordinator = Some(coordinator.clone());
+                        ShouldFetchMorePages::MorePages
                     }
                     PagingStateResponse::NoMorePages => ShouldFetchMorePages::NoMorePages,
                 };
@@ -434,9 +422,8 @@ impl PagingExecutor {
                 let should_fetch_more_pages = match paging_state_response {
                     PagingStateResponse::HasMorePages { state } => {
                         self.paging_state = state;
-                        ShouldFetchMorePages::MorePages {
-                            successful_coordinator: coordinator,
-                        }
+                        self.stable_coordinator = Some(coordinator);
+                        ShouldFetchMorePages::MorePages
                     }
                     PagingStateResponse::NoMorePages => ShouldFetchMorePages::NoMorePages,
                 };
@@ -777,8 +764,9 @@ If you are using this API, you are probably doing something wrong."
             is_idempotent: statement.config.is_idempotent,
             consistency,
             metrics,
-            paging_state: PagingState::start(),
             history_listener: statement.config.history_listener.as_ref().map(Arc::clone),
+            paging_state: PagingState::start(),
+            stable_coordinator: None,
         };
 
         let (first_page, should_fetch_more_pages) = {
@@ -806,9 +794,7 @@ If you are using this API, you are probably doing something wrong."
                 // No more pages - we are done, return the first page and an empty receiver.
                 std::mem::drop(sender);
             }
-            ShouldFetchMorePages::MorePages {
-                successful_coordinator: first_page_coordinator,
-            } => {
+            ShouldFetchMorePages::MorePages => {
                 /* REMAINING PAGES */
                 let worker_task = async move {
                     let routing_info = RoutingInfo {
@@ -845,7 +831,6 @@ If you are using this API, you are probably doing something wrong."
                             page_query,
                             routing_info,
                             span_creator,
-                            first_page_coordinator,
                         )
                         .await;
                 };
@@ -983,13 +968,14 @@ If you are using this API, you are probably doing something wrong."
             is_idempotent: config.prepared.config.is_idempotent,
             consistency,
             metrics: config.metrics,
-            paging_state: PagingState::start(),
             history_listener: config
                 .prepared
                 .config
                 .history_listener
                 .as_ref()
                 .map(Arc::clone),
+            paging_state: PagingState::start(),
+            stable_coordinator: None,
         };
 
         let (first_page, should_fetch_more_pages) = executor
@@ -1012,9 +998,7 @@ If you are using this API, you are probably doing something wrong."
                 // No more pages - we are done, return the first page and an empty receiver.
                 std::mem::drop(sender);
             }
-            ShouldFetchMorePages::MorePages {
-                successful_coordinator: first_page_coordinator,
-            } => {
+            ShouldFetchMorePages::MorePages => {
                 /* REMAINING PAGES */
                 let worker_task = async move {
                     let partition_key = if config.prepared.is_token_aware() {
@@ -1077,7 +1061,6 @@ If you are using this API, you are probably doing something wrong."
                             page_query,
                             routing_info,
                             span_creator,
-                            first_page_coordinator,
                         )
                         .await;
                 };

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -726,7 +726,7 @@ If you are using this API, you are probably doing something wrong."
         TypedRowStream::<RowT>::new(self)
     }
 
-    pub(crate) async fn new_for_query(
+    pub(crate) async fn new_for_unprepared_statement_without_values(
         session: &Session,
         statement: Statement,
     ) -> Result<Self, PagerExecutionError> {

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -125,6 +125,7 @@ enum ShouldFetchMorePages {
 /// - turning each successful page into a [`NextReceivedPage`] sent over the
 ///   channel, and stopping once the server reports no more pages.
 struct PagingExecutor {
+    cluster_state: Arc<ClusterState>,
     load_balancing_policy: Arc<dyn LoadBalancingPolicy>,
     retry_policy: Arc<dyn RetryPolicy>,
     speculative_policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
@@ -149,7 +150,6 @@ impl PagingExecutor {
     /// for retry.
     async fn query_remaining_pages<QueryFunc, QueryFut, SpanCreator>(
         mut self,
-        cluster_state: Arc<ClusterState>,
         sender: mpsc::Sender<ResultNextPage>,
         page_query: QueryFunc,
         routing_info: RoutingInfo<'_>,
@@ -164,7 +164,7 @@ impl PagingExecutor {
             let page_span = span_creator();
 
             let page_res = self
-                .fetch_one_page(&cluster_state, &routing_info, &page_span, &page_query)
+                .fetch_one_page(&routing_info, &page_span, &page_query)
                 .instrument(page_span.span().clone())
                 .await;
 
@@ -204,7 +204,6 @@ impl PagingExecutor {
     /// Returns the first page and whether more pages should be fetched.
     async fn query_first_page<QueryFunc, QueryFut>(
         &mut self,
-        cluster_state: &ClusterState,
         request_span: &RequestSpan,
         routing_info: &RoutingInfo<'_>,
         page_query: QueryFunc,
@@ -214,7 +213,7 @@ impl PagingExecutor {
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
     {
         let fetch_result = self
-            .fetch_one_page(cluster_state, routing_info, request_span, &page_query)
+            .fetch_one_page(routing_info, request_span, &page_query)
             .instrument(request_span.span().clone())
             .await;
 
@@ -248,7 +247,6 @@ impl PagingExecutor {
     /// of the fresh load balancing plan so it is not attempted twice).
     async fn fetch_one_page<PageQuery, QueryFut>(
         &self,
-        cluster_state: &ClusterState,
         routing_info: &RoutingInfo<'_>,
         page_span: &RequestSpan,
         page_query: &PageQuery,
@@ -280,7 +278,7 @@ impl PagingExecutor {
 
         let load_balancing_policy = self.load_balancing_policy.as_ref();
         let base_plan =
-            load_balancing::Plan::new(load_balancing_policy, routing_info, cluster_state);
+            load_balancing::Plan::new(load_balancing_policy, routing_info, &self.cluster_state);
 
         // Coordinator stability: try the previous page's coordinator first.
         let stability_target = self.stable_coordinator.as_ref().map(|coordinator| {
@@ -757,6 +755,7 @@ If you are using this API, you are probably doing something wrong."
         };
 
         let mut executor = PagingExecutor {
+            cluster_state,
             load_balancing_policy,
             retry_policy,
             speculative_policy,
@@ -782,7 +781,7 @@ If you are using this API, you are probably doing something wrong."
             let request_span = create_span(&statement.contents);
 
             executor
-                .query_first_page(&cluster_state, &request_span, &routing_info, page_query)
+                .query_first_page(&request_span, &routing_info, page_query)
                 .await
                 .map_err(NextPageError::RequestFailure)?
         };
@@ -825,13 +824,7 @@ If you are using this API, you are probably doing something wrong."
                     let span_creator = move || create_span(&statement_ref.contents);
 
                     executor
-                        .query_remaining_pages(
-                            cluster_state,
-                            sender,
-                            page_query,
-                            routing_info,
-                            span_creator,
-                        )
+                        .query_remaining_pages(sender, page_query, routing_info, span_creator)
                         .await;
                 };
                 let _worker_handle = tokio::task::spawn(worker_task);
@@ -961,6 +954,7 @@ If you are using this API, you are probably doing something wrong."
         );
 
         let mut executor = PagingExecutor {
+            cluster_state: config.cluster_state,
             load_balancing_policy,
             retry_policy,
             speculative_policy,
@@ -979,12 +973,7 @@ If you are using this API, you are probably doing something wrong."
         };
 
         let (first_page, should_fetch_more_pages) = executor
-            .query_first_page(
-                &config.cluster_state,
-                &request_span,
-                &routing_info,
-                page_query,
-            )
+            .query_first_page(&request_span, &routing_info, page_query)
             .await
             .map_err(NextPageError::RequestFailure)?;
 
@@ -1055,13 +1044,7 @@ If you are using this API, you are probably doing something wrong."
                     };
 
                     executor
-                        .query_remaining_pages(
-                            config.cluster_state,
-                            sender,
-                            page_query,
-                            routing_info,
-                            span_creator,
-                        )
+                        .query_remaining_pages(sender, page_query, routing_info, span_creator)
                         .await;
                 };
                 let _worker_handle = tokio::task::spawn(worker_task);

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -133,6 +133,7 @@ struct PagingExecutor {
     request_timeout: Option<Duration>,
     is_idempotent: bool,
     consistency: Consistency,
+    serial_consistency: Option<SerialConsistency>,
     metrics: Arc<Metrics>,
     history_listener: Option<Arc<dyn HistoryListener>>,
     paging_state: PagingState,
@@ -171,6 +172,9 @@ impl PagingExecutor {
             consistency: statement
                 .consistency
                 .unwrap_or(execution_profile.consistency),
+            serial_consistency: statement
+                .serial_consistency
+                .unwrap_or(execution_profile.serial_consistency),
             metrics: session.get_metrics_priv(),
             history_listener: statement.history_listener.as_ref().map(Arc::clone),
             paging_state: PagingState::start(),
@@ -730,10 +734,9 @@ If you are using this API, you are probably doing something wrong."
             .unwrap_or_else(|| session.get_default_execution_profile_handle())
             .access();
 
-        let serial_consistency = statement
-            .config
-            .serial_consistency
-            .unwrap_or(execution_profile.serial_consistency);
+        let mut executor = PagingExecutor::new(session, &statement.config, &execution_profile);
+        let consistency = executor.consistency;
+        let serial_consistency = executor.serial_consistency;
 
         fn create_span(statement_contents: &str) -> RequestSpan {
             let span = RequestSpan::new_query(statement_contents);
@@ -758,9 +761,6 @@ If you are using this API, you are probably doing something wrong."
                     .await
             }
         };
-
-        let mut executor = PagingExecutor::new(session, &statement.config, &execution_profile);
-        let consistency = executor.consistency;
 
         let (first_page, should_fetch_more_pages) = {
             let routing_info = RoutingInfo {
@@ -842,11 +842,7 @@ If you are using this API, you are probably doing something wrong."
         let mut executor = PagingExecutor::new(session, &prepared.config, &execution_profile);
 
         let consistency = executor.consistency;
-
-        let serial_consistency = prepared
-            .config
-            .serial_consistency
-            .unwrap_or(execution_profile.serial_consistency);
+        let serial_consistency = executor.serial_consistency;
 
         type Replicas = smallvec::SmallVec<[(Arc<Node>, Shard); 8]>;
 

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -17,6 +17,7 @@ use tracing::{Instrument, warn};
 use uuid::Uuid;
 
 use crate::client::execution::{RequestExecutionParams, RequestPaging, RunRequestResult};
+use crate::client::execution_profile::ExecutionProfileInner;
 use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node};
 use crate::deserialize::DeserializeOwnedRow;
@@ -41,6 +42,7 @@ use crate::response::query_result::ColumnSpecs;
 use crate::response::{Coordinator, NonErrorQueryResponse, QueryResponse};
 use crate::routing::{Shard, Token};
 use crate::serialize::row::SerializedValues;
+use crate::statement::StatementConfig;
 use crate::statement::prepared::{PartitionKey, PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
 
@@ -138,6 +140,44 @@ struct PagingExecutor {
 }
 
 impl PagingExecutor {
+    fn new(
+        session: &Session,
+        statement: &StatementConfig,
+        execution_profile: &ExecutionProfileInner,
+    ) -> Self {
+        Self {
+            cluster_state: session.get_cluster_state(),
+            load_balancing_policy: Arc::clone(
+                statement
+                    .load_balancing_policy
+                    .as_ref()
+                    .unwrap_or(&execution_profile.load_balancing_policy),
+            ),
+            retry_policy: Arc::clone(
+                statement
+                    .retry_policy
+                    .as_ref()
+                    .unwrap_or(&execution_profile.retry_policy),
+            ),
+            speculative_policy: execution_profile
+                .speculative_execution_policy
+                .as_ref()
+                .map(Arc::clone),
+
+            request_timeout: statement
+                .request_timeout
+                .or(execution_profile.request_timeout),
+            is_idempotent: statement.is_idempotent,
+            consistency: statement
+                .consistency
+                .unwrap_or(execution_profile.consistency),
+            metrics: session.get_metrics_priv(),
+            history_listener: statement.history_listener.as_ref().map(Arc::clone),
+            paging_state: PagingState::start(),
+            stable_coordinator: None,
+        }
+    }
+
     /// Fetches remaining pages (pages 2+) in a background task.
     /// Sends each page through the mpsc channel.
     ///
@@ -685,45 +725,16 @@ If you are using this API, you are probably doing something wrong."
         session: &Session,
         statement: Statement,
     ) -> Result<Self, PagerExecutionError> {
+        let page_size = statement.get_validated_page_size();
         let execution_profile = statement
             .get_execution_profile_handle()
             .unwrap_or_else(|| session.get_default_execution_profile_handle())
             .access();
 
-        let consistency = statement
-            .config
-            .consistency
-            .unwrap_or(execution_profile.consistency);
         let serial_consistency = statement
             .config
             .serial_consistency
             .unwrap_or(execution_profile.serial_consistency);
-
-        let request_timeout = statement
-            .get_request_timeout()
-            .or(execution_profile.request_timeout);
-
-        let page_size = statement.get_validated_page_size();
-
-        let load_balancing_policy = Arc::clone(
-            statement
-                .get_load_balancing_policy()
-                .unwrap_or(&execution_profile.load_balancing_policy),
-        );
-
-        let retry_policy = Arc::clone(
-            statement
-                .get_retry_policy()
-                .unwrap_or(&execution_profile.retry_policy),
-        );
-
-        let speculative_policy = execution_profile
-            .speculative_execution_policy
-            .as_ref()
-            .map(Arc::clone);
-
-        let cluster_state = session.get_cluster_state();
-        let metrics = session.get_metrics_priv();
 
         fn create_span(statement_contents: &str) -> RequestSpan {
             let span = RequestSpan::new_query(statement_contents);
@@ -748,19 +759,8 @@ If you are using this API, you are probably doing something wrong."
             }
         };
 
-        let mut executor = PagingExecutor {
-            cluster_state,
-            load_balancing_policy,
-            retry_policy,
-            speculative_policy,
-            request_timeout,
-            is_idempotent: statement.config.is_idempotent,
-            consistency,
-            metrics,
-            history_listener: statement.config.history_listener.as_ref().map(Arc::clone),
-            paging_state: PagingState::start(),
-            stable_coordinator: None,
-        };
+        let mut executor = PagingExecutor::new(session, &statement.config, &execution_profile);
+        let consistency = executor.consistency;
 
         let (first_page, should_fetch_more_pages) = {
             let routing_info = RoutingInfo {
@@ -839,40 +839,16 @@ If you are using this API, you are probably doing something wrong."
             .unwrap_or_else(|| session.get_default_execution_profile_handle())
             .access();
 
-        let consistency = prepared
-            .config
-            .consistency
-            .unwrap_or(execution_profile.consistency);
+        let mut executor = PagingExecutor::new(session, &prepared.config, &execution_profile);
+
+        let consistency = executor.consistency;
+
         let serial_consistency = prepared
             .config
             .serial_consistency
             .unwrap_or(execution_profile.serial_consistency);
 
-        let request_timeout = prepared
-            .get_request_timeout()
-            .or(execution_profile.request_timeout);
-
         let page_size = prepared.get_validated_page_size();
-
-        let load_balancing_policy = Arc::clone(
-            prepared
-                .get_load_balancing_policy()
-                .unwrap_or(&execution_profile.load_balancing_policy),
-        );
-
-        let retry_policy = Arc::clone(
-            prepared
-                .get_retry_policy()
-                .unwrap_or(&execution_profile.retry_policy),
-        );
-
-        let speculative_policy = execution_profile
-            .speculative_execution_policy
-            .as_ref()
-            .map(Arc::clone);
-
-        let metrics = session.get_metrics_priv();
-        let cluster_state = session.get_cluster_state();
 
         type Replicas = smallvec::SmallVec<[(Arc<Node>, Shard); 8]>;
 
@@ -935,7 +911,8 @@ If you are using this API, you are probably doing something wrong."
 
         let replicas: Option<Replicas> =
             Option::zip(routing_info.table, routing_info.token).map(|(table_spec, token)| {
-                cluster_state
+                executor
+                    .cluster_state
                     .get_token_endpoints_iter(table_spec, token)
                     .map(|(node, shard)| (node.clone(), shard))
                     .collect()
@@ -947,20 +924,6 @@ If you are using this API, you are probably doing something wrong."
             serialized_values_size,
             replicas.as_ref(),
         );
-
-        let mut executor = PagingExecutor {
-            cluster_state,
-            load_balancing_policy,
-            retry_policy,
-            speculative_policy,
-            request_timeout,
-            is_idempotent: prepared.config.is_idempotent,
-            consistency,
-            metrics,
-            history_listener: prepared.config.history_listener.as_ref().map(Arc::clone),
-            paging_state: PagingState::start(),
-            stable_coordinator: None,
-        };
 
         let (first_page, should_fetch_more_pages) = executor
             .query_first_page(&request_span, &routing_info, page_query)

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -725,7 +725,6 @@ If you are using this API, you are probably doing something wrong."
         session: &Session,
         statement: Statement,
     ) -> Result<Self, PagerExecutionError> {
-        let page_size = statement.get_validated_page_size();
         let execution_profile = statement
             .get_execution_profile_handle()
             .unwrap_or_else(|| session.get_default_execution_profile_handle())
@@ -742,6 +741,7 @@ If you are using this API, you are probably doing something wrong."
             span
         }
 
+        let page_size = statement.get_validated_page_size();
         let statement_ref = &statement;
         let page_query = |connection: Arc<Connection>,
                           consistency: Consistency,
@@ -848,8 +848,6 @@ If you are using this API, you are probably doing something wrong."
             .serial_consistency
             .unwrap_or(execution_profile.serial_consistency);
 
-        let page_size = prepared.get_validated_page_size();
-
         type Replicas = smallvec::SmallVec<[(Arc<Node>, Shard); 8]>;
 
         fn create_span(
@@ -890,6 +888,7 @@ If you are using this API, you are probably doing something wrong."
             node_location_preference: session.get_node_location_preference(),
         };
 
+        let page_size = prepared.get_validated_page_size();
         let prepared_ref = &prepared;
         let values_ref = &values;
         let page_query = |connection: Arc<Connection>,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1475,20 +1475,7 @@ impl Session {
         &self,
         statement: Statement,
     ) -> Result<QueryPager, PagerExecutionError> {
-        let execution_profile = statement
-            .get_execution_profile_handle()
-            .unwrap_or_else(|| self.get_default_execution_profile_handle())
-            .access();
-
-        QueryPager::new_for_query(
-            self,
-            statement,
-            execution_profile,
-            self.cluster.get_state(),
-            Arc::clone(&self.metrics),
-            Arc::clone(&self.node_location_preference),
-        )
-        .await
+        QueryPager::new_for_query(self, statement).await
     }
 
     /// Prepares a statement on the server side and returns a prepared statement,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1475,7 +1475,7 @@ impl Session {
         &self,
         statement: Statement,
     ) -> Result<QueryPager, PagerExecutionError> {
-        QueryPager::new_for_query(self, statement).await
+        QueryPager::new_for_unprepared_statement_without_values(self, statement).await
     }
 
     /// Prepares a statement on the server side and returns a prepared statement,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -3,7 +3,7 @@
 
 use super::execution::RequestPaging;
 use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle, ExecutionProfileInner};
-use super::pager::{PreparedPagerConfig, QueryPager};
+use super::pager::QueryPager;
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
 use crate::client::client_routes::ClientRoutesConfig;
@@ -1797,23 +1797,7 @@ impl Session {
         prepared: PreparedStatement,
         values: SerializedValues,
     ) -> Result<QueryPager, PagerExecutionError> {
-        let execution_profile = prepared
-            .get_execution_profile_handle()
-            .unwrap_or_else(|| self.get_default_execution_profile_handle())
-            .access();
-
-        QueryPager::new_for_prepared_statement(
-            self,
-            PreparedPagerConfig {
-                prepared,
-                values,
-                execution_profile,
-                cluster_state: self.cluster.get_state(),
-                metrics: Arc::clone(&self.metrics),
-                location_preference: Arc::clone(&self.node_location_preference),
-            },
-        )
-        .await
+        QueryPager::new_for_prepared_statement(self, prepared, values).await
     }
 
     /// This is essentially the same as `execute_iter_nongeneric`, but it is *public*
@@ -1956,6 +1940,10 @@ impl Session {
     /// They can be read using this method
     #[cfg(feature = "metrics")]
     pub fn get_metrics(&self) -> Arc<Metrics> {
+        self.get_metrics_priv()
+    }
+
+    pub(crate) fn get_metrics_priv(&self) -> Arc<Metrics> {
         Arc::clone(&self.metrics)
     }
 
@@ -2444,6 +2432,12 @@ impl Session {
     /// by default, i.e. when an executed statement does not define its own handle.
     pub fn get_default_execution_profile_handle(&self) -> &ExecutionProfileHandle {
         &self.default_execution_profile_handle
+    }
+
+    /// Retrieves the node location preference that is used by this session
+    /// by default, i.e. when the used LBP does not define its own preference.
+    pub(crate) fn get_node_location_preference(&self) -> &Arc<NodeLocationPreference> {
+        &self.node_location_preference
     }
 }
 


### PR DESCRIPTION
Ref: #1549

This deduplicates two `QueryPager`'s constructors: `new_for_query` and `new_for_prepared_statement`. Shared logic, namely resolving various execution config params, is now in `PagingExecutor::new()`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
