### PR TITLE
TLS tickets tests

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -172,3 +172,6 @@ tempfile = "3.19"
 rcgen = "0.14"
 uuid = { version = "1.0", features = ["v1"] }
 env_logger = "0.11"
+# Used by the TLS-inspecting proxy of the session ticket ccm test to classify
+# the handshakes it forwards.
+tls-parser = "0.12.2"

--- a/scylla/tests/integration/ccm/lib/mod.rs
+++ b/scylla/tests/integration/ccm/lib/mod.rs
@@ -17,7 +17,7 @@ use ip_allocator::IpAllocator;
 use tracing::info;
 
 pub(crate) static CLUSTER_VERSION: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("SCYLLA_TEST_CLUSTER").unwrap_or("release:2026.1.0".to_string())
+    std::env::var("SCYLLA_TEST_CLUSTER").unwrap_or("release:2026.2.0".to_string())
 });
 
 static TEST_KEEP_CLUSTER_ON_FAILURE: LazyLock<bool> = LazyLock::new(|| {

--- a/scylla/tests/integration/ccm/mod.rs
+++ b/scylla/tests/integration/ccm/mod.rs
@@ -9,6 +9,8 @@ mod host_listener;
 
 #[cfg(all(feature = "openssl-010", feature = "rustls-023"))]
 mod tls;
+#[cfg(all(feature = "openssl-010", feature = "rustls-023"))]
+mod tls_tickets;
 
 mod result_metadata_extension;
 mod using_timeout;

--- a/scylla/tests/integration/ccm/mod.rs
+++ b/scylla/tests/integration/ccm/mod.rs
@@ -7,6 +7,10 @@ mod host_listener;
 
 #[cfg(all(feature = "openssl-010", feature = "rustls-023"))]
 mod tls;
+#[cfg(all(feature = "openssl-010", feature = "rustls-023"))]
+mod tls_inspecting_proxy;
+#[cfg(all(feature = "openssl-010", feature = "rustls-023"))]
+mod tls_tickets;
 
 mod result_metadata_extension;
 mod using_timeout;

--- a/scylla/tests/integration/ccm/tls.rs
+++ b/scylla/tests/integration/ccm/tls.rs
@@ -82,7 +82,7 @@ fn prepare_authority_cert_params() -> CertificateParams {
     params
 }
 
-async fn run_ccm_tls_test(
+pub(super) async fn run_ccm_tls_test(
     prepare_cert: impl Fn(CertificateParams, &Node) -> CertificateParams,
     cluster_config: impl AsyncFnOnce(Cluster) -> Cluster,
     test: impl AsyncFnOnce(&CertifiedIssuer<'static, KeyPair>, &mut Cluster) -> (),
@@ -131,7 +131,7 @@ async fn run_ccm_tls_test(
     .await
 }
 
-fn build_openssl_ca_store(ca: &CertifiedIssuer<'_, KeyPair>) -> X509Store {
+pub(super) fn build_openssl_ca_store(ca: &CertifiedIssuer<'_, KeyPair>) -> X509Store {
     let mut store_builder = X509StoreBuilder::new().unwrap();
     let ca = X509::from_der(ca.der()).unwrap();
     store_builder.add_cert(ca).unwrap();

--- a/scylla/tests/integration/ccm/tls_inspecting_proxy.rs
+++ b/scylla/tests/integration/ccm/tls_inspecting_proxy.rs
@@ -1,0 +1,801 @@
+//! A TLS-transparent TCP proxy that classifies the handshakes passing through it, used by
+//! [`super::tls_tickets`] to observe whether the driver's TLS backends resume TLS sessions.
+//!
+//! It does not terminate TLS: it forwards every byte verbatim, reads only what is in the
+//! clear, and stops inspecting a connection once it has determined
+//! - the TLS version the server selected,
+//! - whether the client offered resumption: `pre_shared_key` in TLS 1.3, a non-empty
+//!   `session_ticket` extension or legacy `session_id` in TLS 1.2,
+//! - whether the server accepted it: `pre_shared_key` in the ServerHello in TLS 1.3, an
+//!   abbreviated first flight (ChangeCipherSpec with no Certificate before it) in TLS 1.2.
+//!
+//! Messages and extensions are parsed by `tls-parser`. Reassembly across records, message
+//! dispatch and the ordering that the TLS 1.2 signal needs are done here.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use tls_parser::nom::IResult;
+use tls_parser::nom::bytes::streaming::take;
+use tls_parser::nom::number::streaming::{be_u8, be_u24};
+use tls_parser::{
+    TlsExtension, TlsHandshakeType, TlsRecordType, TlsVersion as WireVersion,
+    parse_tls_client_hello_extensions, parse_tls_handshake_client_hello,
+    parse_tls_handshake_server_hello, parse_tls_record_header, parse_tls_server_hello_extensions,
+};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// A TLS version a test pins.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum TlsVersion {
+    V1_2,
+    V1_3,
+}
+
+impl TlsVersion {
+    /// Its on-the-wire value.
+    pub(super) const fn wire(self) -> WireVersion {
+        match self {
+            TlsVersion::V1_2 => WireVersion::Tls12,
+            TlsVersion::V1_3 => WireVersion::Tls13,
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Handshake observations
+// -----------------------------------------------------------------------------
+
+/// What the proxy saw in a connection's ClientHello.
+#[derive(Clone, Copy, Debug)]
+struct ClientHelloInfo {
+    /// A non-empty `session_ticket` extension: an RFC 5077 ticket. Clients that merely
+    /// *support* tickets send the extension empty, which does not count.
+    presents_ticket: bool,
+    /// A `pre_shared_key` extension: a TLS 1.3 PSK, which here can only be a ticket.
+    presents_psk: bool,
+    /// A non-empty legacy `session_id`. Only means anything in TLS 1.2: a TLS 1.3 client
+    /// always sends a random one, for middlebox compatibility.
+    nonempty_session_id: bool,
+}
+
+/// What the proxy saw in a connection's ServerHello.
+#[derive(Clone, Copy, Debug)]
+struct ServerHelloInfo {
+    /// The version the server selected.
+    version: WireVersion,
+    /// A `pre_shared_key` extension: the server accepted TLS 1.3 resumption.
+    accepts_psk: bool,
+}
+
+/// Everything the proxy observed about a single connection's handshake.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ConnRecord {
+    /// Real IP of the node this connection was forwarded to.
+    node_ip: IpAddr,
+    client_hello: Option<ClientHelloInfo>,
+    server_hello: Option<ServerHelloInfo>,
+    /// Pre-1.3: whether the server sent ChangeCipherSpec with no preceding Certificate,
+    /// which is how it signals that it accepted resumption. `None` in TLS 1.3, where the
+    /// flight after the ServerHello is encrypted - and where the ServerHello already says.
+    abbreviated_flight: Option<bool>,
+}
+
+/// A fully classified handshake: what the proxy *concluded* about one connection.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct Handshake {
+    pub(super) node_ip: IpAddr,
+    /// The TLS version the server selected.
+    pub(super) version: WireVersion,
+    /// Whether the client presented a *session ticket*: a non-empty `session_ticket`
+    /// extension in TLS 1.2, a PSK in TLS 1.3. The mechanism under test.
+    pub(super) presented_ticket: bool,
+    /// Whether the client offered to resume by any means. Weaker than
+    /// [`Handshake::presented_ticket`]: a TLS 1.2 client may offer a cached session id
+    /// instead, which is what rustls does when it holds no ticket.
+    pub(super) offered_resumption: bool,
+    /// Whether the server accepted resumption.
+    pub(super) accepted_resumption: bool,
+}
+
+impl ConnRecord {
+    fn new(node_ip: IpAddr) -> Self {
+        Self {
+            node_ip,
+            client_hello: None,
+            server_hello: None,
+            abbreviated_flight: None,
+        }
+    }
+
+    /// Interprets the observations, or `None` if the handshake was not observed in full.
+    /// The test asserts only about complete ones, and separately requires that every
+    /// connection got there - a missed handshake must not pass as "nothing resumed".
+    pub(super) fn finish(&self) -> Option<Handshake> {
+        let client = self.client_hello?;
+        let server = self.server_hello?;
+        let (presented_ticket, offered_resumption, accepted_resumption) =
+            if server.version == TlsVersion::V1_3.wire() {
+                // In TLS 1.3 resumption is always PSK-based, and the only PSKs in play
+                // here come from tickets.
+                (client.presents_psk, client.presents_psk, server.accepts_psk)
+            } else {
+                // TLS 1.2 and earlier: the client offers a ticket and/or a cached session
+                // id, and the server signals acceptance by abbreviating its first flight.
+                (
+                    client.presents_ticket,
+                    client.presents_ticket || client.nonempty_session_id,
+                    self.abbreviated_flight?,
+                )
+            };
+        Some(Handshake {
+            node_ip: self.node_ip,
+            version: server.version,
+            presented_ticket,
+            offered_resumption,
+            accepted_resumption,
+        })
+    }
+}
+
+impl Handshake {
+    pub(super) fn resumed(&self) -> bool {
+        self.offered_resumption && self.accepted_resumption
+    }
+}
+
+/// Thread-safe log of per-connection handshake observations, in the order the proxies
+/// accepted the connections.
+#[derive(Clone)]
+pub(super) struct SharedRecords(Arc<Mutex<Vec<Arc<Mutex<ConnRecord>>>>>);
+
+impl SharedRecords {
+    pub(super) fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+
+    fn push(&self, rec: Arc<Mutex<ConnRecord>>) {
+        self.0.lock().unwrap().push(rec);
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.0.lock().unwrap().len()
+    }
+
+    /// How many records have been logged since `start` (inclusive). Cheaper than
+    /// [`SharedRecords::collect_from`], which locks every record it copies.
+    pub(super) fn count_from(&self, start: usize) -> usize {
+        self.0.lock().unwrap().len() - start
+    }
+
+    /// Snapshot of all records logged since `start` (inclusive).
+    pub(super) fn collect_from(&self, start: usize) -> Vec<ConnRecord> {
+        let guard = self.0.lock().unwrap();
+        guard[start..].iter().map(|r| *r.lock().unwrap()).collect()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// TLS handshake inspection
+// -----------------------------------------------------------------------------
+
+/// `ContentType` + `ProtocolVersion` + length.
+const RECORD_HEADER_LEN: usize = 5;
+
+#[derive(Clone, Copy)]
+enum Direction {
+    ClientToServer,
+    ServerToClient,
+}
+
+/// The `random` a TLS 1.3 server puts in a ServerHello to mark it as a
+/// HelloRetryRequest: SHA-256 of the string "HelloRetryRequest" (RFC 8446 section 4.1.3).
+const HELLO_RETRY_REQUEST_RANDOM: [u8; 32] = [
+    0xcf, 0x21, 0xad, 0x74, 0xe5, 0x9a, 0x61, 0x11, 0xbe, 0x1d, 0x8c, 0x02, 0x1e, 0x65, 0xb8, 0x91,
+    0xc2, 0xa2, 0x11, 0x16, 0x7a, 0xbb, 0x8c, 0x5e, 0x07, 0x9e, 0x09, 0xe2, 0xc8, 0xa8, 0x33, 0x9c,
+];
+
+/// Fields of interest of a ClientHello or ServerHello.
+struct Hello {
+    /// The version the message names: a ServerHello's `supported_versions` extension if
+    /// it has one (that is how TLS 1.3 is signalled), otherwise the legacy version field.
+    version: WireVersion,
+    nonempty_session_id: bool,
+    nonempty_session_ticket: bool,
+    has_psk: bool,
+    /// Whether this "ServerHello" is really a HelloRetryRequest, told apart only by its
+    /// `random`.
+    is_hello_retry_request: bool,
+}
+
+/// Cuts one handshake message - its type and body - off the front of `input`. Built from
+/// the *streaming* nom parsers, so a message that has not fully arrived fails with
+/// `Incomplete` rather than as malformed.
+fn parse_handshake_message(input: &[u8]) -> IResult<&[u8], (TlsHandshakeType, &[u8])> {
+    let (input, msg_type) = be_u8(input)?;
+    let (input, len) = be_u24(input)?;
+    let (input, body) = take(len)(input)?;
+    Ok((input, (TlsHandshakeType(msg_type), body)))
+}
+
+/// Parses a ClientHello/ServerHello message body. `None` if it is truncated or malformed,
+/// never a partly populated result: the caller must not read a failed parse as "the
+/// client did not offer resumption".
+fn parse_hello(body: &[u8], is_server: bool) -> Option<Hello> {
+    // A Hello that leaves part of its body unconsumed is malformed: that is how an
+    // extensions block whose length prefix overruns the message shows up.
+    let (version, random, session_id, block) = if is_server {
+        let (rest, h) = parse_tls_handshake_server_hello(body).ok()?;
+        rest.is_empty()
+            .then_some((h.version, h.random, h.session_id, h.ext))?
+    } else {
+        let (rest, h) = parse_tls_handshake_client_hello(body).ok()?;
+        rest.is_empty()
+            .then_some((h.version, h.random, h.session_id, h.ext))?
+    };
+
+    let mut hello = Hello {
+        version,
+        nonempty_session_id: session_id.is_some_and(|id| !id.is_empty()),
+        nonempty_session_ticket: false,
+        has_psk: false,
+        is_hello_retry_request: is_server && random == HELLO_RETRY_REQUEST_RANDOM.as_slice(),
+    };
+
+    // An extension the crate cannot parse silently stops the walk, so leftover bytes fail
+    // the Hello too: the resumption signal may be the extension behind it.
+    let (rest, extensions) = match block {
+        Some(block) if is_server => parse_tls_server_hello_extensions(block).ok()?,
+        Some(block) => parse_tls_client_hello_extensions(block).ok()?,
+        None => (&[][..], Vec::new()),
+    };
+    if !rest.is_empty() {
+        return None;
+    }
+    for extension in extensions {
+        match extension {
+            TlsExtension::SessionTicket(data) => hello.nonempty_session_ticket = !data.is_empty(),
+            TlsExtension::PreSharedKey(_) => hello.has_psk = true,
+            // In a ServerHello this extension carries the single selected version.
+            TlsExtension::SupportedVersions(v) if is_server && v.len() == 1 => hello.version = v[0],
+            _ => {}
+        }
+    }
+
+    Some(hello)
+}
+
+/// Classifies one direction of a connection into the shared [`ConnRecord`], stopping as
+/// soon as it has seen enough.
+struct HandshakeParser {
+    dir: Direction,
+    /// Reassembly buffer: a message may span records, a record may carry several messages.
+    buf: Vec<u8>,
+    /// The version from the ServerHello, once seen. Server direction only.
+    selected_version: Option<WireVersion>,
+    done: bool,
+}
+
+impl HandshakeParser {
+    fn new(dir: Direction) -> Self {
+        Self {
+            dir,
+            buf: Vec::new(),
+            selected_version: None,
+            done: false,
+        }
+    }
+
+    /// Whether this direction has been classified.
+    fn done(&self) -> bool {
+        self.done
+    }
+
+    /// Whether the server picked TLS 1.2 or older, where resumption is visible from the
+    /// shape of its first flight.
+    fn is_pre_tls13(&self) -> bool {
+        self.selected_version
+            .is_some_and(|version| version != TlsVersion::V1_3.wire())
+    }
+
+    fn feed(&mut self, record_type: TlsRecordType, body: &[u8], rec: &Mutex<ConnRecord>) {
+        if self.done {
+            return;
+        }
+        match record_type {
+            TlsRecordType::Handshake => {
+                self.buf.extend_from_slice(body);
+                self.parse_messages(rec);
+            }
+            // No Certificate before it, so the flight was abbreviated - i.e. resumed.
+            TlsRecordType::ChangeCipherSpec
+                if matches!(self.dir, Direction::ServerToClient) && self.is_pre_tls13() =>
+            {
+                rec.lock().unwrap().abbreviated_flight = Some(true);
+                self.done = true;
+            }
+            _ => {}
+        }
+    }
+
+    fn parse_messages(&mut self, rec: &Mutex<ConnRecord>) {
+        // `handle_message` needs `&mut self`, so the buffer is moved out and the
+        // unconsumed remainder moved back afterwards.
+        let mut buf = std::mem::take(&mut self.buf);
+        let mut rest: &[u8] = &buf;
+        while !self.done {
+            // Only `Incomplete` is reachable: a fixed-size header plus a body taken at
+            // its declared length cannot be malformed, only unfinished.
+            let Ok((tail, (msg_type, body))) = parse_handshake_message(rest) else {
+                break;
+            };
+            self.handle_message(msg_type, body, rec);
+            rest = tail;
+        }
+        let consumed = buf.len() - rest.len();
+        buf.drain(..consumed);
+        self.buf = buf;
+    }
+
+    fn handle_message(&mut self, msg_type: TlsHandshakeType, body: &[u8], rec: &Mutex<ConnRecord>) {
+        match self.dir {
+            Direction::ClientToServer => {
+                if msg_type != TlsHandshakeType::ClientHello {
+                    return;
+                }
+                // What follows is either irrelevant or (in TLS 1.3) encrypted.
+                self.done = true;
+                if let Some(hello) = parse_hello(body, false) {
+                    rec.lock().unwrap().client_hello = Some(ClientHelloInfo {
+                        presents_ticket: hello.nonempty_session_ticket,
+                        presents_psk: hello.has_psk,
+                        nonempty_session_id: hello.nonempty_session_id,
+                    });
+                }
+            }
+            Direction::ServerToClient => match msg_type {
+                TlsHandshakeType::ServerHello => {
+                    let Some(hello) = parse_hello(body, true) else {
+                        self.done = true;
+                        return;
+                    };
+                    // A HelloRetryRequest shares the ServerHello encoding but never
+                    // carries `pre_shared_key`, so taking it for the ServerHello would
+                    // report a resumed session as refused. The real one follows it in the
+                    // clear, and the PSK offer was read from the first ClientHello.
+                    if hello.is_hello_retry_request {
+                        return;
+                    }
+                    self.selected_version = Some(hello.version);
+                    rec.lock().unwrap().server_hello = Some(ServerHelloInfo {
+                        version: hello.version,
+                        accepts_psk: hello.has_psk,
+                    });
+                    // In TLS 1.3 everything after the ServerHello is encrypted.
+                    self.done = !self.is_pre_tls13();
+                }
+                // A Certificate means a full handshake, so resumption was not accepted.
+                // In TLS 1.3 the message is encrypted, hence the version guard.
+                TlsHandshakeType::Certificate if self.is_pre_tls13() => {
+                    rec.lock().unwrap().abbreviated_flight = Some(false);
+                    self.done = true;
+                }
+                _ => {}
+            },
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Forwarding
+// -----------------------------------------------------------------------------
+
+/// Forwards one direction of a connection, inspecting the handshake as it goes and then
+/// copying the rest - all the CQL traffic - as an opaque byte stream.
+async fn forward<R, W>(mut reader: R, mut writer: W, dir: Direction, rec: &Mutex<ConnRecord>)
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut parser = HandshakeParser::new(dir);
+    let mut fragment = Vec::new();
+    while !parser.done() {
+        let mut header_bytes = [0u8; RECORD_HEADER_LEN];
+        if reader.read_exact(&mut header_bytes).await.is_err() {
+            return;
+        }
+        // Infallible: five fixed-size bytes, all of them in hand.
+        let (_, header) = parse_tls_record_header(&header_bytes).unwrap();
+        fragment.clear();
+        fragment.resize(header.len as usize, 0);
+        if reader.read_exact(&mut fragment).await.is_err() {
+            return;
+        }
+
+        parser.feed(header.record_type, &fragment, rec);
+
+        if writer.write_all(&header_bytes).await.is_err()
+            || writer.write_all(&fragment).await.is_err()
+            || writer.flush().await.is_err()
+        {
+            return;
+        }
+    }
+    let _ = tokio::io::copy(&mut reader, &mut writer).await;
+}
+
+/// Carries one proxied connection until both directions are done. One future drives both,
+/// so the connection has a single owner and nothing is detached.
+async fn proxy_connection(client: TcpStream, server: TcpStream, rec: &Mutex<ConnRecord>) {
+    let (client_read, client_write) = client.into_split();
+    let (server_read, server_write) = server.into_split();
+    tokio::join!(
+        forward(client_read, server_write, Direction::ClientToServer, rec),
+        forward(server_read, client_write, Direction::ServerToClient, rec),
+    );
+}
+
+/// Accepts connections on `listener`, forwards each to `real_addr`, and logs what their
+/// handshakes revealed into `records`.
+///
+/// Never returns. Nothing is spawned, so dropping it closes the listener and every
+/// connection it carries, and a panic while forwarding surfaces in whoever polls it.
+/// Accepting is serialised with dialling the node so that `records` is in accept order,
+/// which the test slices by index to tell one session's connections from another's.
+pub(super) async fn run_proxy(
+    listener: TcpListener,
+    real_addr: SocketAddr,
+    node_ip: IpAddr,
+    records: SharedRecords,
+) {
+    // Owns every connection accepted so far; completed ones are reaped as it is polled.
+    let mut connections = FuturesUnordered::new();
+    loop {
+        tokio::select! {
+            // Keep the connections already accepted moving.
+            Some(()) = connections.next() => {}
+            accepted = listener.accept() => {
+                let client = match accepted {
+                    Ok((stream, _)) => stream,
+                    Err(err) => {
+                        tracing::warn!("TLS ticket proxy accept error: {err}");
+                        continue;
+                    }
+                };
+                let server = match TcpStream::connect(real_addr).await {
+                    Ok(stream) => stream,
+                    Err(err) => {
+                        tracing::warn!("TLS ticket proxy failed to connect to {real_addr}: {err}");
+                        continue;
+                    }
+                };
+
+                let rec = Arc::new(Mutex::new(ConnRecord::new(node_ip)));
+                records.push(Arc::clone(&rec));
+                connections.push(async move { proxy_connection(client, server, &rec).await });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tls_parser::{TlsExtensionType as Ext, TlsHandshakeType as Hs};
+
+    use super::*;
+
+    const NODE_IP: IpAddr = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+
+    /// Wraps a handshake message body in its `HandshakeType` + 24-bit length header.
+    fn handshake_msg(msg_type: Hs, body: &[u8]) -> Vec<u8> {
+        let len = body.len();
+        let mut out = vec![msg_type.0, (len >> 16) as u8, (len >> 8) as u8, len as u8];
+        out.extend_from_slice(body);
+        out
+    }
+
+    fn extension(ext_type: Ext, data: &[u8]) -> Vec<u8> {
+        let mut out = ext_type.0.to_be_bytes().to_vec();
+        out.extend_from_slice(&(data.len() as u16).to_be_bytes());
+        out.extend_from_slice(data);
+        out
+    }
+
+    /// A ServerHello body declaring `declared_ext_len` for its extensions block, which
+    /// is `extensions.len()` unless a test is deliberately lying.
+    fn server_hello_declaring(
+        random: [u8; 32],
+        declared_ext_len: u16,
+        extensions: &[u8],
+    ) -> Vec<u8> {
+        let mut out = server_hello_prefix(random);
+        out.extend_from_slice(&declared_ext_len.to_be_bytes());
+        out.extend_from_slice(extensions);
+        out
+    }
+
+    fn server_hello(random: [u8; 32], extensions: &[u8]) -> Vec<u8> {
+        server_hello_declaring(random, extensions.len() as u16, extensions)
+    }
+
+    /// A ServerHello up to (not including) its extensions block - on its own a
+    /// well-formed TLS 1.2 one, whose version can only come from the legacy field.
+    fn server_hello_prefix(random: [u8; 32]) -> Vec<u8> {
+        let mut out = vec![0x03, 0x03]; // legacy_version
+        out.extend_from_slice(&random);
+        out.push(0); // empty legacy_session_id_echo
+        out.extend_from_slice(&[0x13, 0x01]); // cipher_suite
+        out.push(0); // legacy_compression_method
+        out
+    }
+
+    fn client_hello(session_id: &[u8], extensions: &[u8]) -> Vec<u8> {
+        let mut out = vec![0x03, 0x03]; // legacy_version
+        out.extend_from_slice(&[0x22; 32]); // random
+        out.push(session_id.len() as u8);
+        out.extend_from_slice(session_id);
+        out.extend_from_slice(&2u16.to_be_bytes()); // cipher_suites
+        out.extend_from_slice(&[0x13, 0x01]);
+        out.push(1); // compression_methods
+        out.push(0);
+        out.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+        out.extend_from_slice(extensions);
+        out
+    }
+
+    /// Feeds `records` to one server-direction parser, in order, one TLS record each.
+    fn feed_server(records: &[&[u8]]) -> ConnRecord {
+        let rec = Mutex::new(ConnRecord::new(NODE_IP));
+        let mut parser = HandshakeParser::new(Direction::ServerToClient);
+        for record in records {
+            parser.feed(TlsRecordType::Handshake, record, &rec);
+        }
+        rec.into_inner().unwrap()
+    }
+
+    fn conn_record(
+        client_hello: Option<ClientHelloInfo>,
+        server_hello: Option<ServerHelloInfo>,
+        abbreviated_flight: Option<bool>,
+    ) -> ConnRecord {
+        ConnRecord {
+            node_ip: NODE_IP,
+            client_hello,
+            server_hello,
+            abbreviated_flight,
+        }
+    }
+
+    /// A HelloRetryRequest never carries `pre_shared_key`, so mistaking it for the
+    /// ServerHello would report a session that did resume as refused.
+    #[test]
+    fn hello_retry_request_is_not_mistaken_for_the_server_hello() {
+        let tls13 = extension(Ext::SupportedVersions, &[0x03, 0x04]);
+        let mut accepting = tls13.clone();
+        accepting.extend(extension(Ext::PreSharedKey, &[0x00, 0x00]));
+
+        let mut stream = handshake_msg(
+            Hs::ServerHello,
+            &server_hello(HELLO_RETRY_REQUEST_RANDOM, &tls13),
+        );
+        stream.extend(handshake_msg(
+            Hs::ServerHello,
+            &server_hello([0x11; 32], &accepting),
+        ));
+
+        let server_hello = feed_server(&[&stream])
+            .server_hello
+            .expect("the real ServerHello must still be recorded");
+        assert_eq!(server_hello.version, TlsVersion::V1_3.wire());
+        assert!(
+            server_hello.accepts_psk,
+            "PSK acceptance is signalled by the real ServerHello, not the retry request"
+        );
+    }
+
+    /// An extensions block whose length prefix overruns the message must discard the
+    /// Hello: read as "no extensions" it is indistinguishable from "no resumption
+    /// offered".
+    #[test]
+    fn overlong_extensions_length_discards_the_hello() {
+        let extensions = extension(Ext::PreSharedKey, &[0x00, 0x00]);
+        let declared = extensions.len() as u16 + 1;
+        let body = server_hello_declaring([0x11; 32], declared, &extensions);
+
+        assert!(
+            feed_server(&[&handshake_msg(Hs::ServerHello, &body)])
+                .server_hello
+                .is_none(),
+            "a malformed Hello must leave the record unclassified, not read as 'no PSK'"
+        );
+    }
+
+    /// The counterpart: a TLS 1.2 ServerHello may legally carry no extensions block, and
+    /// must then be read at its legacy version.
+    #[test]
+    fn server_hello_without_extensions_uses_the_legacy_version() {
+        let server_hello = feed_server(&[&handshake_msg(
+            Hs::ServerHello,
+            &server_hello_prefix([0x11; 32]),
+        )])
+        .server_hello
+        .expect("a ServerHello without extensions is well-formed");
+
+        assert_eq!(server_hello.version, TlsVersion::V1_2.wire());
+        assert!(!server_hello.accepts_psk);
+    }
+
+    /// Splitting a two-message flight at every offset walks every path through the
+    /// reassembly buffer: a partial header, a partial body, and the exact boundary
+    /// between two messages. The integration test reaches none of them - on loopback
+    /// every message arrives in a single record.
+    #[test]
+    fn a_flight_split_at_any_offset_is_reassembled() {
+        let mut flight = handshake_msg(Hs::ServerHello, &server_hello_prefix([0x11; 32]));
+        flight.extend(handshake_msg(Hs::Certificate, &[0xcc; 12]));
+
+        for split in 0..=flight.len() {
+            let record = feed_server(&[&flight[..split], &flight[split..]]);
+
+            let server_hello = record
+                .server_hello
+                .unwrap_or_else(|| panic!("ServerHello lost when split at {split}"));
+            assert_eq!(
+                server_hello.version,
+                TlsVersion::V1_2.wire(),
+                "split at {split}"
+            );
+            assert_eq!(
+                record.abbreviated_flight,
+                Some(false),
+                "the Certificate must still be seen when split at {split}"
+            );
+        }
+    }
+
+    /// A message must not be acted on before it has fully arrived. A Certificate is
+    /// dispatched on its type alone, so acting on a partial one leaves the final verdict
+    /// unchanged - the bug is only visible mid-flight.
+    #[test]
+    fn an_incomplete_message_is_not_acted_on_before_its_last_byte() {
+        let certificate = handshake_msg(Hs::Certificate, &[0xcc; 12]);
+        let (all_but_last, last) = certificate.split_at(certificate.len() - 1);
+        let mut first_record = handshake_msg(Hs::ServerHello, &server_hello_prefix([0x11; 32]));
+        first_record.extend_from_slice(all_but_last);
+
+        let rec = Mutex::new(ConnRecord::new(NODE_IP));
+        let mut parser = HandshakeParser::new(Direction::ServerToClient);
+
+        parser.feed(TlsRecordType::Handshake, &first_record, &rec);
+        assert!(
+            rec.lock().unwrap().server_hello.is_some(),
+            "the complete ServerHello ahead of it must have been read"
+        );
+        assert!(
+            rec.lock().unwrap().abbreviated_flight.is_none(),
+            "the Certificate is one byte short, so the flight is not classified yet"
+        );
+
+        parser.feed(TlsRecordType::Handshake, last, &rec);
+        assert_eq!(
+            rec.into_inner().unwrap().abbreviated_flight,
+            Some(false),
+            "and once its last byte arrives, it is"
+        );
+    }
+
+    /// What counts as "fully observed" is version-dependent: a pre-1.3 verdict also needs
+    /// the shape of the server's first flight, while a TLS 1.3 ServerHello suffices on its
+    /// own. Every record the integration test sees is complete, so only these cases
+    /// exercise the rule.
+    #[test]
+    fn finish_withholds_a_verdict_until_the_handshake_is_fully_observed() {
+        let client = ClientHelloInfo {
+            presents_ticket: true,
+            presents_psk: true,
+            nonempty_session_id: true,
+        };
+        let tls12 = ServerHelloInfo {
+            version: TlsVersion::V1_2.wire(),
+            accepts_psk: false,
+        };
+        let tls13 = ServerHelloInfo {
+            version: TlsVersion::V1_3.wire(),
+            accepts_psk: true,
+        };
+
+        assert!(
+            conn_record(None, Some(tls13), None).finish().is_none(),
+            "no ClientHello was ever seen"
+        );
+        assert!(
+            conn_record(Some(client), None, None).finish().is_none(),
+            "no ServerHello was ever seen"
+        );
+        assert!(
+            conn_record(Some(client), Some(tls12), None)
+                .finish()
+                .is_none(),
+            "a pre-1.3 flight that was never classified cannot yield a verdict"
+        );
+        assert!(
+            conn_record(Some(client), Some(tls13), None)
+                .finish()
+                .is_some(),
+            "a TLS 1.3 ServerHello says on its own whether the PSK was accepted"
+        );
+    }
+
+    /// A TLS 1.2 client with no ticket can offer its cached session id instead, and be
+    /// accepted - what rustls does when the server issues no tickets. The two signals must
+    /// stay apart: the openssl assertions turn on "offered resumption at all", the rustls
+    /// ones demand a ticket.
+    #[test]
+    fn a_tls12_session_id_offer_resumes_without_presenting_a_ticket() {
+        let handshake = conn_record(
+            Some(ClientHelloInfo {
+                presents_ticket: false,
+                presents_psk: false,
+                nonempty_session_id: true,
+            }),
+            Some(ServerHelloInfo {
+                version: TlsVersion::V1_2.wire(),
+                accepts_psk: false,
+            }),
+            Some(true),
+        )
+        .finish()
+        .expect("the handshake was fully observed");
+
+        assert!(
+            !handshake.presented_ticket,
+            "no session_ticket extension was present"
+        );
+        assert!(
+            handshake.offered_resumption,
+            "a cached session id is an offer to resume"
+        );
+        assert!(
+            handshake.resumed(),
+            "and the server abbreviated its flight, so it accepted"
+        );
+    }
+
+    /// `parse_hello` must never report a signal it did not see. A Hello truncated before
+    /// its extensions is legal input (they are optional pre-1.3), so the tempting bug is
+    /// to report the defaults as fact; every truncation of one bearing a ticket and a PSK
+    /// is checked.
+    #[test]
+    fn truncating_a_hello_cannot_manufacture_a_resumption_signal() {
+        let mut extensions = extension(Ext::SessionTicketTLS, &[0xab; 16]);
+        extensions.extend(extension(Ext::PreSharedKey, &[0x00, 0x00]));
+
+        for (is_server, body) in [
+            (false, client_hello(&[0x33; 32], &extensions)),
+            (true, server_hello([0x11; 32], &extensions)),
+        ] {
+            for len in 0..body.len() {
+                if let Some(hello) = parse_hello(&body[..len], is_server) {
+                    assert!(
+                        !hello.nonempty_session_ticket,
+                        "is_server={is_server}: reported a ticket it could not have seen, \
+                         truncated to {len} of {} bytes",
+                        body.len()
+                    );
+                    assert!(
+                        !hello.has_psk,
+                        "is_server={is_server}: reported a PSK it could not have seen, \
+                         truncated to {len} of {} bytes",
+                        body.len()
+                    );
+                }
+            }
+
+            // The signals really are in the untruncated bytes: the loop is not vacuous.
+            let hello = parse_hello(&body, is_server).expect("the whole Hello parses");
+            assert!(hello.nonempty_session_ticket && hello.has_psk);
+        }
+    }
+}

--- a/scylla/tests/integration/ccm/tls_tickets.rs
+++ b/scylla/tests/integration/ccm/tls_tickets.rs
@@ -1,0 +1,674 @@
+//! Tests verifying TLS session resumption (via TLS session tickets / PSK) behaviour
+//! of the driver's two TLS backends.
+//!
+//! Expectation being verified:
+//! - the rustls backend reuses session tickets, so subsequent connections resume
+//!   previous TLS sessions,
+//! - the openssl backend (as used by the driver) does NOT reuse session tickets,
+//!   so every connection performs a full handshake.
+//!
+//! This is verified for both TLS 1.2 and TLS 1.3.
+//!
+//! # How it works
+//!
+//! We put a small, TLS-transparent TCP proxy in front of every node. The proxy does
+//! not terminate TLS; it merely forwards bytes and passively inspects the plaintext
+//! parts of the TLS handshake (ClientHello, ServerHello, and - for TLS 1.2 - whether
+//! the server performs a full or an abbreviated handshake). For each connection it
+//! records:
+//! - the negotiated TLS version,
+//! - whether the client *offered* resumption (non-empty SessionTicket extension for
+//!   TLS 1.2, or a pre_shared_key extension for TLS 1.3),
+//! - whether the server *accepted* resumption (pre_shared_key extension in ServerHello
+//!   for TLS 1.3, or an abbreviated handshake - i.e. no Certificate message - for TLS 1.2).
+//!
+//! A connection is considered *resumed* iff the client offered and the server accepted.
+//!
+//! To route the driver's connections through the proxies we use an [`AddressTranslator`]
+//! that maps each node's real address to its proxy address. Because the driver verifies
+//! the contact point against the proxy IP, but discovered peers are reached via translated
+//! (also proxy) IPs, we generate node certificates with BOTH the node's real IP and its
+//! proxy IP in the SAN.
+//!
+//! [`AddressTranslator`]: scylla::policies::address_translator::AddressTranslator
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use openssl::ssl::{SslContext, SslMethod, SslVerifyMode, SslVersion};
+use rcgen::{CertificateParams, CertifiedIssuer, KeyPair, SanType};
+use rustls::ClientConfig;
+use scylla::client::PoolSize;
+use scylla::client::session::TlsContext;
+use scylla::client::session_builder::SessionBuilder;
+use scylla_proxy::get_exclusive_local_address;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use super::tls::{build_openssl_ca_store, run_ccm_tls_test};
+use crate::ccm::lib::cluster::Cluster;
+use crate::ccm::lib::node::Node;
+use crate::utils::{check_session_works_and_fully_connected, setup_tracing};
+
+const CQL_PORT: u16 = 9042;
+
+/// TLS protocol version, as observed on the wire.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TlsVersion {
+    V1_2,
+    V1_3,
+}
+
+/// The TLS backend under test.
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    Rustls,
+    OpenSsl,
+}
+
+/// Result of inspecting a single TLS handshake as it passed through the proxy.
+#[derive(Clone, Copy, Debug, Default)]
+struct ConnRecord {
+    /// Real IP of the node this connection was forwarded to.
+    node_ip: Option<IpAddr>,
+    /// Negotiated TLS version, determined from the ServerHello.
+    version: Option<TlsVersion>,
+    /// Whether the client offered to resume a previous session.
+    client_offered_resumption: bool,
+    /// Whether the server accepted resumption.
+    server_accepted_resumption: bool,
+}
+
+impl ConnRecord {
+    fn resumed(&self) -> bool {
+        self.client_offered_resumption && self.server_accepted_resumption
+    }
+}
+
+/// Thread-safe collection of per-connection handshake inspection results.
+#[derive(Clone)]
+struct SharedRecords(Arc<Mutex<Vec<Arc<Mutex<ConnRecord>>>>>);
+
+impl SharedRecords {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+
+    fn push(&self, rec: Arc<Mutex<ConnRecord>>) {
+        self.0.lock().unwrap().push(rec);
+    }
+
+    fn len(&self) -> usize {
+        self.0.lock().unwrap().len()
+    }
+
+    /// Snapshot of all records recorded since `start` (inclusive).
+    fn collect_from(&self, start: usize) -> Vec<ConnRecord> {
+        let guard = self.0.lock().unwrap();
+        guard[start..].iter().map(|r| *r.lock().unwrap()).collect()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// TLS handshake inspection
+// -----------------------------------------------------------------------------
+
+// TLS record content types.
+const CONTENT_TYPE_CHANGE_CIPHER_SPEC: u8 = 20;
+const CONTENT_TYPE_HANDSHAKE: u8 = 22;
+
+// Handshake message types.
+const HS_CLIENT_HELLO: u8 = 1;
+const HS_SERVER_HELLO: u8 = 2;
+const HS_CERTIFICATE: u8 = 11;
+
+// TLS extension types.
+const EXT_SESSION_TICKET: u16 = 35;
+const EXT_PRE_SHARED_KEY: u16 = 41;
+const EXT_SUPPORTED_VERSIONS: u16 = 43;
+
+#[derive(Clone, Copy)]
+enum Direction {
+    ClientToServer,
+    ServerToClient,
+}
+
+/// Information extracted from a ClientHello or ServerHello message.
+#[derive(Default)]
+struct HelloInfo {
+    /// Version selected by the server (`supported_versions` extension in ServerHello).
+    selected_version: Option<TlsVersion>,
+    /// Whether a non-empty SessionTicket extension is present (used by TLS 1.2 clients
+    /// to present a ticket).
+    nonempty_session_ticket: bool,
+    /// Whether a pre_shared_key extension is present.
+    has_psk: bool,
+}
+
+/// Parses a ClientHello/ServerHello handshake message body (i.e. the bytes after the
+/// 4-byte handshake message header). Best-effort and bounds-checked: on any malformed
+/// input it simply returns whatever it managed to parse.
+fn parse_hello(body: &[u8], is_server: bool) -> HelloInfo {
+    let mut info = HelloInfo::default();
+
+    // legacy_version (2) + random (32)
+    if body.len() < 34 {
+        return info;
+    }
+    let mut idx = 34usize;
+
+    // session_id
+    if idx >= body.len() {
+        return info;
+    }
+    let sid_len = body[idx] as usize;
+    idx += 1 + sid_len;
+
+    if is_server {
+        // cipher_suite (2) + compression_method (1)
+        idx += 3;
+    } else {
+        // cipher_suites
+        if idx + 2 > body.len() {
+            return info;
+        }
+        let cs_len = u16::from_be_bytes([body[idx], body[idx + 1]]) as usize;
+        idx += 2 + cs_len;
+        // compression_methods
+        if idx >= body.len() {
+            return info;
+        }
+        let comp_len = body[idx] as usize;
+        idx += 1 + comp_len;
+    }
+
+    // extensions
+    if idx + 2 > body.len() {
+        return info;
+    }
+    let ext_total = u16::from_be_bytes([body[idx], body[idx + 1]]) as usize;
+    idx += 2;
+    let end = (idx + ext_total).min(body.len());
+
+    while idx + 4 <= end {
+        let etype = u16::from_be_bytes([body[idx], body[idx + 1]]);
+        let elen = u16::from_be_bytes([body[idx + 2], body[idx + 3]]) as usize;
+        let dstart = idx + 4;
+        let dend = (dstart + elen).min(body.len());
+        let data = &body[dstart..dend];
+
+        match etype {
+            EXT_SESSION_TICKET => {
+                if elen > 0 {
+                    info.nonempty_session_ticket = true;
+                }
+            }
+            EXT_PRE_SHARED_KEY => {
+                info.has_psk = true;
+            }
+            EXT_SUPPORTED_VERSIONS if is_server && data.len() >= 2 => {
+                // In a ServerHello this carries the single selected version.
+                let v = u16::from_be_bytes([data[0], data[1]]);
+                info.selected_version = Some(if v == 0x0304 {
+                    TlsVersion::V1_3
+                } else {
+                    TlsVersion::V1_2
+                });
+            }
+            _ => {}
+        }
+
+        idx = dstart + elen;
+    }
+
+    info
+}
+
+/// Incrementally parses one direction of a TLS connection, updating a [`ConnRecord`]
+/// with resumption-related observations. Once enough has been observed, it stops parsing.
+struct HandshakeParser {
+    dir: Direction,
+    /// Reassembly buffer for handshake-record payloads.
+    buf: Vec<u8>,
+    /// Negotiated version, once the ServerHello has been parsed (server direction only).
+    version: Option<TlsVersion>,
+    /// Whether the ServerHello has been parsed already (server direction only).
+    server_hello_parsed: bool,
+    /// Whether we are done inspecting this direction.
+    done: bool,
+}
+
+impl HandshakeParser {
+    fn new(dir: Direction) -> Self {
+        Self {
+            dir,
+            buf: Vec::new(),
+            version: None,
+            server_hello_parsed: false,
+            done: false,
+        }
+    }
+
+    fn feed(&mut self, content_type: u8, body: &[u8], rec: &Arc<Mutex<ConnRecord>>) {
+        if self.done {
+            return;
+        }
+        match content_type {
+            CONTENT_TYPE_CHANGE_CIPHER_SPEC => {
+                // For TLS 1.2, a ChangeCipherSpec arriving from the server before any
+                // Certificate message means an abbreviated (resumed) handshake.
+                if matches!(self.dir, Direction::ServerToClient)
+                    && self.version == Some(TlsVersion::V1_2)
+                {
+                    rec.lock().unwrap().server_accepted_resumption = true;
+                    self.done = true;
+                }
+            }
+            CONTENT_TYPE_HANDSHAKE => {
+                self.buf.extend_from_slice(body);
+                self.parse_messages(rec);
+            }
+            _ => {}
+        }
+    }
+
+    fn parse_messages(&mut self, rec: &Arc<Mutex<ConnRecord>>) {
+        loop {
+            if self.done || self.buf.len() < 4 {
+                return;
+            }
+            let mlen = ((self.buf[1] as usize) << 16)
+                | ((self.buf[2] as usize) << 8)
+                | (self.buf[3] as usize);
+            if self.buf.len() < 4 + mlen {
+                return;
+            }
+            let mtype = self.buf[0];
+            let mbody = self.buf[4..4 + mlen].to_vec();
+            self.handle_message(mtype, &mbody, rec);
+            self.buf.drain(0..4 + mlen);
+        }
+    }
+
+    fn handle_message(&mut self, mtype: u8, mbody: &[u8], rec: &Arc<Mutex<ConnRecord>>) {
+        match self.dir {
+            Direction::ClientToServer => {
+                if mtype == HS_CLIENT_HELLO {
+                    let info = parse_hello(mbody, false);
+                    rec.lock().unwrap().client_offered_resumption =
+                        info.nonempty_session_ticket || info.has_psk;
+                    self.done = true;
+                }
+            }
+            Direction::ServerToClient => {
+                if mtype == HS_SERVER_HELLO {
+                    let info = parse_hello(mbody, true);
+                    let version = info
+                        .selected_version
+                        .unwrap_or(TlsVersion::V1_2 /* legacy, either 1.2 or 1.0/1.1 */);
+                    self.version = Some(version);
+                    {
+                        let mut r = rec.lock().unwrap();
+                        r.version = Some(version);
+                        if version == TlsVersion::V1_3 {
+                            r.server_accepted_resumption = info.has_psk;
+                        }
+                    }
+                    if version == TlsVersion::V1_3 {
+                        // For TLS 1.3 everything after ServerHello is encrypted; the
+                        // ServerHello alone tells us whether resumption was accepted.
+                        self.done = true;
+                    } else {
+                        self.server_hello_parsed = true;
+                    }
+                } else if self.server_hello_parsed
+                    && self.version == Some(TlsVersion::V1_2)
+                    && mtype == HS_CERTIFICATE
+                {
+                    // A Certificate message means a full (non-resumed) TLS 1.2 handshake.
+                    rec.lock().unwrap().server_accepted_resumption = false;
+                    self.done = true;
+                }
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// TLS-transparent TCP proxy
+// -----------------------------------------------------------------------------
+
+/// Forwards TLS records from `reader` to `writer`, inspecting the handshake as it goes.
+async fn forward<R, W>(mut reader: R, mut writer: W, dir: Direction, rec: Arc<Mutex<ConnRecord>>)
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut parser = HandshakeParser::new(dir);
+    let mut header = [0u8; 5];
+    loop {
+        if reader.read_exact(&mut header).await.is_err() {
+            break;
+        }
+        let content_type = header[0];
+        let len = u16::from_be_bytes([header[3], header[4]]) as usize;
+        let mut body = vec![0u8; len];
+        if len > 0 && reader.read_exact(&mut body).await.is_err() {
+            break;
+        }
+
+        parser.feed(content_type, &body, &rec);
+
+        if writer.write_all(&header).await.is_err()
+            || writer.write_all(&body).await.is_err()
+            || writer.flush().await.is_err()
+        {
+            break;
+        }
+    }
+}
+
+/// Accepts connections on `listener`, forwards each to `real_addr`, and records the
+/// result of inspecting the TLS handshake into `records`.
+async fn run_proxy(
+    listener: TcpListener,
+    real_addr: SocketAddr,
+    node_ip: IpAddr,
+    records: SharedRecords,
+) {
+    loop {
+        let client = match listener.accept().await {
+            Ok((stream, _)) => stream,
+            Err(err) => {
+                tracing::warn!("TLS ticket proxy accept error: {err}");
+                continue;
+            }
+        };
+        let server = match TcpStream::connect(real_addr).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                tracing::warn!("TLS ticket proxy failed to connect to {real_addr}: {err}");
+                continue;
+            }
+        };
+
+        let rec = Arc::new(Mutex::new(ConnRecord {
+            node_ip: Some(node_ip),
+            ..Default::default()
+        }));
+        records.push(Arc::clone(&rec));
+
+        let (client_read, client_write) = client.into_split();
+        let (server_read, server_write) = server.into_split();
+
+        tokio::spawn(forward(
+            client_read,
+            server_write,
+            Direction::ClientToServer,
+            Arc::clone(&rec),
+        ));
+        tokio::spawn(forward(
+            server_read,
+            client_write,
+            Direction::ServerToClient,
+            rec,
+        ));
+    }
+}
+
+// -----------------------------------------------------------------------------
+// TLS context construction
+// -----------------------------------------------------------------------------
+
+fn make_openssl_context(ca: &CertifiedIssuer<'_, KeyPair>, version: TlsVersion) -> SslContext {
+    let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
+    builder.set_verify(SslVerifyMode::PEER);
+    builder.set_cert_store(build_openssl_ca_store(ca));
+    let ssl_version = match version {
+        TlsVersion::V1_2 => SslVersion::TLS1_2,
+        TlsVersion::V1_3 => SslVersion::TLS1_3,
+    };
+    builder.set_min_proto_version(Some(ssl_version)).unwrap();
+    builder.set_max_proto_version(Some(ssl_version)).unwrap();
+    builder.build()
+}
+
+fn make_rustls_config(ca: &CertifiedIssuer<'_, KeyPair>, version: TlsVersion) -> Arc<ClientConfig> {
+    let mut store = rustls::RootCertStore::empty();
+    store.add(ca.der().to_owned()).unwrap();
+    let versions: &[&rustls::SupportedProtocolVersion] = match version {
+        TlsVersion::V1_2 => &[&rustls::version::TLS12],
+        TlsVersion::V1_3 => &[&rustls::version::TLS13],
+    };
+    let config = ClientConfig::builder_with_protocol_versions(versions)
+        .with_root_certificates(store)
+        .with_no_client_auth();
+    Arc::new(config)
+}
+
+// -----------------------------------------------------------------------------
+// Sub-test
+// -----------------------------------------------------------------------------
+
+/// Runs a single sub-test for the given backend and TLS version against the
+/// already-running cluster (fronted by proxies).
+///
+/// It creates two sessions sharing the same TLS context. The first performs full
+/// handshakes; the second, if the backend reuses session tickets, resumes them.
+/// The proxy observations are then asserted.
+async fn run_subtest(
+    backend: Backend,
+    version: TlsVersion,
+    contact: SocketAddr,
+    translation: &HashMap<SocketAddr, SocketAddr>,
+    ca: &CertifiedIssuer<'static, KeyPair>,
+    records: &SharedRecords,
+    node_count: usize,
+) {
+    tracing::info!("TLS session ticket sub-test: {backend:?} / {version:?}");
+
+    let start_idx = records.len();
+
+    let tls_context: TlsContext = match backend {
+        Backend::Rustls => TlsContext::Rustls023(make_rustls_config(ca, version)),
+        Backend::OpenSsl => TlsContext::OpenSsl010(make_openssl_context(ca, version)),
+    };
+
+    // Session A: establishes the sessions and obtains session tickets.
+    let session_a = SessionBuilder::new()
+        .known_node_addr(contact)
+        .address_translator(Arc::new(translation.clone()))
+        .tls_context(Some(tls_context.clone()))
+        .disallow_shard_aware_port(true)
+        .pool_size(PoolSize::PerHost(NonZeroUsize::new(1).unwrap()))
+        .build()
+        .await
+        .unwrap();
+    check_session_works_and_fully_connected(node_count, &session_a).await;
+
+    // Session B: shares the same TLS context, so a ticket-reusing backend will resume.
+    let session_b = SessionBuilder::new()
+        .known_node_addr(contact)
+        .address_translator(Arc::new(translation.clone()))
+        .tls_context(Some(tls_context.clone()))
+        .disallow_shard_aware_port(true)
+        .pool_size(PoolSize::PerHost(NonZeroUsize::new(1).unwrap()))
+        .build()
+        .await
+        .unwrap();
+    check_session_works_and_fully_connected(node_count, &session_b).await;
+
+    let observed = records.collect_from(start_idx);
+    assert!(
+        !observed.is_empty(),
+        "{backend:?}/{version:?}: proxy observed no connections"
+    );
+
+    // Sanity: every observed connection negotiated the pinned TLS version.
+    for rec in &observed {
+        assert_eq!(
+            rec.version,
+            Some(version),
+            "{backend:?}/{version:?}: connection negotiated unexpected TLS version {:?}",
+            rec.version
+        );
+    }
+
+    // Aggregate per node: (total connections, resumed connections).
+    let mut per_node: HashMap<IpAddr, (usize, usize)> = HashMap::new();
+    for rec in &observed {
+        let ip = rec.node_ip.expect("proxy always records the node IP");
+        let entry = per_node.entry(ip).or_default();
+        entry.0 += 1;
+        if rec.resumed() {
+            entry.1 += 1;
+        }
+    }
+
+    assert_eq!(
+        per_node.len(),
+        node_count,
+        "{backend:?}/{version:?}: expected connections through all {node_count} proxies, got {}",
+        per_node.len()
+    );
+
+    match backend {
+        Backend::Rustls => {
+            // The rustls backend caches session tickets in the (shared) ClientConfig, so
+            // once the first connection to a node has obtained a ticket, subsequent
+            // connections to that node resume the session.
+            for (ip, (total, resumed)) in &per_node {
+                assert!(
+                    *resumed >= 1,
+                    "{backend:?}/{version:?}: node {ip} had no resumed connections (out of {total}); \
+                     rustls is expected to reuse session tickets"
+                );
+            }
+        }
+        Backend::OpenSsl => {
+            // The driver's openssl backend creates a fresh SSL object per connection and
+            // does not reuse session tickets, so no connection ever resumes.
+            for (ip, (total, resumed)) in &per_node {
+                assert_eq!(
+                    *resumed, 0,
+                    "{backend:?}/{version:?}: node {ip} resumed {resumed} connection(s) (out of \
+                     {total}); the driver's openssl backend is expected never to resume"
+                );
+            }
+        }
+    }
+
+    drop(session_a);
+    drop(session_b);
+}
+
+// -----------------------------------------------------------------------------
+// Test
+// -----------------------------------------------------------------------------
+
+/// Enables session tickets on the server. Scylla does not issue TLS session tickets by
+/// default (the `enable_session_tickets` client-encryption option defaults to `false`),
+/// so without opting in no backend could ever resume a session. Note that although the
+/// option is documented as controlling "TLS 1.3 session tickets", the underlying GnuTLS
+/// implementation also issues RFC 5077 tickets for TLS 1.2, so enabling it makes
+/// resumption possible for both TLS versions.
+async fn enable_session_tickets(mut cluster: Cluster) -> Cluster {
+    cluster
+        .updateconf([("client_encryption_options.enable_session_tickets", "true")])
+        .await
+        .unwrap();
+    cluster
+}
+
+/// Verifies TLS session-ticket resumption behaviour of both TLS backends, for both
+/// TLS 1.2 and TLS 1.3.
+///
+/// All backend/version combinations are exercised against a single CCM cluster, since
+/// creating CCM clusters is expensive.
+#[tokio::test]
+async fn test_tls_session_tickets() {
+    setup_tracing();
+
+    // Real node IP -> proxy IP. Populated lazily while preparing certificates (which
+    // happens before the cluster starts), then read in the test body to start the
+    // proxies and build the address translator.
+    let proxy_map: Arc<Mutex<HashMap<IpAddr, IpAddr>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let prepare_cert = {
+        let proxy_map = Arc::clone(&proxy_map);
+        move |mut params: CertificateParams, node: &Node| {
+            let real_ip = node.broadcast_rpc_address();
+            let proxy_ip = *proxy_map
+                .lock()
+                .unwrap()
+                .entry(real_ip)
+                .or_insert_with(get_exclusive_local_address);
+            // The driver verifies the contact point against the proxy IP, and discovered
+            // peers against their (translated, also proxy) IPs; include the real IP too so
+            // the same cert works regardless of which address is used for verification.
+            params.subject_alt_names.push(SanType::IpAddress(real_ip));
+            params.subject_alt_names.push(SanType::IpAddress(proxy_ip));
+            params
+        }
+    };
+
+    let test = {
+        let proxy_map = Arc::clone(&proxy_map);
+        async move |ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster| {
+            let node_count = cluster.nodes().len();
+            let real_ips: Vec<IpAddr> = cluster
+                .nodes()
+                .iter()
+                .map(|node| node.broadcast_rpc_address())
+                .collect();
+
+            let map = proxy_map.lock().unwrap().clone();
+            let records = SharedRecords::new();
+
+            // Start a proxy in front of every node.
+            let mut translation: HashMap<SocketAddr, SocketAddr> = HashMap::new();
+            let mut proxy_tasks = Vec::new();
+            for (&real_ip, &proxy_ip) in &map {
+                let real_addr = SocketAddr::new(real_ip, CQL_PORT);
+                let proxy_addr = SocketAddr::new(proxy_ip, CQL_PORT);
+                let listener = TcpListener::bind(proxy_addr).await.unwrap();
+                translation.insert(real_addr, proxy_addr);
+                proxy_tasks.push(tokio::spawn(run_proxy(
+                    listener,
+                    real_addr,
+                    real_ip,
+                    records.clone(),
+                )));
+            }
+
+            // Use the first node's proxy as the contact point.
+            let contact = SocketAddr::new(map[&real_ips[0]], CQL_PORT);
+
+            for (backend, version) in [
+                (Backend::Rustls, TlsVersion::V1_2),
+                (Backend::Rustls, TlsVersion::V1_3),
+                (Backend::OpenSsl, TlsVersion::V1_2),
+                (Backend::OpenSsl, TlsVersion::V1_3),
+            ] {
+                run_subtest(
+                    backend,
+                    version,
+                    contact,
+                    &translation,
+                    ca,
+                    &records,
+                    node_count,
+                )
+                .await;
+            }
+
+            for task in proxy_tasks {
+                task.abort();
+            }
+        }
+    };
+
+    run_ccm_tls_test(prepare_cert, enable_session_tickets, test).await
+}

--- a/scylla/tests/integration/ccm/tls_tickets.rs
+++ b/scylla/tests/integration/ccm/tls_tickets.rs
@@ -1,0 +1,499 @@
+//! Tests verifying TLS session resumption (via TLS session tickets / PSK) behaviour
+//! of the driver's two TLS backends.
+//!
+//! Expectation being verified:
+//! - the rustls backend reuses session tickets; TLS 1.2 pools resume every connection after
+//!   the first, while TLS 1.3 pools resume at least two connections per node,
+//! - the openssl backend (as used by the driver) does NOT reuse session tickets, so every
+//!   connection performs a full handshake.
+//!
+//! This is verified for both TLS 1.2 and TLS 1.3.
+//!
+//! # How it works
+//!
+//! One session per sub-test, with a pool of [`POOL_SIZE`] connections per node.
+//!
+//! Every node is fronted by a TLS-transparent TCP proxy (see
+//! [`super::tls_inspecting_proxy`]) that forwards bytes without terminating TLS and
+//! passively classifies every handshake it carries: which TLS version the server
+//! selected, whether the client offered to resume an earlier session, and whether the
+//! server accepted. A connection counts as *resumed* iff the client offered and the
+//! server accepted.
+//!
+//! How many of a pool's connections can resume is not the same for the two TLS versions,
+//! and the reason is worth knowing before touching the numbers here:
+//! see [`min_resumptions_per_node`].
+//!
+//! To route the driver's connections through the proxies we use an [`AddressTranslator`]
+//! that maps each node's real address to its proxy address. Because the driver verifies
+//! the contact point against the proxy IP, but discovered peers are reached via translated
+//! (also proxy) IPs, we generate node certificates with BOTH the node's real IP and its
+//! proxy IP in the SAN.
+//!
+//! [`AddressTranslator`]: scylla::policies::address_translator::AddressTranslator
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use openssl::ssl::{SslContext, SslMethod, SslVerifyMode, SslVersion};
+use rcgen::{CertificateParams, CertifiedIssuer, KeyPair, SanType};
+use rustls::ClientConfig;
+use scylla::client::PoolSize;
+use scylla::client::session::TlsContext;
+use scylla::client::session_builder::SessionBuilder;
+use scylla_proxy::get_exclusive_local_address;
+use tokio::net::TcpListener;
+
+use super::tls::{build_openssl_ca_store, run_ccm_tls_test};
+use super::tls_inspecting_proxy::{ConnRecord, Handshake, SharedRecords, TlsVersion, run_proxy};
+use crate::utils::setup_tracing;
+use scylla_ccm_bridge::cluster::Cluster;
+use scylla_ccm_bridge::node::Node;
+
+const CQL_PORT: u16 = 9042;
+
+/// The TLS backend under test.
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    Rustls023,
+    OpenSsl010,
+}
+
+impl Backend {
+    /// Whether the driver reuses TLS session tickets on this backend.
+    fn reuses_session_tickets(self) -> bool {
+        match self {
+            Backend::Rustls023 => true,
+            // The driver builds a fresh `Ssl` from the `SslContext` per connection and
+            // never calls `SSL_set_session`.
+            Backend::OpenSsl010 => false,
+        }
+    }
+}
+
+/// The fewest resumptions a pool of `pool_size` connections to one node must show, for a
+/// backend that reuses tickets.
+///
+/// The driver fills a pool by opening one connection while the pool is empty and only
+/// then the rest, concurrently (`connection_pool.rs`, `start_filling`). So the first
+/// connection has always completed - and banked whatever tickets the server issued -
+/// before its siblings start.
+///
+/// From there the two TLS versions differ, and not by a little:
+///
+/// - In TLS 1.2 an RFC 5077 ticket is *reusable*: nothing in that RFC says otherwise, so
+///   the single ticket banked by the first connection serves every remaining one and all
+///   but the first resume.
+/// - In TLS 1.3 a ticket is spent when it is used, so the concurrent siblings can only
+///   resume as many times as there are tickets already banked. ScyllaDB issues two per
+///   handshake. ScyllaDB also ignores the RFC 9149 `ticket_request` extension that allows
+///   clients to request specific amount of tickets.
+///
+/// The single-use rule is *not* an anti-replay measure - RFC 8446 section 8.1
+/// ("Single-Use Tickets") is about a **server** optionally spending each ticket once to
+/// blunt 0-RTT replay, and asks nothing of clients. The client-side rule is a privacy one,
+/// RFC 8446 appendix C.4 ("Client Tracking Prevention"):
+///
+/// > Clients SHOULD NOT reuse a ticket for multiple connections. Reuse of a ticket allows
+/// > passive observers to correlate different connections.
+///
+/// Reuse is linkable because a resumed ClientHello carries the ticket as its
+/// `PskIdentity`; section 4.2.11.1 notes that `obfuscated_ticket_age` hides the
+/// correlation only "unless tickets are reused". rustls encodes the rule in the shape of
+/// its store API rather than citing the RFC: TLS 1.2 gets a plain getter
+/// (`ClientSessionStore::tls12_session`), TLS 1.3 a taker whose contract is that
+/// implementations "must return each value [...] _at most once_"
+/// (`ClientSessionStore::take_tls13_ticket`).
+///
+/// Worth noting which side is actually falling short of C.4 here. It also says servers
+/// "SHOULD offer at least as many tickets as the number of connections that a client
+/// might use" and "SHOULD issue new tickets with every connection" - so a pool of
+/// [`POOL_SIZE`] wanting [`POOL_SIZE`] tickets is the behaviour the RFC anticipates, and
+/// two-per-handshake is the server declining to supply it. rustls is doing exactly as it
+/// should; the floor below is a server limitation, not a client one.
+///
+/// OTOH Rustls has a hardcoded limitation of only storing 8 tickets per host.
+/// This means even if server provides ticket count equal to shard count, on big deployments
+/// most of those tickets would be dropped by rustls.
+const fn min_resumptions_per_node(version: TlsVersion, pool_size: usize) -> usize {
+    match version {
+        TlsVersion::V1_2 => pool_size - 1,
+        TlsVersion::V1_3 => TLS13_TICKETS_PER_HANDSHAKE,
+    }
+}
+
+/// Session tickets ScyllaDB issues per TLS 1.3 handshake. Fewer than a pool needs; see
+/// [`min_resumptions_per_node`].
+///
+/// It is not a ScyllaDB setting, and there is no server-side knob for it. ScyllaDB only
+/// passes a boolean down (`db/config.cc` turns `enable_session_tickets` into
+/// `seastar::tls::session_resume_mode::TLS13_SESSION_TICKET`), and Seastar in turn only
+/// calls `gnutls_session_ticket_enable_server` - never `gnutls_session_ticket_send(nr)`,
+/// which is the API that would set a count. Two is also what rustls's *server* side and
+/// OpenSSL default to, so it is the cross-implementation norm rather than a ScyllaDB
+/// quirk.
+///
+/// GnuTLS raised it from one to two in 2019 (commit `c6754cf52`, "handshake: increase the
+/// default number of tickets we send to 2"), reasoning:
+///
+/// > This makes it easier for clients which perform multiple connections to the server to
+/// > use the tickets sent by a default server. That's because 2 tickets allow for 2 new
+/// > connections (if one is using each ticket once as recommended), which in turn lead to
+/// > 4 new and so on.
+///
+/// That compounding argument assumes connections are opened *one after another*, each
+/// banking its own two tickets before the next needs one. A connection pool defeats it:
+/// the driver opens the first connection alone and then the rest at once, so every
+/// sibling draws on the same two tickets the first one banked. The doubling never gets a
+/// round to happen, which is why the floor here is two and not `pool_size - 1`.
+///
+/// Relevant server issue: https://scylladb.atlassian.net/browse/SCYLLADB-3949
+const TLS13_TICKETS_PER_HANDSHAKE: usize = 2;
+
+// -----------------------------------------------------------------------------
+// TLS context construction
+// -----------------------------------------------------------------------------
+
+fn make_openssl_010_context(ca: &CertifiedIssuer<'_, KeyPair>, version: TlsVersion) -> SslContext {
+    let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
+    builder.set_verify(SslVerifyMode::PEER);
+    builder.set_cert_store(build_openssl_ca_store(ca));
+    let ssl_version = match version {
+        TlsVersion::V1_2 => SslVersion::TLS1_2,
+        TlsVersion::V1_3 => SslVersion::TLS1_3,
+    };
+    builder.set_min_proto_version(Some(ssl_version)).unwrap();
+    builder.set_max_proto_version(Some(ssl_version)).unwrap();
+    builder.build()
+}
+
+fn make_rustls_023_config(
+    ca: &CertifiedIssuer<'_, KeyPair>,
+    version: TlsVersion,
+) -> Arc<ClientConfig> {
+    let mut store = rustls::RootCertStore::empty();
+    store.add(ca.der().to_owned()).unwrap();
+    let versions: &[&rustls::SupportedProtocolVersion] = match version {
+        TlsVersion::V1_2 => &[&rustls::version::TLS12],
+        TlsVersion::V1_3 => &[&rustls::version::TLS13],
+    };
+    let config = ClientConfig::builder_with_protocol_versions(versions)
+        .with_root_certificates(store)
+        .with_no_client_auth();
+    Arc::new(config)
+}
+
+// -----------------------------------------------------------------------------
+// Sub-test
+// -----------------------------------------------------------------------------
+
+/// Connections the driver is told to keep in each node's pool. Larger than one so that a
+/// single session, on its own, has to open several connections per node: the first must
+/// perform a full handshake and the rest can resume it. That is a property of one pool
+/// rather than of two sessions sharing a TLS context, which is what makes it meaningful
+/// for any backend that caches tickets, however it scopes the cache.
+const POOL_SIZE: usize = 5;
+
+/// Upper bound for [`wait_for_handshakes`]. Generous, because it is only ever reached
+/// when the driver fails to fill its pools at all.
+const POOL_FILL_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Builds a session that reaches the cluster through the proxies.
+async fn connect(
+    contact: SocketAddr,
+    translation: &HashMap<SocketAddr, SocketAddr>,
+    tls_context: TlsContext,
+) -> scylla::client::session::Session {
+    SessionBuilder::new()
+        .known_node_addr(contact)
+        .address_translator(Arc::new(translation.clone()))
+        .tls_context(Some(tls_context))
+        .disallow_shard_aware_port(true)
+        .pool_size(PoolSize::PerHost(NonZeroUsize::new(POOL_SIZE).unwrap()))
+        .build()
+        .await
+        .unwrap()
+}
+
+/// Waits until the proxies have observed at least `expected` connections, all of them
+/// fully classified.
+///
+/// Pool filling is asynchronous and the driver exposes no completion signal for it:
+/// `Node::is_connected()` only means the pool holds *one* connection, so waiting on that
+/// would race the remaining [`POOL_SIZE`] - 1 handshakes. The proxies see every
+/// connection, so they are the thing to wait on.
+async fn wait_for_handshakes(
+    records: &SharedRecords,
+    first: usize,
+    expected: usize,
+    case: &str,
+) -> Vec<Handshake> {
+    let wait = async {
+        loop {
+            // Counting costs a single lock, whereas snapshotting locks every record it
+            // copies - and until enough connections have even been accepted, there is
+            // nothing a snapshot could tell us. So poll on the count and take at most one
+            // snapshot per attempt that could actually succeed.
+            if records.count_from(first) >= expected {
+                let observed = records.collect_from(first);
+                let classified: Vec<Handshake> =
+                    observed.iter().filter_map(ConnRecord::finish).collect();
+                if classified.len() == observed.len() {
+                    return classified;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    };
+    tokio::time::timeout(POOL_FILL_TIMEOUT, wait)
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "{case}: timed out waiting for {expected} fully classified handshake(s); \
+                 the proxies saw {:#?}",
+                records.collect_from(first)
+            )
+        })
+}
+
+/// Runs a single sub-test for the given backend and TLS version against the
+/// already-running cluster (fronted by proxies).
+async fn run_subtest(
+    backend: Backend,
+    version: TlsVersion,
+    contact: SocketAddr,
+    translation: &HashMap<SocketAddr, SocketAddr>,
+    ca: &CertifiedIssuer<'static, KeyPair>,
+    records: &SharedRecords,
+    node_count: usize,
+) {
+    let case = format!("{backend:?}/{version:?}");
+    tracing::info!("TLS session ticket sub-test: {case}");
+
+    // A fresh TLS context per sub-test, hence a fresh (empty) session cache.
+    let tls_context: TlsContext = match backend {
+        Backend::Rustls023 => TlsContext::Rustls023(make_rustls_023_config(ca, version)),
+        Backend::OpenSsl010 => TlsContext::OpenSsl010(make_openssl_010_context(ca, version)),
+    };
+
+    // One pool of POOL_SIZE connections per node, plus the single control connection,
+    // which is not part of any pool.
+    let expected = node_count * POOL_SIZE + 1;
+
+    let first = records.len();
+    // Kept alive until the end of the sub-test: dropping it would close its connections
+    // and could make the driver open fresh ones mid-assertion.
+    let _session = connect(contact, translation, tls_context).await;
+    let handshakes = wait_for_handshakes(records, first, expected, &case).await;
+
+    tracing::debug!("{case}: {} handshake(s): {handshakes:#?}", handshakes.len());
+
+    // The count is deterministic: `PerHost(n)` targets exactly n connections (it is not
+    // scaled per shard) and keeps no excess ones, so anything else means a connection was
+    // re-established behind our back and the per-node conclusions below would be drawn
+    // from a shifted picture.
+    assert_eq!(
+        handshakes.len(),
+        expected,
+        "{case}: expected {expected} connections ({node_count} x {POOL_SIZE} pooled + 1 \
+         control), the proxies saw {}: {handshakes:#?}",
+        handshakes.len()
+    );
+
+    // The pinned version must be the one actually negotiated - otherwise the sub-test
+    // would be silently checking resumption for some other TLS version.
+    for hs in &handshakes {
+        assert_eq!(
+            hs.version,
+            version.wire(),
+            "{case}: connection to node {} negotiated TLS version {}, expected {}",
+            hs.node_ip,
+            hs.version,
+            version.wire()
+        );
+    }
+
+    // Grouped per node, in accept order.
+    let mut per_node: HashMap<IpAddr, Vec<Handshake>> = HashMap::new();
+    for hs in &handshakes {
+        per_node.entry(hs.node_ip).or_default().push(*hs);
+    }
+    assert_eq!(
+        per_node.len(),
+        node_count,
+        "{case}: expected connections to all {node_count} nodes, saw {:?}",
+        per_node.keys()
+    );
+
+    for (ip, conns) in &per_node {
+        // Every node carries a full pool; one of them also carries the control
+        // connection, which belongs to no pool.
+        assert!(
+            conns.len() >= POOL_SIZE,
+            "{case}: node {ip} got {} connection(s), expected at least the pool's \
+             {POOL_SIZE}: {conns:#?}",
+            conns.len()
+        );
+
+        // The first connection to a node cannot resume: the TLS context, and with it the
+        // session cache, is created fresh for each sub-test. This is what proves the
+        // checks below can tell the two outcomes apart at all.
+        assert!(
+            !conns[0].resumed(),
+            "{case}: the first connection to node {ip} resumed a session, which is \
+             impossible with a freshly created TLS context: {:?}",
+            conns[0]
+        );
+
+        let resumed: Vec<&Handshake> = conns.iter().filter(|hs| hs.resumed()).collect();
+        if backend.reuses_session_tickets() {
+            let least = min_resumptions_per_node(version, conns.len());
+            assert!(
+                resumed.len() >= least,
+                "{case}: node {ip} resumed {} of {} connection(s), expected at least \
+                 {least}; the pool is expected to reuse the ticket(s) banked by its first \
+                 connection: {conns:#?}",
+                resumed.len(),
+                conns.len()
+            );
+            // And by presenting a *ticket* - not, say, by falling back to a cached TLS 1.2
+            // session id, which the server may accept for reasons of its own.
+            for hs in resumed {
+                assert!(
+                    hs.presented_ticket,
+                    "{case}: connection to node {ip} resumed without presenting a session \
+                     ticket, so this says nothing about ticket reuse: {hs:?}"
+                );
+            }
+        } else {
+            assert!(
+                resumed.is_empty(),
+                "{case}: node {ip} resumed {} connection(s); this backend is expected \
+                 never to reuse a session: {conns:#?}",
+                resumed.len()
+            );
+            for hs in conns {
+                assert!(
+                    !hs.offered_resumption,
+                    "{case}: connection to node {ip} offered resumption; this backend is \
+                     expected never to present a cached session: {hs:?}"
+                );
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Test
+// -----------------------------------------------------------------------------
+
+/// Enables session tickets on the server. Scylla does not issue TLS session tickets by
+/// default (the `enable_session_tickets` client-encryption option defaults to `false`),
+/// so without opting in no backend could ever resume a session.
+///
+/// The option is documented as controlling "TLS 1.3 session tickets", but the underlying
+/// GnuTLS implementation also issues RFC 5077 tickets for TLS 1.2 - so it is what makes
+/// resumption possible for *both* TLS versions here. Flipping it back to `false` makes
+/// the TLS 1.2 sub-test fail too, not just the TLS 1.3 one.
+async fn enable_session_tickets(mut cluster: Cluster) -> Cluster {
+    cluster
+        .updateconf([("client_encryption_options.enable_session_tickets", "true")])
+        .await
+        .unwrap();
+    cluster
+}
+
+/// Verifies TLS session-ticket resumption behaviour of both TLS backends, for both
+/// TLS 1.2 and TLS 1.3.
+#[tokio::test]
+async fn test_tls_session_tickets() {
+    setup_tracing();
+
+    // Real node IP -> proxy IP. Populated lazily while preparing certificates (which
+    // happens before the cluster starts), then read in the test body to start the
+    // proxies and build the address translator.
+    let proxy_map: Arc<Mutex<HashMap<IpAddr, IpAddr>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let prepare_cert = {
+        let proxy_map = Arc::clone(&proxy_map);
+        move |mut params: CertificateParams, node: &Node| {
+            let real_ip = node.broadcast_rpc_address();
+            let proxy_ip = *proxy_map
+                .lock()
+                .unwrap()
+                .entry(real_ip)
+                .or_insert_with(get_exclusive_local_address);
+            // The driver verifies the contact point against the proxy IP, and discovered
+            // peers against their (translated, also proxy) IPs; include the real IP too so
+            // the same cert works regardless of which address is used for verification.
+            params.subject_alt_names.push(SanType::IpAddress(real_ip));
+            params.subject_alt_names.push(SanType::IpAddress(proxy_ip));
+            params
+        }
+    };
+
+    let test = {
+        let proxy_map = Arc::clone(&proxy_map);
+        async move |ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster| {
+            let node_count = cluster.nodes().len();
+            let real_ips: Vec<IpAddr> = cluster
+                .nodes()
+                .iter()
+                .map(|node| node.broadcast_rpc_address())
+                .collect();
+
+            let map = proxy_map.lock().unwrap().clone();
+            let records = SharedRecords::new();
+
+            // A proxy in front of every node, all served by this task: nothing is
+            // spawned, so no proxy - and no connection it carries - can outlive the
+            // sub-tests below.
+            let mut translation: HashMap<SocketAddr, SocketAddr> = HashMap::new();
+            let mut proxies = Vec::new();
+            for (&real_ip, &proxy_ip) in &map {
+                let real_addr = SocketAddr::new(real_ip, CQL_PORT);
+                let proxy_addr = SocketAddr::new(proxy_ip, CQL_PORT);
+                let listener = TcpListener::bind(proxy_addr).await.unwrap();
+                translation.insert(real_addr, proxy_addr);
+                proxies.push(run_proxy(listener, real_addr, real_ip, records.clone()));
+            }
+
+            // Use the first node's proxy as the contact point.
+            let contact = SocketAddr::new(map[&real_ips[0]], CQL_PORT);
+
+            let subtests = async {
+                for (backend, version) in [
+                    (Backend::Rustls023, TlsVersion::V1_2),
+                    (Backend::Rustls023, TlsVersion::V1_3),
+                    (Backend::OpenSsl010, TlsVersion::V1_2),
+                    (Backend::OpenSsl010, TlsVersion::V1_3),
+                ] {
+                    run_subtest(
+                        backend,
+                        version,
+                        contact,
+                        &translation,
+                        ca,
+                        &records,
+                        node_count,
+                    )
+                    .await;
+                }
+            };
+
+            // The proxies never finish on their own, so this runs the sub-tests with the
+            // proxies serving, then drops the proxies the moment the sub-tests are done.
+            tokio::select! {
+                () = subtests => {}
+                _ = futures::future::join_all(proxies) => {
+                    unreachable!("a proxy only stops when dropped")
+                }
+            }
+        }
+    };
+
+    run_ccm_tls_test(prepare_cert, enable_session_tickets, test).await
+}


### PR DESCRIPTION
TLS tickets are a mechanism that allows creating TLS connections quicker
(with a less amount of round-trips, and less CPU time).
Conceptually, it looks like this:
 - We open a full normal TLS connection
 - Server sends us some ticket / tickets
 - We use them when opening more connections to the same host
   in order to skip most of the required handshake.

The mechanism differs between TLS 1.2 and 1.3. From our perspective, the
most important difference is that TLS 1.3 tickets are single-use, while
TLS 1.2 tickets are multi-use.

Also connected to the above and relevant later: Scylla currently always
sends exactly 2 TLS 1.3 tickets. It also doesn't support the TLS
extension that allows the client to request a specific amount of
tickets. It sends 2 unconditionally.

This commit adds tests for TLS tickets support so that we have a proof
of what the current behavior is. The current behavior is that Rustls
supports tickets out of the box, and OpenSSL doesn't (so we'll need to
add support).

There is a caveat with rustls (but we'll hit the same problem with
openssl when we add support). As I mentioned, Scylla sends exactly 2 TLS
1.3 tickets per connection. When we create new connection pool, we open
a first connection, then discover the shard structure, and then open the
rest of the connections concurrently.
First connection will receive 2 tickets. Each will be used for one
subsequent connection. That means if we have a 12-shard node, and we are
missing 11 shards (after the scout connection is opened), then 2 will
use TLS tickets, while the rest will fallback to full handshake.

We could improve this on a server side, by changing the server to send
more tickets, or support RFC 9149 that allows client to request more
tickets. None of those however solve the problem in full, because Rustls
has a hard cap of 8 stored tickets per host. So if we have a node with
more than 9 shards, we'll still fallback to full handshake, no matter
how many tickets we get.

The only resilient solution for rustls is to pace the connection
opening: look at how many tickets we have, and open that many
connection, instead of opening all missing ones concurrently. I think
implementing that properly requires a greater rework of
NodeConnectionPool and is also tied to ReconnectPolicy, so let's address
it some other time.

For that reason, the rustls tests variants only require at least 2
resumptions to happen per node.

Now about the tests. They are located in a new `tls_tickets.rs` file.
This file itself should not be very hard to understand. It has some long
comments that mostly explain what I explained above.
Tests assert both that rustls works, and that openssl doesn't (with
regards to tls tickets).

To function, the tests need to inspect TLS traffic to check what version
was used, if ticket was offered and if it was accepted. For that we need
a TLS proxy, which was implemented in `tls_inspecting_proxy.rs`. This
uses `tls-parser` crate for actual parsing of the wire format, but still
needs a bit of code for everything else.

This file is fully vibe-coded. I think this is ok in this case because:
 - This is a fully self-contained piece of code.
 - It only affects tests.
 - It has perfectly concrete requirements: correctly parse traffic
between driver and Scylla, return 3 parameters (version, offer,
response).
 - If something doesn't work, we'll notice in tests.

I don't understand the TLS protocol, so those parts of the file I didn't
even read. I did verify Tokio interactions: all spawned tasks must be
awaited, so that we have no silent hidden panics.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/879

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
