### PR TITLE
Make metadata fetching non-blocking

### DIFF
--- a/scylla/src/client/client_routes.rs
+++ b/scylla/src/client/client_routes.rs
@@ -481,7 +481,22 @@ mod tests {
         event: &ClientRoutesChangeEvent,
         fetched: ClientRoutes,
     ) -> ClientRoutesUpdate {
-        ClientRoutesUpdate::from_event(event, translator.get_connection_ids(), &fetched)
+        let ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids,
+            host_ids,
+        } = event
+        else {
+            unreachable!("tests only construct UpdateNodes events")
+        };
+        ClientRoutesUpdate::from_pairs(
+            &connection_ids
+                .iter()
+                .cloned()
+                .zip(host_ids.iter().copied())
+                .collect(),
+            translator.get_connection_ids(),
+            &fetched,
+        )
     }
 
     fn make_config(proxies: Vec<ClientRoutesProxy>) -> ClientRoutesConfig {

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -10,8 +10,9 @@ use dashmap::DashMap;
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
+use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::client::pager::QueryPager;
-use crate::cluster::metadata::UntranslatedEndpoint;
+use crate::cluster::metadata::{SchemaMetadataFetchMode, UntranslatedEndpoint};
 use crate::errors::{
     ConnectionError, NextPageError, NextRowError, RequestAttemptError, RequestError,
 };
@@ -72,6 +73,25 @@ pub(crate) enum ControlConnectionEvent {
     Broken(ConnectionError),
     ServerEvent(Event),
     Shutdown,
+}
+
+/// Configuration for the queries a [`ControlConnection`] runs on behalf of the
+/// driver: what metadata to fetch and how.
+///
+/// Not to be confused with [`ConnectionConfig`](crate::network::ConnectionConfig),
+/// which configures how the underlying network connection is opened.
+#[derive(Clone)]
+pub(super) struct ControlConnectionConfig {
+    /// Keyspaces to restrict the schema metadata fetch to. Empty means no restriction.
+    pub(super) keyspaces_to_fetch: Vec<String>,
+    /// Whether (and in what detail) to fetch schema metadata.
+    pub(super) schema_metadata_fetch_mode: SchemaMetadataFetchMode,
+    /// The subscriber interested in `system.client_routes`, if any. Provides the
+    /// connection ids to filter routes by; its presence also makes the control
+    /// connection register for CLIENT_ROUTES_CHANGE events.
+    pub(super) client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
+    /// The custom server-side timeout set for requests executed on the control connection.
+    pub(super) request_timeouts: MetadataRequestTimeouts,
 }
 
 /// The single connection used to fetch metadata and receive events from the cluster.

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -98,8 +98,7 @@ pub(super) struct ControlConnectionConfig {
 pub(super) struct ControlConnection {
     conn: Arc<Connection>,
     endpoint: UntranslatedEndpoint,
-    /// The timeouts applied to requests executed on the control connection.
-    request_timeouts: MetadataRequestTimeouts,
+    pub(super) config: ControlConnectionConfig,
     cache: Arc<ControlConnectionCache>,
 }
 
@@ -118,6 +117,7 @@ impl ControlConnection {
     pub(super) fn new(
         conn: Arc<Connection>,
         endpoint: UntranslatedEndpoint,
+        config: ControlConnectionConfig,
         cache: Arc<ControlConnectionCache>,
         error_channel: oneshot::Receiver<ConnectionError>,
         events_channel: mpsc::Receiver<Event>,
@@ -126,7 +126,7 @@ impl ControlConnection {
             Self {
                 conn,
                 endpoint,
-                request_timeouts: MetadataRequestTimeouts::default(),
+                config,
                 cache,
             },
             ControlConnectionEvents {
@@ -138,14 +138,6 @@ impl ControlConnection {
 
     pub(super) fn endpoint(&self) -> &UntranslatedEndpoint {
         &self.endpoint
-    }
-
-    /// Sets the timeouts applied to requests executed on the control connection.
-    pub(super) fn with_request_timeouts(self, timeouts: MetadataRequestTimeouts) -> Self {
-        Self {
-            request_timeouts: timeouts,
-            ..self
-        }
     }
 
     pub(super) fn get_connect_address(&self) -> SocketAddr {
@@ -160,7 +152,11 @@ impl ControlConnection {
     /// Appends the custom server-side timeout to the statement string, if such custom timeout
     /// is provided and we are connected to ScyllaDB (since custom timeouts is ScyllaDB-only feature).
     fn maybe_append_timeout_override(&self, statement: &mut Statement) {
-        if let Some(timeout) = self.request_timeouts.serverside(self.is_to_scylladb()) {
+        if let Some(timeout) = self
+            .config
+            .request_timeouts
+            .serverside(self.is_to_scylladb())
+        {
             // SAFETY: io::fmt::Write impl for String is infallible.
             write!(
                 statement.contents,
@@ -212,7 +208,7 @@ impl ControlConnection {
 
         // Set on this per-use clone rather than in `get_or_prepare_statement`, so that
         // the shared cache never bakes a timeout in.
-        prepared.set_request_timeout(Some(self.request_timeouts.clientside()));
+        prepared.set_request_timeout(Some(self.config.request_timeouts.clientside()));
 
         let serialized_values = prepared.serialize_values(&values).map_err(|ser_err| {
             NextRowError::NextPageError(NextPageError::RequestFailure(
@@ -277,15 +273,15 @@ mod tests {
 
     use std::num::NonZeroU16;
 
-    use crate::cluster::control_connection::ControlConnectionCache;
-    use crate::cluster::metadata::UntranslatedEndpoint;
+    use crate::cluster::control_connection::{ControlConnectionCache, MetadataRequestTimeouts};
+    use crate::cluster::metadata::{SchemaMetadataFetchMode, UntranslatedEndpoint};
     use crate::cluster::node::ResolvedContactPoint;
     use crate::network::HostConnectionConfig;
     use crate::network::open_connection;
     use crate::routing::ShardInfo;
     use crate::test_utils::setup_tracing;
 
-    use super::{ControlConnection, MetadataRequestTimeouts};
+    use super::{ControlConnection, ControlConnectionConfig, ControlConnectionEvents};
 
     /// Tests that ControlConnection enforces the provided custom timeout
     /// iff ScyllaDB is the target node (else ignores the custom timeout).
@@ -400,10 +396,17 @@ mod tests {
             }
         }
 
-        async fn test_metadata_timeouts(
+        /// Opens a fresh connection to the proxy and builds a `ControlConnection`
+        /// configured with the given custom server-side timeout. Returns whether the
+        /// (simulated) target node is a ScyllaDB node, too.
+        ///
+        /// The `ControlConnectionEvents` are returned only to be kept alive by the
+        /// caller: dropping the events channel would break the connection on an
+        /// incoming event.
+        async fn make_control_connection(
             proxy_addr: SocketAddr,
-            feedback_rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
-        ) {
+            overridden_serverside_timeout: Option<Duration>,
+        ) -> (ControlConnection, ControlConnectionEvents, bool) {
             let endpoint = UntranslatedEndpoint::ContactPoint(ResolvedContactPoint {
                 address: proxy_addr,
             });
@@ -420,20 +423,34 @@ mod tests {
             .unwrap();
 
             let connected_to_scylladb = conn.get_shard_info().is_some();
-            let (conn_with_default_timeout, _events) = ControlConnection::new(
+            let (cc, cc_events) = ControlConnection::new(
                 Arc::new(conn),
                 endpoint,
+                ControlConnectionConfig {
+                    keyspaces_to_fetch: Vec::new(),
+                    schema_metadata_fetch_mode: SchemaMetadataFetchMode::Disabled,
+                    client_routes_subscriber: None,
+                    request_timeouts: MetadataRequestTimeouts {
+                        serverside_override: overridden_serverside_timeout,
+                        clientside_override: None,
+                    },
+                },
                 Arc::new(ControlConnectionCache::new()),
                 error_receiver,
                 events_receiver,
             );
+            (cc, cc_events, connected_to_scylladb)
+        }
 
+        async fn test_metadata_timeouts(
+            proxy_addr: SocketAddr,
+            feedback_rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
+        ) {
             // No custom timeout set.
             {
-                conn_with_default_timeout
-                    .query_iter(QUERY_STR, &())
-                    .await
-                    .unwrap_err();
+                let (cc, _events, _) = make_control_connection(proxy_addr, None).await;
+
+                cc.query_iter(QUERY_STR, &()).await.unwrap_err();
 
                 assert_no_custom_timeout(feedback_rx).await;
             }
@@ -441,16 +458,10 @@ mod tests {
             // Custom timeout set, so it should be set in query strings iff the target node is ScyllaDB.
             {
                 let custom_timeout = Duration::from_millis(2137);
-                let conn_with_custom_timeout =
-                    conn_with_default_timeout.with_request_timeouts(MetadataRequestTimeouts {
-                        serverside_override: Some(custom_timeout),
-                        clientside_override: None,
-                    });
+                let (cc, _events, connected_to_scylladb) =
+                    make_control_connection(proxy_addr, Some(custom_timeout)).await;
 
-                conn_with_custom_timeout
-                    .query_iter(QUERY_STR, &())
-                    .await
-                    .unwrap_err();
+                cc.query_iter(QUERY_STR, &()).await.unwrap_err();
 
                 assert_custom_timeout_iff_scylladb(
                     feedback_rx,

--- a/scylla/src/cluster/metadata/cc_establisher.rs
+++ b/scylla/src/cluster/metadata/cc_establisher.rs
@@ -1,4 +1,4 @@
-//! This module contains the [`MetadataReader`] struct, which is responsible for
+//! This module contains the [`ControlConnectionEstablisher`] struct, which is responsible for
 //! creating control connections and fetching cluster metadata through them.
 //!
 //! The control connection is a dedicated connection to one of the cluster nodes
@@ -6,13 +6,13 @@
 //! - Fetch cluster metadata (topology, schema, token ring information)
 //! - Receive server-side events (topology changes, schema changes, status changes)
 //!
-//! [`MetadataReader`] establishes control connections, including:
+//! [`ControlConnectionEstablisher`] establishes control connections, including:
 //! - Connection establishment to contact points or known peers
 //! - Iterating over known peers and initial contact points on connection failure
 //! - Host filtering to ensure the control connection is established to an accepted node
 //!
-//! Ownership of the established control connection lives outside the reader (in the
-//! metadata worker); the reader only knows how to create one. The metadata queries
+//! Ownership of the established control connection lives outside the establisher (in the
+//! metadata worker); the establisher only knows how to create one. The metadata queries
 //! themselves are methods on [`ControlConnection`], configured at its creation.
 
 use std::sync::Arc;
@@ -40,13 +40,13 @@ use crate::utils::safe_format::IteratorSafeFormatExt;
 
 /// Maintains the persistent state needed to create control connections and
 /// fetch cluster metadata. The established control connection itself is owned by
-/// the caller (the metadata worker), not by the reader.
-pub(crate) struct MetadataReader {
+/// the caller (the metadata worker), not by the establisher.
+pub(crate) struct ControlConnectionEstablisher {
     // =======================================================================================
-    // Configuration values - they will stay the same during whole lifetime of MetadataReader.
+    // Configuration values - they will stay the same during whole lifetime of ControlConnectionEstablisher.
     // =======================================================================================
     control_connection_config: ConnectionConfig,
-    /// Configuration stamped onto every control connection this reader creates;
+    /// Configuration stamped onto every control connection this establisher creates;
     /// governs what the control connection's metadata queries fetch.
     cc_config: ControlConnectionConfig,
     hostname_resolution_timeout: Option<Duration>,
@@ -56,18 +56,18 @@ pub(crate) struct MetadataReader {
     initial_known_nodes: Vec<KnownNode>,
 
     // ====================================================================
-    // Mutable state of MetadataReader. It will change during its lifetime.
+    // Mutable state of ControlConnectionEstablisher. It will change during its lifetime.
     // ====================================================================
-    // when a control connection fails, MetadataReader tries to connect to one of known_peers
+    // when a control connection fails, ControlConnectionEstablisher tries to connect to one of known_peers
     known_peers: Vec<UntranslatedEndpoint>,
     cc_cache: Arc<ControlConnectionCache>,
 }
 
 /// The per-candidate metadata fetch that
-/// [`MetadataReader::establish_cc_and_fetch_metadata`] runs on each candidate
+/// [`ControlConnectionEstablisher::establish_cc_and_fetch_metadata`] runs on each candidate
 /// connection - implemented by the metadata worker.
 ///
-/// When `MetadataReader` open a new `Connection`, it needs to fetch initial
+/// When `ControlConnectionEstablisher` open a new `Connection`, it needs to fetch initial
 /// `Metadata` on it before returning it as a new CC. A candidate is such
 /// potential CC until the `Metadata` is done fetching.
 ///
@@ -91,8 +91,8 @@ pub(super) trait FetchOnCandidate {
     ) -> Result<(TopologyUpdateGuard, Self::Payload), MetadataError>;
 }
 
-impl MetadataReader {
-    /// Creates a new MetadataReader.
+impl ControlConnectionEstablisher {
+    /// Creates a new ControlConnectionEstablisher.
     ///
     /// Resolves the initial contact points and populates the initial known peers
     /// list. Does **not** establish a control connection — use
@@ -120,7 +120,7 @@ impl MetadataReader {
 
         let cc_cache = Arc::new(ControlConnectionCache::new());
 
-        Ok(MetadataReader {
+        Ok(ControlConnectionEstablisher {
             control_connection_config: connection_config,
             cc_config: ControlConnectionConfig {
                 keyspaces_to_fetch,
@@ -449,13 +449,13 @@ impl MetadataReader {
     }
 }
 
-/// Freshly fetched [`Metadata`] that the [`MetadataReader`] has not yet absorbed.
+/// Freshly fetched [`Metadata`] that the [`ControlConnectionEstablisher`] has not yet absorbed.
 ///
 /// [`ControlConnection::query_metadata`] returns its result wrapped in this
-/// guard, so that the fetched metadata cannot be used without the reader
+/// guard, so that the fetched metadata cannot be used without the establisher
 /// updating its known peers from it first: the only way to extract the
 /// [`Metadata`] is [`apply`](Self::apply).
-#[must_use = "the fetched metadata must be applied to the MetadataReader"]
+#[must_use = "the fetched metadata must be applied to the ControlConnectionEstablisher"]
 pub(super) struct TopologyUpdateGuard {
     metadata: Metadata,
 }
@@ -465,10 +465,10 @@ impl TopologyUpdateGuard {
         Self { metadata }
     }
 
-    /// Updates the reader's known peers from the fetched metadata and releases
+    /// Updates the establisher's known peers from the fetched metadata and releases
     /// the metadata itself.
-    pub(super) fn apply(self, reader: &mut MetadataReader) -> Metadata {
-        reader.update_known_peers(&self.metadata);
+    pub(super) fn apply(self, establisher: &mut ControlConnectionEstablisher) -> Metadata {
+        establisher.update_known_peers(&self.metadata);
         self.metadata
     }
 }

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -47,7 +47,6 @@ use crate::errors::{
     MetadataError, MetadataFetchError, MetadataFetchErrorKind, NextPageError, NextRowError,
     PeersMetadataError, RequestAttemptError, RequestError, TablesMetadataError, UdtMetadataError,
 };
-use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::routing::Token;
 
 use super::reader::TopologyUpdateGuard;
@@ -552,18 +551,20 @@ impl ControlConnection {
         Ok(routes)
     }
 
-    /// Performs a partial fetch of `system.client_routes`. Partial means that filtering is done
-    /// not only by connection ids known to the driver (which is always the case), but also
-    /// by host ids - only for the hosts whose ids are present in the event payload.
+    /// Performs a partial fetch of `system.client_routes`.
+    ///
+    /// Such partial fetch is restricted to the given (connection id, host id) pairs, as accumulated from
+    /// CLIENT_ROUTES_CHANGE:UPDATE_NODES events. Those pairs are additionally filtered
+    /// to only query connection ids that the driver is interested in.
     ///
     /// Returns the resulting [`ClientRoutesUpdate`], or `None` if there is no subscriber
-    /// configured or the event contained no connection ids relevant to this driver. Merging
+    /// configured or no pair has a connection id relevant to this driver. Merging
     /// the update into the [`ClientRoutesSubscriber`]'s knowledge is the caller's job.
     ///
     /// [`ClientRoutesSubscriber`]: crate::client::client_routes::ClientRoutesSubscriber
-    pub(super) async fn fetch_client_routes_update_on_event(
+    pub(super) async fn fetch_client_routes_update(
         &self,
-        evt: &ClientRoutesChangeEvent,
+        pairs: &HashSet<(String, Uuid)>,
     ) -> Result<Option<ClientRoutesUpdate>, MetadataError> {
         let Some(subscriber) = self.config.client_routes_subscriber.as_ref() else {
             // No subscriber, but received an event? Strange enough, but nothing to be done here.
@@ -571,41 +572,38 @@ impl ControlConnection {
             return Ok(None);
         };
 
-        #[deny(clippy::wildcard_enum_match_arm)]
-        let (connection_ids, host_ids) = match evt {
-            ClientRoutesChangeEvent::UpdateNodes {
-                connection_ids,
-                host_ids,
-            } => (connection_ids, host_ids),
-            _ => unreachable!("clippy testifies that the match is exhaustive"),
-        };
+        let monitored_pairs = pairs
+            .iter()
+            .filter(|(conn_id, _host_id)| subscriber.get_connection_ids().contains(conn_id));
 
-        // TODO: this is wasteful - it allocates both strings and a vec.
+        // The pairs cannot be queried as such: the query is
+        // `WHERE connection id IN ? AND host id IN ?`, which fetches the whole
+        // cross product of the listed ids - possibly more routes than the
+        // pairs name, for example `(A, Y)` for pairs `[(A, X), (B, Y)]`. This
+        // is a tradeoff - the only alternative is issuing multiple queries,
+        // one per connection id. The surplus routes are ignored when the
+        // update is built from the pairs - see
+        // [`ClientRoutesUpdate::from_pairs`].
+        //
+        // TODO: this is wasteful - it allocates strings and vecs.
         // This won't be a performance problem, because UPDATE_NODES events are not frequent.
         // As an optimization, we can implement ser/de for some special new iterator type,
         // to avoid the need to allocate when serializing collections.
-        let connection_ids: Vec<String> = connection_ids
-            .iter()
-            .filter(|&conn_id| subscriber.get_connection_ids().contains(conn_id))
-            .cloned()
-            .collect();
+        let (connection_ids, host_ids): (HashSet<String>, HashSet<Uuid>) =
+            monitored_pairs.cloned().unzip();
 
         if connection_ids.is_empty() {
-            // The event contained no relevant connection IDs.
+            // The events contained no relevant connection IDs.
             // Nothing to be done.
             return Ok(None);
         }
 
-        // Although this is vaguely documented, the semantics of an event with connection ids [A, B, C] and host ids [X, Y, Z]
-        // is that the following entries were added/updated/removed: `[(A, X), (B, Y), (C, Z)]`.
-        // Unfortunately, we can't really query Scylla this way. Therefore, we do the query: `WHERE connection id IN ? AND host id IN ?`,
-        // which fetches possibly more routes than necessary, for example `(A, Z)` or `(C, Y)`.
-        // This is a tradeoff - the only alternative is issuing multiple queries, one per connection id.
-        // I believe the tradeoff here is correct.
-        let client_routes = self.query_client_routes(&connection_ids, host_ids).await?;
+        let client_routes = self
+            .query_client_routes(&Vec::from_iter(connection_ids), &Vec::from_iter(host_ids))
+            .await?;
 
-        Ok(Some(ClientRoutesUpdate::from_event(
-            evt,
+        Ok(Some(ClientRoutesUpdate::from_pairs(
+            pairs,
             subscriber.get_connection_ids(),
             &client_routes,
         )))

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -40,13 +40,14 @@ use crate::DeserializeRow;
 use crate::client::pager::QueryPager;
 use crate::cluster::NodeAddr;
 use crate::cluster::control_connection::ControlConnection;
-use crate::cluster::metadata::ClientRoutes;
+use crate::cluster::metadata::{ClientRoutes, ClientRoutesUpdate};
 use crate::deserialize::DeserializeOwnedRow;
 use crate::errors::{
     ClientRoutesMetadataError, DbError, KeyspaceStrategyError, KeyspacesMetadataError,
     MetadataError, MetadataFetchError, MetadataFetchErrorKind, NextPageError, NextRowError,
     PeersMetadataError, RequestAttemptError, RequestError, TablesMetadataError, UdtMetadataError,
 };
+use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::routing::Token;
 
 type PerKeyspace<T> = HashMap<String, T>;
@@ -156,20 +157,22 @@ impl fmt::Display for InvalidCqlType {
 }
 
 impl ControlConnection {
-    pub(crate) async fn query_metadata(
-        &self,
-        connect_port: u16,
-        keyspace_to_fetch: &[String],
-        schema_metadata_fetch_mode: SchemaMetadataFetchMode,
-        client_routes_connection_ids: Option<&[String]>,
-    ) -> Result<Metadata, MetadataError> {
+    /// Queries the cluster metadata (peers, schema, client routes) as configured
+    /// by this control connection's
+    /// [`ControlConnectionConfig`](crate::cluster::control_connection::ControlConnectionConfig).
+    pub(super) async fn query_metadata(&self) -> Result<Metadata, MetadataError> {
+        let connect_port = self.endpoint().address().port();
+
         let peers_query = self.query_peers(connect_port);
-        let keyspaces_query = self.query_keyspaces(keyspace_to_fetch, schema_metadata_fetch_mode);
+        let keyspaces_query = self.query_keyspaces(
+            &self.config.keyspaces_to_fetch,
+            self.config.schema_metadata_fetch_mode,
+        );
         let client_routes_query = async {
-            let Some(connection_ids) = client_routes_connection_ids else {
+            let Some(subscriber) = self.config.client_routes_subscriber.as_ref() else {
                 return Ok(None);
             };
-            self.query_client_routes(connection_ids, &[])
+            self.query_client_routes(subscriber.get_connection_ids(), &[])
                 .await
                 .map(Some)
         };
@@ -540,6 +543,65 @@ impl ControlConnection {
         let routes = query_client_routes_with_values(self, query_str, values).await?;
 
         Ok(routes)
+    }
+
+    /// Performs a partial fetch of `system.client_routes`. Partial means that filtering is done
+    /// not only by connection ids known to the driver (which is always the case), but also
+    /// by host ids - only for the hosts whose ids are present in the event payload.
+    ///
+    /// Returns the resulting [`ClientRoutesUpdate`], or `None` if there is no subscriber
+    /// configured or the event contained no connection ids relevant to this driver. Merging
+    /// the update into the [`ClientRoutesSubscriber`]'s knowledge is the caller's job.
+    ///
+    /// [`ClientRoutesSubscriber`]: crate::client::client_routes::ClientRoutesSubscriber
+    pub(super) async fn fetch_client_routes_update_on_event(
+        &self,
+        evt: &ClientRoutesChangeEvent,
+    ) -> Result<Option<ClientRoutesUpdate>, MetadataError> {
+        let Some(subscriber) = self.config.client_routes_subscriber.as_ref() else {
+            // No subscriber, but received an event? Strange enough, but nothing to be done here.
+            warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
+            return Ok(None);
+        };
+
+        #[deny(clippy::wildcard_enum_match_arm)]
+        let (connection_ids, host_ids) = match evt {
+            ClientRoutesChangeEvent::UpdateNodes {
+                connection_ids,
+                host_ids,
+            } => (connection_ids, host_ids),
+            _ => unreachable!("clippy testifies that the match is exhaustive"),
+        };
+
+        // TODO: this is wasteful - it allocates both strings and a vec.
+        // This won't be a performance problem, because UPDATE_NODES events are not frequent.
+        // As an optimization, we can implement ser/de for some special new iterator type,
+        // to avoid the need to allocate when serializing collections.
+        let connection_ids: Vec<String> = connection_ids
+            .iter()
+            .filter(|&conn_id| subscriber.get_connection_ids().contains(conn_id))
+            .cloned()
+            .collect();
+
+        if connection_ids.is_empty() {
+            // The event contained no relevant connection IDs.
+            // Nothing to be done.
+            return Ok(None);
+        }
+
+        // Although this is vaguely documented, the semantics of an event with connection ids [A, B, C] and host ids [X, Y, Z]
+        // is that the following entries were added/updated/removed: `[(A, X), (B, Y), (C, Z)]`.
+        // Unfortunately, we can't really query Scylla this way. Therefore, we do the query: `WHERE connection id IN ? AND host id IN ?`,
+        // which fetches possibly more routes than necessary, for example `(A, Z)` or `(C, Y)`.
+        // This is a tradeoff - the only alternative is issuing multiple queries, one per connection id.
+        // I believe the tradeoff here is correct.
+        let client_routes = self.query_client_routes(&connection_ids, host_ids).await?;
+
+        Ok(Some(ClientRoutesUpdate::from_event(
+            evt,
+            subscriber.get_connection_ids(),
+            &client_routes,
+        )))
     }
 
     fn query_filter_keyspace_name<'a, R>(

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -50,6 +50,8 @@ use crate::errors::{
 use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::routing::Token;
 
+use super::reader::TopologyUpdateGuard;
+
 type PerKeyspace<T> = HashMap<String, T>;
 type PerKeyspaceResult<T, E> = PerKeyspace<Result<T, E>>;
 type PerTable<T> = HashMap<String, T>;
@@ -160,7 +162,12 @@ impl ControlConnection {
     /// Queries the cluster metadata (peers, schema, client routes) as configured
     /// by this control connection's
     /// [`ControlConnectionConfig`](crate::cluster::control_connection::ControlConnectionConfig).
-    pub(super) async fn query_metadata(&self) -> Result<Metadata, MetadataError> {
+    ///
+    /// The result comes wrapped in a [`TopologyUpdateGuard`]: the fetched metadata
+    /// affects which peers the [`MetadataReader`](super::reader::MetadataReader)
+    /// establishes control connections to, so the reader must absorb it before
+    /// anything else can use it.
+    pub(super) async fn query_metadata(&self) -> Result<TopologyUpdateGuard, MetadataError> {
         let connect_port = self.endpoint().address().port();
 
         let peers_query = self.query_peers(connect_port);
@@ -196,12 +203,12 @@ impl ControlConnection {
             return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists));
         }
 
-        Ok(Metadata {
+        Ok(TopologyUpdateGuard::new(Metadata {
             peers,
             keyspaces,
             cluster_name,
             client_routes,
-        })
+        }))
     }
 }
 

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -49,7 +49,7 @@ use crate::errors::{
 };
 use crate::routing::Token;
 
-use super::reader::TopologyUpdateGuard;
+use super::cc_establisher::TopologyUpdateGuard;
 
 type PerKeyspace<T> = HashMap<String, T>;
 type PerKeyspaceResult<T, E> = PerKeyspace<Result<T, E>>;
@@ -163,8 +163,8 @@ impl ControlConnection {
     /// [`ControlConnectionConfig`](crate::cluster::control_connection::ControlConnectionConfig).
     ///
     /// The result comes wrapped in a [`TopologyUpdateGuard`]: the fetched metadata
-    /// affects which peers the [`MetadataReader`](super::reader::MetadataReader)
-    /// establishes control connections to, so the reader must absorb it before
+    /// affects which peers the [`ControlConnectionEstablisher`](super::cc_establisher::ControlConnectionEstablisher)
+    /// establishes control connections to, so the establisher must absorb it before
     /// anything else can use it.
     pub(super) async fn query_metadata(&self) -> Result<TopologyUpdateGuard, MetadataError> {
         let connect_port = self.endpoint().address().port();

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -17,9 +17,9 @@
 //  - client routes:
 //    - [ClientRoute]
 
+pub(super) mod cc_establisher;
 mod fetching;
 pub(crate) mod merge_channel;
-pub(super) mod reader;
 pub(crate) mod update;
 pub(super) mod worker;
 

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -63,6 +63,34 @@ pub(crate) struct MetadataReader {
     cc_cache: Arc<ControlConnectionCache>,
 }
 
+/// The per-candidate metadata fetch that
+/// [`MetadataReader::establish_cc_and_fetch_metadata`] runs on each candidate
+/// connection - implemented by the metadata worker.
+///
+/// When `MetadataReader` open a new `Connection`, it needs to fetch initial
+/// `Metadata` on it before returning it as a new CC. A candidate is such
+/// potential CC until the `Metadata` is done fetching.
+///
+/// This trait allows the caller to customize the behavior of the fetch
+/// and return a custom type alongisde the new CC. Intended usage is draining
+/// the event channel concurrently to the fetch to avoid a deadlock.
+///
+/// A trait rather than an `AsyncFnMut` bound: the implementor lends state
+/// (e.g. the updates channel) to each call, and a capturing async closure
+/// defeats `Send` inference for every future built on top of it (rustc's
+/// "implementation of `Send` is not general enough").
+pub(super) trait FetchOnCandidate {
+    /// Whatever the fetch produces besides the metadata itself; handed back
+    /// with the kept connection.
+    type Payload;
+
+    async fn fetch(
+        &mut self,
+        cc: &ControlConnection,
+        cc_events: &mut ControlConnectionEvents,
+    ) -> Result<(TopologyUpdateGuard, Self::Payload), MetadataError>;
+}
+
 impl MetadataReader {
     /// Creates a new MetadataReader.
     ///
@@ -113,26 +141,35 @@ impl MetadataReader {
 
     /// Establishes a control connection and fetches metadata in one go.
     ///
-    /// Iterates over known peers (shuffled), trying to connect and fetch metadata
-    /// on each. If `initial` is false and all known peers are exhausted, falls back
-    /// to re-resolving the initial contact points.
+    /// Iterates over known peers (shuffled), trying to connect and run
+    /// `fetcher` on each. If `initial` is false and all known peers are
+    /// exhausted, falls back to re-resolving the initial contact points.
+    ///
+    /// `fetcher` is invoked once per candidate connection and must perform the
+    /// metadata fetch on it; it is also free to consume the connection's server
+    /// events meanwhile. Its payload is returned alongside the connection
+    /// it was produced on, so a payload never outlives its candidate. On
+    /// success the connection is handed onward together with its event
+    /// channels, which must remain pollable: `fetcher` must not consume a
+    /// lifecycle event (`Broken`/`Shutdown`) and still return `Ok`.
     ///
     /// On success, updates `known_peers` and returns the fetched metadata together
     /// with a control connection to use going forward. The returned control
     /// connection is `None` when metadata was obtained but no usable control
     /// connection remains:
-    /// - on an `initial` read whose metadata query failed (dummy metadata is
+    /// - on an `initial` read whose metadata fetch failed (dummy metadata is
     ///   returned so the session can still start), or
     /// - when every node that yielded metadata is rejected by the host filter.
     ///
     /// In both of these cases the caller is expected to re-establish the control
     /// connection at the repair cadence.
-    pub(super) async fn establish_cc_and_fetch_metadata(
+    pub(super) async fn establish_cc_and_fetch_metadata<F: FetchOnCandidate>(
         &mut self,
         initial: bool,
+        fetcher: &mut F,
     ) -> Result<
         (
-            Option<(ControlConnection, ControlConnectionEvents)>,
+            Option<(ControlConnection, ControlConnectionEvents, F::Payload)>,
             Metadata,
         ),
         MetadataError,
@@ -149,7 +186,7 @@ impl MetadataReader {
         // failed to resolve). We carry the most recent error across attempts and only
         // synthesize a fallback error if no connection was ever attempted.
         let known_peers_err = match self
-            .try_establish_on_nodes(initial, self.known_peers.clone().into_iter())
+            .try_establish_on_nodes(initial, self.known_peers.clone().into_iter(), fetcher)
             .await
         {
             Ok(result) => return Ok(result),
@@ -180,6 +217,7 @@ impl MetadataReader {
                 initial_peers
                     .into_iter()
                     .map(UntranslatedEndpoint::ContactPoint),
+                fetcher,
             )
             .await
         {
@@ -197,26 +235,27 @@ impl MetadataReader {
         }
     }
 
-    /// Tries to establish a control connection and fetch metadata on each node from
-    /// the given iterator.
+    /// Tries to establish a control connection and fetch metadata (through the
+    /// caller-provided `fetch`) on each node from the given iterator.
     ///
-    /// Returns the first working, host-filter-accepted control connection together
-    /// with its metadata. Two situations yield metadata but no control connection
-    /// (`Ok((None, metadata))`):
+    /// Returns the first working, host-filter-accepted control connection
+    /// together with its metadata and the payload `fetch` produced on it. Two
+    /// situations yield metadata but no control connection (`Ok((None, metadata))`):
     /// - every node that could be queried is rejected by the host filter — the
     ///   metadata is valid cluster-wide, but none of the connections may be kept;
-    /// - `initial` is true and a connection was established but its metadata query
+    /// - `initial` is true and a connection was established but its metadata fetch
     ///   failed — dummy metadata is returned so the session can still start.
     ///
     /// Returns `Err(None)` if the iterator was empty (no connection was ever
     /// attempted), or `Err(Some(err))` with the most recent error otherwise.
-    async fn try_establish_on_nodes(
+    async fn try_establish_on_nodes<F: FetchOnCandidate>(
         &mut self,
         initial: bool,
         nodes: impl Iterator<Item = UntranslatedEndpoint>,
+        fetcher: &mut F,
     ) -> Result<
         (
-            Option<(ControlConnection, ControlConnectionEvents)>,
+            Option<(ControlConnection, ControlConnectionEvents, F::Payload)>,
             Metadata,
         ),
         Option<MetadataError>,
@@ -231,7 +270,7 @@ impl MetadataReader {
             let peer_address = peer.address();
             debug!("Trying to establish control connection on {peer_address}");
 
-            let (cc, cc_events) = match Self::make_control_connection(
+            let (cc, mut cc_events) = match Self::make_control_connection(
                 peer,
                 self.control_connection_config.clone(),
                 self.cc_config.clone(),
@@ -251,12 +290,12 @@ impl MetadataReader {
                 }
             };
 
-            let metadata = match cc.query_metadata().await {
-                Ok(topology_update) => topology_update.apply(self),
+            let (topology_update, payload) = match fetcher.fetch(&cc, &mut cc_events).await {
+                Ok(fetched) => fetched,
                 Err(err) => {
                     if initial {
                         // The control connection was established, but the initial
-                        // metadata query failed. Prefer any valid metadata already
+                        // metadata fetch failed. Prefer any valid metadata already
                         // obtained from a rejected node; otherwise fall back to dummy
                         // metadata so the session can still start. Either way, drop the
                         // control connection so it is re-established at the repair cadence.
@@ -283,6 +322,7 @@ impl MetadataReader {
                 }
             };
 
+            let metadata = topology_update.apply(self);
             debug!("Fetched new metadata");
 
             if self.is_cc_endpoint_rejected(cc.endpoint(), &metadata) {
@@ -293,7 +333,7 @@ impl MetadataReader {
                 continue;
             }
 
-            return Ok((Some((cc, cc_events)), metadata));
+            return Ok((Some((cc, cc_events, payload)), metadata));
         }
 
         match rejected_metadata {

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -24,7 +24,8 @@ use tracing::{debug, error, warn};
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{
-    ControlConnection, ControlConnectionCache, ControlConnectionEvents, MetadataRequestTimeouts,
+    ControlConnection, ControlConnectionCache, ControlConnectionConfig, ControlConnectionEvents,
+    MetadataRequestTimeouts,
 };
 use crate::cluster::metadata::{
     ClientRoutesUpdate, Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
@@ -45,15 +46,14 @@ pub(crate) struct MetadataReader {
     // Configuration values - they will stay the same during whole lifetime of MetadataReader.
     // =======================================================================================
     control_connection_config: ConnectionConfig,
-    request_timeouts: MetadataRequestTimeouts,
+    /// Configuration stamped onto every control connection this reader creates;
+    /// governs what the control connection's metadata queries fetch.
+    cc_config: ControlConnectionConfig,
     hostname_resolution_timeout: Option<Duration>,
-    keyspaces_to_fetch: Vec<String>,
-    schema_metadata_fetch_mode: SchemaMetadataFetchMode,
     host_filter: Option<Arc<dyn HostFilter>>,
     // When no known peer is reachable, initial known nodes are resolved once again as a fallback
     // and establishing control connection to them is attempted.
     initial_known_nodes: Vec<KnownNode>,
-    client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
 
     // ====================================================================
     // Mutable state of MetadataReader. It will change during its lifetime.
@@ -94,18 +94,20 @@ impl MetadataReader {
 
         Ok(MetadataReader {
             control_connection_config: connection_config,
-            request_timeouts,
+            cc_config: ControlConnectionConfig {
+                keyspaces_to_fetch,
+                schema_metadata_fetch_mode,
+                client_routes_subscriber,
+                request_timeouts,
+            },
             hostname_resolution_timeout,
             known_peers: initial_peers
                 .into_iter()
                 .map(UntranslatedEndpoint::ContactPoint)
                 .collect(),
-            keyspaces_to_fetch,
-            schema_metadata_fetch_mode,
             host_filter: host_filter.clone(),
             initial_known_nodes,
             cc_cache,
-            client_routes_subscriber,
         })
     }
 
@@ -249,9 +251,9 @@ impl MetadataReader {
             let (cc, cc_events) = match Self::make_control_connection(
                 peer,
                 self.control_connection_config.clone(),
-                self.request_timeouts,
+                self.cc_config.request_timeouts,
                 Arc::clone(&self.cc_cache),
-                self.client_routes_subscriber.is_some(),
+                self.cc_config.client_routes_subscriber.is_some(),
             )
             .await
             {
@@ -330,9 +332,10 @@ impl MetadataReader {
     ) -> Result<Metadata, MetadataError> {
         cc.query_metadata(
             cc.endpoint().address().port(),
-            &self.keyspaces_to_fetch,
-            self.schema_metadata_fetch_mode,
-            self.client_routes_subscriber
+            &self.cc_config.keyspaces_to_fetch,
+            self.cc_config.schema_metadata_fetch_mode,
+            self.cc_config
+                .client_routes_subscriber
                 .as_ref()
                 .map(|subscriber| subscriber.get_connection_ids()),
         )
@@ -455,7 +458,7 @@ impl MetadataReader {
         cc: &ControlConnection,
         evt: &ClientRoutesChangeEvent,
     ) -> Result<Option<ClientRoutesUpdate>, MetadataError> {
-        let Some(subscriber) = &self.client_routes_subscriber else {
+        let Some(subscriber) = &self.cc_config.client_routes_subscriber else {
             // No subscriber, but received an event? Strange enough, but nothing to be done here.
             warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
             return Ok(None);

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -252,7 +252,7 @@ impl MetadataReader {
             };
 
             let metadata = match cc.query_metadata().await {
-                Ok(metadata) => metadata,
+                Ok(topology_update) => topology_update.apply(self),
                 Err(err) => {
                     if initial {
                         // The control connection was established, but the initial
@@ -284,7 +284,6 @@ impl MetadataReader {
             };
 
             debug!("Fetched new metadata");
-            self.update_known_peers(&metadata);
 
             if self.is_cc_endpoint_rejected(cc.endpoint(), &metadata) {
                 // The node hosting this control connection is rejected by the host
@@ -303,7 +302,7 @@ impl MetadataReader {
         }
     }
 
-    pub(super) fn update_known_peers(&mut self, metadata: &Metadata) {
+    fn update_known_peers(&mut self, metadata: &Metadata) {
         let host_filter = self.host_filter.as_ref();
         self.known_peers = metadata
             .peers
@@ -407,6 +406,30 @@ impl MetadataReader {
                 },
             )),
         }
+    }
+}
+
+/// Freshly fetched [`Metadata`] that the [`MetadataReader`] has not yet absorbed.
+///
+/// [`ControlConnection::query_metadata`] returns its result wrapped in this
+/// guard, so that the fetched metadata cannot be used without the reader
+/// updating its known peers from it first: the only way to extract the
+/// [`Metadata`] is [`apply`](Self::apply).
+#[must_use = "the fetched metadata must be applied to the MetadataReader"]
+pub(super) struct TopologyUpdateGuard {
+    metadata: Metadata,
+}
+
+impl TopologyUpdateGuard {
+    pub(super) fn new(metadata: Metadata) -> Self {
+        Self { metadata }
+    }
+
+    /// Updates the reader's known peers from the fetched metadata and releases
+    /// the metadata itself.
+    pub(super) fn apply(self, reader: &mut MetadataReader) -> Metadata {
+        reader.update_known_peers(&self.metadata);
+        self.metadata
     }
 }
 

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -12,7 +12,8 @@
 //! - Host filtering to ensure the control connection is established to an accepted node
 //!
 //! Ownership of the established control connection lives outside the reader (in the
-//! metadata worker); the reader only knows how to create one and fetch metadata on it.
+//! metadata worker); the reader only knows how to create one. The metadata queries
+//! themselves are methods on [`ControlConnection`], configured at its creation.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,11 +29,10 @@ use crate::cluster::control_connection::{
     MetadataRequestTimeouts,
 };
 use crate::cluster::metadata::{
-    ClientRoutesUpdate, Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
+    Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
 };
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
-use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::frame::server_event_type::EventTypeV2 as EventType;
 use crate::network::{ConnectionConfig, open_connection};
 use crate::policies::host_filter::HostFilter;
@@ -109,23 +109,6 @@ impl MetadataReader {
             initial_known_nodes,
             cc_cache,
         })
-    }
-
-    /// Fetches metadata using an already-established control connection.
-    ///
-    /// On success, updates `self.known_peers` with the peers from the fetched
-    /// metadata. Does **not** retry on other nodes — the caller should drop the
-    /// control connection and call
-    /// [`establish_cc_and_fetch_metadata`](Self::establish_cc_and_fetch_metadata)
-    /// if this fails.
-    pub(crate) async fn fetch_metadata_on_cc(
-        &mut self,
-        cc: &ControlConnection,
-    ) -> Result<Metadata, MetadataError> {
-        let metadata = self.query_metadata_on_cc(cc).await?;
-        debug!("Fetched new metadata");
-        self.update_known_peers(&metadata);
-        Ok(metadata)
     }
 
     /// Establishes a control connection and fetches metadata in one go.
@@ -251,9 +234,8 @@ impl MetadataReader {
             let (cc, cc_events) = match Self::make_control_connection(
                 peer,
                 self.control_connection_config.clone(),
-                self.cc_config.request_timeouts,
+                self.cc_config.clone(),
                 Arc::clone(&self.cc_cache),
-                self.cc_config.client_routes_subscriber.is_some(),
             )
             .await
             {
@@ -269,7 +251,7 @@ impl MetadataReader {
                 }
             };
 
-            let metadata = match self.query_metadata_on_cc(&cc).await {
+            let metadata = match cc.query_metadata().await {
                 Ok(metadata) => metadata,
                 Err(err) => {
                     if initial {
@@ -321,28 +303,7 @@ impl MetadataReader {
         }
     }
 
-    /// Queries metadata on the given control connection.
-    ///
-    /// This is a thin wrapper over [`ControlConnection::query_metadata`] that fills in
-    /// the reader's configuration (keyspaces to fetch, whether to fetch schema). It does
-    /// **not** update `known_peers` nor touch the control connection state.
-    async fn query_metadata_on_cc(
-        &self,
-        cc: &ControlConnection,
-    ) -> Result<Metadata, MetadataError> {
-        cc.query_metadata(
-            cc.endpoint().address().port(),
-            &self.cc_config.keyspaces_to_fetch,
-            self.cc_config.schema_metadata_fetch_mode,
-            self.cc_config
-                .client_routes_subscriber
-                .as_ref()
-                .map(|subscriber| subscriber.get_connection_ids()),
-        )
-        .await
-    }
-
-    fn update_known_peers(&mut self, metadata: &Metadata) {
+    pub(super) fn update_known_peers(&mut self, metadata: &Metadata) {
         let host_filter = self.host_filter.as_ref();
         self.known_peers = metadata
             .peers
@@ -407,9 +368,8 @@ impl MetadataReader {
     async fn make_control_connection(
         endpoint: UntranslatedEndpoint,
         mut config: ConnectionConfig,
-        request_timeouts: MetadataRequestTimeouts,
+        cc_config: ControlConnectionConfig,
         cache: Arc<ControlConnectionCache>,
-        register_for_client_routes_events: bool,
     ) -> Result<(ControlConnection, ControlConnectionEvents), MetadataError> {
         let (sender, receiver) = tokio::sync::mpsc::channel(32);
         // setting event_sender field in connection config will cause control connection to
@@ -420,7 +380,7 @@ impl MetadataReader {
             EventType::StatusChange,
             EventType::SchemaChange,
         ];
-        if register_for_client_routes_events {
+        if cc_config.client_routes_subscriber.is_some() {
             events_to_register_for.push(EventType::ClientRoutesChange);
         }
 
@@ -433,75 +393,20 @@ impl MetadataReader {
         .await;
 
         match open_result {
-            Ok((con, recv)) => {
-                let (cc, cc_events) =
-                    ControlConnection::new(Arc::new(con), endpoint, cache, recv, receiver);
-                Ok((cc.with_request_timeouts(request_timeouts), cc_events))
-            }
+            Ok((con, recv)) => Ok(ControlConnection::new(
+                Arc::new(con),
+                endpoint,
+                cc_config,
+                cache,
+                recv,
+                receiver,
+            )),
             Err(conn_err) => Err(MetadataError::ConnectionPoolError(
                 ConnectionPoolError::Broken {
                     last_connection_error: conn_err,
                 },
             )),
         }
-    }
-
-    /// Performs a partial fetch of `system.client_routes`. Partial means that filtering is done
-    /// not only by connection ids known to the driver (which is always the case), but also
-    /// by host ids - only for the hosts whose ids are present in the event payload.
-    ///
-    /// Returns the resulting [`ClientRoutesUpdate`], or `None` if there is no subscriber
-    /// configured or the event contained no connection ids relevant to this driver. Merging
-    /// the update into the [`ClientRoutesSubscriber`]'s knowledge is the caller's job.
-    pub(in super::super) async fn fetch_client_routes_update_on_event(
-        &self,
-        cc: &ControlConnection,
-        evt: &ClientRoutesChangeEvent,
-    ) -> Result<Option<ClientRoutesUpdate>, MetadataError> {
-        let Some(subscriber) = &self.cc_config.client_routes_subscriber else {
-            // No subscriber, but received an event? Strange enough, but nothing to be done here.
-            warn!("BUG: Received ClientRoutesChange event, but no ClientRoutesSubscriber was set!");
-            return Ok(None);
-        };
-
-        #[deny(clippy::wildcard_enum_match_arm)]
-        let (connection_ids, host_ids) = match evt {
-            ClientRoutesChangeEvent::UpdateNodes {
-                connection_ids,
-                host_ids,
-            } => (connection_ids, host_ids),
-            _ => unreachable!("clippy testifies that the match is exhaustive"),
-        };
-
-        // TODO: this is wasteful - it allocates both strings and a vec.
-        // This won't be a performance problem, because UPDATE_NODES events are not frequent.
-        // As an optimization, we can implement ser/de for some special new iterator type,
-        // to avoid the need to allocate when serializing collections.
-        let connection_ids: Vec<String> = connection_ids
-            .iter()
-            .filter(|&conn_id| subscriber.get_connection_ids().contains(conn_id))
-            .cloned()
-            .collect();
-
-        if connection_ids.is_empty() {
-            // The event contained no relevant connection IDs.
-            // Nothing to be done.
-            return Ok(None);
-        }
-
-        // Although this is vaguely documented, the semantics of an event with connection ids [A, B, C] and host ids [X, Y, Z]
-        // is that the following entries were added/updated/removed: `[(A, X), (B, Y), (C, Z)]`.
-        // Unfortunately, we can't really query Scylla this way. Therefore, we do the query: `WHERE connection id IN ? AND host id IN ?`,
-        // which fetches possibly more routes than necessary, for example `(A, Z)` or `(C, Y)`.
-        // This is a tradeoff - the only alternative is issuing multiple queries, one per connection id.
-        // I believe the tradeoff here is correct.
-        let client_routes = cc.query_client_routes(&connection_ids, host_ids).await?;
-
-        Ok(Some(ClientRoutesUpdate::from_event(
-            evt,
-            subscriber.get_connection_ids(),
-            &client_routes,
-        )))
     }
 }
 

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -127,7 +127,7 @@ impl MetadataReader {
     ///
     /// In both of these cases the caller is expected to re-establish the control
     /// connection at the repair cadence.
-    pub(crate) async fn establish_cc_and_fetch_metadata(
+    pub(super) async fn establish_cc_and_fetch_metadata(
         &mut self,
         initial: bool,
     ) -> Result<

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -43,12 +43,35 @@ pub(in super::super) enum MetadataChanges {
         /// state resulting from `metadata` has been published.
         refresh_responses: Vec<tokio::sync::oneshot::Sender<Result<(), MetadataError>>>,
     },
-    /// For know, only client_routes can be updates separately. Later we'll add more stuff here.
-    Partial {
-        /// Partial client-routes snapshots fetched in response to
-        /// CLIENT_ROUTES_CHANGE events.
-        client_routes_updates: ClientRoutesUpdate,
-    },
+    /// Partial updates: everything learned since the last full fetch, one field
+    /// per partial fetch type.
+    Partial(PartialMetadataChanges),
+}
+
+/// The partial counterpart of a full metadata fetch: independently fetched
+/// updates of individual metadata aspects, one field per partial fetch type.
+/// Currently only client routes can be fetched partially.
+///
+/// Each field merges on its own, without looking at the others. This makes
+/// merging commutative across types, which keeps this struct correct even when
+/// partial fetches of different types run concurrently and complete in an
+/// order different from the one they were started in.
+#[derive(Default)]
+pub(in super::super) struct PartialMetadataChanges {
+    /// Partial client-routes snapshots fetched in response to
+    /// CLIENT_ROUTES_CHANGE events.
+    pub(in super::super) client_routes_updates: Option<ClientRoutesUpdate>,
+}
+
+impl PartialMetadataChanges {
+    /// Records a partial client-routes snapshot, merging it into the one
+    /// already pending, if any.
+    fn merge_client_routes_update(&mut self, new_client_routes: ClientRoutesUpdate) {
+        match &mut self.client_routes_updates {
+            None => self.client_routes_updates = Some(new_client_routes),
+            Some(existing) => existing.merge(new_client_routes),
+        }
+    }
 }
 
 impl MetadataUpdate {
@@ -70,7 +93,7 @@ impl MetadataUpdate {
         // Newest wins: an older, not-yet-applied fetch is worthless now.
         // Caveat: We need to NOT drop the old refresh channel.
         match &mut update.metadata_changes {
-            None | Some(MetadataChanges::Partial { .. }) => {
+            None | Some(MetadataChanges::Partial(_)) => {
                 update.metadata_changes = Some(MetadataChanges::Full {
                     metadata,
                     refresh_responses: refresh_response.into_iter().collect(),
@@ -96,14 +119,12 @@ impl MetadataUpdate {
         let update = Self::slot_mut(slot);
         match &mut update.metadata_changes {
             None => {
-                update.metadata_changes = Some(MetadataChanges::Partial {
-                    client_routes_updates: new_client_routes,
-                });
+                let mut partial = PartialMetadataChanges::default();
+                partial.merge_client_routes_update(new_client_routes);
+                update.metadata_changes = Some(MetadataChanges::Partial(partial));
             }
-            Some(MetadataChanges::Partial {
-                client_routes_updates,
-            }) => {
-                client_routes_updates.merge(new_client_routes);
+            Some(MetadataChanges::Partial(partial)) => {
+                partial.merge_client_routes_update(new_client_routes);
             }
             Some(MetadataChanges::Full {
                 metadata,
@@ -195,12 +216,6 @@ impl ClientRoutesUpdate {
                     .into_iter()
                     .map(move |(connection_id, route)| (host_id, connection_id, route))
             })
-    }
-
-    /// Return self by value, leaving empty update in its place.
-    pub(crate) fn take(&mut self) -> Self {
-        let map = std::mem::take(&mut self.updates);
-        Self { updates: map }
     }
 
     /// Merges a newer update into this one. Entries of `newer` override entries of `self`

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 
 use tokio::sync::oneshot;
@@ -7,7 +7,6 @@ use uuid::Uuid;
 
 use crate::cluster::metadata::{ClientRoute, ClientRoutes, Metadata};
 use crate::errors::MetadataError;
-use crate::frame::response::event::ClientRoutesChangeEvent;
 
 /// An explicit request to refresh cluster metadata, sent by
 /// [`Cluster::refresh_metadata`](crate::cluster::worker::Cluster::refresh_metadata).
@@ -136,12 +135,14 @@ impl MetadataUpdate {
     }
 }
 
-/// A partial, mergeable update of client routes, derived from a
-/// CLIENT_ROUTES_CHANGE:UPDATE_NODES event and from the partial snapshot of
-/// `system.client_routes` fetched in response to that event.
+/// A partial, mergeable update of client routes, derived from the
+/// (connection id, host id) pairs listed by CLIENT_ROUTES_CHANGE:UPDATE_NODES
+/// events and from the partial snapshot of `system.client_routes` fetched in
+/// response to them.
 ///
-/// Each entry corresponds to a (host id, connection id) pair listed in the event
-/// and relevant to the driver (i.e. with a connection id the driver monitors):
+/// Each entry corresponds to a (host id, connection id) pair listed by an
+/// event and relevant to the driver (i.e. with a connection id the driver
+/// monitors):
 /// - `Some(route)` - the route was created or updated;
 /// - `None` - the route was removed.
 #[derive(Debug, Default)]
@@ -151,40 +152,33 @@ pub(crate) struct ClientRoutesUpdate {
 }
 
 impl ClientRoutesUpdate {
-    /// Builds an update from the event and the partial snapshot fetched in response to it.
+    /// Builds an update from the (connection id, host id) pairs listed by
+    /// CLIENT_ROUTES_CHANGE:UPDATE_NODES events and the partial snapshot
+    /// fetched in response to them.
     ///
-    /// Only the (connection id, host id) pairs actually listed in the event and having
-    /// a connection id monitored by the driver are taken into account. Routes present in
-    /// `fetched` that do not correspond to any such pair are ignored: the fetch query is
-    /// `WHERE connection_id IN ? AND host_id IN ?`, so it returns the full cross product,
-    /// while the event's semantics is a zip of both lists.
-    pub(crate) fn from_event(
-        event: &ClientRoutesChangeEvent,
+    /// Only the pairs with a connection id monitored by the driver (i.e.
+    /// present in `relevant_connection_ids`) are taken into account. Routes
+    /// present in `fetched` that do not correspond to any such pair are
+    /// ignored: the fetch query is `WHERE connection_id IN ? AND host_id IN ?`,
+    /// so it returns the full cross product of the ids, while the events'
+    /// semantics is the pairs.
+    pub(crate) fn from_pairs(
+        pairs: &HashSet<(String, Uuid)>,
         relevant_connection_ids: &[String],
         fetched: &ClientRoutes,
     ) -> Self {
-        #[deny(clippy::wildcard_enum_match_arm)]
-        let (connection_ids, host_ids) = match event {
-            ClientRoutesChangeEvent::UpdateNodes {
-                connection_ids,
-                host_ids,
-            } => (connection_ids, host_ids),
-            _ => unreachable!("clippy testifies that the match is exhaustive"),
-        };
-
         let mut updates: HashMap<Uuid, HashMap<String, Option<ClientRoute>>> = HashMap::new();
 
-        for (connection_id, &host_id) in connection_ids
+        for (connection_id, host_id) in pairs
             .iter()
-            .zip(host_ids)
-            .filter(|(connection_id, _host_id)| relevant_connection_ids.contains(connection_id))
+            .filter(|(conn_id, _host_id)| relevant_connection_ids.contains(conn_id))
         {
             let route = fetched
                 .routes
-                .get(&host_id)
+                .get(host_id)
                 .and_then(|routes_for_host| routes_for_host.get(connection_id).cloned());
             updates
-                .entry(host_id)
+                .entry(*host_id)
                 .or_default()
                 .insert(connection_id.clone(), route);
         }
@@ -250,7 +244,7 @@ mod tests {
     }
 
     // Builds a ClientRoutesUpdate directly from (host, connection id, entry) triples,
-    // bypassing `from_event` — the merge logic is independent of how the update
+    // bypassing `from_pairs` — the merge logic is independent of how the update
     // was derived.
     fn update_from_entries(entries: Vec<(Uuid, &str, Option<ClientRoute>)>) -> ClientRoutesUpdate {
         let mut updates: HashMap<Uuid, HashMap<String, Option<ClientRoute>>> = HashMap::new();
@@ -311,7 +305,22 @@ mod tests {
         event: &ClientRoutesChangeEvent,
         fetched: ClientRoutes,
     ) -> ClientRoutesUpdate {
-        ClientRoutesUpdate::from_event(event, translator.get_connection_ids(), &fetched)
+        let ClientRoutesChangeEvent::UpdateNodes {
+            connection_ids,
+            host_ids,
+        } = event
+        else {
+            unreachable!("tests only construct UpdateNodes events")
+        };
+        ClientRoutesUpdate::from_pairs(
+            &connection_ids
+                .iter()
+                .cloned()
+                .zip(host_ids.iter().copied())
+                .collect(),
+            translator.get_connection_ids(),
+            &fetched,
+        )
     }
 
     // `ClientRoutesUpdate::merge`: entries of the newer update override entries of
@@ -524,12 +533,12 @@ mod tests {
         assert!(!sequential.routes.contains_key(&host_b));
     }
 
-    // `ClientRoutesUpdate::from_event` must only pick up (host id, connection id)
-    // pairs listed in the event and relevant to the driver; routes returned by the
+    // `ClientRoutesUpdate::from_pairs` must only pick up (host id, connection id)
+    // pairs listed by the event and relevant to the driver; routes returned by the
     // re-fetch that do not correspond to an event pair are cross-product artifacts
     // of the `WHERE connection_id IN ? AND host_id IN ?` query and must be ignored.
     #[test]
-    fn update_from_event_ignores_cross_product_artifacts_and_irrelevant_conn_ids() {
+    fn update_from_pairs_ignores_cross_product_artifacts_and_irrelevant_conn_ids() {
         let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
             "conn-1".to_string(),
         )]);
@@ -562,10 +571,10 @@ mod tests {
         );
     }
 
-    // `ClientRoutesUpdate::from_event`: an event pair with no matching route in the
-    // re-fetch yields an explicit `None` entry, i.e. a deletion.
+    // `ClientRoutesUpdate::from_pairs`: an event pair with no matching route in
+    // the re-fetch yields an explicit `None` entry, i.e. a deletion.
     #[test]
-    fn update_from_event_yields_none_for_missing_route() {
+    fn update_from_pairs_yields_none_for_missing_route() {
         let config = make_config(vec![ClientRoutesProxy::new_with_connection_id(
             "conn-1".to_string(),
         )]);

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::ops::ControlFlow;
-use std::pin::Pin;
+use std::pin::{Pin, pin};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -13,7 +13,9 @@ use crate::cluster::control_connection::{
 };
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
 use crate::cluster::metadata::{ClientRoutesUpdate, Metadata};
-use crate::errors::MetadataError;
+use crate::errors::{
+    BrokenConnectionErrorKind, ConnectionError, ConnectionPoolError, MetadataError,
+};
 use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::frame::response::event::EventV2 as Event;
 use crate::frame::response::event::StatusChangeEvent;
@@ -81,22 +83,22 @@ pub(in super::super) struct EstablishedCc {
     plan: FetchPlan,
 }
 
-/// The [`FetchOnCandidate`] implementation that
-/// [`MetadataReader::establish_cc_and_fetch_metadata`] runs on each candidate
-/// connection on the worker's behalf.
-struct CandidateFetcher;
+/// Adapts [`MetadataWorker::fetch_on_candidate`] to the [`FetchOnCandidate`]
+/// trait that [`MetadataReader::establish_cc_and_fetch_metadata`] consumes,
+/// lending it the worker's updates channel.
+struct CandidateFetcher<'a> {
+    updates: &'a mut merge_channel::Sender<MetadataUpdate>,
+}
 
-impl FetchOnCandidate for CandidateFetcher {
+impl FetchOnCandidate for CandidateFetcher<'_> {
     type Payload = FetchPlan;
 
     async fn fetch(
         &mut self,
         cc: &ControlConnection,
-        _cc_events: &mut ControlConnectionEvents,
+        cc_events: &mut ControlConnectionEvents,
     ) -> Result<(TopologyUpdateGuard, FetchPlan), MetadataError> {
-        cc.query_metadata()
-            .await
-            .map(|topology_update| (topology_update, FetchPlan::default()))
+        MetadataWorker::fetch_on_candidate(self.updates, cc, cc_events).await
     }
 }
 
@@ -114,7 +116,9 @@ enum EventAction {
 }
 
 /// The fetch work that [`MetadataWorker::work_on_cc`] owes but has not started
-/// yet, because the fetch that must precede it is still in flight.
+/// yet, because the fetch that must precede it is still in flight. Also
+/// produced by [`MetadataWorker::fetch_on_candidate`], recording the fetch
+/// work that accrued during establishment for `work_on_cc` to start from.
 ///
 /// The starter step at the top of the loop drains this plan into
 /// [`PendingFetches`] as soon as the blocking fetch completes, so whenever the
@@ -348,19 +352,87 @@ impl MetadataWorker {
 
     /// Establishes a control connection, fetching metadata in the process -
     /// see [`MetadataReader::establish_cc_and_fetch_metadata`], to which this
-    /// delegates the candidate iteration.
+    /// delegates the candidate iteration. Each candidate is fetched on (and
+    /// its events drained) by [`fetch_on_candidate`](Self::fetch_on_candidate).
     async fn establish(
         &mut self,
         initial: bool,
     ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {
         let (kept, metadata) = self
             .metadata_reader
-            .establish_cc_and_fetch_metadata(initial, &mut CandidateFetcher)
+            .establish_cc_and_fetch_metadata(
+                initial,
+                &mut CandidateFetcher {
+                    updates: &mut self.updates,
+                },
+            )
             .await?;
         Ok((
             kept.map(|(cc, events, plan)| EstablishedCc { cc, events, plan }),
             metadata,
         ))
+    }
+
+    /// Function that fetches `Metadata` on a new potential CC,
+    /// while concurrently draining events and preparing initial `FetchPlan`.
+    ///
+    /// # Establishment never blocks either
+    ///
+    /// The rule of [`work_on_cc`](Self::work_on_cc) applies here too: the
+    /// connection's reader task delivers server events through a bounded
+    /// channel and blocks once it fills, no longer processing query responses
+    /// either - and events flow from the moment the connection is opened (it
+    /// REGISTERs during setup). Awaiting `query_metadata` without draining
+    /// events would thus let a burst of events deadlock the establishment.
+    /// Hence the fetch is awaited only in `select!`, with event draining as
+    /// the other branch.
+    async fn fetch_on_candidate(
+        updates: &mut merge_channel::Sender<MetadataUpdate>,
+        cc: &ControlConnection,
+        cc_events: &mut ControlConnectionEvents,
+    ) -> Result<(TopologyUpdateGuard, FetchPlan), MetadataError> {
+        let mut plan = FetchPlan::default();
+        let mut fetch = pin!(cc.query_metadata());
+        loop {
+            tokio::select! {
+                fetch_result = &mut fetch => {
+                    return fetch_result.map(|topology_update| (topology_update, plan));
+                }
+
+                cc_event = cc_events.wait_for_event() => match cc_event {
+                    ControlConnectionEvent::ServerEvent(event) => {
+                        // `Break` (the cluster worker is gone) is deliberately
+                        // ignored.
+                        // Returning Err will cause MetadataReader to move to the next
+                        // node in the plan, which is pointless on shutdown. It will only
+                        // cause unnecessary connections, and weird errors, potentially
+                        // even returning dummy metadata on initial fetch.
+                        // If ClusterWorker is shutting down (which is the only case this
+                        // could happen), then we will shutdown soon too, so ignoring is not a problem.
+                        let _ = Self::absorb_server_event(updates, event, &mut plan);
+                    }
+                    ControlConnectionEvent::Broken(err) => {
+                        return Err(MetadataError::ConnectionPoolError(
+                            ConnectionPoolError::Broken {
+                                last_connection_error: err,
+                            },
+                        ));
+                    }
+                    ControlConnectionEvent::Shutdown => {
+                        // The runtime is shutting down; the connection's router
+                        // is gone without a farewell. Fail the candidate with
+                        // the closest error the vocabulary offers.
+                        return Err(MetadataError::ConnectionPoolError(
+                            ConnectionPoolError::Broken {
+                                last_connection_error: ConnectionError::BrokenConnection(
+                                    BrokenConnectionErrorKind::ChannelError.into(),
+                                ),
+                            },
+                        ));
+                    }
+                },
+            }
+        }
     }
 
     /// Runs the worker until the cluster (or the runtime) is gone.

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 use tracing::{debug, error};
+use uuid::Uuid;
 
 use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
@@ -59,6 +60,19 @@ pub(in super::super) struct MetadataWorker {
     /// (answering it, directly or through the cluster worker) before awaiting
     /// the next one.
     pending_request: Option<RefreshRequest>,
+}
+
+/// What a server event obliges the worker to fetch, as classified by
+/// [`MetadataWorker::handle_server_event`].
+enum EventAction {
+    /// Nothing to fetch - the event was fully handled synchronously.
+    None,
+    /// Fetch full metadata: the event describes a change (e.g. in topology)
+    /// that only a full fetch picks up.
+    FetchFull,
+    /// Fetch the client routes for these (connection id, host id) pairs, as
+    /// listed in a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
+    FetchClientRoutes { pairs: HashSet<(String, Uuid)> },
 }
 
 impl MetadataWorker {
@@ -217,22 +231,10 @@ impl MetadataWorker {
                             return ControlFlow::Continue(());
                         },
                         ControlConnectionEvent::ServerEvent(event) => {
-                            debug!("Received server event: {:?}", event);
-                            match event {
-                                Event::TopologyChange(_) => (), // Refresh immediately
-                                Event::ClientRoutesChange(evt) => {
-                                    // An UPDATE_NODES event pairs `connection_ids[i]`
-                                    // with `host_ids[i]`.
-                                    #[deny(clippy::wildcard_enum_match_arm)]
-                                    let pairs: HashSet<_> = match evt {
-                                        ClientRoutesChangeEvent::UpdateNodes {
-                                            connection_ids,
-                                            host_ids,
-                                        } => connection_ids.into_iter().zip(host_ids).collect(),
-                                        _ => unreachable!(
-                                            "clippy testifies that the match is exhaustive"
-                                        ),
-                                    };
+                            match self.handle_server_event(event)? {
+                                EventAction::None => continue, // Don't go to refreshing.
+                                EventAction::FetchFull => (), // Refresh immediately.
+                                EventAction::FetchClientRoutes { pairs } => {
                                     let res = cc.fetch_client_routes_update(&pairs).await;
                                     match res {
                                         Ok(None) => continue, // Nothing to apply; don't go to refreshing.
@@ -252,45 +254,6 @@ impl MetadataWorker {
                                         }
                                     }
                                 }
-                                Event::StatusChange(status) => {
-                                    // Tracking node status using events is unreliable because of the possibility of losing events
-                                    // when control connection is broken. A better thing to do here is to treat those events as hints
-                                    // for:
-                                    // - PoolRefiller - UP triggers immediate pool refill attempt, and
-                                    // - Keepaliver - DOWN triggers immediate keepalive query attempt.
-
-                                    match status {
-                                        StatusChangeEvent::Up(addr) => {
-                                            // When receiving an UP event, it is likely that the node just came back up and is now reachable.
-                                            // We optimistically trigger pool refill for this node.
-                                            // This is not guaranteed to be correct. It is for example possible that a network partition happened,
-                                            // the node lost connectivity to the cluster and driver; then it regained connectivity to the cluster,
-                                            // but not to the driver, and thus is still unreachable from the driver's perspective.
-                                            // However, in this case triggering pool refill is not harmful - if the node is actually reachable,
-                                            // then new connections will be opened to it, and if it is not reachable,
-                                            // then connection attempts will fail and the node will be marked as unreachable by `PoolRefiller`,
-                                            // so it won't be targeted by the load balancing policy.
-                                            if self.send_update(|slot| MetadataUpdate::merge_up_hint(slot, addr)).is_err() {
-                                                return ControlFlow::Break(());
-                                            }
-                                        },
-                                        StatusChangeEvent::Down(addr) => {
-                                            // When receiving a DOWN event, and the driver still sees the node as connected,
-                                            // we send a keepalive query on its connections to verify their liveness.
-                                            // The node is supposedly DOWN, so connections to this node are likely defunct.
-                                            // We expect that the keepalive query fails, in which case connections will be closed.
-                                            // As a result, the connection pool will report 0 connections to this node,
-                                            // and thus the node will not be targeted by the LoadBalancingPolicy,
-                                            // which is the desired behaviour. However, if the keepalive query succeeds,
-                                            // then the node is likely still alive (got stale event?), and we keep targeting it.
-                                            if self.send_update(|slot| MetadataUpdate::merge_down_hint(slot, addr)).is_err() {
-                                                return ControlFlow::Break(());
-                                            }
-                                        },
-                                    }
-                                    continue; // Don't go to refreshing.
-                                },
-                                _ => continue, // Don't go to refreshing.
                             }
                         }
                     }
@@ -318,6 +281,76 @@ impl MetadataWorker {
                     return ControlFlow::Continue(());
                 }
             }
+        }
+    }
+
+    /// Handles a single server event synchronously (status hints are published
+    /// right away) and returns the fetch work the event implies.
+    ///
+    /// Returns [`ControlFlow::Break`] if the worker should stop (the cluster
+    /// worker is gone).
+    fn handle_server_event(&mut self, event: Event) -> ControlFlow<(), EventAction> {
+        debug!("Received server event: {:?}", event);
+        match event {
+            Event::TopologyChange(_) => ControlFlow::Continue(EventAction::FetchFull),
+            Event::ClientRoutesChange(evt) => {
+                // An UPDATE_NODES event pairs `connection_ids[i]` with
+                // `host_ids[i]`.
+                #[deny(clippy::wildcard_enum_match_arm)]
+                let pairs = match evt {
+                    ClientRoutesChangeEvent::UpdateNodes {
+                        connection_ids,
+                        host_ids,
+                    } => connection_ids.into_iter().zip(host_ids).collect(),
+                    _ => unreachable!("clippy testifies that the match is exhaustive"),
+                };
+                ControlFlow::Continue(EventAction::FetchClientRoutes { pairs })
+            }
+            Event::StatusChange(status) => {
+                // Tracking node status using events is unreliable because of the possibility of losing events
+                // when control connection is broken. A better thing to do here is to treat those events as hints
+                // for:
+                // - PoolRefiller - UP triggers immediate pool refill attempt, and
+                // - Keepaliver - DOWN triggers immediate keepalive query attempt.
+
+                match status {
+                    StatusChangeEvent::Up(addr) => {
+                        // When receiving an UP event, it is likely that the node just came back up and is now reachable.
+                        // We optimistically trigger pool refill for this node.
+                        // This is not guaranteed to be correct. It is for example possible that a network partition happened,
+                        // the node lost connectivity to the cluster and driver; then it regained connectivity to the cluster,
+                        // but not to the driver, and thus is still unreachable from the driver's perspective.
+                        // However, in this case triggering pool refill is not harmful - if the node is actually reachable,
+                        // then new connections will be opened to it, and if it is not reachable,
+                        // then connection attempts will fail and the node will be marked as unreachable by `PoolRefiller`,
+                        // so it won't be targeted by the load balancing policy.
+                        if self
+                            .send_update(|slot| MetadataUpdate::merge_up_hint(slot, addr))
+                            .is_err()
+                        {
+                            return ControlFlow::Break(());
+                        }
+                    }
+                    StatusChangeEvent::Down(addr) => {
+                        // When receiving a DOWN event, and the driver still sees the node as connected,
+                        // we send a keepalive query on its connections to verify their liveness.
+                        // The node is supposedly DOWN, so connections to this node are likely defunct.
+                        // We expect that the keepalive query fails, in which case connections will be closed.
+                        // As a result, the connection pool will report 0 connections to this node,
+                        // and thus the node will not be targeted by the LoadBalancingPolicy,
+                        // which is the desired behaviour. However, if the keepalive query succeeds,
+                        // then the node is likely still alive (got stale event?), and we keep targeting it.
+                        if self
+                            .send_update(|slot| MetadataUpdate::merge_down_hint(slot, addr))
+                            .is_err()
+                        {
+                            return ControlFlow::Break(());
+                        }
+                    }
+                }
+                ControlFlow::Continue(EventAction::None)
+            }
+            _ => ControlFlow::Continue(EventAction::None),
         }
     }
 

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -303,6 +303,26 @@ impl MetadataWorker {
         }
     }
 
+    /// Establishes the initial control connection, fetching the initial
+    /// metadata in the process.
+    ///
+    /// Called by `Cluster::new` before the worker is spawned; the returned
+    /// control connection (if one could be kept) is handed back to
+    /// [`work`](Self::work) once the worker starts.
+    pub(in super::super) async fn establish_initial(
+        &mut self,
+    ) -> Result<
+        (
+            Option<(ControlConnection, ControlConnectionEvents)>,
+            Metadata,
+        ),
+        MetadataError,
+    > {
+        self.metadata_reader
+            .establish_cc_and_fetch_metadata(true)
+            .await
+    }
+
     /// Runs the worker until the cluster (or the runtime) is gone.
     ///
     /// `initial_cc` is the control connection that the initial metadata was fetched

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -20,8 +20,8 @@ use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::frame::response::event::EventV2 as Event;
 use crate::frame::response::event::StatusChangeEvent;
 
+use super::cc_establisher::{ControlConnectionEstablisher, FetchOnCandidate, TopologyUpdateGuard};
 use super::merge_channel;
-use super::reader::{FetchOnCandidate, MetadataReader, TopologyUpdateGuard};
 
 /// How often the worker attempts to establish a control connection while it has none.
 const CONTROL_CONNECTION_REPAIR_INTERVAL: Duration = Duration::from_secs(1);
@@ -41,7 +41,7 @@ const CONTROL_CONNECTION_REPAIR_INTERVAL: Duration = Duration::from_secs(1);
 pub(in super::super) struct MetadataWorker {
     /// Establishes control connections (fetching metadata in the process) and
     /// keeps the known peers to establish them to.
-    metadata_reader: MetadataReader,
+    cc_establisher: ControlConnectionEstablisher,
 
     // This value determines how frequently the metadata
     // worker will refresh the cluster metadata
@@ -84,7 +84,7 @@ pub(in super::super) struct EstablishedCc {
 }
 
 /// Adapts [`MetadataWorker::fetch_on_candidate`] to the [`FetchOnCandidate`]
-/// trait that [`MetadataReader::establish_cc_and_fetch_metadata`] consumes,
+/// trait that [`ControlConnectionEstablisher::establish_cc_and_fetch_metadata`] consumes,
 /// lending it the worker's updates channel.
 struct CandidateFetcher<'a> {
     updates: &'a mut merge_channel::Sender<MetadataUpdate>,
@@ -324,13 +324,13 @@ impl Future for PendingFetches<'_> {
 
 impl MetadataWorker {
     pub(in super::super) fn new(
-        metadata_reader: MetadataReader,
+        cc_establisher: ControlConnectionEstablisher,
         cluster_metadata_refresh_interval: Duration,
         refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
         updates: merge_channel::Sender<MetadataUpdate>,
     ) -> Self {
         Self {
-            metadata_reader,
+            cc_establisher,
             cluster_metadata_refresh_interval,
             refresh_channel,
             updates,
@@ -351,7 +351,7 @@ impl MetadataWorker {
     }
 
     /// Establishes a control connection, fetching metadata in the process -
-    /// see [`MetadataReader::establish_cc_and_fetch_metadata`], to which this
+    /// see [`ControlConnectionEstablisher::establish_cc_and_fetch_metadata`], to which this
     /// delegates the candidate iteration. Each candidate is fetched on (and
     /// its events drained) by [`fetch_on_candidate`](Self::fetch_on_candidate).
     async fn establish(
@@ -359,7 +359,7 @@ impl MetadataWorker {
         initial: bool,
     ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {
         let (kept, metadata) = self
-            .metadata_reader
+            .cc_establisher
             .establish_cc_and_fetch_metadata(
                 initial,
                 &mut CandidateFetcher {
@@ -403,7 +403,7 @@ impl MetadataWorker {
                     ControlConnectionEvent::ServerEvent(event) => {
                         // `Break` (the cluster worker is gone) is deliberately
                         // ignored.
-                        // Returning Err will cause MetadataReader to move to the next
+                        // Returning Err will cause ControlConnectionEstablisher to move to the next
                         // node in the plan, which is pointless on shutdown. It will only
                         // cause unnecessary connections, and weird errors, potentially
                         // even returning dummy metadata on initial fetch.
@@ -562,7 +562,7 @@ impl MetadataWorker {
 
         // The in-flight fetches. Their futures borrow `cc` and nothing else,
         // so the loop stays free to use `self` (in particular
-        // `self.metadata_reader`) while fetches are in flight.
+        // `self.cc_establisher`) while fetches are in flight.
         let mut pending_fetches = PendingFetches::Idle;
 
         loop {
@@ -582,7 +582,7 @@ impl MetadataWorker {
                     match fetch_outcome {
                         FetchOutcome::Full(Ok(topology_update)) => {
                             debug!("Fetched new metadata");
-                            let metadata = topology_update.apply(&mut self.metadata_reader);
+                            let metadata = topology_update.apply(&mut self.cc_establisher);
                             self.publish_metadata(metadata)?;
                         }
                         FetchOutcome::Full(Err(err)) => {

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -525,13 +525,7 @@ impl MetadataWorker {
                             return ControlFlow::Continue(());
                         },
                         ControlConnectionEvent::ServerEvent(event) => {
-                            match self.handle_server_event(event)? {
-                                EventAction::None => (),
-                                EventAction::FetchFull => plan.note_full_needed(),
-                                EventAction::FetchClientRoutes { pairs } => {
-                                    plan.note_client_routes(ClientRoutesFetchRequest { pairs })
-                                }
-                            }
+                            Self::absorb_server_event(&mut self.updates, event, &mut plan)?;
                         }
                     }
                 }
@@ -551,9 +545,15 @@ impl MetadataWorker {
     /// Handles a single server event synchronously (status hints are published
     /// right away) and returns the fetch work the event implies.
     ///
+    /// An associated function taking just the updates sender, so that event
+    /// handling does not require exclusive access to the whole worker.
+    ///
     /// Returns [`ControlFlow::Break`] if the worker should stop (the cluster
     /// worker is gone).
-    fn handle_server_event(&mut self, event: Event) -> ControlFlow<(), EventAction> {
+    fn handle_server_event(
+        updates: &mut merge_channel::Sender<MetadataUpdate>,
+        event: Event,
+    ) -> ControlFlow<(), EventAction> {
         debug!("Received server event: {:?}", event);
         match event {
             Event::TopologyChange(_) => ControlFlow::Continue(EventAction::FetchFull),
@@ -588,9 +588,10 @@ impl MetadataWorker {
                         // then new connections will be opened to it, and if it is not reachable,
                         // then connection attempts will fail and the node will be marked as unreachable by `PoolRefiller`,
                         // so it won't be targeted by the load balancing policy.
-                        if self
-                            .send_update(|slot| MetadataUpdate::merge_up_hint(slot, addr))
-                            .is_err()
+                        if Self::send_update_on(updates, |slot| {
+                            MetadataUpdate::merge_up_hint(slot, addr)
+                        })
+                        .is_err()
                         {
                             return ControlFlow::Break(());
                         }
@@ -604,9 +605,10 @@ impl MetadataWorker {
                         // and thus the node will not be targeted by the LoadBalancingPolicy,
                         // which is the desired behaviour. However, if the keepalive query succeeds,
                         // then the node is likely still alive (got stale event?), and we keep targeting it.
-                        if self
-                            .send_update(|slot| MetadataUpdate::merge_down_hint(slot, addr))
-                            .is_err()
+                        if Self::send_update_on(updates, |slot| {
+                            MetadataUpdate::merge_down_hint(slot, addr)
+                        })
+                        .is_err()
                         {
                             return ControlFlow::Break(());
                         }
@@ -616,6 +618,26 @@ impl MetadataWorker {
             }
             _ => ControlFlow::Continue(EventAction::None),
         }
+    }
+
+    /// Handles a single server event and folds the fetch work it implies into
+    /// `plan`.
+    ///
+    /// Returns [`ControlFlow::Break`] if the worker should stop (the cluster
+    /// worker is gone).
+    fn absorb_server_event(
+        updates: &mut merge_channel::Sender<MetadataUpdate>,
+        event: Event,
+        plan: &mut FetchPlan,
+    ) -> ControlFlow<()> {
+        match Self::handle_server_event(updates, event)? {
+            EventAction::None => (),
+            EventAction::FetchFull => plan.note_full_needed(),
+            EventAction::FetchClientRoutes { pairs } => {
+                plan.note_client_routes(ClientRoutesFetchRequest { pairs })
+            }
+        }
+        ControlFlow::Continue(())
     }
 
     /// Publishes freshly fetched metadata to the cluster worker.
@@ -656,7 +678,16 @@ impl MetadataWorker {
         &mut self,
         f: impl FnOnce(&mut Option<MetadataUpdate>),
     ) -> Result<(), merge_channel::SendError> {
-        self.updates.modify(f).inspect_err(|_| {
+        Self::send_update_on(&mut self.updates, f)
+    }
+
+    /// [`send_update`](Self::send_update) for callers that hold the updates
+    /// sender rather than the whole worker.
+    fn send_update_on(
+        updates: &mut merge_channel::Sender<MetadataUpdate>,
+        f: impl FnOnce(&mut Option<MetadataUpdate>),
+    ) -> Result<(), merge_channel::SendError> {
+        updates.modify(f).inspect_err(|_| {
             debug!("The cluster worker is gone. Shutting down MetadataWorker.");
         })
     }

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::ops::ControlFlow;
-use std::pin::{Pin, pin};
+use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -358,15 +358,20 @@ impl MetadataWorker {
         &mut self,
         initial: bool,
     ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {
-        let (kept, metadata) = self
-            .cc_establisher
-            .establish_cc_and_fetch_metadata(
-                initial,
-                &mut CandidateFetcher {
-                    updates: &mut self.updates,
-                },
-            )
-            .await?;
+        let mut fetcher = CandidateFetcher {
+            updates: &mut self.updates,
+        };
+        // Boxed AND `dyn`-erased for the same reason as the `query_metadata`
+        // future in [`fetch_on_candidate`](Self::fetch_on_candidate): this
+        // severs the whole establishment machinery (candidate iteration,
+        // connection opening, handshake) from the future type of
+        // `Session::connect`, which downstream crates compute the layout of.
+        // One allocation per establishment attempt.
+        let fetch: Pin<Box<dyn Future<Output = _> + Send>> = Box::pin(
+            self.cc_establisher
+                .establish_cc_and_fetch_metadata(initial, &mut fetcher),
+        );
+        let (kept, metadata) = fetch.await?;
         Ok((
             kept.map(|(cc, events, plan)| EstablishedCc { cc, events, plan }),
             metadata,
@@ -392,7 +397,17 @@ impl MetadataWorker {
         cc_events: &mut ControlConnectionEvents,
     ) -> Result<(TopologyUpdateGuard, FetchPlan), MetadataError> {
         let mut plan = FetchPlan::default();
-        let mut fetch = pin!(cc.query_metadata());
+        // Boxed AND `dyn`-erased (rather than `pin!`ed) to cut the future-type
+        // nesting here: `query_metadata`'s future tree is ~75 levels deep, and
+        // exposing it in this future's type - which every caller of
+        // `Session::connect` awaits through - used to blow past rustc's
+        // default 128 `recursion_limit` when computing layouts in downstream
+        // crates (including doctests, which cannot raise the limit). Note that
+        // the coercion to `dyn Future` is what actually cuts the layout
+        // recursion; a `Pin<Box<ConcreteFuture>>` is still recursed into. The
+        // cost is one allocation per establishment attempt, as negligible as
+        // in [`PendingFetches`].
+        let mut fetch: FullFetch<'_> = Box::pin(cc.query_metadata());
         loop {
             tokio::select! {
                 fetch_result = &mut fetch => {

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -301,9 +301,9 @@ impl MetadataWorker {
             last_refresh_time = Instant::now();
 
             match cc.query_metadata().await {
-                Ok(metadata) => {
+                Ok(topology_update) => {
                     debug!("Fetched new metadata");
-                    self.metadata_reader.update_known_peers(&metadata);
+                    let metadata = topology_update.apply(&mut self.metadata_reader);
                     // The refresh request, if any, is answered by the cluster worker, once the
                     // state resulting from this metadata is published - this is what makes
                     // `Cluster::refresh_metadata` return only after the new state is visible.

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ops::ControlFlow;
 use std::time::Duration;
 
@@ -8,6 +9,7 @@ use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
 };
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
+use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::frame::response::event::EventV2 as Event;
 use crate::frame::response::event::StatusChangeEvent;
 
@@ -232,7 +234,19 @@ impl MetadataWorker {
                             match event {
                                 Event::TopologyChange(_) => (), // Refresh immediately
                                 Event::ClientRoutesChange(evt) => {
-                                    let res = cc.fetch_client_routes_update_on_event(&evt).await;
+                                    // An UPDATE_NODES event pairs `connection_ids[i]`
+                                    // with `host_ids[i]`.
+                                    #[deny(clippy::wildcard_enum_match_arm)]
+                                    let pairs: HashSet<_> = match evt {
+                                        ClientRoutesChangeEvent::UpdateNodes {
+                                            connection_ids,
+                                            host_ids,
+                                        } => connection_ids.into_iter().zip(host_ids).collect(),
+                                        _ => unreachable!(
+                                            "clippy testifies that the match is exhaustive"
+                                        ),
+                                    };
+                                    let res = cc.fetch_client_routes_update(&pairs).await;
                                     match res {
                                         Ok(None) => continue, // Nothing to apply; don't go to refreshing.
                                         Ok(Some(routes)) => {

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 use std::ops::ControlFlow;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use tokio::time::Instant;
@@ -9,14 +11,15 @@ use uuid::Uuid;
 use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
 };
-use crate::cluster::metadata::Metadata;
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
+use crate::cluster::metadata::{ClientRoutesUpdate, Metadata};
+use crate::errors::MetadataError;
 use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::frame::response::event::EventV2 as Event;
 use crate::frame::response::event::StatusChangeEvent;
 
 use super::merge_channel;
-use super::reader::MetadataReader;
+use super::reader::{MetadataReader, TopologyUpdateGuard};
 
 /// How often the worker attempts to establish a control connection while it has none.
 const CONTROL_CONNECTION_REPAIR_INTERVAL: Duration = Duration::from_secs(1);
@@ -34,9 +37,8 @@ const CONTROL_CONNECTION_REPAIR_INTERVAL: Duration = Duration::from_secs(1);
 /// The control connection is therefore not a field, but a value owned by the
 /// currently running loop.
 pub(in super::super) struct MetadataWorker {
-    /// Fetches metadata and (re-)establishes control connections. Also keeps the
-    /// known peers and the client-routes subscriber, which it needs for
-    /// connection ids and event registration.
+    /// Establishes control connections (fetching metadata in the process) and
+    /// keeps the known peers to establish them to.
     metadata_reader: MetadataReader,
 
     // This value determines how frequently the metadata
@@ -59,6 +61,11 @@ pub(in super::super) struct MetadataWorker {
     /// Invariant: at most one request is pending at a time - both loops take it
     /// (answering it, directly or through the cluster worker) before awaiting
     /// the next one.
+    ///
+    /// Within [`work_on_cc`](Self::work_on_cc) a stronger invariant holds: while
+    /// a request is pending, the full fetch in flight was started after (and
+    /// because of) its receipt - see the `refresh_channel` branch there for how
+    /// its guard upholds this.
     pending_request: Option<RefreshRequest>,
 }
 
@@ -73,6 +80,211 @@ enum EventAction {
     /// Fetch the client routes for these (connection id, host id) pairs, as
     /// listed in a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
     FetchClientRoutes { pairs: HashSet<(String, Uuid)> },
+}
+
+/// The fetch work that [`MetadataWorker::work_on_cc`] owes but has not started
+/// yet, because the fetch that must precede it is still in flight.
+///
+/// The starter step at the top of the loop drains this plan into
+/// [`PendingFetches`] as soon as the blocking fetch completes, so whenever the
+/// loop awaits, everything still recorded here is genuinely blocked.
+///
+/// There is deliberately no state for "a full fetch and partial work owed at
+/// once": a due full fetch subsumes all partial work (see
+/// [`note_full_needed`](Self::note_full_needed)), so recording both would keep
+/// data only to throw it away.
+#[derive(Default)]
+enum FetchPlan {
+    /// Nothing is owed.
+    #[default]
+    Idle,
+    /// A full metadata fetch is owed: requested explicitly, implied by a
+    /// server event, or owed because a partial fetch failed.
+    Full,
+    /// Partial fetch work is owed, at most one entry per partial fetch type.
+    /// Currently client routes is the only such type; when more are added,
+    /// the payload becomes a struct with one optional entry per type (like
+    /// `PartialMetadataChanges`).
+    Partial(ClientRoutesFetchRequest),
+}
+
+impl FetchPlan {
+    /// Records that a full fetch is owed.
+    ///
+    /// Any partial work recorded so far is dropped: the full fetch starts no
+    /// earlier than now - hence after the events that made the partial work
+    /// due - and reads everything a partial fetch would, so it subsumes that
+    /// work.
+    fn note_full_needed(&mut self) {
+        *self = FetchPlan::Full;
+    }
+
+    /// Records client-routes work, merging it into the work already owed.
+    ///
+    /// If a full fetch is already owed, the work is dropped - subsumed, by the
+    /// argument in [`note_full_needed`](Self::note_full_needed).
+    fn note_client_routes(&mut self, request: ClientRoutesFetchRequest) {
+        match self {
+            FetchPlan::Idle => *self = FetchPlan::Partial(request),
+            FetchPlan::Partial(pending) => pending.merge(request),
+            FetchPlan::Full => (),
+        }
+    }
+}
+
+/// The (connection id, host id) pairs accumulated from CLIENT_ROUTES_CHANGE
+/// events, to be resolved by one partial client-routes fetch.
+///
+/// A set: merging the work of several events is a plain union, and identical
+/// pairs listed repeatedly are deduplicated for free.
+struct ClientRoutesFetchRequest {
+    pairs: HashSet<(String, Uuid)>,
+}
+
+impl ClientRoutesFetchRequest {
+    /// Merges another event's pairs in.
+    fn merge(&mut self, newer: Self) {
+        self.pairs.extend(newer.pairs);
+    }
+
+    /// Performs the partial fetch for the accumulated pairs.
+    ///
+    /// Takes `self` by value so that the returned future borrows only the
+    /// control connection - it is stored in [`PendingFetches`] across
+    /// `select!` iterations.
+    async fn fetch_on(
+        self,
+        cc: &ControlConnection,
+    ) -> Result<Option<ClientRoutesUpdate>, MetadataError> {
+        cc.fetch_client_routes_update(&self.pairs).await
+    }
+}
+
+/// A full-metadata fetch in flight.
+///
+/// Boxed to give the anonymous `async fn` future a nameable type, which is
+/// what lets [`PendingFetches`] offer
+/// [`start_due_fetches`](PendingFetches::start_due_fetches) as a plain method.
+/// The allocation cost is negligible: a fetch starts at most once per refresh
+/// interval, server event or refresh request.
+type FullFetch<'cc> =
+    Pin<Box<dyn Future<Output = Result<TopologyUpdateGuard, MetadataError>> + Send + 'cc>>;
+
+/// A partial client-routes fetch in flight; boxed for the same reason as
+/// [`FullFetch`].
+type ClientRoutesFetch<'cc> =
+    Pin<Box<dyn Future<Output = Result<Option<ClientRoutesUpdate>, MetadataError>> + Send + 'cc>>;
+
+/// The fetches of [`MetadataWorker::work_on_cc`] currently in flight, owning
+/// their futures - which borrow the control connection, hence the lifetime.
+///
+/// The shape makes the scheduling rules structural:
+/// - a full fetch never has anything running beside it (it subsumes and
+///   preempts all partial work), and
+/// - per partial fetch type, at most one fetch runs at a time. Currently
+///   client routes is the only such type; when more are added, `Partial`
+///   becomes a struct variant with one optional future per type, which is
+///   also how partial fetches of different types get to run concurrently.
+///
+/// [`start_due_fetches`](Self::start_due_fetches) starts the fetches that the
+/// [`FetchPlan`] owes. As a [`Future`], `PendingFetches` resolves to the
+/// [`FetchOutcome`] of the in-flight fetch once it completes, emptying `self`
+/// back to [`Idle`](Self::Idle) - so a completed fetch is never polled again.
+/// While `Idle`, polling pends forever *without registering a waker*: an idle
+/// value alone never wakes the worker. This is sound in `work_on_cc` because
+/// fetches are only started between `select!`s, never while one is being
+/// awaited, and the `select!` always has branches that do register wakers
+/// (e.g. event draining).
+///
+/// Cancel-safe: the futures live in this value, not in the `select!` branch
+/// polling it, so losing the `select!` race leaves the in-flight fetch intact.
+enum PendingFetches<'cc> {
+    /// No fetch is in flight.
+    Idle,
+    /// A full metadata fetch is in flight.
+    Full { fetch: FullFetch<'cc> },
+    /// A partial client-routes fetch is in flight.
+    Partial {
+        client_routes_fetch: ClientRoutesFetch<'cc>,
+    },
+}
+
+impl<'cc> PendingFetches<'cc> {
+    /// The starter step of [`MetadataWorker::work_on_cc`]: starts every fetch
+    /// that is due per `plan` (or per the periodic refresh schedule) and not
+    /// blocked, so that the worker never awaits while startable work is owed.
+    fn start_due_fetches(
+        &mut self,
+        plan: &mut FetchPlan,
+        next_refresh_deadline: &mut Instant,
+        refresh_interval: Duration,
+        cc: &'cc ControlConnection,
+    ) {
+        // A full fetch is due when a server event or a refresh request
+        // demanded one, or when the periodic deadline has passed.
+        if !matches!(self, PendingFetches::Full { .. })
+            && (matches!(plan, FetchPlan::Full) || Instant::now() >= *next_refresh_deadline)
+        {
+            // Starting the full fetch drops both the partial work owed by the
+            // plan and any running partial fetch: the full fetch reads all of
+            // that data, and reads it after the events that made the partial
+            // work due, so both are subsumed.
+            *plan = FetchPlan::Idle;
+            *next_refresh_deadline = deadline_after(Instant::now(), refresh_interval);
+
+            debug!("Requesting metadata refresh");
+            *self = PendingFetches::Full {
+                fetch: Box::pin(cc.query_metadata()),
+            };
+            return;
+        }
+
+        // Partial client-routes work starts only when nothing at all is in flight.
+        if matches!(self, PendingFetches::Idle) {
+            let request = match std::mem::take(plan) {
+                FetchPlan::Idle => return, // Nothing to do.
+                FetchPlan::Partial(request) => request,
+                FetchPlan::Full => unreachable!("Covered by the previous block"),
+            };
+            *self = PendingFetches::Partial {
+                client_routes_fetch: Box::pin(request.fetch_on(cc)),
+            };
+        }
+    }
+}
+
+/// What [`PendingFetches`] resolves to: the output of whichever in-flight
+/// fetch completed, tagged with its fetch type.
+enum FetchOutcome {
+    Full(Result<TopologyUpdateGuard, MetadataError>),
+    ClientRoutes(Result<Option<ClientRoutesUpdate>, MetadataError>),
+}
+
+impl Future for PendingFetches<'_> {
+    type Output = FetchOutcome;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // `PendingFetches` is `Unpin` (the fetch futures are heap-pinned), so
+        // it can be worked on through a plain `&mut`.
+        let this = self.get_mut();
+        let outcome = match this {
+            PendingFetches::Idle => return Poll::Pending,
+            PendingFetches::Full { fetch } => match fetch.as_mut().poll(cx) {
+                Poll::Ready(result) => FetchOutcome::Full(result),
+                Poll::Pending => return Poll::Pending,
+            },
+            PendingFetches::Partial {
+                client_routes_fetch,
+            } => match client_routes_fetch.as_mut().poll(cx) {
+                Poll::Ready(result) => FetchOutcome::ClientRoutes(result),
+                Poll::Pending => return Poll::Pending,
+            },
+        };
+
+        // The completed fetch has been consumed; drop its future.
+        *this = PendingFetches::Idle;
+        Poll::Ready(outcome)
+    }
 }
 
 impl MetadataWorker {
@@ -166,9 +378,7 @@ impl MetadataWorker {
 
             // Wait until it's time for the next attempt, unless a refresh request
             // makes us attempt earlier.
-            let sleep_until = attempt_time
-                .checked_add(CONTROL_CONNECTION_REPAIR_INTERVAL)
-                .unwrap_or_else(Instant::now);
+            let sleep_until = deadline_after(attempt_time, CONTROL_CONNECTION_REPAIR_INTERVAL);
 
             tokio::select! {
                 _sleep_finished = tokio::time::sleep_until(sleep_until) => (),
@@ -186,6 +396,31 @@ impl MetadataWorker {
     /// Serves the given control connection: refreshes metadata on it (periodically,
     /// on request and in reaction to server events) and drains its events.
     ///
+    /// # This loop never blocks
+    ///
+    /// The connection's reader task delivers server events through a bounded
+    /// channel and blocks when the channel is full; blocked, it does not process
+    /// query responses either. If this loop awaited a fetch directly, a burst of
+    /// events could thus deadlock it: the fetch would wait for the reader task,
+    /// which waits for this loop to drain events, which waits for the fetch.
+    ///
+    /// Hence the rule: this loop awaits only in `select!`, with event draining as
+    /// one of the branches, and everything outside the `select!` is synchronous.
+    /// Fetches run as futures owned by a [`PendingFetches`] value, polled by the
+    /// `select!` alongside the other branches. Fetch work that cannot start yet
+    /// is recorded in a [`FetchPlan`]. On every iteration, before awaiting,
+    /// [`PendingFetches::start_due_fetches`] converts due plan entries into
+    /// pending fetches, under these rules:
+    ///
+    /// - At most one fetch per type runs at a time; work for a busy type waits
+    ///   in the plan.
+    /// - A due full fetch preempts everything: it abandons the running partial
+    ///   fetch and drops the plan's partial work. Both are subsumed - the full
+    ///   fetch reads all of that data, and reads it after the events that made
+    ///   the partial work due. Conversely, partial work that becomes due *while*
+    ///   a full fetch runs stays in the plan: the fetch may have read the
+    ///   corresponding tables before the triggering event arrived.
+    ///
     /// Returns [`ControlFlow::Continue`] once the control connection is deemed
     /// defunct and should be replaced, or [`ControlFlow::Break`] if the worker
     /// should stop.
@@ -194,25 +429,74 @@ impl MetadataWorker {
         cc: ControlConnection,
         mut cc_events: ControlConnectionEvents,
     ) -> ControlFlow<()> {
-        let mut last_refresh_time = Instant::now();
+        let mut plan = FetchPlan::default();
+        let mut next_refresh_deadline =
+            deadline_after(Instant::now(), self.cluster_metadata_refresh_interval);
+
+        // The in-flight fetches. Their futures borrow `cc` and nothing else,
+        // so the loop stays free to use `self` (in particular
+        // `self.metadata_reader`) while fetches are in flight.
+        let mut pending_fetches = PendingFetches::Idle;
 
         loop {
-            // Wait until it's time for the next refresh
-            let sleep_until: Instant = last_refresh_time
-                .checked_add(self.cluster_metadata_refresh_interval)
-                .unwrap_or_else(Instant::now);
+            pending_fetches.start_due_fetches(
+                &mut plan,
+                &mut next_refresh_deadline,
+                self.cluster_metadata_refresh_interval,
+                &cc,
+            );
 
-            let sleep_future = tokio::time::sleep_until(sleep_until);
-            tokio::pin!(sleep_future);
+            // Computed before `select!` for the branch guards, which cannot
+            // borrow `pending_fetches`: the fetch branch polls it mutably.
+            let full_fetch_in_flight = matches!(pending_fetches, PendingFetches::Full { .. });
 
             tokio::select! {
-                _sleep_finished = sleep_future => {
-                    // Time to do periodic refresh.
-                },
+                fetch_outcome = &mut pending_fetches => {
+                    match fetch_outcome {
+                        FetchOutcome::Full(Ok(topology_update)) => {
+                            debug!("Fetched new metadata");
+                            let metadata = topology_update.apply(&mut self.metadata_reader);
+                            self.publish_metadata(metadata)?;
+                        }
+                        FetchOutcome::Full(Err(err)) => {
+                            debug!(
+                                error = %err,
+                                "Failed to fetch metadata on the current control connection. \
+                                Will try to establish a new one."
+                            );
+                            // The control connection is considered defunct - drop it. The pending
+                            // request, if any, is retried (and answered) while establishing a new one.
+                            return ControlFlow::Continue(());
+                        }
+                        FetchOutcome::ClientRoutes(Ok(None)) => (), // Nothing to apply.
+                        FetchOutcome::ClientRoutes(Ok(Some(routes))) => {
+                            if self.send_update(|slot| MetadataUpdate::merge_client_routes_update(slot, routes)).is_err() {
+                                return ControlFlow::Break(());
+                            }
+                        }
+                        FetchOutcome::ClientRoutes(Err(err)) => {
+                            error!(
+                                "Error when fetching client route updates: {err}. \
+                                Scheduling a metadata refresh, because the control connection is likely defunct."
+                            );
+                            plan.note_full_needed();
+                        }
+                    }
+                }
 
-                maybe_refresh_request = self.refresh_channel.recv() => {
+                // While a full fetch is in flight, refresh requests wait in the
+                // channel (`Cluster::refresh_metadata` awaits the bounded send).
+                // Accepting one now would break the promise behind
+                // `pending_request`: the running fetch was started before the
+                // request, so its data may predate it. With this guard, a
+                // request is only received when the starter step can begin a
+                // full fetch for it right away.
+                maybe_refresh_request = self.refresh_channel.recv(), if !full_fetch_in_flight => {
                     match maybe_refresh_request {
-                        Some(request) => self.set_pending_request(request),
+                        Some(request) => {
+                            self.set_pending_request(request);
+                            plan.note_full_needed();
+                        }
                         None => return ControlFlow::Break(()), // If refresh_channel was closed then cluster was dropped, we can stop working
                     }
                 }
@@ -221,6 +505,12 @@ impl MetadataWorker {
                     match control_connection_event {
                         ControlConnectionEvent::Shutdown => {
                             // The runtime is shutting down. We can stop working.
+                            //
+                            // Known issue (predating this worker): if a refresh
+                            // request is pending, dropping it here makes the
+                            // requester's `Cluster::refresh_metadata` panic on the
+                            // response channel. During runtime shutdown the
+                            // requester task is being torn down anyway.
                             debug!("Got shutdown control connection event. Shutting down MetadataWorker.");
                             return ControlFlow::Break(());
                         },
@@ -228,57 +518,31 @@ impl MetadataWorker {
                             // The control connection was broken. Have a new one established;
                             // the first attempt will be immediate, and if it does not succeed,
                             // subsequent attempts will be issued every second.
+                            //
+                            // The in-flight fetches, if any, are abandoned: establishing
+                            // a new control connection fetches full metadata, which
+                            // subsumes them.
                             return ControlFlow::Continue(());
                         },
                         ControlConnectionEvent::ServerEvent(event) => {
                             match self.handle_server_event(event)? {
-                                EventAction::None => continue, // Don't go to refreshing.
-                                EventAction::FetchFull => (), // Refresh immediately.
+                                EventAction::None => (),
+                                EventAction::FetchFull => plan.note_full_needed(),
                                 EventAction::FetchClientRoutes { pairs } => {
-                                    let res = cc.fetch_client_routes_update(&pairs).await;
-                                    match res {
-                                        Ok(None) => continue, // Nothing to apply; don't go to refreshing.
-                                        Ok(Some(routes)) => {
-                                            if self.send_update(|slot| MetadataUpdate::merge_client_routes_update(slot, routes)).is_err() {
-                                                return ControlFlow::Break(());
-                                            }
-                                            continue; // Don't go to refreshing.
-                                        }
-                                        Err(err) =>
-                                        {
-                                            error!(
-                                                "Error when fetching client route updates: {err}. \
-                                                Proceeding with metadata refresh, because the control connection is likely defunct."
-                                            );
-                                            // Refresh immediately.
-                                        }
-                                    }
+                                    plan.note_client_routes(ClientRoutesFetchRequest { pairs })
                                 }
                             }
                         }
                     }
                 }
-            }
 
-            // Perform the refresh
-            debug!("Requesting metadata refresh");
-            last_refresh_time = Instant::now();
-
-            match cc.query_metadata().await {
-                Ok(topology_update) => {
-                    debug!("Fetched new metadata");
-                    let metadata = topology_update.apply(&mut self.metadata_reader);
-                    self.publish_metadata(metadata)?;
-                }
-                Err(err) => {
-                    debug!(
-                        error = %err,
-                        "Failed to fetch metadata on the current control connection. \
-                        Will try to establish a new one."
-                    );
-                    // The control connection is considered defunct - drop it. The pending
-                    // request, if any, is retried (and answered) while establishing a new one.
-                    return ControlFlow::Continue(());
+                // While a full fetch is in flight the deadline is irrelevant:
+                // it is reset when the next fetch starts. Once no full fetch
+                // runs, a passed deadline completes this branch immediately and
+                // the starter step begins the periodic fetch.
+                _deadline_passed = tokio::time::sleep_until(next_refresh_deadline), if !full_fetch_in_flight => {
+                    // Nothing to do here: the starter step notices the passed
+                    // deadline.
                 }
             }
         }
@@ -395,5 +659,76 @@ impl MetadataWorker {
         self.updates.modify(f).inspect_err(|_| {
             debug!("The cluster worker is gone. Shutting down MetadataWorker.");
         })
+    }
+}
+
+/// `start + interval`, saturating to "now" on overflow (as good as any instant
+/// that far in the future).
+fn deadline_after(start: Instant, interval: Duration) -> Instant {
+    start.checked_add(interval).unwrap_or_else(Instant::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::pin::Pin;
+    use std::task::{Context, Poll, Waker};
+
+    use crate::cluster::metadata::Metadata;
+
+    use super::{FetchOutcome, PendingFetches, TopologyUpdateGuard};
+
+    fn poll_once(pending_fetches: &mut PendingFetches<'_>) -> Poll<FetchOutcome> {
+        Pin::new(pending_fetches).poll(&mut Context::from_waker(Waker::noop()))
+    }
+
+    fn dummy_topology_update() -> TopologyUpdateGuard {
+        TopologyUpdateGuard::new(Metadata::new_dummy(&[]))
+    }
+
+    /// While idle, `PendingFetches` must pend (and not panic or spin):
+    /// `work_on_cc` polls it in its `select!` unconditionally.
+    #[test]
+    fn idle_pends() {
+        let mut pending_fetches = PendingFetches::Idle;
+
+        assert!(poll_once(&mut pending_fetches).is_pending());
+    }
+
+    /// A completed fetch yields its output, tagged with the fetch type, and
+    /// empties the value back to `Idle`, so that the next starter step can
+    /// start another fetch (and the completed future is never polled again).
+    #[test]
+    fn completed_fetch_resolves_and_empties() {
+        let mut pending_fetches = PendingFetches::Full {
+            fetch: Box::pin(async { Ok(dummy_topology_update()) }),
+        };
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::Full(Ok(_)))
+        ));
+        assert!(matches!(pending_fetches, PendingFetches::Idle));
+        assert!(poll_once(&mut pending_fetches).is_pending());
+
+        let mut pending_fetches = PendingFetches::Partial {
+            client_routes_fetch: Box::pin(async { Ok(None) }),
+        };
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::ClientRoutes(Ok(None)))
+        ));
+        assert!(matches!(pending_fetches, PendingFetches::Idle));
+    }
+
+    /// Losing a `select!` race (the polling borrow being dropped) must leave
+    /// the in-flight fetch intact.
+    #[test]
+    fn unfinished_fetch_stays_in_flight() {
+        let mut pending_fetches = PendingFetches::Full {
+            fetch: Box::pin(pending()),
+        };
+
+        assert!(poll_once(&mut pending_fetches).is_pending());
+        assert!(matches!(pending_fetches, PendingFetches::Full { .. }));
     }
 }

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -69,6 +69,13 @@ pub(in super::super) struct MetadataWorker {
     pending_request: Option<RefreshRequest>,
 }
 
+/// A [`ControlConnection`] established by [`MetadataWorker::establish`],
+/// bundled with everything the worker needs to serve it.
+pub(in super::super) struct EstablishedCc {
+    cc: ControlConnection,
+    events: ControlConnectionEvents,
+}
+
 /// What a server event obliges the worker to fetch, as classified by
 /// [`MetadataWorker::handle_server_event`].
 enum EventAction {
@@ -311,38 +318,44 @@ impl MetadataWorker {
     /// [`work`](Self::work) once the worker starts.
     pub(in super::super) async fn establish_initial(
         &mut self,
-    ) -> Result<
-        (
-            Option<(ControlConnection, ControlConnectionEvents)>,
-            Metadata,
-        ),
-        MetadataError,
-    > {
-        self.metadata_reader
-            .establish_cc_and_fetch_metadata(true)
-            .await
+    ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {
+        self.establish(true).await
+    }
+
+    /// Establishes a control connection, fetching metadata in the process -
+    /// see [`MetadataReader::establish_cc_and_fetch_metadata`], to which this
+    /// delegates the candidate iteration.
+    async fn establish(
+        &mut self,
+        initial: bool,
+    ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {
+        let (kept, metadata) = self
+            .metadata_reader
+            .establish_cc_and_fetch_metadata(initial)
+            .await?;
+        Ok((
+            kept.map(|(cc, events)| EstablishedCc { cc, events }),
+            metadata,
+        ))
     }
 
     /// Runs the worker until the cluster (or the runtime) is gone.
     ///
     /// `initial_cc` is the control connection that the initial metadata was fetched
     /// on; `None` means none could be kept, in which case one is established first.
-    pub(in super::super) async fn work(
-        mut self,
-        initial_cc: Option<(ControlConnection, ControlConnectionEvents)>,
-    ) {
+    pub(in super::super) async fn work(mut self, initial_cc: Option<EstablishedCc>) {
         let mut next_cc = initial_cc;
 
         loop {
-            let (cc, cc_events) = match next_cc.take() {
-                Some(cc) => cc,
+            let established = match next_cc.take() {
+                Some(established) => established,
                 None => match self.work_without_cc().await {
                     ControlFlow::Break(()) => return,
-                    ControlFlow::Continue(cc) => cc,
+                    ControlFlow::Continue(established) => established,
                 },
             };
 
-            match self.work_on_cc(cc, cc_events).await {
+            match self.work_on_cc(established).await {
                 ControlFlow::Break(()) => return,
                 // The control connection is defunct - establish a new one.
                 ControlFlow::Continue(()) => (),
@@ -360,23 +373,17 @@ impl MetadataWorker {
     /// pending refresh request (through the cluster worker) and publishes an update.
     ///
     /// Returns [`ControlFlow::Break`] if the worker should stop.
-    async fn work_without_cc(
-        &mut self,
-    ) -> ControlFlow<(), (ControlConnection, ControlConnectionEvents)> {
+    async fn work_without_cc(&mut self) -> ControlFlow<(), EstablishedCc> {
         loop {
             debug!("Attempting to establish a new control connection");
             let attempt_time = Instant::now();
 
-            match self
-                .metadata_reader
-                .establish_cc_and_fetch_metadata(false)
-                .await
-            {
-                Ok((cc, metadata)) => {
+            match self.establish(false).await {
+                Ok((kept, metadata)) => {
                     self.publish_metadata(metadata)?;
 
-                    if let Some(cc) = cc {
-                        return ControlFlow::Continue(cc);
+                    if let Some(established) = kept {
+                        return ControlFlow::Continue(established);
                     }
                     // Metadata was fetched, but no control connection could be kept
                     // (e.g. every reachable node is rejected by the host filter).
@@ -444,11 +451,11 @@ impl MetadataWorker {
     /// Returns [`ControlFlow::Continue`] once the control connection is deemed
     /// defunct and should be replaced, or [`ControlFlow::Break`] if the worker
     /// should stop.
-    async fn work_on_cc(
-        &mut self,
-        cc: ControlConnection,
-        mut cc_events: ControlConnectionEvents,
-    ) -> ControlFlow<()> {
+    async fn work_on_cc(&mut self, established: EstablishedCc) -> ControlFlow<()> {
+        let EstablishedCc {
+            cc,
+            events: mut cc_events,
+        } = established;
         let mut plan = FetchPlan::default();
         let mut next_refresh_deadline =
             deadline_after(Instant::now(), self.cluster_metadata_refresh_interval);

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -19,7 +19,7 @@ use crate::frame::response::event::EventV2 as Event;
 use crate::frame::response::event::StatusChangeEvent;
 
 use super::merge_channel;
-use super::reader::{MetadataReader, TopologyUpdateGuard};
+use super::reader::{FetchOnCandidate, MetadataReader, TopologyUpdateGuard};
 
 /// How often the worker attempts to establish a control connection while it has none.
 const CONTROL_CONNECTION_REPAIR_INTERVAL: Duration = Duration::from_secs(1);
@@ -74,6 +74,30 @@ pub(in super::super) struct MetadataWorker {
 pub(in super::super) struct EstablishedCc {
     cc: ControlConnection,
     events: ControlConnectionEvents,
+    /// The fetch work implied by server events that arrived while the
+    /// establishment fetch was in flight. Such events may postdate the data
+    /// that fetch read, so [`MetadataWorker::work_on_cc`] starts from this
+    /// plan rather than from an empty one.
+    plan: FetchPlan,
+}
+
+/// The [`FetchOnCandidate`] implementation that
+/// [`MetadataReader::establish_cc_and_fetch_metadata`] runs on each candidate
+/// connection on the worker's behalf.
+struct CandidateFetcher;
+
+impl FetchOnCandidate for CandidateFetcher {
+    type Payload = FetchPlan;
+
+    async fn fetch(
+        &mut self,
+        cc: &ControlConnection,
+        _cc_events: &mut ControlConnectionEvents,
+    ) -> Result<(TopologyUpdateGuard, FetchPlan), MetadataError> {
+        cc.query_metadata()
+            .await
+            .map(|topology_update| (topology_update, FetchPlan::default()))
+    }
 }
 
 /// What a server event obliges the worker to fetch, as classified by
@@ -331,10 +355,10 @@ impl MetadataWorker {
     ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {
         let (kept, metadata) = self
             .metadata_reader
-            .establish_cc_and_fetch_metadata(initial)
+            .establish_cc_and_fetch_metadata(initial, &mut CandidateFetcher)
             .await?;
         Ok((
-            kept.map(|(cc, events)| EstablishedCc { cc, events }),
+            kept.map(|(cc, events, plan)| EstablishedCc { cc, events, plan }),
             metadata,
         ))
     }
@@ -448,6 +472,10 @@ impl MetadataWorker {
     ///   a full fetch runs stays in the plan: the fetch may have read the
     ///   corresponding tables before the triggering event arrived.
     ///
+    /// The plan starts seeded from the [`EstablishedCc`]: events that arrived
+    /// while the establishment fetch was in flight may postdate its data, so
+    /// the fetch work they imply is still owed.
+    ///
     /// Returns [`ControlFlow::Continue`] once the control connection is deemed
     /// defunct and should be replaced, or [`ControlFlow::Break`] if the worker
     /// should stop.
@@ -455,8 +483,8 @@ impl MetadataWorker {
         let EstablishedCc {
             cc,
             events: mut cc_events,
+            mut plan,
         } = established;
-        let mut plan = FetchPlan::default();
         let mut next_refresh_deadline =
             deadline_after(Instant::now(), self.cluster_metadata_refresh_interval);
 

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -8,6 +8,7 @@ use tracing::{debug, error};
 use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
 };
+use crate::cluster::metadata::Metadata;
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
 use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::frame::response::event::EventV2 as Event;
@@ -126,21 +127,7 @@ impl MetadataWorker {
                 .await
             {
                 Ok((cc, metadata)) => {
-                    // The refresh request, if any, is answered by the cluster worker, once the
-                    // state resulting from this metadata is published - this is what makes
-                    // `Cluster::refresh_metadata` return only after the new state is visible.
-                    let response_chan = self
-                        .pending_request
-                        .take()
-                        .map(|request| request.response_chan);
-                    if self
-                        .send_update(|slot| {
-                            MetadataUpdate::merge_metadata(slot, metadata, response_chan)
-                        })
-                        .is_err()
-                    {
-                        return ControlFlow::Break(());
-                    }
+                    self.publish_metadata(metadata)?;
 
                     if let Some(cc) = cc {
                         return ControlFlow::Continue(cc);
@@ -318,21 +305,7 @@ impl MetadataWorker {
                 Ok(topology_update) => {
                     debug!("Fetched new metadata");
                     let metadata = topology_update.apply(&mut self.metadata_reader);
-                    // The refresh request, if any, is answered by the cluster worker, once the
-                    // state resulting from this metadata is published - this is what makes
-                    // `Cluster::refresh_metadata` return only after the new state is visible.
-                    let response_chan = self
-                        .pending_request
-                        .take()
-                        .map(|request| request.response_chan);
-                    if self
-                        .send_update(|slot| {
-                            MetadataUpdate::merge_metadata(slot, metadata, response_chan)
-                        })
-                        .is_err()
-                    {
-                        return ControlFlow::Break(());
-                    }
+                    self.publish_metadata(metadata)?;
                 }
                 Err(err) => {
                     debug!(
@@ -345,6 +318,27 @@ impl MetadataWorker {
                     return ControlFlow::Continue(());
                 }
             }
+        }
+    }
+
+    /// Publishes freshly fetched metadata to the cluster worker.
+    ///
+    /// The pending refresh request, if any, is attached: it is answered by the
+    /// cluster worker once the state resulting from this metadata is published -
+    /// this is what makes `Cluster::refresh_metadata` return only after the new
+    /// state is visible.
+    ///
+    /// Returns [`ControlFlow::Break`] if the worker should stop (the cluster
+    /// worker is gone).
+    fn publish_metadata(&mut self, metadata: Metadata) -> ControlFlow<()> {
+        let response_chan = self
+            .pending_request
+            .take()
+            .map(|request| request.response_chan);
+        match self.send_update(|slot| MetadataUpdate::merge_metadata(slot, metadata, response_chan))
+        {
+            Ok(()) => ControlFlow::Continue(()),
+            Err(_) => ControlFlow::Break(()),
         }
     }
 

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -232,7 +232,7 @@ impl MetadataWorker {
                             match event {
                                 Event::TopologyChange(_) => (), // Refresh immediately
                                 Event::ClientRoutesChange(evt) => {
-                                    let res = self.metadata_reader.fetch_client_routes_update_on_event(&cc, &evt).await;
+                                    let res = cc.fetch_client_routes_update_on_event(&evt).await;
                                     match res {
                                         Ok(None) => continue, // Nothing to apply; don't go to refreshing.
                                         Ok(Some(routes)) => {
@@ -300,8 +300,10 @@ impl MetadataWorker {
             debug!("Requesting metadata refresh");
             last_refresh_time = Instant::now();
 
-            match self.metadata_reader.fetch_metadata_on_cc(&cc).await {
+            match cc.query_metadata().await {
                 Ok(metadata) => {
+                    debug!("Fetched new metadata");
+                    self.metadata_reader.update_known_peers(&metadata);
                     // The refresh request, if any, is answered by the cluster worker, once the
                     // state resulting from this metadata is published - this is what makes
                     // `Cluster::refresh_metadata` return only after the new state is visible.

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -100,7 +100,7 @@ impl Cluster {
         let client_routes_subscriber = client_routes_address_translator
             .map(|translator| translator as Arc<dyn ClientRoutesSubscriber>);
 
-        let mut metadata_reader = MetadataReader::new(
+        let metadata_reader = MetadataReader::new(
             known_nodes,
             hostname_resolution_timeout,
             pool_config.connection_config.clone(),
@@ -114,13 +114,20 @@ impl Cluster {
 
         let mut node_status = HashMap::new();
 
-        let (cc, mut metadata) = metadata_reader
-            .establish_cc_and_fetch_metadata(true)
-            .await?;
+        let (metadata_updates_sender, metadata_updates_receiver) = merge_channel();
 
-        // The initial metadata is fetched before the worker exists, so the routes must be
-        // applied here - `ClusterState::new` below creates connection pools, which translate
-        // addresses through the subscriber.
+        let mut metadata_worker = MetadataWorker::new(
+            metadata_reader,
+            cluster_metadata_refresh_interval,
+            refresh_receiver,
+            metadata_updates_sender,
+        );
+
+        let (cc, mut metadata) = metadata_worker.establish_initial().await?;
+
+        // The initial metadata is fetched before the metadata worker is spawned, so the routes
+        // must be applied here - `ClusterState::new` below creates connection pools, which
+        // translate addresses through the subscriber.
         if let (Some(subscriber), Some(routes)) = (
             client_routes_subscriber.as_ref(),
             metadata.client_routes.take(),
@@ -154,8 +161,6 @@ impl Cluster {
         let cluster_state: Arc<ArcSwap<ClusterState>> =
             Arc::new(ArcSwap::from(Arc::new(cluster_state)));
 
-        let (metadata_updates_sender, metadata_updates_receiver) = merge_channel();
-
         let worker = ClusterWorker {
             cluster_state: cluster_state.clone(),
             node_status,
@@ -176,13 +181,6 @@ impl Cluster {
 
             metrics,
         };
-
-        let metadata_worker = MetadataWorker::new(
-            metadata_reader,
-            cluster_metadata_refresh_interval,
-            refresh_receiver,
-            metadata_updates_sender,
-        );
 
         let (fut, worker_handle) = worker.work().remote_handle();
         tokio::spawn(fut);

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -28,8 +28,8 @@ use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
 use super::metadata::Metadata;
+use super::metadata::cc_establisher::ControlConnectionEstablisher;
 use super::metadata::merge_channel::{self, merge_channel};
-use super::metadata::reader::MetadataReader;
 use super::metadata::worker::MetadataWorker;
 use super::state::ClusterState;
 
@@ -100,7 +100,7 @@ impl Cluster {
         let client_routes_subscriber = client_routes_address_translator
             .map(|translator| translator as Arc<dyn ClientRoutesSubscriber>);
 
-        let metadata_reader = MetadataReader::new(
+        let cc_establisher = ControlConnectionEstablisher::new(
             known_nodes,
             hostname_resolution_timeout,
             pool_config.connection_config.clone(),
@@ -117,7 +117,7 @@ impl Cluster {
         let (metadata_updates_sender, metadata_updates_receiver) = merge_channel();
 
         let mut metadata_worker = MetadataWorker::new(
-            metadata_reader,
+            cc_establisher,
             cluster_metadata_refresh_interval,
             refresh_receiver,
             metadata_updates_sender,

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -5,7 +5,7 @@ use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::cluster::metadata::SchemaMetadataFetchMode;
 use crate::cluster::metadata::update::{
-    MetadataChanges, MetadataUpdate, RefreshRequest, StatusHint,
+    MetadataChanges, MetadataUpdate, PartialMetadataChanges, RefreshRequest, StatusHint,
 };
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
@@ -424,9 +424,14 @@ impl ClusterWorker {
                         HashSet::new()
                     }
                 }
-                MetadataChanges::Partial {
+                MetadataChanges::Partial(PartialMetadataChanges {
                     client_routes_updates,
-                } => subscriber.merge_client_routes_update(client_routes_updates.take()),
+                }) => match client_routes_updates.take() {
+                    Some(client_routes_update) => {
+                        subscriber.merge_client_routes_update(client_routes_update)
+                    }
+                    None => HashSet::new(),
+                },
             }
         } else {
             HashSet::new()
@@ -466,10 +471,7 @@ impl ClusterWorker {
                     let _ = response_chan.send(Ok(()));
                 }
             }
-            None
-            | Some(MetadataChanges::Partial {
-                client_routes_updates: _,
-            }) => {
+            None | Some(MetadataChanges::Partial(_)) => {
                 // For now there is nothing that requires publishing new ClusterState.
                 // The only thing left to do is processing up hints.
                 process_up_hints(self.cluster_state.load().as_ref());

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -99,7 +99,7 @@ impl QueryResult {
     ///
     /// Rationale: driver uses [QueryResult] internally even if it does not have a [Node](crate::cluster::Node)
     /// corresponding to the connection that it executes requests on. This happens in
-    /// non-[Session](crate::client::session::Session) APIs (`MetadataReader::query_metadata()`,
+    /// non-[Session](crate::client::session::Session) APIs (`ControlConnectionEstablisher::query_metadata()`,
     /// `Connection::query_iter()`, etc.), most notably for a control connection upon initial metadata fetch.
     /// However, [QueryResult::request_coordinator] panics if [Coordinator] stored is [None].
     /// Therefore, extra care must be taken not to leak such [QueryResult] to the user.

--- a/scylla/tests/future_depth.rs
+++ b/scylla/tests/future_depth.rs
@@ -1,0 +1,67 @@
+//! Compile-time guard on how deeply the driver's public futures are nested.
+//!
+//! Awaiting an `async fn` embeds the callee's anonymous future type as a field
+//! of the caller's, so a chain of N awaits produces a type nested N deep, and
+//! `rustc` must recurse just as deep to compute its layout. That recursion is
+//! bounded by `recursion_limit`, and - this is the part that makes it our
+//! problem rather than a private one - the limit that applies is the one of
+//! *the crate being compiled*, not of the crate that defines the futures.
+//!
+//! So when `SessionBuilder::build()`'s future gets too deep, it is not this
+//! crate that stops compiling: it is every user crate that awaits it, with
+//!
+//! ```text
+//! error: queries overflow the depth limit!
+//!   = help: consider increasing the recursion limit by adding a
+//!           `#![recursion_limit = "256"]` attribute to your crate
+//! ```
+//!
+//! and nothing the user can do about it short of that attribute. Our doctests
+//! and integration tests are separate crates too, so they hit it first - but
+//! only as a puzzling CI failure whose obvious "fix" is to paste the attribute
+//! everywhere and let the real depth go on growing.
+//!
+//! Hence this file. It awaits the deepest chains we expose - session
+//! establishment and request execution - under a `recursion_limit` far below the
+//! 128 that `rustc` defaults to, so that growing those chains past the budget
+//! breaks this test, with the note below, instead of breaking users.
+//!
+//! At the time of writing the deepest of them - request execution - compiles at
+//! a limit of 68 but not at 64, against the budget of 80 set here and the 128 a
+//! user crate has. Session establishment, the chain this guard was written for,
+//! needs under 40.
+//!
+//! # If this test stops compiling
+//!
+//! Do not raise the limit here - the number is the point. Find the `.await`
+//! chain that grew and break it with a `Box::pin`, the way `Cluster::new` and
+//! `MetadataWorker::fetch_on_candidate` do: `Pin<Box<_>>` is a pointer, and the
+//! layout computation does not descend through it. Raise the budget only
+//! deliberately, knowing that it is spent out of a user's 128.
+#![recursion_limit = "80"]
+#![allow(missing_docs)]
+
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::errors::{ExecutionError, NewSessionError};
+use scylla::response::query_result::QueryResult;
+
+/// Session establishment: control connection, initial metadata fetch, pools.
+async fn _establish() -> Result<Session, NewSessionError> {
+    SessionBuilder::new()
+        .known_node("127.0.0.1:9042")
+        .build()
+        .await
+}
+
+/// Request execution: the other chain that user code awaits directly.
+async fn _execute(session: &Session) -> Result<QueryResult, ExecutionError> {
+    session
+        .query_unpaged("SELECT * FROM system.local", &[])
+        .await
+}
+
+/// Nothing to run: the test is that this file compiles under the
+/// `recursion_limit` set above.
+#[test]
+fn futures_are_shallow_enough_for_user_crates() {}

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -1,9 +1,3 @@
-// This hopefully fixes the following error that occurs in CI:
-// error: queries overflow the depth limit!
-//   |
-//   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`integration`)
-//   = note: query depth increased by 130 when computing layout of `{async block@scylla/tests/integration/ccm/authenticate.rs:39:1: 39:15}`
-#![recursion_limit = "256"]
 // Rigorous documentation is not necessary for integration tests.
 #![allow(missing_docs)]
 

--- a/scylla/tests/integration/metadata/event_flood.rs
+++ b/scylla/tests/integration/metadata/event_flood.rs
@@ -1,5 +1,20 @@
-//! Regression test: the metadata worker must keep draining server events while
-//! a metadata fetch is in flight.
+//! Regression tests: metadata fetches must keep draining server events while
+//! in flight.
+//!
+//! The control connection delivers server events through a bounded channel,
+//! and the connection's reader task blocks once that channel is full - which
+//! also stops query responses from being processed. Whoever awaits a metadata
+//! fetch must therefore keep draining events meanwhile: a fetch awaited
+//! without draining deadlocks with the reader task (the fetch's response is
+//! only processed once the events are drained, and events are only drained
+//! once the fetch completes). This holds for the metadata worker's serving
+//! loop as much as for the establishment paths (the initial fetch of session
+//! build, and the re-establishment of a broken control connection), because
+//! a control connection is registered for events from the moment it opens.
+//!
+//! Each test stalls metadata queries at the proxy, floods the control
+//! connection with far more events than the channel holds while a fetch is
+//! stalled, and requires the stalled operation to complete.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -25,23 +40,36 @@ const METADATA_QUERY_DELAY: Duration = Duration::from_secs(1);
 /// (32 entries as of writing) can hold.
 const FLOODED_EVENTS: usize = 100;
 
-/// Upper bound for the stalled refresh to complete. The refresh performs a
-/// handful of [`METADATA_QUERY_DELAY`]-stalled round trips, so a healthy
+/// Upper bound for the stalled operation to complete. Each operation performs
+/// a handful of [`METADATA_QUERY_DELAY`]-stalled round trips, so a healthy
 /// driver stays well under this; only a deadlocked one reaches it.
-const REFRESH_TIMEOUT: Duration = Duration::from_secs(30);
+const STALLED_OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// The control connection delivers server events through a bounded channel,
-/// and the connection's reader task blocks once that channel is full - which
-/// also stops query responses from being processed. The metadata worker must
-/// therefore keep draining events while a metadata fetch is in flight: a
-/// worker that awaited the fetch without draining would deadlock with it (the
-/// fetch's response is only processed once the events are drained, and the
-/// worker only drains events once the fetch completes).
+/// Matches the metadata queries of a control connection (only the control
+/// connection registers for events, hence the registration condition).
+fn cc_metadata_query_condition() -> Condition {
+    Condition::ConnectionRegisteredAnyEvent.and(
+        Condition::RequestOpcode(RequestOpcode::Query)
+            .or(Condition::RequestOpcode(RequestOpcode::Execute)),
+    )
+}
+
+/// Floods the control connections with forged STATUS_CHANGE events. The
+/// address named by the events does not matter: the deadlock under test sits
+/// in event *draining*, which precedes any interpretation of the event.
+fn flood_with_events(running_proxy: &scylla_proxy::RunningProxy) {
+    let flood_addr = SocketAddr::from(([127, 0, 0, 1], 9042));
+    for _ in 0..FLOODED_EVENTS {
+        inject_status_change_down(running_proxy, flood_addr);
+    }
+}
+
+/// The metadata worker must keep draining server events while a metadata
+/// fetch on its established control connection is in flight.
 ///
 /// The test stalls metadata queries on the control connection at the proxy,
-/// requests a refresh, floods the control connection with far more events
-/// than the channel holds while the fetch is stalled, and requires the
-/// refresh to complete.
+/// requests a refresh, floods the control connection while the fetch is
+/// stalled, and requires the refresh to complete.
 #[tokio::test]
 async fn metadata_fetch_completes_despite_event_flood() {
     setup_tracing();
@@ -61,18 +89,13 @@ async fn metadata_fetch_completes_despite_event_flood() {
                 .unwrap();
             wait_until_all_nodes_are_connected(3, &session).await;
 
-            // Stall every metadata query on the control connection (only the
-            // control connection registers for events, hence the condition)
-            // and observe the stalled frames. Installed only now, so that the
+            // Stall every metadata query on the control connection and
+            // observe the stalled frames. Installed only now, so that the
             // session's initial metadata fetch is unaffected.
             let (fetch_started_tx, mut fetch_started_rx) = mpsc::unbounded_channel();
-            let metadata_query_condition = Condition::ConnectionRegisteredAnyEvent.and(
-                Condition::RequestOpcode(RequestOpcode::Query)
-                    .or(Condition::RequestOpcode(RequestOpcode::Execute)),
-            );
             for node in running_proxy.running_nodes.iter_mut() {
                 node.prepend_request_rules(vec![RequestRule(
-                    metadata_query_condition.clone(),
+                    cc_metadata_query_condition(),
                     RequestReaction::delay(METADATA_QUERY_DELAY)
                         .with_feedback_when_performed(fetch_started_tx.clone()),
                 )]);
@@ -94,21 +117,180 @@ async fn metadata_fetch_completes_despite_event_flood() {
                 .await
                 .expect("proxy feedback channel closed unexpectedly");
 
-            // Flood the control connection. The address named by the events
-            // does not matter: the deadlock under test sits in event
-            // *draining*, which precedes any interpretation of the event.
-            let flood_addr = SocketAddr::from(([127, 0, 0, 1], 9042));
-            for _ in 0..FLOODED_EVENTS {
-                inject_status_change_down(&running_proxy, flood_addr);
-            }
+            flood_with_events(&running_proxy);
 
             // A worker that stops draining events during its fetch never sees
             // the fetch complete; the refresh then never resolves.
-            tokio::time::timeout(REFRESH_TIMEOUT, refresh)
+            tokio::time::timeout(STALLED_OPERATION_TIMEOUT, refresh)
                 .await
                 .expect(
                     "metadata refresh deadlocked: the metadata worker stopped draining \
                     server events while its metadata fetch was in flight",
+                )
+                .expect("refresh task panicked")
+                .expect("metadata refresh failed");
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Session build must drain server events while the initial metadata fetch is
+/// in flight: the fetch runs before the metadata worker is spawned, on a
+/// control connection that is already registered for events.
+///
+/// The test stalls metadata queries from the very start, floods the control
+/// connection while the initial fetch is stalled, and requires
+/// `SessionBuilder::build` to complete.
+#[tokio::test]
+async fn session_build_completes_despite_event_flood() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            // Stall every metadata query on the control connection from the
+            // very start: the session's initial fetch is the one under test.
+            let (fetch_started_tx, mut fetch_started_rx) = mpsc::unbounded_channel();
+            for node in running_proxy.running_nodes.iter_mut() {
+                node.prepend_request_rules(vec![RequestRule(
+                    cc_metadata_query_condition(),
+                    RequestReaction::delay(METADATA_QUERY_DELAY)
+                        .with_feedback_when_performed(fetch_started_tx.clone()),
+                )]);
+            }
+
+            let build = tokio::spawn({
+                let uri = proxy_uris[0].clone();
+                let translation_map = translation_map.clone();
+                async move {
+                    SessionBuilder::new()
+                        .known_node(uri)
+                        .address_translator(Arc::new(translation_map))
+                        .fetch_schema_metadata(false)
+                        .build()
+                        .await
+                }
+            });
+
+            // The first stalled frame proves the initial fetch is in flight.
+            fetch_started_rx
+                .recv()
+                .await
+                .expect("proxy feedback channel closed unexpectedly");
+
+            flood_with_events(&running_proxy);
+
+            // A build that stops draining events during the initial fetch
+            // never sees the fetch complete, and thus never returns.
+            tokio::time::timeout(STALLED_OPERATION_TIMEOUT, build)
+                .await
+                .expect(
+                    "session build deadlocked: the initial metadata fetch stopped draining \
+                    server events while in flight",
+                )
+                .expect("session build task panicked")
+                .expect("session build failed");
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Re-establishing a broken control connection must drain server events while
+/// the establishment's metadata fetch is in flight, for the same reason as in
+/// [`session_build_completes_despite_event_flood`].
+///
+/// The test breaks the control connection at the proxy (the connection is
+/// dropped on the next metadata query, i.e. once the requested refresh starts
+/// fetching), which sends the metadata worker into re-establishment. The
+/// re-establishment's metadata queries are stalled, and the flood is injected
+/// while one is in flight. The refresh request survives the broken connection
+/// and is answered from the re-established one, so its completion proves
+/// recovery.
+#[tokio::test]
+async fn cc_reestablishment_completes_despite_event_flood() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map.clone()))
+                .fetch_schema_metadata(false)
+                // Far beyond the test duration, so that the only fetches are
+                // those the test provokes.
+                .cluster_metadata_refresh_interval(Duration::from_secs(10_000))
+                .build()
+                .await
+                .unwrap();
+            wait_until_all_nodes_are_connected(3, &session).await;
+
+            // Stall every metadata query on the control connection at nodes
+            // 1 and 2 and observe the stalled frames. Node 0 - the node
+            // hosting the control connection (it is the sole initial contact
+            // point) - instead drops the connection on every metadata query:
+            // the refresh below thus breaks the control connection, and the
+            // re-establishment cannot settle on node 0 either (its fetch is
+            // dropped too, failing that candidate), so the new control
+            // connection always lands on a node whose queries are stalled.
+            // Only stalled frames produce feedback: metadata queries of the
+            // broken connection are dropped, never stalled, so the first
+            // feedback provably comes from a re-establishment fetch.
+            let (fetch_started_tx, mut fetch_started_rx) = mpsc::unbounded_channel();
+            for node in running_proxy.running_nodes[1..].iter_mut() {
+                node.prepend_request_rules(vec![RequestRule(
+                    cc_metadata_query_condition(),
+                    RequestReaction::delay(METADATA_QUERY_DELAY)
+                        .with_feedback_when_performed(fetch_started_tx.clone()),
+                )]);
+            }
+            running_proxy.running_nodes[0].prepend_request_rules(vec![RequestRule(
+                cc_metadata_query_condition(),
+                RequestReaction::drop_connection(),
+            )]);
+
+            // Request a refresh. Its fetch breaks the control connection; the
+            // request survives (the worker retries the refresh while
+            // re-establishing), so its completion proves the re-established
+            // fetch went through.
+            let session = Arc::new(session);
+            let refresh = tokio::spawn({
+                let session = Arc::clone(&session);
+                async move { session.refresh_metadata().await }
+            });
+
+            // The first stalled frame proves the re-establishment fetch is in
+            // flight, on a fresh control connection registered for events.
+            fetch_started_rx
+                .recv()
+                .await
+                .expect("proxy feedback channel closed unexpectedly");
+
+            flood_with_events(&running_proxy);
+
+            // Re-establishment that stops draining events during its fetch
+            // never completes, and the refresh request is never answered.
+            tokio::time::timeout(STALLED_OPERATION_TIMEOUT, refresh)
+                .await
+                .expect(
+                    "control connection re-establishment deadlocked: its metadata fetch \
+                    stopped draining server events while in flight",
                 )
                 .expect("refresh task panicked")
                 .expect("metadata refresh failed");

--- a/scylla/tests/integration/metadata/event_flood.rs
+++ b/scylla/tests/integration/metadata/event_flood.rs
@@ -1,0 +1,126 @@
+//! Regression test: the metadata worker must keep draining server events while
+//! a metadata fetch is in flight.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use scylla::client::session_builder::SessionBuilder;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, ShardAwareness,
+    WorkerError,
+};
+use tokio::sync::mpsc;
+
+use crate::utils::{
+    inject_status_change_down, setup_tracing, test_with_3_node_cluster,
+    wait_until_all_nodes_are_connected,
+};
+
+/// How long the proxy withholds each metadata query frame. The event flood is
+/// injected within this window, i.e. while the fetch is in flight.
+const METADATA_QUERY_DELAY: Duration = Duration::from_secs(1);
+
+/// Comfortably more events than the control connection's bounded event channel
+/// (32 entries as of writing) can hold.
+const FLOODED_EVENTS: usize = 100;
+
+/// Upper bound for the stalled refresh to complete. The refresh performs a
+/// handful of [`METADATA_QUERY_DELAY`]-stalled round trips, so a healthy
+/// driver stays well under this; only a deadlocked one reaches it.
+const REFRESH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The control connection delivers server events through a bounded channel,
+/// and the connection's reader task blocks once that channel is full - which
+/// also stops query responses from being processed. The metadata worker must
+/// therefore keep draining events while a metadata fetch is in flight: a
+/// worker that awaited the fetch without draining would deadlock with it (the
+/// fetch's response is only processed once the events are drained, and the
+/// worker only drains events once the fetch completes).
+///
+/// The test stalls metadata queries on the control connection at the proxy,
+/// requests a refresh, floods the control connection with far more events
+/// than the channel holds while the fetch is stalled, and requires the
+/// refresh to complete.
+#[tokio::test]
+async fn metadata_fetch_completes_despite_event_flood() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map.clone()))
+                .fetch_schema_metadata(false)
+                // Far beyond the test duration: the only full fetch on the
+                // established control connection is the explicit one below.
+                .cluster_metadata_refresh_interval(Duration::from_secs(10_000))
+                .build()
+                .await
+                .unwrap();
+            wait_until_all_nodes_are_connected(3, &session).await;
+
+            // Stall every metadata query on the control connection (only the
+            // control connection registers for events, hence the condition)
+            // and observe the stalled frames. Installed only now, so that the
+            // session's initial metadata fetch is unaffected.
+            let (fetch_started_tx, mut fetch_started_rx) = mpsc::unbounded_channel();
+            let metadata_query_condition = Condition::ConnectionRegisteredAnyEvent.and(
+                Condition::RequestOpcode(RequestOpcode::Query)
+                    .or(Condition::RequestOpcode(RequestOpcode::Execute)),
+            );
+            for node in running_proxy.running_nodes.iter_mut() {
+                node.prepend_request_rules(vec![RequestRule(
+                    metadata_query_condition.clone(),
+                    RequestReaction::delay(METADATA_QUERY_DELAY)
+                        .with_feedback_when_performed(fetch_started_tx.clone()),
+                )]);
+            }
+
+            // Request a refresh. It cannot complete before METADATA_QUERY_DELAY
+            // elapses, which leaves the flood below plenty of time to land
+            // while the fetch is in flight.
+            let session = Arc::new(session);
+            let refresh = tokio::spawn({
+                let session = Arc::clone(&session);
+                async move { session.refresh_metadata().await }
+            });
+
+            // The first stalled frame proves the fetch is in flight (feedback
+            // is emitted before the proxy starts delaying the frame).
+            fetch_started_rx
+                .recv()
+                .await
+                .expect("proxy feedback channel closed unexpectedly");
+
+            // Flood the control connection. The address named by the events
+            // does not matter: the deadlock under test sits in event
+            // *draining*, which precedes any interpretation of the event.
+            let flood_addr = SocketAddr::from(([127, 0, 0, 1], 9042));
+            for _ in 0..FLOODED_EVENTS {
+                inject_status_change_down(&running_proxy, flood_addr);
+            }
+
+            // A worker that stops draining events during its fetch never sees
+            // the fetch complete; the refresh then never resolves.
+            tokio::time::timeout(REFRESH_TIMEOUT, refresh)
+                .await
+                .expect(
+                    "metadata refresh deadlocked: the metadata worker stopped draining \
+                    server events while its metadata fetch was in flight",
+                )
+                .expect("refresh task panicked")
+                .expect("metadata refresh failed");
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/metadata/mod.rs
+++ b/scylla/tests/integration/metadata/mod.rs
@@ -1,2 +1,3 @@
 mod configuration;
 mod contents;
+mod event_flood;

--- a/scylla/tests/integration/session/status_change_hints.rs
+++ b/scylla/tests/integration/session/status_change_hints.rs
@@ -3,19 +3,18 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::{Bytes, BytesMut};
 use scylla::client::PoolSize;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
-    RunningProxy, ShardAwareness, TargetShard, WorkerError,
+    ShardAwareness, TargetShard, WorkerError,
 };
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::utils::{
-    calculate_proxy_host_ids, setup_tracing, test_with_3_node_cluster,
+    calculate_proxy_host_ids, inject_status_change_down, setup_tracing, test_with_3_node_cluster,
     wait_until_all_nodes_are_connected,
 };
 
@@ -44,18 +43,6 @@ const POOL_SIZE: PoolSize = PoolSize::PerHost(NonZeroUsize::new(1).unwrap());
 type FeedbackItem = (RequestFrame, Option<TargetShard>);
 type FeedbackRx = mpsc::UnboundedReceiver<FeedbackItem>;
 
-/// Builds the body of a `STATUS_CHANGE` / `DOWN` EVENT frame for `addr`:
-/// `[string] "STATUS_CHANGE"`, `[string] "DOWN"`, `[inet] addr`.
-fn status_change_down_event_body(addr: SocketAddr) -> Bytes {
-    use scylla_cql::frame::types::{write_inet, write_string};
-
-    let mut body = BytesMut::new();
-    write_string("STATUS_CHANGE", &mut body).unwrap();
-    write_string("DOWN", &mut body).unwrap();
-    write_inet(addr, &mut body);
-    body.freeze()
-}
-
 /// Returns the driver-visible address of the node with the given host id.
 ///
 /// This is the address that `ClusterState` compares against the address
@@ -67,25 +54,6 @@ fn driver_visible_address(session: &Session, host_id: Uuid) -> SocketAddr {
         .get_node_by_host_id(host_id)
         .unwrap_or_else(|| panic!("node with host id {host_id} unknown to the driver"));
     SocketAddr::new(node.address.ip(), node.address.port())
-}
-
-/// Injects a forged `STATUS_CHANGE DOWN` event for `addr` into every proxy
-/// node's control connections.
-///
-/// Only one of the three proxied nodes hosts the driver's control connection,
-/// hence the broadcast; at least one injection must have found a registered
-/// control connection.
-fn inject_status_change_down(running_proxy: &RunningProxy, addr: SocketAddr) {
-    let body = status_change_down_event_body(addr);
-    let injected = running_proxy
-        .running_nodes
-        .iter()
-        .filter(|node| node.inject_event_to_cc(body.clone()))
-        .count();
-    assert!(
-        injected > 0,
-        "no proxy node had a registered control connection to inject the event into"
-    );
 }
 
 /// Verifies that a `STATUS_CHANGE DOWN` server event is used as a hint for the

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -1,3 +1,4 @@
+use bytes::{Bytes, BytesMut};
 use futures::Future;
 use futures::future::try_join_all;
 use itertools::Either;
@@ -694,4 +695,35 @@ impl RetrySession for CapturingRetrySession {
     fn reset(&mut self) {
         self.call_count = 0;
     }
+}
+
+/// Builds the body of a `STATUS_CHANGE` / `DOWN` EVENT frame for `addr`:
+/// `[string] "STATUS_CHANGE"`, `[string] "DOWN"`, `[inet] addr`.
+pub(crate) fn status_change_down_event_body(addr: SocketAddr) -> Bytes {
+    use scylla_cql::frame::types::{write_inet, write_string};
+
+    let mut body = BytesMut::new();
+    write_string("STATUS_CHANGE", &mut body).unwrap();
+    write_string("DOWN", &mut body).unwrap();
+    write_inet(addr, &mut body);
+    body.freeze()
+}
+
+/// Injects a forged `STATUS_CHANGE DOWN` event for `addr` into every proxy
+/// node's control connections.
+///
+/// Only one of the proxied nodes hosts the driver's control connection, hence
+/// the broadcast; at least one injection must have found a registered control
+/// connection.
+pub(crate) fn inject_status_change_down(running_proxy: &RunningProxy, addr: SocketAddr) {
+    let body = status_change_down_event_body(addr);
+    let injected = running_proxy
+        .running_nodes
+        .iter()
+        .filter(|node| node.inject_event_to_cc(body.clone()))
+        .count();
+    assert!(
+        injected > 0,
+        "no proxy node had a registered control connection to inject the event into"
+    );
 }


### PR DESCRIPTION
This PR makes metadata fetching done in MetadataWorker non-blocking.

What does it even mean?

Until now we had a bug, specifically a deadlock.
Events from CC are handled in a `select!` in a worker loop. However,
metadata fetch is an async work done outside this `select!`, so during the metadata fetch
we did not handle events. If the event channel became full during the fetch, the CC could no longer receive responses from the server because its reader would hand on trying to send an event to the channel.

The solution (implemented here): only perform async work in a branch of `select!`. That way we never starve any work we need to do.
Two most important structures here:
- `FetchPlan` records what fetches we need to do (but didn't start yet)
- `PendingFetches` kepp the futures with currently running fetches.

Before each `select!` we look at both and start fetches that can and must be started.

This approach has one more advantage: when implementing smarter metadata fetching ( https://github.com/scylladb/scylla-rust-driver/issues/1280 ) it will make it easy to perform multiple partial fetches (e.g. topology and client routes) concurrently.

## Problem with initial fetch

The solution above applies to `work_on_cc`, so when the CC is already created and its initial metadata fetch.
Unfortunately it is possible for this problem to also happen during the initial metadata fetch!
The idea for a solution is ofc the same: we need to drain the events when reading metadata.

Some details were problematic: FetchPlan is private to MetadataWorker, and I wanted to keep it that way.
So the solution here is to make MetadataReader accept a callback (in the form of trait because of rustc). Impl of this trait is provided by the worker, and what it does is create an FetchPlan from the receive events (as expected).

Commits up to "Add regression test for event flood during metadata fetch" address the first path (`work_on_cc`).
Later commits address the second path: metadata fetch done on connection creation.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1670
Ref: https://github.com/scylladb/scylla-rust-driver/issues/1280

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
