### PR TITLE
connection: linger deprecated expect -> allow

### DIFF
--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2192,7 +2192,7 @@ fn apply_socket_options(
 
     let sf = SockRef::from(&socket);
     if let Some(linger) = options.linger {
-        #[expect(deprecated)]
+        #[allow(deprecated)]
         socket.set_linger(Some(linger))?;
     }
     if let Some(keepalive_interval) = options.keepalive_interval {


### PR DESCRIPTION
On older Tokio versions, which we do allow in Cargo.toml, this is not yet deprecated.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
