### PR TITLE
session: Deduplicate exec params resolution

### DIFF
--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use tracing::{Instrument as _, trace, trace_span};
 
+use crate::client::execution_profile::ExecutionProfileInner;
 use crate::errors::{RequestAttemptError, RequestError};
 use crate::frame::types::Consistency;
 
@@ -15,6 +16,7 @@ use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
 use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy};
 use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
 use crate::response::{Coordinator, NonErrorQueryResponse};
+use crate::statement::StatementConfig;
 use crate::{cluster::NodeRef, routing::Shard};
 
 /// Result of running a request, before side effects are handled.
@@ -75,6 +77,46 @@ pub(crate) struct RequestExecutionParams<'a> {
     pub(crate) history_listener: Option<&'a dyn HistoryListener>,
     /// Paged vs non-paged, for metrics.
     pub(crate) request_kind: RequestPaging,
+}
+
+/// Constructor(s) for [`RequestExecutionParams`].
+impl<'a> RequestExecutionParams<'a> {
+    pub(crate) fn new_for_session_apis(
+        statement_config: &'a StatementConfig,
+        execution_profile: &'a ExecutionProfileInner,
+        metrics: &'a Arc<Metrics>,
+        request_kind: RequestPaging,
+    ) -> Self {
+        let is_idempotent = statement_config.is_idempotent;
+        let consistency = statement_config
+            .consistency
+            .unwrap_or(execution_profile.consistency);
+        let retry_policy = statement_config
+            .retry_policy
+            .as_deref()
+            .unwrap_or(execution_profile.retry_policy.as_ref());
+        let load_balancing_policy = statement_config
+            .load_balancing_policy
+            .as_deref()
+            .unwrap_or(execution_profile.load_balancing_policy.as_ref());
+        let request_timeout = statement_config
+            .request_timeout
+            .or(execution_profile.request_timeout);
+        let history_listener = statement_config.history_listener.as_deref();
+        let speculative_policy = execution_profile.speculative_execution_policy.as_deref();
+
+        Self {
+            is_idempotent,
+            consistency,
+            retry_policy,
+            load_balancing_policy,
+            metrics,
+            speculative_policy,
+            request_timeout,
+            history_listener,
+            request_kind,
+        }
+    }
 }
 
 /// History data threaded through a single fiber.

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -6,7 +6,7 @@ use tracing::{Instrument as _, trace, trace_span};
 
 use crate::client::execution_profile::ExecutionProfileInner;
 use crate::errors::{RequestAttemptError, RequestError};
-use crate::frame::types::Consistency;
+use crate::frame::types::{Consistency, SerialConsistency};
 
 use crate::network::Connection;
 use crate::observability::driver_tracing::RequestSpan;
@@ -63,6 +63,8 @@ pub(crate) struct RequestExecutionParams<'a> {
     pub(crate) is_idempotent: bool,
     /// Consistency to use.
     pub(crate) consistency: Consistency,
+    /// Serial consistency to use, if any.
+    pub(crate) serial_consistency: Option<SerialConsistency>,
     /// Retry policy used to start a fresh retry session per fiber.
     pub(crate) retry_policy: &'a dyn RetryPolicy,
     /// Load balancing policy used to order targets for the execution.
@@ -91,6 +93,9 @@ impl<'a> RequestExecutionParams<'a> {
         let consistency = statement_config
             .consistency
             .unwrap_or(execution_profile.consistency);
+        let serial_consistency = statement_config
+            .serial_consistency
+            .unwrap_or(execution_profile.serial_consistency);
         let retry_policy = statement_config
             .retry_policy
             .as_deref()
@@ -108,6 +113,7 @@ impl<'a> RequestExecutionParams<'a> {
         Self {
             is_idempotent,
             consistency,
+            serial_consistency,
             retry_policy,
             load_balancing_policy,
             metrics,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -302,6 +302,7 @@ impl PagingExecutor {
         let exec_params = RequestExecutionParams {
             is_idempotent: self.is_idempotent,
             consistency: self.consistency,
+            serial_consistency: self.serial_consistency,
             retry_policy: self.retry_policy.as_ref(),
             load_balancing_policy: self.load_balancing_policy.as_ref(),
             metrics: &self.metrics,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2060,38 +2060,19 @@ impl Session {
     where
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
-        let consistency = statement_config
-            .consistency
-            .unwrap_or(execution_profile.consistency);
-
-        let load_balancer = statement_config
-            .load_balancing_policy
-            .as_deref()
-            .unwrap_or(execution_profile.load_balancing_policy.as_ref());
-
-        let retry_policy = statement_config
-            .retry_policy
-            .as_deref()
-            .unwrap_or(&*execution_profile.retry_policy);
-
-        let request_timeout = statement_config
-            .request_timeout
-            .or(execution_profile.request_timeout);
-
-        let exec_params = RequestExecutionParams {
-            is_idempotent: statement_config.is_idempotent,
-            consistency,
-            retry_policy,
-            load_balancing_policy: load_balancer,
-            metrics: &self.metrics,
-            speculative_policy: execution_profile.speculative_execution_policy.as_deref(),
-            request_timeout,
-            history_listener: statement_config.history_listener.as_deref(),
+        let exec_params = RequestExecutionParams::new_for_session_apis(
+            statement_config,
+            &execution_profile,
+            &self.metrics,
             request_kind,
-        };
+        );
 
         let cluster_state = self.cluster.get_state();
-        let request_plan = load_balancing::Plan::new(load_balancer, &routing_info, &cluster_state);
+        let request_plan = load_balancing::Plan::new(
+            exec_params.load_balancing_policy,
+            &routing_info,
+            &cluster_state,
+        );
 
         let result = exec_params
             .run_request_no_side_effects(

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2,7 +2,7 @@
 //! It manages all connections to the cluster and allows to execute CQL requests.
 
 use super::execution::RequestPaging;
-use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle, ExecutionProfileInner};
+use super::execution_profile::{ExecutionProfile, ExecutionProfileHandle};
 use super::pager::QueryPager;
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
@@ -45,7 +45,7 @@ use crate::statement::batch::batch_values;
 use crate::statement::batch::{Batch, BatchStatement};
 use crate::statement::prepared::{PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
-use crate::statement::{Consistency, PageSize, StatementConfig};
+use crate::statement::{Consistency, PageSize};
 use arc_swap::ArcSwapOption;
 use futures::future::join_all;
 use futures::future::try_join_all;
@@ -980,10 +980,13 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        let consistency = batch
-            .config
-            .consistency
-            .unwrap_or(execution_profile.consistency);
+        let exec_params = RequestExecutionParams::new_for_session_apis(
+            &batch.config,
+            &execution_profile,
+            &self.metrics,
+            // Batch statements are always unpaged, because they can't contain SELECTs.
+            RequestPaging::Unpaged,
+        );
 
         let serial_consistency = batch
             .config
@@ -1002,7 +1005,7 @@ impl Session {
             };
 
         let routing_info = RoutingInfo {
-            consistency,
+            consistency: exec_params.consistency,
             serial_consistency,
             token: first_value_token,
             table: table_spec,
@@ -1018,10 +1021,7 @@ impl Session {
         ) = self
             .run_request(
                 routing_info,
-                &batch.config,
-                execution_profile,
-                // Batch statements are always unpaged, because they can't contain SELECTs.
-                RequestPaging::Unpaged,
+                exec_params,
                 |connection: Arc<Connection>, consistency: Consistency| async move {
                     connection
                         .batch_with_consistency(batch, values_ref, consistency, serial_consistency)
@@ -1299,10 +1299,12 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        let consistency = statement
-            .config
-            .consistency
-            .unwrap_or(execution_profile.consistency);
+        let exec_params = RequestExecutionParams::new_for_session_apis(
+            &statement.config,
+            &execution_profile,
+            &self.metrics,
+            request_paging,
+        );
 
         let serial_consistency = statement
             .config
@@ -1310,7 +1312,7 @@ impl Session {
             .unwrap_or(execution_profile.serial_consistency);
 
         let routing_info = RoutingInfo {
-            consistency,
+            consistency: exec_params.consistency,
             serial_consistency,
             token: None,
             table: None,
@@ -1326,9 +1328,7 @@ impl Session {
         ) = self
             .run_request(
                 routing_info,
-                &statement.config,
-                execution_profile,
-                request_paging,
+                exec_params,
                 |connection: Arc<Connection>, consistency: Consistency| {
                     // Needed to avoid moving query and values into async move block
                     let values_ref = &values;
@@ -1686,10 +1686,12 @@ impl Session {
             .unwrap_or_else(|| self.get_default_execution_profile_handle())
             .access();
 
-        let consistency = prepared
-            .config
-            .consistency
-            .unwrap_or(execution_profile.consistency);
+        let exec_params = RequestExecutionParams::new_for_session_apis(
+            &prepared.config,
+            &execution_profile,
+            &self.metrics,
+            request_paging,
+        );
 
         let serial_consistency = prepared
             .config
@@ -1699,7 +1701,7 @@ impl Session {
         let table_spec = prepared.get_table_spec();
 
         let routing_info = RoutingInfo {
-            consistency,
+            consistency: exec_params.consistency,
             serial_consistency,
             token,
             table: table_spec,
@@ -1727,9 +1729,7 @@ impl Session {
         ) = self
             .run_request(
                 routing_info,
-                &prepared.config,
-                execution_profile,
-                request_paging,
+                exec_params,
                 |connection: Arc<Connection>, consistency: Consistency| async move {
                     connection
                         .execute_raw_with_consistency(
@@ -2051,22 +2051,13 @@ impl Session {
     async fn run_request<'a, QueryFut>(
         &'a self,
         routing_info: RoutingInfo<'a>,
-        statement_config: &'a StatementConfig,
-        execution_profile: Arc<ExecutionProfileInner>,
-        request_kind: RequestPaging,
+        exec_params: RequestExecutionParams<'a>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         request_span: &'a RequestSpan,
     ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), ExecutionError>
     where
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
-        let exec_params = RequestExecutionParams::new_for_session_apis(
-            statement_config,
-            &execution_profile,
-            &self.metrics,
-            request_kind,
-        );
-
         let cluster_state = self.cluster.get_state();
         let request_plan = load_balancing::Plan::new(
             exec_params.load_balancing_policy,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -988,10 +988,7 @@ impl Session {
             RequestPaging::Unpaged,
         );
 
-        let serial_consistency = batch
-            .config
-            .serial_consistency
-            .unwrap_or(execution_profile.serial_consistency);
+        let serial_consistency = exec_params.serial_consistency;
 
         let (first_value_token, values) =
             batch_values::peek_first_token(values, batch.statements.first())?;
@@ -1306,10 +1303,7 @@ impl Session {
             request_paging,
         );
 
-        let serial_consistency = statement
-            .config
-            .serial_consistency
-            .unwrap_or(execution_profile.serial_consistency);
+        let serial_consistency = exec_params.serial_consistency;
 
         let routing_info = RoutingInfo {
             consistency: exec_params.consistency,
@@ -1693,10 +1687,7 @@ impl Session {
             request_paging,
         );
 
-        let serial_consistency = prepared
-            .config
-            .serial_consistency
-            .unwrap_or(execution_profile.serial_consistency);
+        let serial_consistency = exec_params.serial_consistency;
 
         let table_spec = prepared.get_table_spec();
 


### PR DESCRIPTION
Refs: #1549

This deduplicates various execution parameters resolution, by moving them into `RequestExecutionParams` constructor.
The net line change is not impressive, but the resolution logic is now really nearly only there. Unfortunately I couldn't move exec profile resolution to the `RequestExecutionParams` constructor for the "lifetimes reason" - see the last commit message for explanation.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
