### PR TITLE
Bump syn to v3 and darling to 0.24

### DIFF
--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -16,8 +16,8 @@ proc-macro = true
 all-features = true
 
 [dependencies]
-darling = "0.23.0"
-syn = "2.0"
+darling = "0.24.0"
+syn = "3.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/scylla-macros/src/deserialize/row.rs
+++ b/scylla-macros/src/deserialize/row.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use darling::{FromAttributes, FromField};
 use proc_macro2::Span;
 use syn::ext::IdentExt;
-use syn::parse_quote;
+use syn::{ImplItem, parse_quote};
 
 use crate::Flavor;
 
@@ -85,8 +85,8 @@ pub(crate) fn deserialize_row_derive(
     validate_attrs(&s.attrs, &s.fields)?;
 
     let items = [
-        s.generate_type_check_method().into(),
-        s.generate_deserialize_method().into(),
+        ImplItem::Fn(s.generate_type_check_method()),
+        ImplItem::Fn(s.generate_deserialize_method()),
     ];
 
     Ok(s.generate_impl(implemented_trait, items))

--- a/scylla-macros/src/deserialize/value.rs
+++ b/scylla-macros/src/deserialize/value.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use darling::{FromAttributes, FromField};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
+use syn::ImplItem;
 use syn::{ext::IdentExt, parse_quote};
 
 use crate::Flavor;
@@ -98,8 +99,8 @@ pub(crate) fn deserialize_value_derive(
     validate_attrs(&s.attrs, s.fields())?;
 
     let items = [
-        s.generate_type_check_method().into(),
-        s.generate_deserialize_method().into(),
+        ImplItem::Fn(s.generate_type_check_method()),
+        ImplItem::Fn(s.generate_deserialize_method()),
     ];
 
     Ok(s.generate_impl(implemented_trait, items))


### PR DESCRIPTION
v3 is a major version, but we were only slightly affected by breaking changes. Changelog says:
> Some enums no longer provide From impls. Construct the variant by name
instead, such as Expr::Array(e) in place of e.into().

In our case, ImplItemFn no longer implements Into<ImplItem>, so in 2 places `.into()` calls had to be changed to manual variant construction.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
