### PR TITLE
Split metadata worker

### DIFF
--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -11,13 +11,13 @@ use std::net::SocketAddr;
 use std::sync::RwLock;
 use std::time::Duration;
 use thiserror::Error;
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
+use crate::cluster::metadata::update::ClientRoutesUpdate;
 use crate::cluster::metadata::{ClientRoute, ClientRoutes};
 use crate::cluster::node::resolve_hostname;
 use crate::errors::{DnsLookupError, TranslationError};
-use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 
 /// Represents a single ClientRoutes proxy, identified by a connection ID.
@@ -107,18 +107,14 @@ pub(crate) trait ClientRoutesSubscriber: Send + Sync {
     /// compared to the previous state (i.e., hosts that may need pool refill).
     fn replace_client_routes(&self, client_routes: ClientRoutes) -> HashSet<Uuid>;
 
-    /// Merges existing knowledge about client routes with a partial snapshot,
-    /// fetched in response to a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
-    /// The snapshot contains all entries that match connection ids and host ids
-    /// present in the event.
+    /// Merges existing knowledge about client routes with a partial, mergeable update
+    /// derived from a CLIENT_ROUTES_CHANGE:UPDATE_NODES event. The update contains one
+    /// entry per (host id, connection id) pair listed in the event and relevant to the
+    /// driver: `Some(route)` for a created/updated route, `None` for a removed one.
     ///
     /// Returns the set of host IDs that were added or updated (i.e., hosts
     /// that now have a route and may need pool refill).
-    fn merge_client_routes_update(
-        &self,
-        event: &ClientRoutesChangeEvent,
-        client_routes: ClientRoutes,
-    ) -> HashSet<Uuid>;
+    fn merge_client_routes_update(&self, update: ClientRoutesUpdate) -> HashSet<Uuid>;
 }
 
 /// Translator for client routes: uses content of system.client_routes
@@ -300,92 +296,79 @@ impl ClientRoutesSubscriber for ClientRoutesAddressTranslator {
         added_or_updated_host_ids
     }
 
-    fn merge_client_routes_update(
-        &self,
-        event: &ClientRoutesChangeEvent,
-        new_routes: ClientRoutes,
-    ) -> HashSet<Uuid> {
-        #[deny(clippy::wildcard_enum_match_arm)]
-        let (connection_ids, host_ids) = match event {
-            ClientRoutesChangeEvent::UpdateNodes {
-                connection_ids,
-
-                host_ids,
-            } => (connection_ids, host_ids),
-            _ => unreachable!("clippy testifies the match is exhaustive"),
-        };
-
+    fn merge_client_routes_update(&self, update: ClientRoutesUpdate) -> HashSet<Uuid> {
         let mut guard = self.client_routes.write().unwrap();
         let mut added_or_updated_host_ids = HashSet::new();
 
-        // Iterate over all entries listed in the event.
-        // Filter only those with connection ids that the driver cares about.
-        // For each, determine the type of the entry change: deletion, creation or update.
-        for (connection_id, &host_id) in connection_ids
-            .iter()
-            .zip(host_ids)
-            .filter(|(connection_id, _host_id)| self.get_connection_ids().contains(connection_id))
-        {
-            let new_routes_for_host = new_routes.routes.get(&host_id);
-            let maybe_route = new_routes_for_host
-                .as_ref()
-                .and_then(|host_routes| host_routes.get(connection_id).cloned());
-            match maybe_route {
-                None => {
-                    // Route specified in the event is absent, which means that the event reported route deletion.
-                    let Some(known_host_routes) = guard.get_mut(&host_id) else {
-                        // We didn't have any routes for that host, so nothing to be deleted.
-                        continue;
-                    };
-
-                    // If the route was in other_routes, we remove it here. Else, this is no-op.
-                    known_host_routes
-                        .other_routes
-                        .remove(connection_id.as_str());
-
-                    // If the route was the sticky route, we need to replace it with any from other_routes, if present.
-                    // Otherwise, we remove the whole entry for that host.
-                    if &known_host_routes.sticky_route.connection_id == connection_id {
-                        if let Some(RouteCmpByConnId(replacement_route)) =
-                            known_host_routes.other_routes.extract_if(|_| true).next()
-                        {
-                            known_host_routes.sticky_route = replacement_route;
-                        } else {
-                            guard.remove(&host_id);
-                        }
-                    }
+        // Iterate over all entries of the update. Filtering by connection ids that the
+        // driver cares about has already been done when the update was created.
+        // For each entry, the type of the change is determined: deletion, creation or update.
+        for (host_id, routes_for_host) in update.updates {
+            for (connection_id, maybe_route) in routes_for_host {
+                // Filtering by connection id should have been done by the caller.
+                // Let's double check that nothing slipped trough.
+                if !self.connection_ids.contains(&connection_id) {
+                    warn!("Received update for non-tracked connection_id: {connection_id}");
+                    continue;
                 }
+                match maybe_route {
+                    None => {
+                        // Route specified in the event is absent, which means that the event reported route deletion.
+                        let Some(known_host_routes) = guard.get_mut(&host_id) else {
+                            // We didn't have any routes for that host, so nothing to be deleted.
+                            continue;
+                        };
 
-                Some(new_route) => {
-                    // Route specified in the event is present, which means that the event reported route creation or update.
-                    // In both cases, we just insert it. Let's just handle the sticky route update separately.
-                    added_or_updated_host_ids.insert(host_id);
-                    match guard.get_mut(&host_id) {
-                        // There have already been routes for that host.
-                        Some(host_routes) => {
-                            // Let's see if the new route is the sticky one.
-                            if host_routes.sticky_route.connection_id == new_route.connection_id {
-                                // We update the sticky route.
-                                host_routes.sticky_route = new_route;
+                        // If the route was in other_routes, we remove it here. Else, this is no-op.
+                        known_host_routes
+                            .other_routes
+                            .remove(connection_id.as_str());
+
+                        // If the route was the sticky route, we need to replace it with any from other_routes, if present.
+                        // Otherwise, we remove the whole entry for that host.
+                        if known_host_routes.sticky_route.connection_id == connection_id {
+                            if let Some(RouteCmpByConnId(replacement_route)) =
+                                known_host_routes.other_routes.extract_if(|_| true).next()
+                            {
+                                known_host_routes.sticky_route = replacement_route;
                             } else {
-                                // We add a new route or update an existing one.
-                                // `replace` not `insert`: `other_routes` is a `HashSet`.
-                                // `HashSet::insert` retains old value if it already exists,
-                                // so it would not replace the route but keep the old one.
-                                host_routes
-                                    .other_routes
-                                    .replace(RouteCmpByConnId(new_route));
+                                guard.remove(&host_id);
                             }
                         }
-                        // There was no route for that host yet.
-                        None => {
-                            guard.insert(
-                                host_id,
-                                KnownHostRoutes {
-                                    sticky_route: new_route,
-                                    other_routes: HashSet::new(),
-                                },
-                            );
+                    }
+
+                    Some(new_route) => {
+                        // Route specified in the event is present, which means that the event reported route creation or update.
+                        // In both cases, we just insert it. Let's just handle the sticky route update separately.
+                        added_or_updated_host_ids.insert(host_id);
+                        match guard.get_mut(&host_id) {
+                            // There have already been routes for that host.
+                            Some(host_routes) => {
+                                // Let's see if the new route is the sticky one.
+                                if host_routes.sticky_route.connection_id == new_route.connection_id
+                                {
+                                    // We update the sticky route.
+                                    host_routes.sticky_route = new_route;
+                                } else {
+                                    // We add a new route or update an existing one.
+                                    // `replace` not `insert`: `other_routes` is a `HashSet`.
+                                    // `HashSet::insert` retains old value if it already exists,
+                                    // so it would not replace the route but keep the old one.
+                                    host_routes
+                                        .other_routes
+                                        .replace(RouteCmpByConnId(new_route));
+                                }
+                            }
+                            // There was no route for that host yet.
+                            None => {
+                                guard.insert(
+                                    host_id,
+                                    KnownHostRoutes {
+                                        sticky_route: new_route,
+                                        other_routes: HashSet::new(),
+                                    },
+                                );
+                            }
                         }
                     }
                 }
@@ -471,6 +454,7 @@ impl AddressTranslator for ClientRoutesAddressTranslator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cluster::metadata::update::ClientRoutesUpdate;
     use crate::cluster::metadata::{ClientRoute, ClientRoutes};
     use crate::frame::response::event::ClientRoutesChangeEvent;
     use assert_matches::assert_matches;
@@ -490,6 +474,14 @@ mod tests {
         let mut cr = ClientRoutes::default();
         cr.extend(routes);
         cr
+    }
+
+    fn make_update(
+        translator: &ClientRoutesAddressTranslator,
+        event: &ClientRoutesChangeEvent,
+        fetched: ClientRoutes,
+    ) -> ClientRoutesUpdate {
+        ClientRoutesUpdate::from_event(event, translator.get_connection_ids(), &fetched)
     }
 
     fn make_config(proxies: Vec<ClientRoutesProxy>) -> ClientRoutesConfig {
@@ -893,7 +885,8 @@ mod tests {
         };
 
         // Port changes via merge.
-        translator.merge_client_routes_update(
+        translator.merge_client_routes_update(make_update(
+            &translator,
             &make_event(),
             make_client_routes(vec![ClientRoute {
                 connection_id: "conn-1".to_owned(),
@@ -902,14 +895,15 @@ mod tests {
                 port: Some(9050),
                 tls_port: None,
             }]),
-        );
+        ));
         assert_eq!(
             translator.translate_address(&peer).await.unwrap(),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)), 9050),
         );
 
         // Hostname changes via merge.
-        translator.merge_client_routes_update(
+        translator.merge_client_routes_update(make_update(
+            &translator,
             &make_event(),
             make_client_routes(vec![ClientRoute {
                 connection_id: "conn-1".to_owned(),
@@ -918,14 +912,15 @@ mod tests {
                 port: Some(9050),
                 tls_port: None,
             }]),
-        );
+        ));
         assert_eq!(
             translator.translate_address(&peer).await.unwrap(),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 4)), 9050),
         );
 
         // Both hostname and port change via merge.
-        translator.merge_client_routes_update(
+        translator.merge_client_routes_update(make_update(
+            &translator,
             &make_event(),
             make_client_routes(vec![ClientRoute {
                 connection_id: "conn-1".to_owned(),
@@ -934,7 +929,7 @@ mod tests {
                 port: Some(9060),
                 tls_port: None,
             }]),
-        );
+        ));
         assert_eq!(
             translator.translate_address(&peer).await.unwrap(),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 5)), 9060),
@@ -1054,7 +1049,7 @@ mod tests {
             port: Some(9044),
             tls_port: None,
         }]);
-        translator.merge_client_routes_update(&event, partial);
+        translator.merge_client_routes_update(make_update(&translator, &event, partial));
 
         // host_a got the updated port.
         let peer_a = make_peer(host_a, localhost_addr(19999));
@@ -1172,7 +1167,7 @@ mod tests {
                 tls_port: None,
             },
         ]);
-        translator.merge_client_routes_update(&event, partial);
+        translator.merge_client_routes_update(make_update(&translator, &event, partial));
 
         // Resilient: host_a updated to new port, not removed.
         assert_eq!(
@@ -1301,7 +1296,8 @@ mod tests {
             connection_ids: vec!["conn-1".to_owned(), "conn-0".to_owned()],
             host_ids: vec![host_id, host_id],
         };
-        translator.merge_client_routes_update(
+        translator.merge_client_routes_update(make_update(
+            &translator,
             &event,
             make_client_routes(vec![ClientRoute {
                 connection_id: "conn-0".to_owned(),
@@ -1310,7 +1306,7 @@ mod tests {
                 port: Some(9070),
                 tls_port: None,
             }]),
-        );
+        ));
         assert_eq!(
             translator.translate_address(&peer).await.unwrap(),
             localhost_addr(9070)
@@ -1377,7 +1373,8 @@ mod tests {
             connection_ids: vec!["conn-1".to_owned(), "conn-0".to_owned()],
             host_ids: vec![host_id, host_id],
         };
-        translator.merge_client_routes_update(
+        translator.merge_client_routes_update(make_update(
+            &translator,
             &event,
             make_client_routes(vec![ClientRoute {
                 connection_id: "conn-0".to_owned(),
@@ -1386,7 +1383,7 @@ mod tests {
                 port: Some(9060),
                 tls_port: None,
             }]),
-        );
+        ));
         assert_eq!(
             translator.translate_address(&peer).await.unwrap(),
             localhost_addr(9060)
@@ -1461,7 +1458,7 @@ mod tests {
                 tls_port: None,
             },
         ]);
-        translator.merge_client_routes_update(&event, refetched);
+        translator.merge_client_routes_update(make_update(&translator, &event, refetched));
 
         // host_y should now translate via conn-2.
         assert_eq!(
@@ -1518,7 +1515,11 @@ mod tests {
             connection_ids: vec!["conn-1".to_owned()],
             host_ids: vec![host_x],
         };
-        translator.merge_client_routes_update(&event, ClientRoutes::default());
+        translator.merge_client_routes_update(make_update(
+            &translator,
+            &event,
+            ClientRoutes::default(),
+        ));
 
         // Correct behaviour: host_x should still be translatable.
         // The driver previously knew about conn-2's route for this host, so it
@@ -1577,12 +1578,14 @@ mod tests {
             port: Some(9099),
             tls_port: None,
         }]);
-        translator.merge_client_routes_update(&event, refetched);
+        translator.merge_client_routes_update(make_update(&translator, &event, refetched));
 
-        // Correct behaviour: host_x should be reachable via conn-2 at port 9099.
-        // The first iteration handles (conn-1, host_x) — deletion + re-insert
-        // with conn-2.  The second iteration handles (conn-2, host_x) — should
-        // recognise that the route is present and keep it, not delete it.
+        // Correct behaviour: host_x should be reachable via conn-2 at port 9099,
+        // regardless of the (arbitrary) order in which the update's entries for
+        // host_x are processed: handling the (conn-1, host_x) deletion first drops
+        // the host entry and the (conn-2, host_x) entry re-creates it, while the
+        // reverse order replaces conn-2's route in `other_routes` and then promotes
+        // it to sticky when conn-1's route is deleted.
         assert_eq!(
             translator.translate_address(&peer).await.unwrap(),
             localhost_addr(9099),
@@ -1634,7 +1637,7 @@ mod tests {
             port: Some(9099),
             tls_port: None,
         }]);
-        translator.merge_client_routes_update(&event, refetched);
+        translator.merge_client_routes_update(make_update(&translator, &event, refetched));
 
         // The route should be updated to port 9099, not deleted.
         assert_eq!(
@@ -1946,7 +1949,8 @@ mod tests {
             port: Some(9042),
             tls_port: None,
         }]);
-        let returned = translator.merge_client_routes_update(&event, routes);
+        let returned =
+            translator.merge_client_routes_update(make_update(&translator, &event, routes));
         assert_eq!(returned, HashSet::from([host]));
     }
 
@@ -1979,7 +1983,8 @@ mod tests {
             port: Some(9099),
             tls_port: None,
         }]);
-        let returned = translator.merge_client_routes_update(&event, routes);
+        let returned =
+            translator.merge_client_routes_update(make_update(&translator, &event, routes));
         assert_eq!(returned, HashSet::from([host]));
     }
 
@@ -2006,7 +2011,11 @@ mod tests {
             connection_ids: vec!["conn-1".to_owned()],
             host_ids: vec![host],
         };
-        let returned = translator.merge_client_routes_update(&event, make_client_routes(vec![]));
+        let returned = translator.merge_client_routes_update(make_update(
+            &translator,
+            &event,
+            make_client_routes(vec![]),
+        ));
         assert!(
             returned.is_empty(),
             "Deleted host should not be returned, got: {:?}",
@@ -2035,7 +2044,8 @@ mod tests {
             port: Some(9042),
             tls_port: None,
         }]);
-        let returned = translator.merge_client_routes_update(&event, routes);
+        let returned =
+            translator.merge_client_routes_update(make_update(&translator, &event, routes));
         assert!(
             returned.is_empty(),
             "Irrelevant connection_id should be ignored, got: {:?}",
@@ -2098,7 +2108,8 @@ mod tests {
                 tls_port: None,
             },
         ]);
-        let returned = translator.merge_client_routes_update(&event, routes);
+        let returned =
+            translator.merge_client_routes_update(make_update(&translator, &event, routes));
         assert_eq!(returned, HashSet::from([host_updated, host_added]));
     }
 
@@ -2134,7 +2145,7 @@ mod tests {
             port: Some(9099),
             tls_port: None,
         }]);
-        let _ = translator.merge_client_routes_update(&event, routes);
+        let _ = translator.merge_client_routes_update(make_update(&translator, &event, routes));
 
         // Replace the route with conn id 2.
         let event = ClientRoutesChangeEvent::UpdateNodes {
@@ -2148,7 +2159,7 @@ mod tests {
             port: Some(9100),
             tls_port: None,
         }]);
-        let _ = translator.merge_client_routes_update(&event, routes);
+        let _ = translator.merge_client_routes_update(make_update(&translator, &event, routes));
 
         // Now let's remove conn id 1, so conn id 2 has to be used.
         // We expect the last route (with port 9100 to be used),
@@ -2158,7 +2169,7 @@ mod tests {
             host_ids: vec![host_id],
         };
         let routes = make_client_routes(vec![]);
-        let _ = translator.merge_client_routes_update(&event, routes);
+        let _ = translator.merge_client_routes_update(make_update(&translator, &event, routes));
 
         let peer = make_peer(host_id, localhost_addr(19999));
         assert_eq!(

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -38,7 +38,15 @@ pub(super) struct ControlConnection {
     /// The custom server-side timeout set for requests executed on the control connection.
     overridden_serverside_timeout: Option<Duration>,
     cache: Arc<ControlConnectionCache>,
+}
 
+/// The event side of a control connection: the channels on which the connection
+/// reports server events and its own failure.
+///
+/// Kept apart from [`ControlConnection`] so that awaiting events (which requires
+/// a mutable borrow) does not conflict with running metadata queries on the
+/// connection (which require a shared borrow).
+pub(super) struct ControlConnectionEvents {
     error_channel: oneshot::Receiver<ConnectionError>,
     events_channel: mpsc::Receiver<Event>,
 }
@@ -50,15 +58,19 @@ impl ControlConnection {
         cache: Arc<ControlConnectionCache>,
         error_channel: oneshot::Receiver<ConnectionError>,
         events_channel: mpsc::Receiver<Event>,
-    ) -> Self {
-        Self {
-            conn,
-            endpoint,
-            overridden_serverside_timeout: None,
-            cache,
-            error_channel,
-            events_channel,
-        }
+    ) -> (Self, ControlConnectionEvents) {
+        (
+            Self {
+                conn,
+                endpoint,
+                overridden_serverside_timeout: None,
+                cache,
+            },
+            ControlConnectionEvents {
+                error_channel,
+                events_channel,
+            },
+        )
     }
 
     pub(super) fn endpoint(&self) -> &UntranslatedEndpoint {
@@ -146,8 +158,10 @@ impl ControlConnection {
             .execute_iter(prepared, serialized_values)
             .await
     }
+}
 
-    pub(crate) async fn wait_for_event(&mut self) -> ControlConnectionEvent {
+impl ControlConnectionEvents {
+    pub(super) async fn wait_for_event(&mut self) -> ControlConnectionEvent {
         tokio::select! {
             // Why only `Some`? `None` means that event channel was dropped.
             // In current implementation (as of writing this comment)
@@ -341,7 +355,7 @@ mod tests {
             .unwrap();
 
             let connected_to_scylladb = conn.get_shard_info().is_some();
-            let conn_with_default_timeout = ControlConnection::new(
+            let (conn_with_default_timeout, _events) = ControlConnection::new(
                 Arc::new(conn),
                 endpoint,
                 Arc::new(ControlConnectionCache::new()),

--- a/scylla/src/cluster/metadata/merge_channel.rs
+++ b/scylla/src/cluster/metadata/merge_channel.rs
@@ -1,0 +1,292 @@
+#![allow(dead_code)] // `expect` would need to be put in a lot of places.
+//! A single-producer single-consumer, capacity-one, merge-on-send channel.
+//!
+//! This is the primitive over which the metadata worker (producer) talks to the
+//! cluster worker (consumer). The consumer can be busy for a long time - it
+//! builds a new `ClusterState` and awaits connection pools - while the producer
+//! keeps generating updates: freshly fetched metadata, partial client-routes
+//! snapshots, node UP/DOWN hints, replies owed to explicit refresh requests.
+//!
+//! Queueing all of those would make the consumer apply stale intermediate
+//! states one after another; dropping them would lose information. Instead,
+//! this channel holds *at most one* in-flight value and hands the producer
+//! mutable access to it, so that a new update can be **merged** into the
+//! pending one ([`Sender::modify`]).
+//!
+//! The single-producer/single-consumer discipline is enforced statically: both
+//! [`Sender::modify`] and [`Receiver::recv`] take `&mut self`, and neither
+//! endpoint is `Clone`.
+//!
+//! # Implementation notes
+//!
+//! - The slot is guarded by a [`std::sync::Mutex`], not a `tokio` one: the
+//!   critical section is purely synchronous (it never awaits). Lock poisoning
+//!   is handled the same way as elsewhere in this crate - with `unwrap()`. The
+//!   only code inside the critical section that can panic is the
+//!   caller-provided merge closure; the producer of this channel is a driver
+//!   worker task, so a panicking closure means the worker is already dead and
+//!   the session is unusable. Propagating the poison as a panic to the consumer
+//!   is then strictly better than silently continuing with a possibly
+//!   half-merged update.
+//! - Wakeups go through [`tokio::sync::Notify`].
+//! - Endpoint liveness is tracked with explicit `AtomicBool` flags rather than
+//!   `Arc::strong_count`. `Arc`'s refcount is only decremented *after* our
+//!   `Drop` impl returns, so a receiver woken from `Drop for Sender` would
+//!   still observe a strong count of 2 and park again, losing the wakeup
+//!   forever. An explicit flag set *before* notifying has no such race.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use thiserror::Error;
+use tokio::sync::Notify;
+
+/// State shared by the two endpoints of the channel.
+struct Shared<T> {
+    /// The single in-flight value, if any.
+    slot: Mutex<Option<T>>,
+    /// Signals "the slot may have changed" or "the sender was dropped".
+    notify: Notify,
+    /// Set by `Drop for Sender`, before notifying the receiver.
+    sender_dropped: AtomicBool,
+    /// Set by `Drop for Receiver`.
+    receiver_dropped: AtomicBool,
+}
+
+/// The producing endpoint of a [`merge_channel`].
+pub(crate) struct Sender<T> {
+    shared: Arc<Shared<T>>,
+}
+
+/// The consuming endpoint of a [`merge_channel`].
+pub(crate) struct Receiver<T> {
+    shared: Arc<Shared<T>>,
+}
+
+/// Returned by [`Sender::modify`] when the [`Receiver`] has been dropped,
+/// so that no update can ever be observed again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("the receiving end of the channel has been dropped")]
+pub(crate) struct SendError;
+
+/// Creates a capacity-one, merge-on-send channel.
+pub(crate) fn merge_channel<T>() -> (Sender<T>, Receiver<T>) {
+    let shared = Arc::new(Shared {
+        slot: Mutex::new(None),
+        notify: Notify::new(),
+        sender_dropped: AtomicBool::new(false),
+        receiver_dropped: AtomicBool::new(false),
+    });
+    (
+        Sender {
+            shared: Arc::clone(&shared),
+        },
+        Receiver { shared },
+    )
+}
+
+impl<T> Sender<T> {
+    /// Merges an update into the pending value.
+    ///
+    /// `f` is applied to the currently pending value, which is `None` if the
+    /// receiver already took the previous one (or if nothing was sent yet).
+    ///
+    /// If, after `f` returns, the slot holds a value, the receiver is notified.
+    /// If `f` leaves the slot as `None` - i.e. it decided there is nothing to
+    /// send, or it cancelled a previously pending update - no notification is
+    /// emitted: there would be nothing for the receiver to take, and a spurious
+    /// wakeup would only make it re-check the slot and park again.
+    ///
+    /// Returns [`SendError`] if the receiver has been dropped. In that case `f`
+    /// is not applied at all.
+    pub(crate) fn modify<F>(&mut self, f: F) -> Result<(), SendError>
+    where
+        F: FnOnce(&mut Option<T>),
+    {
+        if self.shared.receiver_dropped.load(Ordering::Acquire) {
+            return Err(SendError);
+        }
+
+        let has_value = {
+            let mut slot = self.shared.slot.lock().unwrap();
+            f(&mut slot);
+            slot.is_some()
+        };
+
+        if has_value {
+            self.shared.notify.notify_one();
+        }
+        Ok(())
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        // The flag must be set before notifying, so that a receiver woken by
+        // this notification is guaranteed to observe it.
+        self.shared.sender_dropped.store(true, Ordering::Release);
+        self.shared.notify.notify_one();
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Takes the pending value without waiting.
+    #[cfg_attr(not(test), expect(dead_code,))]
+    pub(crate) fn try_recv(&mut self) -> Option<T> {
+        self.shared.slot.lock().unwrap().take()
+    }
+
+    /// Takes the pending value, awaiting until one is available.
+    ///
+    /// Returns `None` once the sender has been dropped *and* the slot is empty,
+    /// so an update produced right before the sender was dropped is still
+    /// delivered.
+    ///
+    /// This method is cancel-safe: the value is only removed from the slot when
+    /// it is actually returned, and the `Notified` future is enabled (i.e.
+    /// registered in the wait list) before the slot is inspected, so no wakeup
+    /// can be lost by dropping the returned future.
+    pub(crate) async fn recv(&mut self) -> Option<T> {
+        // Borrow the shared state through a local `Arc` reference so that the
+        // `Notified` future (which borrows `notify`) does not conflict with the
+        // `&mut self` receiver.
+        let shared: &Shared<T> = &self.shared;
+        let take = || shared.slot.lock().unwrap().take();
+
+        loop {
+            let mut notified = std::pin::pin!(shared.notify.notified());
+            // Register in the wait list *before* looking at the slot, so that a
+            // concurrent `modify` either is seen below or wakes us up.
+            notified.as_mut().enable();
+
+            if let Some(value) = take() {
+                return Some(value);
+            }
+
+            if shared.sender_dropped.load(Ordering::Acquire) {
+                // The sender fills the slot before setting the flag, but we
+                // read the slot before the flag - so re-check it once more to
+                // avoid losing that last update.
+                return take();
+            }
+
+            notified.as_mut().await;
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        self.shared.receiver_dropped.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SendError, merge_channel};
+
+    #[tokio::test]
+    async fn merges_updates_sent_before_recv() {
+        let (mut tx, mut rx) = merge_channel::<Vec<u32>>();
+
+        tx.modify(|slot| slot.get_or_insert_default().push(1))
+            .unwrap();
+        tx.modify(|slot| {
+            // The second closure must see what the first one left behind.
+            assert_eq!(slot.as_deref(), Some(&[1][..]));
+            slot.get_or_insert_default().push(2);
+        })
+        .unwrap();
+
+        assert_eq!(rx.recv().await, Some(vec![1, 2]));
+        assert_eq!(rx.try_recv(), None);
+    }
+
+    #[tokio::test]
+    async fn recv_wakes_on_later_modify() {
+        let (mut tx, mut rx) = merge_channel::<u32>();
+
+        let receiving = tokio::task::spawn(async move { rx.recv().await });
+
+        // Let the spawned task reach the await point. Even if it does not, the
+        // test still passes - the value simply is already pending.
+        tokio::task::yield_now().await;
+
+        tx.modify(|slot| *slot = Some(42)).unwrap();
+        assert_eq!(receiving.await.unwrap(), Some(42));
+    }
+
+    #[tokio::test]
+    async fn try_recv_is_non_blocking() {
+        let (mut tx, mut rx) = merge_channel::<u32>();
+
+        assert_eq!(rx.try_recv(), None);
+        tx.modify(|slot| *slot = Some(7)).unwrap();
+        assert_eq!(rx.try_recv(), Some(7));
+        assert_eq!(rx.try_recv(), None);
+    }
+
+    #[tokio::test]
+    async fn modify_fails_after_receiver_dropped() {
+        let (mut tx, rx) = merge_channel::<u32>();
+        drop(rx);
+
+        assert_eq!(tx.modify(|slot| *slot = Some(1)), Err(SendError));
+    }
+
+    #[tokio::test]
+    async fn pending_value_survives_sender_drop() {
+        let (mut tx, mut rx) = merge_channel::<u32>();
+
+        tx.modify(|slot| *slot = Some(5)).unwrap();
+        drop(tx);
+
+        assert_eq!(rx.recv().await, Some(5));
+        assert_eq!(rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn parked_recv_wakes_on_sender_drop() {
+        let (tx, mut rx) = merge_channel::<u32>();
+
+        let receiving = tokio::task::spawn(async move { rx.recv().await });
+        tokio::task::yield_now().await;
+
+        drop(tx);
+        assert_eq!(receiving.await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn cancelled_recv_does_not_lose_value() {
+        let (mut tx, mut rx) = merge_channel::<u32>();
+
+        // Poll `recv` once so that it actually parks: it registers in the
+        // wait list and enables its `Notified` future.
+        {
+            let mut receiving = std::pin::pin!(rx.recv());
+            assert!(futures::poll!(receiving.as_mut()).is_pending());
+
+            // The parked waiter consumes the notification emitted here...
+            tx.modify(|slot| *slot = Some(9)).unwrap();
+
+            // ...and then the future is cancelled without ever being polled
+            // again, so the value is still in the slot.
+        }
+
+        assert_eq!(rx.recv().await, Some(9));
+    }
+
+    #[tokio::test]
+    async fn modify_may_decide_not_to_send() {
+        let (mut tx, mut rx) = merge_channel::<u32>();
+
+        tx.modify(|slot| *slot = None).unwrap();
+        assert_eq!(rx.try_recv(), None);
+
+        // A pending update may also be retracted before it is observed.
+        tx.modify(|slot| *slot = Some(1)).unwrap();
+        tx.modify(|slot| *slot = None).unwrap();
+        assert_eq!(rx.try_recv(), None);
+    }
+}

--- a/scylla/src/cluster/metadata/merge_channel.rs
+++ b/scylla/src/cluster/metadata/merge_channel.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // `expect` would need to be put in a lot of places.
 //! A single-producer single-consumer, capacity-one, merge-on-send channel.
 //!
 //! This is the primitive over which the metadata worker (producer) talks to the

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -18,6 +18,7 @@
 //    - [ClientRoute]
 
 mod fetching;
+pub(crate) mod merge_channel;
 pub(super) mod reader;
 pub(crate) mod update;
 

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -19,7 +19,9 @@
 
 mod fetching;
 pub(super) mod reader;
+pub(crate) mod update;
 
+use crate::cluster::metadata::update::ClientRoutesUpdate;
 use crate::cluster::node::{NodeAddr, ResolvedContactPoint};
 use crate::routing::Token;
 
@@ -334,6 +336,35 @@ impl Extend<ClientRoute> for ClientRoutes {
                 .entry(route.host_id)
                 .or_default() // Insert empty HashMap.
                 .insert(route.connection_id.clone(), route);
+        }
+    }
+}
+
+impl ClientRoutes {
+    /// Applies a partial update to this full snapshot: `Some(route)` inserts or overwrites
+    /// the route, `None` removes it. A host entry whose inner map becomes empty is removed
+    /// entirely, to uphold the invariant that inner maps are never empty.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn merge(&mut self, update: ClientRoutesUpdate) {
+        for (host_id, connection_id, route) in update.into_entries() {
+            match route {
+                Some(route) => {
+                    self.routes
+                        .entry(host_id)
+                        .or_default()
+                        .insert(connection_id, route);
+                }
+                None => {
+                    if let std::collections::hash_map::Entry::Occupied(mut entry) =
+                        self.routes.entry(host_id)
+                    {
+                        entry.get_mut().remove(&connection_id);
+                        if entry.get().is_empty() {
+                            entry.remove();
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -21,6 +21,7 @@ mod fetching;
 pub(crate) mod merge_channel;
 pub(super) mod reader;
 pub(crate) mod update;
+pub(super) mod worker;
 
 use crate::cluster::metadata::update::ClientRoutesUpdate;
 use crate::cluster::node::{NodeAddr, ResolvedContactPoint};
@@ -345,7 +346,6 @@ impl ClientRoutes {
     /// Applies a partial update to this full snapshot: `Some(route)` inserts or overwrites
     /// the route, `None` removes it. A host entry whose inner map becomes empty is removed
     /// entirely, to uphold the invariant that inner maps are never empty.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn merge(&mut self, update: ClientRoutesUpdate) {
         for (host_id, connection_id, route) in update.into_entries() {
             match route {

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -23,7 +23,9 @@ use tracing::{debug, error, warn};
 
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
-use crate::cluster::control_connection::{ControlConnection, ControlConnectionCache};
+use crate::cluster::control_connection::{
+    ControlConnection, ControlConnectionCache, ControlConnectionEvents,
+};
 use crate::cluster::metadata::{
     ClientRoutesUpdate, Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
 };
@@ -143,7 +145,13 @@ impl MetadataReader {
     pub(crate) async fn establish_cc_and_fetch_metadata(
         &mut self,
         initial: bool,
-    ) -> Result<(Option<ControlConnection>, Metadata), MetadataError> {
+    ) -> Result<
+        (
+            Option<(ControlConnection, ControlConnectionEvents)>,
+            Metadata,
+        ),
+        MetadataError,
+    > {
         // shuffle known_peers to iterate through them in random order
         self.known_peers.shuffle(&mut rng());
         debug!(
@@ -221,7 +229,13 @@ impl MetadataReader {
         &mut self,
         initial: bool,
         nodes: impl Iterator<Item = UntranslatedEndpoint>,
-    ) -> Result<(Option<ControlConnection>, Metadata), Option<MetadataError>> {
+    ) -> Result<
+        (
+            Option<(ControlConnection, ControlConnectionEvents)>,
+            Metadata,
+        ),
+        Option<MetadataError>,
+    > {
         let mut last_err: Option<MetadataError> = None;
         // Metadata fetched from a host-filter-rejected node. It is valid cluster-wide,
         // so it is kept as a fallback in case no accepted node can be reached, while we
@@ -232,7 +246,7 @@ impl MetadataReader {
             let peer_address = peer.address();
             debug!("Trying to establish control connection on {peer_address}");
 
-            let cc = match Self::make_control_connection(
+            let (cc, cc_events) = match Self::make_control_connection(
                 peer,
                 self.control_connection_config.clone(),
                 self.request_serverside_timeout,
@@ -296,7 +310,7 @@ impl MetadataReader {
                 continue;
             }
 
-            return Ok((Some(cc), metadata));
+            return Ok((Some((cc, cc_events)), metadata));
         }
 
         match rejected_metadata {
@@ -393,7 +407,7 @@ impl MetadataReader {
         request_serverside_timeout: Option<Duration>,
         cache: Arc<ControlConnectionCache>,
         register_for_client_routes_events: bool,
-    ) -> Result<ControlConnection, MetadataError> {
+    ) -> Result<(ControlConnection, ControlConnectionEvents), MetadataError> {
         let (sender, receiver) = tokio::sync::mpsc::channel(32);
         // setting event_sender field in connection config will cause control connection to
         // - send REGISTER message to receive server events
@@ -417,10 +431,12 @@ impl MetadataReader {
 
         match open_result {
             Ok((con, recv)) => {
-                Ok(
-                    ControlConnection::new(Arc::new(con), endpoint, cache, recv, receiver)
-                        .override_serverside_timeout(request_serverside_timeout),
-                )
+                let (cc, cc_events) =
+                    ControlConnection::new(Arc::new(con), endpoint, cache, recv, receiver);
+                Ok((
+                    cc.override_serverside_timeout(request_serverside_timeout),
+                    cc_events,
+                ))
             }
             Err(conn_err) => Err(MetadataError::ConnectionPoolError(
                 ConnectionPoolError::Broken {

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -12,7 +12,7 @@
 //! - Host filtering to ensure the control connection is established to an accepted node
 //!
 //! Ownership of the established control connection lives outside the reader (in the
-//! cluster worker); the reader only knows how to create one and fetch metadata on it.
+//! metadata worker); the reader only knows how to create one and fetch metadata on it.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,7 +37,7 @@ use crate::utils::safe_format::IteratorSafeFormatExt;
 
 /// Maintains the persistent state needed to create control connections and
 /// fetch cluster metadata. The established control connection itself is owned by
-/// the caller (the cluster worker), not by the reader.
+/// the caller (the metadata worker), not by the reader.
 pub(crate) struct MetadataReader {
     // =======================================================================================
     // Configuration values - they will stay the same during whole lifetime of MetadataReader.

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -25,7 +25,7 @@ use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{ControlConnection, ControlConnectionCache};
 use crate::cluster::metadata::{
-    ClientRoutes, Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
+    ClientRoutesUpdate, Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
 };
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
@@ -434,14 +434,14 @@ impl MetadataReader {
     /// not only by connection ids known to the driver (which is always the case), but also
     /// by host ids - only for the hosts whose ids are present in the event payload.
     ///
-    /// Returns the raw partial snapshot, or `None` if there is no subscriber configured
-    /// or the event contained no connection ids relevant to this driver. Merging the
-    /// update into the [`ClientRoutesSubscriber`]'s knowledge is the caller's job.
+    /// Returns the resulting [`ClientRoutesUpdate`], or `None` if there is no subscriber
+    /// configured or the event contained no connection ids relevant to this driver. Merging
+    /// the update into the [`ClientRoutesSubscriber`]'s knowledge is the caller's job.
     pub(in super::super) async fn fetch_client_routes_update_on_event(
         &self,
         cc: &ControlConnection,
         evt: &ClientRoutesChangeEvent,
-    ) -> Result<Option<ClientRoutes>, MetadataError> {
+    ) -> Result<Option<ClientRoutesUpdate>, MetadataError> {
         let Some(subscriber) = &self.client_routes_subscriber else {
             // No subscriber, but received an event? Strange enough, but nothing to be done here.
             warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
@@ -481,7 +481,11 @@ impl MetadataReader {
         // I believe the tradeoff here is correct.
         let client_routes = cc.query_client_routes(&connection_ids, host_ids).await?;
 
-        Ok(Some(client_routes))
+        Ok(Some(ClientRoutesUpdate::from_event(
+            evt,
+            subscriber.get_connection_ids(),
+            &client_routes,
+        )))
     }
 }
 

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -17,7 +17,6 @@ pub(in super::super) struct RefreshRequest {
 }
 
 #[derive(PartialEq, Eq)]
-#[expect(dead_code)]
 pub(in super::super) enum StatusHint {
     Up,
     Down,
@@ -37,7 +36,6 @@ pub(in super::super) struct MetadataUpdate {
     pub(in super::super) status_hints: HashMap<SocketAddr, StatusHint>,
 }
 
-#[expect(dead_code)]
 pub(in super::super) enum MetadataChanges {
     Full {
         /// Full fetch of metadata. Later partial fetch is allowed to modify this.
@@ -54,7 +52,6 @@ pub(in super::super) enum MetadataChanges {
     },
 }
 
-#[expect(dead_code)]
 impl MetadataUpdate {
     fn slot_mut(slot: &mut Option<Self>) -> &mut Self {
         slot.get_or_insert_with(Self::default)
@@ -207,7 +204,6 @@ impl ClientRoutesUpdate {
     }
 
     /// Return self by value, leaving empty update in its place.
-    #[expect(dead_code)]
     pub(crate) fn take(&mut self) -> Self {
         let map = std::mem::take(&mut self.updates);
         Self { updates: map }
@@ -215,7 +211,6 @@ impl ClientRoutesUpdate {
 
     /// Merges a newer update into this one. Entries of `newer` override entries of `self`
     /// for the same (host id, connection id) pair; all other entries are kept.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn merge(&mut self, newer: ClientRoutesUpdate) {
         for (host_id, connection_id, route) in newer.into_entries() {
             self.updates

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -1,9 +1,143 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 
+use tokio::sync::oneshot;
+use tracing::warn;
 use uuid::Uuid;
 
-use crate::cluster::metadata::{ClientRoute, ClientRoutes};
+use crate::cluster::metadata::{ClientRoute, ClientRoutes, Metadata};
+use crate::errors::MetadataError;
 use crate::frame::response::event::ClientRoutesChangeEvent;
+
+/// An explicit request to refresh cluster metadata, sent by
+/// [`Cluster::refresh_metadata`](crate::cluster::worker::Cluster::refresh_metadata).
+#[derive(Debug)]
+pub(in super::super) struct RefreshRequest {
+    pub(in super::super) response_chan: oneshot::Sender<Result<(), MetadataError>>,
+}
+
+#[derive(PartialEq, Eq)]
+#[expect(dead_code)]
+pub(in super::super) enum StatusHint {
+    Up,
+    Down,
+}
+
+/// Everything the [`MetadataWorker`] learned about the cluster and did not yet
+/// hand over to the cluster worker.
+///
+/// Because the channel carrying it has capacity one, several consecutive
+/// discoveries may end up merged into a single value - see the `merge_*`
+/// constructors below, which are the only way to fill it in.
+#[derive(Default)]
+pub(in super::super) struct MetadataUpdate {
+    pub(in super::super) metadata_changes: Option<MetadataChanges>,
+    /// Nodes for which we received status hints, and the type of hints.
+    /// Latest hint wins during merge.
+    pub(in super::super) status_hints: HashMap<SocketAddr, StatusHint>,
+}
+
+#[expect(dead_code)]
+pub(in super::super) enum MetadataChanges {
+    Full {
+        /// Full fetch of metadata. Later partial fetch is allowed to modify this.
+        metadata: Metadata,
+        /// Response channels of explicit refresh requests, to be answered once the
+        /// state resulting from `metadata` has been published.
+        refresh_responses: Vec<tokio::sync::oneshot::Sender<Result<(), MetadataError>>>,
+    },
+    /// For know, only client_routes can be updates separately. Later we'll add more stuff here.
+    Partial {
+        /// Partial client-routes snapshots fetched in response to
+        /// CLIENT_ROUTES_CHANGE events.
+        client_routes_updates: ClientRoutesUpdate,
+    },
+}
+
+#[expect(dead_code)]
+impl MetadataUpdate {
+    fn slot_mut(slot: &mut Option<Self>) -> &mut Self {
+        slot.get_or_insert_with(Self::default)
+    }
+
+    /// Records freshly fetched metadata, together with the response channel of
+    /// the explicit refresh request that triggered the fetch, if any.
+    ///
+    /// Any partial updates pending so far are dropped: they were
+    /// fetched before this metadata that subsumes them.
+    pub(crate) fn merge_metadata(
+        slot: &mut Option<Self>,
+        metadata: Metadata,
+        refresh_response: Option<tokio::sync::oneshot::Sender<Result<(), MetadataError>>>,
+    ) {
+        let update = Self::slot_mut(slot);
+        // Newest wins: an older, not-yet-applied fetch is worthless now.
+        // Caveat: We need to NOT drop the old refresh channel.
+        match &mut update.metadata_changes {
+            None | Some(MetadataChanges::Partial { .. }) => {
+                update.metadata_changes = Some(MetadataChanges::Full {
+                    metadata,
+                    refresh_responses: refresh_response.into_iter().collect(),
+                });
+            }
+            Some(MetadataChanges::Full {
+                metadata: slot_metadata,
+                refresh_responses,
+            }) => {
+                *slot_metadata = metadata;
+                if let Some(response_channel) = refresh_response {
+                    refresh_responses.push(response_channel);
+                }
+            }
+        }
+    }
+
+    /// Records a partial client-routes snapshot fetched in response to `event`.
+    pub(crate) fn merge_client_routes_update(
+        slot: &mut Option<Self>,
+        new_client_routes: ClientRoutesUpdate,
+    ) {
+        let update = Self::slot_mut(slot);
+        match &mut update.metadata_changes {
+            None => {
+                update.metadata_changes = Some(MetadataChanges::Partial {
+                    client_routes_updates: new_client_routes,
+                });
+            }
+            Some(MetadataChanges::Partial {
+                client_routes_updates,
+            }) => {
+                client_routes_updates.merge(new_client_routes);
+            }
+            Some(MetadataChanges::Full {
+                metadata,
+                refresh_responses: _,
+            }) => {
+                let Some(metadata_routes) = metadata.client_routes.as_mut() else {
+                    warn!(
+                        "Received update for client routes despite client routes not being configured"
+                    );
+                    return;
+                };
+                metadata_routes.merge(new_client_routes);
+            }
+        }
+    }
+
+    /// Records that `addr` was hinted to be UP.
+    pub(crate) fn merge_up_hint(slot: &mut Option<Self>, addr: SocketAddr) {
+        Self::slot_mut(slot)
+            .status_hints
+            .insert(addr, StatusHint::Up);
+    }
+
+    /// Records that `addr` was hinted to be DOWN.
+    pub(crate) fn merge_down_hint(slot: &mut Option<Self>, addr: SocketAddr) {
+        Self::slot_mut(slot)
+            .status_hints
+            .insert(addr, StatusHint::Down);
+    }
+}
 
 /// A partial, mergeable update of client routes, derived from a
 /// CLIENT_ROUTES_CHANGE:UPDATE_NODES event and from the partial snapshot of

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -1,0 +1,458 @@
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::cluster::metadata::{ClientRoute, ClientRoutes};
+use crate::frame::response::event::ClientRoutesChangeEvent;
+
+/// A partial, mergeable update of client routes, derived from a
+/// CLIENT_ROUTES_CHANGE:UPDATE_NODES event and from the partial snapshot of
+/// `system.client_routes` fetched in response to that event.
+///
+/// Each entry corresponds to a (host id, connection id) pair listed in the event
+/// and relevant to the driver (i.e. with a connection id the driver monitors):
+/// - `Some(route)` - the route was created or updated;
+/// - `None` - the route was removed.
+#[derive(Debug, Default)]
+pub(crate) struct ClientRoutesUpdate {
+    /// Grouped by host id first, then by connection id - same as `ClientRoutes`.
+    pub(crate) updates: HashMap<Uuid, HashMap<String, Option<ClientRoute>>>,
+}
+
+impl ClientRoutesUpdate {
+    /// Builds an update from the event and the partial snapshot fetched in response to it.
+    ///
+    /// Only the (connection id, host id) pairs actually listed in the event and having
+    /// a connection id monitored by the driver are taken into account. Routes present in
+    /// `fetched` that do not correspond to any such pair are ignored: the fetch query is
+    /// `WHERE connection_id IN ? AND host_id IN ?`, so it returns the full cross product,
+    /// while the event's semantics is a zip of both lists.
+    pub(crate) fn from_event(
+        event: &ClientRoutesChangeEvent,
+        relevant_connection_ids: &[String],
+        fetched: &ClientRoutes,
+    ) -> Self {
+        #[deny(clippy::wildcard_enum_match_arm)]
+        let (connection_ids, host_ids) = match event {
+            ClientRoutesChangeEvent::UpdateNodes {
+                connection_ids,
+                host_ids,
+            } => (connection_ids, host_ids),
+            _ => unreachable!("clippy testifies that the match is exhaustive"),
+        };
+
+        let mut updates: HashMap<Uuid, HashMap<String, Option<ClientRoute>>> = HashMap::new();
+
+        for (connection_id, &host_id) in connection_ids
+            .iter()
+            .zip(host_ids)
+            .filter(|(connection_id, _host_id)| relevant_connection_ids.contains(connection_id))
+        {
+            let route = fetched
+                .routes
+                .get(&host_id)
+                .and_then(|routes_for_host| routes_for_host.get(connection_id).cloned());
+            updates
+                .entry(host_id)
+                .or_default()
+                .insert(connection_id.clone(), route);
+        }
+
+        Self { updates }
+    }
+
+    /// Flattens the update into (host id, connection id, maybe route) triples.
+    pub(crate) fn into_entries(self) -> impl Iterator<Item = (Uuid, String, Option<ClientRoute>)> {
+        self.updates
+            .into_iter()
+            .flat_map(|(host_id, routes_for_host)| {
+                routes_for_host
+                    .into_iter()
+                    .map(move |(connection_id, route)| (host_id, connection_id, route))
+            })
+    }
+
+    /// Return self by value, leaving empty update in its place.
+    #[expect(dead_code)]
+    pub(crate) fn take(&mut self) -> Self {
+        let map = std::mem::take(&mut self.updates);
+        Self { updates: map }
+    }
+
+    /// Merges a newer update into this one. Entries of `newer` override entries of `self`
+    /// for the same (host id, connection id) pair; all other entries are kept.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn merge(&mut self, newer: ClientRoutesUpdate) {
+        for (host_id, connection_id, route) in newer.into_entries() {
+            self.updates
+                .entry(host_id)
+                .or_default()
+                .insert(connection_id, route);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    // ---------------------------------------------------------------
+    // Tests for ClientRoutesUpdate::merge and ClientRoutes::merge
+    // ---------------------------------------------------------------
+
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    use crate::client::client_routes::{
+        ClientRoutesAddressTranslator, ClientRoutesConfig, ClientRoutesProxy,
+        ClientRoutesSubscriber,
+    };
+    use crate::cluster::metadata::update::ClientRoutesUpdate;
+    use crate::cluster::metadata::{ClientRoute, ClientRoutes};
+    use crate::frame::response::event::ClientRoutesChangeEvent;
+
+    fn route(host: Uuid, conn: &str, port: u16) -> ClientRoute {
+        ClientRoute {
+            connection_id: conn.to_owned(),
+            host_id: host,
+            hostname: "127.0.0.1".to_string(),
+            port: Some(port),
+            tls_port: None,
+        }
+    }
+
+    // Builds a ClientRoutesUpdate directly from (host, connection id, entry) triples,
+    // bypassing `from_event` — the merge logic is independent of how the update
+    // was derived.
+    fn update_from_entries(entries: Vec<(Uuid, &str, Option<ClientRoute>)>) -> ClientRoutesUpdate {
+        let mut updates: HashMap<Uuid, HashMap<String, Option<ClientRoute>>> = HashMap::new();
+        for (host, conn, entry) in entries {
+            updates
+                .entry(host)
+                .or_default()
+                .insert(conn.to_owned(), entry);
+        }
+        ClientRoutesUpdate { updates }
+    }
+
+    // Flattens a ClientRoutes into a deterministically ordered list, so that two
+    // snapshots can be compared for equality (ClientRoutes itself is not PartialEq).
+    fn sorted_entries(routes: &ClientRoutes) -> Vec<(Uuid, String, ClientRoute)> {
+        let mut entries: Vec<(Uuid, String, ClientRoute)> = routes
+            .routes
+            .iter()
+            .flat_map(|(host, per_conn)| {
+                per_conn
+                    .iter()
+                    .map(move |(conn, route)| (*host, conn.clone(), route.clone()))
+            })
+            .collect();
+        entries.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
+        entries
+    }
+
+    // Flattens a ClientRoutesUpdate the same way, for assertions on merge results.
+    fn sorted_update_entries(
+        update: &ClientRoutesUpdate,
+    ) -> Vec<(Uuid, String, Option<ClientRoute>)> {
+        let mut entries: Vec<(Uuid, String, Option<ClientRoute>)> = update
+            .updates
+            .iter()
+            .flat_map(|(host, per_conn)| {
+                per_conn
+                    .iter()
+                    .map(move |(conn, entry)| (*host, conn.clone(), entry.clone()))
+            })
+            .collect();
+        entries.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
+        entries
+    }
+
+    fn make_client_routes(routes: Vec<ClientRoute>) -> ClientRoutes {
+        let mut cr = ClientRoutes::default();
+        cr.extend(routes);
+        cr
+    }
+
+    fn make_config(proxies: Vec<ClientRoutesProxy>) -> ClientRoutesConfig {
+        ClientRoutesConfig::new(proxies).unwrap()
+    }
+
+    fn make_update(
+        translator: &ClientRoutesAddressTranslator,
+        event: &ClientRoutesChangeEvent,
+        fetched: ClientRoutes,
+    ) -> ClientRoutesUpdate {
+        ClientRoutesUpdate::from_event(event, translator.get_connection_ids(), &fetched)
+    }
+
+    // `ClientRoutesUpdate::merge`: entries of the newer update override entries of
+    // the older one for the same (host id, connection id) pair; entries only present
+    // in one of the updates are retained as-is. This covers all four combinations
+    // of Some/None overriding Some/None.
+    #[test]
+    fn update_merge_newer_overrides_older_and_keeps_disjoint() {
+        let host_a = Uuid::new_v4();
+        let host_b = Uuid::new_v4();
+        let host_c = Uuid::new_v4();
+
+        let mut older = update_from_entries(vec![
+            // Overridden by a newer Some.
+            (host_a, "conn-1", Some(route(host_a, "conn-1", 9042))),
+            // Overridden by a newer None (deletion wins).
+            (host_a, "conn-2", Some(route(host_a, "conn-2", 9043))),
+            // Overridden by a newer Some (resurrection wins).
+            (host_b, "conn-1", None),
+            // Disjoint: only in the older update.
+            (host_c, "conn-1", Some(route(host_c, "conn-1", 9044))),
+        ]);
+
+        let newer = update_from_entries(vec![
+            (host_a, "conn-1", Some(route(host_a, "conn-1", 9099))),
+            (host_a, "conn-2", None),
+            (host_b, "conn-1", Some(route(host_b, "conn-1", 9050))),
+            // Disjoint: only in the newer update.
+            (host_c, "conn-2", None),
+        ]);
+
+        older.merge(newer);
+
+        let expected = sorted_update_entries(&update_from_entries(vec![
+            (host_a, "conn-1", Some(route(host_a, "conn-1", 9099))),
+            (host_a, "conn-2", None),
+            (host_b, "conn-1", Some(route(host_b, "conn-1", 9050))),
+            (host_c, "conn-1", Some(route(host_c, "conn-1", 9044))),
+            (host_c, "conn-2", None),
+        ]));
+        assert_eq!(sorted_update_entries(&older), expected);
+    }
+
+    // `ClientRoutes::merge`: a `Some` entry for a host absent from the snapshot
+    // inserts a brand-new host entry.
+    #[test]
+    fn client_routes_merge_some_inserts_new_host() {
+        let host_existing = Uuid::new_v4();
+        let host_new = Uuid::new_v4();
+
+        let mut routes = make_client_routes(vec![route(host_existing, "conn-1", 9042)]);
+        routes.merge(update_from_entries(vec![(
+            host_new,
+            "conn-1",
+            Some(route(host_new, "conn-1", 9099)),
+        )]));
+
+        assert_eq!(
+            routes.routes.get(&host_new).unwrap().get("conn-1"),
+            Some(&route(host_new, "conn-1", 9099))
+        );
+        // The pre-existing host is untouched.
+        assert_eq!(
+            routes.routes.get(&host_existing).unwrap().get("conn-1"),
+            Some(&route(host_existing, "conn-1", 9042))
+        );
+    }
+
+    // `ClientRoutes::merge`: a `Some` entry for an already-known
+    // (host id, connection id) overwrites the stored route.
+    #[test]
+    fn client_routes_merge_some_overwrites_existing_route() {
+        let host = Uuid::new_v4();
+
+        let mut routes = make_client_routes(vec![
+            route(host, "conn-1", 9042),
+            route(host, "conn-2", 9043),
+        ]);
+        routes.merge(update_from_entries(vec![(
+            host,
+            "conn-1",
+            Some(route(host, "conn-1", 9099)),
+        )]));
+
+        let per_conn = routes.routes.get(&host).unwrap();
+        assert_eq!(per_conn.get("conn-1"), Some(&route(host, "conn-1", 9099)));
+        // The other connection id of the same host is unaffected.
+        assert_eq!(per_conn.get("conn-2"), Some(&route(host, "conn-2", 9043)));
+    }
+
+    // `ClientRoutes::merge`: a `None` entry removes only that connection id's route,
+    // leaving the host's other routes in place.
+    #[test]
+    fn client_routes_merge_none_removes_single_route() {
+        let host = Uuid::new_v4();
+
+        let mut routes = make_client_routes(vec![
+            route(host, "conn-1", 9042),
+            route(host, "conn-2", 9043),
+        ]);
+        routes.merge(update_from_entries(vec![(host, "conn-1", None)]));
+
+        let per_conn = routes.routes.get(&host).unwrap();
+        assert_eq!(per_conn.get("conn-1"), None);
+        assert_eq!(per_conn.get("conn-2"), Some(&route(host, "conn-2", 9043)));
+    }
+
+    // `ClientRoutes::merge`: removing a host's last route drops the host entry
+    // entirely. ClientRoutes maintains the invariant that inner maps are never
+    // empty, so an empty inner map must not be left behind.
+    #[test]
+    fn client_routes_merge_none_removing_last_route_drops_host() {
+        let host = Uuid::new_v4();
+        let other_host = Uuid::new_v4();
+
+        let mut routes = make_client_routes(vec![
+            route(host, "conn-1", 9042),
+            route(other_host, "conn-1", 9043),
+        ]);
+        routes.merge(update_from_entries(vec![(host, "conn-1", None)]));
+
+        assert!(
+            !routes.routes.contains_key(&host),
+            "host with no remaining routes must be dropped, got: {:?}",
+            routes.routes.get(&host)
+        );
+        // Unrelated hosts survive.
+        assert_eq!(
+            routes.routes.get(&other_host).unwrap().get("conn-1"),
+            Some(&route(other_host, "conn-1", 9043))
+        );
+    }
+
+    // `ClientRoutes::merge`: a `None` for a host that is not known at all is a no-op.
+    #[test]
+    fn client_routes_merge_none_for_unknown_host_is_noop() {
+        let host = Uuid::new_v4();
+        let unknown = Uuid::new_v4();
+
+        let mut routes = make_client_routes(vec![route(host, "conn-1", 9042)]);
+        let before = sorted_entries(&routes);
+        routes.merge(update_from_entries(vec![
+            (unknown, "conn-1", None),
+            // Also: unknown connection id of a known host.
+            (host, "conn-9", None),
+        ]));
+
+        assert_eq!(sorted_entries(&routes), before);
+    }
+
+    // The point of making updates mergeable: applying update A and then update B to
+    // a snapshot must yield exactly the same snapshot as applying the single merged
+    // update `A.merge(B)`. This is what allows the driver to coalesce pending
+    // partial updates before applying them.
+    #[test]
+    fn client_routes_merge_is_equivalent_to_sequential_application() {
+        let host_a = Uuid::new_v4();
+        let host_b = Uuid::new_v4();
+        let host_c = Uuid::new_v4();
+
+        let initial = || {
+            make_client_routes(vec![
+                route(host_a, "conn-1", 9042),
+                route(host_a, "conn-2", 9043),
+                route(host_b, "conn-1", 9044),
+            ])
+        };
+
+        // A: updates host_a/conn-1, deletes host_a/conn-2, adds host_c/conn-1.
+        let update_a = || {
+            update_from_entries(vec![
+                (host_a, "conn-1", Some(route(host_a, "conn-1", 9050))),
+                (host_a, "conn-2", None),
+                (host_c, "conn-1", Some(route(host_c, "conn-1", 9051))),
+            ])
+        };
+        // B: overrides host_a/conn-1 again, resurrects host_a/conn-2,
+        //    deletes host_b's only route, adds host_c/conn-2.
+        let update_b = || {
+            update_from_entries(vec![
+                (host_a, "conn-1", Some(route(host_a, "conn-1", 9060))),
+                (host_a, "conn-2", Some(route(host_a, "conn-2", 9061))),
+                (host_b, "conn-1", None),
+                (host_c, "conn-2", Some(route(host_c, "conn-2", 9062))),
+            ])
+        };
+
+        // Sequential application.
+        let mut sequential = initial();
+        sequential.merge(update_a());
+        sequential.merge(update_b());
+
+        // Coalesced application.
+        let mut coalesced_update = update_a();
+        coalesced_update.merge(update_b());
+        let mut coalesced = initial();
+        coalesced.merge(coalesced_update);
+
+        assert_eq!(sorted_entries(&sequential), sorted_entries(&coalesced));
+        // Sanity: the merged result is what we expect, not two equal empty maps.
+        assert_eq!(
+            sorted_entries(&sequential),
+            sorted_entries(&make_client_routes(vec![
+                route(host_a, "conn-1", 9060),
+                route(host_a, "conn-2", 9061),
+                route(host_c, "conn-1", 9051),
+                route(host_c, "conn-2", 9062),
+            ]))
+        );
+        assert!(!sequential.routes.contains_key(&host_b));
+    }
+
+    // `ClientRoutesUpdate::from_event` must only pick up (host id, connection id)
+    // pairs listed in the event and relevant to the driver; routes returned by the
+    // re-fetch that do not correspond to an event pair are cross-product artifacts
+    // of the `WHERE connection_id IN ? AND host_id IN ?` query and must be ignored.
+    #[test]
+    fn update_from_event_ignores_cross_product_artifacts_and_irrelevant_conn_ids() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host_x = Uuid::new_v4();
+        let host_y = Uuid::new_v4();
+
+        // The event lists (conn-1, host_x) — relevant — and (conn-other, host_y),
+        // whose connection id the driver does not monitor.
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned(), "conn-other".to_owned()],
+            host_ids: vec![host_x, host_y],
+        };
+        // The re-fetch additionally contains (conn-1, host_y), a cross-product artifact.
+        let fetched = make_client_routes(vec![
+            route(host_x, "conn-1", 9042),
+            route(host_y, "conn-1", 9043),
+        ]);
+
+        let update = make_update(&translator, &event, fetched);
+
+        assert_eq!(
+            sorted_update_entries(&update),
+            vec![(
+                host_x,
+                "conn-1".to_owned(),
+                Some(route(host_x, "conn-1", 9042))
+            )]
+        );
+    }
+
+    // `ClientRoutesUpdate::from_event`: an event pair with no matching route in the
+    // re-fetch yields an explicit `None` entry, i.e. a deletion.
+    #[test]
+    fn update_from_event_yields_none_for_missing_route() {
+        let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
+            "conn-1".to_string(),
+        )]);
+        let translator = ClientRoutesAddressTranslator::new(config, None, false);
+
+        let host = Uuid::new_v4();
+        let event = ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids: vec!["conn-1".to_owned()],
+            host_ids: vec![host],
+        };
+
+        let update = make_update(&translator, &event, ClientRoutes::default());
+
+        assert_eq!(
+            sorted_update_entries(&update),
+            vec![(host, "conn-1".to_owned(), None)]
+        );
+    }
+}

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -1,34 +1,39 @@
+use std::ops::ControlFlow;
 use std::time::Duration;
 
+use tokio::time::Instant;
 use tracing::{debug, error};
 
 use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
 };
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
-use crate::errors::MetadataError;
 use crate::frame::response::event::EventV2 as Event;
 use crate::frame::response::event::StatusChangeEvent;
 
-use super::Metadata;
 use super::merge_channel;
 use super::reader::MetadataReader;
+
+/// How often the worker attempts to establish a control connection while it has none.
+const CONTROL_CONNECTION_REPAIR_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Works in the background to keep learning about the cluster: fetches metadata
 /// periodically and on request, and drains CQL server events from the control
 /// connection. All of its output is put into the `merge_channel` that the
 /// caller of `new` provides.
+///
+/// The worker alternates between two loops:
+/// - [`work_on_cc`](Self::work_on_cc), which serves a specific control connection
+///   until it breaks, and
+/// - [`work_without_cc`](Self::work_without_cc), which establishes a new one.
+///
+/// The control connection is therefore not a field, but a value owned by the
+/// currently running loop.
 pub(in super::super) struct MetadataWorker {
     /// Fetches metadata and (re-)establishes control connections. Also keeps the
     /// known peers and the client-routes subscriber, which it needs for
     /// connection ids and event registration.
     metadata_reader: MetadataReader,
-
-    /// The control connection, on which metadata is fetched and CQL server
-    /// events are received, together with the channels the events arrive on.
-    /// `None` means it is currently broken (or was never established) and needs
-    /// to be re-established, which happens during the next metadata refresh.
-    control_connection: Option<(ControlConnection, ControlConnectionEvents)>,
 
     // This value determines how frequently the metadata
     // worker will refresh the cluster metadata
@@ -39,41 +44,159 @@ pub(in super::super) struct MetadataWorker {
 
     /// Produces updates for the cluster worker.
     updates: merge_channel::Sender<MetadataUpdate>,
+
+    /// A received refresh request whose refresh has not been performed yet.
+    ///
+    /// This is worker state rather than a local of either loop: a request may
+    /// arrive on a control connection that then turns out to be defunct, in which
+    /// case it must survive the switch to [`work_without_cc`](Self::work_without_cc),
+    /// which retries the refresh and ultimately answers it.
+    ///
+    /// Invariant: at most one request is pending at a time - both loops take it
+    /// (answering it, directly or through the cluster worker) before awaiting
+    /// the next one.
+    pending_request: Option<RefreshRequest>,
 }
 
 impl MetadataWorker {
     pub(in super::super) fn new(
         metadata_reader: MetadataReader,
-        initial_control_connection: Option<(ControlConnection, ControlConnectionEvents)>,
         cluster_metadata_refresh_interval: Duration,
         refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
         updates: merge_channel::Sender<MetadataUpdate>,
     ) -> Self {
         Self {
             metadata_reader,
-            control_connection: initial_control_connection,
             cluster_metadata_refresh_interval,
             refresh_channel,
             updates,
+            pending_request: None,
         }
     }
 
-    pub(in super::super) async fn work(mut self) {
-        use tokio::time::Instant;
+    /// Runs the worker until the cluster (or the runtime) is gone.
+    ///
+    /// `initial_cc` is the control connection that the initial metadata was fetched
+    /// on; `None` means none could be kept, in which case one is established first.
+    pub(in super::super) async fn work(
+        mut self,
+        initial_cc: Option<(ControlConnection, ControlConnectionEvents)>,
+    ) {
+        let mut next_cc = initial_cc;
 
-        let control_connection_repair_duration = Duration::from_secs(1); // Attempt control connection repair every second
+        loop {
+            let (cc, cc_events) = match next_cc.take() {
+                Some(cc) => cc,
+                None => match self.work_without_cc().await {
+                    ControlFlow::Break(()) => return,
+                    ControlFlow::Continue(cc) => cc,
+                },
+            };
+
+            match self.work_on_cc(cc, cc_events).await {
+                ControlFlow::Break(()) => return,
+                // The control connection is defunct - establish a new one.
+                ControlFlow::Continue(()) => (),
+            }
+        }
+    }
+
+    /// Attempts to establish a control connection until one is available.
+    ///
+    /// The first attempt is made immediately; further ones are spaced by
+    /// [`CONTROL_CONNECTION_REPAIR_INTERVAL`], with an incoming refresh request
+    /// triggering an attempt right away.
+    ///
+    /// Each attempt fetches metadata, too, so a successful one both satisfies the
+    /// pending refresh request (through the cluster worker) and publishes an update.
+    ///
+    /// Returns [`ControlFlow::Break`] if the worker should stop.
+    async fn work_without_cc(
+        &mut self,
+    ) -> ControlFlow<(), (ControlConnection, ControlConnectionEvents)> {
+        loop {
+            debug!("Attempting to establish a new control connection");
+            let attempt_time = Instant::now();
+
+            match self
+                .metadata_reader
+                .establish_cc_and_fetch_metadata(false)
+                .await
+            {
+                Ok((cc, metadata)) => {
+                    // The refresh request, if any, is answered by the cluster worker, once the
+                    // state resulting from this metadata is published - this is what makes
+                    // `Cluster::refresh_metadata` return only after the new state is visible.
+                    let response_chan = self
+                        .pending_request
+                        .take()
+                        .map(|request| request.response_chan);
+                    if self
+                        .send_update(|slot| {
+                            MetadataUpdate::merge_metadata(slot, metadata, response_chan)
+                        })
+                        .is_err()
+                    {
+                        return ControlFlow::Break(());
+                    }
+
+                    if let Some(cc) = cc {
+                        return ControlFlow::Continue(cc);
+                    }
+                    // Metadata was fetched, but no control connection could be kept
+                    // (e.g. every reachable node is rejected by the host filter).
+                    // Keep trying at the repair cadence.
+                }
+                Err(err) => {
+                    debug!(
+                        error = %err,
+                        "Failed to establish a control connection and fetch metadata"
+                    );
+                    // Nobody else can act on a failed fetch, so the error only goes to the
+                    // requester, if there is one.
+                    if let Some(request) = self.pending_request.take() {
+                        // We can ignore sending error - if no one waits for the response we can drop it
+                        let _ = request.response_chan.send(Err(err));
+                    }
+                }
+            }
+
+            // Wait until it's time for the next attempt, unless a refresh request
+            // makes us attempt earlier.
+            let sleep_until = attempt_time
+                .checked_add(CONTROL_CONNECTION_REPAIR_INTERVAL)
+                .unwrap_or_else(Instant::now);
+
+            tokio::select! {
+                _sleep_finished = tokio::time::sleep_until(sleep_until) => (),
+
+                maybe_refresh_request = self.refresh_channel.recv() => {
+                    match maybe_refresh_request {
+                        Some(request) => self.set_pending_request(request),
+                        None => return ControlFlow::Break(()), // If refresh_channel was closed then cluster was dropped, we can stop working
+                    }
+                }
+            }
+        }
+    }
+
+    /// Serves the given control connection: refreshes metadata on it (periodically,
+    /// on request and in reaction to server events) and drains its events.
+    ///
+    /// Returns [`ControlFlow::Continue`] once the control connection is deemed
+    /// defunct and should be replaced, or [`ControlFlow::Break`] if the worker
+    /// should stop.
+    async fn work_on_cc(
+        &mut self,
+        cc: ControlConnection,
+        mut cc_events: ControlConnectionEvents,
+    ) -> ControlFlow<()> {
         let mut last_refresh_time = Instant::now();
 
         loop {
-            let mut cur_request: Option<RefreshRequest> = None;
-
             // Wait until it's time for the next refresh
             let sleep_until: Instant = last_refresh_time
-                .checked_add(if self.control_connection.is_some() {
-                    self.cluster_metadata_refresh_interval
-                } else {
-                    control_connection_repair_duration
-                })
+                .checked_add(self.cluster_metadata_refresh_interval)
                 .unwrap_or_else(Instant::now);
 
             let sleep_future = tokio::time::sleep_until(sleep_until);
@@ -86,41 +209,35 @@ impl MetadataWorker {
 
                 maybe_refresh_request = self.refresh_channel.recv() => {
                     match maybe_refresh_request {
-                        Some(request) => cur_request = Some(request),
-                        None => return, // If refresh_channel was closed then cluster was dropped, we can stop working
+                        Some(request) => self.set_pending_request(request),
+                        None => return ControlFlow::Break(()), // If refresh_channel was closed then cluster was dropped, we can stop working
                     }
                 }
 
-                control_connection_event = Self::wait_for_control_connection_event(&mut self.control_connection) => {
+                control_connection_event = cc_events.wait_for_event() => {
                     match control_connection_event {
                         ControlConnectionEvent::Shutdown => {
                             // The runtime is shutting down. We can stop working.
                             debug!("Got shutdown control connection event. Shutting down MetadataWorker.");
-                            return;
+                            return ControlFlow::Break(());
                         },
                         ControlConnectionEvent::Broken(_err) => {
-                            // The control connection was broken. Drop it and start attempting to reconnect.
-                            // The first reconnect attempt will be immediate (by attempting metadata refresh below),
-                            // and if it does not succeed, then the control connection will stay `None`, so
+                            // The control connection was broken. Have a new one established;
+                            // the first attempt will be immediate, and if it does not succeed,
                             // subsequent attempts will be issued every second.
-                            self.control_connection = None;
+                            return ControlFlow::Continue(());
                         },
                         ControlConnectionEvent::ServerEvent(event) => {
                             debug!("Received server event: {:?}", event);
                             match event {
                                 Event::TopologyChange(_) => (), // Refresh immediately
                                 Event::ClientRoutesChange(evt) => {
-                                    // We received this event on the control connection, so it must be present.
-                                    let Some((cc, _events)) = self.control_connection.as_ref() else {
-                                        error!("BUG: Received a server event without a control connection.");
-                                        continue;
-                                    };
-                                    let res = self.metadata_reader.fetch_client_routes_update_on_event(cc, &evt).await;
+                                    let res = self.metadata_reader.fetch_client_routes_update_on_event(&cc, &evt).await;
                                     match res {
                                         Ok(None) => continue, // Nothing to apply; don't go to refreshing.
                                         Ok(Some(routes)) => {
                                             if self.send_update(|slot| MetadataUpdate::merge_client_routes_update(slot, routes)).is_err() {
-                                                return;
+                                                return ControlFlow::Break(());
                                             }
                                             continue; // Don't go to refreshing.
                                         }
@@ -153,7 +270,7 @@ impl MetadataWorker {
                                             // then connection attempts will fail and the node will be marked as unreachable by `PoolRefiller`,
                                             // so it won't be targeted by the load balancing policy.
                                             if self.send_update(|slot| MetadataUpdate::merge_up_hint(slot, addr)).is_err() {
-                                                return;
+                                                return ControlFlow::Break(());
                                             }
                                         },
                                         StatusChangeEvent::Down(addr) => {
@@ -166,7 +283,7 @@ impl MetadataWorker {
                                             // which is the desired behaviour. However, if the keepalive query succeeds,
                                             // then the node is likely still alive (got stale event?), and we keep targeting it.
                                             if self.send_update(|slot| MetadataUpdate::merge_down_hint(slot, addr)).is_err() {
-                                                return;
+                                                return ControlFlow::Break(());
                                             }
                                         },
                                     }
@@ -182,33 +299,46 @@ impl MetadataWorker {
             // Perform the refresh
             debug!("Requesting metadata refresh");
             last_refresh_time = Instant::now();
-            let refresh_res = self.read_metadata().await;
 
-            match refresh_res {
+            match self.metadata_reader.fetch_metadata_on_cc(&cc).await {
                 Ok(metadata) => {
                     // The refresh request, if any, is answered by the cluster worker, once the
                     // state resulting from this metadata is published - this is what makes
                     // `Cluster::refresh_metadata` return only after the new state is visible.
-                    let response_chan = cur_request.map(|request| request.response_chan);
+                    let response_chan = self
+                        .pending_request
+                        .take()
+                        .map(|request| request.response_chan);
                     if self
                         .send_update(|slot| {
                             MetadataUpdate::merge_metadata(slot, metadata, response_chan)
                         })
                         .is_err()
                     {
-                        return;
+                        return ControlFlow::Break(());
                     }
                 }
                 Err(err) => {
-                    // Nobody else can act on a failed fetch, so the error only goes to the
-                    // requester, if there is one.
-                    if let Some(request) = cur_request {
-                        // We can ignore sending error - if no one waits for the response we can drop it
-                        let _ = request.response_chan.send(Err(err));
-                    }
+                    debug!(
+                        error = %err,
+                        "Failed to fetch metadata on the current control connection. \
+                        Will try to establish a new one."
+                    );
+                    // The control connection is considered defunct - drop it. The pending
+                    // request, if any, is retried (and answered) while establishing a new one.
+                    return ControlFlow::Continue(());
                 }
             }
         }
+    }
+
+    /// Stores a freshly received refresh request as the pending one.
+    ///
+    /// Upholds the `pending_request` invariant: both loops take the pending request
+    /// before awaiting the next one, so there can never be one already stored.
+    fn set_pending_request(&mut self, request: RefreshRequest) {
+        debug_assert!(self.pending_request.is_none());
+        self.pending_request = Some(request);
     }
 
     /// Merges an update into the pending one, to be picked up by the cluster worker.
@@ -222,50 +352,5 @@ impl MetadataWorker {
         self.updates.modify(f).inspect_err(|_| {
             debug!("The cluster worker is gone. Shutting down MetadataWorker.");
         })
-    }
-
-    /// Waits for the next control connection event.
-    ///
-    /// If there is no working control connection (it is broken and awaiting
-    /// re-establishment), this never resolves — the worker will rely on the
-    /// periodic refresh timer to attempt re-establishment instead.
-    async fn wait_for_control_connection_event(
-        control_connection: &mut Option<(ControlConnection, ControlConnectionEvents)>,
-    ) -> ControlConnectionEvent {
-        match control_connection {
-            None => std::future::pending().await,
-            Some((_cc, events)) => events.wait_for_event().await,
-        }
-    }
-
-    /// Fetches the latest metadata, (re-)establishing the control connection if needed.
-    ///
-    /// If a working control connection is present, metadata is fetched on it. If that
-    /// fails, the connection is dropped and a fresh one is established (iterating over
-    /// known peers and, as a last resort, the initial contact points). The (possibly
-    /// new) working control connection is stored back into `self.control_connection`.
-    async fn read_metadata(&mut self) -> Result<Metadata, MetadataError> {
-        if let Some((cc, _events)) = self.control_connection.as_ref() {
-            match self.metadata_reader.fetch_metadata_on_cc(cc).await {
-                Ok(metadata) => return Ok(metadata),
-                Err(err) => {
-                    debug!(
-                        error = %err,
-                        "Failed to fetch metadata on the current control connection. \
-                        Will try to establish a new one."
-                    );
-                    // The control connection is considered defunct - drop it.
-                    self.control_connection = None;
-                }
-            }
-        }
-
-        // We have no working control connection - establish a new one and fetch metadata on it.
-        let (cc, metadata) = self
-            .metadata_reader
-            .establish_cc_and_fetch_metadata(false)
-            .await?;
-        self.control_connection = cc;
-        Ok(metadata)
     }
 }

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -1,0 +1,269 @@
+use std::time::Duration;
+
+use tracing::{debug, error};
+
+use crate::cluster::control_connection::{ControlConnection, ControlConnectionEvent};
+use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
+use crate::errors::MetadataError;
+use crate::frame::response::event::EventV2 as Event;
+use crate::frame::response::event::StatusChangeEvent;
+
+use super::Metadata;
+use super::merge_channel;
+use super::reader::MetadataReader;
+
+/// Works in the background to keep learning about the cluster: fetches metadata
+/// periodically and on request, and drains CQL server events from the control
+/// connection. All of its output is put into the `merge_channel` that the
+/// caller of `new` provides.
+pub(in super::super) struct MetadataWorker {
+    /// Fetches metadata and (re-)establishes control connections. Also keeps the
+    /// known peers and the client-routes subscriber, which it needs for
+    /// connection ids and event registration.
+    metadata_reader: MetadataReader,
+
+    /// The control connection, on which metadata is fetched and CQL server
+    /// events are received. `None` means it is currently broken (or was never
+    /// established) and needs to be re-established, which happens during the
+    /// next metadata refresh.
+    control_connection: Option<ControlConnection>,
+
+    // This value determines how frequently the metadata
+    // worker will refresh the cluster metadata
+    cluster_metadata_refresh_interval: Duration,
+
+    // To listen for refresh requests
+    refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
+
+    /// Produces updates for the cluster worker.
+    updates: merge_channel::Sender<MetadataUpdate>,
+}
+
+impl MetadataWorker {
+    pub(in super::super) fn new(
+        metadata_reader: MetadataReader,
+        initial_control_connection: Option<ControlConnection>,
+        cluster_metadata_refresh_interval: Duration,
+        refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
+        updates: merge_channel::Sender<MetadataUpdate>,
+    ) -> Self {
+        Self {
+            metadata_reader,
+            control_connection: initial_control_connection,
+            cluster_metadata_refresh_interval,
+            refresh_channel,
+            updates,
+        }
+    }
+
+    pub(in super::super) async fn work(mut self) {
+        use tokio::time::Instant;
+
+        let control_connection_repair_duration = Duration::from_secs(1); // Attempt control connection repair every second
+        let mut last_refresh_time = Instant::now();
+
+        loop {
+            let mut cur_request: Option<RefreshRequest> = None;
+
+            // Wait until it's time for the next refresh
+            let sleep_until: Instant = last_refresh_time
+                .checked_add(if self.control_connection.is_some() {
+                    self.cluster_metadata_refresh_interval
+                } else {
+                    control_connection_repair_duration
+                })
+                .unwrap_or_else(Instant::now);
+
+            let sleep_future = tokio::time::sleep_until(sleep_until);
+            tokio::pin!(sleep_future);
+
+            tokio::select! {
+                _sleep_finished = sleep_future => {
+                    // Time to do periodic refresh.
+                },
+
+                maybe_refresh_request = self.refresh_channel.recv() => {
+                    match maybe_refresh_request {
+                        Some(request) => cur_request = Some(request),
+                        None => return, // If refresh_channel was closed then cluster was dropped, we can stop working
+                    }
+                }
+
+                control_connection_event = Self::wait_for_control_connection_event(&mut self.control_connection) => {
+                    match control_connection_event {
+                        ControlConnectionEvent::Shutdown => {
+                            // The runtime is shutting down. We can stop working.
+                            debug!("Got shutdown control connection event. Shutting down MetadataWorker.");
+                            return;
+                        },
+                        ControlConnectionEvent::Broken(_err) => {
+                            // The control connection was broken. Drop it and start attempting to reconnect.
+                            // The first reconnect attempt will be immediate (by attempting metadata refresh below),
+                            // and if it does not succeed, then the control connection will stay `None`, so
+                            // subsequent attempts will be issued every second.
+                            self.control_connection = None;
+                        },
+                        ControlConnectionEvent::ServerEvent(event) => {
+                            debug!("Received server event: {:?}", event);
+                            match event {
+                                Event::TopologyChange(_) => (), // Refresh immediately
+                                Event::ClientRoutesChange(evt) => {
+                                    // We received this event on the control connection, so it must be present.
+                                    let Some(cc) = self.control_connection.as_ref() else {
+                                        error!("BUG: Received a server event without a control connection.");
+                                        continue;
+                                    };
+                                    let res = self.metadata_reader.fetch_client_routes_update_on_event(cc, &evt).await;
+                                    match res {
+                                        Ok(None) => continue, // Nothing to apply; don't go to refreshing.
+                                        Ok(Some(routes)) => {
+                                            if self.send_update(|slot| MetadataUpdate::merge_client_routes_update(slot, routes)).is_err() {
+                                                return;
+                                            }
+                                            continue; // Don't go to refreshing.
+                                        }
+                                        Err(err) =>
+                                        {
+                                            error!(
+                                                "Error when fetching client route updates: {err}. \
+                                                Proceeding with metadata refresh, because the control connection is likely defunct."
+                                            );
+                                            // Refresh immediately.
+                                        }
+                                    }
+                                }
+                                Event::StatusChange(status) => {
+                                    // Tracking node status using events is unreliable because of the possibility of losing events
+                                    // when control connection is broken. A better thing to do here is to treat those events as hints
+                                    // for:
+                                    // - PoolRefiller - UP triggers immediate pool refill attempt, and
+                                    // - Keepaliver - DOWN triggers immediate keepalive query attempt.
+
+                                    match status {
+                                        StatusChangeEvent::Up(addr) => {
+                                            // When receiving an UP event, it is likely that the node just came back up and is now reachable.
+                                            // We optimistically trigger pool refill for this node.
+                                            // This is not guaranteed to be correct. It is for example possible that a network partition happened,
+                                            // the node lost connectivity to the cluster and driver; then it regained connectivity to the cluster,
+                                            // but not to the driver, and thus is still unreachable from the driver's perspective.
+                                            // However, in this case triggering pool refill is not harmful - if the node is actually reachable,
+                                            // then new connections will be opened to it, and if it is not reachable,
+                                            // then connection attempts will fail and the node will be marked as unreachable by `PoolRefiller`,
+                                            // so it won't be targeted by the load balancing policy.
+                                            if self.send_update(|slot| MetadataUpdate::merge_up_hint(slot, addr)).is_err() {
+                                                return;
+                                            }
+                                        },
+                                        StatusChangeEvent::Down(addr) => {
+                                            // When receiving a DOWN event, and the driver still sees the node as connected,
+                                            // we send a keepalive query on its connections to verify their liveness.
+                                            // The node is supposedly DOWN, so connections to this node are likely defunct.
+                                            // We expect that the keepalive query fails, in which case connections will be closed.
+                                            // As a result, the connection pool will report 0 connections to this node,
+                                            // and thus the node will not be targeted by the LoadBalancingPolicy,
+                                            // which is the desired behaviour. However, if the keepalive query succeeds,
+                                            // then the node is likely still alive (got stale event?), and we keep targeting it.
+                                            if self.send_update(|slot| MetadataUpdate::merge_down_hint(slot, addr)).is_err() {
+                                                return;
+                                            }
+                                        },
+                                    }
+                                    continue; // Don't go to refreshing.
+                                },
+                                _ => continue, // Don't go to refreshing.
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Perform the refresh
+            debug!("Requesting metadata refresh");
+            last_refresh_time = Instant::now();
+            let refresh_res = self.read_metadata().await;
+
+            match refresh_res {
+                Ok(metadata) => {
+                    // The refresh request, if any, is answered by the cluster worker, once the
+                    // state resulting from this metadata is published - this is what makes
+                    // `Cluster::refresh_metadata` return only after the new state is visible.
+                    let response_chan = cur_request.map(|request| request.response_chan);
+                    if self
+                        .send_update(|slot| {
+                            MetadataUpdate::merge_metadata(slot, metadata, response_chan)
+                        })
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Err(err) => {
+                    // Nobody else can act on a failed fetch, so the error only goes to the
+                    // requester, if there is one.
+                    if let Some(request) = cur_request {
+                        // We can ignore sending error - if no one waits for the response we can drop it
+                        let _ = request.response_chan.send(Err(err));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Merges an update into the pending one, to be picked up by the cluster worker.
+    ///
+    /// An error means that the cluster worker is gone, in which case this worker
+    /// has nothing left to work for and should end.
+    fn send_update(
+        &mut self,
+        f: impl FnOnce(&mut Option<MetadataUpdate>),
+    ) -> Result<(), merge_channel::SendError> {
+        self.updates.modify(f).inspect_err(|_| {
+            debug!("The cluster worker is gone. Shutting down MetadataWorker.");
+        })
+    }
+
+    /// Waits for the next control connection event.
+    ///
+    /// If there is no working control connection (it is broken and awaiting
+    /// re-establishment), this never resolves — the worker will rely on the
+    /// periodic refresh timer to attempt re-establishment instead.
+    async fn wait_for_control_connection_event(
+        control_connection: &mut Option<ControlConnection>,
+    ) -> ControlConnectionEvent {
+        match control_connection {
+            None => std::future::pending().await,
+            Some(cc) => cc.wait_for_event().await,
+        }
+    }
+
+    /// Fetches the latest metadata, (re-)establishing the control connection if needed.
+    ///
+    /// If a working control connection is present, metadata is fetched on it. If that
+    /// fails, the connection is dropped and a fresh one is established (iterating over
+    /// known peers and, as a last resort, the initial contact points). The (possibly
+    /// new) working control connection is stored back into `self.control_connection`.
+    async fn read_metadata(&mut self) -> Result<Metadata, MetadataError> {
+        if let Some(cc) = self.control_connection.as_ref() {
+            match self.metadata_reader.fetch_metadata_on_cc(cc).await {
+                Ok(metadata) => return Ok(metadata),
+                Err(err) => {
+                    debug!(
+                        error = %err,
+                        "Failed to fetch metadata on the current control connection. \
+                        Will try to establish a new one."
+                    );
+                    // The control connection is considered defunct - drop it.
+                    self.control_connection = None;
+                }
+            }
+        }
+
+        // We have no working control connection - establish a new one and fetch metadata on it.
+        let (cc, metadata) = self
+            .metadata_reader
+            .establish_cc_and_fetch_metadata(false)
+            .await?;
+        self.control_connection = cc;
+        Ok(metadata)
+    }
+}

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 use tracing::{debug, error};
 
-use crate::cluster::control_connection::{ControlConnection, ControlConnectionEvent};
+use crate::cluster::control_connection::{
+    ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
+};
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
 use crate::errors::MetadataError;
 use crate::frame::response::event::EventV2 as Event;
@@ -23,10 +25,10 @@ pub(in super::super) struct MetadataWorker {
     metadata_reader: MetadataReader,
 
     /// The control connection, on which metadata is fetched and CQL server
-    /// events are received. `None` means it is currently broken (or was never
-    /// established) and needs to be re-established, which happens during the
-    /// next metadata refresh.
-    control_connection: Option<ControlConnection>,
+    /// events are received, together with the channels the events arrive on.
+    /// `None` means it is currently broken (or was never established) and needs
+    /// to be re-established, which happens during the next metadata refresh.
+    control_connection: Option<(ControlConnection, ControlConnectionEvents)>,
 
     // This value determines how frequently the metadata
     // worker will refresh the cluster metadata
@@ -42,7 +44,7 @@ pub(in super::super) struct MetadataWorker {
 impl MetadataWorker {
     pub(in super::super) fn new(
         metadata_reader: MetadataReader,
-        initial_control_connection: Option<ControlConnection>,
+        initial_control_connection: Option<(ControlConnection, ControlConnectionEvents)>,
         cluster_metadata_refresh_interval: Duration,
         refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
         updates: merge_channel::Sender<MetadataUpdate>,
@@ -109,7 +111,7 @@ impl MetadataWorker {
                                 Event::TopologyChange(_) => (), // Refresh immediately
                                 Event::ClientRoutesChange(evt) => {
                                     // We received this event on the control connection, so it must be present.
-                                    let Some(cc) = self.control_connection.as_ref() else {
+                                    let Some((cc, _events)) = self.control_connection.as_ref() else {
                                         error!("BUG: Received a server event without a control connection.");
                                         continue;
                                     };
@@ -228,11 +230,11 @@ impl MetadataWorker {
     /// re-establishment), this never resolves — the worker will rely on the
     /// periodic refresh timer to attempt re-establishment instead.
     async fn wait_for_control_connection_event(
-        control_connection: &mut Option<ControlConnection>,
+        control_connection: &mut Option<(ControlConnection, ControlConnectionEvents)>,
     ) -> ControlConnectionEvent {
         match control_connection {
             None => std::future::pending().await,
-            Some(cc) => cc.wait_for_event().await,
+            Some((_cc, events)) => events.wait_for_event().await,
         }
     }
 
@@ -243,7 +245,7 @@ impl MetadataWorker {
     /// known peers and, as a last resort, the initial contact points). The (possibly
     /// new) working control connection is stored back into `self.control_connection`.
     async fn read_metadata(&mut self) -> Result<Metadata, MetadataError> {
-        if let Some(cc) = self.control_connection.as_ref() {
+        if let Some((cc, _events)) = self.control_connection.as_ref() {
             match self.metadata_reader.fetch_metadata_on_cc(cc).await {
                 Ok(metadata) => return Ok(metadata),
                 Err(err) => {

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -2,12 +2,12 @@ use crate::client::client_routes::{
     ClientRoutesAddressTranslator, ClientRoutesConfig, ClientRoutesSubscriber,
 };
 use crate::client::session::TABLET_CHANNEL_SIZE;
-use crate::cluster::control_connection::{ControlConnection, ControlConnectionEvent};
 use crate::cluster::metadata::SchemaMetadataFetchMode;
-use crate::cluster::metadata::update::RefreshRequest;
+use crate::cluster::metadata::update::{
+    MetadataChanges, MetadataUpdate, RefreshRequest, StatusHint,
+};
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
-use crate::frame::response::event::EventV2 as Event;
 use crate::network::{ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
 use crate::observability::metrics::Metrics;
 use crate::policies::address_translator::AddressTranslator;
@@ -15,20 +15,21 @@ use crate::policies::host_filter::HostFilter;
 use crate::policies::host_listener::{HostEvent, HostEventContext, HostListener};
 use crate::routing::locator::tablets::{RawTablet, TabletsInfo};
 
-use crate::frame::response::event::StatusChangeEvent;
 use crate::frame::response::result::TableSpec;
 use arc_swap::ArcSwap;
 use futures::future::join_all;
 use futures::{FutureExt, future::RemoteHandle};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
 use super::metadata::Metadata;
+use super::metadata::merge_channel::{self, merge_channel};
 use super::metadata::reader::MetadataReader;
+use super::metadata::worker::MetadataWorker;
 use super::state::ClusterState;
 
 /// Cluster manages up to date information and connections to database nodes.
@@ -42,6 +43,7 @@ pub(crate) struct Cluster {
     use_keyspace_channel: tokio::sync::mpsc::Sender<UseKeyspaceRequest>,
 
     _worker_handle: RemoteHandle<()>,
+    _metadata_worker_handle: RemoteHandle<()>,
 }
 
 /// Enables printing [Cluster] struct in a neat way, by skipping the rather useless
@@ -151,15 +153,16 @@ impl Cluster {
         let cluster_state: Arc<ArcSwap<ClusterState>> =
             Arc::new(ArcSwap::from(Arc::new(cluster_state)));
 
+        let (metadata_updates_sender, metadata_updates_receiver) = merge_channel();
+
         let worker = ClusterWorker {
             cluster_state: cluster_state.clone(),
             node_status,
 
-            metadata_reader,
             client_routes_subscriber,
             pool_config,
 
-            refresh_channel: refresh_receiver,
+            metadata_updates: metadata_updates_receiver,
             connectivity_events_sender,
             connectivity_events_receiver,
             tablets_channel: tablet_receiver,
@@ -169,19 +172,30 @@ impl Cluster {
 
             host_filter,
             host_listener,
-            cluster_metadata_refresh_interval,
 
             metrics,
         };
 
-        let (fut, worker_handle) = worker.work(cc).remote_handle();
+        let metadata_worker = MetadataWorker::new(
+            metadata_reader,
+            cc,
+            cluster_metadata_refresh_interval,
+            refresh_receiver,
+            metadata_updates_sender,
+        );
+
+        let (fut, worker_handle) = worker.work().remote_handle();
         tokio::spawn(fut);
+
+        let (metadata_fut, metadata_worker_handle) = metadata_worker.work().remote_handle();
+        tokio::spawn(metadata_fut);
 
         let result = Cluster {
             state: cluster_state,
             refresh_channel: refresh_sender,
             use_keyspace_channel: use_keyspace_sender,
             _worker_handle: worker_handle,
+            _metadata_worker_handle: metadata_worker_handle,
         };
 
         Ok(result)
@@ -200,12 +214,12 @@ impl Cluster {
             })
             .await
             .expect("Bug in Cluster::refresh_metadata sending");
-        // Other end of this channel is in ClusterWorker, can't be dropped while we have &self to Cluster with _worker_handle
+        // Other end of this channel is in MetadataWorker, can't be dropped while we have &self to Cluster with _metadata_worker_handle
 
         response_receiver
             .await
             .expect("Bug in Cluster::refresh_metadata receiving")
-        // ClusterWorker always responds
+        // The workers always respond
     }
 
     pub(crate) async fn use_keyspace(
@@ -248,16 +262,14 @@ struct ClusterWorker {
     /// Used to track node status in order to deduplicate HostListener events.
     node_status: HashMap<Uuid, NodeConnectivityStatus>,
 
-    // Cluster connections
-    metadata_reader: MetadataReader,
-
     /// The applier of client routes snapshots fetched from `system.client_routes`.
     /// `None` if client routes are not configured.
     client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
     pool_config: PoolConfig,
 
-    // To listen for refresh requests
-    refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
+    // Channel over which the metadata worker delivers everything it learned
+    // about the cluster.
+    metadata_updates: merge_channel::Receiver<MetadataUpdate>,
 
     // Channel used to receive use keyspace requests
     use_keyspace_channel: tokio::sync::mpsc::Receiver<UseKeyspaceRequest>,
@@ -281,10 +293,6 @@ struct ClusterWorker {
     // The host listener allows to listen for topology and node status changes.
     host_listener: Option<Arc<dyn HostListener>>,
 
-    // This value determines how frequently the cluster
-    // worker will refresh the cluster metadata
-    cluster_metadata_refresh_interval: Duration,
-
     metrics: Metrics,
 }
 
@@ -295,46 +303,11 @@ struct UseKeyspaceRequest {
 }
 
 impl ClusterWorker {
-    pub(crate) async fn work(mut self, initial_cc: Option<ControlConnection>) {
-        use tokio::time::Instant;
-
-        let control_connection_repair_duration = Duration::from_secs(1); // Attempt control connection repair every second
-        let mut last_refresh_time = Instant::now();
-
-        // The control connection is now owned by the worker. `None` means it is
-        // currently broken (or was never established) and needs to be re-established,
-        // which happens during the next metadata refresh.
-        let mut control_connection: Option<ControlConnection> = initial_cc;
-
+    pub(crate) async fn work(mut self) {
         loop {
-            let mut cur_request: Option<RefreshRequest> = None;
-
-            // Wait until it's time for the next refresh
-            let sleep_until: Instant = last_refresh_time
-                .checked_add(if control_connection.is_some() {
-                    self.cluster_metadata_refresh_interval
-                } else {
-                    control_connection_repair_duration
-                })
-                .unwrap_or_else(Instant::now);
-
             let mut tablets = Vec::new();
 
-            let sleep_future = tokio::time::sleep_until(sleep_until);
-            tokio::pin!(sleep_future);
-
             tokio::select! {
-                _sleep_finished = sleep_future => {
-                    // Time to do periodic refresh.
-                },
-
-                maybe_refresh_request = self.refresh_channel.recv() => {
-                    match maybe_refresh_request {
-                        Some(request) => cur_request = Some(request),
-                        None => return, // If refresh_channel was closed then cluster was dropped, we can stop working
-                    }
-                }
-
                 tablets_count = self.tablets_channel.recv_many(&mut tablets, TABLET_CHANNEL_SIZE) => {
                     tracing::trace!("Performing tablets update - received {} tablets", tablets_count);
                     if tablets_count == 0 {
@@ -363,92 +336,17 @@ impl ClusterWorker {
                     let mut new_cluster_state: ClusterState = self.cluster_state.load().as_ref().clone();
                     new_cluster_state.update_tablets(tablets);
                     self.update_cluster_state(Arc::new(new_cluster_state));
-
-                    continue;
                 }
 
-                control_connection_event = Self::wait_for_control_connection_event(&mut control_connection) => {
-                    match control_connection_event {
-                        ControlConnectionEvent::Shutdown => {
-                            // The runtime is shutting down. We can stop working.
-                            debug!("Got shutdown control connection event. Shutting down ClusterWorker.");
-                            return;
-                        },
-                        ControlConnectionEvent::Broken(_err) => {
-                            // The control connection was broken. Drop it and start attempting to reconnect.
-                            // The first reconnect attempt will be immediate (by attempting metadata refresh below),
-                            // and if it does not succeed, then the control connection will stay `None`, so
-                            // subsequent attempts will be issued every second.
-                            control_connection = None;
-                        },
-                        ControlConnectionEvent::ServerEvent(event) => {
-                            debug!("Received server event: {:?}", event);
-                            match event {
-                                Event::TopologyChange(_) => (), // Refresh immediately
-                                Event::ClientRoutesChange(evt) => {
-                                    // We received this event on the control connection, so it must be present.
-                                    let Some(cc) = control_connection.as_ref() else {
-                                        error!("BUG: Received a server event without a control connection.");
-                                        continue;
-                                    };
-                                    let res = self.metadata_reader.fetch_client_routes_update_on_event(cc, &evt).await;
-                                    match res {
-                                        Ok(None) => continue, // Nothing to apply; don't go to refreshing.
-                                        Ok(Some(update)) => {
-                                            if let Some(subscriber) = self.client_routes_subscriber.as_ref() {
-                                                let updated_hosts = subscriber.merge_client_routes_update(update);
-                                                self.cluster_state.load().trigger_pool_refills_for_hosts(updated_hosts.iter().copied());
-                                            }
-                                            continue; // Don't go to refreshing.
-                                        }
-                                        Err(err) =>
-                                        {
-                                            error!(
-                                                "Error when fetching client route updates: {err}. \
-                                                Proceeding with metadata refresh, because the control connection is likely defunct."
-                                            );
-                                            // Refresh immediately.
-                                        }
-                                    }
-                                }
-                                Event::StatusChange(status) => {
-                                    // Tracking node status using events is unreliable because of the possibility of losing events
-                                    // when control connection is broken. A better thing to do here is to treat those events as hints
-                                    // for:
-                                    // - PoolRefiller - UP triggers immediate pool refill attempt, and
-                                    // - Keepaliver - DOWN triggers immediate keepalive query attempt.
+                maybe_metadata_update = self.metadata_updates.recv() => {
+                    let Some(update) = maybe_metadata_update else {
+                        // If the channel was closed then the metadata worker is gone,
+                        // so there is nothing left to keep the cluster state updated with.
+                        debug!("The metadata worker is gone. Shutting down ClusterWorker.");
+                        return;
+                    };
 
-                                    match status {
-                                        StatusChangeEvent::Up(addr) => {
-                                            // When receiving an UP event, it is likely that the node just came back up and is now reachable.
-                                            // We optimistically trigger pool refill for this node.
-                                            // This is not guaranteed to be correct. It is for example possible that a network partition happened,
-                                            // the node lost connectivity to the cluster and driver; then it regained connectivity to the cluster,
-                                            // but not to the driver, and thus is still unreachable from the driver's perspective.
-                                            // However, in this case triggering pool refill is not harmful - if the node is actually reachable,
-                                            // then new connections will be opened to it, and if it is not reachable,
-                                            // then connection attempts will fail and the node will be marked as unreachable by `PoolRefiller`,
-                                            // so it won't be targeted by the load balancing policy.
-                                            self.cluster_state.load().trigger_pool_refill_for_addr(addr);
-                                        },
-                                        StatusChangeEvent::Down(addr) => {
-                                            // When receiving a DOWN event, and the driver still sees the node as connected,
-                                            // we send a keepalive query on its connections to verify their liveness.
-                                            // The node is supposedly DOWN, so connections to this node are likely defunct.
-                                            // We expect that the keepalive query fails, in which case connections will be closed.
-                                            // As a result, the connection pool will report 0 connections to this node,
-                                            // and thus the node will not be targeted by the LoadBalancingPolicy,
-                                            // which is the desired behaviour. However, if the keepalive query succeeds,
-                                            // then the node is likely still alive (got stale event?), and we keep targeting it.
-                                            self.cluster_state.load().trigger_keepalive_for_addr(addr);
-                                        },
-                                    }
-                                    continue; // Don't go to refreshing.
-                                },
-                                _ => continue, // Don't go to refreshing.
-                            }
-                        }
-                    }
+                    self.apply_metadata_update(update).await;
                 }
 
                 maybe_connectivity_event = self.connectivity_events_receiver.recv() => {
@@ -461,8 +359,6 @@ impl ClusterWorker {
                     debug!("Received connectivity event: {:?}", event);
 
                     self.handle_connectivity_change_event(&event);
-
-                    continue; // Don't go to refreshing.
                 }
 
                 maybe_use_keyspace_request = self.use_keyspace_channel.recv() => {
@@ -476,20 +372,7 @@ impl ClusterWorker {
                         },
                         None => return, // If use_keyspace_channel was closed then cluster was dropped, we can stop working
                     }
-
-                    continue; // Don't go to refreshing, wait for the next event
                 }
-            }
-
-            // Perform the refresh
-            debug!("Requesting metadata refresh");
-            last_refresh_time = Instant::now();
-            let refresh_res = self.perform_refresh(&mut control_connection).await;
-
-            // Send refresh result if there was a request
-            if let Some(request) = cur_request {
-                // We can ignore sending error - if no one waits for the response we can drop it
-                let _ = request.response_chan.send(refresh_res);
             }
         }
     }
@@ -518,72 +401,95 @@ impl ClusterWorker {
         use_keyspace_result(use_keyspace_results.into_iter())
     }
 
-    /// Waits for the next control connection event.
+    /// Applies everything that the metadata worker learned since the previous update.
     ///
-    /// If there is no working control connection (it is broken and awaiting
-    /// re-establishment), this never resolves — the worker will rely on the
-    /// periodic refresh timer to attempt re-establishment instead.
-    async fn wait_for_control_connection_event(
-        control_connection: &mut Option<ControlConnection>,
-    ) -> ControlConnectionEvent {
-        match control_connection {
-            None => std::future::pending().await,
-            Some(cc) => cc.wait_for_event().await,
-        }
-    }
-
-    /// Fetches the latest metadata, (re-)establishing the control connection if needed.
-    ///
-    /// If a working control connection is present, metadata is fetched on it. If that
-    /// fails, the connection is dropped and a fresh one is established (iterating over
-    /// known peers and, as a last resort, the initial contact points). The (possibly
-    /// new) working control connection is stored back into `control_connection`.
-    async fn read_metadata(
-        &mut self,
-        control_connection: &mut Option<ControlConnection>,
-    ) -> Result<Metadata, MetadataError> {
-        if let Some(cc) = control_connection.as_ref() {
-            match self.metadata_reader.fetch_metadata_on_cc(cc).await {
-                Ok(metadata) => return Ok(metadata),
-                Err(err) => {
-                    debug!(
-                        error = %err,
-                        "Failed to fetch metadata on the current control connection. \
-                        Will try to establish a new one."
-                    );
-                    // The control connection is considered defunct - drop it.
-                    *control_connection = None;
-                }
-            }
-        }
-
-        // We have no working control connection - establish a new one and fetch metadata on it.
-        let (cc, metadata) = self
-            .metadata_reader
-            .establish_cc_and_fetch_metadata(false)
-            .await?;
-        *control_connection = cc;
-        Ok(metadata)
-    }
-
-    async fn perform_refresh(
-        &mut self,
-        control_connection: &mut Option<ControlConnection>,
-    ) -> Result<(), MetadataError> {
-        // Read latest Metadata
-        let mut metadata = self.read_metadata(control_connection).await?;
-
-        // Apply the fetched client routes snapshot BEFORE constructing the new `ClusterState`,
+    /// See [`MetadataUpdate`] for what an update can contain and why several
+    /// discoveries can arrive merged into one.
+    async fn apply_metadata_update(&mut self, mut update: MetadataUpdate) {
+        // Apply the client routes BEFORE constructing the new `ClusterState` below,
         // because `ClusterState::new` creates connection pools, which translate addresses
         // through the subscriber.
-        let client_routes_updated_hosts = match (
-            self.client_routes_subscriber.as_ref(),
-            metadata.client_routes.take(),
-        ) {
-            (Some(subscriber), Some(routes)) => subscriber.replace_client_routes(routes),
-            _ => Default::default(),
+        let client_routes_hosts_to_refill = if let Some(subscriber) =
+            self.client_routes_subscriber.as_ref()
+            && let Some(metadata_changes) = update.metadata_changes.as_mut()
+        {
+            match metadata_changes {
+                MetadataChanges::Full {
+                    metadata,
+                    refresh_responses: _,
+                } => {
+                    if let Some(client_routes) = metadata.client_routes.take() {
+                        subscriber.replace_client_routes(client_routes)
+                    } else {
+                        HashSet::new()
+                    }
+                }
+                MetadataChanges::Partial {
+                    client_routes_updates,
+                } => subscriber.merge_client_routes_update(client_routes_updates.take()),
+            }
+        } else {
+            HashSet::new()
         };
 
+        // Unlike UP hints, DOWN hints are applied to the *current* state: a keepalive
+        // query only makes sense for a node the driver still holds connections to, so
+        // there is nothing a freshly built state could add, and waiting for the refresh
+        // (which awaits pool initialization) would only delay the liveness probe.
+        {
+            let cluster_state = self.cluster_state.load();
+            update
+                .status_hints
+                .iter()
+                .filter(|(_k, v)| **v == StatusHint::Down)
+                .for_each(|(addr, _)| cluster_state.trigger_keepalive_for_addr(*addr));
+        }
+
+        let process_up_hints = |state: &ClusterState| {
+            state.trigger_pool_refills_for_hosts(client_routes_hosts_to_refill.into_iter());
+            update
+                .status_hints
+                .iter()
+                .filter(|(_k, v)| **v == StatusHint::Up)
+                .for_each(|(addr, _)| state.trigger_pool_refill_for_addr(*addr));
+        };
+
+        match update.metadata_changes {
+            Some(MetadataChanges::Full {
+                metadata,
+                refresh_responses,
+            }) => {
+                self.perform_refresh(metadata, process_up_hints).await;
+                // The new state is published, so the awaited refreshes are complete.
+                for response_chan in refresh_responses {
+                    // We can ignore sending error - if no one waits for the response we can drop it
+                    let _ = response_chan.send(Ok(()));
+                }
+            }
+            None
+            | Some(MetadataChanges::Partial {
+                client_routes_updates: _,
+            }) => {
+                // For now there is nothing that requires publishing new ClusterState.
+                // The only thing left to do is processing up hints.
+                process_up_hints(self.cluster_state.load().as_ref());
+            }
+        }
+    }
+
+    /// Builds a new [`ClusterState`] from freshly fetched metadata and publishes it.
+    ///
+    /// The client routes carried by `metadata` must already have been applied by the
+    /// caller - `ClusterState::new` creates connection pools, which translate addresses
+    /// through the subscriber.
+    ///
+    /// `process_up_hints` triggers pool refills for hosts for which we received UP events.
+    /// It is called after new ClusterState is created.
+    async fn perform_refresh(
+        &mut self,
+        metadata: Metadata,
+        process_up_hints: impl FnOnce(&ClusterState),
+    ) {
         let cluster_state: Arc<ClusterState> = self.cluster_state.load_full();
 
         let new_cluster_state = Arc::new(
@@ -609,16 +515,13 @@ impl ClusterWorker {
             .await,
         );
 
-        new_cluster_state
-            .trigger_pool_refills_for_hosts(client_routes_updated_hosts.iter().copied());
+        process_up_hints(&new_cluster_state);
 
         new_cluster_state
             .wait_until_all_pools_are_initialized()
             .await;
 
         self.update_cluster_state(new_cluster_state);
-
-        Ok(())
     }
 
     fn update_cluster_state(&mut self, new_cluster_state: Arc<ClusterState>) {

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -398,9 +398,9 @@ impl ClusterWorker {
                                     let res = self.metadata_reader.fetch_client_routes_update_on_event(cc, &evt).await;
                                     match res {
                                         Ok(None) => continue, // Nothing to apply; don't go to refreshing.
-                                        Ok(Some(routes)) => {
+                                        Ok(Some(update)) => {
                                             if let Some(subscriber) = self.client_routes_subscriber.as_ref() {
-                                                let updated_hosts = subscriber.merge_client_routes_update(&evt, routes);
+                                                let updated_hosts = subscriber.merge_client_routes_update(update);
                                                 self.cluster_state.load().trigger_pool_refills_for_hosts(updated_hosts.iter().copied());
                                             }
                                             continue; // Don't go to refreshing.

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -4,6 +4,7 @@ use crate::client::client_routes::{
 use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::cluster::control_connection::{ControlConnection, ControlConnectionEvent};
 use crate::cluster::metadata::SchemaMetadataFetchMode;
+use crate::cluster::metadata::update::RefreshRequest;
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::frame::response::event::EventV2 as Event;
@@ -285,11 +286,6 @@ struct ClusterWorker {
     cluster_metadata_refresh_interval: Duration,
 
     metrics: Metrics,
-}
-
-#[derive(Debug)]
-struct RefreshRequest {
-    response_chan: tokio::sync::oneshot::Sender<Result<(), MetadataError>>,
 }
 
 #[derive(Debug)]

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -178,7 +178,6 @@ impl Cluster {
 
         let metadata_worker = MetadataWorker::new(
             metadata_reader,
-            cc,
             cluster_metadata_refresh_interval,
             refresh_receiver,
             metadata_updates_sender,
@@ -187,7 +186,7 @@ impl Cluster {
         let (fut, worker_handle) = worker.work().remote_handle();
         tokio::spawn(fut);
 
-        let (metadata_fut, metadata_worker_handle) = metadata_worker.work().remote_handle();
+        let (metadata_fut, metadata_worker_handle) = metadata_worker.work(cc).remote_handle();
         tokio::spawn(metadata_fut);
 
         let result = Cluster {


### PR DESCRIPTION
This PR splits existing ClusterWorker into 2 workers. The new one is called MetadataWorker.
This is a prerequisite (and I think the last prerequisite!)  for fixing our issues with metadata fetching and other internal processes.

# Why?

I spent A LOT of time thinking about refactoring the ClusterWorker to make the internal tasks non-blocking ( ref: https://github.com/scylladb/scylla-rust-driver/issues/1670 ), enabling smarter metadata fetching ( ref: https://github.com/scylladb/scylla-rust-driver/issues/1280 ) and removing unnecessary delays (ref: https://github.com/scylladb/scylla-rust-driver/issues/1410 ). I thought about this a lot (both myself and with various AIs), made some PoCs (again, both myself and with AIs).

My conclusion is that it all can be done, but writing code this way is inherently complicated, and makes ClusterWorker mostly incomprehensible. I certainly wouldn't be sure of its correctness.

How to improve on this? We can notice that there are 2 categories of tasks that ClusterWorker performs. Those that require a working control connection (waiting on events, waiting on broken CC notification, fetching metadata, handling metadata refresh requests) and those that don't (handling connectivity events, handling tablets feedback, creating ClusterState, handling use_keyspace).
We can split those tasks into 2 workers, where the CC worker passes its results to ClusterWorker using a channel.

After such split, we can work on improving each worker independently, and each of them is easier to comprehend (because the combinatorial explosion of task interactions is limited).

The independence mentioned above is quite important: we can now introduce smart metadata fetching and make MetadataWorker non-blocking without even touching ClusterWorker and thinking about interactions between its tasks.

# Implementation

MetadataWorker communicates with ClusterWorker in exactly one way: by providing MetadataUpdate on a newly introduced merge channel. Merge channel is SPSC channel holding at most one value, introduced in this PR.
The idea is that we don't control the time when ClusterWorker consumes produced MetadataUpdates, and we don't want to `await` on `send`, so we do something else: merge the metadata updates. This turns out to be quite easy, and solves the problem nicely.

The only slightly complicated part is handling refresh requests: MetadataWorker is the one receiving them, then after fetching new metadata it passes them to ClusterWorker in the MetadataUpdate, and ClusterWorker responds to them after publishing new ClusterState.

Initially, MetadataWorker is created in a way that minimizes code changes. Later it is refactor to a form that I always imagined for it: with a `work_on_cc` method that takes a CC, and performs work on it (handling events etc), until it breaks. 

# Commits

First 3 commits introduce some new code, that is initially mostly dead.
I am not completely happy with doing it that way, but I don't really see any alternatives, and the pieces of code (ClientRoutesUpdate, merge channel, MetadataUpdate) are self-contained enough to be reviewed independently.

Then we have the main commit ("Split off MetadataWorker") that splits the worker. It is written in a way that minimizes code changes: new worker looks very similar to the old one.

Then there are 2 last commits that refactor the new worker to get it into the shape that I want it in. The main goal of this is having separate loops for the case where we have working CC and the one without. That way in the main loop we always have working CC, getting rid of the Option.


Ref: https://github.com/scylladb/scylla-rust-driver/issues/1280
Ref: https://github.com/scylladb/scylla-rust-driver/issues/1670
Ref: https://github.com/scylladb/scylla-rust-driver/issues/1410 (partially solved by this PR!)

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
