### PR TITLE
Make ClusterWorker the owner of ControlConnection

### DIFF
--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -7,10 +7,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
+use tokio::sync::{mpsc, oneshot};
+use tracing::warn;
 
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::client::pager::QueryPager;
-use crate::errors::{NextPageError, NextRowError, RequestAttemptError, RequestError};
+use crate::cluster::metadata::UntranslatedEndpoint;
+use crate::errors::{
+    ConnectionError, NextPageError, NextRowError, RequestAttemptError, RequestError,
+};
+use crate::frame::response::event::EventV2 as Event;
 use crate::network::Connection;
 use crate::serialize::row::SerializeRow;
 use crate::statement::Statement;
@@ -20,27 +26,47 @@ const METADATA_QUERY_PAGE_SIZE: i32 = 1024;
 
 pub(crate) type ControlConnectionCache = DashMap<String, PreparedStatement>;
 
+pub(crate) enum ControlConnectionEvent {
+    Broken(ConnectionError),
+    ServerEvent(Event),
+    Shutdown,
+}
+
 /// The single connection used to fetch metadata and receive events from the cluster.
 pub(super) struct ControlConnection {
     conn: Arc<Connection>,
+    endpoint: UntranslatedEndpoint,
     /// The custom server-side timeout set for requests executed on the control connection.
     overridden_serverside_timeout: Option<Duration>,
     cache: Arc<ControlConnectionCache>,
     client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
+
+    error_channel: oneshot::Receiver<ConnectionError>,
+    events_channel: mpsc::Receiver<Event>,
 }
 
 impl ControlConnection {
     pub(super) fn new(
         conn: Arc<Connection>,
+        endpoint: UntranslatedEndpoint,
         cache: Arc<ControlConnectionCache>,
         client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
+        error_channel: oneshot::Receiver<ConnectionError>,
+        events_channel: mpsc::Receiver<Event>,
     ) -> Self {
         Self {
             conn,
+            endpoint,
             overridden_serverside_timeout: None,
             cache,
             client_routes_subscriber,
+            error_channel,
+            events_channel,
         }
+    }
+
+    pub(super) fn endpoint(&self) -> &UntranslatedEndpoint {
+        &self.endpoint
     }
 
     /// Sets the custom server-side timeout set for requests executed on the control connection.
@@ -128,6 +154,41 @@ impl ControlConnection {
             .execute_iter(prepared, serialized_values)
             .await
     }
+
+    pub(crate) async fn wait_for_event(&mut self) -> ControlConnectionEvent {
+        tokio::select! {
+            // Why only `Some`? `None` means that event channel was dropped.
+            // In current implementation (as of writing this comment)
+            // this should not be possible: events sender is stored in HostConnectionConfig,
+            // which is a field of Connection that we own. If we got `None`, then most likely
+            // two things happened:
+            //  - The implementation changed, for example by moving event sender to router.
+            //  - Connection was closed, router shutdown.
+            //  - `tokio::select!` chose this branch instead of error channel.
+            // The best thing we can imo do is ignore this `None`. `error_channel` should receive
+            // info about connection shutdown very soon.
+            Some(cql_event) = self.events_channel.recv() => {
+                ControlConnectionEvent::ServerEvent(cql_event)
+            },
+            maybe_control_connection_failed = &mut self.error_channel => {
+                let err = match maybe_control_connection_failed {
+                    Ok(err) => err,
+                    Err(_recv_error) => {
+                        // If we got here then error channel, in a Connection that we own,
+                        // was dropped without sending anything. This is definitely a bug in the driver!
+                        // We could theoretically recover by dropping a connection and creating new one,
+                        // but we would need to add an error variant to `BrokenConnectionErrorKind` that
+                        // could basically never happen. Let's panic instead.
+                        warn!(concat!("Error sender of control connection unexpectedly dropped. The only case when this ",
+                        "may happen is during runtime shutdown. If you see this and the runtime isn't shutting down, ",
+                        "this is a bug in the driver. Then please open an issue!"));
+                        return ControlConnectionEvent::Shutdown;
+                    },
+                };
+                ControlConnectionEvent::Broken(err)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -148,6 +209,7 @@ mod tests {
     use crate::cluster::control_connection::ControlConnectionCache;
     use crate::cluster::metadata::UntranslatedEndpoint;
     use crate::cluster::node::ResolvedContactPoint;
+    use crate::network::HostConnectionConfig;
     use crate::network::open_connection;
     use crate::routing::ShardInfo;
     use crate::test_utils::setup_tracing;
@@ -271,12 +333,17 @@ mod tests {
             proxy_addr: SocketAddr,
             feedback_rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
         ) {
-            let (conn, _error_receiver) = open_connection(
-                &UntranslatedEndpoint::ContactPoint(ResolvedContactPoint {
-                    address: proxy_addr,
-                }),
+            let endpoint = UntranslatedEndpoint::ContactPoint(ResolvedContactPoint {
+                address: proxy_addr,
+            });
+            let (events_sender, events_receiver) = mpsc::channel(32);
+            let (conn, error_receiver) = open_connection(
+                &endpoint,
                 None,
-                &Default::default(),
+                &HostConnectionConfig {
+                    event_sender: Some((events_sender, vec![])),
+                    ..Default::default()
+                },
             )
             .await
             .unwrap();
@@ -284,8 +351,11 @@ mod tests {
             let connected_to_scylladb = conn.get_shard_info().is_some();
             let conn_with_default_timeout = ControlConnection::new(
                 Arc::new(conn),
+                endpoint,
                 Arc::new(ControlConnectionCache::new()),
                 None,
+                error_receiver,
+                events_receiver,
             );
 
             // No custom timeout set.

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -109,7 +109,7 @@ impl MetadataReader {
 
         let cc_cache = Arc::new(ControlConnectionCache::new());
 
-        let control_connection_state = Self::make_control_connection(
+        let control_connection_state = Self::make_control_connection_state(
             control_connection_endpoint,
             connection_config.clone(),
             request_serverside_timeout,
@@ -281,7 +281,7 @@ impl MetadataReader {
                 peer.address()
             );
 
-            self.control_connection_state = Self::make_control_connection(
+            self.control_connection_state = Self::make_control_connection_state(
                 peer,
                 self.control_connection_config.clone(),
                 self.request_serverside_timeout,
@@ -393,7 +393,7 @@ impl MetadataReader {
                     .expect("known_peers is empty - should be impossible")
                     .clone();
 
-                self.control_connection_state = Self::make_control_connection(
+                self.control_connection_state = Self::make_control_connection_state(
                     control_connection_endpoint,
                     self.control_connection_config.clone(),
                     self.request_serverside_timeout,
@@ -405,13 +405,40 @@ impl MetadataReader {
         }
     }
 
+    /// Opens a control connection to `endpoint`, wrapping the outcome in a
+    /// [`ControlConnectionState`] (either `Working` or `Broken`).
+    async fn make_control_connection_state(
+        endpoint: UntranslatedEndpoint,
+        config: ConnectionConfig,
+        request_serverside_timeout: Option<Duration>,
+        cache: Arc<ControlConnectionCache>,
+        client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
+    ) -> ControlConnectionState {
+        let last_endpoint = endpoint.clone();
+        match Self::make_control_connection(
+            endpoint,
+            config,
+            request_serverside_timeout,
+            cache,
+            client_routes_subscriber,
+        )
+        .await
+        {
+            Ok(cc) => ControlConnectionState::Working(cc),
+            Err(last_error) => ControlConnectionState::Broken {
+                last_error,
+                last_endpoint,
+            },
+        }
+    }
+
     async fn make_control_connection(
         endpoint: UntranslatedEndpoint,
         mut config: ConnectionConfig,
         request_serverside_timeout: Option<Duration>,
         cache: Arc<ControlConnectionCache>,
         client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
-    ) -> ControlConnectionState {
+    ) -> Result<ControlConnection, MetadataError> {
         let (sender, receiver) = tokio::sync::mpsc::channel(32);
         // setting event_sender field in connection config will cause control connection to
         // - send REGISTER message to receive server events
@@ -434,23 +461,20 @@ impl MetadataReader {
         .await;
 
         match open_result {
-            Ok((con, recv)) => ControlConnectionState::Working(
-                ControlConnection::new(
-                    Arc::new(con),
-                    endpoint,
-                    cache,
-                    client_routes_subscriber,
-                    recv,
-                    receiver,
-                )
-                .override_serverside_timeout(request_serverside_timeout),
-            ),
-            Err(conn_err) => ControlConnectionState::Broken {
-                last_error: MetadataError::ConnectionPoolError(ConnectionPoolError::Broken {
+            Ok((con, recv)) => Ok(ControlConnection::new(
+                Arc::new(con),
+                endpoint,
+                cache,
+                client_routes_subscriber,
+                recv,
+                receiver,
+            )
+            .override_serverside_timeout(request_serverside_timeout)),
+            Err(conn_err) => Err(MetadataError::ConnectionPoolError(
+                ConnectionPoolError::Broken {
                     last_connection_error: conn_err,
-                }),
-                last_endpoint: endpoint,
-            },
+                },
+            )),
         }
     }
 

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -231,14 +231,8 @@ impl MetadataReader {
                 debug!("Fetched new metadata");
             }
             Err(error) => {
-                let target = self
-                    .control_connection_state
-                    .endpoint()
-                    .address()
-                    .into_inner();
                 error!(
                     error = %error,
-                    target = %target,
                     "Could not fetch metadata"
                 )
             }
@@ -253,25 +247,10 @@ impl MetadataReader {
         nodes: impl Iterator<Item = UntranslatedEndpoint>,
         prev_err: MetadataError,
     ) -> Result<Metadata, MetadataError> {
-        let mut result = Err(prev_err);
+        let mut last_err = prev_err;
         for peer in nodes {
-            let err = match result {
-                Ok(_) => break,
-                Err(err) => err,
-            };
-
-            warn!(
-                control_connection_address = tracing::field::display(self
-                    .control_connection_state.endpoint()
-                    .address()),
-                error = %err,
-                "Failed to fetch metadata using current control connection"
-            );
-
-            debug!(
-                "Retrying to establish the control connection on {}",
-                peer.address()
-            );
+            let peer_address = peer.address();
+            debug!("Retrying to establish the control connection on {peer_address}");
 
             self.control_connection_state = Self::make_control_connection_state(
                 peer,
@@ -282,9 +261,21 @@ impl MetadataReader {
             )
             .await;
 
-            result = self.fetch_metadata(initial).await;
+            let err = match self.fetch_metadata(initial).await {
+                Ok(metadata) => return Ok(metadata),
+                Err(err) => err,
+            };
+
+            warn!(
+                control_connection_address = %peer_address,
+                error = %err,
+                "Failed to fetch metadata using current control connection"
+            );
+
+            last_err = err;
         }
-        result
+
+        Err(last_err)
     }
 
     async fn fetch_metadata(&mut self, initial: bool) -> Result<Metadata, MetadataError> {

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -19,75 +19,25 @@ use std::time::Duration;
 
 use rand::rng;
 use rand::seq::{IndexedRandom, SliceRandom};
-use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
-use crate::cluster::control_connection::{ControlConnection, ControlConnectionCache};
+use crate::cluster::control_connection::{
+    ControlConnection, ControlConnectionCache, ControlConnectionEvent,
+};
 use crate::cluster::metadata::{Metadata, PeerEndpoint, UntranslatedEndpoint};
 use crate::cluster::node::resolve_contact_points;
-use crate::errors::{ConnectionError, ConnectionPoolError, MetadataError, NewSessionError};
+use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
 use crate::frame::response::event::ClientRoutesChangeEvent;
-use crate::frame::response::event::EventV2 as Event;
 use crate::frame::server_event_type::EventTypeV2 as EventType;
 use crate::network::{ConnectionConfig, open_connection};
 use crate::policies::host_filter::HostFilter;
 use crate::utils::safe_format::IteratorSafeFormatExt;
 
-pub(crate) enum ControlConnectionEvent {
-    Broken(ConnectionError),
-    ServerEvent(Event),
-    Shutdown,
-}
-
-struct WorkingControlConnection {
-    connection: ControlConnection,
-    endpoint: UntranslatedEndpoint,
-    error_channel: oneshot::Receiver<ConnectionError>,
-    events_channel: mpsc::Receiver<Event>,
-}
-
-impl WorkingControlConnection {
-    pub(crate) async fn wait_for_event(&mut self) -> ControlConnectionEvent {
-        tokio::select! {
-            // Why only `Some`? `None` means that event channel was dropped.
-            // In current implementation (as of writing this comment)
-            // this should not be possible: events sender is stored in HostConnectionConfig,
-            // which is a field of Connection that we own. If we got `None`, then most likely
-            // two things happened:
-            //  - The implementation changed, for example by moving event sender to router.
-            //  - Connection was closed, router shutdown.
-            //  - `tokio::select!` chose this branch instead of error channel.
-            // The best thing we can imo do is ignore this `None`. `error_channel` should receive
-            // info about connection shutdown very soon.
-            Some(cql_event) = self.events_channel.recv() => {
-                ControlConnectionEvent::ServerEvent(cql_event)
-            },
-            maybe_control_connection_failed = &mut self.error_channel => {
-                let err = match maybe_control_connection_failed {
-                    Ok(err) => err,
-                    Err(_recv_error) => {
-                        // If we got here then error channel, in a Connection that we own,
-                        // was dropped without sending anything. This is definitely a bug in the driver!
-                        // We could theoretically recover by dropping a connection and creating new one,
-                        // but we would need to add an error variant to `BrokenConnectionErrorKind` that
-                        // could basically never happen. Let's panic instead.
-                        warn!(concat!("Error sender of control connection unexpectedly dropped. The only case when this ",
-                        "may happen is during runtime shutdown. If you see this and the runtime isn't shutting down, ",
-                        "this is a bug in the driver. Then please open an issue!"));
-                        return ControlConnectionEvent::Shutdown;
-                    },
-                };
-                ControlConnectionEvent::Broken(err)
-            }
-        }
-    }
-}
-
 enum ControlConnectionState {
-    Working(WorkingControlConnection),
+    Working(ControlConnection),
     Broken {
         last_error: MetadataError,
         last_endpoint: UntranslatedEndpoint,
@@ -97,7 +47,7 @@ enum ControlConnectionState {
 impl ControlConnectionState {
     fn endpoint(&self) -> &UntranslatedEndpoint {
         match self {
-            ControlConnectionState::Working(c) => &c.endpoint,
+            ControlConnectionState::Working(c) => c.endpoint(),
             ControlConnectionState::Broken { last_endpoint, .. } => last_endpoint,
         }
     }
@@ -198,11 +148,11 @@ impl MetadataReader {
                                 last_connection_error: err.clone(),
                             },
                         ),
-                        last_endpoint: working_connection.endpoint.clone(),
+                        last_endpoint: working_connection.endpoint().clone(),
                     };
                 }
 
-                return event;
+                event
             }
         }
     }
@@ -352,10 +302,9 @@ impl MetadataReader {
                 return Err(e.clone());
             }
         };
-        let endpoint = working_connection.endpoint.clone();
+        let endpoint = working_connection.endpoint().clone();
 
         let res = working_connection
-            .connection
             .query_metadata(
                 endpoint.address().port(),
                 &self.keyspaces_to_fetch,
@@ -485,13 +434,17 @@ impl MetadataReader {
         .await;
 
         match open_result {
-            Ok((con, recv)) => ControlConnectionState::Working(WorkingControlConnection {
-                connection: ControlConnection::new(Arc::new(con), cache, client_routes_subscriber)
-                    .override_serverside_timeout(request_serverside_timeout),
-                error_channel: recv,
-                events_channel: receiver,
-                endpoint,
-            }),
+            Ok((con, recv)) => ControlConnectionState::Working(
+                ControlConnection::new(
+                    Arc::new(con),
+                    endpoint,
+                    cache,
+                    client_routes_subscriber,
+                    recv,
+                    receiver,
+                )
+                .override_serverside_timeout(request_serverside_timeout),
+            ),
             Err(conn_err) => ControlConnectionState::Broken {
                 last_error: MetadataError::ConnectionPoolError(ConnectionPoolError::Broken {
                     last_connection_error: conn_err,
@@ -555,7 +508,6 @@ impl MetadataReader {
         // This is a tradeoff - the only alternative is issuing multiple queries, one per connection id.
         // I believe the tradeoff here is correct.
         let client_routes = working_connection
-            .connection
             .query_client_routes(&connection_ids, host_ids)
             .await?;
 

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -37,7 +37,7 @@ use crate::policies::host_filter::HostFilter;
 use crate::utils::safe_format::IteratorSafeFormatExt;
 
 pub(crate) enum ControlConnectionEvent {
-    Broken,
+    Broken(ConnectionError),
     ServerEvent(Event),
     Shutdown,
 }
@@ -47,6 +47,43 @@ struct WorkingControlConnection {
     endpoint: UntranslatedEndpoint,
     error_channel: oneshot::Receiver<ConnectionError>,
     events_channel: mpsc::Receiver<Event>,
+}
+
+impl WorkingControlConnection {
+    pub(crate) async fn wait_for_event(&mut self) -> ControlConnectionEvent {
+        tokio::select! {
+            // Why only `Some`? `None` means that event channel was dropped.
+            // In current implementation (as of writing this comment)
+            // this should not be possible: events sender is stored in HostConnectionConfig,
+            // which is a field of Connection that we own. If we got `None`, then most likely
+            // two things happened:
+            //  - The implementation changed, for example by moving event sender to router.
+            //  - Connection was closed, router shutdown.
+            //  - `tokio::select!` chose this branch instead of error channel.
+            // The best thing we can imo do is ignore this `None`. `error_channel` should receive
+            // info about connection shutdown very soon.
+            Some(cql_event) = self.events_channel.recv() => {
+                ControlConnectionEvent::ServerEvent(cql_event)
+            },
+            maybe_control_connection_failed = &mut self.error_channel => {
+                let err = match maybe_control_connection_failed {
+                    Ok(err) => err,
+                    Err(_recv_error) => {
+                        // If we got here then error channel, in a Connection that we own,
+                        // was dropped without sending anything. This is definitely a bug in the driver!
+                        // We could theoretically recover by dropping a connection and creating new one,
+                        // but we would need to add an error variant to `BrokenConnectionErrorKind` that
+                        // could basically never happen. Let's panic instead.
+                        warn!(concat!("Error sender of control connection unexpectedly dropped. The only case when this ",
+                        "may happen is during runtime shutdown. If you see this and the runtime isn't shutting down, ",
+                        "this is a bug in the driver. Then please open an issue!"));
+                        return ControlConnectionEvent::Shutdown;
+                    },
+                };
+                ControlConnectionEvent::Broken(err)
+            }
+        }
+    }
 }
 
 enum ControlConnectionState {
@@ -153,42 +190,19 @@ impl MetadataReader {
         match &mut self.control_connection_state {
             ControlConnectionState::Broken { .. } => std::future::pending().await,
             ControlConnectionState::Working(working_connection) => {
-                tokio::select! {
-                    // Why only `Some`? `None` means that event channel was dropped.
-                    // In current implementation (as of writing this comment)
-                    // this should not be possible: events sender is stored in HostConnectionConfig,
-                    // which is a field of Connection that we own. If we got `None`, then most likely
-                    // two things happened:
-                    //  - The implementation changed, for example by moving event sender to router.
-                    //  - Connection was closed, router shutdown.
-                    //  - `tokio::select!` chose this branch instead of error channel.
-                    // The best thing we can imo do is ignore this `None`. `error_channel` should receive
-                    // info about connection shutdown very soon.
-                    Some(cql_event) = working_connection.events_channel.recv() => {
-                        ControlConnectionEvent::ServerEvent(cql_event)
-                    },
-                    maybe_control_connection_failed = &mut working_connection.error_channel => {
-                        let err = match maybe_control_connection_failed {
-                            Ok(err) => err,
-                            Err(_recv_error) => {
-                                // If we got here then error channel, in a Connection that we own,
-                                // was dropped without sending anything. This is definitely a bug in the driver!
-                                // We could theoretically recover by dropping a connection and creating new one,
-                                // but we would need to add an error variant to `BrokenConnectionErrorKind` that
-                                // could basically never happen. Let's panic instead.
-                                warn!(concat!("Error sender of control connection unexpectedly dropped. The only case when this ",
-                                "may happen is during runtime shutdown. If you see this and the runtime isn't shutting down, ",
-                                "this is a bug in the driver. Then please open an issue!"));
-                                return ControlConnectionEvent::Shutdown;
+                let event = working_connection.wait_for_event().await;
+                if let ControlConnectionEvent::Broken(err) = &event {
+                    self.control_connection_state = ControlConnectionState::Broken {
+                        last_error: MetadataError::ConnectionPoolError(
+                            ConnectionPoolError::Broken {
+                                last_connection_error: err.clone(),
                             },
-                        };
-                        self.control_connection_state = ControlConnectionState::Broken {
-                            last_error: MetadataError::ConnectionPoolError(ConnectionPoolError::Broken { last_connection_error: err }),
-                            last_endpoint: working_connection.endpoint.clone()
-                        };
-                        ControlConnectionEvent::Broken
-                    }
+                        ),
+                        last_endpoint: working_connection.endpoint.clone(),
+                    };
                 }
+
+                return event;
             }
         }
     }

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -190,18 +190,10 @@ impl MetadataReader {
             self.known_peers.iter().safe_format(", ")
         );
 
-        let address_of_failed_control_connection =
-            self.control_connection_state.endpoint().address();
-        let filtered_known_peers = self
-            .known_peers
-            .clone()
-            .into_iter()
-            .filter(|peer| peer.address() != address_of_failed_control_connection);
-
         // if fetching metadata on current control connection failed,
         // try to fetch metadata from other known peer
         result = self
-            .retry_fetch_metadata_on_nodes(initial, filtered_known_peers, prev_err)
+            .retry_fetch_metadata_on_nodes(initial, self.known_peers.clone().into_iter(), prev_err)
             .await;
 
         if let Err(prev_err) = result {

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -155,19 +155,9 @@ impl MetadataReader {
                     }
                     return Ok(metadata);
                 }
-                Err(err) => {
+                Err(_err) => {
                     // The current control connection is considered broken; it has
                     // been taken out of `self.control_connection` and is dropped here.
-                    if initial {
-                        warn!(
-                            error = ?err,
-                            "Initial metadata read failed, proceeding with metadata \
-                            consisting only of the initial peer list and dummy tokens. \
-                            This might result in suboptimal performance and schema \
-                            information not being available."
-                        );
-                        return Ok(Metadata::new_dummy(&self.known_peers));
-                    }
                     // Establish a fresh control connection below.
                 }
             }
@@ -179,7 +169,7 @@ impl MetadataReader {
         // on failure (so that subsequent refreshes keep trying to reconnect).
         match self.establish_cc_and_fetch_metadata(initial).await {
             Ok((cc, metadata)) => {
-                self.control_connection = Some(cc);
+                self.control_connection = cc;
                 self.handle_unaccepted_host_in_control_connection(&metadata)
                     .await;
                 Ok(metadata)
@@ -197,12 +187,16 @@ impl MetadataReader {
     /// on each. If `initial` is false and all known peers are exhausted, falls back
     /// to re-resolving the initial contact points.
     ///
-    /// On success, updates `known_peers` and returns the working control connection
-    /// together with the fetched metadata.
+    /// On success, updates `known_peers` and returns the fetched metadata together
+    /// with a control connection to use going forward. The returned control
+    /// connection is `None` when metadata was obtained but no usable control
+    /// connection remains: on an `initial` read whose metadata query failed, dummy
+    /// metadata is returned so the session can still start, and the caller is
+    /// expected to re-establish the control connection at the repair cadence.
     async fn establish_cc_and_fetch_metadata(
         &mut self,
         initial: bool,
-    ) -> Result<(ControlConnection, Metadata), MetadataError> {
+    ) -> Result<(Option<ControlConnection>, Metadata), MetadataError> {
         // shuffle known_peers to iterate through them in random order
         self.known_peers.shuffle(&mut rng());
         debug!(
@@ -215,10 +209,10 @@ impl MetadataReader {
         // failed to resolve). We carry the most recent error across attempts and only
         // synthesize a fallback error if no connection was ever attempted.
         let known_peers_err = match self
-            .try_establish_on_nodes(self.known_peers.clone().into_iter())
+            .try_establish_on_nodes(initial, self.known_peers.clone().into_iter())
             .await
         {
-            Ok((cc, metadata)) => return Ok((cc, metadata)),
+            Ok(result) => return Ok(result),
             Err(err) => err,
         };
 
@@ -242,13 +236,14 @@ impl MetadataReader {
                 .await;
         match self
             .try_establish_on_nodes(
+                initial,
                 initial_peers
                     .into_iter()
                     .map(UntranslatedEndpoint::ContactPoint),
             )
             .await
         {
-            Ok((cc, metadata)) => Ok((cc, metadata)),
+            Ok(result) => Ok(result),
             Err(fallback_err) => {
                 let err = fallback_err
                     .or(known_peers_err)
@@ -265,12 +260,18 @@ impl MetadataReader {
     /// Tries to establish a control connection and fetch metadata on each node from
     /// the given iterator, returning the first success.
     ///
+    /// If `initial` is true and a connection was established but its metadata query
+    /// failed, dummy metadata is returned so the session can still start, together
+    /// with no control connection (`Ok((None, metadata))`); the caller is expected
+    /// to re-establish the control connection at the repair cadence.
+    ///
     /// Returns `Err(None)` if the iterator was empty (no connection was ever
     /// attempted), or `Err(Some(err))` with the most recent error otherwise.
     async fn try_establish_on_nodes(
         &mut self,
+        initial: bool,
         nodes: impl Iterator<Item = UntranslatedEndpoint>,
-    ) -> Result<(ControlConnection, Metadata), Option<MetadataError>> {
+    ) -> Result<(Option<ControlConnection>, Metadata), Option<MetadataError>> {
         let mut last_err: Option<MetadataError> = None;
 
         for peer in nodes {
@@ -302,9 +303,23 @@ impl MetadataReader {
                 Ok(metadata) => {
                     debug!("Fetched new metadata");
                     self.update_known_peers(&metadata);
-                    return Ok((cc, metadata));
+                    return Ok((Some(cc), metadata));
                 }
                 Err(err) => {
+                    if initial {
+                        // The control connection was established, but the initial
+                        // metadata query failed. Fall back to dummy metadata so the
+                        // session can still start. Drop the control connection so it is
+                        // re-established at the repair cadence.
+                        warn!(
+                            error = ?err,
+                            "Initial metadata read failed, proceeding with metadata \
+                            consisting only of the initial peer list and dummy tokens. \
+                            This might result in suboptimal performance and schema \
+                            information not being available."
+                        );
+                        return Ok((None, Metadata::new_dummy(&self.known_peers)));
+                    }
                     warn!(
                         control_connection_address = %peer_address,
                         error = %err,

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -36,11 +36,6 @@ use crate::network::{ConnectionConfig, open_connection};
 use crate::policies::host_filter::HostFilter;
 use crate::utils::safe_format::IteratorSafeFormatExt;
 
-enum ControlConnectionState {
-    Working(ControlConnection),
-    Broken { last_error: MetadataError },
-}
-
 /// Allows to read current metadata from the cluster
 pub(crate) struct MetadataReader {
     // =======================================================================================
@@ -60,7 +55,9 @@ pub(crate) struct MetadataReader {
     // ====================================================================
     // Mutable state of MetadataReader. It will change during its lifetime.
     // ====================================================================
-    control_connection_state: ControlConnectionState,
+    // `None` means the control connection is currently broken (or was never
+    // established) and needs to be re-established during the next metadata read.
+    control_connection: Option<ControlConnection>,
     // when control connection fails, MetadataReader tries to connect to one of known_peers
     known_peers: Vec<UntranslatedEndpoint>,
     cc_cache: Arc<ControlConnectionCache>,
@@ -97,18 +94,19 @@ impl MetadataReader {
 
         let cc_cache = Arc::new(ControlConnectionCache::new());
 
-        let control_connection_state = Self::make_control_connection_state(
+        let control_connection = Self::make_control_connection(
             control_connection_endpoint,
             connection_config.clone(),
             request_serverside_timeout,
             Arc::clone(&cc_cache),
             client_routes_subscriber.as_ref().map(Arc::clone),
         )
-        .await;
+        .await
+        .ok();
 
         Ok(MetadataReader {
             control_connection_config: connection_config,
-            control_connection_state,
+            control_connection,
             request_serverside_timeout,
             hostname_resolution_timeout,
             known_peers: initial_peers
@@ -125,18 +123,12 @@ impl MetadataReader {
     }
 
     pub(crate) async fn wait_for_control_connection_event(&mut self) -> ControlConnectionEvent {
-        match &mut self.control_connection_state {
-            ControlConnectionState::Broken { .. } => std::future::pending().await,
-            ControlConnectionState::Working(working_connection) => {
+        match &mut self.control_connection {
+            None => std::future::pending().await,
+            Some(working_connection) => {
                 let event = working_connection.wait_for_event().await;
-                if let ControlConnectionEvent::Broken(err) = &event {
-                    self.control_connection_state = ControlConnectionState::Broken {
-                        last_error: MetadataError::ConnectionPoolError(
-                            ConnectionPoolError::Broken {
-                                last_connection_error: err.clone(),
-                            },
-                        ),
-                    };
+                if let ControlConnectionEvent::Broken(_) = &event {
+                    self.control_connection = None;
                 }
 
                 event
@@ -145,46 +137,55 @@ impl MetadataReader {
     }
 
     pub(crate) fn control_connection_works(&self) -> bool {
-        matches!(
-            self.control_connection_state,
-            ControlConnectionState::Working(_)
-        )
+        self.control_connection.is_some()
     }
 
     /// Fetches current metadata from the cluster
     pub(crate) async fn read_metadata(&mut self, initial: bool) -> Result<Metadata, MetadataError> {
-        // First, try to fetch metadata on the current control connection.
-        match self.fetch_metadata(initial).await {
-            Ok(metadata) => {
-                debug!("Fetched new metadata");
-                self.update_known_peers(&metadata);
-                if initial {
-                    self.handle_unaccepted_host_in_control_connection(&metadata)
-                        .await;
+        // First, try to fetch metadata on the current control connection, if we have one.
+        if let Some(cc) = self.control_connection.take() {
+            match self.query_metadata_on_cc(&cc).await {
+                Ok(metadata) => {
+                    debug!("Fetched new metadata");
+                    self.update_known_peers(&metadata);
+                    self.control_connection = Some(cc);
+                    if initial {
+                        self.handle_unaccepted_host_in_control_connection(&metadata)
+                            .await;
+                    }
+                    return Ok(metadata);
                 }
-                return Ok(metadata);
-            }
-            Err(_prev_err) => {
-                // Fetching metadata on the current control connection failed.
-                // Establish a fresh control connection below.
+                Err(err) => {
+                    // The current control connection is considered broken; it has
+                    // been taken out of `self.control_connection` and is dropped here.
+                    if initial {
+                        warn!(
+                            error = ?err,
+                            "Initial metadata read failed, proceeding with metadata \
+                            consisting only of the initial peer list and dummy tokens. \
+                            This might result in suboptimal performance and schema \
+                            information not being available."
+                        );
+                        return Ok(Metadata::new_dummy(&self.known_peers));
+                    }
+                    // Establish a fresh control connection below.
+                }
             }
         }
 
         // Establish a fresh control connection (iterating over known peers and, as a
         // last resort, the initial contact points) and fetch metadata on it. Update
-        // the control connection state to reflect the outcome: `Working` on success,
-        // `Broken` on failure (so that subsequent refreshes keep trying to reconnect).
+        // the control connection to reflect the outcome: `Some` on success, `None`
+        // on failure (so that subsequent refreshes keep trying to reconnect).
         match self.establish_cc_and_fetch_metadata(initial).await {
             Ok((cc, metadata)) => {
-                self.control_connection_state = ControlConnectionState::Working(cc);
+                self.control_connection = Some(cc);
                 self.handle_unaccepted_host_in_control_connection(&metadata)
                     .await;
                 Ok(metadata)
             }
             Err(err) => {
-                self.control_connection_state = ControlConnectionState::Broken {
-                    last_error: err.clone(),
-                };
+                self.control_connection = None;
                 Err(err)
             }
         }
@@ -318,37 +319,6 @@ impl MetadataReader {
         Err(last_err)
     }
 
-    async fn fetch_metadata(&mut self, initial: bool) -> Result<Metadata, MetadataError> {
-        let working_connection = match &self.control_connection_state {
-            ControlConnectionState::Working(working_connection) => working_connection,
-            ControlConnectionState::Broken { last_error: e } => {
-                return Err(e.clone());
-            }
-        };
-
-        let res = self.query_metadata_on_cc(working_connection).await;
-
-        // If metadata fetch failed, we consider the connection broken.
-        if let Err(err) = &res {
-            self.control_connection_state = ControlConnectionState::Broken {
-                last_error: err.clone(),
-            }
-        }
-
-        if initial && let Err(err) = res {
-            warn!(
-                error = ?err,
-                "Initial metadata read failed, proceeding with metadata \
-                consisting only of the initial peer list and dummy tokens. \
-                This might result in suboptimal performance and schema \
-                information not being available."
-            );
-            return Ok(Metadata::new_dummy(&self.known_peers));
-        }
-
-        res
-    }
-
     /// Queries metadata on the given control connection.
     ///
     /// This is a thin wrapper over [`ControlConnection::query_metadata`] that fills in
@@ -395,8 +365,7 @@ impl MetadataReader {
 
     async fn handle_unaccepted_host_in_control_connection(&mut self, metadata: &Metadata) {
         // We only care about the endpoint of a working control connection here.
-        let ControlConnectionState::Working(working_connection) = &self.control_connection_state
-        else {
+        let Some(working_connection) = &self.control_connection else {
             return;
         };
         let endpoint = working_connection.endpoint();
@@ -408,14 +377,16 @@ impl MetadataReader {
                 .expect("known_peers is empty - should be impossible")
                 .clone();
 
-            self.control_connection_state = Self::make_control_connection_state(
-                control_connection_endpoint,
-                self.control_connection_config.clone(),
-                self.request_serverside_timeout,
-                Arc::clone(&self.cc_cache),
-                self.client_routes_subscriber.as_ref().map(Arc::clone),
-            )
-            .await;
+                self.control_connection = Self::make_control_connection(
+                    control_connection_endpoint,
+                    self.control_connection_config.clone(),
+                    self.request_serverside_timeout,
+                    Arc::clone(&self.cc_cache),
+                    self.client_routes_subscriber.as_ref().map(Arc::clone),
+                )
+                .await
+                .ok();
+            }
         }
     }
 
@@ -452,29 +423,6 @@ impl MetadataReader {
             return true;
         }
         false
-    }
-
-    /// Opens a control connection to `endpoint`, wrapping the outcome in a
-    /// [`ControlConnectionState`] (either `Working` or `Broken`).
-    async fn make_control_connection_state(
-        endpoint: UntranslatedEndpoint,
-        config: ConnectionConfig,
-        request_serverside_timeout: Option<Duration>,
-        cache: Arc<ControlConnectionCache>,
-        client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
-    ) -> ControlConnectionState {
-        match Self::make_control_connection(
-            endpoint,
-            config,
-            request_serverside_timeout,
-            cache,
-            client_routes_subscriber,
-        )
-        .await
-        {
-            Ok(cc) => ControlConnectionState::Working(cc),
-            Err(last_error) => ControlConnectionState::Broken { last_error },
-        }
     }
 
     async fn make_control_connection(
@@ -532,11 +480,10 @@ impl MetadataReader {
         &mut self,
         evt: &ClientRoutesChangeEvent,
     ) -> Result<HashSet<Uuid>, MetadataError> {
-        let working_connection = match &self.control_connection_state {
-            ControlConnectionState::Working(working_connection) => working_connection,
-            ControlConnectionState::Broken { last_error: e } => {
-                return Err(e.clone());
-            }
+        let Some(working_connection) = &self.control_connection else {
+            // We received this event on the control connection, so it must be present.
+            warn!("BUG: Received a ClientRoutesChange event without a control connection!");
+            return Ok(HashSet::new());
         };
 
         let Some(subscriber) = &self.client_routes_subscriber else {

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -153,8 +153,8 @@ impl MetadataReader {
 
     /// Fetches current metadata from the cluster
     pub(crate) async fn read_metadata(&mut self, initial: bool) -> Result<Metadata, MetadataError> {
-        let mut result = self.fetch_metadata(initial).await;
-        let prev_err = match result {
+        // First, try to fetch metadata on the current control connection.
+        match self.fetch_metadata(initial).await {
             Ok(metadata) => {
                 debug!("Fetched new metadata");
                 self.update_known_peers(&metadata);
@@ -164,102 +164,155 @@ impl MetadataReader {
                 }
                 return Ok(metadata);
             }
-            Err(err) => err,
-        };
+            Err(_prev_err) => {
+                // Fetching metadata on the current control connection failed.
+                // Establish a fresh control connection below.
+            }
+        }
 
-        // At this point, we known that fetching metadata on current control connection failed.
-        // Therefore, we try to fetch metadata from other known peers, in order.
+        // Establish a fresh control connection (iterating over known peers and, as a
+        // last resort, the initial contact points) and fetch metadata on it. Update
+        // the control connection state to reflect the outcome: `Working` on success,
+        // `Broken` on failure (so that subsequent refreshes keep trying to reconnect).
+        match self.establish_cc_and_fetch_metadata(initial).await {
+            Ok((cc, metadata)) => {
+                self.control_connection_state = ControlConnectionState::Working(cc);
+                self.handle_unaccepted_host_in_control_connection(&metadata)
+                    .await;
+                Ok(metadata)
+            }
+            Err(err) => {
+                self.control_connection_state = ControlConnectionState::Broken {
+                    last_error: err.clone(),
+                };
+                Err(err)
+            }
+        }
+    }
 
-        // shuffle known_peers to iterate through them in random order later
+    /// Establishes a control connection and fetches metadata in one go.
+    ///
+    /// Iterates over known peers (shuffled), trying to connect and fetch metadata
+    /// on each. If `initial` is false and all known peers are exhausted, falls back
+    /// to re-resolving the initial contact points.
+    ///
+    /// On success, updates `known_peers` and returns the working control connection
+    /// together with the fetched metadata.
+    async fn establish_cc_and_fetch_metadata(
+        &mut self,
+        initial: bool,
+    ) -> Result<(ControlConnection, Metadata), MetadataError> {
+        // shuffle known_peers to iterate through them in random order
         self.known_peers.shuffle(&mut rng());
         debug!(
             "Known peers: {:?}",
             self.known_peers.iter().safe_format(", ")
         );
 
-        // if fetching metadata on current control connection failed,
-        // try to fetch metadata from other known peer
-        result = self
-            .retry_fetch_metadata_on_nodes(initial, self.known_peers.clone().into_iter(), prev_err)
-            .await;
+        // `try_establish_on_nodes` returns `Err(None)` if the node iterator was empty
+        // (e.g. all known peers were rejected by the host filter, or contact points
+        // failed to resolve). We carry the most recent error across attempts and only
+        // synthesize a fallback error if no connection was ever attempted.
+        let known_peers_err = match self
+            .try_establish_on_nodes(self.known_peers.clone().into_iter())
+            .await
+        {
+            Ok((cc, metadata)) => return Ok((cc, metadata)),
+            Err(err) => err,
+        };
 
-        if let Err(prev_err) = result {
-            if !initial {
-                // If no known peer is reachable, try falling back to initial contact points, in hope that
-                // there are some hostnames there which will resolve to reachable new addresses.
-                warn!(
-                    "Failed to establish control connection and fetch metadata on all known peers. Falling back to initial contact points."
-                );
-                let (initial_peers, _hostnames) = resolve_contact_points(
-                    &self.initial_known_nodes,
-                    self.hostname_resolution_timeout,
-                )
+        if initial {
+            // No point in falling back as this is an initial connection attempt.
+            let err = known_peers_err.unwrap_or_else(no_nodes_available_error);
+            error!(
+                error = ?err,
+                "Could not establish control connection and fetch metadata"
+            );
+            return Err(err);
+        }
+
+        // If no known peer is reachable, try falling back to initial contact points, in hope that
+        // there are some hostnames there which will resolve to reachable new addresses.
+        warn!(
+            "Failed to establish control connection and fetch metadata on all known peers. Falling back to initial contact points."
+        );
+        let (initial_peers, _hostnames) =
+            resolve_contact_points(&self.initial_known_nodes, self.hostname_resolution_timeout)
                 .await;
-                result = self
-                    .retry_fetch_metadata_on_nodes(
-                        initial,
-                        initial_peers
-                            .into_iter()
-                            .map(UntranslatedEndpoint::ContactPoint),
-                        prev_err,
-                    )
-                    .await;
-            } else {
-                // No point in falling back as this is an initial connection attempt.
-                result = Err(prev_err);
-            }
-        }
-
-        match &result {
-            Ok(metadata) => {
-                self.update_known_peers(metadata);
-                self.handle_unaccepted_host_in_control_connection(metadata)
-                    .await;
-                debug!("Fetched new metadata");
-            }
-            Err(error) => {
+        match self
+            .try_establish_on_nodes(
+                initial_peers
+                    .into_iter()
+                    .map(UntranslatedEndpoint::ContactPoint),
+            )
+            .await
+        {
+            Ok((cc, metadata)) => Ok((cc, metadata)),
+            Err(fallback_err) => {
+                let err = fallback_err
+                    .or(known_peers_err)
+                    .unwrap_or_else(no_nodes_available_error);
                 error!(
-                    error = %error,
-                    "Could not fetch metadata"
-                )
+                    error = ?err,
+                    "Could not establish control connection and fetch metadata"
+                );
+                Err(err)
             }
         }
-
-        result
     }
 
-    async fn retry_fetch_metadata_on_nodes(
+    /// Tries to establish a control connection and fetch metadata on each node from
+    /// the given iterator, returning the first success.
+    ///
+    /// Returns `Err(None)` if the iterator was empty (no connection was ever
+    /// attempted), or `Err(Some(err))` with the most recent error otherwise.
+    async fn try_establish_on_nodes(
         &mut self,
-        initial: bool,
         nodes: impl Iterator<Item = UntranslatedEndpoint>,
-        prev_err: MetadataError,
-    ) -> Result<Metadata, MetadataError> {
-        let mut last_err = prev_err;
+    ) -> Result<(ControlConnection, Metadata), Option<MetadataError>> {
+        let mut last_err: Option<MetadataError> = None;
+
         for peer in nodes {
             let peer_address = peer.address();
-            debug!("Retrying to establish the control connection on {peer_address}");
+            debug!("Trying to establish control connection on {peer_address}");
 
-            self.control_connection_state = Self::make_control_connection_state(
+            let cc = match Self::make_control_connection(
                 peer,
                 self.control_connection_config.clone(),
                 self.request_serverside_timeout,
                 Arc::clone(&self.cc_cache),
                 self.client_routes_subscriber.as_ref().map(Arc::clone),
             )
-            .await;
-
-            let err = match self.fetch_metadata(initial).await {
-                Ok(metadata) => return Ok(metadata),
-                Err(err) => err,
+            .await
+            {
+                Ok(cc) => cc,
+                Err(err) => {
+                    warn!(
+                        control_connection_address = %peer_address,
+                        error = %err,
+                        "Failed to establish control connection"
+                    );
+                    last_err = Some(err);
+                    continue;
+                }
             };
 
-            warn!(
-                control_connection_address = %peer_address,
-                error = %err,
-                "Failed to fetch metadata using current control connection"
-            );
-
-            last_err = err;
+            match self.query_metadata_on_cc(&cc).await {
+                Ok(metadata) => {
+                    debug!("Fetched new metadata");
+                    self.update_known_peers(&metadata);
+                    return Ok((cc, metadata));
+                }
+                Err(err) => {
+                    warn!(
+                        control_connection_address = %peer_address,
+                        error = %err,
+                        "Failed to fetch metadata using current control connection"
+                    );
+                    last_err = Some(err);
+                    // CC is dropped here, we continue to next peer.
+                }
+            }
         }
 
         Err(last_err)
@@ -531,4 +584,11 @@ impl MetadataReader {
 
         Ok(updated_hosts)
     }
+}
+
+/// Error to report when there was not a single node to even attempt a control
+/// connection on (e.g. all known peers were rejected by the host filter and the
+/// initial contact points failed to resolve to any address).
+fn no_nodes_available_error() -> MetadataError {
+    MetadataError::ConnectionPoolError(ConnectionPoolError::NodeDisabledByHostFilter)
 }

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -294,15 +294,9 @@ impl MetadataReader {
                 return Err(e.clone());
             }
         };
-        let endpoint = working_connection.endpoint().clone();
 
-        let res = working_connection
-            .query_metadata(
-                endpoint.address().port(),
-                &self.keyspaces_to_fetch,
-                self.fetch_schema,
-            )
-            .await;
+        let endpoint = working_connection.endpoint().clone();
+        let res = self.query_metadata_on_cc(working_connection).await;
 
         // If metadata fetch failed, we consider the connection broken.
         if let Err(err) = &res {
@@ -324,6 +318,23 @@ impl MetadataReader {
         }
 
         res
+    }
+
+    /// Queries metadata on the given control connection.
+    ///
+    /// This is a thin wrapper over [`ControlConnection::query_metadata`] that fills in
+    /// the reader's configuration (keyspaces to fetch, whether to fetch schema). It does
+    /// **not** update `known_peers` nor touch the control connection state.
+    async fn query_metadata_on_cc(
+        &self,
+        cc: &ControlConnection,
+    ) -> Result<Metadata, MetadataError> {
+        cc.query_metadata(
+            cc.endpoint().address().port(),
+            &self.keyspaces_to_fetch,
+            self.fetch_schema,
+        )
+        .await
     }
 
     fn update_known_peers(&mut self, metadata: &Metadata) {

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -149,10 +149,6 @@ impl MetadataReader {
                     debug!("Fetched new metadata");
                     self.update_known_peers(&metadata);
                     self.control_connection = Some(cc);
-                    if initial {
-                        self.handle_unaccepted_host_in_control_connection(&metadata)
-                            .await;
-                    }
                     return Ok(metadata);
                 }
                 Err(_err) => {
@@ -170,8 +166,6 @@ impl MetadataReader {
         match self.establish_cc_and_fetch_metadata(initial).await {
             Ok((cc, metadata)) => {
                 self.control_connection = cc;
-                self.handle_unaccepted_host_in_control_connection(&metadata)
-                    .await;
                 Ok(metadata)
             }
             Err(err) => {
@@ -190,9 +184,13 @@ impl MetadataReader {
     /// On success, updates `known_peers` and returns the fetched metadata together
     /// with a control connection to use going forward. The returned control
     /// connection is `None` when metadata was obtained but no usable control
-    /// connection remains: on an `initial` read whose metadata query failed, dummy
-    /// metadata is returned so the session can still start, and the caller is
-    /// expected to re-establish the control connection at the repair cadence.
+    /// connection remains:
+    /// - on an `initial` read whose metadata query failed (dummy metadata is
+    ///   returned so the session can still start), or
+    /// - when every node that yielded metadata is rejected by the host filter.
+    ///
+    /// In both of these cases the caller is expected to re-establish the control
+    /// connection at the repair cadence.
     async fn establish_cc_and_fetch_metadata(
         &mut self,
         initial: bool,
@@ -258,12 +256,15 @@ impl MetadataReader {
     }
 
     /// Tries to establish a control connection and fetch metadata on each node from
-    /// the given iterator, returning the first success.
+    /// the given iterator.
     ///
-    /// If `initial` is true and a connection was established but its metadata query
-    /// failed, dummy metadata is returned so the session can still start, together
-    /// with no control connection (`Ok((None, metadata))`); the caller is expected
-    /// to re-establish the control connection at the repair cadence.
+    /// Returns the first working, host-filter-accepted control connection together
+    /// with its metadata. Two situations yield metadata but no control connection
+    /// (`Ok((None, metadata))`):
+    /// - every node that could be queried is rejected by the host filter — the
+    ///   metadata is valid cluster-wide, but none of the connections may be kept;
+    /// - `initial` is true and a connection was established but its metadata query
+    ///   failed — dummy metadata is returned so the session can still start.
     ///
     /// Returns `Err(None)` if the iterator was empty (no connection was ever
     /// attempted), or `Err(Some(err))` with the most recent error otherwise.
@@ -273,6 +274,10 @@ impl MetadataReader {
         nodes: impl Iterator<Item = UntranslatedEndpoint>,
     ) -> Result<(Option<ControlConnection>, Metadata), Option<MetadataError>> {
         let mut last_err: Option<MetadataError> = None;
+        // Metadata fetched from a host-filter-rejected node. It is valid cluster-wide,
+        // so it is kept as a fallback in case no accepted node can be reached, while we
+        // keep looking for an accepted node to host the control connection on.
+        let mut rejected_metadata: Option<Metadata> = None;
 
         for peer in nodes {
             let peer_address = peer.address();
@@ -299,26 +304,26 @@ impl MetadataReader {
                 }
             };
 
-            match self.query_metadata_on_cc(&cc).await {
-                Ok(metadata) => {
-                    debug!("Fetched new metadata");
-                    self.update_known_peers(&metadata);
-                    return Ok((Some(cc), metadata));
-                }
+            let metadata = match self.query_metadata_on_cc(&cc).await {
+                Ok(metadata) => metadata,
                 Err(err) => {
                     if initial {
                         // The control connection was established, but the initial
-                        // metadata query failed. Fall back to dummy metadata so the
-                        // session can still start. Drop the control connection so it is
-                        // re-established at the repair cadence.
-                        warn!(
-                            error = ?err,
-                            "Initial metadata read failed, proceeding with metadata \
-                            consisting only of the initial peer list and dummy tokens. \
-                            This might result in suboptimal performance and schema \
-                            information not being available."
-                        );
-                        return Ok((None, Metadata::new_dummy(&self.known_peers)));
+                        // metadata query failed. Prefer any valid metadata already
+                        // obtained from a rejected node; otherwise fall back to dummy
+                        // metadata so the session can still start. Either way, drop the
+                        // control connection so it is re-established at the repair cadence.
+                        let metadata = rejected_metadata.take().unwrap_or_else(|| {
+                            warn!(
+                                error = ?err,
+                                "Initial metadata read failed, proceeding with metadata \
+                                consisting only of the initial peer list and dummy tokens. \
+                                This might result in suboptimal performance and schema \
+                                information not being available."
+                            );
+                            Metadata::new_dummy(&self.known_peers)
+                        });
+                        return Ok((None, metadata));
                     }
                     warn!(
                         control_connection_address = %peer_address,
@@ -326,12 +331,29 @@ impl MetadataReader {
                         "Failed to fetch metadata using current control connection"
                     );
                     last_err = Some(err);
-                    // CC is dropped here, we continue to next peer.
+                    // CC is dropped here, we continue to the next peer.
+                    continue;
                 }
+            };
+
+            debug!("Fetched new metadata");
+            self.update_known_peers(&metadata);
+
+            if self.is_cc_endpoint_rejected(cc.endpoint(), &metadata) {
+                // The node hosting this control connection is rejected by the host
+                // filter. The metadata is valid cluster-wide, so remember it, but drop
+                // the connection and keep looking for a host-filter-accepted node.
+                rejected_metadata = Some(metadata);
+                continue;
             }
+
+            return Ok((Some(cc), metadata));
         }
 
-        Err(last_err)
+        match rejected_metadata {
+            Some(metadata) => Ok((None, metadata)),
+            None => Err(last_err),
+        }
     }
 
     /// Queries metadata on the given control connection.
@@ -375,33 +397,6 @@ impl MetadataReader {
                 no connections that can serve user queries have been \
                 established. The session cannot serve any queries!"
             )
-        }
-    }
-
-    async fn handle_unaccepted_host_in_control_connection(&mut self, metadata: &Metadata) {
-        // We only care about the endpoint of a working control connection here.
-        let Some(working_connection) = &self.control_connection else {
-            return;
-        };
-        let endpoint = working_connection.endpoint();
-        // Assuming here that known_peers are up-to-date
-        if self.is_cc_endpoint_rejected(endpoint, metadata) && !self.known_peers.is_empty() {
-            let control_connection_endpoint = self
-                .known_peers
-                .choose(&mut rng())
-                .expect("known_peers is empty - should be impossible")
-                .clone();
-
-                self.control_connection = Self::make_control_connection(
-                    control_connection_endpoint,
-                    self.control_connection_config.clone(),
-                    self.request_serverside_timeout,
-                    Arc::clone(&self.cc_cache),
-                    self.client_routes_subscriber.as_ref().map(Arc::clone),
-                )
-                .await
-                .ok();
-            }
         }
     }
 

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -38,19 +38,7 @@ use crate::utils::safe_format::IteratorSafeFormatExt;
 
 enum ControlConnectionState {
     Working(ControlConnection),
-    Broken {
-        last_error: MetadataError,
-        last_endpoint: UntranslatedEndpoint,
-    },
-}
-
-impl ControlConnectionState {
-    fn endpoint(&self) -> &UntranslatedEndpoint {
-        match self {
-            ControlConnectionState::Working(c) => c.endpoint(),
-            ControlConnectionState::Broken { last_endpoint, .. } => last_endpoint,
-        }
-    }
+    Broken { last_error: MetadataError },
 }
 
 /// Allows to read current metadata from the cluster
@@ -148,7 +136,6 @@ impl MetadataReader {
                                 last_connection_error: err.clone(),
                             },
                         ),
-                        last_endpoint: working_connection.endpoint().clone(),
                     };
                 }
 
@@ -281,19 +268,17 @@ impl MetadataReader {
     async fn fetch_metadata(&mut self, initial: bool) -> Result<Metadata, MetadataError> {
         let working_connection = match &self.control_connection_state {
             ControlConnectionState::Working(working_connection) => working_connection,
-            ControlConnectionState::Broken { last_error: e, .. } => {
+            ControlConnectionState::Broken { last_error: e } => {
                 return Err(e.clone());
             }
         };
 
-        let endpoint = working_connection.endpoint().clone();
         let res = self.query_metadata_on_cc(working_connection).await;
 
         // If metadata fetch failed, we consider the connection broken.
         if let Err(err) = &res {
             self.control_connection_state = ControlConnectionState::Broken {
                 last_error: err.clone(),
-                last_endpoint: endpoint,
             }
         }
 
@@ -356,7 +341,12 @@ impl MetadataReader {
     }
 
     async fn handle_unaccepted_host_in_control_connection(&mut self, metadata: &Metadata) {
-        let endpoint = self.control_connection_state.endpoint();
+        // We only care about the endpoint of a working control connection here.
+        let ControlConnectionState::Working(working_connection) = &self.control_connection_state
+        else {
+            return;
+        };
+        let endpoint = working_connection.endpoint();
         // Assuming here that known_peers are up-to-date
         if self.is_cc_endpoint_rejected(endpoint, metadata) && !self.known_peers.is_empty() {
             let control_connection_endpoint = self
@@ -420,7 +410,6 @@ impl MetadataReader {
         cache: Arc<ControlConnectionCache>,
         client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
     ) -> ControlConnectionState {
-        let last_endpoint = endpoint.clone();
         match Self::make_control_connection(
             endpoint,
             config,
@@ -431,10 +420,7 @@ impl MetadataReader {
         .await
         {
             Ok(cc) => ControlConnectionState::Working(cc),
-            Err(last_error) => ControlConnectionState::Broken {
-                last_error,
-                last_endpoint,
-            },
+            Err(last_error) => ControlConnectionState::Broken { last_error },
         }
     }
 
@@ -495,7 +481,7 @@ impl MetadataReader {
     ) -> Result<HashSet<Uuid>, MetadataError> {
         let working_connection = match &self.control_connection_state {
             ControlConnectionState::Working(working_connection) => working_connection,
-            ControlConnectionState::Broken { last_error: e, .. } => {
+            ControlConnectionState::Broken { last_error: e } => {
                 return Err(e.clone());
             }
         };

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -362,10 +362,38 @@ impl MetadataReader {
     }
 
     async fn handle_unaccepted_host_in_control_connection(&mut self, metadata: &Metadata) {
+        let endpoint = self.control_connection_state.endpoint();
+        // Assuming here that known_peers are up-to-date
+        if self.is_cc_endpoint_rejected(endpoint, metadata) && !self.known_peers.is_empty() {
+            let control_connection_endpoint = self
+                .known_peers
+                .choose(&mut rng())
+                .expect("known_peers is empty - should be impossible")
+                .clone();
+
+            self.control_connection_state = Self::make_control_connection_state(
+                control_connection_endpoint,
+                self.control_connection_config.clone(),
+                self.request_serverside_timeout,
+                Arc::clone(&self.cc_cache),
+                self.client_routes_subscriber.as_ref().map(Arc::clone),
+            )
+            .await;
+        }
+    }
+
+    /// Returns true if the control connection endpoint is on a node rejected
+    /// by the host filter, meaning the caller should re-establish the CC on
+    /// an accepted node.
+    fn is_cc_endpoint_rejected(
+        &self,
+        endpoint: &UntranslatedEndpoint,
+        metadata: &Metadata,
+    ) -> bool {
         let control_connection_peer = metadata
             .peers
             .iter()
-            .find(|peer| matches!(self.control_connection_state.endpoint(), UntranslatedEndpoint::Peer(PeerEndpoint{address, ..}) if *address == peer.address));
+            .find(|peer| matches!(endpoint, UntranslatedEndpoint::Peer(PeerEndpoint{address, ..}) if *address == peer.address));
         if let Some(peer) = control_connection_peer
             && !self.host_filter.as_ref().is_none_or(|f| f.accept(peer))
         {
@@ -377,32 +405,16 @@ impl MetadataReader {
                     .map(|peer| peer.address)
                     .safe_format(", ")
                 ),
-                control_connection_address = ?self.control_connection_state.endpoint().address(),
+                control_connection_address = ?endpoint.address(),
                 "The node that the control connection is established to \
                 is not accepted by the host filter. Please verify that \
                 the nodes in your initial peers list are accepted by the \
                 host filter. The driver will try to re-establish the \
                 control connection to a different node."
             );
-
-            // Assuming here that known_peers are up-to-date
-            if !self.known_peers.is_empty() {
-                let control_connection_endpoint = self
-                    .known_peers
-                    .choose(&mut rng())
-                    .expect("known_peers is empty - should be impossible")
-                    .clone();
-
-                self.control_connection_state = Self::make_control_connection_state(
-                    control_connection_endpoint,
-                    self.control_connection_config.clone(),
-                    self.request_serverside_timeout,
-                    Arc::clone(&self.cc_cache),
-                    self.client_routes_subscriber.as_ref().map(Arc::clone),
-                )
-                .await;
-            }
+            return true;
         }
+        false
     }
 
     /// Opens a control connection to `endpoint`, wrapping the outcome in a

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -1,32 +1,31 @@
 //! This module contains the [`MetadataReader`] struct, which is responsible for
-//! fetching and maintaining cluster metadata through a control connection.
+//! creating control connections and fetching cluster metadata through them.
 //!
 //! The control connection is a dedicated connection to one of the cluster nodes
 //! that is used to:
 //! - Fetch cluster metadata (topology, schema, token ring information)
 //! - Receive server-side events (topology changes, schema changes, status changes)
 //!
-//! [`MetadataReader`] handles control connection lifecycle, including:
-//! - Initial connection establishment to contact points
-//! - Automatic reconnection to other known peers on connection failure
-//! - Fallback to initial contact points when all known peers are unreachable
+//! [`MetadataReader`] establishes control connections, including:
+//! - Connection establishment to contact points or known peers
+//! - Iterating over known peers and initial contact points on connection failure
 //! - Host filtering to ensure the control connection is established to an accepted node
 //!
+//! Ownership of the established control connection lives outside the reader (in the
+//! cluster worker); the reader only knows how to create one and fetch metadata on it.
 
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use rand::rng;
-use rand::seq::{IndexedRandom, SliceRandom};
+use rand::seq::SliceRandom;
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
-use crate::cluster::control_connection::{
-    ControlConnection, ControlConnectionCache, ControlConnectionEvent,
-};
+use crate::cluster::control_connection::{ControlConnection, ControlConnectionCache};
 use crate::cluster::metadata::{Metadata, PeerEndpoint, UntranslatedEndpoint};
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
@@ -36,7 +35,9 @@ use crate::network::{ConnectionConfig, open_connection};
 use crate::policies::host_filter::HostFilter;
 use crate::utils::safe_format::IteratorSafeFormatExt;
 
-/// Allows to read current metadata from the cluster
+/// Maintains the persistent state needed to create control connections and
+/// fetch cluster metadata. The established control connection itself is owned by
+/// the caller (the cluster worker), not by the reader.
 pub(crate) struct MetadataReader {
     // =======================================================================================
     // Configuration values - they will stay the same during whole lifetime of MetadataReader.
@@ -55,16 +56,18 @@ pub(crate) struct MetadataReader {
     // ====================================================================
     // Mutable state of MetadataReader. It will change during its lifetime.
     // ====================================================================
-    // `None` means the control connection is currently broken (or was never
-    // established) and needs to be re-established during the next metadata read.
-    control_connection: Option<ControlConnection>,
-    // when control connection fails, MetadataReader tries to connect to one of known_peers
+    // when a control connection fails, MetadataReader tries to connect to one of known_peers
     known_peers: Vec<UntranslatedEndpoint>,
     cc_cache: Arc<ControlConnectionCache>,
 }
 
 impl MetadataReader {
-    /// Creates new MetadataReader, which connects to initially_known_peers in the background
+    /// Creates a new MetadataReader.
+    ///
+    /// Resolves the initial contact points and populates the initial known peers
+    /// list. Does **not** establish a control connection — use
+    /// [`establish_cc_and_fetch_metadata`](Self::establish_cc_and_fetch_metadata)
+    /// for that.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         initial_known_nodes: Vec<KnownNode>,
@@ -85,28 +88,10 @@ impl MetadataReader {
             ));
         }
 
-        let control_connection_endpoint = UntranslatedEndpoint::ContactPoint(
-            initial_peers
-                .choose(&mut rng())
-                .expect("Tried to initialize MetadataReader with empty initial_known_nodes list!")
-                .clone(),
-        );
-
         let cc_cache = Arc::new(ControlConnectionCache::new());
-
-        let control_connection = Self::make_control_connection(
-            control_connection_endpoint,
-            connection_config.clone(),
-            request_serverside_timeout,
-            Arc::clone(&cc_cache),
-            client_routes_subscriber.as_ref().map(Arc::clone),
-        )
-        .await
-        .ok();
 
         Ok(MetadataReader {
             control_connection_config: connection_config,
-            control_connection,
             request_serverside_timeout,
             hostname_resolution_timeout,
             known_peers: initial_peers
@@ -122,57 +107,21 @@ impl MetadataReader {
         })
     }
 
-    pub(crate) async fn wait_for_control_connection_event(&mut self) -> ControlConnectionEvent {
-        match &mut self.control_connection {
-            None => std::future::pending().await,
-            Some(working_connection) => {
-                let event = working_connection.wait_for_event().await;
-                if let ControlConnectionEvent::Broken(_) = &event {
-                    self.control_connection = None;
-                }
-
-                event
-            }
-        }
-    }
-
-    pub(crate) fn control_connection_works(&self) -> bool {
-        self.control_connection.is_some()
-    }
-
-    /// Fetches current metadata from the cluster
-    pub(crate) async fn read_metadata(&mut self, initial: bool) -> Result<Metadata, MetadataError> {
-        // First, try to fetch metadata on the current control connection, if we have one.
-        if let Some(cc) = self.control_connection.take() {
-            match self.query_metadata_on_cc(&cc).await {
-                Ok(metadata) => {
-                    debug!("Fetched new metadata");
-                    self.update_known_peers(&metadata);
-                    self.control_connection = Some(cc);
-                    return Ok(metadata);
-                }
-                Err(_err) => {
-                    // The current control connection is considered broken; it has
-                    // been taken out of `self.control_connection` and is dropped here.
-                    // Establish a fresh control connection below.
-                }
-            }
-        }
-
-        // Establish a fresh control connection (iterating over known peers and, as a
-        // last resort, the initial contact points) and fetch metadata on it. Update
-        // the control connection to reflect the outcome: `Some` on success, `None`
-        // on failure (so that subsequent refreshes keep trying to reconnect).
-        match self.establish_cc_and_fetch_metadata(initial).await {
-            Ok((cc, metadata)) => {
-                self.control_connection = cc;
-                Ok(metadata)
-            }
-            Err(err) => {
-                self.control_connection = None;
-                Err(err)
-            }
-        }
+    /// Fetches metadata using an already-established control connection.
+    ///
+    /// On success, updates `self.known_peers` with the peers from the fetched
+    /// metadata. Does **not** retry on other nodes — the caller should drop the
+    /// control connection and call
+    /// [`establish_cc_and_fetch_metadata`](Self::establish_cc_and_fetch_metadata)
+    /// if this fails.
+    pub(crate) async fn fetch_metadata_on_cc(
+        &mut self,
+        cc: &ControlConnection,
+    ) -> Result<Metadata, MetadataError> {
+        let metadata = self.query_metadata_on_cc(cc).await?;
+        debug!("Fetched new metadata");
+        self.update_known_peers(&metadata);
+        Ok(metadata)
     }
 
     /// Establishes a control connection and fetches metadata in one go.
@@ -191,7 +140,7 @@ impl MetadataReader {
     ///
     /// In both of these cases the caller is expected to re-establish the control
     /// connection at the repair cadence.
-    async fn establish_cc_and_fetch_metadata(
+    pub(crate) async fn establish_cc_and_fetch_metadata(
         &mut self,
         initial: bool,
     ) -> Result<(Option<ControlConnection>, Metadata), MetadataError> {
@@ -487,15 +436,10 @@ impl MetadataReader {
     ///
     /// Then, the updates are fed to the [`ClientRoutesSubscriber`] for merging with previous knowledge.
     pub(in super::super) async fn fetch_client_route_updates_on_event(
-        &mut self,
+        &self,
+        cc: &ControlConnection,
         evt: &ClientRoutesChangeEvent,
     ) -> Result<HashSet<Uuid>, MetadataError> {
-        let Some(working_connection) = &self.control_connection else {
-            // We received this event on the control connection, so it must be present.
-            warn!("BUG: Received a ClientRoutesChange event without a control connection!");
-            return Ok(HashSet::new());
-        };
-
         let Some(subscriber) = &self.client_routes_subscriber else {
             // No subscriber, but received an event? Strange enough, but nothing to be done here.
             warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
@@ -533,9 +477,7 @@ impl MetadataReader {
         // which fetches possibly more routes than necessary, for example `(A, Z)` or `(C, Y)`.
         // This is a tradeoff - the only alternative is issuing multiple queries, one per connection id.
         // I believe the tradeoff here is correct.
-        let client_routes = working_connection
-            .query_client_routes(&connection_ids, host_ids)
-            .await?;
+        let client_routes = cc.query_client_routes(&connection_ids, host_ids).await?;
 
         let updated_hosts = subscriber.merge_client_routes_update(evt, client_routes);
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -53,74 +53,6 @@ impl std::fmt::Debug for ClusterNeatDebug<'_> {
     }
 }
 
-/// Used to track node status changes, i.e. whether a node is reachable or not.
-///
-/// Mainly used to deduplicate [ConnectivityChangeEvent]s received from `PoolRefiller`
-/// before notifying [HostListener] about node status changes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NodeConnectivityStatus {
-    Connected,
-    Unreachable,
-}
-
-// Works in the background to keep the cluster updated
-struct ClusterWorker {
-    // Cluster state to keep updated:
-    cluster_state: Arc<ArcSwap<ClusterState>>,
-
-    /// Node status map.
-    ///
-    /// Maps host_id to connectivity status.
-    /// Used to track node status in order to deduplicate HostListener events.
-    node_status: HashMap<Uuid, NodeConnectivityStatus>,
-
-    // Cluster connections
-    metadata_reader: MetadataReader,
-    pool_config: PoolConfig,
-
-    // To listen for refresh requests
-    refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
-
-    // Channel used to receive use keyspace requests
-    use_keyspace_channel: tokio::sync::mpsc::Receiver<UseKeyspaceRequest>,
-
-    // Channel used to receive signals that node is no longer reachable or became reachable.
-    connectivity_events_receiver: tokio::sync::mpsc::UnboundedReceiver<ConnectivityChangeEvent>,
-    // Sender part of that channel to pass to `PoolRefiller`s.
-    connectivity_events_sender: tokio::sync::mpsc::UnboundedSender<ConnectivityChangeEvent>,
-
-    // Channel used to receive info about new tablets from custom payload in responses
-    // sent by server.
-    tablets_channel: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
-
-    // Keyspace send in "USE <keyspace name>" when opening each connection
-    used_keyspace: Option<VerifiedKeyspaceName>,
-
-    // The host filter determines towards which nodes we should open
-    // connections
-    host_filter: Option<Arc<dyn HostFilter>>,
-
-    // The host listener allows to listen for topology and node status changes.
-    host_listener: Option<Arc<dyn HostListener>>,
-
-    // This value determines how frequently the cluster
-    // worker will refresh the cluster metadata
-    cluster_metadata_refresh_interval: Duration,
-
-    metrics: Metrics,
-}
-
-#[derive(Debug)]
-struct RefreshRequest {
-    response_chan: tokio::sync::oneshot::Sender<Result<(), MetadataError>>,
-}
-
-#[derive(Debug)]
-struct UseKeyspaceRequest {
-    keyspace_name: VerifiedKeyspaceName,
-    response_chan: tokio::sync::oneshot::Sender<Result<(), UseKeyspaceError>>,
-}
-
 impl Cluster {
     #[expect(clippy::too_many_arguments)]
     pub(crate) async fn new(
@@ -274,6 +206,74 @@ impl Cluster {
 
         response_receiver.await.unwrap() // ClusterWorker always responds
     }
+}
+
+/// Used to track node status changes, i.e. whether a node is reachable or not.
+///
+/// Mainly used to deduplicate [ConnectivityChangeEvent]s received from `PoolRefiller`
+/// before notifying [HostListener] about node status changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeConnectivityStatus {
+    Connected,
+    Unreachable,
+}
+
+// Works in the background to keep the cluster updated
+struct ClusterWorker {
+    // Cluster state to keep updated:
+    cluster_state: Arc<ArcSwap<ClusterState>>,
+
+    /// Node status map.
+    ///
+    /// Maps host_id to connectivity status.
+    /// Used to track node status in order to deduplicate HostListener events.
+    node_status: HashMap<Uuid, NodeConnectivityStatus>,
+
+    // Cluster connections
+    metadata_reader: MetadataReader,
+    pool_config: PoolConfig,
+
+    // To listen for refresh requests
+    refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
+
+    // Channel used to receive use keyspace requests
+    use_keyspace_channel: tokio::sync::mpsc::Receiver<UseKeyspaceRequest>,
+
+    // Channel used to receive signals that node is no longer reachable or became reachable.
+    connectivity_events_receiver: tokio::sync::mpsc::UnboundedReceiver<ConnectivityChangeEvent>,
+    // Sender part of that channel to pass to `PoolRefiller`s.
+    connectivity_events_sender: tokio::sync::mpsc::UnboundedSender<ConnectivityChangeEvent>,
+
+    // Channel used to receive info about new tablets from custom payload in responses
+    // sent by server.
+    tablets_channel: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
+
+    // Keyspace send in "USE <keyspace name>" when opening each connection
+    used_keyspace: Option<VerifiedKeyspaceName>,
+
+    // The host filter determines towards which nodes we should open
+    // connections
+    host_filter: Option<Arc<dyn HostFilter>>,
+
+    // The host listener allows to listen for topology and node status changes.
+    host_listener: Option<Arc<dyn HostListener>>,
+
+    // This value determines how frequently the cluster
+    // worker will refresh the cluster metadata
+    cluster_metadata_refresh_interval: Duration,
+
+    metrics: Metrics,
+}
+
+#[derive(Debug)]
+struct RefreshRequest {
+    response_chan: tokio::sync::oneshot::Sender<Result<(), MetadataError>>,
+}
+
+#[derive(Debug)]
+struct UseKeyspaceRequest {
+    keyspace_name: VerifiedKeyspaceName,
+    response_chan: tokio::sync::oneshot::Sender<Result<(), UseKeyspaceError>>,
 }
 
 impl ClusterWorker {

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -2,7 +2,7 @@ use crate::client::client_routes::{
     ClientRoutesAddressTranslator, ClientRoutesConfig, ClientRoutesSubscriber,
 };
 use crate::client::session::TABLET_CHANNEL_SIZE;
-use crate::cluster::metadata::reader::ControlConnectionEvent;
+use crate::cluster::control_connection::ControlConnectionEvent;
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::frame::response::event::EventV2 as Event;

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -351,7 +351,7 @@ impl ClusterWorker {
                             debug!("Got shutdown control connection event. Shutting down ClusterWorker.");
                             return;
                         },
-                        ControlConnectionEvent::Broken => {
+                        ControlConnectionEvent::Broken(_err) => {
                             // The control connection was broken. Acknowledge that and start attempting to reconnect.
                             // The first reconnect attempt will be immediate (by attempting metadata refresh below),
                             // and if it does not succeed, then `ControlConnectionState` will be set to `Broken`, so

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -2,7 +2,7 @@ use crate::client::client_routes::{
     ClientRoutesAddressTranslator, ClientRoutesConfig, ClientRoutesSubscriber,
 };
 use crate::client::session::TABLET_CHANNEL_SIZE;
-use crate::cluster::control_connection::ControlConnectionEvent;
+use crate::cluster::control_connection::{ControlConnection, ControlConnectionEvent};
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::frame::response::event::EventV2 as Event;
@@ -25,6 +25,7 @@ use std::time::Duration;
 use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
+use super::metadata::Metadata;
 use super::metadata::reader::MetadataReader;
 use super::state::ClusterState;
 
@@ -106,7 +107,9 @@ impl Cluster {
 
         let mut node_status = HashMap::new();
 
-        let metadata = metadata_reader.read_metadata(true).await?;
+        let (cc, metadata) = metadata_reader
+            .establish_cc_and_fetch_metadata(true)
+            .await?;
 
         let cluster_state = ClusterState::new(
             metadata,
@@ -155,7 +158,7 @@ impl Cluster {
             metrics,
         };
 
-        let (fut, worker_handle) = worker.work().remote_handle();
+        let (fut, worker_handle) = worker.work(cc).remote_handle();
         tokio::spawn(fut);
 
         let result = Cluster {
@@ -277,18 +280,23 @@ struct UseKeyspaceRequest {
 }
 
 impl ClusterWorker {
-    pub(crate) async fn work(mut self) {
+    pub(crate) async fn work(mut self, initial_cc: Option<ControlConnection>) {
         use tokio::time::Instant;
 
         let control_connection_repair_duration = Duration::from_secs(1); // Attempt control connection repair every second
         let mut last_refresh_time = Instant::now();
+
+        // The control connection is now owned by the worker. `None` means it is
+        // currently broken (or was never established) and needs to be re-established,
+        // which happens during the next metadata refresh.
+        let mut control_connection: Option<ControlConnection> = initial_cc;
 
         loop {
             let mut cur_request: Option<RefreshRequest> = None;
 
             // Wait until it's time for the next refresh
             let sleep_until: Instant = last_refresh_time
-                .checked_add(if self.metadata_reader.control_connection_works() {
+                .checked_add(if control_connection.is_some() {
                     self.cluster_metadata_refresh_interval
                 } else {
                     control_connection_repair_duration
@@ -344,7 +352,7 @@ impl ClusterWorker {
                     continue;
                 }
 
-                control_connection_event = self.metadata_reader.wait_for_control_connection_event() => {
+                control_connection_event = Self::wait_for_control_connection_event(&mut control_connection) => {
                     match control_connection_event {
                         ControlConnectionEvent::Shutdown => {
                             // The runtime is shutting down. We can stop working.
@@ -352,17 +360,23 @@ impl ClusterWorker {
                             return;
                         },
                         ControlConnectionEvent::Broken(_err) => {
-                            // The control connection was broken. Acknowledge that and start attempting to reconnect.
+                            // The control connection was broken. Drop it and start attempting to reconnect.
                             // The first reconnect attempt will be immediate (by attempting metadata refresh below),
-                            // and if it does not succeed, then `ControlConnectionState` will be set to `Broken`, so
+                            // and if it does not succeed, then the control connection will stay `None`, so
                             // subsequent attempts will be issued every second.
+                            control_connection = None;
                         },
                         ControlConnectionEvent::ServerEvent(event) => {
                             debug!("Received server event: {:?}", event);
                             match event {
                                 Event::TopologyChange(_) => (), // Refresh immediately
                                 Event::ClientRoutesChange(evt) => {
-                                    let res = self.metadata_reader.fetch_client_route_updates_on_event(&evt).await;
+                                    // We received this event on the control connection, so it must be present.
+                                    let Some(cc) = control_connection.as_ref() else {
+                                        error!("BUG: Received a server event without a control connection.");
+                                        continue;
+                                    };
+                                    let res = self.metadata_reader.fetch_client_route_updates_on_event(cc, &evt).await;
                                     match res {
                                         Ok(updated_hosts) => {
                                             self.cluster_state.load().trigger_pool_refills_for_hosts(updated_hosts.iter().copied());
@@ -450,7 +464,7 @@ impl ClusterWorker {
             // Perform the refresh
             debug!("Requesting metadata refresh");
             last_refresh_time = Instant::now();
-            let refresh_res = self.perform_refresh().await;
+            let refresh_res = self.perform_refresh(&mut control_connection).await;
 
             // Send refresh result if there was a request
             if let Some(request) = cur_request {
@@ -484,9 +498,60 @@ impl ClusterWorker {
         use_keyspace_result(use_keyspace_results.into_iter())
     }
 
-    async fn perform_refresh(&mut self) -> Result<(), MetadataError> {
+    /// Waits for the next control connection event.
+    ///
+    /// If there is no working control connection (it is broken and awaiting
+    /// re-establishment), this never resolves — the worker will rely on the
+    /// periodic refresh timer to attempt re-establishment instead.
+    async fn wait_for_control_connection_event(
+        control_connection: &mut Option<ControlConnection>,
+    ) -> ControlConnectionEvent {
+        match control_connection {
+            None => std::future::pending().await,
+            Some(cc) => cc.wait_for_event().await,
+        }
+    }
+
+    /// Fetches the latest metadata, (re-)establishing the control connection if needed.
+    ///
+    /// If a working control connection is present, metadata is fetched on it. If that
+    /// fails, the connection is dropped and a fresh one is established (iterating over
+    /// known peers and, as a last resort, the initial contact points). The (possibly
+    /// new) working control connection is stored back into `control_connection`.
+    async fn read_metadata(
+        &mut self,
+        control_connection: &mut Option<ControlConnection>,
+    ) -> Result<Metadata, MetadataError> {
+        if let Some(cc) = control_connection.as_ref() {
+            match self.metadata_reader.fetch_metadata_on_cc(cc).await {
+                Ok(metadata) => return Ok(metadata),
+                Err(err) => {
+                    debug!(
+                        error = %err,
+                        "Failed to fetch metadata on the current control connection. \
+                        Will try to establish a new one."
+                    );
+                    // The control connection is considered defunct - drop it.
+                    *control_connection = None;
+                }
+            }
+        }
+
+        // We have no working control connection - establish a new one and fetch metadata on it.
+        let (cc, metadata) = self
+            .metadata_reader
+            .establish_cc_and_fetch_metadata(false)
+            .await?;
+        *control_connection = cc;
+        Ok(metadata)
+    }
+
+    async fn perform_refresh(
+        &mut self,
+        control_connection: &mut Option<ControlConnection>,
+    ) -> Result<(), MetadataError> {
         // Read latest Metadata
-        let metadata = self.metadata_reader.read_metadata(false).await?;
+        let metadata = self.read_metadata(control_connection).await?;
         let client_routes_updated_hosts = metadata.client_routes_updated_hosts.clone();
 
         let cluster_state: Arc<ClusterState> = self.cluster_state.load_full();

--- a/scylla/src/network/mod.rs
+++ b/scylla/src/network/mod.rs
@@ -6,6 +6,8 @@
 
 mod connection;
 
+#[cfg(test)]
+pub(crate) use connection::HostConnectionConfig;
 pub(crate) use connection::open_connection;
 
 pub(crate) use connection::{Connection, ConnectionConfig, TcpSocketOptions, VerifiedKeyspaceName};


### PR DESCRIPTION
I'm still not 100% sure about the approach to refactoring ClusterWorker, I have a few local branches with different approaches.

What I am sure about, because every solution I ever considered has that in common, is that we need to move the ownership of CC out of MetadataReader, to be able to more precisely handle when it is broken / recreated. 

This PR does just that. Some intermediate commits are a little clunky, but the split is anyway much better than I initially hoped for.
It is possible that some details (error messages etc) are not perfect yet, but I'll leave it for next PRs. All the important behaviors we had, including handling HostFilter and initial dummy metadata, and how we respond to refresh requests, are preserved.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1280
Ref: https://scylladb.atlassian.net/browse/DRIVER-764
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1411 (IMO)

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
