### PR TITLE
Improve hostname resolution

### DIFF
--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -443,10 +443,10 @@ impl AddressTranslator for ClientRoutesAddressTranslator {
         // Randomly selects one of the resolved addresses of a client route.
         //
         // Client-route resolution happens on every connection attempt and the chosen
-        // address is never persisted, so picking at random lets successive attempts
-        // cycle through the available addresses. This helps in transient scenarios
-        // where DNS returns both a soon-to-be-invalid old address and the
-        // soon-to-be-valid new one.
+        // address is never persisted, so picking at random gives successive  attempts
+        // a chance to select another available address. This helps in transient
+        // scenarios where DNS returns both a soon-to-be-invalid old address
+        // and the soon-to-be-valid new one.
         let addr = *addrs.choose(&mut rng()).ok_or_else(|| {
             TranslationError::DnsLookupFailed(DnsLookupError::EmptyAddressListForHost(
                 hostport.as_str().into(),

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -13,8 +13,8 @@ use tracing::debug;
 use uuid::Uuid;
 
 use crate::cluster::metadata::{ClientRoute, ClientRoutes};
-use crate::cluster::node::resolve_hostname;
-use crate::errors::TranslationError;
+use crate::cluster::node::{resolve_hostname, select_one};
+use crate::errors::{DnsLookupError, TranslationError};
 use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 
@@ -434,9 +434,14 @@ impl AddressTranslator for ClientRoutesAddressTranslator {
             format!("{}:{}", hostname, port)
         };
 
-        let addr = resolve_hostname(&hostport, self.hostname_resolution_timeout)
+        let addrs = resolve_hostname(&hostport, self.hostname_resolution_timeout)
             .await
             .map_err(TranslationError::DnsLookupFailed)?;
+        let addr = select_one(&addrs).ok_or_else(|| {
+            TranslationError::DnsLookupFailed(DnsLookupError::EmptyAddressListForHost(
+                hostport.as_str().into(),
+            ))
+        })?;
 
         debug!(
             "ClientRoutesAddressTranslator: translated host_id {} to address {}",

--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -3,6 +3,8 @@
 //! Enables connecting to Scylla Cloud clusters using AWS PrivateLink or GCP Private Service Connect, among others.
 
 use async_trait::async_trait;
+use rand::rng;
+use rand::seq::IndexedRandom;
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -13,7 +15,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 use crate::cluster::metadata::{ClientRoute, ClientRoutes};
-use crate::cluster::node::{resolve_hostname, select_one};
+use crate::cluster::node::resolve_hostname;
 use crate::errors::{DnsLookupError, TranslationError};
 use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
@@ -437,7 +439,15 @@ impl AddressTranslator for ClientRoutesAddressTranslator {
         let addrs = resolve_hostname(&hostport, self.hostname_resolution_timeout)
             .await
             .map_err(TranslationError::DnsLookupFailed)?;
-        let addr = select_one(&addrs).ok_or_else(|| {
+
+        // Randomly selects one of the resolved addresses of a client route.
+        //
+        // Client-route resolution happens on every connection attempt and the chosen
+        // address is never persisted, so picking at random lets successive attempts
+        // cycle through the available addresses. This helps in transient scenarios
+        // where DNS returns both a soon-to-be-invalid old address and the
+        // soon-to-be-valid new one.
+        let addr = *addrs.choose(&mut rng()).ok_or_else(|| {
             TranslationError::DnsLookupFailed(DnsLookupError::EmptyAddressListForHost(
                 hostport.as_str().into(),
             ))

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use tokio::net::{ToSocketAddrs, lookup_host};
 use tracing::warn;
 use uuid::Uuid;
@@ -354,20 +353,6 @@ pub(crate) async fn resolve_hostname(
     } else {
         Ok(addrs)
     }
-}
-
-/// Selects a single address from a resolved address list, preserving the
-/// historical behavior of preferring the first IPv4 address, or the last
-/// address if none are IPv4.
-///
-/// This is a temporary shim kept while call sites migrate to consuming the
-/// full address list; it will be removed once all callers handle multiple
-/// addresses.
-pub(crate) fn select_one(addrs: &[SocketAddr]) -> Option<SocketAddr> {
-    addrs
-        .iter()
-        .copied()
-        .find_or_last(|addr| matches!(addr, SocketAddr::V4(_)))
 }
 
 /// Transforms the given [`KnownNode`]s into [`ResolvedContactPoint`]s.

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -370,7 +370,7 @@ pub(crate) fn select_one(addrs: &[SocketAddr]) -> Option<SocketAddr> {
         .find_or_last(|addr| matches!(addr, SocketAddr::V4(_)))
 }
 
-/// Transforms the given [`InternalKnownNode`]s into [`ContactPoint`]s.
+/// Transforms the given [`KnownNode`]s into [`ResolvedContactPoint`]s.
 ///
 /// In case of a hostname, resolves it using a DNS lookup.
 /// In case of a plain IP address, parses it and uses straight.

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -372,11 +372,28 @@ pub(crate) fn select_one(addrs: &[SocketAddr]) -> Option<SocketAddr> {
 
 /// Transforms the given [`KnownNode`]s into [`ResolvedContactPoint`]s.
 ///
-/// In case of a hostname, resolves it using a DNS lookup.
+/// In case of a hostname, resolves it using a DNS lookup, producing one
+/// [`ResolvedContactPoint`] per resolved address.
 /// In case of a plain IP address, parses it and uses straight.
 pub(crate) async fn resolve_contact_points(
     known_nodes: &[KnownNode],
     hostname_resolution_timeout: Option<Duration>,
+) -> (Vec<ResolvedContactPoint>, Vec<String>) {
+    resolve_contact_points_inner(known_nodes, async move |hostname| {
+        resolve_hostname(&hostname, hostname_resolution_timeout).await
+    })
+    .await
+}
+
+/// Inner implementation of [`resolve_contact_points`], generic over the DNS
+/// resolver so that it can be tested deterministically without real DNS lookups.
+///
+/// Each hostname is expanded to *all* of its resolved addresses, so a single
+/// [`KnownNode::Hostname`] may produce multiple [`ResolvedContactPoint`]s.
+async fn resolve_contact_points_inner(
+    known_nodes: &[KnownNode],
+    // This is generic only to allow mocking in unit tests; the real resolver is `resolve_hostname`.
+    resolve: impl AsyncFn(String) -> Result<Vec<SocketAddr>, DnsLookupError>,
 ) -> (Vec<ResolvedContactPoint>, Vec<String>) {
     // Find IP addresses of all known nodes passed in the config
     let mut initial_peers: Vec<ResolvedContactPoint> = Vec::with_capacity(known_nodes.len());
@@ -395,16 +412,20 @@ pub(crate) async fn resolve_contact_points(
             }
         };
     }
-    let resolve_futures = to_resolve.into_iter().map(|hostname| async move {
-        match resolve_hostname(hostname, hostname_resolution_timeout).await {
-            Ok(addresses) => select_one(&addresses).map(|address| ResolvedContactPoint { address }),
-            Err(e) => {
-                warn!("Hostname resolution failed for {}: {}", hostname, &e);
-                None
-            }
-        }
-    });
-    let resolved: Vec<_> = futures::future::join_all(resolve_futures).await;
+    let resolve_futures =
+        to_resolve
+            .into_iter()
+            .map(async |hostname| match resolve(hostname.to_string()).await {
+                Ok(addresses) => addresses
+                    .into_iter()
+                    .map(|address| ResolvedContactPoint { address })
+                    .collect::<Vec<_>>(),
+                Err(e) => {
+                    warn!("Hostname resolution failed for {}: {}", hostname, &e);
+                    Vec::new()
+                }
+            });
+    let resolved: Vec<Vec<ResolvedContactPoint>> = futures::future::join_all(resolve_futures).await;
     initial_peers.extend(resolved.into_iter().flatten());
 
     (initial_peers, hostnames)
@@ -437,5 +458,114 @@ mod tests {
         pub(crate) fn use_enabled_as_connected(&self) {
             self.enabled_as_connected.store(true, Ordering::SeqCst);
         }
+    }
+
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn v4(last_octet: u8, port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, last_octet)), port)
+    }
+
+    fn v6(port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port)
+    }
+
+    // A single hostname resolving to multiple addresses must produce one
+    // ResolvedContactPoint per address, preserving the resolver's order.
+    #[tokio::test]
+    async fn contact_points_expand_hostname_to_all_addresses() {
+        let known = vec![KnownNode::Hostname("multi.example:9042".to_string())];
+        let addrs = vec![v4(1, 9042), v6(9042), v4(2, 9042)];
+        let resolved_addrs = addrs.clone();
+
+        let (peers, hostnames) = resolve_contact_points_inner(&known, |_host| {
+            let resolved_addrs = resolved_addrs.clone();
+            async move { Ok(resolved_addrs) }
+        })
+        .await;
+
+        assert_eq!(peers.iter().map(|p| p.address).collect::<Vec<_>>(), addrs);
+        assert_eq!(hostnames, vec!["multi.example:9042".to_string()]);
+    }
+
+    // Literal addresses are used as-is and come before hostname-resolved ones.
+    // The `hostnames` output must list only the hostnames.
+    #[tokio::test]
+    async fn contact_points_mix_addresses_and_hostnames() {
+        let literal = v4(100, 9042);
+        let known = vec![
+            KnownNode::Address(literal),
+            KnownNode::Hostname("host.example:9042".to_string()),
+        ];
+        let host_addrs = vec![v4(1, 9042), v6(9042)];
+        let resolved_addrs = host_addrs.clone();
+
+        let (peers, hostnames) = resolve_contact_points_inner(&known, |_host| {
+            let resolved_addrs = resolved_addrs.clone();
+            async move { Ok(resolved_addrs) }
+        })
+        .await;
+
+        let mut expected = vec![literal];
+        expected.extend(host_addrs);
+        assert_eq!(
+            peers.iter().map(|p| p.address).collect::<Vec<_>>(),
+            expected
+        );
+        assert_eq!(hostnames, vec!["host.example:9042".to_string()]);
+    }
+
+    // A hostname whose resolution fails is skipped, while others are kept.
+    #[tokio::test]
+    async fn contact_points_skip_failed_resolution() {
+        let known = vec![
+            KnownNode::Hostname("good.example:9042".to_string()),
+            KnownNode::Hostname("bad.example:9042".to_string()),
+        ];
+        let good = v4(1, 9042);
+
+        let (peers, hostnames) = resolve_contact_points_inner(&known, async move |host| {
+            if host.starts_with("good") {
+                Ok(vec![good])
+            } else {
+                Err(DnsLookupError::Timeout(1))
+            }
+        })
+        .await;
+
+        assert_eq!(
+            peers.iter().map(|p| p.address).collect::<Vec<_>>(),
+            vec![good]
+        );
+        assert_eq!(
+            hostnames,
+            vec![
+                "good.example:9042".to_string(),
+                "bad.example:9042".to_string()
+            ]
+        );
+    }
+
+    // If all hostnames fail to resolve and there are no literal addresses,
+    // the resulting contact point list is empty.
+    #[tokio::test]
+    async fn contact_points_all_failed_yields_empty() {
+        let known = vec![
+            KnownNode::Hostname("a.example:9042".to_string()),
+            KnownNode::Hostname("b.example:9042".to_string()),
+        ];
+
+        let (peers, hostnames) =
+            resolve_contact_points_inner(
+                &known,
+                |_host| async move { Err(DnsLookupError::Timeout(1)) },
+            )
+            .await;
+
+        assert!(peers.is_empty());
+        assert_eq!(
+            hostnames,
+            vec!["a.example:9042".to_string(), "b.example:9042".to_string()]
+        );
     }
 }

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -323,12 +323,12 @@ async fn lookup_host_with_timeout(
 }
 
 // Resolve the given hostname using a DNS lookup if necessary.
-// The resolution may return multiple IPs and the function returns one of them.
-// It prefers to return IPv4s first, and only if there are none, IPv6s.
+// The resolution may return multiple IPs, all of which are returned in the
+// order provided by the resolver (without deduplication or reordering).
 pub(crate) async fn resolve_hostname(
     hostname: &str,
     hostname_resolution_timeout: Option<Duration>,
-) -> Result<SocketAddr, DnsLookupError> {
+) -> Result<Vec<SocketAddr>, DnsLookupError> {
     // When passing String to `lookup_host`, it expects it to be in the form "hostname:port".
     // If it is not, error will be returned immediately. In this case, we want to perform
     // check with (hostname, default_port) with the same timeout.
@@ -348,9 +348,26 @@ pub(crate) async fn resolve_hostname(
         }
     };
 
+    let addrs: Vec<SocketAddr> = addrs.collect();
+    if addrs.is_empty() {
+        Err(DnsLookupError::EmptyAddressListForHost(hostname.into()))
+    } else {
+        Ok(addrs)
+    }
+}
+
+/// Selects a single address from a resolved address list, preserving the
+/// historical behavior of preferring the first IPv4 address, or the last
+/// address if none are IPv4.
+///
+/// This is a temporary shim kept while call sites migrate to consuming the
+/// full address list; it will be removed once all callers handle multiple
+/// addresses.
+pub(crate) fn select_one(addrs: &[SocketAddr]) -> Option<SocketAddr> {
     addrs
+        .iter()
+        .copied()
         .find_or_last(|addr| matches!(addr, SocketAddr::V4(_)))
-        .ok_or_else(|| DnsLookupError::EmptyAddressListForHost(hostname.into()))
 }
 
 /// Transforms the given [`InternalKnownNode`]s into [`ContactPoint`]s.
@@ -380,7 +397,7 @@ pub(crate) async fn resolve_contact_points(
     }
     let resolve_futures = to_resolve.into_iter().map(|hostname| async move {
         match resolve_hostname(hostname, hostname_resolution_timeout).await {
-            Ok(address) => Some(ResolvedContactPoint { address }),
+            Ok(addresses) => select_one(&addresses).map(|address| ResolvedContactPoint { address }),
             Err(e) => {
                 warn!("Hostname resolution failed for {}: {}", hostname, &e);
                 None

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -298,7 +298,7 @@ pub enum KnownNode {
 }
 
 /// Describes a database server known on Session startup, with already resolved address.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ResolvedContactPoint {
     pub(crate) address: SocketAddr,
 }
@@ -355,6 +355,22 @@ pub(crate) async fn resolve_hostname(
     }
 }
 
+/// Removes duplicate contact points that share the same socket address.
+///
+/// The same address may be reached via multiple hostnames, or via both a
+/// literal [`KnownNode::Address`] and a hostname. Deduplication avoids creating
+/// redundant control-connection endpoints, which would otherwise waste retry
+/// attempts and bias the random initial-endpoint choice.
+///
+/// Note that the obtained order (sorted by address) is irrelevant,
+/// because the driver randomizes the order of contact points before trying to connect.
+fn dedup_contact_points(mut peers: Vec<ResolvedContactPoint>) -> Vec<ResolvedContactPoint> {
+    peers.sort_unstable();
+    peers.dedup();
+
+    peers
+}
+
 /// Transforms the given [`KnownNode`]s into [`ResolvedContactPoint`]s.
 ///
 /// In case of a hostname, resolves it using a DNS lookup, producing one
@@ -375,6 +391,8 @@ pub(crate) async fn resolve_contact_points(
 ///
 /// Each hostname is expanded to *all* of its resolved addresses, so a single
 /// [`KnownNode::Hostname`] may produce multiple [`ResolvedContactPoint`]s.
+/// The resulting contact points are deduplicated by address
+/// (see [`dedup_contact_points`]).
 async fn resolve_contact_points_inner(
     known_nodes: &[KnownNode],
     // This is generic only to allow mocking in unit tests; the real resolver is `resolve_hostname`.
@@ -412,6 +430,8 @@ async fn resolve_contact_points_inner(
             });
     let resolved: Vec<Vec<ResolvedContactPoint>> = futures::future::join_all(resolve_futures).await;
     initial_peers.extend(resolved.into_iter().flatten());
+
+    let initial_peers = dedup_contact_points(initial_peers);
 
     (initial_peers, hostnames)
 }
@@ -456,12 +476,13 @@ mod tests {
     }
 
     // A single hostname resolving to multiple addresses must produce one
-    // ResolvedContactPoint per address, preserving the resolver's order.
+    // ResolvedContactPoint per address. Duplicate addresses are removed.
     #[tokio::test]
     async fn contact_points_expand_hostname_to_all_addresses() {
         let known = vec![KnownNode::Hostname("multi.example:9042".to_string())];
-        let addrs = vec![v4(1, 9042), v6(9042), v4(2, 9042)];
-        let resolved_addrs = addrs.clone();
+        // Resolver returns a duplicate and mixed families in arbitrary order.
+        let resolved = vec![v4(1, 9042), v6(9042), v4(1, 9042), v4(2, 9042)];
+        let resolved_addrs = resolved.clone();
 
         let (peers, hostnames) = resolve_contact_points_inner(&known, |_host| {
             let resolved_addrs = resolved_addrs.clone();
@@ -469,11 +490,15 @@ mod tests {
         })
         .await;
 
-        assert_eq!(peers.iter().map(|p| p.address).collect::<Vec<_>>(), addrs);
+        let expected = [v4(1, 9042), v6(9042), v4(2, 9042)];
+        assert_eq!(peers.len(), expected.len());
+        for ex in expected {
+            assert!(peers.contains(&ResolvedContactPoint { address: ex }));
+        }
         assert_eq!(hostnames, vec!["multi.example:9042".to_string()]);
     }
 
-    // Literal addresses are used as-is and come before hostname-resolved ones.
+    // Literal addresses are used as-is.
     // The `hostnames` output must list only the hostnames.
     #[tokio::test]
     async fn contact_points_mix_addresses_and_hostnames() {
@@ -491,13 +516,41 @@ mod tests {
         })
         .await;
 
-        let mut expected = vec![literal];
-        expected.extend(host_addrs);
-        assert_eq!(
-            peers.iter().map(|p| p.address).collect::<Vec<_>>(),
-            expected
-        );
+        let expected = [literal, v4(1, 9042), v6(9042)];
+        assert_eq!(peers.len(), expected.len());
+        for ex in expected {
+            assert!(peers.contains(&ResolvedContactPoint { address: ex }))
+        }
         assert_eq!(hostnames, vec!["host.example:9042".to_string()]);
+    }
+
+    // The same address reached via a literal contact point and via multiple
+    // hostnames must appear only once.
+    #[tokio::test]
+    async fn contact_points_dedup_across_sources() {
+        let shared = v4(1, 9042);
+        let a_only = v6(9042);
+        let b_only = v4(2, 9042);
+        let known = vec![
+            KnownNode::Address(shared),
+            KnownNode::Hostname("a.example:9042".to_string()),
+            KnownNode::Hostname("b.example:9042".to_string()),
+        ];
+
+        let (peers, _hostnames) = resolve_contact_points_inner(&known, async |host| {
+            if host.starts_with('a') {
+                Ok(vec![shared, a_only])
+            } else {
+                Ok(vec![shared, b_only])
+            }
+        })
+        .await;
+
+        let expected = [shared, a_only, b_only];
+        assert_eq!(peers.len(), expected.len());
+        for ex in expected {
+            assert!(peers.contains(&ResolvedContactPoint { address: ex }))
+        }
     }
 
     // A hostname whose resolution fails is skipped, while others are kept.
@@ -518,10 +571,11 @@ mod tests {
         })
         .await;
 
-        assert_eq!(
-            peers.iter().map(|p| p.address).collect::<Vec<_>>(),
-            vec![good]
-        );
+        let expected = [good];
+        assert_eq!(peers.len(), expected.len());
+        for ex in expected {
+            assert!(peers.contains(&ResolvedContactPoint { address: ex }))
+        }
         assert_eq!(
             hostnames,
             vec![
@@ -552,5 +606,32 @@ mod tests {
             hostnames,
             vec!["a.example:9042".to_string(), "b.example:9042".to_string()]
         );
+    }
+
+    // Duplicate addresses are removed.
+    #[test]
+    fn dedup_contact_points_removes_duplicate_addresses() {
+        let a = v4(1, 9042);
+        let b = v6(9042);
+        let c = v4(2, 9042);
+        let peers = vec![
+            ResolvedContactPoint { address: a },
+            ResolvedContactPoint { address: b },
+            ResolvedContactPoint { address: a }, // duplicate of `a`
+            ResolvedContactPoint { address: c },
+            ResolvedContactPoint { address: b }, // duplicate of `b`
+        ];
+
+        let dedupped = dedup_contact_points(peers);
+        assert_eq!(dedupped.len(), [a, b, c].len());
+        for addr in [a, b, c] {
+            assert!(dedupped.contains(&ResolvedContactPoint { address: addr }));
+        }
+    }
+
+    // An empty input yields an empty output.
+    #[test]
+    fn dedup_contact_points_empty() {
+        assert!(dedup_contact_points(Vec::new()).is_empty());
     }
 }


### PR DESCRIPTION
Fixes: #1799

-------------------

## Solution

The following improvements to hostname resolution logic are implemented:

### Contact Points are resolved to all addresses

The relationship of hostname-to-address before was one-to-one (to the first IPv4 or last IPv6). Now, the relationship is one-to-many (to all returned addresses). This maximises the chance of successfully connecting to the cluster, which is the goal of the provided contact points.

### Client Routes select a random resolved address for each connection

There's an important scenario that this helps in: if the routing is currently being altered and DNS temporarily return both a now-valid-soon-invalid and a now-invalid-soon-valid addresses, sampling from them randomly gives a chance to eventually succeed in opening connection. This is because the resolution & sampling occur on each reconnection attempt.

### Resolved contact points are deduplicated

Contact Points can be given as IPs and hostnames. All hostnames are resolved, and all returned addresses are now concatenated together and concatenated to originally given IPs. As a result, duplicated addresses might occur. To prevent wasting time and connect attempts for the same duplicated addresses, deduplication logic is added.



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
