### PR TITLE
optimise execution happy path: lazily init retry session

### DIFF
--- a/scylla/src/client/execution.rs
+++ b/scylla/src/client/execution.rs
@@ -304,13 +304,23 @@ struct HistoryData<'a> {
 
 /// Per-fiber execution context.
 struct ExecuteRequestContext<'a> {
-    retry_session: Box<dyn RetrySession>,
+    retry_policy: &'a dyn RetryPolicy,
+    /// Created lazily, upon the first attempt error, in order to avoid
+    /// an allocation on the happy path (where no retry is ever needed).
+    retry_session: Option<Box<dyn RetrySession>>,
     history_data: Option<HistoryData<'a>>,
     routing_info: &'a load_balancing::RoutingInfo<'a>,
     request_span: &'a RequestSpan,
 }
 
 impl ExecuteRequestContext<'_> {
+    fn retry_session(&mut self) -> &mut dyn RetrySession {
+        let retry_policy = self.retry_policy;
+        self.retry_session
+            .get_or_insert_with(|| retry_policy.new_session())
+            .as_mut()
+    }
+
     fn log_attempt_start(&self, node_addr: SocketAddr) -> Option<history::AttemptId> {
         self.history_data.as_ref().map(|hd| {
             hd.listener
@@ -432,7 +442,8 @@ impl<'a> RequestExecutionParams<'a> {
                             &shared_request_plan,
                             &run_request_once,
                             ExecuteRequestContext {
-                                retry_session: self.retry_policy.new_session(),
+                                retry_policy: self.retry_policy,
+                                retry_session: None,
                                 history_data,
                                 routing_info,
                                 request_span,
@@ -459,7 +470,8 @@ impl<'a> RequestExecutionParams<'a> {
                         request_plan,
                         &run_request_once,
                         ExecuteRequestContext {
-                            retry_session: self.retry_policy.new_session(),
+                            retry_policy: self.retry_policy,
+                            retry_session: None,
                             history_data,
                             routing_info,
                             request_span,
@@ -596,7 +608,7 @@ impl<'a> RequestExecutionParams<'a> {
                     consistency: current_consistency,
                 };
 
-                let retry_decision = context.retry_session.decide_should_retry(request_info);
+                let retry_decision = context.retry_session().decide_should_retry(request_info);
                 trace!(
                     parent: &span,
                     retry_decision = ?retry_decision

--- a/scylla/tests/integration/statements/execution_profiles.rs
+++ b/scylla/tests/integration/statements/execution_profiles.rs
@@ -180,74 +180,75 @@ async fn test_execution_profiles() {
         while profile_rx.try_recv().is_ok() {}
         consistency_rx.try_recv().unwrap_err();
 
+        // On the happy path (no attempt fails), the driver never creates a RetrySession
+        // (it is instantiated lazily, upon the first attempt error), so only the load
+        // balancing policy reports itself.
+        async fn assert_lb_report(
+            profile_rx: &mut mpsc::UnboundedReceiver<(Report, u8)>,
+            expected_node: u8,
+        ) {
+            let report = profile_rx.recv().await.unwrap();
+            assert_matches!(report, (Report::LoadBalancing, node) if node == expected_node);
+            profile_rx.try_recv().unwrap_err();
+        }
 
-        /* Test load balancing and retry policy */
+        // Once an attempt fails, the RetrySession is created, so both policies report themselves.
+        async fn assert_lb_and_retry_reports(
+            profile_rx: &mut mpsc::UnboundedReceiver<(Report, u8)>,
+            expected_node: u8,
+        ) {
+            let report1 = profile_rx.recv().await.unwrap();
+            let report2 = profile_rx.recv().await.unwrap();
+            assert_matches!(
+                (report1, report2),
+                ((Report::LoadBalancing, n1), (Report::RetryPolicy, n2))
+                    | ((Report::RetryPolicy, n1), (Report::LoadBalancing, n2))
+                    if n1 == expected_node && n2 == expected_node
+            );
+            profile_rx.try_recv().unwrap_err();
+        }
+
+
+        /* Test load balancing policy */
 
         // Run on default per-session execution profile
         session.query_unpaged(query.clone(), &[]).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 1).await;
 
         session.execute_unpaged(&prepared, &[]).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 1).await;
 
         session.batch(&batch, ((),)).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 1).await;
 
         // Run on query-specific execution profile
         query.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.query_unpaged(query.clone(), &[]).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 2), (Report::RetryPolicy, 2)) | ((Report::RetryPolicy, 2), (Report::LoadBalancing, 2)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 2).await;
 
         prepared.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.execute_unpaged(&prepared, &[]).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 2), (Report::RetryPolicy, 2)) | ((Report::RetryPolicy, 2), (Report::LoadBalancing, 2)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 2).await;
 
         batch.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.batch(&batch, ((),)).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 2), (Report::RetryPolicy, 2)) | ((Report::RetryPolicy, 2), (Report::LoadBalancing, 2)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 2).await;
 
         // Run again on default per-session execution profile
         query.set_execution_profile_handle(None);
         session.query_unpaged(query.clone(), &[]).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 1).await;
 
         prepared.set_execution_profile_handle(None);
         session.execute_unpaged(&prepared, &[]).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 1).await;
 
         batch.set_execution_profile_handle(None);
         session.batch(&batch, ((),)).await.unwrap();
-        let report1 = profile_rx.recv().await.unwrap();
-        let report2 = profile_rx.recv().await.unwrap();
-        assert_matches!((report1, report2), ((Report::LoadBalancing, 1), (Report::RetryPolicy, 1)) | ((Report::RetryPolicy, 1), (Report::LoadBalancing, 1)));
-        profile_rx.try_recv().unwrap_err();
+        assert_lb_report(&mut profile_rx, 1).await;
 
 
-        /* Test consistencies */
+        /* Test retry policy and consistencies */
         let rule_overloaded = RequestRule(
             Condition::True,
             RequestReaction::forge().overloaded()
@@ -263,16 +264,19 @@ async fn test_execution_profiles() {
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::One);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 1).await;
 
         session.execute_unpaged(&prepared, &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::One);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 1).await;
 
         session.batch(&batch, ((),)).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::One);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 1).await;
 
         // Run on statement-specific execution profile
         query.set_execution_profile_handle(Some(profile2.clone().into_handle()));
@@ -280,18 +284,21 @@ async fn test_execution_profiles() {
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::Two);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 2).await;
 
         prepared.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.execute_unpaged(&prepared, &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::Two);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 2).await;
 
         batch.set_execution_profile_handle(Some(profile2.clone().into_handle()));
         session.batch(&batch, ((),)).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::Two);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 2).await;
 
         // Run with statement-set specific options
         query.set_consistency(Consistency::Three);
@@ -299,18 +306,21 @@ async fn test_execution_profiles() {
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::Three);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 2).await;
 
         prepared.set_consistency(Consistency::Three);
         session.execute_unpaged(&prepared, &[]).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::Three);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 2).await;
 
         batch.set_consistency(Consistency::Three);
         session.batch(&batch, ((),)).await.unwrap_err();
         let report_consistency = consistency_rx.recv().await.unwrap();
         assert_matches!(report_consistency, Consistency::Three);
         consistency_rx.try_recv().unwrap_err();
+        assert_lb_and_retry_reports(&mut profile_rx, 2).await;
 
         for i in 0..=2 {
             running_proxy.running_nodes[i].change_request_rules(None);


### PR DESCRIPTION
This PR is purely a performance optimisation of the execution hot path: it makes the RetrySession created lazily, only after the first execution attempt fails. This saves allocation on the hot path.

Benchmarks confirm that the optimisation is meaningful, showing the following reduction in number of allocated blocks:

- INSERT: -11%!
- unpaged SELECT: -11%!
- paged SELECT: -3.25%.
- batch: -6.66%.

    On the example of the batch scenario, `1401|1501` means that we reduced
    the number of allocations by 100, which is exactly one allocation per
    request.

Full benchmark results:

```
requests::requests::insert counts_0:(setup_default(100))
    ======= CALLGRIND ====================================================
    Baselines:                       |base
    Instructions:             2472682|2474429      (-0.07060%) [-1.00071x]
    L1 Hits:                  3548012|3549173      (-0.03271%) [-1.00033x]
    LL Hits:                   204137|207495       (-1.61835%) [-1.01645x]
    RAM Hits:                     106|105          (+0.95238%) [+1.00952x]
    Total read+write:         3752255|3756773      (-0.12026%) [-1.00120x]
    Estimated Cycles:         4572407|4590323      (-0.39030%) [-1.00392x]
    ======= DHAT =========================================================
    Total bytes:                29164|29464        (-1.01819%) [-1.01029x]
    Total blocks:                 801|901          (-11.0988%) [-1.12484x]
    At t-gmax bytes:                0|0            (No change)
    At t-gmax blocks:               0|0            (No change)
    At t-end bytes:                 0|0            (No change)
    At t-end blocks:                0|0            (No change)
    Reads bytes:                40700|40700        (No change)
    Writes bytes:               43100|43400        (-0.69124%) [-1.00696x]
requests::requests::unpaged_select counts_0:(setup_default(100))
    ======= CALLGRIND ====================================================
    Baselines:                       |base
    Instructions:             2540899|2552309      (-0.44705%) [-1.00449x]
    L1 Hits:                  3652515|3664939      (-0.33900%) [-1.00340x]
    LL Hits:                   213041|217093       (-1.86648%) [-1.01902x]
    RAM Hits:                     107|110          (-2.72727%) [-1.02804x]
    Total read+write:         3865663|3882142      (-0.42448%) [-1.00426x]
    Estimated Cycles:         4721465|4754254      (-0.68968%) [-1.00694x]
    ======= DHAT =========================================================
    Total bytes:                54164|54464        (-0.55082%) [-1.00554x]
    Total blocks:                 801|901          (-11.0988%) [-1.12484x]
    At t-gmax bytes:                0|0            (No change)
    At t-gmax blocks:               0|0            (No change)
    At t-end bytes:                 0|0            (No change)
    At t-end blocks:                0|0            (No change)
    Reads bytes:                53100|53100        (No change)
    Writes bytes:               73700|74000        (-0.40541%) [-1.00407x]
requests::requests::paged_select counts_0:(setup_default(100))
    ======= CALLGRIND ====================================================
    Baselines:                       |base
    Instructions:           223052139|223733510    (-0.30455%) [-1.00305x]
    L1 Hits:                331868086|332667177    (-0.24021%) [-1.00241x]
    LL Hits:                 10996129|11216366     (-1.96353%) [-1.02003x]
    RAM Hits:                     633|636          (-0.47170%) [-1.00474x]
    Total read+write:       342864848|343884179    (-0.29642%) [-1.00297x]
    Estimated Cycles:       386870886|388771267    (-0.48882%) [-1.00491x]
    ======= DHAT =========================================================
    Total bytes:             13478964|13494264     (-0.11338%) [-1.00114x]
    Total blocks:              151701|156801       (-3.25253%) [-1.03362x]
    At t-gmax bytes:                0|0            (No change)
    At t-gmax blocks:               0|0            (No change)
    At t-end bytes:                 0|0            (No change)
    At t-end blocks:                0|0            (No change)
    Reads bytes:             33486700|33446700     (+0.11959%) [+1.00120x]
    Writes bytes:            66869100|66434800     (+0.65372%) [+1.00654x]
requests::requests::batch sizes_0:(setup_batch(64, 100))
    ======= CALLGRIND ====================================================
    Baselines:                       |base
    Instructions:             4367396|4378557      (-0.25490%) [-1.00256x]
    L1 Hits:                  6255641|6268125      (-0.19917%) [-1.00200x]
    LL Hits:                   235496|238276       (-1.16671%) [-1.01180x]
    RAM Hits:                     382|379          (+0.79156%) [+1.00792x]
    Total read+write:         6491519|6506780      (-0.23454%) [-1.00235x]
    Estimated Cycles:         7446491|7472770      (-0.35166%) [-1.00353x]
    ======= DHAT =========================================================
    Total bytes:               936364|936664       (-0.03203%) [-1.00032x]
    Total blocks:                1401|1501         (-6.66223%) [-1.07138x]
    At t-gmax bytes:                0|0            (No change)
    At t-gmax blocks:               0|0            (No change)
    At t-end bytes:                 0|0            (No change)
    At t-end blocks:                0|0            (No change)
    Reads bytes:               727600|727600       (No change)
    Writes bytes:              742800|743100       (-0.04037%) [-1.00040x]
```


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
