### PR TITLE
Control Connection client side timeouts

### DIFF
--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -298,8 +298,22 @@ pub struct SessionConfig {
     /// Whenever this timeout is configured, the driver additionally applies a client-side
     /// timeout of this value + 1s to control connection requests - on every target, even
     /// where the clause itself is ignored - as a guard against a node that stops
-    /// responding without breaking the connection.
+    /// responding without breaking the connection. See
+    /// [`Self::metadata_request_clientside_timeout`] for how to override that derived value.
     pub metadata_request_serverside_timeout: Option<Duration>,
+
+    /// Custom client-side timeout for each page fetch of a metadata or
+    /// `system.client_routes` query executed on the control connection (it bounds single
+    /// requests, not the whole multi-page iteration).
+    ///
+    /// If `None` (the default), the timeout is derived from
+    /// [`Self::metadata_request_serverside_timeout`] + 1s, or is 30s if no server-side
+    /// timeout is configured either. If `Some(d)`, `d` is applied instead.
+    ///
+    /// Setting it *below* [`Self::metadata_request_serverside_timeout`] is discouraged: the
+    /// driver would then abort the request before the server can report its own, more
+    /// informative timeout error.
+    pub metadata_request_clientside_timeout: Option<Duration>,
 
     /// Interval of sending keepalive requests.
     /// If `None`, keepalives are never sent, so `Self::keepalive_timeout` has no effect.
@@ -441,6 +455,7 @@ impl SessionConfig {
             fetch_schema_metadata: true,
             fetch_full_schema_metadata: true,
             metadata_request_serverside_timeout: Some(Duration::from_secs(2)),
+            metadata_request_clientside_timeout: None,
             keepalive_interval: Some(Duration::from_secs(30)),
             keepalive_timeout: Some(Duration::from_secs(30)),
             schema_agreement_timeout: Duration::from_secs(60),
@@ -556,6 +571,18 @@ impl SessionConfig {
             );
         }
 
+        if self.clientside_timeout_below_serverside() {
+            warn!(
+                clientside_timeout = ?self.metadata_request_clientside_timeout,
+                serverside_timeout = ?self.metadata_request_serverside_timeout,
+                "`metadata_request_clientside_timeout` is lower than `metadata_request_serverside_timeout`: \
+                against ScyllaDB, where the server-side timeout is honoured, requests on the control \
+                connection will be aborted client-side before the server has a chance to report its own, \
+                more informative timeout error. Set the client-side timeout to at least the server-side \
+                one (ideally higher, to leave the server some margin)."
+            );
+        }
+
         // Ensure no illegal configuration with Client Routes
         #[cfg(feature = "unstable-client-routes")]
         if self.client_routes_config.is_some() {
@@ -576,6 +603,18 @@ impl SessionConfig {
         }
 
         Ok(())
+    }
+
+    /// Whether the configured client-side timeout of control connection requests is lower
+    /// than the configured server-side one, which defeats the purpose of the latter.
+    fn clientside_timeout_below_serverside(&self) -> bool {
+        match (
+            self.metadata_request_clientside_timeout,
+            self.metadata_request_serverside_timeout,
+        ) {
+            (Some(clientside), Some(serverside)) => clientside < serverside,
+            _ => false,
+        }
     }
 }
 
@@ -1200,7 +1239,7 @@ impl Session {
             schema_metadata_fetch_mode,
             MetadataRequestTimeouts {
                 serverside_override: config.metadata_request_serverside_timeout,
-                clientside_override: None,
+                clientside_override: config.metadata_request_clientside_timeout,
             },
             config.hostname_resolution_timeout,
             config.host_filter,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -454,7 +454,7 @@ impl SessionConfig {
             keyspaces_to_fetch: Vec::new(),
             fetch_schema_metadata: true,
             fetch_full_schema_metadata: true,
-            metadata_request_serverside_timeout: Some(Duration::from_secs(2)),
+            metadata_request_serverside_timeout: Some(Duration::from_secs(30)),
             metadata_request_clientside_timeout: None,
             keepalive_interval: Some(Duration::from_secs(30)),
             keepalive_timeout: Some(Duration::from_secs(30)),

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -10,6 +10,7 @@ use crate::client::client_routes::ClientRoutesConfig;
 use crate::client::execution::{
     NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RunRequestResult,
 };
+use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::cluster::metadata::{SchemaMetadataFetchLevel, SchemaMetadataFetchMode};
 use crate::cluster::node::KnownNode;
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
@@ -290,7 +291,9 @@ pub struct SessionConfig {
     /// If false, only lightweight metadata needed for routing (table names, partitioners, tablet info) is fetched.
     pub fetch_full_schema_metadata: bool,
 
-    /// Custom timeout for requests that query metadata.
+    /// Custom server-side timeout for requests that query metadata. It is appended to
+    /// metadata statements as a `USING TIMEOUT` clause, which is a ScyllaDB-only feature,
+    /// so it has no effect on other targets (e.g. Cassandra).
     pub metadata_request_serverside_timeout: Option<Duration>,
 
     /// Interval of sending keepalive requests.
@@ -1190,7 +1193,9 @@ impl Session {
             pool_config,
             config.keyspaces_to_fetch,
             schema_metadata_fetch_mode,
-            config.metadata_request_serverside_timeout,
+            MetadataRequestTimeouts {
+                serverside_override: config.metadata_request_serverside_timeout,
+            },
             config.hostname_resolution_timeout,
             config.host_filter,
             host_listener,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -294,6 +294,11 @@ pub struct SessionConfig {
     /// Custom server-side timeout for requests that query metadata. It is appended to
     /// metadata statements as a `USING TIMEOUT` clause, which is a ScyllaDB-only feature,
     /// so it has no effect on other targets (e.g. Cassandra).
+    ///
+    /// Whenever this timeout is configured, the driver additionally applies a client-side
+    /// timeout of this value + 1s to control connection requests - on every target, even
+    /// where the clause itself is ignored - as a guard against a node that stops
+    /// responding without breaking the connection.
     pub metadata_request_serverside_timeout: Option<Duration>,
 
     /// Interval of sending keepalive requests.
@@ -1195,6 +1200,7 @@ impl Session {
             schema_metadata_fetch_mode,
             MetadataRequestTimeouts {
                 serverside_override: config.metadata_request_serverside_timeout,
+                clientside_override: None,
             },
             config.hostname_resolution_timeout,
             config.host_filter,

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1056,6 +1056,12 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// This prevents timeouts of schema queries when the schema is large
     /// and the default timeout is configured as tight.
     ///
+    /// The `USING TIMEOUT` clause is a ScyllaDB-only feature, so the server-side timeout
+    /// itself has no effect on other targets (e.g. Cassandra). The driver does, however,
+    /// additionally apply a client-side timeout of this value + 1s to control connection
+    /// requests on every target, as a guard against a node that stops responding without
+    /// breaking the connection.
+    ///
     /// # Example
     /// ```
     /// # use scylla::client::session::Session;

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1050,8 +1050,8 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     }
 
     /// Set the server-side timeout for metadata queries.
-    /// The default is `Some(Duration::from_secs(2))`. It means that
-    /// the all metadata queries will be set the 2 seconds timeout
+    /// The default is `Some(Duration::from_secs(30))`. It means that
+    /// the all metadata queries will be set the 30 seconds timeout
     /// no matter what timeout is set as a cluster default.
     /// This prevents timeouts of schema queries when the schema is large
     /// and the default timeout is configured as tight.

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1060,7 +1060,9 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// itself has no effect on other targets (e.g. Cassandra). The driver does, however,
     /// additionally apply a client-side timeout of this value + 1s to control connection
     /// requests on every target, as a guard against a node that stops responding without
-    /// breaking the connection.
+    /// breaking the connection. See
+    /// [`GenericSessionBuilder::metadata_request_clientside_timeout`] for how to override
+    /// that derived value.
     ///
     /// # Example
     /// ```
@@ -1077,6 +1079,38 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// ```
     pub fn metadata_request_serverside_timeout(mut self, timeout: Duration) -> Self {
         self.config.metadata_request_serverside_timeout = Some(timeout);
+        self
+    }
+
+    /// Set the client-side timeout applied to each page fetch of a metadata or
+    /// `system.client_routes` query executed on the control connection.
+    ///
+    /// By default no explicit value is set, and the timeout is derived from
+    /// [`GenericSessionBuilder::metadata_request_serverside_timeout`] + 1s, or is 30s if no
+    /// server-side timeout is configured either. A value set here is used instead of that
+    /// derived one.
+    ///
+    /// This is a guard against a node that keeps its TCP connection accepted but stops
+    /// answering, which would otherwise stall metadata refresh forever. Raise it if metadata
+    /// pages legitimately take longer, e.g. for a large schema. Avoid setting it below the
+    /// server-side timeout: the driver would then abort the request before the server can
+    /// report its own, more informative timeout error.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .metadata_request_clientside_timeout(std::time::Duration::from_secs(10))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn metadata_request_clientside_timeout(mut self, timeout: Duration) -> Self {
+        self.config.metadata_request_clientside_timeout = Some(timeout);
         self
     }
 
@@ -1494,6 +1528,26 @@ mod tests {
 
         assert!(builder.config.known_nodes.is_empty());
         assert_eq!(builder.config.compression, None);
+    }
+
+    #[test]
+    fn metadata_request_clientside_timeout() {
+        setup_tracing();
+        assert_eq!(
+            SessionBuilder::new()
+                .config
+                .metadata_request_clientside_timeout,
+            None
+        );
+
+        let timeout = Duration::from_secs(7);
+        assert_eq!(
+            SessionBuilder::new()
+                .metadata_request_clientside_timeout(timeout)
+                .config
+                .metadata_request_clientside_timeout,
+            Some(timeout)
+        );
     }
 
     #[test]

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -23,6 +23,23 @@ use crate::statement::prepared::PreparedStatement;
 
 const METADATA_QUERY_PAGE_SIZE: i32 = 1024;
 
+/// Timeouts applied to requests executed on the control connection.
+///
+/// The server-side timeout is only an override of the server's own limit, appended
+/// to the statement as a `USING TIMEOUT` clause; it is a ScyllaDB-only feature, so
+/// it is silently inapplicable to other targets (e.g. Cassandra).
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct MetadataRequestTimeouts {
+    pub(crate) serverside_override: Option<Duration>,
+}
+
+impl MetadataRequestTimeouts {
+    /// The server-side timeout override actually in effect.
+    fn serverside(&self, target_is_scylladb: bool) -> Option<Duration> {
+        self.serverside_override.filter(|_| target_is_scylladb)
+    }
+}
+
 pub(crate) type ControlConnectionCache = DashMap<String, PreparedStatement>;
 
 pub(crate) enum ControlConnectionEvent {
@@ -35,8 +52,8 @@ pub(crate) enum ControlConnectionEvent {
 pub(super) struct ControlConnection {
     conn: Arc<Connection>,
     endpoint: UntranslatedEndpoint,
-    /// The custom server-side timeout set for requests executed on the control connection.
-    overridden_serverside_timeout: Option<Duration>,
+    /// The timeouts applied to requests executed on the control connection.
+    request_timeouts: MetadataRequestTimeouts,
     cache: Arc<ControlConnectionCache>,
 }
 
@@ -63,7 +80,7 @@ impl ControlConnection {
             Self {
                 conn,
                 endpoint,
-                overridden_serverside_timeout: None,
+                request_timeouts: MetadataRequestTimeouts::default(),
                 cache,
             },
             ControlConnectionEvents {
@@ -77,10 +94,10 @@ impl ControlConnection {
         &self.endpoint
     }
 
-    /// Sets the custom server-side timeout set for requests executed on the control connection.
-    pub(super) fn override_serverside_timeout(self, overridden_timeout: Option<Duration>) -> Self {
+    /// Sets the timeouts applied to requests executed on the control connection.
+    pub(super) fn with_request_timeouts(self, timeouts: MetadataRequestTimeouts) -> Self {
         Self {
-            overridden_serverside_timeout: overridden_timeout,
+            request_timeouts: timeouts,
             ..self
         }
     }
@@ -97,9 +114,7 @@ impl ControlConnection {
     /// Appends the custom server-side timeout to the statement string, if such custom timeout
     /// is provided and we are connected to ScyllaDB (since custom timeouts is ScyllaDB-only feature).
     fn maybe_append_timeout_override(&self, statement: &mut Statement) {
-        if let Some(timeout) = self.overridden_serverside_timeout
-            && self.is_to_scylladb()
-        {
+        if let Some(timeout) = self.request_timeouts.serverside(self.is_to_scylladb()) {
             // SAFETY: io::fmt::Write impl for String is infallible.
             write!(
                 statement.contents,
@@ -220,7 +235,7 @@ mod tests {
     use crate::routing::ShardInfo;
     use crate::test_utils::setup_tracing;
 
-    use super::ControlConnection;
+    use super::{ControlConnection, MetadataRequestTimeouts};
 
     /// Tests that ControlConnection enforces the provided custom timeout
     /// iff ScyllaDB is the target node (else ignores the custom timeout).
@@ -377,7 +392,9 @@ mod tests {
             {
                 let custom_timeout = Duration::from_millis(2137);
                 let conn_with_custom_timeout =
-                    conn_with_default_timeout.override_serverside_timeout(Some(custom_timeout));
+                    conn_with_default_timeout.with_request_timeouts(MetadataRequestTimeouts {
+                        serverside_override: Some(custom_timeout),
+                    });
 
                 conn_with_custom_timeout
                     .query_iter(QUERY_STR, &())

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -23,20 +23,46 @@ use crate::statement::prepared::PreparedStatement;
 
 const METADATA_QUERY_PAGE_SIZE: i32 = 1024;
 
+/// How much longer the client-side timeout of a control connection request is
+/// than the server-side one it is derived from.
+const CLIENTSIDE_TIMEOUT_MARGIN: Duration = Duration::from_secs(1);
+
+/// The client-side timeout of a control connection request when there is no
+/// server-side timeout configured to derive it from.
+const DEFAULT_CLIENTSIDE_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Timeouts applied to requests executed on the control connection.
 ///
 /// The server-side timeout is only an override of the server's own limit, appended
 /// to the statement as a `USING TIMEOUT` clause; it is a ScyllaDB-only feature, so
 /// it is silently inapplicable to other targets (e.g. Cassandra).
+///
+/// The client-side timeout is applicable to all targets.
+/// By default it is server-side timeout + CLIENTSIDE_TIMEOUT_MARGIN.
+/// If no server-side timeout is set, then a default of 30s is used for client-side timeout.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct MetadataRequestTimeouts {
     pub(crate) serverside_override: Option<Duration>,
+    pub(crate) clientside_override: Option<Duration>,
 }
 
 impl MetadataRequestTimeouts {
     /// The server-side timeout override actually in effect.
     fn serverside(&self, target_is_scylladb: bool) -> Option<Duration> {
         self.serverside_override.filter(|_| target_is_scylladb)
+    }
+
+    /// The client-side timeout actually in effect, derived from the configured
+    /// server-side timeout unless explicitly overridden.
+    fn clientside(&self) -> Duration {
+        self.clientside_override.unwrap_or_else(|| {
+            self.serverside_override.map_or(
+                DEFAULT_CLIENTSIDE_TIMEOUT,
+                // Saturating, as a pathologically large configured server-side timeout
+                // must not panic the driver.
+                |t| t.saturating_add(CLIENTSIDE_TIMEOUT_MARGIN),
+            )
+        })
     }
 }
 
@@ -157,12 +183,16 @@ impl ControlConnection {
         // Without this `Sync` compiler complains that cluster worker future is not Send.
         values: &(dyn SerializeRow + Sync),
     ) -> Result<QueryPager, NextRowError> {
-        let prepared: PreparedStatement =
-            self.get_or_prepare_statement(statement)
-                .await
-                .map_err(|attempt_err| {
-                    NextRowError::NextPageError(NextPageError::RequestFailure(attempt_err.into()))
-                })?;
+        let mut prepared: PreparedStatement = self
+            .get_or_prepare_statement(statement)
+            .await
+            .map_err(|attempt_err| {
+                NextRowError::NextPageError(NextPageError::RequestFailure(attempt_err.into()))
+            })?;
+
+        // Set on this per-use clone rather than in `get_or_prepare_statement`, so that
+        // the shared cache never bakes a timeout in.
+        prepared.set_request_timeout(Some(self.request_timeouts.clientside()));
 
         let serialized_values = prepared.serialize_values(&values).map_err(|ser_err| {
             NextRowError::NextPageError(NextPageError::RequestFailure(
@@ -394,6 +424,7 @@ mod tests {
                 let conn_with_custom_timeout =
                     conn_with_default_timeout.with_request_timeouts(MetadataRequestTimeouts {
                         serverside_override: Some(custom_timeout),
+                        clientside_override: None,
                     });
 
                 conn_with_custom_timeout

--- a/scylla/src/cluster/metadata/reader.rs
+++ b/scylla/src/cluster/metadata/reader.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, warn};
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{
-    ControlConnection, ControlConnectionCache, ControlConnectionEvents,
+    ControlConnection, ControlConnectionCache, ControlConnectionEvents, MetadataRequestTimeouts,
 };
 use crate::cluster::metadata::{
     ClientRoutesUpdate, Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
@@ -45,7 +45,7 @@ pub(crate) struct MetadataReader {
     // Configuration values - they will stay the same during whole lifetime of MetadataReader.
     // =======================================================================================
     control_connection_config: ConnectionConfig,
-    request_serverside_timeout: Option<Duration>,
+    request_timeouts: MetadataRequestTimeouts,
     hostname_resolution_timeout: Option<Duration>,
     keyspaces_to_fetch: Vec<String>,
     schema_metadata_fetch_mode: SchemaMetadataFetchMode,
@@ -75,7 +75,7 @@ impl MetadataReader {
         initial_known_nodes: Vec<KnownNode>,
         hostname_resolution_timeout: Option<Duration>,
         connection_config: ConnectionConfig,
-        request_serverside_timeout: Option<Duration>,
+        request_timeouts: MetadataRequestTimeouts,
         keyspaces_to_fetch: Vec<String>,
         schema_metadata_fetch_mode: SchemaMetadataFetchMode,
         host_filter: &Option<Arc<dyn HostFilter>>,
@@ -94,7 +94,7 @@ impl MetadataReader {
 
         Ok(MetadataReader {
             control_connection_config: connection_config,
-            request_serverside_timeout,
+            request_timeouts,
             hostname_resolution_timeout,
             known_peers: initial_peers
                 .into_iter()
@@ -249,7 +249,7 @@ impl MetadataReader {
             let (cc, cc_events) = match Self::make_control_connection(
                 peer,
                 self.control_connection_config.clone(),
-                self.request_serverside_timeout,
+                self.request_timeouts,
                 Arc::clone(&self.cc_cache),
                 self.client_routes_subscriber.is_some(),
             )
@@ -404,7 +404,7 @@ impl MetadataReader {
     async fn make_control_connection(
         endpoint: UntranslatedEndpoint,
         mut config: ConnectionConfig,
-        request_serverside_timeout: Option<Duration>,
+        request_timeouts: MetadataRequestTimeouts,
         cache: Arc<ControlConnectionCache>,
         register_for_client_routes_events: bool,
     ) -> Result<(ControlConnection, ControlConnectionEvents), MetadataError> {
@@ -433,10 +433,7 @@ impl MetadataReader {
             Ok((con, recv)) => {
                 let (cc, cc_events) =
                     ControlConnection::new(Arc::new(con), endpoint, cache, recv, receiver);
-                Ok((
-                    cc.override_serverside_timeout(request_serverside_timeout),
-                    cc_events,
-                ))
+                Ok((cc.with_request_timeouts(request_timeouts), cc_events))
             }
             Err(conn_err) => Err(MetadataError::ConnectionPoolError(
                 ConnectionPoolError::Broken {

--- a/scylla/src/cluster/mod.rs
+++ b/scylla/src/cluster/mod.rs
@@ -24,6 +24,6 @@ pub use state::ClusterState;
 pub(crate) mod node;
 pub use node::{KnownNode, Node, NodeAddr, NodeRef};
 
-mod control_connection;
+pub(crate) mod control_connection;
 
 pub mod metadata;

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -2,6 +2,7 @@ use crate::client::client_routes::{
     ClientRoutesAddressTranslator, ClientRoutesConfig, ClientRoutesSubscriber,
 };
 use crate::client::session::TABLET_CHANNEL_SIZE;
+use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::cluster::metadata::SchemaMetadataFetchMode;
 use crate::cluster::metadata::update::{
     MetadataChanges, MetadataUpdate, RefreshRequest, StatusHint,
@@ -65,7 +66,7 @@ impl Cluster {
         mut pool_config: PoolConfig,
         keyspaces_to_fetch: Vec<String>,
         schema_metadata_fetch_mode: SchemaMetadataFetchMode,
-        metadata_request_serverside_timeout: Option<Duration>,
+        metadata_request_timeouts: MetadataRequestTimeouts,
         hostname_resolution_timeout: Option<Duration>,
         host_filter: Option<Arc<dyn HostFilter>>,
         host_listener: Option<Arc<dyn HostListener>>,
@@ -103,7 +104,7 @@ impl Cluster {
             known_nodes,
             hostname_resolution_timeout,
             pool_config.connection_config.clone(),
-            metadata_request_serverside_timeout,
+            metadata_request_timeouts,
             keyspaces_to_fetch,
             schema_metadata_fetch_mode,
             &host_filter,

--- a/scylla/tests/integration/metadata/configuration.rs
+++ b/scylla/tests/integration/metadata/configuration.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tracing::info;
 
 // By default, custom metadata request timeout is set to 2 seconds.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn map_fedback_message<'a, T, F: Fn(RequestFrame) -> T + 'a>(
     rx: &'a mut UnboundedReceiver<(RequestFrame, Option<u16>)>,


### PR DESCRIPTION
This PR introduces client-side timeouts to control connection queries.
The timeout is by default derived from server-side timeout:
- If server-side timeout is present, then 1s is added to it
- If it isn't present, a default of 30s is used

The timeout can be overwritten by the user.

Additionally, I changed the default server-side timeout from 2s to 30s.
Our default timeout is 30s, and we don't want to waste work (by dropping requests that db would respond to at some point). I don't think that metadata timeouts should be lower than the default one.
This may become more of a problem with sl:driver now released on server side, which is why I made the change now.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1419

Based on https://github.com/scylladb/scylla-rust-driver/pull/1830

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
