### PR TITLE
Implement TABLETS_ROUTING_V2

### DIFF
--- a/docs/source/SUMMARY.md
+++ b/docs/source/SUMMARY.md
@@ -56,6 +56,7 @@
 
 - [Load balancing](load-balancing/load-balancing.md)
     - [Default policy](load-balancing/default-policy.md)
+    - [Tablet awareness](load-balancing/tablets.md)
 
 - [Retry policy configuration](retry-policy/retry-policy.md)
     - [Fallthrough retry policy](retry-policy/fallthrough.md)

--- a/docs/source/load-balancing/default-policy.md
+++ b/docs/source/load-balancing/default-policy.md
@@ -178,13 +178,18 @@ let policy = DefaultPolicy::builder()
 
 The DefaultPolicy prefers to return nodes in the following order:
 
-1. Alive local replicas (if token is available & token awareness is enabled)
-2. Alive remote replicas (if datacenter failover is permitted & possible due to consistency constraints)
-3. Alive local nodes
-4. Alive remote nodes (if datacenter failover is permitted & possible due to consistency constraints)
-5. Enabled down nodes
+1. The tablet's Raft leader, for a leader-requiring request against a
+   strongly-consistent table — see [Tablet awareness](tablets.md). This
+   position outranks the ones below, but only among the nodes the policy would
+   contact anyway: a leader in a remote datacenter is skipped unless datacenter
+   failover is permitted.
+2. Alive local replicas (if token is available & token awareness is enabled)
+3. Alive remote replicas (if datacenter failover is permitted & possible due to consistency constraints)
+4. Alive local nodes
+5. Alive remote nodes (if datacenter failover is permitted & possible due to consistency constraints)
+6. Enabled down nodes
 And only if latency awareness is enabled:
-6. Penalised: alive local replicas, alive remote replicas, ... (in order as above).
+7. Penalised: alive local replicas, alive remote replicas, ... (in order as above).
 
 If no preferred datacenter is specified, all nodes are treated as local ones.
 
@@ -196,3 +201,8 @@ to the replicas in the ring order (as it prevents contention due to Paxos confli
 The optimisation is applied in two cases:
 1. when an LWT statement (containing an `IF` clause) is prepared — ScyllaDB sets a flag that the driver uses for routing;
 2. when a statement is executed with `Serial` or `LocalSerial` consistency (this is the only way to execute `SELECT` as LWT, since it may not contain an `IF` clause), the driver detects it automatically.
+
+Leader-aware routing (see [Tablet awareness](tablets.md)) is a separate
+mechanism and does not change this: it moves one replica — the tablet's Raft
+leader — to the front of the plan and leaves the ordering of the rest untouched,
+so the remaining replicas are still shuffled as described above.

--- a/docs/source/load-balancing/load-balancing.md
+++ b/docs/source/load-balancing/load-balancing.md
@@ -126,4 +126,5 @@ again until it's recovered.
    :glob:
 
    default-policy
+   tablets
 ```

--- a/docs/source/load-balancing/tablets.md
+++ b/docs/source/load-balancing/tablets.md
@@ -75,3 +75,71 @@ upgrade a session can hold V2 connections to some nodes and V1 connections to
 others at the same time. Both are handled correctly and no configuration
 changes when this happens.
 ```
+
+## Leader-aware routing for strongly-consistent tables
+
+A keyspace created with `consistency = 'global'` is *strongly consistent*: its
+tablets are replicated through Raft, and one replica of each tablet is the Raft
+leader that coordinates the tablet's writes and its linearizable reads. A
+request that has to go through the leader but arrives elsewhere is forwarded
+there by the receiving node, which costs an extra network hop.
+
+On a `TABLETS_ROUTING_V2` connection, the driver knows which replica leads each
+tablet it has cached and sends such requests to the leader directly. Nothing
+needs to be configured; as with tablet awareness in general, a token-aware
+`DefaultPolicy` suffices.
+
+Which requests are routed to the leader follows from how ScyllaDB serves each
+operation on a strongly-consistent table:
+
+| Operation | Consistency level        | Served by                       | Routed to the leader |
+| --------- | ------------------------ | ------------------------------- | -------------------- |
+| Read      | `ONE`, `LOCAL_ONE`       | any replica, no read barrier    | no                   |
+| Read      | anything else            | the Raft leader (linearizable)  | yes                  |
+| Write     | `QUORUM`, `LOCAL_QUORUM` | the Raft leader, through Raft   | yes                  |
+| Write     | anything else            | rejected by the server          | –                    |
+
+A read at `ONE` or `LOCAL_ONE` is not linearizable: any replica may serve it
+without taking a Raft read barrier, so there is nothing to gain from preferring
+the leader and these keep normal token-aware routing, spread across the
+replicas. Everything else has to be coordinated by the leader, so the driver
+targets it directly. Writes are restricted to `QUORUM` and `LOCAL_QUORUM`;
+the server rejects the rest regardless of routing.
+
+Eventually-consistent tables are unaffected and keep their usual token-aware
+(optionally shuffled) replica ordering.
+
+### Interaction with datacenter and rack preferences
+
+For a leader-requiring request, the leader outranks *distance*: it is tried
+ahead of nearer replicas, including a leader in a remote datacenter ahead of a
+replica in the preferred rack. A nearer replica would only forward the request
+to the leader anyway, and since the table is globally consistent — there is one
+leader for the whole cluster, not one per datacenter — keeping the request
+inside a single datacenter buys no consistency either.
+
+Leader awareness does not, however, override the policy's own restrictions. The
+leader is only targeted if the policy would contact it at all:
+
+- with a preferred datacenter and datacenter failover disabled
+  (`permit_dc_failover: false`, the default), a leader in another datacenter is
+  not contacted. The request goes to a local replica and the server forwards it
+  to the leader, exactly as it would without V2. **Leader awareness never
+  introduces cross-datacenter traffic that the policy would otherwise forbid.**
+- a leader that is down, or excluded by the policy's own predicate, is skipped
+  and the request is routed normally.
+
+Rack preference does not restrict the leader: a leader elsewhere in the
+preferred datacenter is still targeted directly.
+
+Only the leader is promoted. The remaining replicas keep their normal ordering,
+so if the leader cannot be reached, retries still spread across the others
+rather than piling onto one node.
+
+```{note}
+Because the leader is only reported over `TABLETS_ROUTING_V2`, and because that
+extension is experimental, leader-aware routing is active only against a
+cluster that negotiates it. Elsewhere the requests are routed by plain tablet
+awareness and the server does the forwarding — correct either way, just with
+the extra hop.
+```

--- a/docs/source/load-balancing/tablets.md
+++ b/docs/source/load-balancing/tablets.md
@@ -1,0 +1,77 @@
+# Tablet awareness
+
+ScyllaDB can partition a table into *tablets* instead of distributing it over
+the token ring. A tablet owns a contiguous token range and is replicated on a
+small set of nodes, and — unlike token-ring replication — the driver cannot
+compute a tablet's replicas from the ring: tablets move between nodes as the
+cluster balances itself, so the mapping has to be learned from the cluster and
+kept up to date.
+
+The driver learns it from the server, which piggy-backs routing information on
+query responses. Two protocol extensions do this, negotiated per connection
+during the handshake. No configuration is required for either: a token-aware
+`DefaultPolicy` (the default) is all that is needed.
+
+Because the routing information arrives on responses to prepared statements,
+tablet awareness applies to prepared statements only. Unprepared statements
+carry no token and are routed without it, exactly as they are for token-ring
+tables.
+
+## `TABLETS_ROUTING_V1`
+
+Whenever the driver sends a request to a shard that does not own the target
+tablet, the response carries a `tablets-routing-v1` payload describing that
+tablet: its token range and its replicas. The driver caches it and routes
+subsequent requests for that token range accordingly.
+
+This is corrective: the driver only learns about a tablet by first guessing
+wrong about it. That is cheap when a tablet is new to the driver, but it also
+means a stale mapping is only noticed once it causes a misrouted request — and
+if the driver's replica list is a subset of the real one, requests may keep
+landing on a correct-but-outdated replica and the stale entry survives
+indefinitely.
+
+## `TABLETS_ROUTING_V2`
+
+V2 subsumes V1 — a connection negotiates one or the other, never both — and
+replaces the corrective scheme with an explicit staleness check.
+
+Every tablet carries a **tablet version**: an opaque 64-bit value that changes
+whenever anything the driver routes by changes, that is, the tablet's replica
+set or (for the strongly-consistent tables described below) its leader. The
+driver caches the version alongside the replicas.
+
+On a V2 connection the driver appends a single byte, the *tablet-version block*,
+to every `EXECUTE` request. The byte encodes one 4-bit slice of the cached
+version together with that slice's position, and the server compares it against
+its own version for the tablet:
+
+- if they agree, the response carries no routing information at all;
+- if they differ, the response carries a `tablets-routing-v2` payload with the
+  tablet's token range, its replicas and its current version, and the driver
+  replaces its cached entry.
+
+The position is chosen at random for each request, so consecutive requests
+sample different parts of the version and the driver converges on any change
+within a few requests. When the driver has no version cached for a tablet, it
+sends a random byte, which almost certainly disagrees and so prompts the server
+to send the routing information straight away.
+
+Compared to V1, this costs one byte on every request and, in exchange:
+
+- staleness is detected without having to misroute a request first, so a changed
+  replica set is picked up even while every request still happens to reach a
+  valid replica;
+- conversely, a request that *does* reach a non-owning shard costs nothing when
+  the driver's cached mapping is already up to date. V1 keys off locality and
+  resends the payload every time; V2 keys off the version and stays silent.
+
+```{note}
+`TABLETS_ROUTING_V2` is experimental. A node advertises it (on the wire as
+`TABLETS_ROUTING_V2_EXPERIMENTAL`) only when started with the
+`strongly-consistent-tables` experimental feature enabled; otherwise it offers
+only `TABLETS_ROUTING_V1`. Negotiation is per connection, so during a rolling
+upgrade a session can hold V2 connections to some nodes and V1 connections to
+others at the same time. Both are handled correctly and no configuration
+changes when this happens.
+```

--- a/scylla-cql-core/src/frame/protocol_features.rs
+++ b/scylla-cql-core/src/frame/protocol_features.rs
@@ -13,6 +13,7 @@ pub const SCYLLA_LWT_ADD_METADATA_MARK_EXTENSION: &str = "SCYLLA_LWT_ADD_METADAT
 /// which entry is a bit mask for the frame flags used to mark LWT frames.
 pub const LWT_OPTIMIZATION_META_BIT_MASK_KEY: &str = "LWT_OPTIMIZATION_META_BIT_MASK";
 const TABLETS_ROUTING_V1_KEY: &str = "TABLETS_ROUTING_V1";
+const TABLETS_ROUTING_V2_KEY: &str = "TABLETS_ROUTING_V2_EXPERIMENTAL";
 const SCYLLA_USE_METADATA_ID_KEY: &str = "SCYLLA_USE_METADATA_ID";
 
 /// Which protocol extensions are supported by the server.
@@ -50,6 +51,14 @@ pub struct ProtocolFeatures {
     /// Whether the server supports tablets routing v1.
     pub tablets_v1_supported: bool,
 
+    /// Whether the server supports tablets routing v2.
+    ///
+    /// V2 subsumes V1: when the server advertises both, the driver negotiates only V2.
+    /// In addition to keeping the tablet routing cache fresh (like V1), V2 lets the driver
+    /// send a tablet-version block on each `EXECUTE`, so the server only returns updated
+    /// routing information when the driver's cached version is stale.
+    pub tablets_v2_supported: bool,
+
     /// Does the server supports sending metadata id (introduced in CQL v5) for CQL v4.
     pub scylla_metadata_id_supported: bool,
 }
@@ -65,6 +74,7 @@ impl ProtocolFeatures {
                 supported,
             ),
             tablets_v1_supported: Self::check_tablets_routing_v1_support(supported),
+            tablets_v2_supported: Self::check_tablets_routing_v2_support(supported),
             scylla_metadata_id_supported: Self::check_scylla_metadata_id_support(supported),
         }
     }
@@ -86,6 +96,10 @@ impl ProtocolFeatures {
 
     fn check_tablets_routing_v1_support(supported: &HashMap<String, Vec<String>>) -> bool {
         supported.contains_key(TABLETS_ROUTING_V1_KEY)
+    }
+
+    fn check_tablets_routing_v2_support(supported: &HashMap<String, Vec<String>>) -> bool {
+        supported.contains_key(TABLETS_ROUTING_V2_KEY)
     }
 
     fn check_scylla_metadata_id_support(supported: &HashMap<String, Vec<String>>) -> bool {
@@ -110,7 +124,10 @@ impl ProtocolFeatures {
             );
         }
 
-        if self.tablets_v1_supported {
+        // V2 subsumes V1: when the server supports both, negotiate only V2.
+        if self.tablets_v2_supported {
+            options.insert(Cow::Borrowed(TABLETS_ROUTING_V2_KEY), Cow::Borrowed(""));
+        } else if self.tablets_v1_supported {
             options.insert(Cow::Borrowed(TABLETS_ROUTING_V1_KEY), Cow::Borrowed(""));
         }
 
@@ -126,5 +143,63 @@ impl ProtocolFeatures {
         self.lwt_optimization_meta_bit_mask
             .map(|mask| (flags & mask) == mask)
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn supported(keys: &[&str]) -> HashMap<String, Vec<String>> {
+        keys.iter().map(|k| (k.to_string(), Vec::new())).collect()
+    }
+
+    fn startup_keys(features: &ProtocolFeatures) -> Vec<String> {
+        let mut options = HashMap::new();
+        features.add_startup_options(&mut options);
+        let mut keys: Vec<String> = options.into_keys().map(|k| k.into_owned()).collect();
+        keys.sort();
+        keys
+    }
+
+    #[test]
+    fn parses_tablets_v1_and_v2_support() {
+        let features = ProtocolFeatures::parse_from_supported(&supported(&[
+            TABLETS_ROUTING_V1_KEY,
+            TABLETS_ROUTING_V2_KEY,
+        ]));
+        assert!(features.tablets_v1_supported);
+        assert!(features.tablets_v2_supported);
+    }
+
+    #[test]
+    fn negotiates_only_v2_when_both_supported() {
+        // The server advertises both v1 and v2; v2 subsumes v1, so the driver must
+        // echo only the v2 key in STARTUP.
+        let features = ProtocolFeatures::parse_from_supported(&supported(&[
+            TABLETS_ROUTING_V1_KEY,
+            TABLETS_ROUTING_V2_KEY,
+        ]));
+        assert_eq!(startup_keys(&features), vec![TABLETS_ROUTING_V2_KEY]);
+    }
+
+    #[test]
+    fn negotiates_v1_when_only_v1_supported() {
+        let features =
+            ProtocolFeatures::parse_from_supported(&supported(&[TABLETS_ROUTING_V1_KEY]));
+        assert_eq!(startup_keys(&features), vec![TABLETS_ROUTING_V1_KEY]);
+    }
+
+    #[test]
+    fn negotiates_v2_when_only_v2_supported() {
+        let features =
+            ProtocolFeatures::parse_from_supported(&supported(&[TABLETS_ROUTING_V2_KEY]));
+        assert_eq!(startup_keys(&features), vec![TABLETS_ROUTING_V2_KEY]);
+    }
+
+    #[test]
+    fn negotiates_no_tablets_routing_when_unsupported() {
+        let features = ProtocolFeatures::parse_from_supported(&supported(&[]));
+        assert!(startup_keys(&features).is_empty());
     }
 }

--- a/scylla-cql-core/src/frame/protocol_features.rs
+++ b/scylla-cql-core/src/frame/protocol_features.rs
@@ -52,9 +52,6 @@ pub struct ProtocolFeatures {
     pub tablets_v1_supported: bool,
 
     /// Whether the server supports tablets routing v2.
-    ///
-    /// The driver does not opt into the extension in STARTUP yet;
-    /// see [`ProtocolFeatures::add_startup_options`].
     pub tablets_v2_supported: bool,
 
     /// Does the server supports sending metadata id (introduced in CQL v5) for CQL v4.
@@ -122,7 +119,10 @@ impl ProtocolFeatures {
             );
         }
 
-        if self.tablets_v1_supported {
+        // V2 subsumes V1: when the server supports both, negotiate only V2.
+        if self.tablets_v2_supported {
+            options.insert(Cow::Borrowed(TABLETS_ROUTING_V2_KEY), Cow::Borrowed(""));
+        } else if self.tablets_v1_supported {
             options.insert(Cow::Borrowed(TABLETS_ROUTING_V1_KEY), Cow::Borrowed(""));
         }
 
@@ -149,6 +149,14 @@ mod tests {
         keys.iter().map(|k| (k.to_string(), Vec::new())).collect()
     }
 
+    fn startup_keys(features: &ProtocolFeatures) -> Vec<String> {
+        let mut options = HashMap::new();
+        features.add_startup_options(&mut options);
+        let mut keys: Vec<String> = options.into_keys().map(|k| k.into_owned()).collect();
+        keys.sort();
+        keys
+    }
+
     #[test]
     fn parses_tablets_v1_and_v2_support() {
         let features = ProtocolFeatures::parse_from_supported(&supported(&[
@@ -157,5 +165,36 @@ mod tests {
         ]));
         assert!(features.tablets_v1_supported);
         assert!(features.tablets_v2_supported);
+    }
+
+    #[test]
+    fn negotiates_only_v2_when_both_supported() {
+        // The server advertises both v1 and v2; v2 subsumes v1, so the driver must
+        // echo only the v2 key in STARTUP.
+        let features = ProtocolFeatures::parse_from_supported(&supported(&[
+            TABLETS_ROUTING_V1_KEY,
+            TABLETS_ROUTING_V2_KEY,
+        ]));
+        assert_eq!(startup_keys(&features), vec![TABLETS_ROUTING_V2_KEY]);
+    }
+
+    #[test]
+    fn negotiates_v1_when_only_v1_supported() {
+        let features =
+            ProtocolFeatures::parse_from_supported(&supported(&[TABLETS_ROUTING_V1_KEY]));
+        assert_eq!(startup_keys(&features), vec![TABLETS_ROUTING_V1_KEY]);
+    }
+
+    #[test]
+    fn negotiates_v2_when_only_v2_supported() {
+        let features =
+            ProtocolFeatures::parse_from_supported(&supported(&[TABLETS_ROUTING_V2_KEY]));
+        assert_eq!(startup_keys(&features), vec![TABLETS_ROUTING_V2_KEY]);
+    }
+
+    #[test]
+    fn negotiates_no_tablets_routing_when_unsupported() {
+        let features = ProtocolFeatures::parse_from_supported(&supported(&[]));
+        assert!(startup_keys(&features).is_empty());
     }
 }

--- a/scylla-cql-core/src/frame/protocol_features.rs
+++ b/scylla-cql-core/src/frame/protocol_features.rs
@@ -13,6 +13,7 @@ pub const SCYLLA_LWT_ADD_METADATA_MARK_EXTENSION: &str = "SCYLLA_LWT_ADD_METADAT
 /// which entry is a bit mask for the frame flags used to mark LWT frames.
 pub const LWT_OPTIMIZATION_META_BIT_MASK_KEY: &str = "LWT_OPTIMIZATION_META_BIT_MASK";
 const TABLETS_ROUTING_V1_KEY: &str = "TABLETS_ROUTING_V1";
+const TABLETS_ROUTING_V2_KEY: &str = "TABLETS_ROUTING_V2_EXPERIMENTAL";
 const SCYLLA_USE_METADATA_ID_KEY: &str = "SCYLLA_USE_METADATA_ID";
 
 /// Which protocol extensions are supported by the server.
@@ -50,6 +51,12 @@ pub struct ProtocolFeatures {
     /// Whether the server supports tablets routing v1.
     pub tablets_v1_supported: bool,
 
+    /// Whether the server supports tablets routing v2.
+    ///
+    /// The driver does not opt into the extension in STARTUP yet;
+    /// see [`ProtocolFeatures::add_startup_options`].
+    pub tablets_v2_supported: bool,
+
     /// Does the server supports sending metadata id (introduced in CQL v5) for CQL v4.
     pub scylla_metadata_id_supported: bool,
 }
@@ -65,6 +72,7 @@ impl ProtocolFeatures {
                 supported,
             ),
             tablets_v1_supported: Self::check_tablets_routing_v1_support(supported),
+            tablets_v2_supported: Self::check_tablets_routing_v2_support(supported),
             scylla_metadata_id_supported: Self::check_scylla_metadata_id_support(supported),
         }
     }
@@ -86,6 +94,10 @@ impl ProtocolFeatures {
 
     fn check_tablets_routing_v1_support(supported: &HashMap<String, Vec<String>>) -> bool {
         supported.contains_key(TABLETS_ROUTING_V1_KEY)
+    }
+
+    fn check_tablets_routing_v2_support(supported: &HashMap<String, Vec<String>>) -> bool {
+        supported.contains_key(TABLETS_ROUTING_V2_KEY)
     }
 
     fn check_scylla_metadata_id_support(supported: &HashMap<String, Vec<String>>) -> bool {
@@ -126,5 +138,24 @@ impl ProtocolFeatures {
         self.lwt_optimization_meta_bit_mask
             .map(|mask| (flags & mask) == mask)
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn supported(keys: &[&str]) -> HashMap<String, Vec<String>> {
+        keys.iter().map(|k| (k.to_string(), Vec::new())).collect()
+    }
+
+    #[test]
+    fn parses_tablets_v1_and_v2_support() {
+        let features = ProtocolFeatures::parse_from_supported(&supported(&[
+            TABLETS_ROUTING_V1_KEY,
+            TABLETS_ROUTING_V2_KEY,
+        ]));
+        assert!(features.tablets_v1_supported);
+        assert!(features.tablets_v2_supported);
     }
 }

--- a/scylla-cql/src/frame/request/execute.rs
+++ b/scylla-cql/src/frame/request/execute.rs
@@ -66,6 +66,13 @@ pub struct ExecuteV2<'a> {
 
     /// Various parameters controlling the execution of the statement.
     pub parameters: query::QueryParameters<'a>,
+
+    /// Trailing "tablet-version block" byte defined by the `TABLETS_ROUTING_V2` protocol
+    /// extension. When `Some`, exactly one byte is appended after the query parameters.
+    /// The connection layer sets this to `Some(_)` on every `EXECUTE` sent over a
+    /// connection that negotiated V2 (see `Connection::execute_raw_with_consistency`), and
+    /// to `None` otherwise.
+    pub tablet_version_block: Option<u8>,
 }
 
 impl SerializableRequest for ExecuteV2<'_> {
@@ -86,6 +93,13 @@ impl SerializableRequest for ExecuteV2<'_> {
         self.parameters
             .serialize(buf)
             .map_err(ExecuteSerializationError::QueryParametersSerialization)?;
+
+        // Serializing the trailing TABLETS_ROUTING_V2 tablet-version block. On a V2
+        // connection the server reads exactly one such byte after the query parameters for
+        // every EXECUTE, so the connection layer always sets this to `Some(_)` there.
+        if let Some(block) = self.tablet_version_block {
+            buf.push(block);
+        }
         Ok(())
     }
 }
@@ -100,6 +114,14 @@ impl DeserializableRequest for ExecuteV2<'static> {
             id,
             result_metadata_id: Some(result_metadata_id),
             parameters,
+            // Unlike `result_metadata_id` - whose presence is implied by the frame being an
+            // `ExecuteV2` rather than an `Execute` at all - nothing in the frame or in the
+            // choice of type tells us whether a tablet-version block was appended: that
+            // depends solely on whether the sending connection negotiated
+            // TABLETS_ROUTING_V2. A featureless decoder therefore cannot decode it, and must
+            // not consume a trailing byte that may not be there. Use
+            // `deserialize_with_features` when the negotiated features are known.
+            tablet_version_block: None,
         })
     }
 
@@ -115,10 +137,121 @@ impl DeserializableRequest for ExecuteV2<'static> {
         };
         let parameters = QueryParameters::deserialize(buf)?;
 
+        // On a V2 connection every EXECUTE carries exactly one trailing tablet-version
+        // block byte after the query parameters.
+        let tablet_version_block = features
+            .tablets_v2_supported
+            .then(|| types::read_byte(buf))
+            .transpose()?;
+
         Ok(Self {
             id,
             result_metadata_id,
             parameters,
+            tablet_version_block,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use crate::Consistency;
+    use crate::frame::protocol_features::ProtocolFeatures;
+    use crate::frame::request::{DeserializableRequest, SerializableRequest};
+    use crate::frame::response::result::cow_bytes::CowBytes;
+    use crate::serialize::row::SerializedValues;
+
+    use super::ExecuteV2;
+    use super::query::{PagingState, QueryParameters};
+
+    fn sample_parameters() -> QueryParameters<'static> {
+        QueryParameters {
+            consistency: Consistency::One,
+            serial_consistency: None,
+            timestamp: None,
+            page_size: None,
+            paging_state: PagingState::start(),
+            skip_metadata: false,
+            values: Cow::Owned(SerializedValues::new()),
+        }
+    }
+
+    fn v2_features() -> ProtocolFeatures {
+        let mut features = ProtocolFeatures::default();
+        features.tablets_v2_supported = true;
+        features
+    }
+
+    fn non_v2_features() -> ProtocolFeatures {
+        let mut features = ProtocolFeatures::default();
+        features.tablets_v2_supported = false;
+        features
+    }
+
+    /// On a TABLETS_ROUTING_V2 connection the frame is exactly the base EXECUTE frame plus
+    /// one trailing tablet-version block byte.
+    #[test]
+    fn execute_v2_appends_exactly_one_tablet_block_byte() {
+        let with_block = ExecuteV2 {
+            id: CowBytes::from([1u8, 2, 3].as_slice()),
+            result_metadata_id: None,
+            parameters: sample_parameters(),
+            tablet_version_block: Some(0xAB),
+        };
+        let without_block = ExecuteV2 {
+            id: CowBytes::from([1u8, 2, 3].as_slice()),
+            result_metadata_id: None,
+            parameters: sample_parameters(),
+            tablet_version_block: None,
+        };
+
+        let mut buf_with = Vec::new();
+        with_block.serialize(&mut buf_with).unwrap();
+        let mut buf_without = Vec::new();
+        without_block.serialize(&mut buf_without).unwrap();
+
+        assert_eq!(buf_with.len(), buf_without.len() + 1);
+        assert_eq!(&buf_with[..buf_without.len()], buf_without.as_slice());
+        assert_eq!(*buf_with.last().unwrap(), 0xAB);
+    }
+
+    /// Serializing with a block and deserializing with the V2 feature negotiated must
+    /// recover the exact same request, including the tablet block.
+    #[test]
+    fn execute_v2_tablet_block_roundtrip() {
+        let execute = ExecuteV2 {
+            id: CowBytes::from([9u8, 8, 7].as_slice()),
+            result_metadata_id: None,
+            parameters: sample_parameters(),
+            tablet_version_block: Some(0x5C),
+        };
+
+        let mut buf = Vec::new();
+        execute.serialize(&mut buf).unwrap();
+
+        let deserialized =
+            ExecuteV2::deserialize_with_features(&mut &buf[..], &v2_features()).unwrap();
+        assert_eq!(deserialized, execute);
+    }
+
+    /// Without the V2 feature negotiated, no trailing byte is expected or consumed.
+    #[test]
+    fn execute_v2_no_tablet_block_without_feature() {
+        let execute = ExecuteV2 {
+            id: CowBytes::from([9u8, 8, 7].as_slice()),
+            result_metadata_id: None,
+            parameters: sample_parameters(),
+            tablet_version_block: None,
+        };
+
+        let mut buf = Vec::new();
+        execute.serialize(&mut buf).unwrap();
+
+        let deserialized =
+            ExecuteV2::deserialize_with_features(&mut &buf[..], &non_v2_features()).unwrap();
+        assert_eq!(deserialized, execute);
+        assert!(deserialized.tablet_version_block.is_none());
     }
 }

--- a/scylla-cql/src/frame/request/mod.rs
+++ b/scylla-cql/src/frame/request/mod.rs
@@ -343,6 +343,7 @@ mod tests {
             id,
             result_metadata_id,
             parameters,
+            tablet_version_block: None,
         };
         {
             let mut buf = Vec::new();

--- a/scylla-cql/src/frame/types.rs
+++ b/scylla-cql/src/frame/types.rs
@@ -67,6 +67,22 @@ pub fn read_long(buf: &mut &[u8]) -> Result<i64, std::io::Error> {
     Ok(v)
 }
 
+/// Reads a single byte from the buffer, advancing it past that byte.
+/// Fails if the buffer is empty.
+pub fn read_byte(buf: &mut &[u8]) -> Result<u8, std::io::Error> {
+    let v = buf.read_u8()?;
+    Ok(v)
+}
+
+#[test]
+fn type_byte() {
+    for val in [0u8, 1, 0xAB, u8::MAX] {
+        let buf = [val];
+        assert_eq!(read_byte(&mut &buf[..]).unwrap(), val);
+    }
+    assert!(read_byte(&mut &[][..]).is_err());
+}
+
 pub fn write_long(v: i64, buf: &mut impl BufMut) {
     buf.put_i64(v);
 }

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -34,10 +34,9 @@ use tracing::trace;
 use tracing::trace_span;
 
 use crate::client::execution_profile::ExecutionProfileInner;
-use crate::cluster::NodeRef;
-use crate::errors::ConnectionPoolError;
-use crate::errors::RequestAttemptError;
-use crate::errors::RequestError;
+use crate::cluster::{ClusterState, NodeRef};
+use crate::errors::{ConnectionPoolError, RequestAttemptError, RequestError};
+use crate::frame::response::result::TableSpec;
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::network::Connection;
 use crate::observability::driver_tracing::RequestSpan;
@@ -47,15 +46,44 @@ use crate::policies::load_balancing;
 use crate::policies::load_balancing::{LoadBalancingPolicy, RoutingInfo};
 use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
-use crate::response::Coordinator;
-use crate::response::NonErrorQueryResponse;
+use crate::response::{Coordinator, NonErrorQueryResponse};
 use crate::routing::Shard;
+use crate::routing::Token;
+use crate::routing::locator::tablets::TabletVersion;
 use crate::statement::StatementConfig;
 
 /// Result of running a request, before side effects are handled.
 pub(crate) enum RunRequestResult<ResT> {
     IgnoredWriteError,
     Completed(ResT),
+}
+
+/// Chooses the `TABLETS_ROUTING_V2` tablet-version block to attach to an `EXECUTE`.
+///
+/// This decides the byte's *value* for every case, so that nothing downstream has to invent one:
+/// - a cached tablet version: a nibble of it, at a random index;
+/// - a tablet-cache miss: a random byte, which almost certainly mismatches and so makes the
+///   server send fresh routing information;
+/// - no single partition to route by (a range scan, or a statement whose partition key cannot be
+///   computed): there is no tablet version to probe, and the server ignores the block for such a
+///   request, so the value is irrelevant and the cheapest one is used.
+///
+/// Whether a byte is appended at all is a separate, per-connection decision made by
+/// `Connection::execute_raw_with_consistency`.
+pub(crate) fn choose_tablet_block_hint(
+    cluster_state: &ClusterState,
+    table_spec: Option<&TableSpec>,
+    token: Option<Token>,
+) -> u8 {
+    match table_spec.zip(token) {
+        Some((table_spec, token)) => {
+            let version = cluster_state
+                .replica_locator()
+                .tablet_version_for_token(table_spec, token);
+            TabletVersion::block_for(version)
+        }
+        None => 0,
+    }
 }
 
 /// Specifies the mechanism used for query paging.

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use crate::client::execution::{
     NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RequestPaging,
-    RunRequestResult, SingleConnectionTarget,
+    RunRequestResult, SingleConnectionTarget, choose_tablet_block_hint,
 };
 use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node};
@@ -972,6 +972,10 @@ If you are using this API, you are probably doing something wrong."
         let page_size = prepared.get_validated_page_size();
         let prepared_ref = &prepared;
         let values_ref = &values;
+        // Chosen once for the whole paged request: computed here for the eager fetch of the
+        // first page and reused as-is for every remaining page.
+        let tablet_block_hint =
+            choose_tablet_block_hint(&executor.cluster_state, table_spec, token);
         let page_query = |connection: Arc<Connection>,
                           consistency: Consistency,
                           paging_state: PagingState| async move {
@@ -983,7 +987,7 @@ If you are using this API, you are probably doing something wrong."
                     serial_consistency,
                     Some(page_size),
                     paging_state,
-                    0,
+                    tablet_block_hint,
                 )
                 .await
         };
@@ -1065,7 +1069,7 @@ If you are using this API, you are probably doing something wrong."
                                     serial_consistency,
                                     Some(page_size),
                                     paging_state,
-                                    0,
+                                    tablet_block_hint,
                                 )
                                 .await
                         };

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -587,6 +587,9 @@ impl SingleConnectionPagingExecutor {
                         self.serial_consistency,
                         Some(self.page_size),
                         paging_state,
+                        // This API executes on one given connection and has no `ClusterState`
+                        // to consult, so there is no cached tablet version to probe.
+                        0,
                     )
                     .await
                     .and_then(QueryResponse::into_non_error_query_response)
@@ -980,6 +983,7 @@ If you are using this API, you are probably doing something wrong."
                     serial_consistency,
                     Some(page_size),
                     paging_state,
+                    0,
                 )
                 .await
         };
@@ -1061,6 +1065,7 @@ If you are using this API, you are probably doing something wrong."
                                     serial_consistency,
                                     Some(page_size),
                                     paging_state,
+                                    0,
                                 )
                                 .await
                         };

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1660,6 +1660,9 @@ impl Session {
                                     serial_consistency,
                                     page_size,
                                     paging_state_ref.clone(),
+                                    // An unprepared statement is not routed by token, so there
+                                    // is no tablet version to probe.
+                                    0,
                                 )
                                 .await
                                 .and_then(QueryResponse::into_non_error_query_response)
@@ -2069,6 +2072,7 @@ impl Session {
                             serial_consistency,
                             page_size,
                             paging_state_ref.clone(),
+                            0,
                         )
                         .await
                         .and_then(QueryResponse::into_non_error_query_response)

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -10,6 +10,7 @@ use crate::authentication::AuthenticatorProvider;
 use crate::client::client_routes::ClientRoutesConfig;
 use crate::client::execution::{
     NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RunRequestResult,
+    choose_tablet_block_hint,
 };
 use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::cluster::metadata::{
@@ -1314,7 +1315,8 @@ impl Session {
             .run_request(
                 routing_info,
                 exec_params,
-                |connection: Arc<Connection>, consistency: Consistency| async move {
+                // A BATCH frame carries no tablet-version block, so the hint is unused here.
+                |connection: Arc<Connection>, consistency: Consistency, _: u8| async move {
                     connection
                         .batch_with_consistency(batch, values_ref, consistency, serial_consistency)
                         .await
@@ -1631,7 +1633,8 @@ impl Session {
             .run_request(
                 routing_info,
                 exec_params,
-                |connection: Arc<Connection>, consistency: Consistency| {
+                // A QUERY frame carries no tablet-version block, so the hint is unused here.
+                |connection: Arc<Connection>, consistency: Consistency, _: u8| {
                     // Needed to avoid moving query and values into async move block
                     let values_ref = &values;
                     let paging_state_ref = &paging_state;
@@ -2063,7 +2066,9 @@ impl Session {
             .run_request(
                 routing_info,
                 exec_params,
-                |connection: Arc<Connection>, consistency: Consistency| async move {
+                |connection: Arc<Connection>,
+                 consistency: Consistency,
+                 tablet_block_hint: u8| async move {
                     connection
                         .execute_raw_with_consistency(
                             prepared,
@@ -2072,7 +2077,7 @@ impl Session {
                             serial_consistency,
                             page_size,
                             paging_state_ref.clone(),
-                            0,
+                            tablet_block_hint,
                         )
                         .await
                         .and_then(QueryResponse::into_non_error_query_response)
@@ -2390,7 +2395,7 @@ impl Session {
         &'a self,
         routing_info: RoutingInfo<'a>,
         exec_params: RequestExecutionParams<'a>,
-        run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
+        run_request_once: impl Fn(Arc<Connection>, Consistency, u8) -> QueryFut,
         request_span: &'a RequestSpan,
     ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), ExecutionError>
     where
@@ -2404,6 +2409,9 @@ impl Session {
         )
         .map(|(node, shard)| NodeAttemptTarget::new(node, shard));
 
+        let tablet_block_hint =
+            choose_tablet_block_hint(&cluster_state, routing_info.table, routing_info.token);
+
         let RequestExecutionOutcome {
             result,
             coordinator,
@@ -2411,7 +2419,9 @@ impl Session {
             .run_request_no_side_effects(
                 &routing_info,
                 request_plan,
-                run_request_once,
+                |connection: Arc<Connection>, consistency: Consistency| {
+                    run_request_once(connection, consistency, tablet_block_hint)
+                },
                 request_span,
             )
             .await

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -149,6 +149,11 @@ impl ControlConnection {
         self.conn.is_to_scylladb()
     }
 
+    /// Returns true iff this control connection negotiated the `TABLETS_ROUTING_V2` extension.
+    pub(super) fn tablets_v2_supported(&self) -> bool {
+        self.conn.tablets_v2_supported()
+    }
+
     /// Appends the custom server-side timeout to the statement string, if such custom timeout
     /// is provided and we are connected to ScyllaDB (since custom timeouts is ScyllaDB-only feature).
     fn maybe_append_timeout_override(&self, statement: &mut Statement) {

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -32,9 +32,9 @@ use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
 use super::{
-    CollectionType, Column, ColumnKind, ColumnType, Keyspace, MaterializedView, Metadata,
-    MissingUserDefinedType, NativeType, Peer, SchemaMetadataFetchLevel, SchemaMetadataFetchMode,
-    SingleKeyspaceMetadataError, Strategy, Table, UserDefinedType,
+    CollectionType, Column, ColumnKind, ColumnType, ConsistencyMode, Keyspace, MaterializedView,
+    Metadata, MissingUserDefinedType, NativeType, Peer, SchemaMetadataFetchLevel,
+    SchemaMetadataFetchMode, SingleKeyspaceMetadataError, Strategy, Table, UserDefinedType,
 };
 
 use crate::DeserializeRow;
@@ -184,7 +184,6 @@ impl ControlConnection {
                 .await
                 .map(Some)
         };
-
         let peers_and_cluster_name;
         let client_routes: Option<ClientRoutes>;
         let keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>;
@@ -777,9 +776,9 @@ impl ControlConnection {
                 table: "system_schema.keyspaces",
             });
 
-        // Fetching the schema (UDTs, tables, views) and the per-keyspace tablet information
-        // are independent of each other, so we run them concurrently to minimize the
-        // critical path length.
+        // Fetching the schema (UDTs, tables, views) and the ScyllaDB-specific per-keyspace
+        // metadata (tablet-based flag, consistency mode) are independent of each other, so we
+        // run them concurrently to minimize the critical path length.
         let schema_query = async {
             match schema_metadata_fetch_level {
                 SchemaMetadataFetchLevel::Full => {
@@ -833,14 +832,14 @@ impl ControlConnection {
                 }
             }
         };
-        let tablets_query = async {
-            self.query_keyspaces_tablets(keyspaces_to_fetch)
+        let scylladb_specific_query = async {
+            self.query_keyspaces_scylladb_specific(keyspaces_to_fetch)
                 .await
                 .map_err(MetadataError::from)
         };
 
-        let ((mut all_tables, mut all_views, mut all_user_defined_types), tablets_keyspaces) =
-            tokio::try_join!(schema_query, tablets_query)?;
+        let ((mut all_tables, mut all_views, mut all_user_defined_types), scylladb_specific) =
+            tokio::try_join!(schema_query, scylladb_specific_query)?;
 
         rows.map(|row_result| {
             let (keyspace_name, strategy_map, durable_writes) = row_result?;
@@ -882,7 +881,12 @@ impl ControlConnection {
             let keyspace = Keyspace {
                 strategy,
                 durable_writes,
-                tablet_based: tablets_keyspaces.contains(&keyspace_name),
+                tablet_based: scylladb_specific.tablet_based.contains(&keyspace_name),
+                consistency_mode: scylladb_specific
+                    .consistency_modes
+                    .get(&keyspace_name)
+                    .cloned()
+                    .unwrap_or(ConsistencyMode::Eventual),
                 tables,
                 views,
                 user_defined_types,
@@ -1786,36 +1790,99 @@ impl ControlConnection {
             .await;
 
         match result {
-            // FIXME: This match catches all database errors with this error code despite the fact
-            // that we are only interested in the ones resulting from non-existent table
-            // system_schema.scylla_tables.
-            // For more information please refer to https://github.com/scylladb/scylla-rust-driver/pull/349#discussion_r762050262
-            Err(MetadataFetchError {
-                error:
-                    MetadataFetchErrorKind::NextRowError(NextRowError::NextPageError(
-                        NextPageError::RequestFailure(RequestError::LastAttemptError(
-                            RequestAttemptError::DbError(DbError::Invalid, _),
-                        )),
-                    )),
-                ..
-            }) => Ok(HashMap::new()),
+            // `system_schema.scylla_tables` does not exist on Cassandra.
+            Err(error) if is_missing_table_or_column(&error) => Ok(HashMap::new()),
             result => result,
         }
     }
 
-    /// Fetches a (possibly filtered) set of tablet-based keyspaces.
+    /// Fetches the (possibly filtered) per-keyspace ScyllaDB-specific metadata held in
+    /// `system_schema.scylla_keyspaces`: which keyspaces are tablet-based, and which use a
+    /// strong-consistency mode.
     ///
-    /// A keyspace is tablet-based if its `initial_tablets` column in
-    /// `system_schema.scylla_keyspaces` is not NULL.
+    /// Both live in the same table, so a single query reads them together - there is no reason
+    /// to spend a second round trip on the second column.
     ///
-    /// On Cassandra and old ScyllaDB versions the `system_schema.scylla_keyspaces`
-    /// table does not exist. This is handled the same way as in
-    /// [`Self::query_table_partitioners`]: the resulting `DbError::Invalid` is caught
-    /// and an empty set is returned (so all keyspaces default to non-tablet-based).
-    async fn query_keyspaces_tablets(
+    /// The `consistency` column was introduced much later than `initial_tablets`, though, so it
+    /// is only selected when this control connection negotiated `TABLETS_ROUTING_V2`. Even then
+    /// a server could have the extension but not the column (strong consistency is a separate,
+    /// experimental feature), so that case falls back to reading `initial_tablets` alone: tablet
+    /// detection never depends on strong-consistency support being present.
+    ///
+    /// On Cassandra and old ScyllaDB versions the table does not exist at all. In that case,
+    /// empty metadata is returned, so every keyspace defaults to non-tablet-based and eventually
+    /// consistent.
+    async fn query_keyspaces_scylladb_specific(
         &self,
         keyspaces_to_fetch: &[String],
-    ) -> Result<HashSet<String>, MetadataFetchError> {
+    ) -> Result<ScyllaKeyspacesMetadata, MetadataFetchError> {
+        if self.tablets_v2_supported() {
+            match self
+                .query_scylla_keyspaces_with_consistency(keyspaces_to_fetch)
+                .await
+            {
+                // The `consistency` column (or the whole table) is not there - retry without it.
+                // Note that a missing *table* cannot realistically reach this point, since
+                // TABLETS_ROUTING_V2 is a ScyllaDB extension and every ScyllaDB version that
+                // offers it has `system_schema.scylla_keyspaces`.
+                Err(error) if is_missing_table_or_column(&error) => (),
+                result => return result,
+            }
+        }
+
+        match self
+            .query_scylla_keyspaces_tablets_only(keyspaces_to_fetch)
+            .await
+        {
+            Err(error) if is_missing_table_or_column(&error) => {
+                Ok(ScyllaKeyspacesMetadata::default())
+            }
+            result => result,
+        }
+    }
+
+    /// Reads `system_schema.scylla_keyspaces` including the `consistency` column. Fails with a
+    /// [`DbError::Invalid`] if the server does not have that column.
+    async fn query_scylla_keyspaces_with_consistency(
+        &self,
+        keyspaces_to_fetch: &[String],
+    ) -> Result<ScyllaKeyspacesMetadata, MetadataFetchError> {
+        let rows = self
+            .query_filter_keyspace_name::<(String, Option<i32>, Option<String>)>(
+                "SELECT keyspace_name, initial_tablets, consistency FROM system_schema.scylla_keyspaces",
+                keyspaces_to_fetch,
+            )
+            .map_err(|error| MetadataFetchError {
+                error,
+                table: "system_schema.scylla_keyspaces",
+            });
+
+        rows.try_fold(
+            ScyllaKeyspacesMetadata::default(),
+            |mut acc, (keyspace_name, initial_tablets, consistency)| {
+                let consistency_mode = consistency_mode_from_str(consistency.as_deref());
+                // Only non-eventual modes are stored; keyspaces missing from the map are
+                // eventually consistent.
+                if consistency_mode != ConsistencyMode::Eventual {
+                    acc.consistency_modes
+                        .insert(keyspace_name.clone(), consistency_mode);
+                }
+                if initial_tablets.is_some() {
+                    acc.tablet_based.insert(keyspace_name);
+                }
+                future::ready(Ok(acc))
+            },
+        )
+        .await
+    }
+
+    /// Reads `system_schema.scylla_keyspaces` without the `consistency` column, for servers
+    /// that have tablets but no strong consistency. Every keyspace is then reported as
+    /// eventually consistent.
+    async fn query_scylla_keyspaces_tablets_only(
+        &self,
+        keyspaces_to_fetch: &[String],
+    ) -> Result<ScyllaKeyspacesMetadata, MetadataFetchError> {
         let rows = self
             .query_filter_keyspace_name::<(String, Option<i32>)>(
                 "SELECT keyspace_name, initial_tablets FROM system_schema.scylla_keyspaces",
@@ -1826,36 +1893,60 @@ impl ControlConnection {
                 table: "system_schema.scylla_keyspaces",
             });
 
-        let result = rows
-            .filter_map(|row_result| {
-                let result = match row_result {
-                    Ok((keyspace_name, initial_tablets)) => {
-                        initial_tablets.map(|_| Ok(keyspace_name))
-                    }
-                    Err(e) => Some(Err(e)),
-                };
-                future::ready(result)
-            })
-            .try_collect::<HashSet<_, _>>()
-            .await;
-
-        match result {
-            // FIXME: This match catches all database errors with this error code despite the fact
-            // that we are only interested in the ones resulting from non-existent table
-            // system_schema.scylla_keyspaces.
-            // For more information please refer to https://github.com/scylladb/scylla-rust-driver/pull/349#discussion_r762050262
-            Err(MetadataFetchError {
-                error:
-                    MetadataFetchErrorKind::NextRowError(NextRowError::NextPageError(
-                        NextPageError::RequestFailure(RequestError::LastAttemptError(
-                            RequestAttemptError::DbError(DbError::Invalid, _),
-                        )),
-                    )),
-                ..
-            }) => Ok(HashSet::new()),
-            result => result,
-        }
+        rows.try_fold(
+            ScyllaKeyspacesMetadata::default(),
+            |mut acc, (keyspace_name, initial_tablets)| {
+                if initial_tablets.is_some() {
+                    acc.tablet_based.insert(keyspace_name);
+                }
+                future::ready(Ok(acc))
+            },
+        )
+        .await
     }
+}
+
+/// The per-keyspace ScyllaDB-specific metadata read from `system_schema.scylla_keyspaces`.
+#[derive(Default)]
+struct ScyllaKeyspacesMetadata {
+    /// Keyspaces that are tablet-based, i.e. whose `initial_tablets` column is not NULL.
+    tablet_based: HashSet<String>,
+    /// Strong-consistency modes, from the `consistency` column. Keyspaces missing from the map
+    /// are eventually consistent - which includes every keyspace on a server that does not
+    /// report the column at all.
+    consistency_modes: HashMap<String, ConsistencyMode>,
+}
+
+/// Maps the raw `consistency` column value from `system_schema.scylla_keyspaces` to a
+/// [`ConsistencyMode`]. A missing or unrecognized value means eventual consistency.
+fn consistency_mode_from_str(consistency: Option<&str>) -> ConsistencyMode {
+    match consistency {
+        Some("global") => ConsistencyMode::Global,
+        Some("local") => ConsistencyMode::Local,
+        _ => ConsistencyMode::Eventual,
+    }
+}
+
+/// Returns `true` if the error is the `DbError::Invalid` that a server reports when a `SELECT`
+/// names a table or a column it does not have.
+///
+/// This is how the driver detects that a ScyllaDB-specific system table or column is missing on
+/// the node it is talking to, e.g. on Cassandra or on a ScyllaDB version predating the feature.
+// FIXME: This catches every database error carrying this error code, not only the ones caused by
+// a missing table or column.
+// For more information please refer to https://github.com/scylladb/scylla-rust-driver/pull/349#discussion_r762050262
+fn is_missing_table_or_column(error: &MetadataFetchError) -> bool {
+    matches!(
+        error,
+        MetadataFetchError {
+            error: MetadataFetchErrorKind::NextRowError(NextRowError::NextPageError(
+                NextPageError::RequestFailure(RequestError::LastAttemptError(
+                    RequestAttemptError::DbError(DbError::Invalid, _),
+                )),
+            )),
+            ..
+        }
+    )
 }
 
 fn strategy_from_string_map(
@@ -1913,6 +2004,32 @@ mod tests {
     use crate::test_utils::setup_tracing;
 
     use super::*;
+
+    #[test]
+    fn test_consistency_mode_parsing() {
+        setup_tracing();
+        assert_eq!(
+            consistency_mode_from_str(Some("global")),
+            ConsistencyMode::Global
+        );
+        assert_eq!(
+            consistency_mode_from_str(Some("local")),
+            ConsistencyMode::Local
+        );
+        for unrecognised in [
+            None,
+            Some(""),
+            Some("GLOBAL"),
+            Some("none"),
+            Some("whatever"),
+        ] {
+            assert_eq!(
+                consistency_mode_from_str(unrecognised),
+                ConsistencyMode::Eventual,
+                "unrecognised consistency {unrecognised:?} must mean eventual consistency"
+            );
+        }
+    }
 
     #[test]
     fn test_cql_type_parsing() {

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -181,6 +181,25 @@ impl Peer {
     }
 }
 
+/// The consistency mode of a keyspace, as reported by the `consistency` column of
+/// `system_schema.scylla_keyspaces`.
+///
+/// Deliberately crate-private. Strong consistency is an experimental server-side feature and
+/// these mode names come straight from it, so making the type public would freeze names we may
+/// yet have to change - and an enum's variants cannot be renamed without a major release. Should
+/// this ever become public, it needs `#[non_exhaustive]`, which is pointless until then.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ConsistencyMode {
+    /// Eventual consistency. Covers every non-tablet keyspace and every keyspace
+    /// on a server that does not report a consistency mode.
+    Eventual,
+    /// Reserved for a future per-datacenter strong-consistency mode (`consistency = 'local'`).
+    Local,
+    /// Global strong consistency (`consistency = 'global'`): the keyspace uses
+    /// strongly-consistent (Raft-based) tablets.
+    Global,
+}
+
 /// Describes a keyspace in the cluster.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -195,6 +214,10 @@ pub struct Keyspace {
     /// `system_schema.scylla_keyspaces`. On Cassandra and old ScyllaDB versions,
     /// where this table or column is not present, this is always `false`.
     pub tablet_based: bool,
+    /// The consistency mode of the keyspace.
+    ///
+    /// Crate-private along with [`ConsistencyMode`] itself; see that type for why.
+    pub(crate) consistency_mode: ConsistencyMode,
     /// Tables in the keyspace.
     ///
     /// Empty HashMap may as well mean that the client disabled schema fetching in SessionConfig.

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -797,7 +797,9 @@ mod tests {
     use crate::cluster::metadata::update::{
         FetchedKeyspace, MetadataChanges, MetadataUpdate, SchemaUpdate,
     };
-    use crate::cluster::metadata::{Keyspace, Metadata, SingleKeyspaceMetadataError, Strategy};
+    use crate::cluster::metadata::{
+        ConsistencyMode, Keyspace, Metadata, SingleKeyspaceMetadataError, Strategy,
+    };
 
     // Keyspaces are told apart by `durable_writes`, which is all it takes to
     // tell which reading of a keyspace a merge kept.
@@ -806,6 +808,7 @@ mod tests {
             strategy: Strategy::LocalStrategy,
             durable_writes,
             tablet_based: false,
+            consistency_mode: ConsistencyMode::Eventual,
             tables: HashMap::new(),
             views: HashMap::new(),
             user_defined_types: HashMap::new(),

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -703,7 +703,7 @@ impl ClusterState {
         &self.known_nodes
     }
 
-    pub(super) fn update_tablets(&mut self, raw_tablets: Vec<(TableSpec<'static>, RawTablet)>) {
+    pub(crate) fn update_tablets(&mut self, raw_tablets: Vec<(TableSpec<'static>, RawTablet)>) {
         let replica_translator = |uuid: Uuid| self.known_nodes.get(&uuid).cloned();
 
         for (table, raw_tablet) in raw_tablets.into_iter() {

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1906,6 +1906,7 @@ impl Connection {
             || features.shard_aware_port.is_some()
             || proto_features.rate_limit_error.is_some()
             || proto_features.tablets_v1_supported
+            || proto_features.tablets_v2_supported
             || proto_features.scylla_metadata_id_supported
     }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -972,6 +972,9 @@ impl Connection {
             prepared.config.serial_consistency.flatten(),
             None,
             PagingState::start(),
+            // A test-only helper executing on one given connection: no cached tablet version
+            // to probe.
+            0,
         )
         .await
     }
@@ -1084,6 +1087,7 @@ impl Connection {
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     pub(crate) async fn execute_raw_with_consistency(
         &self,
         prepared_statement: &PreparedStatement,
@@ -1092,6 +1096,7 @@ impl Connection {
         serial_consistency: Option<SerialConsistency>,
         page_size: Option<PageSize>,
         paging_state: PagingState,
+        tablet_block_hint: u8,
     ) -> Result<QueryResponse, RequestAttemptError> {
         let get_timestamp_from_gen = || {
             self.config
@@ -1107,6 +1112,20 @@ impl Connection {
         let cached_metadata_params =
             self.calculate_cached_metadata_params(prepared_statement, &current_result_metadata);
 
+        // On a connection that negotiated TABLETS_ROUTING_V2 the server reads exactly one
+        // tablet-version block byte after the query parameters for every EXECUTE. Enforce
+        // that invariant here, at the single chokepoint through which all EXECUTE frames
+        // pass: append the caller's byte on a V2 connection, never append one otherwise.
+        //
+        // Note the split of responsibilities: the byte's *value* is entirely the caller's, while
+        // whether one is sent at all is decided only here, because only this connection knows
+        // what it negotiated.
+        let tablet_version_block = self
+            .features
+            .protocol_features
+            .tablets_v2_supported
+            .then_some(tablet_block_hint);
+
         let execute_frame = execute::ExecuteV2 {
             id: prepared_statement.get_id().as_ref().into(),
             result_metadata_id: cached_metadata_params.result_metadata_id.map(Into::into),
@@ -1119,6 +1138,7 @@ impl Connection {
                 skip_metadata: cached_metadata_params.skip_metadata,
                 paging_state,
             },
+            tablet_version_block,
         };
 
         let query_response = self

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -1976,6 +1976,7 @@ impl Connection {
             || features.shard_aware_port.is_some()
             || proto_features.rate_limit_error.is_some()
             || proto_features.tablets_v1_supported
+            || proto_features.tablets_v2_supported
             || proto_features.scylla_metadata_id_supported
     }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2000,6 +2000,10 @@ impl Connection {
             || proto_features.scylla_metadata_id_supported
     }
 
+    pub(crate) fn tablets_v2_supported(&self) -> bool {
+        self.features.protocol_features.tablets_v2_supported
+    }
+
     pub(crate) fn get_connect_address(&self) -> SocketAddr {
         self.connect_address
     }

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -4,9 +4,10 @@ pub use self::latency_awareness::LatencyAwarenessBuilder;
 use super::{FallbackPlan, LoadBalancingPolicy, NodeRef, RoutingInfo};
 use crate::cluster::ClusterState;
 use crate::frame::response::result::TableSpec;
+use crate::frame::types::Consistency;
 use crate::routing::NodeLocationPreference;
 use crate::{
-    cluster::metadata::Strategy,
+    cluster::metadata::{ConsistencyMode, Strategy},
     cluster::node::Node,
     errors::RequestAttemptError,
     routing::locator::ReplicaSet,
@@ -178,6 +179,20 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         /* Token-aware logic - if routing info is available, we know what are the replicas
          * for the statement. Try to pick one of them. */
         if let (Some(ts), Some(table_spec)) = (&routing_info.token_with_strategy, query.table) {
+            /* Leader-aware logic - for a strongly-consistent keyspace the leader has to
+             * coordinate the request anyway, so it outranks distance and is tried before the
+             * locality buckets below. See `leader_to_prefer`. */
+            if let Some((leader, shard)) = self.leader_to_prefer(
+                query,
+                ts,
+                &routing_info,
+                |node, shard| (self.pick_predicate)(node, Some(shard)),
+                cluster,
+                table_spec,
+            ) {
+                return Some((leader, Some(shard)));
+            }
+
             if let NodeLocationPreference::DatacenterAndRack(dc, rack) = routing_info.preference {
                 // Try to pick some alive local rack random replica.
                 let local_rack_picked = self.pick_replica(
@@ -338,6 +353,19 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         let maybe_replicas = if let (Some(ts), Some(table_spec)) =
             (&routing_info.token_with_strategy, query.table)
         {
+            // The tablet's Raft leader, when leader-aware routing applies to this request. It
+            // outranks distance, so it is yielded before the locality-ordered replicas below.
+            // The leader also appears among those replicas, but the plan is deduplicated as a
+            // whole further down, so it is only attempted once. See `leader_to_prefer`.
+            let maybe_leader = self.leader_to_prefer(
+                query,
+                ts,
+                &routing_info,
+                |node, shard| Self::is_alive(node, Some(shard)),
+                cluster,
+                table_spec,
+            );
+
             // Iterator over alive local rack replicas (shuffled or deterministically ordered,
             // depending on the statement being LWT or not).
             let maybe_local_rack_replicas = if let NodeLocationPreference::DatacenterAndRack(
@@ -396,10 +424,12 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
                 Either::Right(std::iter::empty())
             };
 
-            // Produce an iterator, prioritizing local replicas.
+            // Produce an iterator, prioritizing the leader (if any) and then local replicas.
             // If preferred datacenter is not specified, every replica is treated as a remote one.
             Either::Left(
-                maybe_local_rack_replicas
+                maybe_leader
+                    .into_iter()
+                    .chain(maybe_local_rack_replicas)
                     .chain(maybe_local_replicas)
                     .chain(maybe_remote_replicas)
                     .map(|(node, shard)| (node, Some(shard))),
@@ -898,6 +928,75 @@ impl DefaultPolicy {
         //  - There is no public API to check that, and I don't want DefaultPolicy to use private APIs.
         //  - Shards returned from policy are only a hint anyway, so it probably makes no sense to throw out the whole host.
         node.is_connected()
+    }
+
+    /// Returns true iff the request should be routed to the tablet's leader replica.
+    ///
+    /// Whether the tablet's leader is *known* is a separate question, answered by
+    /// [`Self::leader_to_prefer`], which is this predicate's only caller.
+    fn should_route_to_leader(query: &RoutingInfo, cluster: &ClusterState) -> bool {
+        let Some(table_spec) = query.table else {
+            return false;
+        };
+
+        // Note: For the time being, only global consistency is implemented in Scylla.
+        let strongly_consistent = cluster
+            .get_keyspace(table_spec.ks_name())
+            .is_some_and(|ks| ks.consistency_mode == ConsistencyMode::Global);
+
+        if !strongly_consistent {
+            return false;
+        }
+
+        // Requests at ONE / LOCAL_ONE may be served by any replica, so let them spread across
+        // replicas; everything else is routed to the leader.
+        !matches!(query.consistency, Consistency::One | Consistency::LocalOne)
+    }
+
+    /// Returns the tablet's Raft leader for this request, if leader-aware routing applies, the
+    /// leader is known, and it is a host this policy is willing to contact.
+    ///
+    /// For a strongly-consistent keyspace the leader coordinates every write and every
+    /// linearizable read, so a request sent to any other replica is merely forwarded to it. The
+    /// leader therefore outranks *distance*: callers put it ahead of nearer replicas, a remote-DC
+    /// leader ahead of a local-rack one. Keeping the request inside one datacenter buys no
+    /// consistency either, the table being globally consistent.
+    ///
+    /// It does not override this policy's own filter, though. The leader qualifies only if it
+    /// satisfies `predicate` (which always includes liveness) and sits in a datacenter this
+    /// policy would use at all: the preferred one, any of them when no datacenter is preferred,
+    /// or a remote one when datacenter failover is permitted. With a preferred datacenter and
+    /// failover disabled, a leader elsewhere is a host this policy would never contact, so `None`
+    /// is returned, the request keeps normal routing, and the server forwards it to the leader --
+    /// exactly as it would without the extension.
+    fn leader_to_prefer<'a>(
+        &'a self,
+        query: &RoutingInfo,
+        ts: &TokenWithStrategy<'a>,
+        routing_info: &ProcessedRoutingInfo<'a>,
+        predicate: impl FnOnce(NodeRef<'a>, Shard) -> bool,
+        cluster: &'a ClusterState,
+        table_spec: &TableSpec,
+    ) -> Option<(NodeRef<'a>, Shard)> {
+        if !Self::should_route_to_leader(query, cluster) {
+            return None;
+        }
+
+        let (host, shard) = cluster
+            .replica_locator()
+            .tablet_leader_for_token(table_spec, ts.token)?;
+
+        if !predicate(host, shard) {
+            return None;
+        }
+
+        match routing_info.preference.datacenter() {
+            // No preferred datacenter, so every datacenter is fair game.
+            None => Some((host, shard)),
+            Some(preferred_dc) => (host.datacenter.as_deref() == Some(preferred_dc)
+                || self.is_datacenter_failover_possible(routing_info))
+            .then_some((host, shard)),
+        }
     }
 
     /// Returns true iff the datacenter failover is permitted for the statement being executed.
@@ -2661,6 +2760,410 @@ mod tests {
                 &expected_groups,
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_default_policy_leader_aware_routing() {
+        setup_tracing();
+        use crate::frame::response::result::TableSpec;
+        use crate::routing::locator::test::{A, B, C, D, E, F, G, KEYSPACE_NTS_RF_3};
+
+        let cluster = mock_cluster_state_for_leader_aware_tests(&[]).await;
+
+        // A table in a strongly-consistent keyspace for which no routing payload has ever
+        // arrived, so the tablet cache knows nothing about it.
+        let table_without_tablets = TableSpec::borrowed(KEYSPACE_NTS_RF_3, "table_without_tablets");
+        let table_with_unresolved_leader =
+            TableSpec::borrowed(KEYSPACE_NTS_RF_3, "table_with_unresolved_leader");
+
+        struct Test<'a> {
+            routing_info: RoutingInfo<'a>,
+            expected_groups: ExpectedGroups,
+        }
+
+        // A token-aware policy with no DC preference: each plan is simply the tablet's
+        // replicas (the leader promoted to the front, or all of them shuffled) followed by the
+        // other nodes.
+        let policy = || DefaultPolicy {
+            preferences: Some(NodeLocationPreference::Any),
+            is_token_aware: true,
+            permit_dc_failover: true,
+            ..Default::default()
+        };
+
+        let tests = [
+            // 1. Strongly consistent request at CL Quorum -> the leader (C) is promoted to the
+            //    front. Only the leader is pinned: the remaining replicas keep their usual
+            //    shuffled order, so retries after the leader still spread.
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_3),
+                    consistency: Consistency::Quorum,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([C]) // the leader, first
+                    .group([A, F]) // remaining replicas, shuffled
+                    .group([B, D, E, G]) // other nodes
+                    .build(),
+            },
+            // 2. Strongly consistent request at CL LocalQuorum -> also routed to the leader.
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_3),
+                    consistency: Consistency::LocalQuorum,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([C])
+                    .group([A, F])
+                    .group([B, D, E, G])
+                    .build(),
+            },
+            // 3. Strongly consistent request at CL One -> spread across replicas. ONE/LOCAL_ONE
+            //    are weak reads (writes at those levels are rejected by the server), so they
+            //    keep the normal load-spreading routing.
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_3),
+                    consistency: Consistency::One,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .group([C, A, F]) // replicas, shuffled
+                    .group([B, D, E, G])
+                    .build(),
+            },
+            // 4. Strongly consistent request at CL LocalOne -> spread across replicas.
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_3),
+                    consistency: Consistency::LocalOne,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .group([C, A, F])
+                    .group([B, D, E, G])
+                    .build(),
+            },
+            // 5. Request on an eventually-consistent keyspace, even at a strong CL -> spread
+            //    (never leader-routed, because the keyspace is not strongly consistent).
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_2),
+                    consistency: Consistency::Quorum,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .group([B, G, F]) // replicas, shuffled
+                    .group([A, C, D, E])
+                    .build(),
+            },
+            // 6. Strongly consistent request for a table with no cached tablet at all -> spread,
+            //    no promotion. Until the first routing payload arrives the table is unknown to
+            //    the tablet cache, and the replica set falls back to the token ring, which knows
+            //    nothing about tablets, let alone which replica leads one. Promoting its first
+            //    element would be calling an arbitrary ring replica "the leader".
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(&table_without_tablets),
+                    consistency: Consistency::Quorum,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    // Ring replicas, shuffled. Note they differ from the tablet's replicas
+                    // ([C, A, F]): the ring is not where tablet replicas come from.
+                    // (RF 3 in each of the two datacenters, so six of the seven nodes.)
+                    .group([A, C, D, E, F, G])
+                    .group([B])
+                    .build(),
+            },
+            // 7. Strongly consistent request whose tablet is versioned, but whose leader could
+            //    not be resolved to a known node -> spread, no promotion. The unresolved replica
+            //    is dropped from the replica list, so its first element is a follower; promoting
+            //    it would mean routing every strong request to a node we know is not the leader.
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(&table_with_unresolved_leader),
+                    consistency: Consistency::Quorum,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .group([A, F]) // the replicas that did resolve, shuffled
+                    .group([B, C, D, E, G])
+                    .build(),
+            },
+            // 8. LWT on an eventually-consistent keyspace -> leader-first via LWT routing,
+            //    unaffected by strong-consistency handling (both select a deterministic order).
+            Test {
+                routing_info: RoutingInfo {
+                    token: Some(Token::new(160)),
+                    table: Some(TABLE_NTS_RF_2),
+                    consistency: Consistency::One,
+                    is_confirmed_lwt: true,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([B, G, F])
+                    .group([A, C, D, E])
+                    .build(),
+            },
+        ];
+
+        for Test {
+            routing_info,
+            expected_groups,
+        } in tests
+        {
+            test_default_policy_with_given_cluster_and_routing_info(
+                &policy(),
+                &cluster,
+                &routing_info,
+                &expected_groups,
+            );
+        }
+    }
+
+    /// How leader-aware routing interacts with the policy's datacenter/rack preference.
+    ///
+    /// The leader outranks *distance* but never the policy's own filter, so:
+    /// - a leader in the preferred datacenter is promoted, whatever its rack;
+    /// - a leader in another datacenter is promoted too, but only when datacenter failover is
+    ///   permitted, since that is what makes remote nodes usable at all;
+    /// - with failover disabled, a remote leader is a host this policy would never contact, so
+    ///   the request keeps plain token-aware routing and the server forwards it to the leader.
+    ///
+    /// The tablet under test (`TABLE_NTS_RF_3`, token 160) has replicas `[C, A, F]` with C the
+    /// leader. C and A are in `eu`, F is in `us`, so a `us` preference makes the leader remote.
+    #[tokio::test]
+    async fn test_default_policy_leader_aware_routing_with_dc_preference() {
+        setup_tracing();
+        use crate::routing::locator::test::{A, B, C, D, E, F, G};
+
+        let cluster = mock_cluster_state_for_leader_aware_tests(&[]).await;
+
+        let strong_read = RoutingInfo {
+            token: Some(Token::new(160)),
+            table: Some(TABLE_NTS_RF_3),
+            consistency: Consistency::Quorum,
+            ..Default::default()
+        };
+
+        struct Test {
+            policy: DefaultPolicy,
+            expected_groups: ExpectedGroups,
+        }
+
+        let tests = [
+            // The leader (C) is in the preferred datacenter, so it is promoted even with
+            // failover disabled. Only `eu` hosts are usable, so F (us) drops out entirely.
+            Test {
+                policy: DefaultPolicy {
+                    preferences: Some(NodeLocationPreference::Datacenter("eu".to_owned())),
+                    is_token_aware: true,
+                    permit_dc_failover: false,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([C]) // the leader, local
+                    .group([A]) // the other local replica
+                    .group([B, G]) // other local nodes
+                    .build(),
+            },
+            // The leader is remote but failover is permitted, so it still outranks the local
+            // replica F -- the whole point of leader awareness: F would only forward to C.
+            Test {
+                policy: DefaultPolicy {
+                    preferences: Some(NodeLocationPreference::Datacenter("us".to_owned())),
+                    is_token_aware: true,
+                    permit_dc_failover: true,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([C]) // the leader, remote, still first
+                    .group([F]) // local replica
+                    .group([A]) // remaining remote replica
+                    .group([D, E]) // other local nodes
+                    .group([B, G]) // other remote nodes
+                    .build(),
+            },
+            // The leader is remote and failover is disabled, so it is not a host this policy
+            // would contact: plain token-aware routing, and the server does the forwarding.
+            Test {
+                policy: DefaultPolicy {
+                    preferences: Some(NodeLocationPreference::Datacenter("us".to_owned())),
+                    is_token_aware: true,
+                    permit_dc_failover: false,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .group([F]) // the only local replica
+                    .group([D, E]) // other local nodes
+                    .build(),
+            },
+            // Rack preference does not gate the leader: C is in `eu` but in another rack than
+            // the preferred one, and is still promoted.
+            Test {
+                policy: DefaultPolicy {
+                    preferences: Some(NodeLocationPreference::DatacenterAndRack(
+                        "eu".to_owned(),
+                        "r2".to_owned(),
+                    )),
+                    is_token_aware: true,
+                    permit_dc_failover: false,
+                    ..Default::default()
+                },
+                expected_groups: ExpectedGroupsBuilder::new()
+                    .ordered([C]) // the leader: eu/r1, i.e. preferred DC, different rack
+                    .group([A]) // the other replica in eu
+                    .group([G]) // other nodes in the preferred rack, eu/r2
+                    .group([B]) // other nodes in eu
+                    .build(),
+            },
+        ];
+
+        for Test {
+            policy,
+            expected_groups,
+        } in tests
+        {
+            test_default_policy_with_given_cluster_and_routing_info(
+                &policy,
+                &cluster,
+                &strong_read,
+                &expected_groups,
+            );
+        }
+    }
+
+    /// When the leader is known but not alive, `leader_to_prefer`'s predicate rejects it, so the
+    /// plan falls back to plain replica-then-node routing: the request spreads across the other
+    /// alive replicas, and the down leader is tried only as an absolute last resort, exactly
+    /// like any other unreachable node.
+    #[tokio::test]
+    async fn test_default_policy_leader_aware_routing_falls_back_when_leader_down() {
+        setup_tracing();
+        use crate::routing::locator::test::{A, B, C, D, E, F, G};
+
+        // C is the leader of TABLE_NTS_RF_3's tablet (see the mock below) and is left down.
+        let cluster = mock_cluster_state_for_leader_aware_tests(&[C]).await;
+
+        let policy = DefaultPolicy {
+            preferences: Some(NodeLocationPreference::Any),
+            is_token_aware: true,
+            permit_dc_failover: true,
+            ..Default::default()
+        };
+
+        let routing_info = RoutingInfo {
+            token: Some(Token::new(160)),
+            table: Some(TABLE_NTS_RF_3),
+            consistency: Consistency::Quorum,
+            ..Default::default()
+        };
+
+        let expected_groups = ExpectedGroupsBuilder::new()
+            .group([A, F]) // the other replicas, alive, shuffled
+            .group([B, D, E, G]) // remaining alive nodes, shuffled
+            .group([C]) // down, tried only as a last resort
+            .build();
+
+        test_default_policy_with_given_cluster_and_routing_info(
+            &policy,
+            &cluster,
+            &routing_info,
+            &expected_groups,
+        );
+    }
+
+    // Builds a cluster with tablet mappings and per-keyspace consistency set up to exercise
+    // leader-aware routing:
+    // - KEYSPACE_NTS_RF_3 (TABLE_NTS_RF_3): strongly consistent, versioned tablet
+    //   -> requests may be routed to the leader (replicas[0]).
+    // - KEYSPACE_NTS_RF_2 (TABLE_NTS_RF_2): eventually consistent, versioned tablet
+    //   -> never leader-routed (keyspace is not strongly consistent).
+    //
+    // Each tablet's replica list is injected leader-first, mimicking a mapping the driver would
+    // have cached from a TABLETS_ROUTING_V2 payload -- the only place the server reveals which
+    // replica leads the tablet's Raft group.
+    /// `down` lists node ids (see the numbering on [`crate::routing::locator::test`]) to leave
+    /// disconnected, so that [`DefaultPolicy::is_alive`] rejects them -- simulating a node that
+    /// is enabled (known, not host-filtered) but currently unreachable.
+    async fn mock_cluster_state_for_leader_aware_tests(down: &[u16]) -> ClusterState {
+        use crate::cluster::metadata::ConsistencyMode;
+        use crate::frame::response::result::TableSpec;
+        use crate::routing::locator::tablets::RawTablet;
+        use crate::routing::locator::test::{A, B, C, F, G, KEYSPACE_NTS_RF_3, id_to_invalid_addr};
+        use std::collections::HashMap;
+        use uuid::Uuid;
+
+        let mut metadata = mock_metadata_for_token_aware_tests();
+        if let Some(Ok(ks)) = metadata.keyspaces.get_mut(KEYSPACE_NTS_RF_3) {
+            ks.consistency_mode = ConsistencyMode::Global;
+        }
+
+        let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
+        let node_config = NodeConfig {
+            pool_config: Default::default(),
+            used_keyspace: None,
+            connectivity_events_sender,
+            metrics: Default::default(),
+        };
+        let mut state = ClusterState::new(metadata, &node_config, None).await;
+
+        let down_addrs: Vec<_> = down.iter().map(|&id| id_to_invalid_addr(id)).collect();
+        for node in state.get_nodes_info() {
+            if !down_addrs.contains(&node.address) {
+                node.use_enabled_as_connected();
+            }
+        }
+
+        let addr_to_host_id: HashMap<_, _> = state
+            .get_nodes_info()
+            .iter()
+            .map(|node| (node.address, node.host_id))
+            .collect();
+        let replica = |id: u16| (addr_to_host_id[&id_to_invalid_addr(id)], 0);
+
+        // Tablets cover the whole test token range [1, 1000] (in particular Token(160)).
+        state.update_tablets(vec![
+            // Strongly consistent, versioned -> leader-first routing. Leader = C.
+            (
+                TABLE_NTS_RF_3.clone(),
+                RawTablet::new_for_test(
+                    1,
+                    1000,
+                    vec![replica(C), replica(A), replica(F)],
+                    Some(42),
+                ),
+            ),
+            // Eventually consistent, versioned -> no leader routing.
+            (
+                TABLE_NTS_RF_2.clone(),
+                RawTablet::new_for_test(1, 1000, vec![replica(B), replica(G), replica(F)], Some(7)),
+            ),
+            // Strongly consistent and versioned, but its first replica -- the leader -- is a
+            // node this driver does not know, so it is dropped from the resolved replica list
+            // and the tablet is marked as having unresolved replicas.
+            (
+                TableSpec::borrowed(KEYSPACE_NTS_RF_3, "table_with_unresolved_leader").into_owned(),
+                RawTablet::new_for_test(
+                    1,
+                    1000,
+                    vec![(Uuid::from_u128(0xdead_beef), 0), replica(A), replica(F)],
+                    Some(11),
+                ),
+            ),
+        ]);
+
+        state
     }
 
     #[tokio::test]

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -21,7 +21,7 @@ use crate::frame::response::result::TableSpec;
 use rand::{Rng, seq::IteratorRandom};
 pub use token_ring::TokenRing;
 
-use self::tablets::TabletsInfo;
+use self::tablets::{TabletVersion, TabletsInfo};
 
 use crate::cluster::metadata::Strategy;
 use crate::cluster::{Node, NodeRef};
@@ -193,6 +193,21 @@ impl ReplicaLocator {
                 table_spec,
             )
         }
+    }
+
+    /// Returns the cached tablet version for the tablet owning `token` in `table_spec`, if
+    /// known via the TABLETS_ROUTING_V2 protocol extension.
+    ///
+    /// `None` means the table does not use tablets, no tablet is cached for the token, or the
+    /// cached tablet was learned via TABLETS_ROUTING_V1 (which carries no version).
+    pub(crate) fn tablet_version_for_token(
+        &self,
+        table_spec: &TableSpec,
+        token: Token,
+    ) -> Option<TabletVersion> {
+        self.tablets
+            .tablets_for_table(table_spec)
+            .and_then(|tablets| tablets.tablet_version_for_token(token))
     }
 
     /// Gives access to the token ring, based on which all token ranges/replica sets are computed.

--- a/scylla/src/routing/locator/mod.rs
+++ b/scylla/src/routing/locator/mod.rs
@@ -210,6 +210,22 @@ impl ReplicaLocator {
             .and_then(|tablets| tablets.tablet_version_for_token(token))
     }
 
+    /// Returns the replica leading the Raft group of the tablet owning `token`, if it is known.
+    ///
+    /// The caller must ensure the tablet is strongly-consistent.
+    ///
+    /// `None` means the table does not use tablets, no tablet is cached for the token, or the
+    /// cached tablet does not identify its leader. See [`Tablet::known_leader`].
+    pub(crate) fn tablet_leader_for_token(
+        &self,
+        table_spec: &TableSpec,
+        token: Token,
+    ) -> Option<(&Arc<Node>, Shard)> {
+        self.tablets
+            .tablets_for_table(table_spec)
+            .and_then(|tablets| tablets.leader_for_token(token))
+    }
+
     /// Gives access to the token ring, based on which all token ranges/replica sets are computed.
     pub fn ring(&self) -> &TokenRing<Arc<Node>> {
         self.replication_data.get_global_ring()

--- a/scylla/src/routing/locator/precomputed_replicas.rs
+++ b/scylla/src/routing/locator/precomputed_replicas.rs
@@ -215,7 +215,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::{
-        cluster::metadata::{Keyspace, Strategy},
+        cluster::metadata::{ConsistencyMode, Keyspace, Strategy},
         routing::Token,
         routing::locator::test::{
             A, C, D, E, F, G, create_ring, mock_metadata_for_token_aware_tests,
@@ -237,6 +237,7 @@ mod tests {
                 },
                 durable_writes: true,
                 tablet_based: false,
+                consistency_mode: ConsistencyMode::Eventual,
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -48,10 +48,19 @@ pub(crate) struct RawTablet {
     tablet_version: Option<TabletVersion>,
 }
 
-type RawTabletPayload<'frame, 'metadata> =
+type RawTabletPayloadV1<'frame, 'metadata> =
     (i64, i64, ListlikeIterator<'frame, 'metadata, (Uuid, i32)>);
 
-static RAW_TABLETS_CQL_TYPE: LazyLock<ColumnType<'static>> = LazyLock::new(|| {
+/// TABLETS_ROUTING_V2 payload is the V1 tuple with an extra trailing `bigint`
+/// carrying the tablet version.
+type RawTabletPayloadV2<'frame, 'metadata> = (
+    i64,
+    i64,
+    ListlikeIterator<'frame, 'metadata, (Uuid, i32)>,
+    i64,
+);
+
+static RAW_TABLETS_V1_CQL_TYPE: LazyLock<ColumnType<'static>> = LazyLock::new(|| {
     ColumnType::Tuple(vec![
         ColumnType::Native(NativeType::BigInt),
         ColumnType::Native(NativeType::BigInt),
@@ -65,7 +74,23 @@ static RAW_TABLETS_CQL_TYPE: LazyLock<ColumnType<'static>> = LazyLock::new(|| {
     ])
 });
 
+static RAW_TABLETS_V2_CQL_TYPE: LazyLock<ColumnType<'static>> = LazyLock::new(|| {
+    ColumnType::Tuple(vec![
+        ColumnType::Native(NativeType::BigInt),
+        ColumnType::Native(NativeType::BigInt),
+        ColumnType::Collection {
+            frozen: false,
+            typ: CollectionType::List(Box::new(ColumnType::Tuple(vec![
+                ColumnType::Native(NativeType::Uuid),
+                ColumnType::Native(NativeType::Int),
+            ]))),
+        },
+        ColumnType::Native(NativeType::BigInt),
+    ])
+});
+
 const CUSTOM_PAYLOAD_TABLETS_V1_KEY: &str = "tablets-routing-v1";
+const CUSTOM_PAYLOAD_TABLETS_V2_KEY: &str = "tablets-routing-v2";
 
 /// An opaque tablet version learned via the `TABLETS_ROUTING_V2` protocol extension.
 ///
@@ -84,9 +109,6 @@ pub(crate) struct TabletVersion([u8; 8]);
 impl TabletVersion {
     /// Builds a version from the signed `bigint` the server sends in a TABLETS_ROUTING_V2
     /// payload. Only the bit pattern matters.
-    // Only exercised by tests until the commit that parses the TABLETS_ROUTING_V2 payload
-    // wires it into the driver.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn from_server_value(raw: i64) -> Self {
         Self(raw.to_be_bytes())
     }
@@ -136,34 +158,60 @@ impl RawTablet {
     pub(crate) fn from_custom_payload(
         payload: &HashMap<String, Bytes>,
     ) -> Option<Result<RawTablet, TabletParsingError>> {
-        let payload = payload.get(CUSTOM_PAYLOAD_TABLETS_V1_KEY)?;
+        // A V2 connection receives the V2 key, a V1 connection the V1 key. The keys are
+        // mutually exclusive and self-describing (V2 carries an extra `bigint` version),
+        // so prefer V2 and fall back to V1.
+        if let Some(payload) = payload.get(CUSTOM_PAYLOAD_TABLETS_V2_KEY) {
+            Some(Self::parse_v2(payload))
+        } else {
+            let payload = payload.get(CUSTOM_PAYLOAD_TABLETS_V1_KEY)?;
+            Some(Self::parse_v1(payload))
+        }
+    }
 
-        if let Err(err) =
-            <RawTabletPayload as DeserializeValue<'_, '_>>::type_check(RAW_TABLETS_CQL_TYPE.deref())
-        {
-            return Some(Err(err.into()));
-        };
-
-        let (first_token, last_token, replicas): RawTabletPayload =
-            match <RawTabletPayload as DeserializeValue<'_, '_>>::deserialize(
-                RAW_TABLETS_CQL_TYPE.deref(),
+    fn parse_v1(payload: &Bytes) -> Result<RawTablet, TabletParsingError> {
+        <RawTabletPayloadV1 as DeserializeValue<'_, '_>>::type_check(
+            RAW_TABLETS_V1_CQL_TYPE.deref(),
+        )?;
+        let (first_token, last_token, replicas): RawTabletPayloadV1 =
+            <RawTabletPayloadV1 as DeserializeValue<'_, '_>>::deserialize(
+                RAW_TABLETS_V1_CQL_TYPE.deref(),
                 Some(FrameSlice::new(payload)),
-            ) {
-                Ok(tuple) => tuple,
-                Err(err) => return Some(Err(err.into())),
-            };
+            )?;
+        Self::build(first_token, last_token, replicas, None)
+    }
 
+    fn parse_v2(payload: &Bytes) -> Result<RawTablet, TabletParsingError> {
+        <RawTabletPayloadV2 as DeserializeValue<'_, '_>>::type_check(
+            RAW_TABLETS_V2_CQL_TYPE.deref(),
+        )?;
+        let (first_token, last_token, replicas, tablet_version): RawTabletPayloadV2 =
+            <RawTabletPayloadV2 as DeserializeValue<'_, '_>>::deserialize(
+                RAW_TABLETS_V2_CQL_TYPE.deref(),
+                Some(FrameSlice::new(payload)),
+            )?;
+        Self::build(
+            first_token,
+            last_token,
+            replicas,
+            Some(TabletVersion::from_server_value(tablet_version)),
+        )
+    }
+
+    fn build(
+        first_token: i64,
+        last_token: i64,
+        replicas: ListlikeIterator<'_, '_, (Uuid, i32)>,
+        tablet_version: Option<TabletVersion>,
+    ) -> Result<RawTablet, TabletParsingError> {
         // Important invariant. That way we guarantee that:
         // - Token range is not empty.
         // - Token range doesn't cross the i64::MAX/i64::MIN boundary.
         if last_token <= first_token {
-            return Some(Err(TabletParsingError::WrongTokenRange(
-                first_token,
-                last_token,
-            )));
+            return Err(TabletParsingError::WrongTokenRange(first_token, last_token));
         }
 
-        let replicas = match replicas
+        let replicas = replicas
             .map(|res| {
                 res.map_err(TabletParsingError::from)
                     .and_then(|(uuid, shard_num)| match shard_num.try_into() {
@@ -171,13 +219,9 @@ impl RawTablet {
                         Err(_) => Err(TabletParsingError::ShardNum(shard_num)),
                     })
             })
-            .collect::<Result<Vec<(Uuid, Shard)>, TabletParsingError>>()
-        {
-            Ok(r) => r,
-            Err(err) => return Some(Err(err)),
-        };
+            .collect::<Result<Vec<(Uuid, Shard)>, TabletParsingError>>()?;
 
-        Some(Ok(RawTablet {
+        Ok(RawTablet {
             // +1 because ScyllaDB sends left-open range, so received
             // number is the last token not belonging to this tablet.
             // This won't overflow because we checked that first token
@@ -186,8 +230,8 @@ impl RawTablet {
             first_token: Token::new(first_token + 1),
             last_token: Token::new(last_token),
             replicas: RawTabletReplicas { replicas },
-            tablet_version: None,
-        }))
+            tablet_version,
+        })
     }
 }
 
@@ -766,8 +810,8 @@ mod tests {
     use crate::cluster::Node;
     use crate::routing::Token;
     use crate::routing::locator::tablets::{
-        CUSTOM_PAYLOAD_TABLETS_V1_KEY, RAW_TABLETS_CQL_TYPE, RawTablet, RawTabletReplicas,
-        TabletParsingError, TabletVersion,
+        CUSTOM_PAYLOAD_TABLETS_V1_KEY, CUSTOM_PAYLOAD_TABLETS_V2_KEY, RAW_TABLETS_V1_CQL_TYPE,
+        RAW_TABLETS_V2_CQL_TYPE, RawTablet, RawTabletReplicas, TabletParsingError, TabletVersion,
     };
     use crate::test_utils::setup_tracing;
     use crate::value::CqlValue;
@@ -837,7 +881,7 @@ mod tests {
             Some(CqlValue::BigInt(last_token)),
             Some(CqlValue::List(vec![])),
         ]);
-        SerializeValue::serialize(&value, &RAW_TABLETS_CQL_TYPE, CellWriter::new(&mut data))
+        SerializeValue::serialize(&value, &RAW_TABLETS_V1_CQL_TYPE, CellWriter::new(&mut data))
             .unwrap();
         // Skip the 4-byte length prefix added by SerializeValue::serialize,
         // because ScyllaDB sends the value without it.
@@ -898,7 +942,7 @@ mod tests {
             ])),
         ]);
 
-        SerializeValue::serialize(&value, &RAW_TABLETS_CQL_TYPE, CellWriter::new(&mut data))
+        SerializeValue::serialize(&value, &RAW_TABLETS_V1_CQL_TYPE, CellWriter::new(&mut data))
             .unwrap();
         tracing::debug!("{:?}", data);
 
@@ -975,6 +1019,102 @@ mod tests {
         assert!(
             blocks.len() >= 2,
             "block did not vary across draws on a cache miss"
+        );
+    }
+
+    #[test]
+    fn test_raw_tablet_deser_v2_correct() {
+        // TABLETS_ROUTING_V2 payload: the V1 tuple plus a trailing bigint tablet version.
+        let mut data = vec![];
+
+        const FIRST_TOKEN: i64 = 1234;
+        const LAST_TOKEN: i64 = 5678;
+        const TABLET_VERSION: u64 = 0x0123_4567_89AB_CDEF;
+
+        let value = CqlValue::Tuple(vec![
+            Some(CqlValue::BigInt(FIRST_TOKEN)),
+            Some(CqlValue::BigInt(LAST_TOKEN)),
+            Some(CqlValue::List(vec![CqlValue::Tuple(vec![
+                Some(CqlValue::Uuid(Uuid::from_u64_pair(1, 2))),
+                Some(CqlValue::Int(15)),
+            ])])),
+            Some(CqlValue::BigInt(TABLET_VERSION as i64)),
+        ]);
+
+        SerializeValue::serialize(&value, &RAW_TABLETS_V2_CQL_TYPE, CellWriter::new(&mut data))
+            .unwrap();
+
+        let custom_payload = HashMap::from([(
+            CUSTOM_PAYLOAD_TABLETS_V2_KEY.to_string(),
+            // Skip the 4-byte length prefix, matching what ScyllaDB sends on the wire.
+            Bytes::copy_from_slice(&data[4..]),
+        )]);
+
+        let tablet = RawTablet::from_custom_payload(&custom_payload)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            tablet,
+            RawTablet {
+                // Note: +1 because ScyllaDB sends left-open range, so received
+                //       number is the last token not belonging to this tablet.
+                //       See `RawTablet::build`, which performs the shift.
+                first_token: Token::new(FIRST_TOKEN + 1),
+                last_token: Token::new(LAST_TOKEN),
+                replicas: RawTabletReplicas {
+                    replicas: vec![(Uuid::from_u64_pair(1, 2), 15)],
+                },
+                tablet_version: Some(TabletVersion::from_server_value(TABLET_VERSION as i64)),
+            }
+        );
+    }
+
+    #[test]
+    fn test_raw_tablet_deser_prefers_v2_over_v1() {
+        // The server should never send both V1 and V2 payloads.
+        // However, let's test that the driver only looks at the
+        // V2 one if both are present (as a sanity check).
+        const V1_FIRST_TOKEN: i64 = 1;
+        const V1_LAST_TOKEN: i64 = 2;
+        let mut custom_payload = make_tablet_custom_payload(V1_FIRST_TOKEN, V1_LAST_TOKEN);
+
+        const V2_FIRST_TOKEN: i64 = 1234;
+        const V2_LAST_TOKEN: i64 = 5678;
+        const TABLET_VERSION: u64 = 0x0123_4567_89AB_CDEF;
+
+        let mut data = vec![];
+        let value = CqlValue::Tuple(vec![
+            Some(CqlValue::BigInt(V2_FIRST_TOKEN)),
+            Some(CqlValue::BigInt(V2_LAST_TOKEN)),
+            Some(CqlValue::List(vec![CqlValue::Tuple(vec![
+                Some(CqlValue::Uuid(Uuid::from_u64_pair(1, 2))),
+                Some(CqlValue::Int(15)),
+            ])])),
+            Some(CqlValue::BigInt(TABLET_VERSION as i64)),
+        ]);
+        SerializeValue::serialize(&value, &RAW_TABLETS_V2_CQL_TYPE, CellWriter::new(&mut data))
+            .unwrap();
+
+        custom_payload.insert(
+            CUSTOM_PAYLOAD_TABLETS_V2_KEY.to_string(),
+            Bytes::copy_from_slice(&data[4..]),
+        );
+
+        let tablet = RawTablet::from_custom_payload(&custom_payload)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            tablet,
+            RawTablet {
+                first_token: Token::new(V2_FIRST_TOKEN + 1),
+                last_token: Token::new(V2_LAST_TOKEN),
+                replicas: RawTabletReplicas {
+                    replicas: vec![(Uuid::from_u64_pair(1, 2), 15)],
+                },
+                tablet_version: Some(TabletVersion::from_server_value(TABLET_VERSION as i64)),
+            }
         );
     }
 

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -71,6 +71,27 @@ pub(crate) struct RawTablet {
     tablet_version: Option<TabletVersion>,
 }
 
+#[cfg(test)]
+impl RawTablet {
+    /// Builds a raw tablet directly, for tests that need to inject tablet mappings
+    /// (with a chosen replica order and version) into a `ClusterState`.
+    ///
+    /// `tablet_version` is given as the signed `bigint` the server would have sent.
+    pub(crate) fn new_for_test(
+        first_token: i64,
+        last_token: i64,
+        replicas: Vec<(Uuid, Shard)>,
+        tablet_version: Option<i64>,
+    ) -> Self {
+        Self {
+            first_token: Token::new(first_token),
+            last_token: Token::new(last_token),
+            replicas: RawTabletReplicas { replicas },
+            tablet_version: tablet_version.map(TabletVersion::from_server_value),
+        }
+    }
+}
+
 type RawTabletPayloadV1<'frame, 'metadata> =
     (i64, i64, ListlikeIterator<'frame, 'metadata, (Uuid, i32)>);
 
@@ -381,6 +402,26 @@ pub(crate) struct Tablet {
 }
 
 impl Tablet {
+    /// The replica leading this tablet's Raft group, if it is known.
+    ///
+    /// Precondition: the tablet is strongly-consistent.
+    pub(crate) fn known_leader(&self) -> Option<(&Arc<Node>, Shard)> {
+        let leader = self.replicas.all.first()?;
+
+        // `failed` holds the *original* replica list, so its first entry is the
+        // leader the payload named. If that host is the one `replicas` starts
+        // with, the leader resolved fine and the unresolved replicas are all
+        // followers; otherwise the leader itself is missing and we know of none.
+        if let Some(failed) = self.failed.as_ref() {
+            let named_leader = failed.replicas.first()?;
+            if named_leader.0 != leader.0.host_id {
+                return None;
+            }
+        }
+
+        Some((&leader.0, leader.1))
+    }
+
     // Ignore clippy lints here. Clippy suggests to
     // Box<> `Err` variant, because it's too large. It does not
     // make much sense to do so, looking at the caller of this function.
@@ -542,6 +583,13 @@ impl TableTablets {
     pub(crate) fn tablet_version_for_token(&self, token: Token) -> Option<TabletVersion> {
         self.tablet_for_token(token)
             .and_then(|tablet| tablet.tablet_version)
+    }
+
+    /// Returns the replica leading the Raft group of the tablet owning `token`, if it is known.
+    ///
+    /// The caller must ensure the tablet is strongly-consistent.
+    pub(crate) fn leader_for_token(&self, token: Token) -> Option<(&Arc<Node>, Shard)> {
+        self.tablet_for_token(token)?.known_leader()
     }
 
     /// This method:
@@ -1848,5 +1896,77 @@ mod tests {
         );
 
         assert_eq!(pre, expected_after);
+    }
+
+    /// Builds a tablet whose payload lists `replica_ids` in order -- the first being the
+    /// leader, as TABLETS_ROUTING_V2 does -- resolving every id except those in `unresolvable`.
+    fn tablet_with_unresolvable(
+        replica_ids: &[Uuid],
+        unresolvable: &[Uuid],
+        tablet_version: Option<i64>,
+    ) -> Tablet {
+        let nodes: HashMap<Uuid, Arc<Node>> = replica_ids
+            .iter()
+            .filter(|id| !unresolvable.contains(id))
+            .map(|id| {
+                let node = Node::new_for_test(Some(*id), None, Some(DC1.to_string()), None);
+                (node.host_id, Arc::new(node))
+            })
+            .collect();
+
+        let raw = RawTablet::new_for_test(
+            0,
+            100,
+            replica_ids.iter().map(|id| (*id, 0)).collect(),
+            tablet_version,
+        );
+
+        match Tablet::from_raw_tablet(raw, |uuid| nodes.get(&uuid).cloned()) {
+            Ok(tablet) => tablet,
+            Err((tablet, _failed)) => tablet,
+        }
+    }
+
+    /// A follower that cannot be resolved must not cost us the leader: the leader is still
+    /// the first replica of the payload, and it resolved.
+    #[test]
+    fn known_leader_survives_a_follower_failing_to_resolve() {
+        let leader = Uuid::from_u64_pair(1, 1);
+        let follower = Uuid::from_u64_pair(1, 2);
+
+        let tablet = tablet_with_unresolvable(&[leader, follower], &[follower], Some(7));
+
+        let (node, shard) = tablet
+            .known_leader()
+            .expect("the leader resolved, so it is known");
+        assert_eq!(node.host_id, leader);
+        assert_eq!(shard, 0);
+    }
+
+    /// If the leader itself is the replica that could not be resolved, the first *remaining*
+    /// replica is a follower -- it must not be mistaken for the leader.
+    #[test]
+    fn known_leader_is_unknown_when_the_leader_fails_to_resolve() {
+        let leader = Uuid::from_u64_pair(1, 1);
+        let follower = Uuid::from_u64_pair(1, 2);
+
+        let tablet = tablet_with_unresolvable(&[leader, follower], &[leader], Some(7));
+
+        // The follower did resolve, so the replica list is non-empty ...
+        assert_eq!(tablet.replicas.all.len(), 1);
+        assert_eq!(tablet.replicas.all[0].0.host_id, follower);
+        // ... but it is not the leader, so no leader is known.
+        assert!(tablet.known_leader().is_none());
+    }
+
+    #[test]
+    fn known_leader_is_the_first_replica_when_all_resolve() {
+        let leader = Uuid::from_u64_pair(1, 1);
+        let follower = Uuid::from_u64_pair(1, 2);
+
+        let tablet = tablet_with_unresolvable(&[leader, follower], &[], Some(7));
+
+        let (node, _) = tablet.known_leader().expect("nothing failed to resolve");
+        assert_eq!(node.host_id, leader);
     }
 }

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -20,6 +20,48 @@
 //! The tablet version is an opaque 64-bit hash of the tablet's ordered replica list (not a
 //! monotonic counter); only its bit pattern is meaningful. Because V2 is experimental its wire
 //! name and payload are subject to change.
+//!
+//! # Leader-aware routing for strongly-consistent tables
+//!
+//! For a strongly-consistent (Raft-based) keyspace — one created with `consistency = 'global'`,
+//! reflected in [`Keyspace::consistency_mode`] as [`ConsistencyMode::Global`] — one replica of
+//! each tablet is the Raft leader that coordinates its writes and its linearizable reads.
+//!
+//! The server does not publish which replica that is: it is absent from schema and from
+//! `system.tablets`, and it can change at any time through a Raft re-election. The one place it
+//! surfaces is the `tablets-routing-v2` payload, which lists the leader first. The driver stores
+//! the replicas in that payload order, so `replicas[0]` of a cached tablet is the leader, and the
+//! built-in load balancing policy uses it to route leader-requiring requests straight there,
+//! saving the extra coordinator-to-leader hop.
+//!
+//! A request to such a keyspace is routed to the leader whenever its consistency level is
+//! anything other than `ONE` or `LOCAL_ONE`:
+//!
+//! - writes to such a keyspace must use `QUORUM`/`LOCAL_QUORUM` (the server rejects
+//!   `ONE`/`LOCAL_ONE` writes), so they always reach the leader — and a write sent to a follower
+//!   would only be bounced to it anyway;
+//! - reads at `ONE`/`LOCAL_ONE` may be served by any replica, so they keep the normal
+//!   load-spreading routing;
+//! - all other reads go to the leader.
+//!
+//! The leader outranks *distance*: it is targeted ahead of nearer replicas, a leader in a remote
+//! datacenter ahead of one in the preferred rack. Every write and every linearizable read on such
+//! a table has to be coordinated by the leader anyway, so contacting a nearer replica only adds a
+//! forwarding hop -- and because the table is globally consistent, keeping the request inside one
+//! datacenter buys no consistency either.
+//!
+//! It does not override the policy's own filter, though. A leader the policy would never contact
+//! is left alone: with a preferred datacenter and datacenter failover disabled, a leader elsewhere
+//! is skipped, the request goes to a local replica, and the server forwards it to the leader --
+//! exactly as it would without the extension. Only the leader is promoted; the remaining replicas
+//! keep their usual ordering, so retries after it still spread.
+//!
+//! This mirrors the Python driver's `TokenAwarePolicy` behavior, so the two drivers agree on how
+//! leader awareness interacts with locality preferences. The decision itself lives in the load
+//! balancing policy.
+//!
+//! [`Keyspace::consistency_mode`]: crate::cluster::metadata::Keyspace::consistency_mode
+//! [`ConsistencyMode::Global`]: crate::cluster::metadata::ConsistencyMode::Global
 
 use crate::cluster::metadata::Keyspace;
 use crate::deserialize::value::{DeserializeValue, ListlikeIterator};

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -143,9 +143,6 @@ impl TabletVersion {
     /// TABLETS_ROUTING_V2 connection: the cached version's block when known (see
     /// [`choose_block`](TabletVersion::choose_block)), or a random probe byte on a cache miss
     /// (see [`random_block`](TabletVersion::random_block)).
-    // Only exercised by tests until the commit that computes the block once per request
-    // wires it into the driver.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn block_for(version: Option<Self>) -> u8 {
         match version {
             Some(version) => version.choose_block(),
@@ -519,8 +516,6 @@ impl TableTablets {
     ///
     /// `None` means either no tablet is cached for the token, or the cached tablet was
     /// learned via TABLETS_ROUTING_V1 (which carries no version).
-    // Wired up by the commit that computes the block once per request.
-    #[expect(dead_code)]
     pub(crate) fn tablet_version_for_token(&self, token: Token) -> Option<TabletVersion> {
         self.tablet_for_token(token)
             .and_then(|tablet| tablet.tablet_version)

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -1,3 +1,26 @@
+//! Tablet routing information and the tablet-version tracking used to keep it fresh.
+//!
+//! For a tablet-enabled table the driver caches, per tablet, the token range and the replica
+//! set so it can route each request straight to a replica. The server keeps that cache
+//! correct by piggy-backing routing information on responses, negotiated through one of two
+//! protocol extensions:
+//!
+//! - `TABLETS_ROUTING_V1`: whenever the driver contacts a shard that does not own the target
+//!   tablet, the response carries a `tablets-routing-v1` custom payload describing the tablet
+//!   so the driver can correct its cache.
+//! - `TABLETS_ROUTING_V2` (experimental; negotiated on the wire as
+//!   `TABLETS_ROUTING_V2_EXPERIMENTAL`): V2 subsumes V1 and adds *tablet-version tracking*.
+//!   The driver attaches a one-byte "tablet-version block" to every `EXECUTE` (see
+//!   [`TabletVersion`]); the server compares it against its own tablet version and returns a
+//!   fresh `tablets-routing-v2` payload only when the driver's cached version is stale. The
+//!   block encodes one randomly chosen nibble of the version, so successive requests probe
+//!   the whole version and detect any change without the driver having to contact a wrong
+//!   replica first.
+//!
+//! The tablet version is an opaque 64-bit hash of the tablet's ordered replica list (not a
+//! monotonic counter); only its bit pattern is meaningful. Because V2 is experimental its wire
+//! name and payload are subject to change.
+
 use crate::cluster::metadata::Keyspace;
 use crate::deserialize::value::{DeserializeValue, ListlikeIterator};
 use crate::deserialize::{DeserializationError, FrameSlice, TypeCheckError};

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -817,7 +817,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
-    use crate::cluster::metadata::{Keyspace, Strategy, Table};
+    use crate::cluster::metadata::{ConsistencyMode, Keyspace, Strategy, Table};
     use crate::frame::response::result::{CollectionType, ColumnType, NativeType, TableSpec};
     use crate::serialize::value::SerializeValue;
     use crate::serialize::writers::CellWriter;
@@ -1817,6 +1817,7 @@ mod tests {
                     strategy: Strategy::LocalStrategy,
                     durable_writes: false,
                     tablet_based: true,
+                    consistency_mode: ConsistencyMode::Eventual,
                     tables: HashMap::from([(
                         spec.table_name().to_owned(),
                         Table {

--- a/scylla/src/routing/locator/tablets.rs
+++ b/scylla/src/routing/locator/tablets.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use crate::cluster::Node;
 use crate::routing::{Shard, Token};
 use crate::utils::safe_format::IteratorSafeFormatExt;
+use rand::Rng as _;
 
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
@@ -41,6 +42,10 @@ pub(crate) struct RawTablet {
     /// Last token belonging to the tablet, inclusive
     last_token: Token,
     replicas: RawTabletReplicas,
+    /// Tablet version, present only when the tablet was learned via the
+    /// TABLETS_ROUTING_V2 extension. Used to keep the driver's routing cache fresh -
+    /// see [`TabletVersion`].
+    tablet_version: Option<TabletVersion>,
 }
 
 type RawTabletPayload<'frame, 'metadata> =
@@ -61,6 +66,71 @@ static RAW_TABLETS_CQL_TYPE: LazyLock<ColumnType<'static>> = LazyLock::new(|| {
 });
 
 const CUSTOM_PAYLOAD_TABLETS_V1_KEY: &str = "tablets-routing-v1";
+
+/// An opaque tablet version learned via the `TABLETS_ROUTING_V2` protocol extension.
+///
+/// It is a 64-bit hash of the tablet's ordered replica list -- not a numeric counter -- so only
+/// its bit pattern is ever meaningful, never its value as an integer. It is therefore stored as
+/// the raw big-endian bytes the server sent (a CQL `bigint`), which makes that explicit and
+/// keeps the type free of sign-changing casts.
+///
+/// The driver uses it to keep its tablet-routing cache fresh: a "block" byte sampled from the
+/// version is sent with every `EXECUTE`, and the server replies with fresh routing information
+/// whenever the sampled nibble disagrees with its own version. See
+/// [`block_for`](TabletVersion::block_for).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct TabletVersion([u8; 8]);
+
+impl TabletVersion {
+    /// Builds a version from the signed `bigint` the server sends in a TABLETS_ROUTING_V2
+    /// payload. Only the bit pattern matters.
+    // Only exercised by tests until the commit that parses the TABLETS_ROUTING_V2 payload
+    // wires it into the driver.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn from_server_value(raw: i64) -> Self {
+        Self(raw.to_be_bytes())
+    }
+
+    /// Chooses a tablet-version "block" byte to send with an `EXECUTE` on a
+    /// TABLETS_ROUTING_V2 connection.
+    ///
+    /// The index of the block is randomized so that, over successive requests,
+    /// the driver eventually probes every nibble and detects any version change.
+    fn choose_block(self) -> u8 {
+        let index: u8 = rand::rng().random::<u8>() & 0x0F; // 0..=15
+        // Bytes are big-endian, so nibble `index` (counted from the least significant one)
+        // lives in byte `7 - index / 2`: its low half for an even index, its high half for an
+        // odd one.
+        let byte = self.0[7 - (index / 2) as usize];
+        let nibble = if index.is_multiple_of(2) {
+            byte & 0xF
+        } else {
+            byte >> 4
+        };
+        (index << 4) | nibble
+    }
+
+    /// Returns a random tablet-version block byte, used when no tablet version
+    /// is cached for the target token. A random block maximizes the chance of
+    /// a mismatch, which prompts the server to return fresh routing information.
+    pub(crate) fn random_block() -> u8 {
+        rand::rng().random::<u8>()
+    }
+
+    /// Returns the tablet-version block byte to attach to an `EXECUTE` on a
+    /// TABLETS_ROUTING_V2 connection: the cached version's block when known (see
+    /// [`choose_block`](TabletVersion::choose_block)), or a random probe byte on a cache miss
+    /// (see [`random_block`](TabletVersion::random_block)).
+    // Only exercised by tests until the commit that computes the block once per request
+    // wires it into the driver.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn block_for(version: Option<Self>) -> u8 {
+        match version {
+            Some(version) => version.choose_block(),
+            None => Self::random_block(),
+        }
+    }
+}
 
 impl RawTablet {
     pub(crate) fn from_custom_payload(
@@ -116,6 +186,7 @@ impl RawTablet {
             first_token: Token::new(first_token + 1),
             last_token: Token::new(last_token),
             replicas: RawTabletReplicas { replicas },
+            tablet_version: None,
         }))
     }
 }
@@ -237,6 +308,9 @@ pub(crate) struct Tablet {
     /// Last token belonging to the tablet, inclusive
     last_token: Token,
     replicas: TabletReplicas,
+    /// Present only when the tablet was learned via the
+    /// TABLETS_ROUTING_V2 extension.
+    tablet_version: Option<TabletVersion>,
     /// If any of the replicas failed to resolve to a Node,
     /// then this field will contain the original list of replicas.
     failed: Option<RawTabletReplicas>,
@@ -260,6 +334,7 @@ impl Tablet {
                 first_token: raw_tablet.first_token,
                 last_token: raw_tablet.last_token,
                 replicas,
+                tablet_version: raw_tablet.tablet_version,
                 failed: None,
             }),
             Err((replicas, failed_replicas)) => Err((
@@ -267,6 +342,7 @@ impl Tablet {
                     first_token: raw_tablet.first_token,
                     last_token: raw_tablet.last_token,
                     replicas,
+                    tablet_version: raw_tablet.tablet_version,
                     failed: Some(raw_tablet.replicas),
                 },
                 failed_replicas,
@@ -329,6 +405,7 @@ impl Tablet {
             first_token: Token::new(token),
             last_token: Token::new(token),
             replicas: TabletReplicas::new_for_test(replicas),
+            tablet_version: None,
             failed: failed.map(|vec| RawTabletReplicas {
                 replicas: vec.into_iter().map(|id| (id, 0)).collect::<Vec<_>>(),
             }),
@@ -392,6 +469,17 @@ impl TableTablets {
                 .map(|x| x.as_slice())
                 .unwrap_or(&[])
         })
+    }
+
+    /// Returns the tablet version for the tablet owning `token`, if known.
+    ///
+    /// `None` means either no tablet is cached for the token, or the cached tablet was
+    /// learned via TABLETS_ROUTING_V1 (which carries no version).
+    // Wired up by the commit that computes the block once per request.
+    #[expect(dead_code)]
+    pub(crate) fn tablet_version_for_token(&self, token: Token) -> Option<TabletVersion> {
+        self.tablet_for_token(token)
+            .and_then(|tablet| tablet.tablet_version)
     }
 
     /// This method:
@@ -679,7 +767,7 @@ mod tests {
     use crate::routing::Token;
     use crate::routing::locator::tablets::{
         CUSTOM_PAYLOAD_TABLETS_V1_KEY, RAW_TABLETS_CQL_TYPE, RawTablet, RawTabletReplicas,
-        TabletParsingError,
+        TabletParsingError, TabletVersion,
     };
     use crate::test_utils::setup_tracing;
     use crate::value::CqlValue;
@@ -836,8 +924,57 @@ mod tests {
                         (Uuid::from_u64_pair(1, 2), 15),
                         (Uuid::from_u64_pair(3, 4), 19)
                     ]
-                }
+                },
+                tablet_version: None,
             }
+        );
+    }
+
+    #[test]
+    fn test_choose_tablet_version_block_encoding() {
+        // The block byte encodes `(index << 4) | nibble`, where `index` (high nibble)
+        // selects one of the 16 nibbles of the version and `nibble` (low nibble) is that
+        // nibble's value. This must match ScyllaDB's `compare_tablet_version_block`.
+        let versions = [
+            0x0000_0000_0000_0000u64,
+            0x0123_4567_89AB_CDEFu64,
+            0xFFFF_FFFF_FFFF_FFFFu64,
+            0xDEAD_BEEF_CAFE_BABEu64,
+        ];
+        for version in versions {
+            let tablet_version = TabletVersion::from_server_value(version as i64);
+            let mut seen_indices = HashSet::new();
+            for _ in 0..1000 {
+                let block = tablet_version.choose_block();
+                let index = block >> 4;
+                let nibble = block & 0x0F;
+                // This invariant holds for every possible RNG outcome, so the assertion
+                // is deterministic regardless of which index happened to be drawn.
+                let expected_nibble = ((version >> (index * 4)) & 0xF) as u8;
+                assert_eq!(
+                    nibble, expected_nibble,
+                    "version={version:#018x} index={index} block={block:#04x}"
+                );
+                seen_indices.insert(index);
+            }
+            // Liveness: confirm the index is actually randomized. With 1000 draws over 16
+            // possible indices, seeing only one is impossible in practice
+            // (probability < 16 * (1/16)^999).
+            assert!(
+                seen_indices.len() >= 2,
+                "index did not vary across draws for version {version:#018x}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_tablet_version_block_for_cache_miss_is_random() {
+        // With no cached version there is nothing to probe, so the block is drawn at random -
+        // over the whole byte, not just the nibble, since the index is meaningless too.
+        let blocks: HashSet<u8> = (0..1000).map(|_| TabletVersion::block_for(None)).collect();
+        assert!(
+            blocks.len() >= 2,
+            "block did not vary across draws on a cache miss"
         );
     }
 
@@ -958,6 +1095,7 @@ mod tests {
                 first_token: Token::new(*first),
                 last_token: Token::new(*last),
                 replicas: Default::default(),
+                tablet_version: None,
                 failed: None,
             });
         }

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::tablets::TabletsInfo;
 use super::{ReplicaLocator, ReplicaSet};
 use crate::cluster::Node;
-use crate::cluster::metadata::{Keyspace, Metadata, Peer, Strategy};
+use crate::cluster::metadata::{ConsistencyMode, Keyspace, Metadata, Peer, Strategy};
 use crate::cluster::{NodeAddr, NodeRef};
 use crate::network::PoolConfig;
 use crate::routing::Token;
@@ -124,6 +124,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
                 },
                 durable_writes: true,
                 tablet_based: false,
+                consistency_mode: ConsistencyMode::Eventual,
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),
@@ -139,6 +140,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
                 },
                 durable_writes: true,
                 tablet_based: false,
+                consistency_mode: ConsistencyMode::Eventual,
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),
@@ -154,6 +156,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
                 },
                 durable_writes: true,
                 tablet_based: false,
+                consistency_mode: ConsistencyMode::Eventual,
                 tables: HashMap::new(),
                 views: HashMap::new(),
                 user_defined_types: HashMap::new(),

--- a/scylla/tests/integration/load_balancing/mod.rs
+++ b/scylla/tests/integration/load_balancing/mod.rs
@@ -3,4 +3,5 @@ mod lwt_optimisation;
 mod shards;
 mod simple_strategy;
 mod tablets;
+mod tablets_routing_v2;
 mod token_awareness;

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -228,12 +228,20 @@ fn cdc_stream_id_key_per_tablet(tablets: &[Tablet]) -> Vec<Vec<u8>> {
         .collect()
 }
 
+const CUSTOM_PAYLOAD_TABLETS_V1_KEY: &str = "tablets-routing-v1";
+const CUSTOM_PAYLOAD_TABLETS_V2_KEY: &str = "tablets-routing-v2";
+
+/// Whether a captured response carries tablets-routing feedback, under either
+/// V1 or V2 extension's key.
 fn frame_has_tablet_feedback(frame: ResponseFrame) -> bool {
     let response =
         scylla_cql::frame::parse_response_body_extensions(frame.params.flags, None, frame.body)
             .unwrap();
     match response.custom_payload {
-        Some(map) => map.contains_key("tablets-routing-v1"),
+        Some(map) => {
+            map.contains_key(CUSTOM_PAYLOAD_TABLETS_V1_KEY)
+                || map.contains_key(CUSTOM_PAYLOAD_TABLETS_V2_KEY)
+        }
         None => false,
     }
 }
@@ -283,9 +291,14 @@ async fn prepare_schema(session: &Session, ks: &str, table: &str, tablet_count: 
 /// tablet feedback that teaches the driver where each tablet lives.
 ///
 /// Also asserts that every key produced at least one feedback, which confirms
-/// the `TABLETS_ROUTING_V1` extension was negotiated and feedback is flowing --
+/// a tablet-routing extension was negotiated and feedback is flowing --
 /// otherwise the later verification phase, which relies on the *absence* of
 /// feedback, would pass vacuously.
+///
+/// Note that this function is non-deterministic when TABLETS_ROUTING_V2 is used.
+/// That extension relies on randomization and so the driver may not receive any
+/// feedback from any server. However, the probability of this happening rapidly
+/// decreases with the number of requests sent for a given token.
 async fn learn_tablet_info(
     session: &Session,
     per_key: &[PreparedForKey],

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -656,33 +656,17 @@ async fn verify_feedback_for_keys(
 /// verifies routing), retrying while tablet migrations invalidate the driver's
 /// cache mid-run.
 ///
-/// Tablet info for `base_table` is read before each attempt and passed in. On
-/// failure we re-read it: if the tablets are unchanged the failure is real and
-/// we panic; if they changed a migration raced the test and we retry.
+/// Thin wrapper over [`crate::utils::with_migration_retry`] that snapshots this
+/// module's resolved tablet view of `base_table` and hands it to each attempt.
 async fn with_migration_retry<F>(session: &Session, ks: &str, base_table: &str, mut attempt: F)
 where
     F: AsyncFnMut(&[Tablet]) -> Result<(), String>,
 {
-    let mut last_error = None;
-    for _ in 0..5 {
-        let tablets = get_tablets(session, ks, base_table).await;
-        match attempt(&tablets).await {
-            Ok(()) => return,
-            Err(e) => {
-                let new_tablets = get_tablets(session, ks, base_table).await;
-                if tablets == new_tablets {
-                    // We failed, but there was no migration.
-                    panic!("Test attempt failed despite no migration. Error: {e}");
-                }
-                last_error = Some(e);
-                // There was a migration, let's try again.
-            }
-        }
-    }
-    panic!(
-        "There was a tablet migration during each attempt! Last error: {}",
-        last_error.unwrap()
-    );
+    crate::utils::with_migration_retry(
+        async || get_tablets(session, ks, base_table).await,
+        async |tablets: &Vec<Tablet>| attempt(tablets).await,
+    )
+    .await
 }
 
 /// Prepares the statement(s) needed to run `descriptor` for every key, pairing

--- a/scylla/tests/integration/load_balancing/tablets_routing_v2.rs
+++ b/scylla/tests/integration/load_balancing/tablets_routing_v2.rs
@@ -1,0 +1,681 @@
+//! End-to-end tests for the `TABLETS_ROUTING_V2` protocol extension.
+//!
+//! The extension is experimental: the server only advertises it (on the wire under the name
+//! `TABLETS_ROUTING_V2_EXPERIMENTAL`) when started with the experimental feature that gates it
+//! (`--experimental-features strongly-consistent-tables`). When the server does not negotiate
+//! it, the V2 tests here skip, exactly like the other feature-gated integration tests in this
+//! suite. The V1 test deliberately does not skip: it hides the extension from every node, so it
+//! exercises the V1 path either way.
+
+use std::sync::Arc;
+
+use futures::future::try_join_all;
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::routing::Shard;
+use scylla::serialize::row::SerializeRow;
+use scylla::statement::prepared::PreparedStatement;
+use uuid::Uuid;
+
+use scylla_cql::frame::parse_response_body_extensions;
+use scylla_cql::frame::protocol_features::ProtocolFeatures;
+use scylla_cql::frame::request::DeserializableRequest;
+use scylla_cql::frame::request::execute::ExecuteV2;
+use scylla_cql::frame::response::Supported;
+use scylla_cql::frame::types;
+
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    ResponseFrame, ResponseOpcode, ResponseReaction, ResponseRule, RunningProxy, ShardAwareness,
+    TargetShard, WorkerError,
+};
+
+use tokio::sync::mpsc;
+
+use crate::utils::{
+    PerformDDL, execute_prepared_statement_everywhere, fetch_negotiated_features,
+    scylla_supports_tablets, setup_tracing, supports_feature, test_with_3_node_cluster,
+    unique_keyspace_name, with_migration_retry,
+};
+
+const CUSTOM_PAYLOAD_TABLETS_V2_KEY: &str = "tablets-routing-v2";
+const CUSTOM_PAYLOAD_TABLETS_V1_KEY: &str = "tablets-routing-v1";
+const TABLETS_ROUTING_V2_EXTENSION: &str = "TABLETS_ROUTING_V2_EXPERIMENTAL";
+
+/// The driver's *cached* routing view of the tablet owning `pk` in `ks.t`: the replica list in
+/// the order the driver currently holds it.
+///
+/// This is what [`with_migration_retry`] snapshots here, and it is deliberately the driver's own
+/// view rather than anything read from `system.tablets`. The assertions in these tests compare
+/// where a request landed against what the driver believed at the time, so the thing that
+/// invalidates a measurement is precisely *the driver's view changing mid-flight* -- and that is
+/// what this observes directly.
+///
+/// It changes whenever the driver learns a new mapping for the tablet, i.e. whenever the tablet
+/// migrated and its replica set moved.
+async fn cached_tablet_routing(session: &Session, ks: &str, pk: i32) -> Vec<(Uuid, Shard)> {
+    session
+        .get_cluster_state()
+        .get_endpoints(ks, "t", &(pk,))
+        .unwrap()
+        .iter()
+        .map(|(node, shard)| (node.host_id, *shard))
+        .collect()
+}
+
+/// Creates a keyspace and a single-partition table that use tablets.
+async fn create_tablet_table(session: &Session, ks: &str) {
+    let supports_table_tablet_options = supports_feature(session, "TABLET_OPTIONS").await;
+    let (ks_tablet_opts, table_tablet_opts) = if supports_table_tablet_options {
+        (
+            "AND tablets = { 'enabled': true }".to_string(),
+            "WITH tablets = { 'min_tablet_count': 8 }".to_string(),
+        )
+    } else {
+        ("AND tablets = { 'initial': 8 }".to_string(), String::new())
+    };
+
+    session
+        .ddl(format!(
+            "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = \
+             {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}} {ks_tablet_opts}"
+        ))
+        .await
+        .unwrap();
+    session
+        .ddl(format!(
+            "CREATE TABLE IF NOT EXISTS {ks}.t (pk int PRIMARY KEY, v int) {table_tablet_opts}"
+        ))
+        .await
+        .unwrap();
+}
+
+/// Decodes a captured `EXECUTE` request frame with the given negotiated `features` and returns
+/// its trailing tablet-version block.
+///
+/// Also asserts that the frame is exactly shaped: after decoding there must be no leftover
+/// bytes. A missing or extra byte would leave the buffer non-empty (or make the decode fail),
+/// which is precisely the on-wire desync this extension must never cause.
+fn decode_execute_block(frame: RequestFrame, features: &ProtocolFeatures) -> Option<u8> {
+    let body = parse_response_body_extensions(frame.params.flags, None, frame.body).unwrap();
+    let mut buf: &[u8] = &body.body;
+    let execute = ExecuteV2::deserialize_with_features(&mut buf, features).unwrap();
+    assert!(
+        buf.is_empty(),
+        "EXECUTE body had {} leftover byte(s) after decoding with the negotiated features; \
+         the on-wire frame is desynced",
+        buf.len()
+    );
+    execute.tablet_version_block
+}
+
+/// Returns whether a captured RESULT response carries a fresh tablet-routing payload under
+/// `payload_key`.
+///
+/// For V2 the server includes it only when the driver's tablet-version block does not match its
+/// own, so its absence over many requests means the driver's cache is in sync. For V1 it is
+/// included whenever the driver contacted a shard that does not own the tablet.
+fn response_carries_tablets_payload(frame: ResponseFrame, payload_key: &str) -> bool {
+    let response = parse_response_body_extensions(frame.params.flags, None, frame.body).unwrap();
+    match response.custom_payload {
+        Some(map) => map.contains_key(payload_key),
+        None => false,
+    }
+}
+
+/// The receiving end of a proxy feedback channel carrying captured `EXECUTE` requests.
+type ExecuteFeedback = mpsc::UnboundedReceiver<(RequestFrame, Option<TargetShard>)>;
+/// The receiving end of a proxy feedback channel carrying captured `RESULT` responses.
+type ResultFeedback = mpsc::UnboundedReceiver<(ResponseFrame, Option<TargetShard>)>;
+
+/// Installs proxy rules capturing every `EXECUTE` request and every `RESULT` response on every
+/// node, and returns the receiving ends.
+///
+/// Rules are prepended, and callers install them only after schema setup, so that just the
+/// measured phase of a test is captured.
+fn capture_executes_and_results(
+    running_proxy: &mut RunningProxy,
+) -> (ExecuteFeedback, ResultFeedback) {
+    let (tx_exec, rx_exec) = mpsc::unbounded_channel();
+    let (tx_resp, rx_resp) = mpsc::unbounded_channel();
+    running_proxy.running_nodes.iter_mut().for_each(|node| {
+        node.prepend_request_rules(vec![RequestRule(
+            Condition::not(Condition::ConnectionRegisteredAnyEvent)
+                .and(Condition::RequestOpcode(RequestOpcode::Execute)),
+            RequestReaction::noop().with_feedback_when_performed(tx_exec.clone()),
+        )]);
+        node.prepend_response_rules(vec![ResponseRule(
+            Condition::not(Condition::ConnectionRegisteredAnyEvent)
+                .and(Condition::ResponseOpcode(ResponseOpcode::Result)),
+            ResponseReaction::noop().with_feedback_when_performed(tx_resp.clone()),
+        )]);
+    });
+    (rx_exec, rx_resp)
+}
+
+/// A proxy rule that strips `TABLETS_ROUTING_V2_EXPERIMENTAL` from a node's SUPPORTED frame
+/// so the driver never negotiates V2 on any connection to that node.
+///
+/// Installed for the whole test, so reconnections stay non-V2 too. This is what lets these
+/// tests cover the V1 path, and mixed clusters, against a server that does support V2.
+fn hide_v2_extension_rule() -> ResponseRule {
+    ResponseRule(
+        Condition::ResponseOpcode(ResponseOpcode::Supported),
+        ResponseReaction::transform_frame(Arc::new(|mut response: ResponseFrame| {
+            let mut msg = Supported::deserialize(&mut &*response.body).unwrap();
+            msg.options.remove(TABLETS_ROUTING_V2_EXTENSION);
+            // scylla-cql has no capability to serialize responses, so re-encode the
+            // string multimap by hand.
+            let mut new_body = Vec::new();
+            types::write_string_multimap(&msg.options, &mut new_body).unwrap();
+            response.body = new_body.into();
+            response
+        })),
+    )
+}
+
+/// Discards everything currently queued in a proxy feedback channel so that an assertion only
+/// sees frames produced by the phase it is measuring.
+fn drain<T>(rx: &mut mpsc::UnboundedReceiver<T>) {
+    while rx.try_recv().is_ok() {}
+}
+
+/// Executes `statement` `count` times concurrently, returning the coordinator of each execution.
+async fn execute_concurrently(
+    session: &Session,
+    statement: &PreparedStatement,
+    values: &(dyn SerializeRow + Sync),
+    count: usize,
+) -> Result<Vec<Uuid>, String> {
+    try_join_all((0..count).map(|_| async move {
+        let result = session
+            .execute_unpaged(statement, values)
+            .await
+            .map_err(|e| format!("execution failed: {e}"))?;
+        Ok::<_, String>(result.request_coordinator().node().host_id)
+    }))
+    .await
+}
+
+/// On a `TABLETS_ROUTING_V2` connection every `EXECUTE` must carry exactly one trailing
+/// tablet-version block byte, and the driver's block encoding must agree with the server's.
+///
+/// The server returns a `tablets-routing-v2` payload only on a version mismatch. From a cold
+/// cache the driver sends a random block, which almost always mismatches, so the server
+/// teaches it the current version; once the cache is warm the driver sends a block derived
+/// from that version, which matches, so the payloads stop. A wrong block encoding
+/// (e.g. a bad bit-shift) would mismatch forever and never converge.
+#[tokio::test]
+async fn test_tablets_routing_v2_execute_carries_block_and_converges() {
+    setup_tracing();
+
+    let features = fetch_negotiated_features(None).await;
+    if !features.tablets_v2_supported {
+        tracing::warn!(
+            "Skipping test because the server did not negotiate TABLETS_ROUTING_V2_EXPERIMENTAL"
+        );
+        return;
+    }
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            if !scylla_supports_tablets(&session).await {
+                tracing::warn!("Skipping test because this Scylla version doesn't support tablets");
+                return running_proxy;
+            }
+
+            let ks = unique_keyspace_name();
+
+            create_tablet_table(&session, &ks).await;
+
+            // A single fixed partition key, so every request targets the same tablet and we
+            // observe that one tablet's version converge.
+            const PK: i32 = 42;
+
+            let select = session
+                .prepare(format!("SELECT v FROM {ks}.t WHERE pk = ?"))
+                .await
+                .unwrap();
+
+            // Capture EXECUTE requests and RESULT responses on every node. Rules are installed
+            // after schema setup, so only the phases below are captured -- but *before* the
+            // insert, which matters: the server returns V2 routing information only while the
+            // driver's tablet-version cache is cold, so whichever request fills that cache
+            // consumes the only payload there is. The insert below is unprepared, and an
+            // unprepared QUERY carries no tablet-version block and is not token-routed, so today
+            // it cannot fill the cache. Capturing from before it anyway keeps the warm-up
+            // assertion from silently depending on that.
+            let (mut rx_exec, mut rx_resp) = capture_executes_and_results(&mut running_proxy);
+
+            session
+                .query_unpaged(format!("INSERT INTO {ks}.t (pk, v) VALUES ({PK}, 1)"), &())
+                .await
+                .unwrap();
+
+            // Phase 1, run once: warm the cache. These are independent of each other, so run
+            // them concurrently: each request carries its own randomly chosen block, so every
+            // cold one mismatches on its own and the server answers each with routing
+            // information. Applying it repeatedly is idempotent, so nothing needs sequencing --
+            // only that the batch has finished before the measured phase begins.
+            const WARMUP: usize = 12;
+            execute_concurrently(&session, &select, &(PK,), WARMUP)
+                .await
+                .unwrap();
+
+            // From a cold cache the driver sends a randomly chosen block, which almost always
+            // mismatches the server's version, so the server teaches it the current one. (With a
+            // 1-in-16 chance per request the random block matches and no payload is returned, but
+            // over WARMUP requests it is essentially certain that at least one mismatches.)
+            let mut saw_payload = false;
+            while let Ok((frame, _shard)) = rx_resp.try_recv() {
+                saw_payload |=
+                    response_carries_tablets_payload(frame, CUSTOM_PAYLOAD_TABLETS_V2_KEY);
+            }
+            assert!(
+                saw_payload,
+                "server never returned a tablets-routing-v2 payload during warm-up; the V2 \
+                 payload path was not exercised (is the table really using tablets?)"
+            );
+
+            // The warm-up EXECUTEs must already carry the block -- the driver sends one from the
+            // very first request, cold cache or not. Checked here because the measured phase
+            // below drains the channel before running.
+            let mut warmup_executes = 0usize;
+            while let Ok((frame, _shard)) = rx_exec.try_recv() {
+                assert!(
+                    decode_execute_block(frame, &features).is_some(),
+                    "EXECUTE on a V2 connection must carry a tablet-version block"
+                );
+                warmup_executes += 1;
+            }
+            assert!(
+                warmup_executes >= WARMUP,
+                "expected to capture at least {WARMUP} warm-up EXECUTE frames, captured \
+                 {warmup_executes}"
+            );
+
+            // Phase 2, retried: with the cache warm, the block the driver sends must agree with
+            // the server's encoding, so NOT ONE of these responses may carry a payload. A wrong
+            // block encoding (e.g. a bad bit-shift) would mismatch forever.
+            //
+            // Anything that changes the tablet's version mid-phase (a migration, say) also makes
+            // the server send a fresh payload, which would fail this through no fault of the
+            // driver -- so snapshot the driver's routing view around the phase and retry if it
+            // moved. The warm-up above is deliberately outside the retry: snapshotting a cold
+            // cache would register the warm-up itself as a change.
+            with_migration_retry(
+                async || cached_tablet_routing(&session, &ks, PK).await,
+                async |_| {
+                    drain(&mut rx_exec);
+                    drain(&mut rx_resp);
+
+                    // These are independent, so run them concurrently.
+                    const MEASURED: usize = 60;
+                    execute_concurrently(&session, &select, &(PK,), MEASURED).await?;
+
+                    let mut payloads = 0usize;
+                    while let Ok((frame, _shard)) = rx_resp.try_recv() {
+                        if response_carries_tablets_payload(frame, CUSTOM_PAYLOAD_TABLETS_V2_KEY) {
+                            payloads += 1;
+                        }
+                    }
+                    if payloads != 0 {
+                        return Err(format!(
+                            "the driver's tablet-version cache did not converge: {payloads} of \
+                             {MEASURED} responses still carried a tablets-routing-v2 payload, so \
+                             its block encoding likely disagrees with the server's"
+                        ));
+                    }
+
+                    // Every measured EXECUTE must carry exactly one well-formed trailing block
+                    // byte, just as the warm-up ones did.
+                    let mut executes_seen = 0usize;
+                    while let Ok((frame, _shard)) = rx_exec.try_recv() {
+                        if decode_execute_block(frame, &features).is_none() {
+                            return Err(
+                                "EXECUTE on a V2 connection must carry a tablet-version block"
+                                    .to_owned(),
+                            );
+                        }
+                        executes_seen += 1;
+                    }
+                    if executes_seen < MEASURED {
+                        return Err(format!(
+                            "expected to capture at least {MEASURED} EXECUTE frames, captured \
+                             {executes_seen}"
+                        ));
+                    }
+
+                    Ok(())
+                },
+            )
+            .await;
+
+            session
+                .ddl(format!("DROP KEYSPACE IF EXISTS {ks}"))
+                .await
+                .unwrap();
+            running_proxy
+        },
+    )
+    .await;
+
+    // `test_with_3_node_cluster` returns the proxy's final status. When the session is dropped
+    // as the proxy shuts down, an in-flight request can observe the connection closing and the
+    // proxy reports `DriverDisconnected`; that is benign here (the measurement already
+    // finished), so we accept it. Any other error is a real failure.
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// A mixed cluster where one node does not advertise `TABLETS_ROUTING_V2`.
+///
+/// `EXECUTE` frames sent to the V2 nodes must carry the trailing tablet-version block, while
+/// frames sent to the non-V2 node must carry none. Both framings must stay exactly shaped
+/// (each decodes with no leftover bytes) and every request must succeed. This is exactly the
+/// invariant a retry relies on when it crosses a V2 and a non-V2 connection: neither frame
+/// desyncs.
+#[tokio::test]
+async fn test_tablets_routing_v2_mixed_feature_connections() {
+    setup_tracing();
+
+    let features = fetch_negotiated_features(None).await;
+    if !features.tablets_v2_supported {
+        tracing::warn!(
+            "Skipping test because the server did not negotiate TABLETS_ROUTING_V2_EXPERIMENTAL"
+        );
+        return;
+    }
+    // The non-V2 node keeps every other negotiated feature (e.g. the metadata id), so its
+    // EXECUTE frames must be decoded with V2 turned off but the rest left on.
+    let mut non_v2_features = features;
+    non_v2_features.tablets_v2_supported = false;
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            // Hide the extension from node 0 only, so the driver negotiates V2
+            // with nodes 1 and 2 but not with node 0.
+            running_proxy.running_nodes[0]
+                .change_response_rules(Some(vec![hide_v2_extension_rule()]));
+
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            if !scylla_supports_tablets(&session).await {
+                tracing::warn!("Skipping test because this Scylla version doesn't support tablets");
+                return running_proxy;
+            }
+
+            let ks = unique_keyspace_name();
+
+            create_tablet_table(&session, &ks).await;
+            session
+                .query_unpaged(format!("INSERT INTO {ks}.t (pk, v) VALUES (0, 1)"), &())
+                .await
+                .unwrap();
+
+            let select = session
+                .prepare(format!("SELECT v FROM {ks}.t WHERE pk = ?"))
+                .await
+                .unwrap();
+
+            // Capture EXECUTEs per node so each frame is decoded with that node's features.
+            let mut exec_rxs = Vec::new();
+            for node in running_proxy.running_nodes.iter_mut() {
+                let (tx, rx) = mpsc::unbounded_channel::<(RequestFrame, Option<TargetShard>)>();
+                node.prepend_request_rules(vec![RequestRule(
+                    Condition::not(Condition::ConnectionRegisteredAnyEvent)
+                        .and(Condition::RequestOpcode(RequestOpcode::Execute)),
+                    RequestReaction::noop().with_feedback_when_performed(tx),
+                )]);
+                exec_rxs.push(rx);
+            }
+
+            // Force the SELECT onto every node and shard, so the non-V2 node 0 and the V2
+            // nodes 1-2 all receive EXECUTEs regardless of replica placement. That every call
+            // succeeds already proves neither framing desynced on the wire.
+            execute_prepared_statement_everywhere(
+                &session,
+                session.get_cluster_state().as_ref(),
+                &select,
+                &(0i32,),
+            )
+            .await
+            .unwrap();
+
+            // Node 0 negotiated non-V2: its EXECUTEs must carry NO trailing block.
+            let mut non_v2_frames = 0usize;
+            while let Ok((frame, _shard)) = exec_rxs[0].try_recv() {
+                assert_eq!(
+                    decode_execute_block(frame, &non_v2_features),
+                    None,
+                    "EXECUTE to the non-V2 node must not carry a tablet-version block"
+                );
+                non_v2_frames += 1;
+            }
+
+            // Nodes 1 and 2 negotiated V2: their EXECUTEs must carry the trailing block.
+            let mut v2_frames = 0usize;
+            for rx in exec_rxs[1..].iter_mut() {
+                while let Ok((frame, _shard)) = rx.try_recv() {
+                    assert!(
+                        decode_execute_block(frame, &features).is_some(),
+                        "EXECUTE to a V2 node must carry a tablet-version block"
+                    );
+                    v2_frames += 1;
+                }
+            }
+
+            assert!(non_v2_frames >= 1, "the non-V2 node received no EXECUTEs");
+            assert!(v2_frames >= 1, "the V2 nodes received no EXECUTEs");
+
+            session
+                .ddl(format!("DROP KEYSPACE IF EXISTS {ks}"))
+                .await
+                .unwrap();
+            running_proxy
+        },
+    )
+    .await;
+
+    // A `DriverDisconnected` error is benign here (the session is dropped as the proxy shuts
+    // down). Any other error is a real failure.
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// `TABLETS_ROUTING_V1` must keep working on a server that does not offer V2.
+///
+/// V2 subsumes V1 and the driver negotiates exactly one of them, so the V1 path would silently
+/// stop being exercised the moment a server starts advertising V2. Hiding the V2 extension from
+/// every node puts the driver back on V1 against that same cluster, which must still:
+///
+/// - send no trailing tablet-version block on any `EXECUTE` - that byte belongs to V2 alone, and
+///   a V1 server would read it as the start of the next frame;
+/// - receive `tablets-routing-v1` payloads, i.e. the V1 feedback path really runs;
+/// - converge: once the cache is warm, every request for a key reaches one of that tablet's
+///   replicas.
+#[tokio::test]
+async fn test_tablets_routing_v1_used_when_v2_unavailable() {
+    setup_tracing();
+
+    // Deliberately *not* gated on the server supporting V2. On a server that offers V2 the rule
+    // below forces the driver back onto V1; on one that does not, the rule is a no-op and the
+    // driver is on V1 anyway. Either way this is a V1 test, so it runs in ordinary CI too --
+    // which is the point, since V1 is not going away when V2 ships.
+    let mut v1_features = fetch_negotiated_features(None).await;
+    // With V2 hidden the driver negotiates V1, so its EXECUTE frames must be decoded with V2
+    // turned off but every other negotiated feature left on.
+    v1_features.tablets_v2_supported = false;
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            // Hide the extension from every node so no connection negotiates V2.
+            for node in running_proxy.running_nodes.iter_mut() {
+                node.change_response_rules(Some(vec![hide_v2_extension_rule()]));
+            }
+
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            if !scylla_supports_tablets(&session).await {
+                tracing::warn!("Skipping test because this Scylla version doesn't support tablets");
+                return running_proxy;
+            }
+
+            let ks = unique_keyspace_name();
+            create_tablet_table(&session, &ks).await;
+
+            const PK: i32 = 7;
+            session
+                .query_unpaged(format!("INSERT INTO {ks}.t (pk, v) VALUES ({PK}, 1)"), &())
+                .await
+                .unwrap();
+
+            let select = session
+                .prepare(format!("SELECT v FROM {ks}.t WHERE pk = ?"))
+                .await
+                .unwrap();
+
+            let (mut rx_exec, mut rx_resp) = capture_executes_and_results(&mut running_proxy);
+
+            // Warm the cache, once. V1 teaches the driver a tablet's replicas whenever it
+            // contacts a shard that does not own it, so from a cold cache a few requests suffice
+            // to converge. Run them concurrently: they are independent, and applying the same
+            // feedback repeatedly is idempotent.
+            //
+            // Unlike V2, V1 feedback is not one-shot: it is triggered by misrouting rather than
+            // by a version mismatch, so it recurs for as long as the driver keeps missing the
+            // owning shard. An earlier request therefore cannot consume the payload this phase
+            // is waiting for, and where capture is installed does not affect the assertion.
+            const WARMUP: usize = 12;
+            execute_concurrently(&session, &select, &(PK,), WARMUP)
+                .await
+                .unwrap();
+
+            let mut saw_v1_payload = false;
+            let mut v2_payloads = 0usize;
+            while let Ok((frame, _shard)) = rx_resp.try_recv() {
+                saw_v1_payload |=
+                    response_carries_tablets_payload(frame.clone(), CUSTOM_PAYLOAD_TABLETS_V1_KEY);
+                if response_carries_tablets_payload(frame, CUSTOM_PAYLOAD_TABLETS_V2_KEY) {
+                    v2_payloads += 1;
+                }
+            }
+            assert!(
+                saw_v1_payload,
+                "server never returned a tablets-routing-v1 payload; the V1 feedback path was \
+                 not exercised"
+            );
+            // The two extensions are mutually exclusive, so a V1 connection must never see V2
+            // routing information. This is the direct check that we really are on V1, rather
+            // than inferring it from the V1 payload above.
+            assert_eq!(
+                v2_payloads, 0,
+                "a V1 connection received {v2_payloads} tablets-routing-v2 payload(s); the \
+                 driver must not have negotiated V2"
+            );
+
+            // The warm-up EXECUTEs must already be free of the block, from the very first
+            // request. Checked here because the measured phase below drains the channel.
+            let mut warmup_executes = 0usize;
+            while let Ok((frame, _shard)) = rx_exec.try_recv() {
+                assert_eq!(
+                    decode_execute_block(frame, &v1_features),
+                    None,
+                    "EXECUTE on a V1 connection must not carry a tablet-version block"
+                );
+                warmup_executes += 1;
+            }
+            assert!(
+                warmup_executes >= WARMUP,
+                "expected to capture at least {WARMUP} warm-up EXECUTE frames, captured \
+                 {warmup_executes}"
+            );
+
+            // A migration mid-batch would move the tablet's replicas out from under the check
+            // below, so snapshot the driver's routing view around it and read the expected
+            // replica set from that same snapshot.
+            with_migration_retry(
+                async || cached_tablet_routing(&session, &ks, PK).await,
+                async |routing| {
+                    drain(&mut rx_exec);
+
+                    // Once warm, every request must reach a replica of the tablet.
+                    const ITERATIONS: usize = 20;
+                    let coordinators =
+                        execute_concurrently(&session, &select, &(PK,), ITERATIONS).await?;
+                    let replicas: Vec<Uuid> = routing.iter().map(|(host, _shard)| *host).collect();
+                    if let Some(other) = coordinators.iter().find(|c| !replicas.contains(c)) {
+                        return Err(format!(
+                            "request coordinated by {other}, which is not a replica of the \
+                             tablet ({replicas:?}); the V1 routing cache did not converge"
+                        ));
+                    }
+
+                    // No EXECUTE may carry the V2-only trailing block byte.
+                    // `decode_execute_block` also asserts the frame decodes with nothing left
+                    // over, so an accidentally appended byte is caught here rather than
+                    // corrupting the next frame.
+                    let mut executes_seen = 0usize;
+                    while let Ok((frame, _shard)) = rx_exec.try_recv() {
+                        if decode_execute_block(frame, &v1_features).is_some() {
+                            return Err("EXECUTE on a V1 connection must not carry a \
+                                        tablet-version block"
+                                .to_owned());
+                        }
+                        executes_seen += 1;
+                    }
+                    if executes_seen < ITERATIONS {
+                        return Err(format!(
+                            "expected to capture at least {ITERATIONS} EXECUTE frames, captured \
+                             {executes_seen}"
+                        ));
+                    }
+
+                    Ok(())
+                },
+            )
+            .await;
+
+            session
+                .ddl(format!("DROP KEYSPACE IF EXISTS {ks}"))
+                .await
+                .unwrap();
+            running_proxy
+        },
+    )
+    .await;
+
+    // A `DriverDisconnected` error is benign here (the session is dropped as the proxy shuts
+    // down). Any other error is a real failure.
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/load_balancing/tablets_routing_v2.rs
+++ b/scylla/tests/integration/load_balancing/tablets_routing_v2.rs
@@ -7,13 +7,18 @@
 //! suite. The V1 test deliberately does not skip: it hides the extension from every node, so it
 //! exercises the V1 path either way.
 
+use std::cell::Cell;
 use std::sync::Arc;
 
 use futures::future::try_join_all;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::cluster::metadata::{CollectionType, ColumnType, NativeType};
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::value::{DeserializeValue, ListlikeIterator};
 use scylla::routing::Shard;
 use scylla::serialize::row::SerializeRow;
+use scylla::statement::Consistency;
 use scylla::statement::prepared::PreparedStatement;
 use uuid::Uuid;
 
@@ -51,8 +56,17 @@ const TABLETS_ROUTING_V2_EXTENSION: &str = "TABLETS_ROUTING_V2_EXPERIMENTAL";
 /// invalidates a measurement is precisely *the driver's view changing mid-flight* -- and that is
 /// what this observes directly.
 ///
-/// It changes whenever the driver learns a new mapping for the tablet, i.e. whenever the tablet
-/// migrated and its replica set moved.
+/// It changes whenever the driver learns a new mapping for the tablet, which covers both events
+/// that matter and which are largely independent of each other:
+///
+/// - the tablet migrated, changing its replica set;
+/// - a strongly-consistent tablet elected a new Raft leader. A re-election alone is enough: the
+///   tablet version stays the same only as long as *both* the replica set and the leader do, so
+///   a new leader (very probably) changes the version, and the server then hands the driver a
+///   freshly ordered list.
+///
+/// A snapshot of the replica set read from `system.tablets` would have caught only the first of
+/// those -- the leader appears nowhere in that table.
 async fn cached_tablet_routing(session: &Session, ks: &str, pk: i32) -> Vec<(Uuid, Shard)> {
     session
         .get_cluster_state()
@@ -63,8 +77,9 @@ async fn cached_tablet_routing(session: &Session, ks: &str, pk: i32) -> Vec<(Uui
         .collect()
 }
 
-/// Creates a keyspace and a single-partition table that use tablets.
-async fn create_tablet_table(session: &Session, ks: &str) {
+/// Creates a keyspace and a single-partition table that use tablets, appending
+/// `extra_ks_options` to the `CREATE KEYSPACE` statement.
+async fn create_tablet_table_with_ks_options(session: &Session, ks: &str, extra_ks_options: &str) {
     let supports_table_tablet_options = supports_feature(session, "TABLET_OPTIONS").await;
     let (ks_tablet_opts, table_tablet_opts) = if supports_table_tablet_options {
         (
@@ -78,7 +93,8 @@ async fn create_tablet_table(session: &Session, ks: &str) {
     session
         .ddl(format!(
             "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = \
-             {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}} {ks_tablet_opts}"
+             {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}} \
+             {ks_tablet_opts} {extra_ks_options}"
         ))
         .await
         .unwrap();
@@ -88,6 +104,11 @@ async fn create_tablet_table(session: &Session, ks: &str) {
         ))
         .await
         .unwrap();
+}
+
+/// Creates a keyspace and a single-partition table that use tablets.
+async fn create_tablet_table(session: &Session, ks: &str) {
+    create_tablet_table_with_ks_options(session, ks, "").await
 }
 
 /// Decodes a captured `EXECUTE` request frame with the given negotiated `features` and returns
@@ -127,6 +148,52 @@ fn response_carries_tablets_payload(frame: ResponseFrame, payload_key: &str) -> 
 type ExecuteFeedback = mpsc::UnboundedReceiver<(RequestFrame, Option<TargetShard>)>;
 /// The receiving end of a proxy feedback channel carrying captured `RESULT` responses.
 type ResultFeedback = mpsc::UnboundedReceiver<(ResponseFrame, Option<TargetShard>)>;
+
+/// The replica list of a captured `tablets-routing-v2` payload, in the order the server sent it,
+/// or `None` if the response carries no such payload.
+///
+/// `replicas[0]` is the tablet's Raft leader. This is decoded straight from the captured frame
+/// rather than read back from the driver, on purpose: the leader is what these tests assert
+/// about, so taking it from the driver's own cache would make the assertion circular -- a driver
+/// that mis-parsed the payload's replica order would agree with itself and the test would pass.
+///
+/// It is also the only way to learn the leader at all. The server publishes it nowhere else: not
+/// in schema, not in `system.tablets`; it only lists it first in this payload, and a Raft
+/// re-election can move it at any time.
+fn decode_v2_payload_replicas(frame: ResponseFrame) -> Option<Vec<(Uuid, i32)>> {
+    type V2Payload<'frame, 'metadata> = (
+        i64,
+        i64,
+        ListlikeIterator<'frame, 'metadata, (Uuid, i32)>,
+        i64,
+    );
+
+    let response = parse_response_body_extensions(frame.params.flags, None, frame.body).unwrap();
+    let payload = response
+        .custom_payload?
+        .remove(CUSTOM_PAYLOAD_TABLETS_V2_KEY)?;
+
+    // The same shape the driver expects: (first_token, last_token, [(host, shard)], version).
+    let typ = ColumnType::Tuple(vec![
+        ColumnType::Native(NativeType::BigInt),
+        ColumnType::Native(NativeType::BigInt),
+        ColumnType::Collection {
+            frozen: false,
+            typ: CollectionType::List(Box::new(ColumnType::Tuple(vec![
+                ColumnType::Native(NativeType::Uuid),
+                ColumnType::Native(NativeType::Int),
+            ]))),
+        },
+        ColumnType::Native(NativeType::BigInt),
+    ]);
+
+    <V2Payload as DeserializeValue<'_, '_>>::type_check(&typ).unwrap();
+    let (_first_token, _last_token, replicas, _version) =
+        <V2Payload as DeserializeValue<'_, '_>>::deserialize(&typ, Some(FrameSlice::new(&payload)))
+            .unwrap();
+
+    Some(replicas.map(|replica| replica.unwrap()).collect())
+}
 
 /// Installs proxy rules capturing every `EXECUTE` request and every `RESULT` response on every
 /// node, and returns the receiving ends.
@@ -487,6 +554,188 @@ async fn test_tablets_routing_v2_mixed_feature_connections() {
 
             session
                 .ddl(format!("DROP KEYSPACE IF EXISTS {ks}"))
+                .await
+                .unwrap();
+            running_proxy
+        },
+    )
+    .await;
+
+    // A `DriverDisconnected` error is benign here (the session is dropped as the proxy shuts
+    // down). Any other error is a real failure.
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+// -- strongly-consistent (leader-aware) routing -----------------------------
+
+/// Creates a strongly-consistent (Raft-based) keyspace and a single-partition table.
+async fn create_strongly_consistent_tablet_table(session: &Session, ks: &str) {
+    create_tablet_table_with_ks_options(session, ks, "AND consistency = 'global'").await
+}
+
+/// For a table in a strongly-consistent (Raft-based) keyspace, every leader-requiring request
+/// (here a `LOCAL_QUORUM` read) must be coordinated by the tablet's Raft leader, saving the extra
+/// coordinator->leader hop.
+///
+/// This also covers, indirectly, that the driver discovered the keyspace's consistency mode from
+/// `system_schema.scylla_keyspaces` at all: leader-aware routing only engages for a keyspace the
+/// driver believes is strongly consistent, so a mode that failed to be read would show up here as
+/// requests spreading across replicas. The mode itself is crate-private, and the mapping from the
+/// raw `consistency` column value to it is unit-tested next to the code that does it.
+///
+/// A read at `ONE`/`LOCAL_ONE` is intentionally *not* pinned to the leader (any single replica
+/// satisfies it); that carve-out is covered by the policy unit tests.
+#[tokio::test]
+async fn test_leader_aware_routing_targets_the_raft_leader() {
+    setup_tracing();
+
+    let features = fetch_negotiated_features(None).await;
+    if !features.tablets_v2_supported {
+        tracing::warn!(
+            "Skipping test because the server did not negotiate TABLETS_ROUTING_V2_EXPERIMENTAL"
+        );
+        return;
+    }
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            if !scylla_supports_tablets(&session).await {
+                tracing::warn!("Skipping test because this Scylla version doesn't support tablets");
+                return running_proxy;
+            }
+
+            let sc_ks = unique_keyspace_name();
+            create_strongly_consistent_tablet_table(&session, &sc_ks).await;
+
+            // A single fixed partition key, so every request targets the same tablet.
+            const PK: i32 = 2;
+
+            // Writes to a strongly-consistent (Raft) table are rejected unless they use
+            // QUORUM/LOCAL_QUORUM, so pin the insert to LOCAL_QUORUM.
+            let mut insert = session
+                .prepare(format!("INSERT INTO {sc_ks}.t (pk, v) VALUES (?, ?)"))
+                .await
+                .unwrap();
+            insert.set_consistency(Consistency::LocalQuorum);
+
+            // A strong read (LOCAL_QUORUM) is a leader-requiring request.
+            let mut select = session
+                .prepare(format!("SELECT v FROM {sc_ks}.t WHERE pk = ?"))
+                .await
+                .unwrap();
+            select.set_consistency(Consistency::LocalQuorum);
+
+            // Capture must be installed before the *first* request that routes by this tablet.
+            // The server sends routing information only when the tablet-version block it
+            // receives disagrees with its own version, so only requests made while the driver's
+            // tablet cache is still cold provoke a payload. The very first such request -- the
+            // insert below -- is what fills that cache.
+            let (mut rx_exec, mut rx_resp) = capture_executes_and_results(&mut running_proxy);
+
+            session.execute_unpaged(&insert, (PK, 1)).await.unwrap();
+
+            // Warm the cache, and in doing so learn who leads this tablet. While the cache is
+            // cold the driver sends a random tablet-version block, so the server answers with
+            // routing information -- and that payload is the only place it says which replica
+            // leads the Raft group. The insert above is what provokes it; these reads then leave
+            // the cache warm for the measured phase.
+            //
+            // One batch and one drain is enough, with no retry: the proxy queues its feedback
+            // copy of a response before forwarding that response to the driver, so every frame
+            // the driver has seen is already in `rx_resp` by the time this batch resolves.
+            const WARMUP: usize = 32;
+            execute_concurrently(&session, &select, &(PK,), WARMUP)
+                .await
+                .unwrap();
+
+            let mut leader = None;
+            while let Ok((frame, _shard)) = rx_resp.try_recv() {
+                if let Some(replicas) = decode_v2_payload_replicas(frame) {
+                    leader = replicas.first().map(|(host, _shard)| *host);
+                }
+            }
+            let leader = Cell::new(leader.expect(
+                "server never sent a tablets-routing-v2 payload during warm-up, so the tablet's \
+                 leader could not be determined",
+            ));
+
+            // A migration or a Raft re-election can move the leader while the batch below is in
+            // flight, which would fail the check through no fault of the driver. Either shows up
+            // as the server re-sending routing information, so a measurement that sees a payload
+            // is discarded and repeated against the leader that payload just reported.
+            //
+            // That is handled here rather than by returning `Err` to `with_migration_retry`,
+            // because that helper decides "did anything move?" by re-reading the driver's cached
+            // routing. The driver applies tablet feedback asynchronously, so right after a
+            // payload lands on the wire its cache may still hold the old mapping -- the snapshot
+            // would compare equal and the helper would panic instead of retrying. The outer
+            // retry still covers migrations that make the *assertion* fail without any payload
+            // reaching this test.
+            with_migration_retry(
+                async || cached_tablet_routing(&session, &sc_ks, PK).await,
+                async |_| {
+                    // Bounded, so that a tablet that keeps churning fails the test rather than
+                    // spinning forever.
+                    const MAX_MEASUREMENTS: usize = 5;
+                    const ITERATIONS: usize = 20;
+
+                    for _ in 0..MAX_MEASUREMENTS {
+                        drain(&mut rx_exec);
+                        drain(&mut rx_resp);
+
+                        let coordinators =
+                            execute_concurrently(&session, &select, &(PK,), ITERATIONS).await?;
+
+                        let mut moved = false;
+                        while let Ok((frame, _shard)) = rx_resp.try_recv() {
+                            if let Some(replicas) = decode_v2_payload_replicas(frame) {
+                                if let Some((host, _shard)) = replicas.first() {
+                                    leader.set(*host);
+                                }
+                                moved = true;
+                            }
+                        }
+                        if moved {
+                            // The tablet migrated or re-elected mid-measurement. Measure again,
+                            // now expecting the leader the server just reported.
+                            continue;
+                        }
+
+                        // With the cache warm and the mapping stable, every strong read for this
+                        // tablet must be coordinated by the leader.
+                        let expected = leader.get();
+                        if let Some(other) = coordinators.iter().find(|c| **c != expected) {
+                            return Err(format!(
+                                "strong read coordinated by {other} but the tablet's Raft leader \
+                                 is {expected}; leader-aware routing did not target the leader"
+                            ));
+                        }
+                        return Ok(());
+                    }
+
+                    Err(format!(
+                        "the server re-sent routing information in each of the \
+                         {MAX_MEASUREMENTS} measurements, so the tablet never stayed put long \
+                         enough to check where requests landed"
+                    ))
+                },
+            )
+            .await;
+
+            session
+                .ddl(format!("DROP KEYSPACE IF EXISTS {sc_ks}"))
                 .await
                 .unwrap();
             running_proxy

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -509,6 +509,48 @@ where
     try_join_all(tasks).await
 }
 
+/// Runs `attempt`, retrying while concurrent tablet migrations invalidate what it observed.
+///
+/// Tablet migrations run in the background and can move a tablet's replicas -- or, for a
+/// strongly-consistent table, its Raft leader -- while a test is measuring routing, which makes
+/// an otherwise correct driver look wrong. `snapshot` captures the server-side tablet state
+/// before and after each attempt: if the attempt failed but the snapshot is unchanged, the
+/// failure is real and we panic; if it changed, a migration raced the test, so we retry.
+///
+/// The snapshot type is left to the caller, since different tests care about different amounts
+/// of detail. Any value that compares equal iff "nothing relevant moved" works.
+pub(crate) async fn with_migration_retry<Snapshot, TakeSnapshot, Attempt>(
+    mut snapshot: TakeSnapshot,
+    mut attempt: Attempt,
+) where
+    Snapshot: PartialEq,
+    TakeSnapshot: AsyncFnMut() -> Snapshot,
+    Attempt: AsyncFnMut(&Snapshot) -> Result<(), String>,
+{
+    const MAX_ATTEMPTS: usize = 5;
+
+    let mut last_error = None;
+    for _ in 0..MAX_ATTEMPTS {
+        let before = snapshot().await;
+        match attempt(&before).await {
+            Ok(()) => return,
+            Err(error) => {
+                if snapshot().await == before {
+                    // We failed, but there was no migration.
+                    panic!("Test attempt failed despite no migration. Error: {error}");
+                }
+                // There was a migration, let's try again.
+                last_error = Some(error);
+            }
+        }
+    }
+    panic!(
+        "There was a tablet migration during each of the {MAX_ATTEMPTS} attempts! \
+         Last error: {}",
+        last_error.unwrap()
+    );
+}
+
 pub(crate) async fn execute_prepared_statement_everywhere(
     session: &Session,
     cluster: &ClusterState,


### PR DESCRIPTION
In scylladb/scylla-rust-driver@1166cc7f, we introduced tablet awareness.
Thanks to it, the driver was finally able to learn about the replicas
of a given tablet and successfully route requests to the right nodes
and shards.

Unfortunately, the solution doesn't handle the situation when the
replica set grows properly. Consider the following scenario:

* A keyspace K uses RF=2.
* Tablet T in this keyspace has two replicas: A and B.
* The driver sends requests to T and learns, via TABLETS_ROUTING_V1,
  about the replicas of the tablet. Once that happens, it routes
  subsequent requests to A and B.
* Then, the user increases the replication factor of K from 2 to 3.
* It happens that the new replicas of T are: A, B, and C.
* The driver still routes requests to A and B, and because it always
  hits a replica, it never realises that the replica set has changed.

As a result, C is never targeted by the driver and the load balancing
is suboptimal.

---

Besides that scenario, the existing algorithm isn't that well suited to
work with strongly consistent tables.

Just like an eventually consistent tablet, a strongly consistent one
has a set of replicas that own it. The difference is that the latter
also has a distinguished replica called the leader that coordinates all
of the writes and (almost) all of the reads to the tablet. That creates
a need for the driver to route its requests to the leader instead of an
arbitrary replica.

Although it's technically possible to adjust the existing tablet
awareness to carry information about the identity of the leader, we
devise a brand new solution that should improve the algorithm.

---

We introduce the notion of a tablet version -- a 64-bit hash that
corresponds to the replicas of a tablet and (in the case of strongly
consistent tablets) its leader.

With every EXECUTE request, the driver provides information about the
tablet version it knows. If the server detects a mismatch, the response
to the request will contain full routing information: the boundary
tokens of the tablet, the list of its replicas, and the tablet version.
The driver then updates its cache and routes subsequent requests to the
right replicas.

---

This way, we gain a better control of detecting changes to a tablet.
Furthermore, if the driver routes a request to a seemingly wrong node
because the replicas were unavailable, there is no penalty to it:
routing information will *only* be returned when the tablet changes
in some way.

---

Tests have been provided to verify that the implementation is correct.

---

Refs: SCYLLADB-288
Fixes: SCYLLADB-290

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
