### PR TITLE
Minimal metadata fetching

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -8,6 +8,7 @@ use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
 use crate::client::client_routes::ClientRoutesConfig;
 use crate::client::execution::{RequestExecutionParams, RunRequestResult};
+use crate::cluster::metadata::{SchemaMetadataFetchLevel, SchemaMetadataFetchMode};
 use crate::cluster::node::KnownNode;
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::DbError;
@@ -281,6 +282,11 @@ pub struct SessionConfig {
     /// If true, full schema is fetched with every metadata refresh.
     pub fetch_schema_metadata: bool,
 
+    /// If true, full schema details (columns, partition keys, clustering keys, UDTs) are fetched.
+    /// Only has effect when fetch_schema_metadata is true.
+    /// If false, only lightweight metadata needed for routing (table names, partitioners, tablet info) is fetched.
+    pub fetch_full_schema_metadata: bool,
+
     /// Custom timeout for requests that query metadata.
     pub metadata_request_serverside_timeout: Option<Duration>,
 
@@ -422,6 +428,7 @@ impl SessionConfig {
             timestamp_generator: None,
             keyspaces_to_fetch: Vec::new(),
             fetch_schema_metadata: true,
+            fetch_full_schema_metadata: true,
             metadata_request_serverside_timeout: Some(Duration::from_secs(2)),
             keepalive_interval: Some(Duration::from_secs(30)),
             keepalive_timeout: Some(Duration::from_secs(30)),
@@ -1157,11 +1164,20 @@ impl Session {
             }
         };
 
+        let schema_metadata_fetch_mode = match (
+            config.fetch_schema_metadata,
+            config.fetch_full_schema_metadata,
+        ) {
+            (false, _) => SchemaMetadataFetchMode::Disabled,
+            (true, false) => SchemaMetadataFetchMode::Enabled(SchemaMetadataFetchLevel::Minimal),
+            (true, true) => SchemaMetadataFetchMode::Enabled(SchemaMetadataFetchLevel::Full),
+        };
+
         let cluster = Cluster::new(
             known_nodes,
             pool_config,
             config.keyspaces_to_fetch,
-            config.fetch_schema_metadata,
+            schema_metadata_fetch_mode,
             config.metadata_request_serverside_timeout,
             config.hostname_resolution_timeout,
             config.host_filter,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -60,7 +60,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use thiserror::Error;
 use tokio::time::timeout;
-use tracing::{Instrument, debug, error};
+use tracing::{Instrument, debug, error, warn};
 use uuid::Uuid;
 
 pub(crate) const TABLET_CHANNEL_SIZE: usize = 8192;
@@ -535,6 +535,15 @@ impl SessionConfig {
             return Err(NewSessionError::IllegalConfig(
                 "Keepalive interval must be non-zero".into(),
             ));
+        }
+
+        if !self.fetch_schema_metadata && self.fetch_full_schema_metadata {
+            warn!(
+                "Inconsistent schema metadata configuration: `fetch_schema_metadata` is `false`, \
+                         but `fetch_full_schema_metadata` is `true`. Because overall schema metadata fetching \
+                         is turned off, ALL schema metadata fetching is now disabled, and `fetch_full_schema_metadata` \
+                         will have no effect. Token-aware and tablet-aware routing will NOT function."
+            );
         }
 
         // Ensure no illegal configuration with Client Routes

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -279,7 +279,8 @@ pub struct SessionConfig {
     /// If empty, fetch all keyspaces
     pub keyspaces_to_fetch: Vec<String>,
 
-    /// If true, full schema is fetched with every metadata refresh.
+    /// If true, schema metadata is fetched with every metadata refresh.
+    /// If false, NO schema metadata is fetched at all (no keyspaces, no tables, nothing).
     pub fetch_schema_metadata: bool,
 
     /// If true, full schema details (columns, partition keys, clustering keys, UDTs) are fetched.

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -986,6 +986,15 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// Set the fetch schema metadata flag.
     /// The default is true.
     ///
+    /// When false, NO schema metadata is fetched - the driver will not
+    /// fetch keyspaces, tables, partitioners, or any other schema information.
+    /// Token-awareness and tablet-awareness will NOT function.
+    ///
+    /// This should ONLY be used in very specific scenarios where you want to
+    /// completely eliminate schema metadata queries and can accept degraded
+    /// driver performance. For most use cases, you should use
+    /// `fetch_full_schema_metadata(false)` instead.
+    ///
     /// # Example
     /// ```
     /// # use scylla::client::session::Session;

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1004,6 +1004,42 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
+    /// Set the fetch full schema metadata flag.
+    /// This only has effect when `fetch_schema_metadata` is true.
+    /// The default is true.
+    ///
+    /// When false, the driver fetches lightweight metadata necessary for proper
+    /// routing (table names, partitioners, tablet info) but skips heavy metadata
+    /// like column details, partition/clustering key information, and UDTs.
+    /// This significantly reduces memory usage and metadata fetch time while
+    /// maintaining full driver routing functionality.
+    ///
+    /// When true (default), the driver fetches complete schema information
+    /// including all columns, keys, and UDTs, which can be inspected via
+    /// ClusterState API.
+    ///
+    /// Note: When set to false, ClusterState::compute_token
+    /// and ClusterState::get_endpoints will not work.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .fetch_schema_metadata(true)
+    ///     .fetch_full_schema_metadata(false)  // Fetch only minimal metadata
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn fetch_full_schema_metadata(mut self, fetch: bool) -> Self {
+        self.config.fetch_full_schema_metadata = fetch;
+        self
+    }
+
     /// Set the server-side timeout for metadata queries.
     /// The default is `Some(Duration::from_secs(2))`. It means that
     /// the all metadata queries will be set the 2 seconds timeout

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -32,8 +32,8 @@ use uuid::Uuid;
 
 use super::{
     CollectionType, Column, ColumnKind, ColumnType, Keyspace, MaterializedView, Metadata,
-    MissingUserDefinedType, NativeType, Peer, SingleKeyspaceMetadataError, Strategy, Table,
-    UserDefinedType,
+    MissingUserDefinedType, NativeType, Peer, SchemaMetadataFetchLevel, SchemaMetadataFetchMode,
+    SingleKeyspaceMetadataError, Strategy, Table, UserDefinedType,
 };
 
 use crate::DeserializeRow;
@@ -160,11 +160,11 @@ impl ControlConnection {
         &self,
         connect_port: u16,
         keyspace_to_fetch: &[String],
-        fetch_schema: bool,
+        schema_metadata_fetch_mode: SchemaMetadataFetchMode,
         client_routes_connection_ids: Option<&[String]>,
     ) -> Result<Metadata, MetadataError> {
         let peers_query = self.query_peers(connect_port);
-        let keyspaces_query = self.query_keyspaces(keyspace_to_fetch, fetch_schema);
+        let keyspaces_query = self.query_keyspaces(keyspace_to_fetch, schema_metadata_fetch_mode);
         let client_routes_query = async {
             let Some(connection_ids) = client_routes_connection_ids else {
                 return Ok(None);
@@ -586,8 +586,13 @@ impl ControlConnection {
     async fn query_keyspaces(
         &self,
         keyspaces_to_fetch: &[String],
-        fetch_schema: bool,
+        schema_metadata_fetch_mode: SchemaMetadataFetchMode,
     ) -> Result<PerKeyspaceResult<Keyspace, SingleKeyspaceMetadataError>, MetadataError> {
+        let schema_metadata_fetch_level = match schema_metadata_fetch_mode {
+            SchemaMetadataFetchMode::Disabled => return Ok(HashMap::new()),
+            SchemaMetadataFetchMode::Enabled(level) => level,
+        };
+
         let rows = self
             .query_filter_keyspace_name::<(String, HashMap<String, String>, bool)>(
                 "SELECT keyspace_name, replication, durable_writes FROM system_schema.keyspaces",
@@ -602,25 +607,56 @@ impl ControlConnection {
         // are independent of each other, so we run them concurrently to minimize the
         // critical path length.
         let schema_query = async {
-            if fetch_schema {
-                let udts = self.query_user_defined_types(keyspaces_to_fetch).await?;
-                let mut tables_schema = self.query_tables_schema(keyspaces_to_fetch, &udts).await?;
-                Ok::<_, MetadataError>((
-                    // We pass the mutable reference to the same map to the both functions.
-                    // First function fetches `system_schema.tables`, and removes found
-                    // table from `tables_schema`.
-                    // Second does the same for `system_schema.views`.
-                    // The assumption here is that no keys (table names) can appear in both
-                    // of those schema table.
-                    // As far as we know this assumption is true for Scylla and Cassandra.
-                    self.query_tables(keyspaces_to_fetch, &mut tables_schema)
-                        .await?,
-                    self.query_views(keyspaces_to_fetch, &mut tables_schema)
-                        .await?,
-                    udts,
-                ))
-            } else {
-                Ok((HashMap::new(), HashMap::new(), HashMap::new()))
+            match schema_metadata_fetch_level {
+                SchemaMetadataFetchLevel::Full => {
+                    // Fetch full schema: columns, keys, UDTs
+                    let udts = self.query_user_defined_types(keyspaces_to_fetch).await?;
+                    let mut tables_schema =
+                        self.query_tables_schema(keyspaces_to_fetch, &udts).await?;
+                    Ok((
+                        // We pass the mutable reference to the same map to the both functions.
+                        // First function fetches `system_schema.tables`, and removes found
+                        // table from `tables_schema`.
+                        // Second does the same for `system_schema.views`.
+                        // The assumption here is that no keys (table names) can appear in both
+                        // of those schema table.
+                        // As far as we know this assumption is true for Scylla and Cassandra.
+                        self.query_tables(keyspaces_to_fetch, &mut tables_schema)
+                            .await?,
+                        self.query_views(keyspaces_to_fetch, &mut tables_schema)
+                            .await?,
+                        udts,
+                    ))
+                }
+                SchemaMetadataFetchLevel::Minimal => {
+                    // Fetch minimal schema: just table/view names and partitioners
+                    // This is needed for token-awareness and tablet-awareness to work
+                    let mut tables_schema = self
+                        .query_table_partitioners(keyspaces_to_fetch)
+                        .await?
+                        .into_iter()
+                        .map(|(keyspace_and_table_name, partitioner)| {
+                            (
+                                keyspace_and_table_name,
+                                Ok(Table {
+                                    columns: HashMap::new(),
+                                    partition_key: vec![],
+                                    clustering_key: vec![],
+                                    partitioner,
+                                    pk_column_specs: vec![],
+                                }),
+                            )
+                        })
+                        .collect();
+
+                    Ok((
+                        self.query_tables(keyspaces_to_fetch, &mut tables_schema)
+                            .await?,
+                        self.query_views(keyspaces_to_fetch, &mut tables_schema)
+                            .await?,
+                        HashMap::new(),
+                    ))
+                }
             }
         };
         let tablets_query = async {

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -1302,7 +1302,7 @@ impl ControlConnection {
         .try_for_each(|_| future::ok(()))
         .await?;
 
-        let mut all_partitioners = self.query_table_partitioners().await?;
+        let mut all_partitioners = self.query_table_partitioners(keyspaces_to_fetch).await?;
         let mut result = HashMap::new();
 
         'tables_loop: for ((keyspace_name, table_name), table_result) in tables_schema {
@@ -1560,31 +1560,17 @@ impl ControlConnection {
     #[expect(clippy::result_large_err)]
     async fn query_table_partitioners(
         &self,
+        keyspaces_to_fetch: &[String],
     ) -> Result<PerKsTable<Option<String>>, MetadataFetchError> {
-        fn create_err(err: impl Into<MetadataFetchErrorKind>) -> MetadataFetchError {
-            MetadataFetchError {
-                error: err.into(),
-                table: "system_schema.scylla_tables",
-            }
-        }
-
         let rows = self
-            .query_iter(
+            .query_filter_keyspace_name::<(String, String, Option<String>)>(
                 "SELECT keyspace_name, table_name, partitioner FROM system_schema.scylla_tables",
-                &(),
+                keyspaces_to_fetch,
             )
-            .map(|pager_res| {
-                let pager = pager_res.map_err(create_err)?;
-                let stream = pager
-                    .rows_stream::<(String, String, Option<String>)>()
-                    // Map the error of Result<TypedRowStream, TypecheckError>
-                    .map_err(create_err)?
-                    // Map the error of single stream iteration (NextRowError)
-                    .map_err(create_err);
-                Ok::<_, MetadataFetchError>(stream)
-            })
-            .into_stream()
-            .try_flatten();
+            .map_err(|error| MetadataFetchError {
+                error,
+                table: "system_schema.scylla_tables",
+            });
 
         let result = rows
             .map(|row_result| {

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -32,6 +32,18 @@ use uuid::Uuid;
 // Re-export of CQL types.
 pub use crate::frame::response::result::{CollectionType, ColumnType, NativeType, UserDefinedType};
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SchemaMetadataFetchMode {
+    Disabled,
+    Enabled(SchemaMetadataFetchLevel),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SchemaMetadataFetchLevel {
+    Minimal,
+    Full,
+}
+
 /// Indicates that reading metadata failed, but in a way
 /// that we can handle, by throwing out data for a keyspace.
 /// It is possible that some of the errors could be handled in even

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -24,7 +24,9 @@ use tracing::{debug, error, warn};
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{ControlConnection, ControlConnectionCache};
-use crate::cluster::metadata::{ClientRoutes, Metadata, PeerEndpoint, UntranslatedEndpoint};
+use crate::cluster::metadata::{
+    ClientRoutes, Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
+};
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
 use crate::frame::response::event::ClientRoutesChangeEvent;
@@ -44,7 +46,7 @@ pub(crate) struct MetadataReader {
     request_serverside_timeout: Option<Duration>,
     hostname_resolution_timeout: Option<Duration>,
     keyspaces_to_fetch: Vec<String>,
-    fetch_schema: bool,
+    schema_metadata_fetch_mode: SchemaMetadataFetchMode,
     host_filter: Option<Arc<dyn HostFilter>>,
     // When no known peer is reachable, initial known nodes are resolved once again as a fallback
     // and establishing control connection to them is attempted.
@@ -73,7 +75,7 @@ impl MetadataReader {
         connection_config: ConnectionConfig,
         request_serverside_timeout: Option<Duration>,
         keyspaces_to_fetch: Vec<String>,
-        fetch_schema: bool,
+        schema_metadata_fetch_mode: SchemaMetadataFetchMode,
         host_filter: &Option<Arc<dyn HostFilter>>,
         client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
     ) -> Result<Self, NewSessionError> {
@@ -97,7 +99,7 @@ impl MetadataReader {
                 .map(UntranslatedEndpoint::ContactPoint)
                 .collect(),
             keyspaces_to_fetch,
-            fetch_schema,
+            schema_metadata_fetch_mode,
             host_filter: host_filter.clone(),
             initial_known_nodes,
             cc_cache,
@@ -315,7 +317,7 @@ impl MetadataReader {
         cc.query_metadata(
             cc.endpoint().address().port(),
             &self.keyspaces_to_fetch,
-            self.fetch_schema,
+            self.schema_metadata_fetch_mode,
             self.client_routes_subscriber
                 .as_ref()
                 .map(|subscriber| subscriber.get_connection_ids()),

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -3,6 +3,7 @@ use crate::client::client_routes::{
 };
 use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::cluster::control_connection::{ControlConnection, ControlConnectionEvent};
+use crate::cluster::metadata::SchemaMetadataFetchMode;
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::frame::response::event::EventV2 as Event;
@@ -60,7 +61,7 @@ impl Cluster {
         known_nodes: Vec<KnownNode>,
         mut pool_config: PoolConfig,
         keyspaces_to_fetch: Vec<String>,
-        fetch_schema_metadata: bool,
+        schema_metadata_fetch_mode: SchemaMetadataFetchMode,
         metadata_request_serverside_timeout: Option<Duration>,
         hostname_resolution_timeout: Option<Duration>,
         host_filter: Option<Arc<dyn HostFilter>>,
@@ -101,7 +102,7 @@ impl Cluster {
             pool_config.connection_config.clone(),
             metadata_request_serverside_timeout,
             keyspaces_to_fetch,
-            fetch_schema_metadata,
+            schema_metadata_fetch_mode,
             &host_filter,
             client_routes_subscriber.as_ref().map(Arc::clone),
         )

--- a/scylla/tests/integration/load_balancing/tablets.rs
+++ b/scylla/tests/integration/load_balancing/tablets.rs
@@ -1013,7 +1013,7 @@ fn install_feedback_channels(
 /// runs `test_body` with the session and the feedback receivers. The proxy
 /// bookkeeping (including tolerating the expected disconnect at shutdown) is
 /// handled here so each subtest can focus on its own schema and assertions.
-async fn with_tablet_session<F, Fut>(test_body: F)
+async fn with_tablet_session<F, Fut>(fetch_full_schema: bool, test_body: F)
 where
     F: FnOnce(Session, Vec<UnboundedReceiver<(ResponseFrame, Option<TargetShard>)>>) -> Fut,
     Fut: Future<Output = ()>,
@@ -1026,6 +1026,7 @@ where
             let session = scylla::client::session_builder::SessionBuilder::new()
                 .known_node(proxy_uris[0].as_str())
                 .address_translator(Arc::new(translation_map))
+                .fetch_full_schema_metadata(fetch_full_schema)
                 .default_execution_profile_handle(
                     ExecutionProfile::builder()
                         .retry_policy(Arc::new(LwtBallotBugRetryPolicy))
@@ -1063,7 +1064,7 @@ where
 async fn test_tablets() {
     const TABLET_COUNT: usize = 16;
 
-    with_tablet_session(|session, mut feedback_rxs| async move {
+    with_tablet_session(false, |session, mut feedback_rxs| async move {
         let ks = unique_keyspace_name();
 
         /* Prepare schema */
@@ -1187,7 +1188,7 @@ async fn test_tablets() {
 /// keyspace must use RF=1).
 #[tokio::test]
 async fn test_tablets_materialized_view() {
-    with_tablet_session(|session, mut feedback_rxs| async move {
+    with_tablet_session(true, |session, mut feedback_rxs| async move {
         // Gated on the server supporting materialized views on tablet tables.
         if !supports_feature(&session, "VIEWS_WITH_TABLETS").await {
             tracing::warn!(
@@ -1207,7 +1208,7 @@ async fn test_tablets_materialized_view() {
 /// [`verify_cdc_log_tablet_routing`] for details).
 #[tokio::test]
 async fn test_tablets_cdc_log() {
-    with_tablet_session(|session, mut feedback_rxs| async move {
+    with_tablet_session(true, |session, mut feedback_rxs| async move {
         // Gated on the server supporting CDC on tablet tables.
         if !supports_feature(&session, "CDC_WITH_TABLETS").await {
             tracing::warn!(

--- a/scylla/tests/integration/metadata/configuration.rs
+++ b/scylla/tests/integration/metadata/configuration.rs
@@ -2,12 +2,13 @@
 //! iff ScyllaDB is the target node (else ignores the custom timeout).
 
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, setup_tracing, test_with_3_node_cluster,
-    unique_keyspace_name,
+    PerformDDL as _, create_new_session_builder, scylla_supports_tablets, setup_tracing,
+    test_with_3_node_cluster, unique_keyspace_name,
 };
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::cluster::metadata::{ColumnType, NativeType, Strategy, UserDefinedType};
+use scylla::routing::partitioner::PartitionerName;
 use scylla_proxy::{
     Condition, Reaction as _, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
     ShardAwareness,
@@ -36,6 +37,33 @@ fn map_fedback_message<'a, T, F: Fn(RequestFrame) -> T + 'a>(
         }
         Err(TryRecvError::Empty) => None,
     })
+}
+
+async fn setup_minimal_schema_metadata_session() -> (Session, String) {
+    // Two sessions are required here:
+    // 1. The first session fetches full schema metadata, which is required by `scylla_supports_tablets`
+    //    to accurately verify if the cluster supports tablets.
+    // 2. The second session disables schema metadata fetching (`fetch_full_schema_metadata(false)`)
+    let session = create_new_session_builder().build().await.unwrap();
+    let supports_tablets = scylla_supports_tablets(&session).await;
+    let session = create_new_session_builder()
+        .fetch_full_schema_metadata(false)
+        .build()
+        .await
+        .unwrap();
+    let ks = unique_keyspace_name();
+
+    let mut create_ks = format!(
+        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+    );
+    if supports_tablets {
+        create_ks += " AND TABLETS = {'enabled': false}";
+    }
+
+    session.ddl(create_ks).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
+
+    (session, ks)
 }
 
 #[tokio::test]
@@ -301,10 +329,46 @@ async fn test_turning_off_schema_fetching() {
         .await
         .unwrap();
 
-    session.refresh_metadata().await.unwrap();
     let cluster_state = &session.get_cluster_state();
-    let keyspace = cluster_state.get_keyspace(&ks).unwrap();
+    assert!(cluster_state.get_keyspace(&ks).is_none());
 
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fetching_minimal_schema_metadata() {
+    setup_tracing();
+    let session = create_new_session_builder()
+        .fetch_full_schema_metadata(false)
+        .build()
+        .await
+        .unwrap();
+    let ks = unique_keyspace_name();
+
+    session
+        .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
+        .await
+        .unwrap();
+    session
+        .query_unpaged(format!("USE {ks}"), &[])
+        .await
+        .unwrap();
+    session
+        .ddl("CREATE TYPE type_a (a int, b text)")
+        .await
+        .unwrap();
+    session
+        .ddl(
+            "CREATE TABLE table_a (
+                a int PRIMARY KEY,
+                b text
+            )",
+        )
+        .await
+        .unwrap();
+
+    let cluster_state = session.get_cluster_state();
+    let keyspace = cluster_state.get_keyspace(&ks).unwrap();
     let datacenter_repfactors: HashMap<String, usize> = cluster_state
         .replica_locator()
         .datacenter_names()
@@ -318,8 +382,73 @@ async fn test_turning_off_schema_fetching() {
             datacenter_repfactors
         }
     );
-    assert_eq!(keyspace.tables.len(), 0);
-    assert_eq!(keyspace.user_defined_types.len(), 0);
+    assert_eq!(keyspace.tables.len(), 1);
+    let table = keyspace.tables.get("table_a").unwrap();
+    assert!(table.columns.is_empty());
+    assert!(table.partition_key.is_empty());
+    assert!(table.clustering_key.is_empty());
+    assert!(keyspace.user_defined_types.is_empty());
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_token_awareness_with_minimal_schema_metadata() {
+    setup_tracing();
+    let (session, ks) = setup_minimal_schema_metadata_session().await;
+
+    session
+        .ddl("CREATE TABLE token_table (pk int PRIMARY KEY, value text)")
+        .await
+        .unwrap();
+    session.await_schema_agreement().await.unwrap();
+    session.refresh_metadata().await.unwrap();
+
+    let mut prepared = session
+        .prepare("INSERT INTO token_table (pk, value) VALUES (?, ?)")
+        .await
+        .unwrap();
+    assert!(prepared.is_token_aware());
+    assert_eq!(prepared.get_partitioner_name(), &PartitionerName::Murmur3);
+    prepared.set_tracing(true);
+
+    let result = session
+        .execute_unpaged(&prepared, (42_i32, "value"))
+        .await
+        .unwrap();
+    let tracing_info = session
+        .get_tracing_info(result.tracing_id().as_ref().unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(tracing_info.nodes().len(), 1);
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(cassandra_tests, ignore)]
+async fn test_cdc_partitioner_with_minimal_schema_metadata() {
+    setup_tracing();
+    let (session, ks) = setup_minimal_schema_metadata_session().await;
+    session
+        .ddl("CREATE TABLE cdc_table (pk int PRIMARY KEY) WITH cdc = {'enabled': true}")
+        .await
+        .unwrap();
+    session.await_schema_agreement().await.unwrap();
+    session.refresh_metadata().await.unwrap();
+
+    let cluster_state = session.get_cluster_state();
+    let cdc_table = cluster_state
+        .get_keyspace(&ks)
+        .unwrap()
+        .tables
+        .get("cdc_table_scylla_cdc_log")
+        .unwrap();
+    assert_eq!(
+        cdc_table.partitioner.as_deref(),
+        Some("com.scylladb.dht.CDCPartitioner")
+    );
 
     session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
 }

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -139,6 +139,8 @@ where
     running_proxy.finish().await
 }
 
+/// # Warning
+/// This function **requires full schema metadata** to function correctly.
 pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
     // Cassandra doesn't have a concept of features, so first detect
     // if there is the `supported_features` column in system.local
@@ -173,6 +175,8 @@ pub(crate) async fn supports_feature(session: &Session, feature: &str) -> bool {
         .any(|f| f == feature)
 }
 
+/// # Warning
+/// This function **requires full schema metadata** to function correctly.
 pub(crate) async fn scylla_supports_tablets(session: &Session) -> bool {
     supports_feature(session, "TABLETS").await
 }


### PR DESCRIPTION
## Summary
This PR introduces the fetch_full_schema_metadata option to both SessionBuilder and SessionConfig. The option defaults to true and only takes effect when fetch_schema_metadata is enabled.

When full schema metadata fetching is disabled, the driver retrieves only the lightweight metadata required for query routing, such as table and view names, partitioners, and tablet information. Detailed schema data, including column definitions, partition keys, clustering keys, and user-defined types, is not fetched.

The behavior of fetch_schema_metadata(false) has also been updated. It now disables all schema metadata fetching, including keyspaces, tables, views, partitioners, and other schema information. As a result, token-awareness and tablet-awareness are unavailable in this mode. 

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1741

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
