### PR TITLE
connection: trigger immediate keepalive on STATUS_CHANGE DOWN

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -286,6 +286,10 @@ pub struct SessionConfig {
 
     /// Interval of sending keepalive requests.
     /// If `None`, keepalives are never sent, so `Self::keepalive_timeout` has no effect.
+    /// Besides the periodic schedule, a keepalive request is also sent immediately on every
+    /// connection to a node for which a `STATUS_CHANGE DOWN` event was received, in order to
+    /// verify those connections' liveness; setting this to `None` disables that too, since it
+    /// disables keepalives entirely.
     pub keepalive_interval: Option<Duration>,
 
     /// Controls after what time of not receiving response to keepalives a connection is closed.

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1036,6 +1036,11 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// Note: this configures CQL-layer keepalives. See also:
     /// `Self::tcp_keepalive_interval`.
     ///
+    /// Besides the periodic schedule, a keepalive request is also sent immediately on every
+    /// connection to a node for which a `STATUS_CHANGE DOWN` event was received, in order to
+    /// verify those connections' liveness. This hint is only honoured while keepalives are
+    /// enabled: disabling them entirely disables it as well.
+    ///
     /// # Example
     /// ```
     /// # use scylla::client::session::Session;

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -238,6 +238,16 @@ impl Node {
         }
     }
 
+    /// Signals the node's connection pool to issue a keepalive request on all of its
+    /// connections immediately, instead of waiting for the next keepalive interval tick.
+    ///
+    /// This is a no-op if the node has no pool (disabled by host filter).
+    pub(crate) fn trigger_keepalive(&self) {
+        if let Some(pool) = &self.pool {
+            pool.trigger_immediate_keepalive();
+        }
+    }
+
     pub(crate) async fn use_keyspace(
         &self,
         keyspace_name: VerifiedKeyspaceName,

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -102,11 +102,7 @@ impl ClusterState {
     /// `STATUS_CHANGE` events carry the node's broadcast address. For a node learnt from
     /// metadata that is exactly what [`Node::address`] holds
     /// ([`NodeAddr::Translatable`], i.e. before any address translation), so the
-    /// comparison is right. A contact point instead holds the address the driver was
-    /// given ([`NodeAddr::Untranslatable`]), which differs from its broadcast address
-    /// when an address translator is in use, and an event naming such a node matches
-    /// nothing. Missing the hint merely leaves the pool on its regular refill
-    /// backoff, which is not worth extra address bookkeeping to avoid.
+    /// comparison is right. In the current implementation, `Node` object always uses this variant.
     fn node_by_broadcast_address(&self, addr: SocketAddr) -> Option<&Arc<Node>> {
         self.known_nodes
             .values()
@@ -130,6 +126,30 @@ impl ClusterState {
             "STATUS_CHANGE UP: triggering immediate pool refill"
         );
         node.trigger_pool_refill();
+    }
+
+    /// Triggers an immediate keepalive request on all connections to the node with the
+    /// given broadcast address.
+    ///
+    /// Used when a `STATUS_CHANGE DOWN` event hints that the node's connections are
+    /// likely defunct, so the driver probes them immediately instead of waiting for the
+    /// next keepalive interval tick. If the probe fails, the connections are closed and
+    /// the node stops being targeted by the load balancing policy; if it succeeds, the
+    /// node is likely still alive and keeps being targeted.
+    pub(super) fn trigger_keepalive_for_addr(&self, addr: SocketAddr) {
+        let Some(node) = self.node_by_broadcast_address(addr) else {
+            debug!(
+                address = %addr,
+                "STATUS_CHANGE DOWN: no known node with this address"
+            );
+            return;
+        };
+        debug!(
+            address = %addr,
+            host_id = %node.host_id,
+            "STATUS_CHANGE DOWN: triggering immediate keepalive"
+        );
+        node.trigger_keepalive();
     }
 
     /// Creates new ClusterState using information about topology held in `metadata`.

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -97,25 +97,39 @@ impl ClusterState {
         }
     }
 
+    /// Finds the known node whose address equals `addr`, if any.
+    ///
+    /// `STATUS_CHANGE` events carry the node's broadcast address. For a node learnt from
+    /// metadata that is exactly what [`Node::address`] holds
+    /// ([`NodeAddr::Translatable`], i.e. before any address translation), so the
+    /// comparison is right. A contact point instead holds the address the driver was
+    /// given ([`NodeAddr::Untranslatable`]), which differs from its broadcast address
+    /// when an address translator is in use, and an event naming such a node matches
+    /// nothing. Missing the hint merely leaves the pool on its regular refill
+    /// backoff, which is not worth extra address bookkeeping to avoid.
+    fn node_by_broadcast_address(&self, addr: SocketAddr) -> Option<&Arc<Node>> {
+        self.known_nodes
+            .values()
+            .find(|node| node.address.into_inner() == addr)
+    }
+
     /// Triggers an immediate pool refill for the node with the given broadcast
     /// address. Used when a `STATUS_CHANGE UP` event hints that a node is back
     /// and its pool (likely in exponential backoff) should retry immediately.
     pub(super) fn trigger_pool_refill_for_addr(&self, addr: SocketAddr) {
-        for node in self.known_nodes.values() {
-            if node.address.into_inner() == addr {
-                debug!(
-                    address = %addr,
-                    host_id = %node.host_id,
-                    "STATUS_CHANGE UP: triggering immediate pool refill"
-                );
-                node.trigger_pool_refill();
-                return;
-            }
-        }
+        let Some(node) = self.node_by_broadcast_address(addr) else {
+            debug!(
+                address = %addr,
+                "STATUS_CHANGE UP: no known node with this address"
+            );
+            return;
+        };
         debug!(
             address = %addr,
-            "STATUS_CHANGE UP: no known node with this address"
+            host_id = %node.host_id,
+            "STATUS_CHANGE UP: triggering immediate pool refill"
         );
+        node.trigger_pool_refill();
     }
 
     /// Creates new ClusterState using information about topology held in `metadata`.

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -398,15 +398,16 @@ impl ClusterWorker {
                                             // so it won't be targeted by the load balancing policy.
                                             self.cluster_state.load().trigger_pool_refill_for_addr(addr);
                                         },
-                                        StatusChangeEvent::Down(_addr) => {
-                                            // TODO: When receiving a DOWN event, and the driver still sees the node as connected,
-                                            // send a keepalive query to its connections to verify liveness.
+                                        StatusChangeEvent::Down(addr) => {
+                                            // When receiving a DOWN event, and the driver still sees the node as connected,
+                                            // we send a keepalive query on its connections to verify their liveness.
                                             // The node is supposedly DOWN, so connections to this node are likely defunct.
                                             // We expect that the keepalive query fails, in which case connections will be closed.
                                             // As a result, the connection pool will report 0 connections to this node,
                                             // and thus the node will not be targeted by the LoadBalancingPolicy,
                                             // which is the desired behaviour. However, if the keepalive query succeeds,
-                                            // then the node is likely still alive (got stale event?), and we can keep targeting it.
+                                            // then the node is likely still alive (got stale event?), and we keep targeting it.
+                                            self.cluster_state.load().trigger_keepalive_for_addr(addr);
                                         },
                                     }
                                     continue; // Don't go to refreshing.

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -61,7 +61,7 @@ use std::{
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter, split};
 use tokio::net::{TcpSocket, TcpStream};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::time::Instant;
 use tracing::{debug, error, trace, warn};
 
@@ -116,6 +116,15 @@ struct RouterHandle {
     // pushing values in a synchronous way (without an `.await`), which is
     // needed for pushing values in `Drop` implementations.
     orphan_notification_sender: mpsc::UnboundedSender<RequestId>,
+
+    /// Notified in order to make this connection's keepaliver issue a keepalive
+    /// request immediately, without waiting for the next `keepalive_interval` tick.
+    ///
+    /// `RouterHandle` is the natural place for this: it is the `Arc`-shared handle
+    /// that both the `Connection` and the router task (which owns the keepaliver)
+    /// already hold, so the hint needs no extra plumbing through
+    /// `HostConnectionConfig` or `router()`.
+    keepalive_hint: Notify,
 }
 
 impl RouterHandle {
@@ -497,6 +506,7 @@ impl Connection {
             submit_channel: sender,
             request_id_generator: AtomicU64::new(0),
             orphan_notification_sender,
+            keepalive_hint: Notify::new(),
         });
 
         #[cfg(test)]
@@ -1801,7 +1811,21 @@ impl Connection {
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
             loop {
-                interval.tick().await;
+                // A lost wakeup is impossible here: `Notify::notify_one` stores a permit
+                // when no task is awaiting `notified()`, so a hint that arrives while this
+                // loop is busy sending a keepalive is consumed by the next iteration.
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    () = router_handle.keepalive_hint.notified() => {
+                        debug!(
+                            "Received a keepalive hint for the connection to node {} - issuing a keepalive request immediately",
+                            node_address
+                        );
+                        // The keepalive that is about to be sent restarts the idle period,
+                        // so the next periodic keepalive should be a full interval away.
+                        interval.reset();
+                    }
+                }
 
                 let keepalive_query = issue_keepalive_query(&router_handle);
                 let query_result = if let Some(timeout) = keepalive_timeout {
@@ -1911,6 +1935,26 @@ impl Connection {
 
     pub(crate) fn get_connect_address(&self) -> SocketAddr {
         self.connect_address
+    }
+
+    /// Makes this connection's keepaliver issue a keepalive (`OPTIONS`) request
+    /// immediately, instead of waiting for the next `keepalive_interval` tick.
+    ///
+    /// Called upon a `STATUS_CHANGE DOWN` hint for this connection's node: the node is
+    /// supposedly down, so the connection is likely defunct and it is better to probe it
+    /// now than at the next interval tick. If the probe fails, the connection is closed;
+    /// if it succeeds, the node is likely still alive and the connection keeps serving
+    /// requests.
+    ///
+    /// The hint cannot be lost if the keepaliver happens to be busy sending or awaiting
+    /// a keepalive at this moment, because `Notify::notify_one` *stores* a permit that
+    /// the keepaliver consumes on its next iteration.
+    ///
+    /// This is a no-op if keepalives are disabled for this connection
+    /// (`keepalive_interval == None`), because then there is no keepaliver task to
+    /// consume the notification.
+    pub(crate) fn trigger_keepalive(&self) {
+        self.router_handle.keepalive_hint.notify_one();
     }
 
     async fn update_tablets_from_response(

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -282,6 +282,33 @@ impl NodeConnectionPool {
         self.refill_now_notify.notify_one();
     }
 
+    /// Makes every connection currently in the pool issue a keepalive (`OPTIONS`)
+    /// request immediately, instead of waiting for the next keepalive interval tick.
+    ///
+    /// Used upon a `STATUS_CHANGE DOWN` event for this node: the node is supposedly down,
+    /// so its connections are likely defunct. The keepalives are expected to fail, which
+    /// closes those connections; the pool then reports 0 connections and the node stops
+    /// being targeted by the load balancing policy. If they succeed, the node is likely
+    /// still alive (a stale event) and keeps being targeted.
+    ///
+    /// The `Result` is deliberately discarded: if the pool is `Initializing` or `Broken`,
+    /// there are no connections to probe, which is exactly the case where the driver does
+    /// not see the node as connected and the hint is pointless anyway.
+    pub(crate) fn trigger_immediate_keepalive(&self) {
+        let _ = self.with_connections(|pool_conns| match pool_conns {
+            PoolConnections::NotSharded(conns) => {
+                for conn in conns {
+                    conn.trigger_keepalive();
+                }
+            }
+            PoolConnections::Sharded { connections, .. } => {
+                for conn in connections.iter().flatten() {
+                    conn.trigger_keepalive();
+                }
+            }
+        });
+    }
+
     pub(crate) fn sharder(&self) -> Option<Sharder> {
         self.with_connections(|pool_conns| match pool_conns {
             PoolConnections::NotSharded(_) => None,

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -10,5 +10,6 @@ mod pager;
 mod retries;
 mod schema_agreement;
 mod self_identity;
+mod status_change_hints;
 mod tracing;
 mod use_keyspace;

--- a/scylla/tests/integration/session/status_change_hints.rs
+++ b/scylla/tests/integration/session/status_change_hints.rs
@@ -1,0 +1,216 @@
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::{Bytes, BytesMut};
+use scylla::client::PoolSize;
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    RunningProxy, ShardAwareness, TargetShard, WorkerError,
+};
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::utils::{
+    calculate_proxy_host_ids, setup_tracing, test_with_3_node_cluster,
+    wait_until_all_nodes_are_connected,
+};
+
+/// Keepalive interval used by the test session.
+///
+/// Chosen far beyond any realistic test duration, so that no *periodic*
+/// keepalive can possibly fire. Consequently, every `OPTIONS` frame observed
+/// after the session became fully connected is attributable to the
+/// `STATUS_CHANGE DOWN` hint under test.
+const UNREACHABLE_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10_000);
+
+/// Upper bound for waiting on driver reactions. Generous, because it is only
+/// hit when the driver is broken - a healthy driver reacts in microseconds.
+const REACTION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Exactly one connection per node.
+///
+/// This makes the test deterministic in two ways: a pool is complete as soon
+/// as it holds one connection (so no connection handshake can emit a stray
+/// `OPTIONS` once the session is up), and a single hint provokes exactly one
+/// keepalive per node - as opposed to the default `PerShard(1)`, where the
+/// number of connections, and hence of keepalives, depends on the node's
+/// shard count.
+const POOL_SIZE: PoolSize = PoolSize::PerHost(NonZeroUsize::new(1).unwrap());
+
+type FeedbackItem = (RequestFrame, Option<TargetShard>);
+type FeedbackRx = mpsc::UnboundedReceiver<FeedbackItem>;
+
+/// Builds the body of a `STATUS_CHANGE` / `DOWN` EVENT frame for `addr`:
+/// `[string] "STATUS_CHANGE"`, `[string] "DOWN"`, `[inet] addr`.
+fn status_change_down_event_body(addr: SocketAddr) -> Bytes {
+    use scylla_cql::frame::types::{write_inet, write_string};
+
+    let mut body = BytesMut::new();
+    write_string("STATUS_CHANGE", &mut body).unwrap();
+    write_string("DOWN", &mut body).unwrap();
+    write_inet(addr, &mut body);
+    body.freeze()
+}
+
+/// Returns the driver-visible address of the node with the given host id.
+///
+/// This is the address that `ClusterState` compares against the address
+/// carried by a `STATUS_CHANGE` event, so it is the address that must be put
+/// into the forged event. Depending on whether the node was learnt from
+/// metadata or is a contact point, it is either the broadcast (translatable)
+/// or the already-translated address - both are handled uniformly here.
+fn driver_visible_address(session: &Session, host_id: Uuid) -> SocketAddr {
+    let state = session.get_cluster_state();
+    let node = state
+        .get_node_by_host_id(host_id)
+        .unwrap_or_else(|| panic!("node with host id {host_id} unknown to the driver"));
+    SocketAddr::new(node.address.ip(), node.address.port())
+}
+
+/// Injects a forged `STATUS_CHANGE DOWN` event for `addr` into every proxy
+/// node's control connections.
+///
+/// Only one of the three proxied nodes hosts the driver's control connection,
+/// hence the broadcast; at least one injection must have found a registered
+/// control connection.
+fn inject_status_change_down(running_proxy: &RunningProxy, addr: SocketAddr) {
+    let body = status_change_down_event_body(addr);
+    let injected = running_proxy
+        .running_nodes
+        .iter()
+        .filter(|node| node.inject_event_to_cc(body.clone()))
+        .count();
+    assert!(
+        injected > 0,
+        "no proxy node had a registered control connection to inject the event into"
+    );
+}
+
+/// Verifies that a `STATUS_CHANGE DOWN` server event is used as a hint for the
+/// keepaliver: upon receiving it, the driver immediately sends a CQL keepalive
+/// (`OPTIONS`) on the pool connections to exactly the node named by the event,
+/// instead of waiting for the next `keepalive_interval` tick.
+///
+/// This matters because a supposedly-DOWN node's connections are likely
+/// defunct; probing them right away either closes them (so the node stops
+/// being targeted by the load balancing policy) or proves the node is still
+/// alive and the event was stale.
+///
+/// The session's keepalive interval is [`UNREACHABLE_KEEPALIVE_INTERVAL`]
+/// (10_000 s), which cannot elapse while the test runs, and the feedback rules
+/// are installed only once all pools are complete - so no periodic keepalive
+/// and no connection handshake can account for any observed `OPTIONS`. The
+/// only remaining explanation is the DOWN hint.
+///
+/// Every node is targeted in turn, which proves that the hint is
+/// routed to the single node named by the event rather than broadcast to the
+/// whole cluster. The event is forged by the proxy, so the test needs no
+/// server-side support and runs identically against ScyllaDB and Cassandra.
+#[tokio::test]
+async fn test_status_change_down_triggers_immediate_keepalive() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map.clone()))
+                .keepalive_interval(UNREACHABLE_KEEPALIVE_INTERVAL)
+                .pool_size(POOL_SIZE)
+                .fetch_schema_metadata(false)
+                .cluster_metadata_refresh_interval(UNREACHABLE_KEEPALIVE_INTERVAL)
+                .build()
+                .await
+                .unwrap();
+
+            // The DOWN hint acts on *existing* pool connections, so the test
+            // must not start before the pools are complete: the OPTIONS frame
+            // of a connection handshake is indistinguishable from a keepalive
+            // one. With POOL_SIZE a pool is complete as soon as it holds its
+            // single connection, which is what `is_connected()` reports.
+            wait_until_all_nodes_are_connected(3, &session).await;
+
+            let host_ids = calculate_proxy_host_ids(&proxy_uris, &translation_map, &session);
+            let node_addrs: Vec<SocketAddr> = host_ids
+                .iter()
+                .map(|&host_id| driver_visible_address(&session, host_id))
+                .collect();
+
+            // Installed only now, once all pools are complete: the OPTIONS
+            // frames of the connection handshakes are already in the past, so
+            // they cannot be mistaken for hint-driven keepalives.
+            // `Condition::not(ConnectionRegisteredAnyEvent)` excludes the
+            // control connection, leaving only pool connections.
+            let keepalive_condition = Condition::RequestOpcode(RequestOpcode::Options)
+                .and(Condition::not(Condition::ConnectionRegisteredAnyEvent));
+            let mut keepalive_rxs: Vec<FeedbackRx> = Vec::with_capacity(3);
+            for node in running_proxy.running_nodes.iter_mut() {
+                let (tx, rx) = mpsc::unbounded_channel::<FeedbackItem>();
+                node.prepend_request_rules(vec![RequestRule(
+                    keepalive_condition.clone(),
+                    RequestReaction::noop().with_feedback_when_performed(tx),
+                )]);
+                keepalive_rxs.push(rx);
+            }
+
+            // Each sub-case names a different node, which discriminates a
+            // per-node hint from a cluster-wide broadcast. All assertions are
+            // exact: with one connection per node, one hint must produce
+            // exactly one keepalive, on exactly one node.
+            for target in 0..3 {
+                // The same node is named twice in a row, and the second
+                // keepalive is awaited before any channel is inspected. The
+                // second event is injected only after the first keepalive was
+                // forwarded by the proxy, hence after the keepaliver consumed
+                // the first hint - so a keepalive that the first hint wrongly
+                // provoked on another node has necessarily been forwarded by
+                // then too. Without that second round trip, the emptiness
+                // assertion below could race a broadcast bug and miss it,
+                // since each connection's keepaliver runs in its own task.
+                for hint in 1..=2 {
+                    inject_status_change_down(&running_proxy, node_addrs[target]);
+
+                    tokio::time::timeout(REACTION_TIMEOUT, keepalive_rxs[target].recv())
+                        .await
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "node {target} ({}) received no keepalive OPTIONS within \
+                                 {REACTION_TIMEOUT:?} after STATUS_CHANGE DOWN event #{hint} \
+                                 naming it",
+                                node_addrs[target]
+                            )
+                        })
+                        .expect("keepalive feedback channel closed unexpectedly");
+                }
+
+                // Every channel must now be empty: no other node may have been
+                // probed, and the target must have been probed exactly twice.
+                // Periodic keepalives are 10_000 s away and the pools are
+                // complete, so nothing else can emit OPTIONS.
+                for (node_idx, rx) in keepalive_rxs.iter_mut().enumerate() {
+                    assert!(
+                        rx.try_recv().is_err(),
+                        "surplus keepalive OPTIONS on node {node_idx} ({}) after two \
+                         STATUS_CHANGE DOWN events naming node {target} ({})",
+                        node_addrs[node_idx],
+                        node_addrs[target]
+                    );
+                }
+            }
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -510,6 +510,56 @@ pub(crate) async fn check_session_works_and_fully_connected(
         .unwrap();
 }
 
+/// Upper bound for [`wait_until_all_nodes_are_connected`]. Generous, because it is
+/// only ever reached when the driver fails to connect at all.
+const ALL_NODES_CONNECTED_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Waits until the driver knows `expected_nodes` nodes and holds a connection pool
+/// for each of them.
+///
+/// Polling is unavoidable here: pool filling is asynchronous and the driver exposes
+/// no completion signal for it. 1ms polls keep the wait imperceptible.
+///
+/// Beware that `Node::is_connected()` only means the pool holds *at least one*
+/// connection, not that it reached its configured size. A test that must not race
+/// with pool filling - e.g. one observing per-connection traffic - should therefore
+/// also pin the pool to a single connection per node with `PoolSize::PerHost(1)`,
+/// which makes the two coincide.
+///
+/// # Panics
+///
+/// Panics if the nodes do not all become connected within
+/// [`ALL_NODES_CONNECTED_TIMEOUT`].
+pub(crate) async fn wait_until_all_nodes_are_connected(expected_nodes: usize, session: &Session) {
+    let wait = async {
+        loop {
+            {
+                let state = session.get_cluster_state();
+                let nodes = state.get_nodes_info();
+                if nodes.len() == expected_nodes && nodes.iter().all(|node| node.is_connected()) {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    };
+
+    tokio::time::timeout(ALL_NODES_CONNECTED_TIMEOUT, wait)
+        .await
+        .unwrap_or_else(|_| {
+            let state = session.get_cluster_state();
+            let seen: Vec<_> = state
+                .get_nodes_info()
+                .iter()
+                .map(|node| (node.host_id, node.address, node.is_connected()))
+                .collect();
+            panic!(
+                "Timed out after {ALL_NODES_CONNECTED_TIMEOUT:?} waiting for {expected_nodes} \
+                 connected nodes; driver sees (host_id, address, connected): {seen:?}"
+            )
+        });
+}
+
 pub(crate) struct SerializeValueWithFakeType<'typ, T> {
     fake_type: ColumnType<'typ>,
     value: T,


### PR DESCRIPTION
# Treat STATUS_CHANGE DOWN events as hints for the keepaliver

`STATUS_CHANGE` events are unreliable — they can be lost while the control connection is
broken — so the driver deliberately does not track node status from them. Instead it treats
them as *hints*. We already do this for UP events (`b1f468efa`, "connection_pool: trigger
immediate refill on STATUS_CHANGE UP"): an UP event makes the pool refiller skip its wait and
reset its exponential backoff, so the driver reconnects within milliseconds rather than after
up to 10 s of backoff.

That commit left DOWN events ignored, with a `TODO` in the cluster worker describing the
intended symmetric treatment. **This PR implements it: a DOWN event now makes every connection
in that node's pool send a keepalive request immediately, instead of waiting for the next
`keepalive_interval` tick.**

## Why

The node is supposedly down, so its connections are likely defunct. The keepalive is *expected*
to fail, which closes them; the pool then reports 0 connections and the node stops being
targeted by the load balancing policy — the desired outcome, reached in milliseconds instead of
after up to a full keepalive interval (30 s by default). If the keepalive succeeds, the event
was stale and the node keeps being targeted, so a wrong hint costs one `OPTIONS` frame and
nothing else.

## How

Very similar to UP hints.

- The hint rides on a `tokio::sync::Notify` stored in `RouterHandle` — the `Arc`-shared handle
  that both `Connection` and the router task owning the keepaliver already hold. Nothing had to
  be plumbed through `HostConnectionConfig` or `router()`.
- `notify_one()` (not `notify_waiters()`) because it **stores a permit**: a hint that lands
  while the keepaliver is mid-keepalive is consumed on the next loop iteration rather than lost.
- The hint branch calls `Interval::reset()`, so the next *periodic* keepalive is a full interval
  after the hint-driven one.
- `ClusterState::node_by_broadcast_address` was extracted so the UP and DOWN paths share one
  address lookup instead of two copies of the scan.

## Deliberate non-goals / edge cases

- **Empty pool** (`Initializing`/`Broken`) → no-op. That is exactly the case where the driver
  does not consider the node connected, so there is nothing to verify.
- **Keepalives disabled** (`keepalive_interval == None`) → no keepaliver exists, so no hint.

## Tests

New `scylla/tests/integration/session/status_change_hints.rs` forges a `STATUS_CHANGE DOWN`
frame into the control connection via `scylla-proxy`'s `inject_event_to_cc` and asserts that
exactly the named node receives an `OPTIONS` request, for each of the three nodes in turn.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1239

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.


