### PR TITLE
Release 1.8.0

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sphinx-docs"
-version = "1.7"
+version = "1.8"
 description = "ScyllaDB Documentation"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,10 +13,10 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Global variables
 
 # Build documentation for the following tags and branches
-TAGS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0", "v1.6.0", "v1.7.0"]
+TAGS = ["v1.2.0", "v1.3.0", "v1.3.1", "v1.4.0", "v1.4.1", "v1.5.0", "v1.6.0", "v1.7.0", "v1.8.0"]
 BRANCHES = ["main"]
 # Set the latest version.
-LATEST_VERSION = "v1.7.0"
+LATEST_VERSION = "v1.8.0"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["main"]
 # Set which versions are deprecated
@@ -28,6 +28,7 @@ DEPRECATED_VERSIONS = [
     "v1.4.1",
     "v1.5.0",
     "v1.6.0",
+    "v1.7.0",
 ]
 
 # -- General configuration

--- a/docs/source/quickstart/create-project.md
+++ b/docs/source/quickstart/create-project.md
@@ -8,7 +8,7 @@ cargo new myproject
 In `Cargo.toml` add useful dependencies:
 ```toml
 [dependencies]
-scylla = "1.7"
+scylla = "1.8"
 tokio = { version = "1.12", features = ["full"] }
 futures = "0.3.6"
 uuid = "1.0"

--- a/scylla-ccm-bridge/Cargo.toml
+++ b/scylla-ccm-bridge/Cargo.toml
@@ -45,7 +45,7 @@ itertools = "0.15.0"
 
 # Needed for client routes feature only
 scylla = { version = "1.7.0", path = "../scylla", optional = true }
-scylla-cql = { version = "1.7.0", path = "../scylla-cql", optional = true }
+scylla-cql = { version = "1.8.0", path = "../scylla-cql", optional = true }
 scylla-proxy = { version = "0.0.6", path = "../scylla-proxy", optional = true }
 
 [package.metadata.cargo-semver-checks.lints]

--- a/scylla-ccm-bridge/Cargo.toml
+++ b/scylla-ccm-bridge/Cargo.toml
@@ -44,7 +44,7 @@ uuid = { version = "1.0", features = ["v4"] }
 itertools = "0.15.0"
 
 # Needed for client routes feature only
-scylla = { version = "1.7.0", path = "../scylla", optional = true }
+scylla = { version = "1.8.0", path = "../scylla", optional = true }
 scylla-cql = { version = "1.8.0", path = "../scylla-cql", optional = true }
 scylla-proxy = { version = "0.0.6", path = "../scylla-proxy", optional = true }
 

--- a/scylla-ccm-bridge/Cargo.toml
+++ b/scylla-ccm-bridge/Cargo.toml
@@ -46,7 +46,7 @@ itertools = "0.15.0"
 # Needed for client routes feature only
 scylla = { version = "1.8.0", path = "../scylla", optional = true }
 scylla-cql = { version = "1.8.0", path = "../scylla-cql", optional = true }
-scylla-proxy = { version = "0.0.6", path = "../scylla-proxy", optional = true }
+scylla-proxy = { version = "0.0.7", path = "../scylla-proxy", optional = true }
 
 [package.metadata.cargo-semver-checks.lints]
 workspace = true

--- a/scylla-cql-core/Cargo.toml
+++ b/scylla-cql-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql-core"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "CQL data types and primitives that form the stable public API of the ScyllaDB Rust driver."

--- a/scylla-cql-core/Cargo.toml
+++ b/scylla-cql-core/Cargo.toml
@@ -59,7 +59,7 @@ unstable-python-rs = []
 # Important: We use precise version of scylla-macros. This enables
 # us to make breaking changes in the doc(hidden) interfaces that are
 # used by macros.
-scylla-macros = { version = "=1.7.0", path = "../scylla-macros" }
+scylla-macros = { version = "=1.8.0", path = "../scylla-macros" }
 # FrameSlice and other parts of public API (impl SerializeValue for Bytes, BufMut in vint_encode)
 bytes = "1.0.1"
 # CqlTimeuuid, ser/deser of CQL UUID

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cql"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "CQL data types and primitives, for interacting with ScyllaDB."

--- a/scylla-cql/Cargo.toml
+++ b/scylla-cql/Cargo.toml
@@ -68,7 +68,7 @@ unstable-python-rs = ["scylla-cql-core/unstable-python-rs"]
 ###########################
 # Main, public dependencies
 ###########################
-scylla-cql-core = { version = "1.7.0", path = "../scylla-cql-core" }
+scylla-cql-core = { version = "1.8.0", path = "../scylla-cql-core" }
 # AsyncRead trait used in read_response_frame
 tokio = { version = "1.40", features = ["io-util"] }
 # FrameSlice and other parts of public API

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-macros"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "proc macros for the ScyllaDB async CQL driver"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-proxy"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 rust-version = "1.88"
 description = "Proxy layer between ScyllaDB driver and cluster that enables testing ScyllaDB drivers' behaviour in unfavourable conditions"

--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 defaults = []
 
 [dependencies]
-scylla-cql = { version = "1.7.0", path = "../scylla-cql" }
+scylla-cql = { version = "1.8.0", path = "../scylla-cql" }
 bytes = "1.10"
 futures = "0.3.6"
 tokio = { version = "1.40", features = [

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -92,7 +92,7 @@ unstable-client-routes = []
 # Main, public dependencies
 ###########################
 scylla-cql = { version = "=1.7.0", path = "../scylla-cql" }
-scylla-cql-core = { version = "=1.7.0", path = "../scylla-cql-core" }
+scylla-cql-core = { version = "=1.8.0", path = "../scylla-cql-core" }
 tokio = { version = "1.40", features = [
     "net",
     "time",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -91,7 +91,7 @@ unstable-client-routes = []
 ###########################
 # Main, public dependencies
 ###########################
-scylla-cql = { version = "=1.7.0", path = "../scylla-cql" }
+scylla-cql = { version = "=1.8.0", path = "../scylla-cql" }
 scylla-cql-core = { version = "=1.8.0", path = "../scylla-cql-core" }
 tokio = { version = "1.40", features = [
     "net",

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -159,7 +159,7 @@ smallvec = "1.8.0"
 num-bigint-03 = { package = "num-bigint", version = "0.3" }
 num-bigint-04 = { package = "num-bigint", version = "0.4" }
 bigdecimal-04 = { package = "bigdecimal", version = "0.4" }
-scylla-proxy = { version = "0.0.6", path = "../scylla-proxy" }
+scylla-proxy = { version = "0.0.7", path = "../scylla-proxy" }
 scylla-ccm-bridge = { path = "../scylla-ccm-bridge", features = ["driver", "unstable-client-routes"] }
 criterion = "0.8"
 tokio = { version = "1.34", features = ["test-util", "process", "fs"] }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Async CQL driver for Rust, optimized for ScyllaDB, fully compatible with Apache Cassandra™"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB Rust Driver 1.8.0,
an asynchronous CQL driver for Rust, optimized for ScyllaDB, but also compatible with Apache Cassandra!

Some interesting statistics:

- over 8.1M downloads on crates.io!
- over 682 GitHub stars!

## Changes

**New features / enhancements:**
- `QueryPager` (used by `Session::execute_iter` and `Session::query_iter`) was optimized for single-page queries. Now it only starts a `tokio::task` if there is more than one page ([#1739](https://github.com/scylladb/scylla-rust-driver/pull/1739)).
- `QueryPager` now treats each page as a fully separate request: new execution plan is produced for each page, downgraded consistency is reset. Driver still tries to stick to the same coordinator for subsequent pages: the first element of the plan for the next page will be the coordinator of the previous page ([#1739](https://github.com/scylladb/scylla-rust-driver/pull/1739)).
- `QueryPager` (used by `Session::execute_iter` and `Session::query_iter`) now supports Speculative Execution ([#1783](https://github.com/scylladb/scylla-rust-driver/pull/1783)).
- Internal metadata fetching procedures were greatly improved, dropping many unnecessary false dependencies between internal driver tasks, which should improve the delay of some of them ([#1792](https://github.com/scylladb/scylla-rust-driver/pull/1792), [#1823](https://github.com/scylladb/scylla-rust-driver/pull/1823), [#1835](https://github.com/scylladb/scylla-rust-driver/pull/1835)).
- Metadata fetching now supports client-side timeouts ([#1837](https://github.com/scylladb/scylla-rust-driver/pull/1837)).
- Driver will now temporarily stop using shard-aware port on shard mismatch (indicating NAT usage) ([#1804](https://github.com/scylladb/scylla-rust-driver/pull/1804)).
- On STATUS_CHANGE DOWN event a keepalive is now immediately requested on connection to the affected node ([#1806](https://github.com/scylladb/scylla-rust-driver/pull/1806)).
- Driver now correctly resolves DNS names to multiple IP addresses, both v4 and v6 ([#1805](https://github.com/scylladb/scylla-rust-driver/pull/1805)).
- `Client Routes` feature now choose an IP randomly for each connection if DNS resolves to multiple IPs ([#1805](https://github.com/scylladb/scylla-rust-driver/pull/1805)).
- `CqlTimestamp` now implements `Ord` and `Hash` ([#1834](https://github.com/scylladb/scylla-rust-driver/pull/1834)).
- A new crate `scylla-ccm-bridge` is extracted for reuse in different projects ([#1810](https://github.com/scylladb/scylla-rust-driver/pull/1810)).
- Driver can now be configured to fetch only the minimal subset of metadata that doesn't break token-awareness ([#1815](https://github.com/scylladb/scylla-rust-driver/pull/1815)).
- `Keyspace` struct now has a new `tablets` field, indicating if the keyspace is vnode- or tablet-based. This info fetched from system tables and used by the driver for more precise routing ([#1720](https://github.com/scylladb/scylla-rust-driver/pull/1720)).
- Added new metrics accessors that properly distinguish between unpaged, manually paged and automatically paged requests ([#1775](https://github.com/scylladb/scylla-rust-driver/pull/1775)).
- Bugs in our examples are fixed, some examples are restructured. Examples now run in CI to keep them working ([#1813](https://github.com/scylladb/scylla-rust-driver/pull/1813)).
- `RetrySession` is now created lazily when needed, to save an allocation on the hot path ([#1833](https://github.com/scylladb/scylla-rust-driver/pull/1833)).

**Bug fixes:**
- Fixed a deadlock happening when driver was flooded with CQL events during metadata refresh ([#1835](https://github.com/scylladb/scylla-rust-driver/pull/1835)).
- Tablet-awareness now correctly works with materialized views ([#1778](https://github.com/scylladb/scylla-rust-driver/pull/1778)).
- Out-of-range shard ids in ShardingInfo are now correctly rejected ([#1712](https://github.com/scylladb/scylla-rust-driver/pull/1712)).
- Shard set in Coordinator is now set to the real shard from Connection, not the shard requested by LBP ([#1765](https://github.com/scylladb/scylla-rust-driver/pull/1765)).
- Fix bug in `Metrics::get_latency_percentile_ms` that caused it to return completely wrong value ([#1749](https://github.com/scylladb/scylla-rust-driver/pull/1749)).
- Scylla with `enable_shard_aware_drivers: false` is now recognized as Scylla, not Cassandra ([#1719](https://github.com/scylladb/scylla-rust-driver/pull/1719)).
- `Client Routes`: non-sticky routes are now correctly overwritten on updates ([#1822](https://github.com/scylladb/scylla-rust-driver/pull/1822)).
- `RequestInfo` passed to `RetrySession` now gets current (so potentially downgraded) consistency, instead of the original consistency ([#1758](https://github.com/scylladb/scylla-rust-driver/pull/1758), [#1770](https://github.com/scylladb/scylla-rust-driver/pull/1770)).
- Fixed trace span not being finalized when RetrySession issues a `IgnoreWriteError` decision  ([#1761](https://github.com/scylladb/scylla-rust-driver/pull/1761)).

**Internal refactors**:
- Internal request execution paths were deduplicated into a common module. Now all variants (unpaged, QueryPager, ControlConnection) use the same logic to handle retries, tracing, speculative execution, query history, and other mechanism ([#1774](https://github.com/scylladb/scylla-rust-driver/pull/1774), [#1783](https://github.com/scylladb/scylla-rust-driver/pull/1783), [#1786](https://github.com/scylladb/scylla-rust-driver/pull/1786), [#1789](https://github.com/scylladb/scylla-rust-driver/pull/1789), [#1830](https://github.com/scylladb/scylla-rust-driver/pull/1830), [#1751](https://github.com/scylladb/scylla-rust-driver/pull/1751)).
- Reduced `cfg` sprawl from `metrics` feature across the codebase ([#1750](https://github.com/scylladb/scylla-rust-driver/pull/1750)).
- Return client routes in Metadata instead of applying them in ControlConnection ([#1820](https://github.com/scylladb/scylla-rust-driver/pull/1820)).
- Fixed issues pointed out by Clippy after its 1.97 release ([#1779](https://github.com/scylladb/scylla-rust-driver/pull/1779)).
- Removed unused dependencies from `scylla-proxy` ([#1744](https://github.com/scylladb/scylla-rust-driver/pull/1744)).
- `CqlTimeuuid::lsb_signed` is now properly documented. `Timeuuid` ordering test is hardened ([#1766](https://github.com/scylladb/scylla-rust-driver/pull/1766)).
- Various small fixes related to unification of execution paths ([#1770](https://github.com/scylladb/scylla-rust-driver/pull/1770)).

**Documentation:**
- Updated dependencies of documentation ([#1724](https://github.com/scylladb/scylla-rust-driver/pull/1724)).
- Bumped sphinx-scylladb-theme from 1.9.2 to 1.9.3 ([#1791](https://github.com/scylladb/scylla-rust-driver/pull/1791)).

**CI / tests / developer tool improvements:**
- Added Valgrind-based benchmarks, running in CI to catch regressions ([#1780](https://github.com/scylladb/scylla-rust-driver/pull/1780)).
- Renovate was configured to keep our dependencies up to date ([#1753](https://github.com/scylladb/scylla-rust-driver/pull/1753), [#1812](https://github.com/scylladb/scylla-rust-driver/pull/1812), [#1746](https://github.com/scylladb/scylla-rust-driver/pull/1746), [#1740](https://github.com/scylladb/scylla-rust-driver/pull/1740)).
- Updated Scylla version used in tests to v2026.2.3 ([#1826](https://github.com/scylladb/scylla-rust-driver/pull/1826)).
- Speed up vector type integration test by running subtests concurrently ([#1759](https://github.com/scylladb/scylla-rust-driver/pull/1759)).
-  Speed up vector type integration test by  using a single table for all subtests ([#1760](https://github.com/scylladb/scylla-rust-driver/pull/1760)).
- Unified handling of Scylla versions between tests categories ([#1821](https://github.com/scylladb/scylla-rust-driver/pull/1821)).
- Vastly expanded and improved our Tablets tests ([#1777](https://github.com/scylladb/scylla-rust-driver/pull/1777)).
- Cleanly handle startup failures in `Client Routes` test utils ([#1795](https://github.com/scylladb/scylla-rust-driver/pull/1795)).
- Connection: changed `#[expect(deprecated)]` to `#[allow(deprecated)]` on `set_linger` because older Tokio verions don't mark is as deprecated ([#1787](https://github.com/scylladb/scylla-rust-driver/pull/1787)).
- Remove misleading comment in test ([#1808](https://github.com/scylladb/scylla-rust-driver/pull/1808)).

**Dependencies:**
- Updated scylladb/github-automation action multiple times ([#1743](https://github.com/scylladb/scylla-rust-driver/pull/1743), [#1747](https://github.com/scylladb/scylla-rust-driver/pull/1747), [#1752](https://github.com/scylladb/scylla-rust-driver/pull/1752), [#1754](https://github.com/scylladb/scylla-rust-driver/pull/1754), [#1755](https://github.com/scylladb/scylla-rust-driver/pull/1755), [#1757](https://github.com/scylladb/scylla-rust-driver/pull/1757), [#1768](https://github.com/scylladb/scylla-rust-driver/pull/1768), [#1773](https://github.com/scylladb/scylla-rust-driver/pull/1773), [#1797](https://github.com/scylladb/scylla-rust-driver/pull/1797), [#1800](https://github.com/scylladb/scylla-rust-driver/pull/1800), [#1807](https://github.com/scylladb/scylla-rust-driver/pull/1807)).
- Updated actions-rust-lang/setup-rust-toolchain action to v1.16.1 ([#1825](https://github.com/scylladb/scylla-rust-driver/pull/1825)).
- Updated taiki-e/install-action action to v2.77.0 ([#1798](https://github.com/scylladb/scylla-rust-driver/pull/1798), [#1802](https://github.com/scylladb/scylla-rust-driver/pull/1802), [#1803](https://github.com/scylladb/scylla-rust-driver/pull/1803)).
- Updated Rust crate criterion to 0.8 ([#1722](https://github.com/scylladb/scylla-rust-driver/pull/1722)).
- Updated Rust crate darling to 0.24.0 ([#1725](https://github.com/scylladb/scylla-rust-driver/pull/1725), [#1811](https://github.com/scylladb/scylla-rust-driver/pull/1811)).
- Updated Rust crate hashbrown to 0.17 ([#1726](https://github.com/scylladb/scylla-rust-driver/pull/1726)).
- Updated Rust crate itertools to 0.15.0 ([#1727](https://github.com/scylladb/scylla-rust-driver/pull/1727)).
- Updated Rust crate socket2 to 0.6.0 ([#1735](https://github.com/scylladb/scylla-rust-driver/pull/1735)).
- Updated Rust crate syn to v3 ([#1796](https://github.com/scylladb/scylla-rust-driver/pull/1796), [#1811](https://github.com/scylladb/scylla-rust-driver/pull/1811), [#1827](https://github.com/scylladb/scylla-rust-driver/pull/1827)).
- Updated Rust crate lz4_flex to 0.14.0 ([#1728](https://github.com/scylladb/scylla-rust-driver/pull/1728), [#1785](https://github.com/scylladb/scylla-rust-driver/pull/1785)).
- Updated histogram to 1.0 ([#1748](https://github.com/scylladb/scylla-rust-driver/pull/1748)).

**Others:**
- Added public methods required for python-rs driver ([#1771](https://github.com/scylladb/scylla-rust-driver/pull/1771), [#1790](https://github.com/scylladb/scylla-rust-driver/pull/1790)).
- Conditionally published APIs for C# RS Driver ([#1717](https://github.com/scylladb/scylla-rust-driver/pull/1717)).

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/scylla-rust-driver](https://github.com/scylladb/scylla-rust-driver)
Contributions are most welcome!

The official crates.io registry entry is here:
- [https://crates.io/crates/scylla](https://crates.io/crates/scylla)

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

| commits | author               |
|---------|----------------------|
| 116     | Karol Baryła         |
| 112     | Wojciech Przytuła    |
|  25     | renovate[bot]        |
|  19     | Patrycja Ziemkiewicz |
|   2     | Dawid Pawlik         |
|   2     | Floze                |
|   2     | phalat               |
|   2     | Paulina Czajkowska   |
|   1     | Anna Stuchlik        |
|   1     | Photon101            |
|   1     | Vismay               |
|   1     | dependabot[bot]      |
