### PR TITLE
cluster: return client routes in Metadata

### DIFF
--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -10,7 +10,6 @@ use dashmap::DashMap;
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
-use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::client::pager::QueryPager;
 use crate::cluster::metadata::UntranslatedEndpoint;
 use crate::errors::{
@@ -39,7 +38,6 @@ pub(super) struct ControlConnection {
     /// The custom server-side timeout set for requests executed on the control connection.
     overridden_serverside_timeout: Option<Duration>,
     cache: Arc<ControlConnectionCache>,
-    client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
 
     error_channel: oneshot::Receiver<ConnectionError>,
     events_channel: mpsc::Receiver<Event>,
@@ -50,7 +48,6 @@ impl ControlConnection {
         conn: Arc<Connection>,
         endpoint: UntranslatedEndpoint,
         cache: Arc<ControlConnectionCache>,
-        client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
         error_channel: oneshot::Receiver<ConnectionError>,
         events_channel: mpsc::Receiver<Event>,
     ) -> Self {
@@ -59,7 +56,6 @@ impl ControlConnection {
             endpoint,
             overridden_serverside_timeout: None,
             cache,
-            client_routes_subscriber,
             error_channel,
             events_channel,
         }
@@ -75,10 +71,6 @@ impl ControlConnection {
             overridden_serverside_timeout: overridden_timeout,
             ..self
         }
-    }
-
-    pub(super) fn client_routes_subscriber(&self) -> Option<&Arc<dyn ClientRoutesSubscriber>> {
-        self.client_routes_subscriber.as_ref()
     }
 
     pub(super) fn get_connect_address(&self) -> SocketAddr {
@@ -353,7 +345,6 @@ mod tests {
                 Arc::new(conn),
                 endpoint,
                 Arc::new(ControlConnectionCache::new()),
-                None,
                 error_receiver,
                 events_receiver,
             );

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -161,32 +161,27 @@ impl ControlConnection {
         connect_port: u16,
         keyspace_to_fetch: &[String],
         fetch_schema: bool,
+        client_routes_connection_ids: Option<&[String]>,
     ) -> Result<Metadata, MetadataError> {
         let peers_query = self.query_peers(connect_port);
         let keyspaces_query = self.query_keyspaces(keyspace_to_fetch, fetch_schema);
         let client_routes_query = async {
-            let Some(subscriber) = self.client_routes_subscriber() else {
-                return Ok(ClientRoutes::default());
+            let Some(connection_ids) = client_routes_connection_ids else {
+                return Ok(None);
             };
-            let connection_ids = subscriber.get_connection_ids();
-            self.query_client_routes(connection_ids, &[]).await
+            self.query_client_routes(connection_ids, &[])
+                .await
+                .map(Some)
         };
 
         let peers_and_cluster_name;
-        let client_routes: ClientRoutes;
+        let client_routes: Option<ClientRoutes>;
         let keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>;
 
         (peers_and_cluster_name, client_routes, keyspaces) =
             tokio::try_join!(peers_query, client_routes_query, keyspaces_query)?;
 
         let (peers, cluster_name) = peers_and_cluster_name;
-
-        let client_routes_updated_hosts =
-            if let Some(client_routes_subscriber) = self.client_routes_subscriber() {
-                client_routes_subscriber.replace_client_routes(client_routes)
-            } else {
-                HashSet::new()
-            };
 
         // There must be at least one peer
         if peers.is_empty() {
@@ -202,7 +197,7 @@ impl ControlConnection {
             peers,
             keyspaces,
             cluster_name,
-            client_routes_updated_hosts,
+            client_routes,
         })
     }
 }

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -24,7 +24,7 @@ use crate::cluster::node::{NodeAddr, ResolvedContactPoint};
 use crate::routing::Token;
 
 use crate::frame::response::result::ColumnSpec;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
@@ -54,10 +54,10 @@ pub(crate) struct Metadata {
     pub(crate) keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>,
     pub(crate) cluster_name: Option<String>,
 
-    /// Host IDs whose client routes were added or updated during this metadata fetch.
-    /// Used to trigger immediate pool refills for nodes that may have been in backoff
-    /// due to `TranslationError::NoRuleForHost`.
-    pub(crate) client_routes_updated_hosts: HashSet<Uuid>,
+    /// The raw snapshot of client routes, as fetched from `system.client_routes`.
+    /// `None` if client routes are not configured for this session - in that case
+    /// the table is not queried at all and nothing should be applied.
+    pub(crate) client_routes: Option<ClientRoutes>,
 }
 
 /// Represents a node in the cluster, as fetched from the `system.{peers,local}` tables.
@@ -354,7 +354,7 @@ impl Metadata {
             peers,
             keyspaces: HashMap::new(),
             cluster_name: None,
-            client_routes_updated_hosts: HashSet::new(),
+            client_routes: None,
         }
     }
 }

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -14,19 +14,17 @@
 //! Ownership of the established control connection lives outside the reader (in the
 //! cluster worker); the reader only knows how to create one and fetch metadata on it.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use rand::rng;
 use rand::seq::SliceRandom;
 use tracing::{debug, error, warn};
-use uuid::Uuid;
 
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{ControlConnection, ControlConnectionCache};
-use crate::cluster::metadata::{Metadata, PeerEndpoint, UntranslatedEndpoint};
+use crate::cluster::metadata::{ClientRoutes, Metadata, PeerEndpoint, UntranslatedEndpoint};
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
 use crate::frame::response::event::ClientRoutesChangeEvent;
@@ -237,7 +235,7 @@ impl MetadataReader {
                 self.control_connection_config.clone(),
                 self.request_serverside_timeout,
                 Arc::clone(&self.cc_cache),
-                self.client_routes_subscriber.as_ref().map(Arc::clone),
+                self.client_routes_subscriber.is_some(),
             )
             .await
             {
@@ -318,6 +316,9 @@ impl MetadataReader {
             cc.endpoint().address().port(),
             &self.keyspaces_to_fetch,
             self.fetch_schema,
+            self.client_routes_subscriber
+                .as_ref()
+                .map(|subscriber| subscriber.get_connection_ids()),
         )
         .await
     }
@@ -389,7 +390,7 @@ impl MetadataReader {
         mut config: ConnectionConfig,
         request_serverside_timeout: Option<Duration>,
         cache: Arc<ControlConnectionCache>,
-        client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
+        register_for_client_routes_events: bool,
     ) -> Result<ControlConnection, MetadataError> {
         let (sender, receiver) = tokio::sync::mpsc::channel(32);
         // setting event_sender field in connection config will cause control connection to
@@ -400,7 +401,7 @@ impl MetadataReader {
             EventType::StatusChange,
             EventType::SchemaChange,
         ];
-        if client_routes_subscriber.is_some() {
+        if register_for_client_routes_events {
             events_to_register_for.push(EventType::ClientRoutesChange);
         }
 
@@ -413,15 +414,12 @@ impl MetadataReader {
         .await;
 
         match open_result {
-            Ok((con, recv)) => Ok(ControlConnection::new(
-                Arc::new(con),
-                endpoint,
-                cache,
-                client_routes_subscriber,
-                recv,
-                receiver,
-            )
-            .override_serverside_timeout(request_serverside_timeout)),
+            Ok((con, recv)) => {
+                Ok(
+                    ControlConnection::new(Arc::new(con), endpoint, cache, recv, receiver)
+                        .override_serverside_timeout(request_serverside_timeout),
+                )
+            }
             Err(conn_err) => Err(MetadataError::ConnectionPoolError(
                 ConnectionPoolError::Broken {
                     last_connection_error: conn_err,
@@ -434,16 +432,18 @@ impl MetadataReader {
     /// not only by connection ids known to the driver (which is always the case), but also
     /// by host ids - only for the hosts whose ids are present in the event payload.
     ///
-    /// Then, the updates are fed to the [`ClientRoutesSubscriber`] for merging with previous knowledge.
-    pub(in super::super) async fn fetch_client_route_updates_on_event(
+    /// Returns the raw partial snapshot, or `None` if there is no subscriber configured
+    /// or the event contained no connection ids relevant to this driver. Merging the
+    /// update into the [`ClientRoutesSubscriber`]'s knowledge is the caller's job.
+    pub(in super::super) async fn fetch_client_routes_update_on_event(
         &self,
         cc: &ControlConnection,
         evt: &ClientRoutesChangeEvent,
-    ) -> Result<HashSet<Uuid>, MetadataError> {
+    ) -> Result<Option<ClientRoutes>, MetadataError> {
         let Some(subscriber) = &self.client_routes_subscriber else {
             // No subscriber, but received an event? Strange enough, but nothing to be done here.
             warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
-            return Ok(HashSet::new());
+            return Ok(None);
         };
 
         #[deny(clippy::wildcard_enum_match_arm)]
@@ -468,7 +468,7 @@ impl MetadataReader {
         if connection_ids.is_empty() {
             // The event contained no relevant connection IDs.
             // Nothing to be done.
-            return Ok(HashSet::new());
+            return Ok(None);
         }
 
         // Although this is vaguely documented, the semantics of an event with connection ids [A, B, C] and host ids [X, Y, Z]
@@ -479,9 +479,7 @@ impl MetadataReader {
         // I believe the tradeoff here is correct.
         let client_routes = cc.query_client_routes(&connection_ids, host_ids).await?;
 
-        let updated_hosts = subscriber.merge_client_routes_update(evt, client_routes);
-
-        Ok(updated_hosts)
+        Ok(Some(client_routes))
     }
 }
 

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -684,7 +684,7 @@ mod tests {
         Metadata {
             peers,
             keyspaces: HashMap::new(),
-            client_routes_updated_hosts: HashSet::new(),
+            client_routes: None,
             cluster_name: Some("Test Cluster".into()),
         }
     }

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -92,6 +92,9 @@ impl Cluster {
             translator
         });
 
+        let client_routes_subscriber = client_routes_address_translator
+            .map(|translator| translator as Arc<dyn ClientRoutesSubscriber>);
+
         let mut metadata_reader = MetadataReader::new(
             known_nodes,
             hostname_resolution_timeout,
@@ -100,16 +103,26 @@ impl Cluster {
             keyspaces_to_fetch,
             fetch_schema_metadata,
             &host_filter,
-            client_routes_address_translator
-                .map(|translator| translator as Arc<dyn ClientRoutesSubscriber>),
+            client_routes_subscriber.as_ref().map(Arc::clone),
         )
         .await?;
 
         let mut node_status = HashMap::new();
 
-        let (cc, metadata) = metadata_reader
+        let (cc, mut metadata) = metadata_reader
             .establish_cc_and_fetch_metadata(true)
             .await?;
+
+        // The initial metadata is fetched before the worker exists, so the routes must be
+        // applied here - `ClusterState::new` below creates connection pools, which translate
+        // addresses through the subscriber.
+        if let (Some(subscriber), Some(routes)) = (
+            client_routes_subscriber.as_ref(),
+            metadata.client_routes.take(),
+        ) {
+            // The returned host ids are irrelevant here: the pools are being created fresh anyway.
+            let _ = subscriber.replace_client_routes(routes);
+        }
 
         let cluster_state = ClusterState::new(
             metadata,
@@ -141,6 +154,7 @@ impl Cluster {
             node_status,
 
             metadata_reader,
+            client_routes_subscriber,
             pool_config,
 
             refresh_channel: refresh_receiver,
@@ -234,6 +248,10 @@ struct ClusterWorker {
 
     // Cluster connections
     metadata_reader: MetadataReader,
+
+    /// The applier of client routes snapshots fetched from `system.client_routes`.
+    /// `None` if client routes are not configured.
+    client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
     pool_config: PoolConfig,
 
     // To listen for refresh requests
@@ -376,10 +394,14 @@ impl ClusterWorker {
                                         error!("BUG: Received a server event without a control connection.");
                                         continue;
                                     };
-                                    let res = self.metadata_reader.fetch_client_route_updates_on_event(cc, &evt).await;
+                                    let res = self.metadata_reader.fetch_client_routes_update_on_event(cc, &evt).await;
                                     match res {
-                                        Ok(updated_hosts) => {
-                                            self.cluster_state.load().trigger_pool_refills_for_hosts(updated_hosts.iter().copied());
+                                        Ok(None) => continue, // Nothing to apply; don't go to refreshing.
+                                        Ok(Some(routes)) => {
+                                            if let Some(subscriber) = self.client_routes_subscriber.as_ref() {
+                                                let updated_hosts = subscriber.merge_client_routes_update(&evt, routes);
+                                                self.cluster_state.load().trigger_pool_refills_for_hosts(updated_hosts.iter().copied());
+                                            }
                                             continue; // Don't go to refreshing.
                                         }
                                         Err(err) =>
@@ -552,8 +574,18 @@ impl ClusterWorker {
         control_connection: &mut Option<ControlConnection>,
     ) -> Result<(), MetadataError> {
         // Read latest Metadata
-        let metadata = self.read_metadata(control_connection).await?;
-        let client_routes_updated_hosts = metadata.client_routes_updated_hosts.clone();
+        let mut metadata = self.read_metadata(control_connection).await?;
+
+        // Apply the fetched client routes snapshot BEFORE constructing the new `ClusterState`,
+        // because `ClusterState::new` creates connection pools, which translate addresses
+        // through the subscriber.
+        let client_routes_updated_hosts = match (
+            self.client_routes_subscriber.as_ref(),
+            metadata.client_routes.take(),
+        ) {
+            (Some(subscriber), Some(routes)) => subscriber.replace_client_routes(routes),
+            _ => Default::default(),
+        };
 
         let cluster_state: Arc<ClusterState> = self.cluster_state.load_full();
 

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1462,7 +1462,7 @@ mod tests {
             let info = Metadata {
                 peers,
                 keyspaces: HashMap::new(),
-                client_routes_updated_hosts: Default::default(),
+                client_routes: None,
                 cluster_name: Some("TestCluster".into()),
             };
 

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -168,7 +168,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
         peers: Vec::from(peers),
         keyspaces,
         cluster_name: Some("TestCluster".into()),
-        client_routes_updated_hosts: Default::default(),
+        client_routes: None,
     }
 }
 


### PR DESCRIPTION
Metadata fetching used to have a hidden side effect: `query_metadata` called `ClientRoutesSubscriber::replace_client_routes` itself and returned only the derived set of hosts to refill, and the reader's event-driven partial fetch merged into the subscriber the same way. That made the control connection - a component whose only job is to run queries and deliver events - a mutator of driver-wide state, and it hid the fact that routes must be applied before connection pools are created from them.

Return the fetched `ClientRoutes` in `Metadata` (and from the reader's event path) instead, and let the owner of the subscriber apply it: `Cluster::new` for the initial fetch, `ClusterWorker` afterwards. Besides being easier to follow, this is a prerequisite for moving metadata fetching into a separate worker, where the fetched data has to travel over a channel anyway.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1280
Ref: https://github.com/scylladb/scylla-rust-driver/issues/1670
Ref: https://github.com/scylladb/scylla-rust-driver/issues/1410
Ref: https://scylladb.atlassian.net/browse/DRIVER-764

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
