### PR TITLE
Migrate single connection pager to the unified execution core

### DIFF
--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -333,9 +333,9 @@ impl<'a> RequestExecutionParams<'a> {
         let mut current_consistency: Consistency = self.consistency;
 
         'targets_in_plan: for (node, shard) in request_plan {
-            let span = trace_span!("Executing request", node = %node.address, shard = %shard);
+            let span = trace_span!("Executing request on chosen target", node = %node.address, shard = %shard);
             'same_target_retries: loop {
-                trace!(parent: &span, "Execution started");
+                trace!(parent: &span, "Execution attempt started");
                 let connection = match node.connection_for_shard(shard).await {
                     Ok(connection) => connection,
                     Err(e) => {

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -221,6 +221,46 @@ impl AttemptTarget for NodeAttemptTarget<'_> {
     }
 }
 
+/// A target that always uses one specific connection. Used by the control
+/// connection, which has no [`Node`](crate::cluster::Node) and no load
+/// balancing.
+pub(crate) struct SingleConnectionTarget {
+    connection: Arc<Connection>,
+}
+
+impl SingleConnectionTarget {
+    pub(crate) fn new(connection: Arc<Connection>) -> Self {
+        Self { connection }
+    }
+}
+
+impl AttemptTarget for SingleConnectionTarget {
+    type Coordinator = ();
+
+    async fn get_connection(&self) -> Result<Arc<Connection>, ConnectionPoolError> {
+        Ok(Arc::clone(&self.connection))
+    }
+
+    fn coordinator(&self, _connection: &Arc<Connection>) {}
+
+    fn on_attempt_success(
+        &self,
+        _load_balancing_policy: &dyn LoadBalancingPolicy,
+        _routing_info: &RoutingInfo<'_>,
+        _elapsed: Duration,
+    ) {
+    }
+
+    fn on_attempt_failure(
+        &self,
+        _load_balancing_policy: &dyn LoadBalancingPolicy,
+        _routing_info: &RoutingInfo<'_>,
+        _elapsed: Duration,
+        _error: &RequestAttemptError,
+    ) {
+    }
+}
+
 /// Outcome of [`run_request_no_side_effects`]/[`run_request_speculative_fiber`].
 pub(crate) struct RequestExecutionOutcome<C> {
     /// The successful (or ignored-write) result.

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -13,7 +13,7 @@ use crate::observability::driver_tracing::RequestSpan;
 use crate::observability::history::{self, HistoryListener};
 use crate::observability::metrics::Metrics;
 use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
-use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy};
+use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
 use crate::response::{Coordinator, NonErrorQueryResponse};
 use crate::statement::StatementConfig;
@@ -136,6 +136,7 @@ struct HistoryData<'a> {
 
 /// Per-fiber execution context.
 struct ExecuteRequestContext<'a> {
+    retry_session: Box<dyn RetrySession>,
     history_data: Option<HistoryData<'a>>,
     routing_info: &'a load_balancing::RoutingInfo<'a>,
     request_span: &'a RequestSpan,
@@ -264,6 +265,7 @@ impl<'a> RequestExecutionParams<'a> {
                             &shared_request_plan,
                             &run_request_once,
                             ExecuteRequestContext {
+                                retry_session: self.retry_policy.new_session(),
                                 history_data,
                                 routing_info,
                                 request_span,
@@ -290,6 +292,7 @@ impl<'a> RequestExecutionParams<'a> {
                         request_plan,
                         &run_request_once,
                         ExecuteRequestContext {
+                            retry_session: self.retry_policy.new_session(),
                             history_data,
                             routing_info,
                             request_span,
@@ -338,12 +341,11 @@ impl<'a> RequestExecutionParams<'a> {
         &self,
         request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
-        context: ExecuteRequestContext<'a>,
+        mut context: ExecuteRequestContext<'a>,
     ) -> Option<Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>>
     where
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
-        let mut retry_session = self.retry_policy.new_session();
         let mut last_error: Option<RequestError> = None;
         let mut current_consistency: Consistency = self.consistency;
 
@@ -421,7 +423,7 @@ impl<'a> RequestExecutionParams<'a> {
                     consistency: current_consistency,
                 };
 
-                let retry_decision = retry_session.decide_should_retry(request_info);
+                let retry_decision = context.retry_session.decide_should_retry(request_info);
                 trace!(
                     parent: &span,
                     retry_decision = ?retry_decision

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -1,3 +1,28 @@
+//! Unified request-execution core shared by all request paths.
+//!
+//! Historically, request execution (load balancing, retries, speculative
+//! execution, history, metrics) was implemented independently in several
+//! places: [`Session`](crate::client::session::Session) non-paged methods, the
+//! [`QueryPager`](crate::client::pager::QueryPager) worker and the control
+//! connection worker. This module collapses all of that into a single set
+//! of layered functions:
+//!
+//! - [`RequestExecutionParams::run_request_no_side_effects`] - takes no `Session`
+//!   and does not handle side effects. It applies the client-side timeout and dispatches
+//!   speculative-execution fibers. It is generic over the *source* of
+//!   connections (see [`AttemptTarget`]) so that it works both with a
+//!   load-balancing plan of nodes and with a single fixed connection (as used
+//!   by the control connection).
+//! - [`RequestExecutionParams::run_request_speculative_fiber`] - a single speculative fiber:
+//!   iterates the execution plan, picks connections, runs the per-attempt
+//!   closure and applies the retry policy.
+//!
+//! The outermost layer (`run_request`), which additionally handles
+//! side effects coming from `USE <keyspace>` and schema-changing statements,
+//! lives on [`Session`](crate::client::session::Session) because it needs
+//! access to session state. An analogous side-effects-handling layer lives
+//! [`PagingExecutor`](crate::client::pager::PagingExecutor).
+
 use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -10,6 +10,7 @@ use tracing::trace_span;
 
 use crate::client::execution_profile::ExecutionProfileInner;
 use crate::cluster::NodeRef;
+use crate::errors::ConnectionPoolError;
 use crate::errors::RequestAttemptError;
 use crate::errors::RequestError;
 use crate::frame::types::{Consistency, SerialConsistency};
@@ -134,6 +135,92 @@ impl<'a> RequestExecutionParams<'a> {
     }
 }
 
+/// Abstracts a single target that a request attempt can be sent to.
+///
+/// A request plan is an iterator of `AttemptTarget`s. There are two
+/// implementations:
+/// - [`NodeAttemptTarget`] - a `(node, shard)` pair produced by a load
+///   balancing plan. It produces a real [`Coordinator`] and forwards
+///   success/failure feedback to the load balancing policy.
+/// - [`SingleConnectionTarget`] - a single fixed connection (used by the
+///   control connection, which intentionally has no [`Node`](crate::cluster::Node)).
+///   It produces no coordinator (`()`) and has no load balancing feedback.
+pub(crate) trait AttemptTarget {
+    /// Coordinator descriptor reported back to the caller.
+    type Coordinator;
+
+    /// Acquires a connection to send the attempt on.
+    ///
+    /// On `Err`, the fiber skips this target and proceeds to the next one in
+    /// the plan (without counting it as a failed request in metrics).
+    async fn get_connection(&self) -> Result<Arc<Connection>, ConnectionPoolError>;
+
+    /// Builds the coordinator descriptor once a connection has been chosen.
+    fn coordinator(&self, connection: &Arc<Connection>) -> Self::Coordinator;
+
+    /// Load balancing feedback after a successful attempt. No-op for targets
+    /// that are not driven by load balancing.
+    fn on_attempt_success(
+        &self,
+        load_balancing_policy: &dyn LoadBalancingPolicy,
+        routing_info: &RoutingInfo<'_>,
+        elapsed: Duration,
+    );
+
+    /// Load balancing feedback after a failed attempt. No-op for targets that
+    /// are not driven by load balancing.
+    fn on_attempt_failure(
+        &self,
+        load_balancing_policy: &dyn LoadBalancingPolicy,
+        routing_info: &RoutingInfo<'_>,
+        elapsed: Duration,
+        error: &RequestAttemptError,
+    );
+}
+
+/// A load-balancing-driven target: a `(node, shard)` pair.
+pub(crate) struct NodeAttemptTarget<'a> {
+    node: NodeRef<'a>,
+    shard: Shard,
+}
+
+impl<'a> NodeAttemptTarget<'a> {
+    pub(crate) fn new(node: NodeRef<'a>, shard: Shard) -> Self {
+        Self { node, shard }
+    }
+}
+
+impl AttemptTarget for NodeAttemptTarget<'_> {
+    type Coordinator = Coordinator;
+
+    async fn get_connection(&self) -> Result<Arc<Connection>, ConnectionPoolError> {
+        self.node.connection_for_shard(self.shard).await
+    }
+
+    fn coordinator(&self, connection: &Arc<Connection>) -> Coordinator {
+        Coordinator::new(self.node, connection)
+    }
+
+    fn on_attempt_success(
+        &self,
+        load_balancing_policy: &dyn LoadBalancingPolicy,
+        routing_info: &RoutingInfo<'_>,
+        elapsed: Duration,
+    ) {
+        load_balancing_policy.on_request_success(routing_info, elapsed, self.node);
+    }
+
+    fn on_attempt_failure(
+        &self,
+        load_balancing_policy: &dyn LoadBalancingPolicy,
+        routing_info: &RoutingInfo<'_>,
+        elapsed: Duration,
+        error: &RequestAttemptError,
+    ) {
+        load_balancing_policy.on_request_failure(routing_info, elapsed, self.node, error);
+    }
+}
+
 /// Outcome of [`run_request_no_side_effects`]/[`run_request_speculative_fiber`].
 pub(crate) struct RequestExecutionOutcome<C> {
     /// The successful (or ignored-write) result.
@@ -238,14 +325,15 @@ impl<'a> RequestExecutionParams<'a> {
     ///
     /// `request_plan` is an iterator of targets. `run_request_once`
     /// performs a single attempt against a chosen connection and consistency.
-    pub(crate) async fn run_request_no_side_effects<QueryFut>(
-        &'a self,
+    pub(crate) async fn run_request_no_side_effects<Target, QueryFut>(
+        &self,
         routing_info: &'a RoutingInfo<'a>,
-        request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
+        request_plan: impl Iterator<Item = Target>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         request_span: &'a RequestSpan,
-    ) -> Result<RequestExecutionOutcome<Coordinator>, RequestError>
+    ) -> Result<RequestExecutionOutcome<Target::Coordinator>, RequestError>
     where
+        Target: AttemptTarget,
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
         let history_listener_and_id: Option<(&dyn HistoryListener, history::RequestId)> =
@@ -351,23 +439,24 @@ impl<'a> RequestExecutionParams<'a> {
     /// running `run_request_once` and consulting the retry policy on failure.
     ///
     /// Returns `None` only if the plan was empty.
-    async fn run_request_speculative_fiber<QueryFut>(
+    async fn run_request_speculative_fiber<Target, QueryFut>(
         &self,
-        request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
+        request_plan: impl Iterator<Item = Target>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         mut context: ExecuteRequestContext<'a>,
-    ) -> Option<Result<RequestExecutionOutcome<Coordinator>, RequestError>>
+    ) -> Option<Result<RequestExecutionOutcome<Target::Coordinator>, RequestError>>
     where
+        Target: AttemptTarget,
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
         let mut last_error: Option<RequestError> = None;
         let mut current_consistency: Consistency = self.consistency;
 
-        'targets_in_plan: for (node, shard) in request_plan {
-            let span = trace_span!("Executing request on chosen target", node = %node.address, shard = %shard);
+        'targets_in_plan: for target in request_plan {
+            let span = trace_span!("Executing request on chosen target");
             'same_target_retries: loop {
                 trace!(parent: &span, "Execution attempt started");
-                let connection = match node.connection_for_shard(shard).await {
+                let connection = match target.get_connection().await {
                     Ok(connection) => connection,
                     Err(e) => {
                         trace!(
@@ -391,7 +480,8 @@ impl<'a> RequestExecutionParams<'a> {
                     connection = %connect_address,
                     "Sending"
                 );
-                let coordinator = Coordinator::new(node, &connection);
+
+                let coordinator = target.coordinator(&connection);
 
                 let attempt_id: Option<history::AttemptId> =
                     context.log_attempt_start(connect_address);
@@ -407,10 +497,10 @@ impl<'a> RequestExecutionParams<'a> {
                         trace!(parent: &span, "Request succeeded");
                         self.log_query_latency(elapsed.as_millis() as u64);
                         context.log_attempt_success(&attempt_id);
-                        self.load_balancing_policy.on_request_success(
+                        target.on_attempt_success(
+                            self.load_balancing_policy,
                             context.routing_info,
                             elapsed,
-                            node,
                         );
                         return Some(Ok(RequestExecutionOutcome {
                             result: RunRequestResult::Completed(response),
@@ -424,10 +514,10 @@ impl<'a> RequestExecutionParams<'a> {
                             "Request failed"
                         );
                         self.inc_failed_queries();
-                        self.load_balancing_policy.on_request_failure(
+                        target.on_attempt_failure(
+                            self.load_balancing_policy,
                             context.routing_info,
                             elapsed,
-                            node,
                             &e,
                         );
                         e

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -332,9 +332,9 @@ impl<'a> RequestExecutionParams<'a> {
         let mut last_error: Option<RequestError> = None;
         let mut current_consistency: Consistency = self.consistency;
 
-        'nodes_in_plan: for (node, shard) in request_plan {
+        'targets_in_plan: for (node, shard) in request_plan {
             let span = trace_span!("Executing request", node = %node.address, shard = %shard);
-            'same_node_retries: loop {
+            'same_target_retries: loop {
                 trace!(parent: &span, "Execution started");
                 let connection = match node.connection_for_shard(shard).await {
                     Ok(connection) => connection,
@@ -346,7 +346,7 @@ impl<'a> RequestExecutionParams<'a> {
                         );
                         last_error = Some(e.into());
                         // Broken connection doesn't count as a failed request, don't log in metrics
-                        continue 'nodes_in_plan;
+                        continue 'targets_in_plan;
                     }
                 };
                 context.request_span.record_shard_id(&connection);
@@ -420,14 +420,14 @@ impl<'a> RequestExecutionParams<'a> {
                     RetryDecision::RetrySameTarget(new_cl) => {
                         self.inc_retries_num();
                         current_consistency = new_cl.unwrap_or(current_consistency);
-                        continue 'same_node_retries;
+                        continue 'same_target_retries;
                     }
                     RetryDecision::RetryNextTarget(new_cl) => {
                         self.inc_retries_num();
                         current_consistency = new_cl.unwrap_or(current_consistency);
-                        continue 'nodes_in_plan;
+                        continue 'targets_in_plan;
                     }
-                    RetryDecision::DontRetry => break 'nodes_in_plan,
+                    RetryDecision::DontRetry => break 'targets_in_plan,
                     RetryDecision::IgnoreWriteError => {
                         return Some(Ok((RunRequestResult::IgnoredWriteError, coordinator)));
                     }

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -69,10 +69,13 @@ pub(crate) struct RequestExecutionParams<'a> {
     pub(crate) retry_policy: &'a dyn RetryPolicy,
     /// Load balancing policy used to order targets for the execution.
     pub(crate) load_balancing_policy: &'a dyn LoadBalancingPolicy,
-    /// Metrics sink.
-    pub(crate) metrics: &'a Arc<Metrics>,
-    /// Speculative execution policy, if any.
-    pub(crate) speculative_policy: Option<&'a dyn SpeculativeExecutionPolicy>,
+    /// The following two fields are grouped to statically enforce that speculative execution
+    /// is only used when metrics sink is provided.
+    ///
+    /// Metrics sink, if any. The control connection has no metrics.
+    /// Speculative execution policy, if any. Only fires for idempotent requests.
+    pub(crate) metrics_and_speculative_policy:
+        Option<(&'a Arc<Metrics>, Option<&'a dyn SpeculativeExecutionPolicy>)>,
     /// Client-side request timeout, if any.
     pub(crate) request_timeout: Option<Duration>,
     /// History listener, if any.
@@ -116,8 +119,7 @@ impl<'a> RequestExecutionParams<'a> {
             serial_consistency,
             retry_policy,
             load_balancing_policy,
-            metrics,
-            speculative_policy,
+            metrics_and_speculative_policy: Some((metrics, speculative_policy)),
             request_timeout,
             history_listener,
             request_kind,
@@ -173,31 +175,43 @@ impl ExecuteRequestContext<'_> {
 
 impl<'a> RequestExecutionParams<'a> {
     fn inc_total_queries(&self) {
+        let Some((metrics, _)) = self.metrics_and_speculative_policy else {
+            return;
+        };
         match self.request_kind {
-            RequestPaging::Unpaged => self.metrics.inc_total_nonpaged_queries(),
-            RequestPaging::Manual => self.metrics.inc_total_manually_paged_queries(),
-            RequestPaging::Automatic => self.metrics.inc_total_automatically_paged_queries(),
+            RequestPaging::Unpaged => metrics.inc_total_nonpaged_queries(),
+            RequestPaging::Manual => metrics.inc_total_manually_paged_queries(),
+            RequestPaging::Automatic => metrics.inc_total_automatically_paged_queries(),
         }
     }
 
     fn inc_failed_queries(&self) {
+        let Some((metrics, _)) = self.metrics_and_speculative_policy else {
+            return;
+        };
         match self.request_kind {
-            RequestPaging::Unpaged => self.metrics.inc_failed_nonpaged_queries(),
-            RequestPaging::Manual => self.metrics.inc_failed_manually_paged_queries(),
-            RequestPaging::Automatic => self.metrics.inc_failed_automatically_paged_queries(),
+            RequestPaging::Unpaged => metrics.inc_failed_nonpaged_queries(),
+            RequestPaging::Manual => metrics.inc_failed_manually_paged_queries(),
+            RequestPaging::Automatic => metrics.inc_failed_automatically_paged_queries(),
         }
     }
 
     fn inc_retries_num(&self) {
-        self.metrics.inc_retries_num();
+        if let Some((metrics, _)) = self.metrics_and_speculative_policy {
+            metrics.inc_retries_num();
+        }
     }
 
     fn inc_request_timeouts(&self) {
-        self.metrics.inc_request_timeouts();
+        if let Some((metrics, _)) = self.metrics_and_speculative_policy {
+            metrics.inc_request_timeouts();
+        }
     }
 
     fn log_query_latency(&self, latency_ms: u64) {
-        let _ = self.metrics.log_query_latency(latency_ms);
+        if let Some((metrics, _)) = self.metrics_and_speculative_policy {
+            let _ = metrics.log_query_latency(latency_ms);
+        }
     }
 
     /// Executes a request without handling side effects and without
@@ -223,8 +237,9 @@ impl<'a> RequestExecutionParams<'a> {
             self.history_listener.map(|hl| (hl, hl.log_request_start()));
 
         let runner = async {
-            match self.speculative_policy {
-                Some(speculative) if self.is_idempotent => {
+            match self.metrics_and_speculative_policy {
+                #[cfg_attr(not(feature = "metrics"), expect(unused_variables))]
+                Some((metrics, Some(speculative))) if self.is_idempotent => {
                     let shared_request_plan = SharedPlan {
                         iter: std::sync::Mutex::new(request_plan),
                     };
@@ -258,7 +273,7 @@ impl<'a> RequestExecutionParams<'a> {
 
                     let context = speculative_execution::Context {
                         #[cfg(feature = "metrics")]
-                        metrics: Arc::clone(self.metrics),
+                        metrics: Arc::clone(metrics),
                     };
 
                     speculative_execution::execute(speculative, &context, request_runner_generator)

--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -1,23 +1,30 @@
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
-use tracing::{Instrument as _, trace, trace_span};
+use tracing::Instrument;
+use tracing::trace;
+use tracing::trace_span;
 
 use crate::client::execution_profile::ExecutionProfileInner;
-use crate::errors::{RequestAttemptError, RequestError};
+use crate::cluster::NodeRef;
+use crate::errors::RequestAttemptError;
+use crate::errors::RequestError;
 use crate::frame::types::{Consistency, SerialConsistency};
-
 use crate::network::Connection;
 use crate::observability::driver_tracing::RequestSpan;
 use crate::observability::history::{self, HistoryListener};
 use crate::observability::metrics::Metrics;
-use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
+use crate::policies::load_balancing;
+use crate::policies::load_balancing::{LoadBalancingPolicy, RoutingInfo};
 use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 use crate::policies::speculative_execution::{self, SpeculativeExecutionPolicy};
-use crate::response::{Coordinator, NonErrorQueryResponse};
+use crate::response::Coordinator;
+use crate::response::NonErrorQueryResponse;
+use crate::routing::Shard;
 use crate::statement::StatementConfig;
-use crate::{cluster::NodeRef, routing::Shard};
 
 /// Result of running a request, before side effects are handled.
 pub(crate) enum RunRequestResult<ResT> {
@@ -127,6 +134,15 @@ impl<'a> RequestExecutionParams<'a> {
     }
 }
 
+/// Outcome of [`run_request_no_side_effects`]/[`run_request_speculative_fiber`].
+pub(crate) struct RequestExecutionOutcome<C> {
+    /// The successful (or ignored-write) result.
+    pub(crate) result: RunRequestResult<NonErrorQueryResponse>,
+    /// The coordinator that served the request (target-dependent type, only available
+    /// in certain execution contexts).
+    pub(crate) coordinator: C,
+}
+
 /// History data threaded through a single fiber.
 struct HistoryData<'a> {
     listener: &'a dyn HistoryListener,
@@ -154,7 +170,6 @@ impl ExecuteRequestContext<'_> {
         let (Some(history_data), Some(attempt_id)) = (&self.history_data, attempt_id_opt) else {
             return;
         };
-
         history_data.listener.log_attempt_success(*attempt_id);
     }
 
@@ -167,7 +182,6 @@ impl ExecuteRequestContext<'_> {
         let (Some(history_data), Some(attempt_id)) = (&self.history_data, attempt_id_opt) else {
             return;
         };
-
         history_data
             .listener
             .log_attempt_error(*attempt_id, error, retry_decision);
@@ -230,7 +244,7 @@ impl<'a> RequestExecutionParams<'a> {
         request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         request_span: &'a RequestSpan,
-    ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>
+    ) -> Result<RequestExecutionOutcome<Coordinator>, RequestError>
     where
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
@@ -342,7 +356,7 @@ impl<'a> RequestExecutionParams<'a> {
         request_plan: impl Iterator<Item = (NodeRef<'a>, Shard)>,
         run_request_once: impl Fn(Arc<Connection>, Consistency) -> QueryFut,
         mut context: ExecuteRequestContext<'a>,
-    ) -> Option<Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>>
+    ) -> Option<Result<RequestExecutionOutcome<Coordinator>, RequestError>>
     where
         QueryFut: Future<Output = Result<NonErrorQueryResponse, RequestAttemptError>>,
     {
@@ -369,7 +383,7 @@ impl<'a> RequestExecutionParams<'a> {
                 context.request_span.record_shard_id(&connection);
 
                 self.inc_total_queries();
-                let request_start = std::time::Instant::now();
+                let request_start = Instant::now();
 
                 let connect_address = connection.get_connect_address();
                 trace!(
@@ -381,6 +395,7 @@ impl<'a> RequestExecutionParams<'a> {
 
                 let attempt_id: Option<history::AttemptId> =
                     context.log_attempt_start(connect_address);
+
                 let request_result: Result<NonErrorQueryResponse, RequestAttemptError> =
                     run_request_once(connection, current_consistency)
                         .instrument(span.clone())
@@ -397,7 +412,10 @@ impl<'a> RequestExecutionParams<'a> {
                             elapsed,
                             node,
                         );
-                        return Some(Ok((RunRequestResult::Completed(response), coordinator)));
+                        return Some(Ok(RequestExecutionOutcome {
+                            result: RunRequestResult::Completed(response),
+                            coordinator,
+                        }));
                     }
                     Err(e) => {
                         trace!(
@@ -446,7 +464,10 @@ impl<'a> RequestExecutionParams<'a> {
                     }
                     RetryDecision::DontRetry => break 'targets_in_plan,
                     RetryDecision::IgnoreWriteError => {
-                        return Some(Ok((RunRequestResult::IgnoredWriteError, coordinator)));
+                        return Some(Ok(RequestExecutionOutcome {
+                            result: RunRequestResult::IgnoredWriteError,
+                            coordinator,
+                        }));
                     }
                 };
             }

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -305,8 +305,10 @@ impl PagingExecutor {
             serial_consistency: self.serial_consistency,
             retry_policy: self.retry_policy.as_ref(),
             load_balancing_policy: self.load_balancing_policy.as_ref(),
-            metrics: &self.metrics,
-            speculative_policy: self.speculative_policy.as_deref(),
+            metrics_and_speculative_policy: Some((
+                &self.metrics,
+                self.speculative_policy.as_deref(),
+            )),
             request_timeout: self.request_timeout,
             history_listener: self.history_listener.as_deref(),
             request_kind: RequestPaging::Automatic,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use crate::client::execution::{
     NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RequestPaging,
-    RunRequestResult,
+    RunRequestResult, SingleConnectionTarget,
 };
 use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node};
@@ -38,12 +38,13 @@ use crate::observability::driver_tracing::RequestSpan;
 use crate::observability::history::HistoryListener;
 use crate::observability::metrics::Metrics;
 use crate::policies::load_balancing::{self, LoadBalancingPolicy, RoutingInfo};
-use crate::policies::retry::RetryPolicy;
+use crate::policies::retry::{FallthroughRetryPolicy, RetryPolicy};
 use crate::policies::speculative_execution::SpeculativeExecutionPolicy;
 use crate::response::query_result::ColumnSpecs;
 use crate::response::{Coordinator, NonErrorQueryResponse, QueryResponse};
-use crate::routing::{Shard, Token};
+use crate::routing::{NodeLocationPreference, Shard, Token};
 use crate::serialize::row::SerializedValues;
+use crate::statement::PageSize;
 use crate::statement::StatementConfig;
 use crate::statement::prepared::{PartitionKey, PartitionKeyError, PreparedStatement};
 use crate::statement::unprepared::Statement;
@@ -495,111 +496,188 @@ impl PagingExecutor {
     }
 }
 
+/// No-op LBP implementation, whose sole purpose is to enable plugging [SingleConnectionPagingExecutor]
+/// into the unified execution core.
+#[derive(Debug)]
+struct NoopLBP;
+impl LoadBalancingPolicy for NoopLBP {
+    fn pick<'a>(
+        &'a self,
+        _request: &'a RoutingInfo,
+        _cluster: &'a ClusterState,
+    ) -> Option<(crate::cluster::NodeRef<'a>, Option<Shard>)> {
+        None
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        _request: &'a RoutingInfo,
+        _cluster: &'a ClusterState,
+    ) -> load_balancing::FallbackPlan<'a> {
+        Box::new(std::iter::empty())
+    }
+
+    fn name(&self) -> String {
+        "NoopLBP".into()
+    }
+}
+
 /// Drives paged execution over a single fixed connection, used by
 /// [`Connection::execute_iter`](crate::network::Connection::execute_iter).
 ///
 /// Unlike [`PagingExecutor`], it has no load balancing, retries, speculative
 /// execution, metrics or history: it simply fetches each page on the given
-/// connection, applying the client-side timeout.
+/// connection through the unified execution core, applying the client-side
+/// timeout.
 ///
 /// NOTE: This executor only supports executing SELECT statements. More
 /// specifically, it expects that each response is of Rows kind. Other kinds
 /// of responses will result in an error.
-struct SingleConnectionPagingExecutor<Fetcher> {
-    fetcher: Fetcher,
-    timeout: Option<Duration>,
+struct SingleConnectionPagingExecutor {
+    connection: Arc<Connection>,
+    prepared: PreparedStatement,
+    values: SerializedValues,
+    token: Option<Token>,
+    page_size: PageSize,
+    consistency: Consistency,
+    serial_consistency: Option<SerialConsistency>,
+    request_timeout: Option<Duration>,
 }
 
-impl<Fetcher> SingleConnectionPagingExecutor<Fetcher>
-where
-    Fetcher: AsyncFn(PagingState) -> Result<QueryResponse, RequestAttemptError> + Send + Sync,
-{
-    /// Fetches a single page. Returns the page and paging state response.
-    async fn query_one_page(
-        &mut self,
-        paging_state: PagingState,
-    ) -> Result<
-        Result<(NextReceivedPage, PagingStateResponse), RequestAttemptError>,
-        RequestTimeoutError,
-    > {
-        let runner = async {
-            (self.fetcher)(paging_state)
-                .await
-                .and_then(QueryResponse::into_non_error_query_response)
+impl SingleConnectionPagingExecutor {
+    /// Fetches exactly one page from the fixed connection by delegating to
+    /// [`run_request_no_side_effects`] with a single-connection plan.
+    async fn fetch_one_page(
+        &self,
+        paging_state: &PagingState,
+        request_span: &RequestSpan,
+    ) -> Result<RequestExecutionOutcome<()>, RequestError> {
+        // The control-connection-style path never retries: a fallthrough retry
+        // policy makes every attempt terminal.
+        let retry_policy = FallthroughRetryPolicy::new();
+        let exec_params = RequestExecutionParams {
+            is_idempotent: self.prepared.get_is_idempotent(),
+            consistency: self.consistency,
+            serial_consistency: self.serial_consistency,
+            retry_policy: &retry_policy,
+            load_balancing_policy: &NoopLBP,
+            metrics_and_speculative_policy: None,
+            request_timeout: self.request_timeout,
+            history_listener: None,
+            request_kind: RequestPaging::Automatic,
         };
-        let response_res = match self.timeout {
-            Some(timeout) => {
-                match tokio::time::timeout(timeout, runner).await {
-                    Ok(res) => res,
-                    Err(_) /* tokio::time::error::Elapsed */ => {
-                        return Err(RequestTimeoutError(timeout));
-                    }
-                }
-            }
-            None => runner.await,
+
+        let routing_info = RoutingInfo {
+            consistency: self.consistency,
+            serial_consistency: self.serial_consistency,
+            token: self.token,
+            table: self.prepared.get_table_spec(),
+            is_confirmed_lwt: self.prepared.is_confirmed_lwt(),
+            node_location_preference: &NodeLocationPreference::Any,
         };
-        let response = match response_res {
-            Ok(resp) => resp,
-            Err(err) => {
-                return Ok(Err(err));
+
+        let run_request_once = |connection: Arc<Connection>, consistency: Consistency| {
+            let paging_state = paging_state.clone();
+            async move {
+                connection
+                    .execute_raw_with_consistency(
+                        &self.prepared,
+                        &self.values,
+                        consistency,
+                        self.serial_consistency,
+                        Some(self.page_size),
+                        paging_state,
+                    )
+                    .await
+                    .and_then(QueryResponse::into_non_error_query_response)
             }
         };
 
+        let plan = std::iter::once(SingleConnectionTarget::new(Arc::clone(&self.connection)));
+
+        exec_params
+            .run_request_no_side_effects(&routing_info, plan, run_request_once, request_span)
+            .await
+    }
+
+    /// Interprets a page outcome. Only Rows responses are valid here.
+    fn page_from_outcome(
+        outcome: RequestExecutionOutcome<()>,
+    ) -> Result<(NextReceivedPage, PagingStateResponse), NextPageError> {
+        let response = match outcome.result {
+            RunRequestResult::IgnoredWriteError => {
+                unreachable!(
+                    "FallthroughRetryPolicy is used, so errors are always propagated and never ignored."
+                )
+            }
+            RunRequestResult::Completed(response) => response,
+        };
+
+        let tracing_id = response.tracing_id;
         match response.response {
             NonErrorResponseWithDeserializedMetadata::Result(
                 result::ResultWithDeserializedMetadata::Rows((rows, paging_state_response)),
-            ) => {
-                let page = NextReceivedPage {
+            ) => Ok((
+                NextReceivedPage {
                     rows,
-                    tracing_id: response.tracing_id,
+                    tracing_id,
                     request_coordinator: None,
-                };
-                Ok(Ok((page, paging_state_response)))
-            }
-            _ => Ok(Err(RequestAttemptError::UnexpectedResponse(
-                response.response.to_response_kind(),
-            ))),
+                },
+                paging_state_response,
+            )),
+            other => Err(NextPageError::RequestFailure(
+                RequestError::LastAttemptError(RequestAttemptError::UnexpectedResponse(
+                    other.to_response_kind(),
+                )),
+            )),
         }
     }
 
-    /// Fetches remaining pages (pages 2+) and sends them through the channel.
-    async fn work(mut self, paging_state: PagingState, sender: mpsc::Sender<ResultNextPage>) {
-        let mut paging_state = paging_state;
-        loop {
-            let result = self.query_one_page(paging_state).await;
-            match result {
-                Err(RequestTimeoutError(timeout)) => {
-                    let _ = sender
-                        .send(Err(NextPageError::RequestFailure(
-                            RequestError::RequestTimeout(timeout),
-                        )))
-                        .await;
-                    return;
-                }
-                Ok(Err(err)) => {
-                    let _ = sender
-                        .send(Err(NextPageError::RequestFailure(
-                            RequestError::LastAttemptError(err),
-                        )))
-                        .await;
-                    return;
-                }
-                Ok(Ok((page, paging_state_response))) => {
-                    let send_result = sender.send(Ok(page)).await;
-                    if send_result.is_err() {
-                        // channel was closed, QueryPager was dropped - should shutdown
-                        return;
-                    }
+    fn make_span(&self) -> RequestSpan {
+        RequestSpan::new_cc_query(self.prepared.get_statement(), self.values.buffer_size())
+    }
 
-                    match paging_state_response.into_paging_control_flow() {
-                        ControlFlow::Continue(new_paging_state) => {
-                            paging_state = new_paging_state;
-                        }
-                        ControlFlow::Break(()) => {
-                            // Reached the last query, shutdown
-                            return;
-                        }
-                    }
+    /// Fetches remaining pages (pages 2+) and sends them through the channel.
+    async fn fetch_remaining_pages(
+        self,
+        mut paging_state: PagingState,
+        sender: mpsc::Sender<ResultNextPage>,
+    ) {
+        loop {
+            let request_span = self.make_span();
+            let outcome = self
+                .fetch_one_page(&paging_state, &request_span)
+                .instrument(request_span.span().clone())
+                .await;
+
+            let outcome = match outcome {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    let _ = sender.send(Err(NextPageError::RequestFailure(error))).await;
+                    return;
+                }
+            };
+
+            let (page, paging_state_response) = match Self::page_from_outcome(outcome) {
+                Ok(page) => page,
+                Err(error) => {
+                    let _ = sender.send(Err(error)).await;
+                    return;
+                }
+            };
+
+            if sender.send(Ok(page)).await.is_err() {
+                // Channel was closed, QueryPager was dropped - should shutdown.
+                return;
+            }
+
+            match paging_state_response.into_paging_control_flow() {
+                ControlFlow::Continue(new_paging_state) => {
+                    paging_state = new_paging_state;
+                }
+                ControlFlow::Break(()) => {
+                    // Reached the last query, shutdown
+                    return;
                 }
             }
         }
@@ -1016,38 +1094,42 @@ If you are using this API, you are probably doing something wrong."
         serial_consistency: Option<SerialConsistency>,
     ) -> Result<Self, NextPageError> {
         let page_size = prepared.get_validated_page_size();
-        let timeout = prepared.get_request_timeout().or_else(|| {
+        let request_timeout = prepared.get_request_timeout().or_else(|| {
             prepared
                 .get_execution_profile_handle()?
                 .access()
                 .request_timeout
         });
 
-        let mut executor = SingleConnectionPagingExecutor {
-            fetcher: async move |paging_state: PagingState| {
-                connection
-                    .execute_raw_with_consistency(
-                        &prepared,
-                        &values,
-                        consistency,
-                        serial_consistency,
-                        Some(page_size),
-                        paging_state,
-                    )
-                    .await
-            },
-            timeout,
+        let (_, token) = match prepared
+            .extract_partition_key_and_calculate_token(prepared.get_partitioner_name(), &values)
+        {
+            Ok(res) => res.unzip(),
+            Err(err) => {
+                return Err(NextPageError::PartitionKeyError(err));
+            }
         };
 
-        let (first_page, paging_state_response) = executor
-            .query_one_page(PagingState::start())
+        let executor = SingleConnectionPagingExecutor {
+            connection,
+            prepared,
+            values,
+            token,
+            page_size,
+            consistency,
+            serial_consistency,
+            request_timeout,
+        };
+
+        // Fetch the first page on the caller task (no spawning).
+        let request_span = executor.make_span();
+        let outcome = executor
+            .fetch_one_page(&PagingState::start(), &request_span)
+            .instrument(request_span.span().clone())
             .await
-            .map_err(|RequestTimeoutError(timeout)| {
-                NextPageError::RequestFailure(RequestError::RequestTimeout(timeout))
-            })?
-            .map_err(|attempt_error| {
-                NextPageError::RequestFailure(RequestError::LastAttemptError(attempt_error))
-            })?;
+            .map_err(NextPageError::RequestFailure)?;
+        let (first_page, paging_state_response) =
+            SingleConnectionPagingExecutor::page_from_outcome(outcome)?;
 
         /* PROCESS FIRST PAGE */
         let (sender, receiver) = mpsc::channel::<ResultNextPage>(1);
@@ -1058,7 +1140,10 @@ If you are using this API, you are probably doing something wrong."
             }
             PagingStateResponse::HasMorePages { state } => {
                 /* REMAINING PAGES */
-                let worker_task = async move { executor.work(state, sender).await };
+                let parent_span = tracing::Span::current();
+                let worker_task =
+                    async move { executor.fetch_remaining_pages(state, sender).await }
+                        .instrument(parent_span);
                 let _worker_handle = tokio::task::spawn(worker_task);
             }
         }
@@ -1254,14 +1339,6 @@ where
         Poll::Ready(Some(Ok(value)))
     }
 }
-
-/// Failed to run a request within a provided client timeout.
-#[derive(Error, Debug, Clone)]
-#[error(
-    "Request execution exceeded a client timeout of {}ms",
-    std::time::Duration::as_millis(.0)
-)]
-struct RequestTimeoutError(std::time::Duration);
 
 /// An error returned that occurred during next page fetch.
 #[derive(Error, Debug, Clone)]

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -16,7 +16,9 @@ use tokio::sync::mpsc;
 use tracing::{Instrument, warn};
 use uuid::Uuid;
 
-use crate::client::execution::{RequestExecutionParams, RequestPaging, RunRequestResult};
+use crate::client::execution::{
+    RequestExecutionOutcome, RequestExecutionParams, RequestPaging, RunRequestResult,
+};
 use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node};
 use crate::deserialize::DeserializeOwnedRow;
@@ -213,13 +215,17 @@ impl PagingExecutor {
                 .await;
 
             let page_res = match page_res {
-                Ok((RunRequestResult::IgnoredWriteError, _)) => {
+                Ok(RequestExecutionOutcome {
+                    result: RunRequestResult::IgnoredWriteError,
+                    coordinator: _,
+                }) => {
                     warn!("Ignoring error during fetching pages; stopping fetching.");
                     return;
                 }
-                Ok((RunRequestResult::Completed(page), coordinator)) => {
-                    self.process_next_page(coordinator, &page_span, page)
-                }
+                Ok(RequestExecutionOutcome {
+                    result: RunRequestResult::Completed(page),
+                    coordinator,
+                }) => self.process_next_page(coordinator, &page_span, page),
                 Err(err) => Err(err),
             };
             match page_res {
@@ -263,7 +269,10 @@ impl PagingExecutor {
 
         match fetch_result {
             Err(e) => Err(e),
-            Ok((result, coordinator)) => match result {
+            Ok(RequestExecutionOutcome {
+                result,
+                coordinator,
+            }) => match result {
                 RunRequestResult::IgnoredWriteError => {
                     warn!("Ignoring error during fetching pages; stopping fetching.");
                     Ok((
@@ -294,7 +303,7 @@ impl PagingExecutor {
         routing_info: &RoutingInfo<'_>,
         page_span: &RequestSpan,
         page_query: &PageQuery,
-    ) -> Result<(RunRequestResult<NonErrorQueryResponse>, Coordinator), RequestError>
+    ) -> Result<RequestExecutionOutcome<Coordinator>, RequestError>
     where
         PageQuery: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -17,7 +17,8 @@ use tracing::{Instrument, warn};
 use uuid::Uuid;
 
 use crate::client::execution::{
-    RequestExecutionOutcome, RequestExecutionParams, RequestPaging, RunRequestResult,
+    NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RequestPaging,
+    RunRequestResult,
 };
 use crate::client::session::Session;
 use crate::cluster::{ClusterState, Node};
@@ -359,7 +360,8 @@ impl PagingExecutor {
                             .shard()
                             .is_none_or(|last_shard| last_shard == shard))
                 })
-            }));
+            }))
+            .map(|(node, shard)| NodeAttemptTarget::new(node, shard));
 
         exec_params
             .run_request_no_side_effects(routing_info, plan, run_request_once, page_span)

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -7,7 +7,9 @@ use super::pager::QueryPager;
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
 use crate::client::client_routes::ClientRoutesConfig;
-use crate::client::execution::{RequestExecutionOutcome, RequestExecutionParams, RunRequestResult};
+use crate::client::execution::{
+    NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RunRequestResult,
+};
 use crate::cluster::metadata::{SchemaMetadataFetchLevel, SchemaMetadataFetchMode};
 use crate::cluster::node::KnownNode;
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
@@ -2119,7 +2121,8 @@ impl Session {
             exec_params.load_balancing_policy,
             &routing_info,
             &cluster_state,
-        );
+        )
+        .map(|(node, shard)| NodeAttemptTarget::new(node, shard));
 
         let RequestExecutionOutcome {
             result,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -7,7 +7,7 @@ use super::pager::QueryPager;
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
 use crate::client::client_routes::ClientRoutesConfig;
-use crate::client::execution::{RequestExecutionParams, RunRequestResult};
+use crate::client::execution::{RequestExecutionOutcome, RequestExecutionParams, RunRequestResult};
 use crate::cluster::metadata::{SchemaMetadataFetchLevel, SchemaMetadataFetchMode};
 use crate::cluster::node::KnownNode;
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
@@ -2121,7 +2121,10 @@ impl Session {
             &cluster_state,
         );
 
-        let result = exec_params
+        let RequestExecutionOutcome {
+            result,
+            coordinator,
+        } = exec_params
             .run_request_no_side_effects(
                 &routing_info,
                 request_plan,
@@ -2132,13 +2135,13 @@ impl Session {
             .map_err(RequestError::into_execution_error)?;
 
         // Automatically handle meaningful responses.
-        if let (RunRequestResult::Completed(ref response), ref coordinator) = result {
+        if let RunRequestResult::Completed(ref response) = result {
             self.handle_set_keyspace_response(response).await?;
             self.handle_auto_await_schema_agreement(response, coordinator.node().host_id)
                 .await?;
         }
 
-        Ok(result)
+        Ok((result, coordinator))
     }
 }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2523,12 +2523,17 @@ mod tests {
         RequestRule, ResponseFrame, ShardAwareness,
     };
 
+    use bytes::Bytes;
     use tokio::select;
     use tokio::sync::mpsc;
 
     use super::{HostConnectionConfig, open_connection};
     use crate::cluster::metadata::UntranslatedEndpoint;
     use crate::cluster::node::ResolvedContactPoint;
+    use crate::errors::{
+        CqlResponseKind, DbError, NextPageError, NextRowError, RequestAttemptError, RequestError,
+    };
+    use crate::statement::prepared::PreparedStatement;
     use crate::statement::unprepared::Statement;
     use crate::test_utils::setup_tracing;
     use crate::utils::test_utils::{PerformDDL, resolve_hostname, unique_keyspace_name};
@@ -2542,6 +2547,9 @@ mod tests {
     /// 1. SELECT from an empty table.
     /// 2. Create table and insert ints 0..100.
     ///    Then use execute_iter with page_size set to 7 to select all 100 rows.
+    ///
+    /// For the failure modes of this path (timeouts, server errors, non-Rows
+    /// responses), see the `connection_execute_iter_*` tests below.
     #[tokio::test]
     async fn connection_execute_iter_test() {
         use crate::client::session_builder::SessionBuilder;
@@ -2634,6 +2642,358 @@ mod tests {
             // Teardown phase
             session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
         }
+    }
+
+    /// A fixture for tests of the fixed-connection paging path, i.e.
+    /// [`Connection::execute_iter`] -> `SingleConnectionPagingExecutor`.
+    ///
+    /// The connection under test goes through a proxy, so that request rules can
+    /// inject delays and errors into particular pages.
+    struct FixedConnectionPagingFixture {
+        proxy: scylla_proxy::RunningProxy,
+        connection: Arc<super::Connection>,
+    }
+
+    impl FixedConnectionPagingFixture {
+        async fn setup(request_rules: Vec<RequestRule>) -> Self {
+            let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "172.42.0.2:9042".to_string());
+            let node_addr: SocketAddr = resolve_hostname(&uri).await;
+            let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
+
+            let proxy = Proxy::builder()
+                .with_node(
+                    Node::builder()
+                        .proxy_address(proxy_addr)
+                        .real_address(node_addr)
+                        .shard_awareness(ShardAwareness::QueryNode)
+                        .request_rules(request_rules)
+                        .build(),
+                )
+                .build()
+                .run()
+                .await
+                .unwrap();
+
+            let (connection, _) = open_connection(
+                &UntranslatedEndpoint::ContactPoint(ResolvedContactPoint {
+                    address: proxy_addr,
+                }),
+                None,
+                &HostConnectionConfig::default(),
+            )
+            .await
+            .unwrap();
+
+            Self {
+                proxy,
+                connection: Arc::new(connection),
+            }
+        }
+
+        /// Prepares a paged SELECT over a system table, which is guaranteed to
+        /// exist and to contain multiple rows. Page size of 1 makes every row a
+        /// separate page, so that pages 2+ are always fetched.
+        async fn prepare_paged_select(&self) -> PreparedStatement {
+            let select =
+                Statement::new("SELECT keyspace_name FROM system_schema.tables").with_page_size(1);
+            self.connection.prepare(&select).await.unwrap()
+        }
+
+        fn change_request_rules(&mut self, rules: Vec<RequestRule>) {
+            self.proxy.running_nodes[0].change_request_rules(Some(rules));
+        }
+
+        async fn finish(self) {
+            let _ = self.proxy.finish().await;
+        }
+    }
+
+    /// A rule matching EXECUTE frames only. PREPARE requests must not be
+    /// affected, or the statement under test could not even be prepared.
+    fn execute_opcode_condition() -> Condition {
+        Condition::RequestOpcode(RequestOpcode::Execute)
+    }
+
+    /// The timeout configured by the tests below. Its value is arbitrary: those
+    /// tests never wait for it to elapse in real time. It is only chosen far
+    /// longer than any realistic round trip, so that a timeout firing in the test
+    /// can only be the result of the clock being advanced deliberately.
+    const PAGING_TEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// Makes the request under test delayed for more than the timeout's duration,
+    /// so that the only possible outcome is the client-side timeout.
+    fn delay_request_for_more_than_timeout() -> RequestReaction {
+        RequestReaction::delay(PAGING_TEST_TIMEOUT + Duration::from_secs(1))
+    }
+
+    /// Stops the clock, so that the request timeout no longer elapses on its own.
+    ///
+    /// From this point on, time only moves when the runtime runs out of work to
+    /// do, in which case tokio advances it to the nearest deadline - here, the
+    /// request timeout. Since the request under test is delayed by the proxy for
+    /// significantly longer, the response will not race with that, which makes
+    /// the timeout fire deterministically and at no cost in wall-clock time.
+    /// This is why the tests need no timing margins whatsoever.
+    ///
+    /// Must only be called once all the setup that involves real I/O is done,
+    /// as a paused clock would make such I/O race against the advancing time.
+    fn stop_the_clock() {
+        tokio::time::pause();
+    }
+
+    /// Regression test: the client-side request timeout must be applied to the
+    /// fetch of the *first* page, which `QueryPager::new_for_connection_execute_iter`
+    /// performs eagerly, on the caller's task. Hence the error must be returned
+    /// from `execute_iter()` itself.
+    #[tokio::test]
+    async fn connection_execute_iter_first_page_timeout() {
+        setup_tracing();
+
+        let fixture = FixedConnectionPagingFixture::setup(vec![RequestRule(
+            execute_opcode_condition(),
+            delay_request_for_more_than_timeout(),
+        )])
+        .await;
+
+        let mut prepared = fixture.prepare_paged_select().await;
+        prepared.set_request_timeout(Some(PAGING_TEST_TIMEOUT));
+
+        stop_the_clock();
+
+        let err = Arc::clone(&fixture.connection)
+            .execute_iter(prepared, SerializedValues::new())
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            &err,
+            NextRowError::NextPageError(NextPageError::RequestFailure(
+                RequestError::RequestTimeout(got_timeout),
+            )) if *got_timeout == PAGING_TEST_TIMEOUT,
+            "Expected RequestTimeout({PAGING_TEST_TIMEOUT:?}), got: {err:?}"
+        );
+
+        fixture.finish().await;
+    }
+
+    /// Regression test: the client-side request timeout must be applied to each
+    /// page separately, including pages fetched by the worker task spawned by
+    /// `QueryPager::new_for_connection_execute_iter`. Such an error reaches the
+    /// user through the page channel, i.e. from the rows stream rather than from
+    /// `execute_iter()` itself.
+    #[tokio::test]
+    async fn connection_execute_iter_later_page_timeout() {
+        setup_tracing();
+
+        let fixture = FixedConnectionPagingFixture::setup(vec![
+            // Let the first page through, then delay all subsequent requests.
+            RequestRule(
+                execute_opcode_condition().and(Condition::TrueForLimitedTimes(1)),
+                RequestReaction::noop(),
+            ),
+            RequestRule(
+                execute_opcode_condition(),
+                delay_request_for_more_than_timeout(),
+            ),
+        ])
+        .await;
+
+        let mut prepared = fixture.prepare_paged_select().await;
+        prepared.set_request_timeout(Some(PAGING_TEST_TIMEOUT));
+
+        // The first page is served by the real node, so it is fetched while the
+        // clock still runs. The timeout is armed for it as well, but it is far
+        // too long to elapse - and, being the last thing done in real time, it
+        // cannot be advanced past by accident, either.
+        let mut rows_stream = Arc::clone(&fixture.connection)
+            .execute_iter(prepared, SerializedValues::new())
+            .await
+            .unwrap()
+            .rows_stream::<(String,)>()
+            .unwrap();
+
+        // The first page consists of exactly one row, which must arrive intact.
+        let (_ks_name,) = rows_stream.next().await.unwrap().unwrap();
+
+        stop_the_clock();
+
+        // The fetch of the second page, performed by the spawned worker task,
+        // must time out.
+        let err = rows_stream.next().await.unwrap().unwrap_err();
+        assert_matches!(
+            &err,
+            NextRowError::NextPageError(NextPageError::RequestFailure(
+                RequestError::RequestTimeout(got_timeout),
+            )) if *got_timeout == PAGING_TEST_TIMEOUT,
+            "Expected RequestTimeout({PAGING_TEST_TIMEOUT:?}), got: {err:?}"
+        );
+
+        fixture.finish().await;
+    }
+
+    /// Regression test for mapping of server errors on this path. As it employs
+    /// `FallthroughRetryPolicy`, the very first attempt is terminal - both for the
+    /// first page and for subsequent ones - and the DB error is surfaced verbatim.
+    #[tokio::test]
+    async fn connection_execute_iter_server_error() {
+        setup_tracing();
+
+        let (feedback_tx, mut feedback_rx) = mpsc::unbounded_channel();
+
+        let count_executes = |rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>| {
+            let mut count = 0;
+            while rx.try_recv().is_ok() {
+                count += 1;
+            }
+            count
+        };
+
+        // Case 1: the first page fetch fails with a server error.
+        let mut fixture = FixedConnectionPagingFixture::setup(vec![RequestRule(
+            execute_opcode_condition(),
+            RequestReaction::forge()
+                .server_error()
+                .with_feedback_when_performed(feedback_tx.clone()),
+        )])
+        .await;
+
+        let prepared = fixture.prepare_paged_select().await;
+
+        let err = Arc::clone(&fixture.connection)
+            .execute_iter(prepared.clone(), SerializedValues::new())
+            .await
+            .unwrap_err();
+        assert_matches!(
+            &err,
+            NextRowError::NextPageError(NextPageError::RequestFailure(
+                RequestError::LastAttemptError(RequestAttemptError::DbError(
+                    DbError::ServerError,
+                    _
+                )),
+            )),
+            "Expected a terminal ServerError, got: {err:?}"
+        );
+        assert_eq!(
+            count_executes(&mut feedback_rx),
+            1,
+            "FallthroughRetryPolicy must make the first attempt terminal - no retries expected"
+        );
+
+        // Case 2: a subsequent page fetch fails with a server error. The error
+        // must reach the user through the page channel, with the same mapping.
+        fixture.change_request_rules(vec![
+            // Let the first page through, then fail all subsequent ones.
+            RequestRule(
+                execute_opcode_condition().and(Condition::TrueForLimitedTimes(1)),
+                RequestReaction::noop(),
+            ),
+            RequestRule(
+                execute_opcode_condition(),
+                RequestReaction::forge()
+                    .server_error()
+                    .with_feedback_when_performed(feedback_tx.clone()),
+            ),
+        ]);
+
+        let mut rows_stream = Arc::clone(&fixture.connection)
+            .execute_iter(prepared, SerializedValues::new())
+            .await
+            .unwrap()
+            .rows_stream::<(String,)>()
+            .unwrap();
+
+        let (_ks_name,) = rows_stream.next().await.unwrap().unwrap();
+
+        let err = rows_stream.next().await.unwrap().unwrap_err();
+        assert_matches!(
+            &err,
+            NextRowError::NextPageError(NextPageError::RequestFailure(
+                RequestError::LastAttemptError(RequestAttemptError::DbError(
+                    DbError::ServerError,
+                    _
+                )),
+            )),
+            "Expected a terminal ServerError, got: {err:?}"
+        );
+        assert_eq!(
+            count_executes(&mut feedback_rx),
+            1,
+            "FallthroughRetryPolicy must make the attempt terminal on later pages, too"
+        );
+
+        fixture.finish().await;
+    }
+
+    /// Forges a RESULT response of Void kind, i.e. the kind of response that a
+    /// non-SELECT statement would yield.
+    fn forge_void_result() -> RequestReaction {
+        RequestReaction::forge_response(Arc::new(|frame: RequestFrame| ResponseFrame {
+            params: frame.params.for_response(),
+            opcode: scylla_proxy::ResponseOpcode::Result,
+            // The body of a RESULT response begins with its kind; 0x0001 is Void.
+            body: Bytes::from_static(&[0, 0, 0, 1]),
+        }))
+    }
+
+    /// Regression test: this path only supports responses of Rows kind. Any other
+    /// kind - here a Void result, as returned by non-SELECT statements - must be
+    /// rejected as an unexpected response instead of being silently accepted.
+    /// This holds both for the first page and for subsequent ones.
+    #[tokio::test]
+    async fn connection_execute_iter_unexpected_response() {
+        setup_tracing();
+
+        let assert_unexpected_response = |err: NextRowError| {
+            assert_matches!(
+                &err,
+                NextRowError::NextPageError(NextPageError::RequestFailure(
+                    RequestError::LastAttemptError(RequestAttemptError::UnexpectedResponse(
+                        CqlResponseKind::Result
+                    )),
+                )),
+                "Expected UnexpectedResponse(Result), got: {err:?}"
+            );
+        };
+
+        // Case 1: the first page is not of Rows kind.
+        let mut fixture = FixedConnectionPagingFixture::setup(vec![RequestRule(
+            execute_opcode_condition(),
+            forge_void_result(),
+        )])
+        .await;
+
+        let prepared = fixture.prepare_paged_select().await;
+
+        let err = Arc::clone(&fixture.connection)
+            .execute_iter(prepared.clone(), SerializedValues::new())
+            .await
+            .unwrap_err();
+        assert_unexpected_response(err);
+
+        // Case 2: a subsequent page is not of Rows kind. The error must reach the
+        // user through the page channel, with the same mapping.
+        fixture.change_request_rules(vec![
+            // Let the first page through, then spoil all subsequent ones.
+            RequestRule(
+                execute_opcode_condition().and(Condition::TrueForLimitedTimes(1)),
+                RequestReaction::noop(),
+            ),
+            RequestRule(execute_opcode_condition(), forge_void_result()),
+        ]);
+
+        let mut rows_stream = Arc::clone(&fixture.connection)
+            .execute_iter(prepared, SerializedValues::new())
+            .await
+            .unwrap()
+            .rows_stream::<(String,)>()
+            .unwrap();
+
+        let (_ks_name,) = rows_stream.next().await.unwrap().unwrap();
+
+        let err = rows_stream.next().await.unwrap().unwrap_err();
+        assert_unexpected_response(err);
+
+        fixture.finish().await;
     }
 
     #[tokio::test]

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2542,7 +2542,6 @@ mod tests {
     /// 1. SELECT from an empty table.
     /// 2. Create table and insert ints 0..100.
     ///    Then use execute_iter with page_size set to 7 to select all 100 rows.
-    /// 3. INSERT execute_iter should work and not return any rows.
     #[tokio::test]
     async fn connection_execute_iter_test() {
         use crate::client::session_builder::SessionBuilder;

--- a/scylla/src/observability/driver_tracing.rs
+++ b/scylla/src/observability/driver_tracing.rs
@@ -80,6 +80,20 @@ impl RequestSpan {
         }
     }
 
+    pub(crate) fn new_cc_query<'ps, 'spec: 'ps>(contents: &str, request_size: usize) -> Self {
+        let span = trace_span!(
+            "Request on control connection",
+            kind = "prepared",
+            contents = contents,
+            request_size = request_size,
+        );
+
+        Self {
+            span,
+            speculative_executions: 0.into(),
+        }
+    }
+
     pub(crate) fn new_batch() -> Self {
         use tracing::field::Empty;
 

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -1,3 +1,9 @@
+// This hopefully fixes the following error that occurs in CI:
+// error: queries overflow the depth limit!
+//   |
+//   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`integration`)
+//   = note: query depth increased by 130 when computing layout of `{async block@scylla/tests/integration/ccm/authenticate.rs:39:1: 39:15}`
+#![recursion_limit = "256"]
 // Rigorous documentation is not necessary for integration tests.
 #![allow(missing_docs)]
 


### PR DESCRIPTION
Fixes: #1549

## Summary

This PR concludes the unification of execution paths by migrating the `SingleConnectionPagingExecutor` to the unified execution core. There are no behavioral changes intended, other than arising from switching the logic to the unified core.

The key notion of this PR is _genericisation_.

The APIs exposed by the `execution` module had the following constraints:
- Metrics must be passed to REP (for use in speculative execution).
- LBP must be passed to REP (`RequestExecutionParams`) and available for providing feedback (`on_request_success` and `on_request_failure`).
- The _query plan_ must be an iterator over `(NodeRef, Shard)` targets.
- `Coordinator` must be returned from a successful execution.

This PR lifts those limitations by:
- making `Metrics` optional and only (statically) required if SEP is passed.
- making both `Target` and `Coordinator` generic.

Extensive testing for `Connection::execute_iter()` API is added. 

## Details

<details><summary>Detailed description by Opus 5</summary>
<p>

# Genericising the unified execution core

## Background

Request execution — load balancing, retries, speculative execution, history,
metrics, client-side timeout — used to be implemented independently in several
places: `Session`'s non-paged methods, the `QueryPager` worker, and the
control-connection paging path (`SingleConnectionPagingExecutor`). Earlier work
collapsed the first two into a single layered core in
`scylla/src/client/execution.rs`:

- `RequestExecutionParams::run_request_no_side_effects` — no `Session` access,
  no side-effect handling; applies the client-side timeout and dispatches
  speculative-execution fibers.
- `RequestExecutionParams::run_request_speculative_fiber` — a single fiber:
  iterates the execution plan, picks connections, runs the per-attempt closure,
  applies the retry policy.
- the outermost `run_request` layer, which handles `USE <keyspace>` and
  schema-agreement side effects, stays on `Session` / `PagingExecutor` because
  it needs session state.

`SingleConnectionPagingExecutor` could not join that core, because the core was
hardwired to load balancing: the plan was an `Iterator<Item = (NodeRef, Shard)>`,
connections came from `node.connection_for_shard(shard)`, every attempt fed
success/failure back into an LBP, every attempt produced a `Coordinator`, and
metrics were mandatory. The control connection has none of those: it has one
fixed connection, no `Node`, no LBP, and no metrics sink. So it carried its own
duplicate loop — its own timeout handling, its own error mapping, its own
worker.

This PR removes each of those hardwired assumptions, one per commit, and then
migrates the executor.

## The central abstraction: `AttemptTarget`

The key generalisation is that "a thing an attempt can be sent to" is now a
trait rather than a `(NodeRef, Shard)` tuple:

```rust
pub(crate) trait AttemptTarget {
    type Coordinator;
    async fn get_connection(&self) -> Result<Arc<Connection>, ConnectionPoolError>;
    fn coordinator(&self, connection: &Arc<Connection>) -> Self::Coordinator;
    fn on_attempt_success(&self, elapsed: Duration);
    fn on_attempt_failure(&self, elapsed: Duration, error: &RequestAttemptError);
}
```

An execution plan is now simply an `Iterator<Item = Target>`. The fiber loop is
unchanged in structure — `'targets_in_plan` / `'same_target_retries`, connection
acquisition failure skips to the next target, retry decisions map onto the two
loop labels — but every LBP-specific operation is delegated to the target.

Two implementations:

- `NodeAttemptTarget<'a>` — a `(node, shard)` pair plus the `&dyn
  LoadBalancingPolicy` and `&RoutingInfo` needed for feedback. Acquires a
  connection via `node.connection_for_shard(shard)`, produces a real
  `Coordinator`, and forwards success/failure to the policy. Call sites build it
  by mapping over the load balancing plan:
  `plan.map(|(node, shard)| NodeAttemptTarget::new(node, shard, lbp, routing_info))`.
- `SingleConnectionTarget` — wraps one `Arc<Connection>`. `get_connection`
  always succeeds, `Coordinator = ()`, and both feedback hooks are no-ops. The
  plan is `std::iter::once(...)`.

Because `Coordinator` is an associated type, "no coordinator" is expressed
statically as `()` rather than as a runtime `Option` the caller must handle.
`run_request_no_side_effects` now returns `RequestExecutionOutcome<Target::Coordinator>`
— a named struct replacing the previous `(RunRequestResult<_>, Coordinator)`
tuple, which had become awkward once the second field's type varied.

## Supporting decouplings

Each of these existed only to let the core stop assuming a load-balanced,
metric-ed, session-backed request.

**LBP out of `RequestExecutionParams`.** The load balancing policy and
`RoutingInfo` are no longer fields of the params struct; they moved into
`NodeAttemptTarget`, where they belong. `RequestExecutionParams::new` therefore
returns `(Self, &dyn LoadBalancingPolicy)` — callers that do load balancing take
the policy and build targets with it; the control-connection path simply never
sees one.

**Metrics made optional, tied to speculative execution.** The two fields became
one:

```rust
metrics_and_speculative_policy: Option<(&Arc<Metrics>, Option<&dyn SpeculativeExecutionPolicy>)>,
```

This is not just optionality — it statically encodes the invariant that
speculative execution cannot be requested without a metrics sink (the
speculative-execution machinery requires one). The control connection passes
`None` and all the `inc_*` / `log_query_latency` helpers become no-ops.

**`RetrySession` moved onto `ExecuteRequestContext`.** The retry session used to
be created inside the fiber. It is now constructed per fiber at the call site
and threaded through the context, which keeps the fiber body free of policy
construction and makes the per-fiber ownership explicit.

**Statically optional `Coordinator`.** Groundwork for `Target::Coordinator`:
the coordinator became a type-level rather than value-level option across the
execution result types.

## Migrating `SingleConnectionPagingExecutor`

With the above in place, the executor drops its bespoke loop and becomes a thin
layer over the core.

Structurally, it stops storing a boxed `fetcher` closure and instead stores the
request's constituents (`connection`, `prepared`, `values`, `page_size`,
`consistency`, `serial_consistency`, `request_timeout`), so each page can build
its own `run_request_once` closure.

`fetch_one_page` constructs `RequestExecutionParams` with:
- `retry_policy: &FallthroughRetryPolicy` — the control-connection path has
  never retried; a fallthrough policy makes every attempt terminal, preserving
  behaviour while going through the shared retry machinery;
- `metrics_and_speculative_policy: None`;
- `history_listener: None`;
- `request_timeout` — now applied by the core's timeout layer rather than by a
  hand-rolled `tokio::time::timeout`.

and a one-element `SingleConnectionTarget` plan.

Consequences:

- `RequestTimeoutError` and its ad-hoc mapping are deleted; timeouts now surface
  as `RequestError::RequestTimeout` from the shared layer, and the double-nested
  `Result<Result<_, _>, _>` return shape collapses into a single `RequestError`.
- Response interpretation is factored into `page_from_outcome`, which handles
  `IgnoredWriteError` (unreachable in practice, mapped to an empty final page)
  and rejects non-Rows responses.
- The path gains proper `RequestSpan` tracing (`make_span`), which it previously
  lacked, and the spawned worker task now inherits the caller's span.
- The first page is still fetched on the caller's task; only pages 2+ run in the
  spawned `fetch_remaining_pages` worker.

-----------------------------------------

</p>
</details> 

## Net effect

There is now exactly one implementation of the request-attempt loop. Whether a request is dispatched across a load-balancing plan with retries, speculative fibers and metrics, or sent once down a fixed control connection, it goes
through the same code; the differences are expressed as an `AttemptTarget` implementation plus `None`s in the params struct, and are checked by the type system where possible rather than by runtime branching.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
