### PR TITLE
Renovate less often

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -53,7 +53,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y valgrind
     - name: Install cargo-binstall
-      uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
+      uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
       with:
         tool: cargo-binstall
     - name: Setup 3-node ScyllaDB cluster

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
         "helpers:pinGitHubActionDigestsToSemver"
     ],
     "commitBodyTable": true,
+    "description": "Global branch-creation cadence: Renovate may only open update branches on Saturdays. Individual deps can be slowed down further with a per-package `schedule` below.",
+    // See https://crontab.cronhub.io/ for cheatsheet on crontab syntax and translation to natural language.
+    "schedule": [
+        "* * * * 6"
+    ],
     "packageRules": [
         {
             "matchManagers": [
@@ -63,6 +68,19 @@
                 "scylla/Cargo.toml"
             ],
             "dependencyDashboardApproval": true
+        },
+        {
+            "description": "taiki-e/install-action releases (near-)daily and only installs CI tooling, so weekly is still too noisy: restrict it to the 1st and 3rd Saturday of each month. Cron cannot express a true fortnightly cadence; day-of-month and day-of-week are ANDed, so consecutive windows are exactly 14 or 21 days apart - never less than a fortnight.",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchDepNames": [
+                "taiki-e/install-action"
+            ],
+            // See https://crontab.cronhub.io/ for cheatsheet on crontab syntax and translation to natural language.
+            "schedule": [
+                "* * 1-7,15-21 * 6"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Renovate started to be quite spammy. This PR:
- Limits deps updates to Staurdays
- Limits istall-action to each other Saturday

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
