### PR TITLE
examples: complete custom serde traits

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,9 +40,9 @@ cargo run -p examples --example basic
 | `compare_tokens` | Computing a partition key's token in the driver, checking it against the token the cluster reports, and listing the replicas that own it. |
 | `cql_time_types` | Reading and writing `date`, `time` and `timestamp` using `chrono`, `time`, and the raw `CqlDate`/`CqlTime`/`CqlTimestamp` types. |
 | `cqlsh_rs` | A miniature `cqlsh`: a REPL with CQL keyword completion that executes whatever you type. |
-| `custom_deserialization` | Implementing `DeserializeValue` by hand so that a column can be read directly into your own type. |
+| `custom_deserialization` | Implementing `DeserializeValue` by hand for a column value and deriving `DeserializeRow` for a whole row. |
 | `custom_load_balancing_policy` | Writing a load balancing policy of your own - here one restricted to a single datacenter - and checking which node really coordinated each request. |
-| `custom_serialization` | Deriving `SerializeRow` for your own structs, including generic ones, and passing them as statement values. |
+| `custom_serialization` | Implementing `SerializeValue` by hand for a column value and deriving `SerializeRow` for structs of statement values. |
 | `enforce_coordinator` | Forcing a request onto a chosen node, and inspecting the coordinator that executed it. |
 | `execution_profile` | Bundling consistency, timeout, retry, load balancing and speculative execution settings into profiles, and attaching them to sessions and statements. |
 | `get_by_name` | Locating columns in a result by name rather than by position. |

--- a/examples/custom_deserialization.rs
+++ b/examples/custom_deserialization.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use scylla::DeserializeRow;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::deserialize::value::DeserializeValue;
@@ -32,7 +33,11 @@ async fn main() -> Result<()> {
     #[derive(PartialEq, Eq, Debug)]
     struct MyType<'a>(&'a str);
 
-    impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for MyType<'frame> {
+    // The value may borrow for any lifetime shorter than the response frame.
+    impl<'frame, 'metadata, 'a> DeserializeValue<'frame, 'metadata> for MyType<'a>
+    where
+        'frame: 'a,
+    {
         fn type_check(
             typ: &scylla::frame::response::result::ColumnType,
         ) -> std::result::Result<(), scylla::deserialize::TypeCheckError> {
@@ -57,8 +62,15 @@ async fn main() -> Result<()> {
         .await?
         .into_rows_result()?;
 
-    let (v,) = rows_result.single_row::<(MyType,)>()?;
-    assert_eq!(v, MyType("asdf"));
+    // DeserializeRow can be derived for a struct representing a whole row.
+    #[derive(Debug, DeserializeRow)]
+    struct MyRow<'a> {
+        // Field name must correspond to the CQL column's name.
+        v: MyType<'a>,
+    }
+
+    let row = rows_result.single_row::<MyRow>()?;
+    assert_eq!(row.v, MyType("asdf"));
 
     println!("Ok.");
 

--- a/examples/custom_serialization.rs
+++ b/examples/custom_serialization.rs
@@ -2,6 +2,9 @@ use anyhow::Result;
 use futures::StreamExt;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::frame::response::result::ColumnType;
+use scylla::serialize::value::SerializeValue;
+use scylla::serialize::writers::{CellWriter, WrittenCellProof};
 use std::env;
 
 #[tokio::main]
@@ -21,15 +24,30 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    #[derive(scylla::SerializeRow)]
-    struct MyType<'a> {
-        k: i32,
-        my: Option<&'a str>,
+    // You can implement SerializeValue for your own types.
+    struct MyText<'a>(&'a str);
+
+    impl SerializeValue for MyText<'_> {
+        fn serialize<'b>(
+            &self,
+            typ: &ColumnType,
+            writer: CellWriter<'b>,
+        ) -> std::result::Result<WrittenCellProof<'b>, scylla::serialize::SerializationError>
+        {
+            self.0.serialize(typ, writer)
+        }
     }
 
-    let to_insert = MyType {
+    // SerializeRow can be derived for a struct of statement values.
+    #[derive(scylla::SerializeRow)]
+    struct MyRow<'a> {
+        k: i32,
+        my: Option<MyText<'a>>,
+    }
+
+    let to_insert = MyRow {
         k: 17,
-        my: Some("Some str"),
+        my: Some(MyText("Some str")),
     };
 
     session


### PR DESCRIPTION
Complete the custom serialization/deserialization examples so both value- and row-level traits are demonstrated symmetrically.

- implement `SerializeValue` for a custom text wrapper and use it from a derived `SerializeRow`
- derive `DeserializeRow` around the existing zero-copy custom `DeserializeValue`
- clarify the example index descriptions

Validation:
- `cargo check -p examples --examples`
- `make static` (all local checks passed through Clippy and book generation; the final rustdoc leak check could not run because the nightly toolchain is not installed)

Fixes: #1828