### PR TITLE
scylla-cql-core: derive `Ord` and `Hash` for `CqlTimestamp`

### DIFF
--- a/scylla-cql-core/src/value.rs
+++ b/scylla-cql-core/src/value.rs
@@ -712,7 +712,7 @@ pub struct CqlDate(pub u32);
 /// Native CQL timestamp representation that allows full supported timestamp range.
 ///
 /// Represented as signed milliseconds since unix epoch.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct CqlTimestamp(pub i64);
 
 /// Native CQL time representation.


### PR DESCRIPTION
`CqlTimestamp` models an instant and already behaves like one. It carries `MIN` and `MAX`, reads the system clock through `now()`, adds and subtracts `std::time::Duration`, and measures elapsed time. The one thing it could not do was compare two instants. Deriving only `PartialEq` and `Eq` means `<` and `>` do not compile, values cannot be sorted, and the type cannot be used as a `BTreeMap` or `HashSet` key.

Callers who need any of that have to reach through the public field and compare raw `i64` milliseconds, discarding the type at exactly the point where its meaning matters, or wrap `CqlTimestamp` in a newtype and reimplement the traits. That wrapper then also has to forward `SerializeValue` and `DeserializeValue` to remain usable with the driver, so a missing derive costs far more than the line it would take to add.

Deriving is the correct implementation here rather than a hand-written one. The representation is signed milliseconds since the Unix epoch, so the natural `i64` ordering is already chronological, pre-epoch instants included.

`Hash` is derived alongside `Ord` so that it stays consistent with the existing `Eq`. Both are additive and break no existing user.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: VECTOR-847