### PR TITLE
Add code coverage measurement for unit and integration tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,100 @@
+name: Code coverage
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+      - "branch-*"
+  pull_request:
+    branches:
+      - "**"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings --cfg scylla_unstable
+  RUST_BACKTRACE: full
+  # Pinned to a specific dated release rather than floating "nightly", so an
+  # upstream toolchain change cannot silently break this job. Bump the date
+  # deliberately when there's a reason to (a new nightly-only feature, a bug
+  # fix upstream).
+  NIGHTLY_TOOLCHAIN: nightly-2026-08-18
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # nightly is required so cargo-llvm-cov can instrument doctests (its
+      # doctest coverage support is nightly-only); the rest of this repo's CI
+      # keeps using stable, this job is the only one that needs nightly.
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          components: llvm-tools
+      - name: Install cargo-nextest and cargo-llvm-cov
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        with:
+          tool: nextest,cargo-llvm-cov
+      - name: Print rustc version
+        run: rustc --version
+      - name: Setup 3-node ScyllaDB cluster
+        run: |
+          sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+          make up
+
+      # From here on, every step uses `if: always()`: a failing test must not
+      # skip cluster cleanup, the CCM suite, or report generation -- a broken
+      # test would otherwise leave no coverage output at all to diagnose it
+      # with (and would strand the docker cluster running).
+      - name: Run tests with coverage
+        if: always()
+        run: RUST_LOG=trace make test-coverage
+      - name: Stop the docker cluster
+        if: always()
+        run: make stop
+      - name: Print the docker cluster logs
+        if: always()
+        run: make print-logs
+      - name: Remove cluster
+        if: always()
+        run: make down
+      - name: Install scylla-ccm
+        if: always()
+        run: pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
+      # continue-on-error is scoped to just this step: its only purpose is the
+      # side effect of creating ~/.ccm on first run, it is not itself a test,
+      # and `ccm status` legitimately exits non-zero here (no cluster exists
+      # yet). Every other step in this job is a real test/report-generation
+      # step whose failure should still surface in the job's overall status.
+      - name: Run CCM command to create the ~/.ccm dir
+        if: always()
+        continue-on-error: true
+        run: ccm status
+      - name: Run CCM tests with coverage
+        if: always()
+        run: RUST_LOG=trace make ccm-test-coverage
+      - name: Generate coverage report
+        if: always()
+        run: make coverage-report
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          {
+            echo '## Coverage report'
+            echo '```'
+            cargo +$NIGHTLY_TOOLCHAIN llvm-cov report
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: |
+            target/llvm-cov/html
+            target/llvm-cov/lcov.info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,33 @@ You can then execute those tests with `make ccm-test`.
 By default they use the version from `scylla_version.env`, prefixed with `release:`.
 To point them at a different version ad hoc, set `SCYLLA_TEST_CLUSTER` to a full ccm version string, e.g. `release:2026.1.0` or `unstable/master:<id>`.
 
+### Measuring code coverage
+
+We use [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) for code coverage: it's LLVM
+source-based coverage, so unlike ptrace-based tools it handles this driver's async,
+multi-threaded tests correctly. It runs on the **nightly** toolchain -- only for this coverage
+tooling, the rest of the repo (and its MSRV) is unaffected -- because nightly is required to
+include doctests in the coverage data. Install everything needed with:
+```bash
+rustup toolchain install nightly --component llvm-tools-preview
+cargo install cargo-llvm-cov cargo-nextest --locked
+```
+
+Run the coverage-instrumented test suites, then generate the report:
+```bash
+make test-coverage       # doctests, unit tests and integration tests, same scope as `make test`
+make ccm-test-coverage   # ccm tests, same scope as `make ccm-test`; accumulates onto the above
+make coverage-report
+```
+`coverage-report` prints a per-file summary and writes an HTML report to `target/llvm-cov/html/index.html`
+(open it in a browser for a line-by-line view) and an lcov file to `target/llvm-cov/lcov.info`.
+`make clean-coverage` resets the collected data.
+
+The commands above use whatever toolchain `rustup` resolves as plain `nightly`. CI instead pins
+`NIGHTLY_TOOLCHAIN` to a specific dated release (see `.github/workflows/coverage.yml`) so it
+doesn't break when nightly changes upstream; pass the same variable locally
+(`make test-coverage NIGHTLY_TOOLCHAIN=nightly-2026-08-18`) to reproduce a CI run exactly.
+
 ### Writing tests that need to connect to Scylla
 
 If you test requires connecting to Scylla, there are a few things you should consider.

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,71 @@ test: up
 ccm-test:
 	cargo nextest run --all-features -E 'test(ccm::)' --ignore-default-filter --status-level pass
 
+# Coverage-instrumented counterparts of test/ccm-test, using cargo-llvm-cov
+# (LLVM source-based coverage; unlike ptrace-based tools it handles async,
+# multi-threaded code correctly). test-coverage starts from a clean slate;
+# ccm-test-coverage deliberately does not clean, so it accumulates onto
+# whatever test-coverage already collected instead of replacing it. Run
+# test-coverage first, then optionally ccm-test-coverage, then coverage-report.
+#
+# Everything here runs on a nightly toolchain (NIGHTLY_TOOLCHAIN, "nightly" by
+# default): nightly is required for cargo-llvm-cov to instrument doctests.
+# Coverage data recorded under different toolchains' LLVM versions cannot be
+# merged, so every instrumented run and every report read uses the same
+# toolchain. This does not affect `test`/`ccm-test`, which keep using the
+# default (stable) toolchain. Local use needs nightly plus its
+# llvm-tools-preview component: `rustup toolchain install nightly --component
+# llvm-tools-preview`.
+#
+# CI pins NIGHTLY_TOOLCHAIN to a specific dated release (see coverage.yml)
+# rather than floating "nightly", so an upstream toolchain change cannot
+# silently break this job; bump the pinned date deliberately when needed.
+#
+# --no-fail-fast is required: nextest's default is to stop the whole run
+# after the first failing binary, which combined with --no-report (needed so
+# multiple invocations accumulate into one report) would discard coverage
+# data for every test that would otherwise have run afterward. This does not
+# change the process's own exit code, though, so the nextest and doctest exit
+# statuses are captured explicitly: both commands always run, and the target
+# still fails if either did.
+#
+# Branch coverage (--branch) is intentionally not enabled: cargo-llvm-cov's
+# report generation segfaults inside LLVM's own coverage-mapping code
+# (llvm::coverage::CoverageMapping::getInstantiationGroups) once --branch is
+# added to the instrumented test/doctest runs, on x86_64 Linux CI. This is
+# not tied to one LLVM release -- confirmed reproducible under both LLVM
+# 23.1.0 and LLVM 22.1 (two different nightly pins), so switching the pinned
+# nightly does not avoid it. It does not reproduce on aarch64 macOS with
+# either LLVM version, and has also been reproduced on a reviewer's own
+# Linux machine, pointing at a genuine upstream LLVM/cargo-llvm-cov bug
+# rather than anything in this repo or CI-runner-specific. Revisit once the
+# upstream issue is understood or fixed.
+NIGHTLY_TOOLCHAIN ?= nightly
+
+.PHONY: test-coverage
+test-coverage: up
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov clean --workspace
+	set +e; \
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov nextest --all-features --no-report --no-fail-fast; nextest_status=$$?; \
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov --no-report --doc --all-features; doctest_status=$$?; \
+	test $$nextest_status -eq 0 && test $$doctest_status -eq 0
+
+.PHONY: ccm-test-coverage
+ccm-test-coverage:
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov nextest --all-features --no-report --no-fail-fast -E 'test(ccm::)' --ignore-default-filter --status-level pass
+
+.PHONY: coverage-report
+coverage-report:
+	mkdir -p target/llvm-cov
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov report
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov report --html --output-dir target/llvm-cov
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov report --lcov --output-path target/llvm-cov/lcov.info
+
+.PHONY: clean-coverage
+clean-coverage:
+	cargo +$(NIGHTLY_TOOLCHAIN) llvm-cov clean --workspace
+	rm -rf target/llvm-cov
+
 .PHONY: run-examples
 run-examples: up
 	./scripts/run-examples.sh


### PR DESCRIPTION
## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce. (N/A: CI/tooling change, no public API)
- [ ] I have adjusted the documentation in `./docs/source/`. (N/A: `docs/source/` covers driver usage; contributor/tooling docs live in `CONTRIBUTING.md`, which this PR does update)
- [x] I added appropriate `Fixes:` annotations to PR description.

## What

Adds code coverage measurement, runnable locally (via new `make` targets) and in CI, across the full test suite: doctests, unit tests, integration tests (via `cargo nextest`, against the docker-compose ScyllaDB cluster), and the CCM suite (topology-change tests, via `scylla-ccm`).

- `Makefile`: `test-coverage` and `ccm-test-coverage` mirror the existing `test`/`ccm-test` targets, instrumented via `cargo-llvm-cov`. Both write into the same coverage data directory and accumulate together — run `test-coverage` first (it starts from a clean slate), then optionally `ccm-test-coverage`, then `coverage-report` to render everything collected so far. `clean-coverage` resets it.
- `.github/workflows/coverage.yml`: new CI job that runs the instrumented suites against a live cluster on every push/PR, posts a summary to the job log, and uploads the HTML/lcov reports as a build artifact.
- `CONTRIBUTING.md`: documents the above under the existing `## Testing` section.

## Design notes

**Tool**: [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) — LLVM source-based coverage — rather than a ptrace-based tool like `cargo-tarpaulin`, since ptrace-based instrumentation does not handle async, multi-threaded tests reliably (this driver is built on tokio throughout). `cargo-llvm-cov`'s `nextest` subcommand wraps `cargo nextest run` directly, so `test-coverage`/`ccm-test-coverage` are close to drop-in instrumented versions of `test`/`ccm-test` rather than a separately maintained test-running path.

**Nightly toolchain, scoped to this job**: `cargo-llvm-cov`'s doctest instrumentation requires the nightly toolchain, so only the coverage job runs on nightly — `test`/`ccm-test` and the rest of CI stay on stable. This also keeps every instrumented run and report read on one toolchain's LLVM version, since coverage data recorded under different LLVM versions cannot be merged. CI pins the toolchain to a specific dated nightly release rather than a floating one, so an unrelated toolchain update cannot break this job.

**`--no-fail-fast` and exit-status handling**: nextest's default is to stop the whole run after the first failing test binary. Combined with `--no-report` (needed so `test-coverage` and `ccm-test-coverage` accumulate into one report instead of each producing an independent one), a single failure would otherwise discard coverage data for every test that would have run afterward, so every coverage-instrumented nextest invocation passes `--no-fail-fast`. That flag does not change the process's own exit status, though, so the nextest and doctest commands' exit statuses are captured explicitly: both always run, and the target still reports failure if either did.

Coverage results are surfaced via a GitHub Actions job summary and build artifact rather than a third-party service, to avoid requiring an external account or token. There is no coverage threshold gate yet; this establishes a baseline first.

## Testing

- `cargo-llvm-cov` accumulates coverage data correctly across multiple `--no-report` invocations, including cross-crate attribution (a crate's coverage reflects code exercised transitively through another crate's tests, not just its own).
- `--no-fail-fast` is necessary: without it, a single test failure truncates the collected test set and loses coverage data for every test that would otherwise have run afterward.
- The exit-status capture works as intended: a failure in the nextest step still lets the doctest step run, and the target still reports failure overall.
- Doctest coverage is included in the merged report.
- The integration and CCM suites are exercised by this PR's own CI job, against a live cluster.

Fixes: https://scylladb.atlassian.net/browse/DRIVER-888

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1614

