### PR TITLE
Preparations for partial metadata fetching

### DIFF
--- a/scylla-ccm-bridge/Cargo.toml
+++ b/scylla-ccm-bridge/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [lints.rust]
 unreachable_pub = "warn"
-missing-docs = "warn"
+missing_docs = "warn"
 
 [features]
 default = []

--- a/scylla-macros/Cargo.toml
+++ b/scylla-macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro2 = "1.0"
 [lints.rust]
 unnameable_types = "warn"
 unreachable_pub = "warn"
-missing-docs = "warn"
+missing_docs = "warn"
 
 [dev-dependencies]
 scylla = { path = "../scylla" }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 [lints.rust]
 unnameable_types = "warn"
 unreachable_pub = "warn"
-missing-docs = "warn"
+missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(scylla_unstable)',
     'cfg(cassandra_tests)',

--- a/scylla/src/cluster/metadata/cc_establisher.rs
+++ b/scylla/src/cluster/metadata/cc_establisher.rs
@@ -29,7 +29,7 @@ use crate::cluster::control_connection::{
     MetadataRequestTimeouts,
 };
 use crate::cluster::metadata::{
-    Metadata, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
+    Metadata, Peer, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
 };
 use crate::cluster::node::resolve_contact_points;
 use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
@@ -342,10 +342,9 @@ impl ControlConnectionEstablisher {
         }
     }
 
-    fn update_known_peers(&mut self, metadata: &Metadata) {
+    fn update_known_peers(&mut self, peers: &[Peer]) {
         let host_filter = self.host_filter.as_ref();
-        self.known_peers = metadata
-            .peers
+        self.known_peers = peers
             .iter()
             .filter(|peer| host_filter.is_none_or(|f| f.accept(peer)))
             .map(|peer| UntranslatedEndpoint::Peer(peer.to_peer_endpoint()))
@@ -353,14 +352,10 @@ impl ControlConnectionEstablisher {
 
         // Check if the host filter isn't accidentally too restrictive,
         // and print an error message about this fact
-        if !metadata.peers.is_empty() && self.known_peers.is_empty() {
+        if !peers.is_empty() && self.known_peers.is_empty() {
             error!(
                 node_ips = tracing::field::display(
-                    metadata
-                        .peers
-                        .iter()
-                        .map(|peer| peer.address)
-                        .safe_format(", ")
+                    peers.iter().map(|peer| peer.address).safe_format(", ")
                 ),
                 "The host filter rejected all nodes in the cluster, \
                 no connections that can serve user queries have been \
@@ -468,7 +463,7 @@ impl TopologyUpdateGuard {
     /// Updates the establisher's known peers from the fetched metadata and releases
     /// the metadata itself.
     pub(super) fn apply(self, establisher: &mut ControlConnectionEstablisher) -> Metadata {
-        establisher.update_known_peers(&self.metadata);
+        establisher.update_known_peers(&self.metadata.peers);
         self.metadata
     }
 }

--- a/scylla/src/cluster/metadata/cc_establisher.rs
+++ b/scylla/src/cluster/metadata/cc_establisher.rs
@@ -444,27 +444,29 @@ impl ControlConnectionEstablisher {
     }
 }
 
-/// Freshly fetched [`Metadata`] that the [`ControlConnectionEstablisher`] has not yet absorbed.
+/// Freshly fetched topology that the [`ControlConnectionEstablisher`] has not yet absorbed.
 ///
 /// [`ControlConnection::query_metadata`] returns its result wrapped in this
 /// guard, so that the fetched metadata cannot be used without the establisher
 /// updating its known peers from it first: the only way to extract the
 /// [`Metadata`] is [`apply`](Self::apply).
 #[must_use = "the fetched metadata must be applied to the ControlConnectionEstablisher"]
-pub(super) struct TopologyUpdateGuard {
-    metadata: Metadata,
+pub(super) struct TopologyUpdateGuard<T = Metadata> {
+    inner: T,
 }
 
-impl TopologyUpdateGuard {
-    pub(super) fn new(metadata: Metadata) -> Self {
-        Self { metadata }
+impl<T> TopologyUpdateGuard<T> {
+    pub(super) fn new(inner: T) -> Self {
+        Self { inner }
     }
+}
 
+impl TopologyUpdateGuard<Metadata> {
     /// Updates the establisher's known peers from the fetched metadata and releases
     /// the metadata itself.
     pub(super) fn apply(self, establisher: &mut ControlConnectionEstablisher) -> Metadata {
-        establisher.update_known_peers(&self.metadata.peers);
-        self.metadata
+        establisher.update_known_peers(&self.inner.peers);
+        self.inner
     }
 }
 

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -124,10 +124,10 @@ enum FetchPlan {
     /// server event, or owed because a partial fetch failed.
     Full,
     /// Partial fetch work is owed, at most one entry per partial fetch type.
-    /// Currently client routes is the only such type; when more are added,
-    /// the payload becomes a struct with one optional entry per type (like
-    /// `PartialMetadataChanges`).
-    Partial(ClientRoutesFetchRequest),
+    /// Currently client routes is the only such type.
+    Partial {
+        client_routes: Option<ClientRoutesFetchRequest>,
+    },
 }
 
 impl FetchPlan {
@@ -147,8 +147,15 @@ impl FetchPlan {
     /// argument in [`note_full_needed`](Self::note_full_needed).
     fn note_client_routes(&mut self, request: ClientRoutesFetchRequest) {
         match self {
-            FetchPlan::Idle => *self = FetchPlan::Partial(request),
-            FetchPlan::Partial(pending) => pending.merge(request),
+            FetchPlan::Idle => {
+                *self = FetchPlan::Partial {
+                    client_routes: Some(request),
+                }
+            }
+            FetchPlan::Partial { client_routes, .. } => match client_routes {
+                None => *client_routes = Some(request),
+                Some(client_routes) => client_routes.merge(request),
+            },
             FetchPlan::Full => (),
         }
     }
@@ -265,7 +272,12 @@ impl<'cc> PendingFetches<'cc> {
         if matches!(self, PendingFetches::Idle) {
             let request = match std::mem::take(plan) {
                 FetchPlan::Idle => return, // Nothing to do.
-                FetchPlan::Partial(request) => request,
+                FetchPlan::Partial {
+                    client_routes: Some(request),
+                } => request,
+                FetchPlan::Partial {
+                    client_routes: None,
+                } => return, // Nothing to do.
                 FetchPlan::Full => unreachable!("Covered by the previous block"),
             };
             *self = PendingFetches::Partial {

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -673,7 +673,9 @@ impl MetadataWorker {
         plan: &mut FetchPlan,
     ) -> ControlFlow<()> {
         debug!("Received server event: {:?}", event);
+        #[deny(clippy::wildcard_enum_match_arm)]
         match event {
+            Event::SchemaChange(_) => (), // For now only fetched during periodic refresh.
             Event::TopologyChange(_) => plan.note_full_needed(),
             Event::ClientRoutesChange(evt) => {
                 // An UPDATE_NODES event pairs `connection_ids[i]` with
@@ -733,7 +735,7 @@ impl MetadataWorker {
                     }
                 }
             }
-            _ => (), // TODO: unknown event. Probably should use `unreachable!`.
+            _ => unreachable!("clippy testifies that the match is exhaustive"),
         };
         ControlFlow::Continue(())
     }

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -338,23 +338,11 @@ impl MetadataWorker {
         }
     }
 
-    /// Establishes the initial control connection, fetching the initial
-    /// metadata in the process.
-    ///
-    /// Called by `Cluster::new` before the worker is spawned; the returned
-    /// control connection (if one could be kept) is handed back to
-    /// [`work`](Self::work) once the worker starts.
-    pub(in super::super) async fn establish_initial(
-        &mut self,
-    ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {
-        self.establish(true).await
-    }
-
     /// Establishes a control connection, fetching metadata in the process -
     /// see [`ControlConnectionEstablisher::establish_cc_and_fetch_metadata`], to which this
     /// delegates the candidate iteration. Each candidate is fetched on (and
     /// its events drained) by [`fetch_on_candidate`](Self::fetch_on_candidate).
-    async fn establish(
+    pub(in super::super) async fn establish(
         &mut self,
         initial: bool,
     ) -> Result<(Option<EstablishedCc>, Metadata), MetadataError> {

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -102,19 +102,6 @@ impl FetchOnCandidate for CandidateFetcher<'_> {
     }
 }
 
-/// What a server event obliges the worker to fetch, as classified by
-/// [`MetadataWorker::handle_server_event`].
-enum EventAction {
-    /// Nothing to fetch - the event was fully handled synchronously.
-    None,
-    /// Fetch full metadata: the event describes a change (e.g. in topology)
-    /// that only a full fetch picks up.
-    FetchFull,
-    /// Fetch the client routes for these (connection id, host id) pairs, as
-    /// listed in a CLIENT_ROUTES_CHANGE:UPDATE_NODES event.
-    FetchClientRoutes { pairs: HashSet<(String, Uuid)> },
-}
-
 /// The fetch work that [`MetadataWorker::work_on_cc`] owes but has not started
 /// yet, because the fetch that must precede it is still in flight. Also
 /// produced by [`MetadataWorker::fetch_on_candidate`], recording the fetch
@@ -412,7 +399,7 @@ impl MetadataWorker {
                         // even returning dummy metadata on initial fetch.
                         // If ClusterWorker is shutting down (which is the only case this
                         // could happen), then we will shutdown soon too, so ignoring is not a problem.
-                        let _ = Self::absorb_server_event(updates, event, &mut plan);
+                        let _ = Self::handle_server_event(updates, event, &mut plan);
                     }
                     ControlConnectionEvent::Broken(err) => {
                         return Err(MetadataError::ConnectionPoolError(
@@ -655,7 +642,7 @@ impl MetadataWorker {
                             return ControlFlow::Continue(());
                         },
                         ControlConnectionEvent::ServerEvent(event) => {
-                            Self::absorb_server_event(&mut self.updates, event, &mut plan)?;
+                            Self::handle_server_event(&mut self.updates, event, &mut plan)?;
                         }
                     }
                 }
@@ -683,10 +670,11 @@ impl MetadataWorker {
     fn handle_server_event(
         updates: &mut merge_channel::Sender<MetadataUpdate>,
         event: Event,
-    ) -> ControlFlow<(), EventAction> {
+        plan: &mut FetchPlan,
+    ) -> ControlFlow<()> {
         debug!("Received server event: {:?}", event);
         match event {
-            Event::TopologyChange(_) => ControlFlow::Continue(EventAction::FetchFull),
+            Event::TopologyChange(_) => plan.note_full_needed(),
             Event::ClientRoutesChange(evt) => {
                 // An UPDATE_NODES event pairs `connection_ids[i]` with
                 // `host_ids[i]`.
@@ -698,7 +686,7 @@ impl MetadataWorker {
                     } => connection_ids.into_iter().zip(host_ids).collect(),
                     _ => unreachable!("clippy testifies that the match is exhaustive"),
                 };
-                ControlFlow::Continue(EventAction::FetchClientRoutes { pairs })
+                plan.note_client_routes(ClientRoutesFetchRequest { pairs })
             }
             Event::StatusChange(status) => {
                 // Tracking node status using events is unreliable because of the possibility of losing events
@@ -744,29 +732,9 @@ impl MetadataWorker {
                         }
                     }
                 }
-                ControlFlow::Continue(EventAction::None)
             }
-            _ => ControlFlow::Continue(EventAction::None),
-        }
-    }
-
-    /// Handles a single server event and folds the fetch work it implies into
-    /// `plan`.
-    ///
-    /// Returns [`ControlFlow::Break`] if the worker should stop (the cluster
-    /// worker is gone).
-    fn absorb_server_event(
-        updates: &mut merge_channel::Sender<MetadataUpdate>,
-        event: Event,
-        plan: &mut FetchPlan,
-    ) -> ControlFlow<()> {
-        match Self::handle_server_event(updates, event)? {
-            EventAction::None => (),
-            EventAction::FetchFull => plan.note_full_needed(),
-            EventAction::FetchClientRoutes { pairs } => {
-                plan.note_client_routes(ClientRoutesFetchRequest { pairs })
-            }
-        }
+            _ => (), // TODO: unknown event. Probably should use `unreachable!`.
+        };
         ControlFlow::Continue(())
     }
 

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -115,11 +115,7 @@ impl FetchOnCandidate for CandidateFetcher<'_> {
 /// once": a due full fetch subsumes all partial work (see
 /// [`note_full_needed`](Self::note_full_needed)), so recording both would keep
 /// data only to throw it away.
-#[derive(Default)]
 enum FetchPlan {
-    /// Nothing is owed.
-    #[default]
-    Idle,
     /// A full metadata fetch is owed: requested explicitly, implied by a
     /// server event, or owed because a partial fetch failed.
     Full,
@@ -147,16 +143,17 @@ impl FetchPlan {
     /// argument in [`note_full_needed`](Self::note_full_needed).
     fn note_client_routes(&mut self, request: ClientRoutesFetchRequest) {
         match self {
-            FetchPlan::Idle => {
-                *self = FetchPlan::Partial {
-                    client_routes: Some(request),
-                }
-            }
             FetchPlan::Partial { client_routes, .. } => match client_routes {
                 None => *client_routes = Some(request),
                 Some(client_routes) => client_routes.merge(request),
             },
             FetchPlan::Full => (),
+        }
+    }
+
+    const fn empty() -> Self {
+        Self::Partial {
+            client_routes: None,
         }
     }
 }
@@ -211,30 +208,20 @@ type ClientRoutesFetch<'cc> =
 /// - a full fetch never has anything running beside it (it subsumes and
 ///   preempts all partial work), and
 /// - per partial fetch type, at most one fetch runs at a time. Currently
-///   client routes is the only such type; when more are added, `Partial`
-///   becomes a struct variant with one optional future per type, which is
-///   also how partial fetches of different types get to run concurrently.
+///   client routes is the only such type;
 ///
 /// [`start_due_fetches`](Self::start_due_fetches) starts the fetches that the
 /// [`FetchPlan`] owes. As a [`Future`], `PendingFetches` resolves to the
-/// [`FetchOutcome`] of the in-flight fetch once it completes, emptying `self`
-/// back to [`Idle`](Self::Idle) - so a completed fetch is never polled again.
-/// While `Idle`, polling pends forever *without registering a waker*: an idle
-/// value alone never wakes the worker. This is sound in `work_on_cc` because
-/// fetches are only started between `select!`s, never while one is being
-/// awaited, and the `select!` always has branches that do register wakers
-/// (e.g. event draining).
+/// [`FetchOutcome`] of the in-flight fetch once it completes.
 ///
 /// Cancel-safe: the futures live in this value, not in the `select!` branch
 /// polling it, so losing the `select!` race leaves the in-flight fetch intact.
 enum PendingFetches<'cc> {
-    /// No fetch is in flight.
-    Idle,
     /// A full metadata fetch is in flight.
     Full { fetch: FullFetch<'cc> },
-    /// A partial client-routes fetch is in flight.
+    /// Some partial fetches may be in progress.
     Partial {
-        client_routes_fetch: ClientRoutesFetch<'cc>,
+        client_routes_fetch: Option<ClientRoutesFetch<'cc>>,
     },
 }
 
@@ -258,7 +245,7 @@ impl<'cc> PendingFetches<'cc> {
             // plan and any running partial fetch: the full fetch reads all of
             // that data, and reads it after the events that made the partial
             // work due, so both are subsumed.
-            *plan = FetchPlan::Idle;
+            *plan = FetchPlan::empty();
             *next_refresh_deadline = deadline_after(Instant::now(), refresh_interval);
 
             debug!("Requesting metadata refresh");
@@ -268,21 +255,22 @@ impl<'cc> PendingFetches<'cc> {
             return;
         }
 
-        // Partial client-routes work starts only when nothing at all is in flight.
-        if matches!(self, PendingFetches::Idle) {
-            let request = match std::mem::take(plan) {
-                FetchPlan::Idle => return, // Nothing to do.
-                FetchPlan::Partial {
-                    client_routes: Some(request),
-                } => request,
-                FetchPlan::Partial {
-                    client_routes: None,
-                } => return, // Nothing to do.
-                FetchPlan::Full => unreachable!("Covered by the previous block"),
-            };
+        // Partial client-routes work starts when isn't already in flight.
+        if let PendingFetches::Partial {
+            client_routes_fetch: None,
+        } = self
+            && let FetchPlan::Partial { client_routes } = plan
+            && let Some(request) = client_routes.take()
+        {
             *self = PendingFetches::Partial {
-                client_routes_fetch: Box::pin(request.fetch_on(cc)),
+                client_routes_fetch: Some(Box::pin(request.fetch_on(cc))),
             };
+        }
+    }
+
+    const fn empty() -> Self {
+        Self::Partial {
+            client_routes_fetch: None,
         }
     }
 }
@@ -301,23 +289,27 @@ impl Future for PendingFetches<'_> {
         // `PendingFetches` is `Unpin` (the fetch futures are heap-pinned), so
         // it can be worked on through a plain `&mut`.
         let this = self.get_mut();
-        let outcome = match this {
-            PendingFetches::Idle => return Poll::Pending,
-            PendingFetches::Full { fetch } => match fetch.as_mut().poll(cx) {
-                Poll::Ready(result) => FetchOutcome::Full(result),
-                Poll::Pending => return Poll::Pending,
-            },
+        match this {
+            PendingFetches::Full { fetch } => {
+                if let Poll::Ready(result) = fetch.as_mut().poll(cx) {
+                    *this = PendingFetches::empty();
+                    return Poll::Ready(FetchOutcome::Full(result));
+                }
+            }
             PendingFetches::Partial {
                 client_routes_fetch,
-            } => match client_routes_fetch.as_mut().poll(cx) {
-                Poll::Ready(result) => FetchOutcome::ClientRoutes(result),
-                Poll::Pending => return Poll::Pending,
-            },
+            } => {
+                if let Some(client_routes) = client_routes_fetch
+                    && let Poll::Ready(result) = client_routes.as_mut().poll(cx)
+                {
+                    // The completed fetch has been consumed; drop its future.
+                    *client_routes_fetch = None;
+                    return Poll::Ready(FetchOutcome::ClientRoutes(result));
+                }
+            }
         };
 
-        // The completed fetch has been consumed; drop its future.
-        *this = PendingFetches::Idle;
-        Poll::Ready(outcome)
+        Poll::Pending
     }
 }
 
@@ -383,7 +375,7 @@ impl MetadataWorker {
         cc: &ControlConnection,
         cc_events: &mut ControlConnectionEvents,
     ) -> Result<(TopologyUpdateGuard, FetchPlan), MetadataError> {
-        let mut plan = FetchPlan::default();
+        let mut plan = FetchPlan::empty();
         // Boxed AND `dyn`-erased (rather than `pin!`ed) to cut the future-type
         // nesting here: `query_metadata`'s future tree is ~75 levels deep, and
         // exposing it in this future's type - which every caller of
@@ -565,7 +557,7 @@ impl MetadataWorker {
         // The in-flight fetches. Their futures borrow `cc` and nothing else,
         // so the loop stays free to use `self` (in particular
         // `self.cc_establisher`) while fetches are in flight.
-        let mut pending_fetches = PendingFetches::Idle;
+        let mut pending_fetches = PendingFetches::empty();
 
         loop {
             pending_fetches.start_due_fetches(
@@ -833,7 +825,7 @@ mod tests {
     /// `work_on_cc` polls it in its `select!` unconditionally.
     #[test]
     fn idle_pends() {
-        let mut pending_fetches = PendingFetches::Idle;
+        let mut pending_fetches = PendingFetches::empty();
 
         assert!(poll_once(&mut pending_fetches).is_pending());
     }
@@ -850,17 +842,27 @@ mod tests {
             poll_once(&mut pending_fetches),
             Poll::Ready(FetchOutcome::Full(Ok(_)))
         ));
-        assert!(matches!(pending_fetches, PendingFetches::Idle));
+        assert!(matches!(
+            pending_fetches,
+            PendingFetches::Partial {
+                client_routes_fetch: None
+            }
+        ));
         assert!(poll_once(&mut pending_fetches).is_pending());
 
         let mut pending_fetches = PendingFetches::Partial {
-            client_routes_fetch: Box::pin(async { Ok(None) }),
+            client_routes_fetch: Some(Box::pin(async { Ok(None) })),
         };
         assert!(matches!(
             poll_once(&mut pending_fetches),
             Poll::Ready(FetchOutcome::ClientRoutes(Ok(None)))
         ));
-        assert!(matches!(pending_fetches, PendingFetches::Idle));
+        assert!(matches!(
+            pending_fetches,
+            PendingFetches::Partial {
+                client_routes_fetch: None
+            }
+        ));
     }
 
     /// Losing a `select!` race (the polling borrow being dropped) must leave

--- a/scylla/src/cluster/mod.rs
+++ b/scylla/src/cluster/mod.rs
@@ -20,6 +20,8 @@ pub(crate) use worker::{Cluster, ClusterNeatDebug, use_keyspace_result};
 
 mod state;
 pub use state::ClusterState;
+#[cfg(test)]
+pub(crate) use state::NodeConfig;
 
 pub(crate) mod node;
 pub use node::{KnownNode, Node, NodeAddr, NodeRef};

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -158,7 +158,7 @@ impl ClusterState {
     // This allow(clippy::type_complexity) is here because I can't satisfy borrow checker while
     // having the closure type be a type alias.
     #[allow(clippy::type_complexity)]
-    pub(crate) async fn new(
+    pub(crate) async fn new_updated(
         metadata: Metadata,
         pool_config: &PoolConfig,
         known_nodes: &HashMap<Uuid, Arc<Node>>,
@@ -715,7 +715,7 @@ mod tests {
         host_filter: Option<&dyn HostFilter>,
     ) -> ClusterState {
         let (tx, _rx) = mpsc::unbounded_channel();
-        ClusterState::new(
+        ClusterState::new_updated(
             metadata,
             &Default::default(),
             known_nodes,

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -174,33 +174,55 @@ impl ClusterState {
         node_config: &NodeConfig,
         host_filter: Option<&dyn HostFilter>,
     ) -> Self {
-        Self::new_updated(
-            metadata,
-            node_config,
+        let (new_known_nodes, ring) =
+            Self::calculate_new_topology(metadata.peers, &HashMap::new(), node_config, host_filter);
+
+        let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, &HashMap::new());
+
+        let mut tablets = TabletsInfo::new();
+        // Perform maintenance to create empty entries for all tablets-based tables.
+        Self::perform_tablets_maintenance(
+            &mut tablets,
             &HashMap::new(),
-            host_filter,
-            TabletsInfo::new(),
-            &HashMap::new(),
-        )
-        .await
+            &new_known_nodes,
+            &keyspaces,
+        );
+
+        let (locator, keyspaces) = Self::calculate_new_locator(keyspaces, ring, tablets).await;
+
+        ClusterState {
+            all_nodes: new_known_nodes.values().cloned().collect(),
+            known_nodes: new_known_nodes,
+            keyspaces,
+            locator,
+            cluster_name: metadata.cluster_name,
+        }
     }
 
     /// Creates new ClusterState using information about topology held in `metadata`.
-    /// Uses provided `known_nodes` hashmap to recycle nodes if possible.
+    /// Uses `self` to reuse data when possible.
     pub(crate) async fn new_updated(
+        &self,
         metadata: Metadata,
         node_config: &NodeConfig,
-        known_nodes: &KnownNodes,
         host_filter: Option<&dyn HostFilter>,
-        mut tablets: TabletsInfo,
-        old_keyspaces: &HashMap<String, Keyspace>,
     ) -> Self {
-        let (new_known_nodes, ring) =
-            Self::calculate_new_topology(metadata.peers, known_nodes, node_config, host_filter);
+        let (new_known_nodes, ring) = Self::calculate_new_topology(
+            metadata.peers,
+            &self.known_nodes,
+            node_config,
+            host_filter,
+        );
 
-        let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, old_keyspaces);
+        let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, &self.keyspaces);
 
-        Self::perform_tablets_maintenance(&mut tablets, known_nodes, &new_known_nodes, &keyspaces);
+        let mut tablets = self.locator.tablets.clone();
+        Self::perform_tablets_maintenance(
+            &mut tablets,
+            &self.known_nodes,
+            &new_known_nodes,
+            &keyspaces,
+        );
 
         let (locator, keyspaces) = Self::calculate_new_locator(keyspaces, ring, tablets).await;
 
@@ -706,7 +728,6 @@ mod tests {
     use crate::cluster::metadata::{Metadata, Peer};
     use crate::cluster::node::NodeAddr;
     use crate::policies::host_filter::HostFilter;
-    use crate::routing::locator::tablets::TabletsInfo;
     use crate::test_utils::setup_tracing;
 
     use std::collections::{HashMap, HashSet};
@@ -760,10 +781,9 @@ mod tests {
         }
     }
 
-    /// Helper: build a ClusterState from metadata, old known_nodes, and an optional host filter.
-    async fn build_cluster_state(
+    /// Helper: build a ClusterState from metadata and an optional host filter.
+    async fn new_cluster_state(
         metadata: Metadata,
-        known_nodes: &HashMap<Uuid, Arc<Node>>,
         host_filter: Option<&dyn HostFilter>,
     ) -> ClusterState {
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -773,15 +793,25 @@ mod tests {
             connectivity_events_sender: tx,
             metrics: Default::default(),
         };
-        ClusterState::new_updated(
-            metadata,
-            &node_config,
-            known_nodes,
-            host_filter,
-            TabletsInfo::new(),
-            &HashMap::new(),
-        )
-        .await
+        ClusterState::new(metadata, &node_config, host_filter).await
+    }
+
+    /// Helper: build a ClusterState from metadata, old state, and an optional host filter.
+    async fn update_cluster_state(
+        previous: &ClusterState,
+        metadata: Metadata,
+        host_filter: Option<&dyn HostFilter>,
+    ) -> ClusterState {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let node_config = NodeConfig {
+            pool_config: Default::default(),
+            used_keyspace: None,
+            connectivity_events_sender: tx,
+            metrics: Default::default(),
+        };
+        previous
+            .new_updated(metadata, &node_config, host_filter)
+            .await
     }
 
     // Node's address changes so that host filter no longer rejects it.
@@ -802,8 +832,7 @@ mod tests {
             Some("dc1"),
             Some("r1"),
         )]);
-        let initial_state =
-            build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
+        let initial_state = new_cluster_state(initial_metadata, Some(&filter)).await;
         let old_node = initial_state.known_nodes().get(&host_id).unwrap().clone();
         assert!(
             !old_node.is_enabled(),
@@ -817,8 +846,7 @@ mod tests {
             Some("dc1"),
             Some("r1"),
         )]);
-        let new_state =
-            build_cluster_state(new_metadata, initial_state.known_nodes(), Some(&filter)).await;
+        let new_state = update_cluster_state(&initial_state, new_metadata, Some(&filter)).await;
         let new_node = new_state.known_nodes().get(&host_id).unwrap();
 
         assert!(
@@ -849,8 +877,7 @@ mod tests {
             Some("dc1"),
             Some("r1"),
         )]);
-        let initial_state =
-            build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
+        let initial_state = new_cluster_state(initial_metadata, Some(&filter)).await;
         let old_node = initial_state.known_nodes().get(&host_id).unwrap().clone();
         assert!(
             old_node.is_enabled(),
@@ -864,8 +891,7 @@ mod tests {
             Some("dc1"),
             Some("r1"),
         )]);
-        let new_state =
-            build_cluster_state(new_metadata, initial_state.known_nodes(), Some(&filter)).await;
+        let new_state = update_cluster_state(&initial_state, new_metadata, Some(&filter)).await;
         let new_node = new_state.known_nodes().get(&host_id).unwrap();
 
         assert!(
@@ -891,15 +917,13 @@ mod tests {
         // Build initial state: peer at addr ⇒ disabled.
         let initial_metadata =
             make_metadata(vec![make_peer(host_id, addr, Some("dc1"), Some("r1"))]);
-        let initial_state =
-            build_cluster_state(initial_metadata, &HashMap::new(), Some(&filter)).await;
+        let initial_state = new_cluster_state(initial_metadata, Some(&filter)).await;
         let old_node = initial_state.known_nodes().get(&host_id).unwrap().clone();
         assert!(!old_node.is_enabled(), "node should be disabled");
 
         // Refresh with identical attributes, still filtered out.
         let new_metadata = make_metadata(vec![make_peer(host_id, addr, Some("dc1"), Some("r1"))]);
-        let new_state =
-            build_cluster_state(new_metadata, initial_state.known_nodes(), Some(&filter)).await;
+        let new_state = update_cluster_state(&initial_state, new_metadata, Some(&filter)).await;
         let new_node = new_state.known_nodes().get(&host_id).unwrap();
 
         assert!(!new_node.is_enabled(), "node should still be disabled");

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -169,6 +169,22 @@ impl ClusterState {
         node.trigger_keepalive();
     }
 
+    pub(crate) async fn new(
+        metadata: Metadata,
+        node_config: &NodeConfig,
+        host_filter: Option<&dyn HostFilter>,
+    ) -> Self {
+        Self::new_updated(
+            metadata,
+            node_config,
+            &HashMap::new(),
+            host_filter,
+            TabletsInfo::new(),
+            &HashMap::new(),
+        )
+        .await
+    }
+
     /// Creates new ClusterState using information about topology held in `metadata`.
     /// Uses provided `known_nodes` hashmap to recycle nodes if possible.
     pub(crate) async fn new_updated(

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,3 +1,4 @@
+use crate::cluster::metadata::{Peer, SingleKeyspaceMetadataError};
 use crate::errors::{ClusterStateTokenError, ConnectionPoolError};
 use crate::network::{Connection, ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
 use crate::observability::metrics::Metrics;
@@ -86,6 +87,9 @@ impl std::fmt::Debug for ClusterState {
     }
 }
 
+type KnownNodes = HashMap<Uuid, Arc<Node>>;
+type Ring = Vec<(Token, Arc<Node>)>;
+
 impl ClusterState {
     pub(crate) async fn wait_until_all_pools_are_initialized(&self) {
         for node in self.locator.unique_nodes_in_global_ring().iter() {
@@ -167,24 +171,47 @@ impl ClusterState {
 
     /// Creates new ClusterState using information about topology held in `metadata`.
     /// Uses provided `known_nodes` hashmap to recycle nodes if possible.
-    #[allow(clippy::too_many_arguments)]
-    // This allow(clippy::type_complexity) is here because I can't satisfy borrow checker while
-    // having the closure type be a type alias.
-    #[allow(clippy::type_complexity)]
     pub(crate) async fn new_updated(
         metadata: Metadata,
         node_config: &NodeConfig,
-        known_nodes: &HashMap<Uuid, Arc<Node>>,
+        known_nodes: &KnownNodes,
         host_filter: Option<&dyn HostFilter>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
     ) -> Self {
-        // Create new updated known_nodes and ring
-        let mut new_known_nodes: HashMap<Uuid, Arc<Node>> =
-            HashMap::with_capacity(metadata.peers.len());
-        let mut ring: Vec<(Token, Arc<Node>)> = Vec::new();
+        let (new_known_nodes, ring) =
+            Self::calculate_new_topology(metadata.peers, known_nodes, node_config, host_filter);
 
-        for peer in metadata.peers {
+        let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, old_keyspaces);
+
+        Self::perform_tablets_maintenance(&mut tablets, known_nodes, &new_known_nodes, &keyspaces);
+
+        let (locator, keyspaces) = Self::calculate_new_locator(keyspaces, ring, tablets).await;
+
+        ClusterState {
+            all_nodes: new_known_nodes.values().cloned().collect(),
+            known_nodes: new_known_nodes,
+            keyspaces,
+            locator,
+            cluster_name: metadata.cluster_name,
+        }
+    }
+
+    /// Creates a new topology (`Node` objects and token ring) from metadata peers,
+    /// and previous topology.
+    ///
+    /// Previous topology is used to reuse connection pools and `Node` objects when possible.
+    fn calculate_new_topology(
+        peers: Vec<Peer>,
+        known_nodes: &KnownNodes,
+        node_config: &NodeConfig,
+        host_filter: Option<&dyn HostFilter>,
+    ) -> (KnownNodes, Ring) {
+        // Create new updated known_nodes and ring
+        let mut new_known_nodes: KnownNodes = HashMap::with_capacity(peers.len());
+        let mut ring: Ring = Vec::new();
+
+        for peer in peers {
             // Take existing Arc<Node> if possible, otherwise create new one.
             let peer_host_id = peer.host_id;
             let is_enabled = host_filter.is_none_or(|f| f.accept(&peer));
@@ -239,8 +266,16 @@ impl ClusterState {
             }
         }
 
-        let keyspaces: HashMap<String, Keyspace> = metadata
-            .keyspaces
+        (new_known_nodes, ring)
+    }
+
+    /// Handles single-keyspace errors by reusing old `Keyspace` objects for such
+    /// broken keyspaces and warns about it.
+    fn resolve_metadata_keyspaces(
+        meta_keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>,
+        old_keyspaces: &HashMap<String, Keyspace>,
+    ) -> HashMap<String, Keyspace> {
+        meta_keyspaces
             .into_iter()
             .filter_map(|(ks_name, ks)| match ks {
                 Ok(ks) => Some((ks_name, ks)),
@@ -263,43 +298,48 @@ impl ClusterState {
                     }
                 }
             })
-            .collect();
+            .collect()
+    }
 
-        // Tablets maintenance.
-        {
-            let removed_nodes = {
-                let mut removed_nodes = HashSet::new();
-                for old_peer in known_nodes {
-                    if !new_known_nodes.contains_key(old_peer.0) {
-                        removed_nodes.insert(*old_peer.0);
-                    }
+    fn perform_tablets_maintenance(
+        tablets: &mut TabletsInfo,
+        old_known_nodes: &KnownNodes,
+        new_known_nodes: &KnownNodes,
+        keyspaces: &HashMap<String, Keyspace>,
+    ) {
+        let removed_nodes = {
+            let mut removed_nodes = HashSet::new();
+            for old_peer in old_known_nodes {
+                if !new_known_nodes.contains_key(old_peer.0) {
+                    removed_nodes.insert(*old_peer.0);
                 }
+            }
 
-                removed_nodes
-            };
+            removed_nodes
+        };
 
-            let recreated_nodes = {
-                let mut recreated_nodes = HashMap::new();
-                for (old_peer_id, old_peer_node) in known_nodes {
-                    if let Some(new_peer_node) = new_known_nodes.get(old_peer_id)
-                        && !Arc::ptr_eq(old_peer_node, new_peer_node)
-                    {
-                        recreated_nodes.insert(*old_peer_id, Arc::clone(new_peer_node));
-                    }
+        let recreated_nodes = {
+            let mut recreated_nodes = HashMap::new();
+            for (old_peer_id, old_peer_node) in old_known_nodes {
+                if let Some(new_peer_node) = new_known_nodes.get(old_peer_id)
+                    && !Arc::ptr_eq(old_peer_node, new_peer_node)
+                {
+                    recreated_nodes.insert(*old_peer_id, Arc::clone(new_peer_node));
                 }
+            }
 
-                recreated_nodes
-            };
+            recreated_nodes
+        };
 
-            tablets.perform_maintenance(
-                &keyspaces,
-                &removed_nodes,
-                &new_known_nodes,
-                &recreated_nodes,
-            )
-        }
+        tablets.perform_maintenance(keyspaces, &removed_nodes, new_known_nodes, &recreated_nodes)
+    }
 
-        let (locator, keyspaces) = tokio::task::spawn_blocking(move || {
+    async fn calculate_new_locator(
+        keyspaces: HashMap<String, Keyspace>,
+        ring: Ring,
+        tablets: TabletsInfo,
+    ) -> (ReplicaLocator, HashMap<String, Keyspace>) {
+        tokio::task::spawn_blocking(move || {
             let keyspace_strategies = keyspaces
                 .values()
                 .filter(|ks| !ks.tablet_based)
@@ -308,15 +348,7 @@ impl ClusterState {
             (locator, keyspaces)
         })
         .await
-        .unwrap();
-
-        ClusterState {
-            all_nodes: new_known_nodes.values().cloned().collect(),
-            known_nodes: new_known_nodes,
-            keyspaces,
-            locator,
-            cluster_name: metadata.cluster_name,
-        }
+        .unwrap()
     }
 
     /// Returns the name of the cluster, as reported by the `cluster_name` column in `system.local`.

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -21,6 +21,19 @@ use uuid::Uuid;
 use super::metadata::{Keyspace, Metadata, Strategy, Table};
 use super::node::{Node, NodeRef};
 
+/// Helper struct to group parameters that are only needed to
+/// construct `Node` objects.
+pub(crate) struct NodeConfig {
+    // Config for `NodeConnectioPool` for all new nodes.
+    pub(crate) pool_config: PoolConfig,
+    // Keyspace send in "USE <keyspace name>" when opening each connection.
+    pub(crate) used_keyspace: Option<VerifiedKeyspaceName>,
+    // Sender part of that channel to pass to `PoolRefiller`s.
+    pub(crate) connectivity_events_sender: mpsc::UnboundedSender<ConnectivityChangeEvent>,
+    // Metrics passed to each new `NodeConnectionPool`.
+    pub(crate) metrics: Metrics,
+}
+
 /// Represents the state of the cluster, including known nodes, keyspaces, and replica locator.
 ///
 /// It is immutable after creation, and is replaced atomically upon a metadata refresh.
@@ -160,14 +173,11 @@ impl ClusterState {
     #[allow(clippy::type_complexity)]
     pub(crate) async fn new_updated(
         metadata: Metadata,
-        pool_config: &PoolConfig,
+        node_config: &NodeConfig,
         known_nodes: &HashMap<Uuid, Arc<Node>>,
-        used_keyspace: &Option<VerifiedKeyspaceName>,
         host_filter: Option<&dyn HostFilter>,
-        connectivity_events_sender: &mpsc::UnboundedSender<ConnectivityChangeEvent>,
         mut tablets: TabletsInfo,
         old_keyspaces: &HashMap<String, Keyspace>,
-        metrics: &Metrics,
     ) -> Self {
         // Create new updated known_nodes and ring
         let mut new_known_nodes: HashMap<Uuid, Arc<Node>> =
@@ -215,10 +225,10 @@ impl ClusterState {
                 }
                 (true, _) => Arc::new(Node::new(
                     peer_endpoint,
-                    pool_config,
-                    connectivity_events_sender.clone(),
-                    used_keyspace.clone(),
-                    metrics.clone(),
+                    &node_config.pool_config,
+                    node_config.connectivity_events_sender.clone(),
+                    node_config.used_keyspace.clone(),
+                    node_config.metrics.clone(),
                 )),
             };
 
@@ -709,16 +719,19 @@ mod tests {
         host_filter: Option<&dyn HostFilter>,
     ) -> ClusterState {
         let (tx, _rx) = mpsc::unbounded_channel();
+        let node_config = NodeConfig {
+            pool_config: Default::default(),
+            used_keyspace: None,
+            connectivity_events_sender: tx,
+            metrics: Default::default(),
+        };
         ClusterState::new_updated(
             metadata,
-            &Default::default(),
+            &node_config,
             known_nodes,
-            &None,
             host_filter,
-            &tx,
             TabletsInfo::new(),
             &HashMap::new(),
-            &Default::default(),
         )
         .await
     }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -162,10 +162,6 @@ impl ClusterState {
         metadata: Metadata,
         pool_config: &PoolConfig,
         known_nodes: &HashMap<Uuid, Arc<Node>>,
-        // Takes old and new known_nodes maps as arguments.
-        handle_topology_changes: &mut (
-                 dyn FnMut(&HashMap<Uuid, Arc<Node>>, &HashMap<Uuid, Arc<Node>>) + Send + Sync
-             ),
         used_keyspace: &Option<VerifiedKeyspaceName>,
         host_filter: Option<&dyn HostFilter>,
         connectivity_events_sender: &mpsc::UnboundedSender<ConnectivityChangeEvent>,
@@ -232,8 +228,6 @@ impl ClusterState {
                 ring.push((token, Arc::clone(&node)));
             }
         }
-
-        handle_topology_changes(known_nodes, &new_known_nodes);
 
         let keyspaces: HashMap<String, Keyspace> = metadata
             .keyspaces
@@ -719,7 +713,6 @@ mod tests {
             metadata,
             &Default::default(),
             known_nodes,
-            &mut |_, _| (),
             &None,
             host_filter,
             &tx,

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -422,15 +422,9 @@ impl ClusterWorker {
                 refresh_responses,
             }) => {
                 let new_cluster_state = Arc::new(
-                    ClusterState::new_updated(
-                        metadata,
-                        &self.node_config,
-                        &cluster_state.known_nodes,
-                        self.host_filter.as_deref(),
-                        cluster_state.locator.tablets.clone(),
-                        &cluster_state.keyspaces,
-                    )
-                    .await,
+                    cluster_state
+                        .new_updated(metadata, &self.node_config, self.host_filter.as_deref())
+                        .await,
                 );
                 Some((new_cluster_state, refresh_responses))
             }

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -27,7 +27,6 @@ use std::time::Duration;
 use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
-use super::metadata::Metadata;
 use super::metadata::cc_establisher::ControlConnectionEstablisher;
 use super::metadata::merge_channel::{self, merge_channel};
 use super::metadata::worker::MetadataWorker;
@@ -434,18 +433,17 @@ impl ClusterWorker {
             HashSet::new()
         };
 
+        let cluster_state = self.cluster_state.load_full();
+
         // Unlike UP hints, DOWN hints are applied to the *current* state: a keepalive
         // query only makes sense for a node the driver still holds connections to, so
         // there is nothing a freshly built state could add, and waiting for the refresh
         // (which awaits pool initialization) would only delay the liveness probe.
-        {
-            let cluster_state = self.cluster_state.load();
-            update
-                .status_hints
-                .iter()
-                .filter(|(_k, v)| **v == StatusHint::Down)
-                .for_each(|(addr, _)| cluster_state.trigger_keepalive_for_addr(*addr));
-        }
+        update
+            .status_hints
+            .iter()
+            .filter(|(_k, v)| **v == StatusHint::Down)
+            .for_each(|(addr, _)| cluster_state.trigger_keepalive_for_addr(*addr));
 
         let process_up_hints = |state: &ClusterState| {
             state.trigger_pool_refills_for_hosts(client_routes_hosts_to_refill.into_iter());
@@ -456,55 +454,41 @@ impl ClusterWorker {
                 .for_each(|(addr, _)| state.trigger_pool_refill_for_addr(*addr));
         };
 
-        match update.metadata_changes {
+        let new_state_with_requests = match update.metadata_changes {
             Some(MetadataChanges::Full {
                 metadata,
                 refresh_responses,
             }) => {
-                self.perform_refresh(metadata, process_up_hints).await;
-                // The new state is published, so the awaited refreshes are complete.
-                for response_chan in refresh_responses {
-                    // We can ignore sending error - if no one waits for the response we can drop it
-                    let _ = response_chan.send(Ok(()));
-                }
+                let new_cluster_state = Arc::new(
+                    ClusterState::new_updated(
+                        metadata,
+                        &self.pool_config,
+                        &cluster_state.known_nodes,
+                        &self.used_keyspace,
+                        self.host_filter.as_deref(),
+                        &self.connectivity_events_sender,
+                        cluster_state.locator.tablets.clone(),
+                        &cluster_state.keyspaces,
+                        &self.metrics,
+                    )
+                    .await,
+                );
+                Some((new_cluster_state, refresh_responses))
             }
             None | Some(MetadataChanges::Partial(_)) => {
                 // For now there is nothing that requires publishing new ClusterState.
-                // The only thing left to do is processing up hints.
-                process_up_hints(self.cluster_state.load().as_ref());
+                None
             }
-        }
-    }
+        };
 
-    /// Builds a new [`ClusterState`] from freshly fetched metadata and publishes it.
-    ///
-    /// The client routes carried by `metadata` must already have been applied by the
-    /// caller - `ClusterState::new` creates connection pools, which translate addresses
-    /// through the subscriber.
-    ///
-    /// `process_up_hints` triggers pool refills for hosts for which we received UP events.
-    /// It is called after new ClusterState is created.
-    async fn perform_refresh(
-        &mut self,
-        metadata: Metadata,
-        process_up_hints: impl FnOnce(&ClusterState),
-    ) {
-        let cluster_state: Arc<ClusterState> = self.cluster_state.load_full();
+        // Regardless of wheter we have a new state or not, we need to publish UP hints.
+        // If no new state - publish using new one.
+        let Some((new_cluster_state, refresh_responses)) = new_state_with_requests else {
+            process_up_hints(&cluster_state);
+            return;
+        };
 
-        let new_cluster_state = Arc::new(
-            ClusterState::new_updated(
-                metadata,
-                &self.pool_config,
-                &cluster_state.known_nodes,
-                &self.used_keyspace,
-                self.host_filter.as_deref(),
-                &self.connectivity_events_sender,
-                cluster_state.locator.tablets.clone(),
-                &cluster_state.keyspaces,
-                &self.metrics,
-            )
-            .await,
-        );
+        process_up_hints(&new_cluster_state);
 
         ClusterWorker::handle_topology_changes(
             &cluster_state.known_nodes,
@@ -513,13 +497,17 @@ impl ClusterWorker {
             &mut self.node_status,
         );
 
-        process_up_hints(&new_cluster_state);
-
         new_cluster_state
             .wait_until_all_pools_are_initialized()
             .await;
 
         self.update_cluster_state(new_cluster_state);
+
+        // The new state is published, so the awaited refreshes are complete.
+        for response_chan in refresh_responses {
+            // We can ignore sending error - if no one waits for the response we can drop it
+            let _ = response_chan.send(Ok(()));
+        }
     }
 
     fn update_cluster_state(&mut self, new_cluster_state: Arc<ClusterState>) {

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -123,7 +123,7 @@ impl Cluster {
             metadata_updates_sender,
         );
 
-        let (cc, mut metadata) = metadata_worker.establish_initial().await?;
+        let (cc, mut metadata) = metadata_worker.establish(true).await?;
 
         // The initial metadata is fetched before the metadata worker is spawned, so the routes
         // must be applied here - `ClusterState::new` below creates connection pools, which

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -405,33 +405,7 @@ impl ClusterWorker {
         // Apply the client routes BEFORE constructing the new `ClusterState` below,
         // because `ClusterState::new` creates connection pools, which translate addresses
         // through the subscriber.
-        let client_routes_hosts_to_refill = if let Some(subscriber) =
-            self.client_routes_subscriber.as_ref()
-            && let Some(metadata_changes) = update.metadata_changes.as_mut()
-        {
-            match metadata_changes {
-                MetadataChanges::Full {
-                    metadata,
-                    refresh_responses: _,
-                } => {
-                    if let Some(client_routes) = metadata.client_routes.take() {
-                        subscriber.replace_client_routes(client_routes)
-                    } else {
-                        HashSet::new()
-                    }
-                }
-                MetadataChanges::Partial(PartialMetadataChanges {
-                    client_routes_updates,
-                }) => match client_routes_updates.take() {
-                    Some(client_routes_update) => {
-                        subscriber.merge_client_routes_update(client_routes_update)
-                    }
-                    None => HashSet::new(),
-                },
-            }
-        } else {
-            HashSet::new()
-        };
+        let client_routes_hosts_to_refill = self.handle_client_route_update(&mut update);
 
         let cluster_state = self.cluster_state.load_full();
 
@@ -507,6 +481,39 @@ impl ClusterWorker {
         for response_chan in refresh_responses {
             // We can ignore sending error - if no one waits for the response we can drop it
             let _ = response_chan.send(Ok(()));
+        }
+    }
+
+    /// Applies the provided `update` to client route subscriber, if any.
+    ///
+    /// Returns a set of hosts to which UP hint should be applied.
+    fn handle_client_route_update(&self, update: &mut MetadataUpdate) -> HashSet<Uuid> {
+        let (Some(subscriber), Some(metadata_changes)) = (
+            self.client_routes_subscriber.as_ref(),
+            update.metadata_changes.as_mut(),
+        ) else {
+            return HashSet::new();
+        };
+
+        match metadata_changes {
+            MetadataChanges::Full {
+                metadata,
+                refresh_responses: _,
+            } => {
+                if let Some(client_routes) = metadata.client_routes.take() {
+                    subscriber.replace_client_routes(client_routes)
+                } else {
+                    HashSet::new()
+                }
+            }
+            MetadataChanges::Partial(PartialMetadataChanges {
+                client_routes_updates,
+            }) => match client_routes_updates.take() {
+                Some(client_routes_update) => {
+                    subscriber.merge_client_routes_update(client_routes_update)
+                }
+                None => HashSet::new(),
+            },
         }
     }
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -7,6 +7,7 @@ use crate::cluster::metadata::SchemaMetadataFetchMode;
 use crate::cluster::metadata::update::{
     MetadataChanges, MetadataUpdate, PartialMetadataChanges, RefreshRequest, StatusHint,
 };
+use crate::cluster::state::NodeConfig;
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::network::{ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
@@ -135,16 +136,20 @@ impl Cluster {
             let _ = subscriber.replace_client_routes(routes);
         }
 
+        let node_config = NodeConfig {
+            pool_config,
+            used_keyspace: None,
+            connectivity_events_sender,
+            metrics,
+        };
+
         let cluster_state = ClusterState::new_updated(
             metadata,
-            &pool_config,
+            &node_config,
             &HashMap::new(),
-            &None,
             host_filter.as_deref(),
-            &connectivity_events_sender,
             TabletsInfo::new(),
             &HashMap::new(),
-            &metrics,
         )
         .await;
         ClusterWorker::handle_topology_changes(
@@ -164,20 +169,16 @@ impl Cluster {
             node_status,
 
             client_routes_subscriber,
-            pool_config,
+            node_config,
 
             metadata_updates: metadata_updates_receiver,
-            connectivity_events_sender,
             connectivity_events_receiver,
             tablets_channel: tablet_receiver,
 
             use_keyspace_channel: use_keyspace_receiver,
-            used_keyspace: None,
 
             host_filter,
             host_listener,
-
-            metrics,
         };
 
         let (fut, worker_handle) = worker.work().remote_handle();
@@ -261,7 +262,9 @@ struct ClusterWorker {
     /// The applier of client routes snapshots fetched from `system.client_routes`.
     /// `None` if client routes are not configured.
     client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
-    pool_config: PoolConfig,
+
+    /// Used to create all the `Node` objects.
+    node_config: NodeConfig,
 
     // Channel over which the metadata worker delivers everything it learned
     // about the cluster.
@@ -272,15 +275,10 @@ struct ClusterWorker {
 
     // Channel used to receive signals that node is no longer reachable or became reachable.
     connectivity_events_receiver: tokio::sync::mpsc::UnboundedReceiver<ConnectivityChangeEvent>,
-    // Sender part of that channel to pass to `PoolRefiller`s.
-    connectivity_events_sender: tokio::sync::mpsc::UnboundedSender<ConnectivityChangeEvent>,
 
     // Channel used to receive info about new tablets from custom payload in responses
     // sent by server.
     tablets_channel: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
-
-    // Keyspace send in "USE <keyspace name>" when opening each connection
-    used_keyspace: Option<VerifiedKeyspaceName>,
 
     // The host filter determines towards which nodes we should open
     // connections
@@ -288,8 +286,6 @@ struct ClusterWorker {
 
     // The host listener allows to listen for topology and node status changes.
     host_listener: Option<Arc<dyn HostListener>>,
-
-    metrics: Metrics,
 }
 
 #[derive(Debug)]
@@ -360,7 +356,7 @@ impl ClusterWorker {
                 maybe_use_keyspace_request = self.use_keyspace_channel.recv() => {
                     match maybe_use_keyspace_request {
                         Some(request) => {
-                            self.used_keyspace = Some(request.keyspace_name.clone());
+                            self.node_config.used_keyspace = Some(request.keyspace_name.clone());
 
                             let cluster_state = self.cluster_state.load_full();
                             let use_keyspace_future = Self::handle_use_keyspace_request(cluster_state, request);
@@ -436,14 +432,11 @@ impl ClusterWorker {
                 let new_cluster_state = Arc::new(
                     ClusterState::new_updated(
                         metadata,
-                        &self.pool_config,
+                        &self.node_config,
                         &cluster_state.known_nodes,
-                        &self.used_keyspace,
                         self.host_filter.as_deref(),
-                        &self.connectivity_events_sender,
                         cluster_state.locator.tablets.clone(),
                         &cluster_state.keyspaces,
-                        &self.metrics,
                     )
                     .await,
                 );

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -140,14 +140,6 @@ impl Cluster {
             metadata,
             &pool_config,
             &HashMap::new(),
-            &mut |old_nodes, new_nodes| {
-                ClusterWorker::handle_topology_changes(
-                    old_nodes,
-                    new_nodes,
-                    host_listener.as_deref(),
-                    &mut node_status,
-                )
-            },
             &None,
             host_filter.as_deref(),
             &connectivity_events_sender,
@@ -156,6 +148,13 @@ impl Cluster {
             &metrics,
         )
         .await;
+        ClusterWorker::handle_topology_changes(
+            &HashMap::new(),
+            &cluster_state.known_nodes,
+            host_listener.as_deref(),
+            &mut node_status,
+        );
+
         cluster_state.wait_until_all_pools_are_initialized().await;
 
         let cluster_state: Arc<ArcSwap<ClusterState>> =
@@ -497,14 +496,6 @@ impl ClusterWorker {
                 metadata,
                 &self.pool_config,
                 &cluster_state.known_nodes,
-                &mut |old_nodes, new_nodes| {
-                    ClusterWorker::handle_topology_changes(
-                        old_nodes,
-                        new_nodes,
-                        self.host_listener.as_deref(),
-                        &mut self.node_status,
-                    )
-                },
                 &self.used_keyspace,
                 self.host_filter.as_deref(),
                 &self.connectivity_events_sender,
@@ -513,6 +504,13 @@ impl ClusterWorker {
                 &self.metrics,
             )
             .await,
+        );
+
+        ClusterWorker::handle_topology_changes(
+            &cluster_state.known_nodes,
+            &new_cluster_state.known_nodes,
+            self.host_listener.as_deref(),
+            &mut self.node_status,
         );
 
         process_up_hints(&new_cluster_state);

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -136,7 +136,7 @@ impl Cluster {
             let _ = subscriber.replace_client_routes(routes);
         }
 
-        let cluster_state = ClusterState::new(
+        let cluster_state = ClusterState::new_updated(
             metadata,
             &pool_config,
             &HashMap::new(),
@@ -493,7 +493,7 @@ impl ClusterWorker {
         let cluster_state: Arc<ClusterState> = self.cluster_state.load_full();
 
         let new_cluster_state = Arc::new(
-            ClusterState::new(
+            ClusterState::new_updated(
                 metadata,
                 &self.pool_config,
                 &cluster_state.known_nodes,

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -15,7 +15,7 @@ use crate::observability::metrics::Metrics;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::host_listener::{HostEvent, HostEventContext, HostListener};
-use crate::routing::locator::tablets::{RawTablet, TabletsInfo};
+use crate::routing::locator::tablets::RawTablet;
 
 use crate::frame::response::result::TableSpec;
 use arc_swap::ArcSwap;
@@ -143,15 +143,7 @@ impl Cluster {
             metrics,
         };
 
-        let cluster_state = ClusterState::new_updated(
-            metadata,
-            &node_config,
-            &HashMap::new(),
-            host_filter.as_deref(),
-            TabletsInfo::new(),
-            &HashMap::new(),
-        )
-        .await;
+        let cluster_state = ClusterState::new(metadata, &node_config, host_filter.as_deref()).await;
         ClusterWorker::handle_topology_changes(
             &HashMap::new(),
             &cluster_state.known_nodes,

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1424,7 +1424,7 @@ mod tests {
         pub(crate) async fn mock_cluster_state_for_token_aware_tests() -> ClusterState {
             let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
             let metadata = mock_metadata_for_token_aware_tests();
-            let state = ClusterState::new(
+            let state = ClusterState::new_updated(
                 metadata,
                 &Default::default(),
                 &HashMap::new(),
@@ -1467,7 +1467,7 @@ mod tests {
             };
 
             let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
-            let state = ClusterState::new(
+            let state = ClusterState::new_updated(
                 info,
                 &Default::default(),
                 &HashMap::new(),
@@ -2607,7 +2607,7 @@ mod tests {
         }
 
         let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
-        let cluster_with_disabled_node_f = ClusterState::new(
+        let cluster_with_disabled_node_f = ClusterState::new_updated(
             mock_metadata_for_token_aware_tests(),
             &Default::default(),
             &HashMap::new(),

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1175,6 +1175,7 @@ impl<'a> TokenWithStrategy<'a> {
 mod tests {
     use std::collections::HashMap;
 
+    use crate::cluster::NodeConfig;
     use crate::frame::types::{Consistency, SerialConsistency};
     use tracing::info;
 
@@ -1200,6 +1201,7 @@ mod tests {
     use super::{DefaultPolicy, NodeLocationPreference};
 
     pub(crate) mod framework {
+        use crate::cluster::NodeConfig;
         use crate::routing::locator::test::{
             id_to_invalid_addr, mock_metadata_for_token_aware_tests,
         };
@@ -1424,16 +1426,19 @@ mod tests {
         pub(crate) async fn mock_cluster_state_for_token_aware_tests() -> ClusterState {
             let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
             let metadata = mock_metadata_for_token_aware_tests();
+            let node_config = NodeConfig {
+                pool_config: Default::default(),
+                used_keyspace: None,
+                connectivity_events_sender,
+                metrics: Default::default(),
+            };
             let state = ClusterState::new_updated(
                 metadata,
-                &Default::default(),
+                &node_config,
                 &HashMap::new(),
-                &None,
                 None,
-                &connectivity_events_sender,
                 TabletsInfo::new(),
                 &HashMap::new(),
-                &Default::default(),
             )
             .await;
 
@@ -1466,16 +1471,19 @@ mod tests {
             };
 
             let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
+            let node_config = NodeConfig {
+                pool_config: Default::default(),
+                used_keyspace: None,
+                connectivity_events_sender,
+                metrics: Default::default(),
+            };
             let state = ClusterState::new_updated(
                 info,
-                &Default::default(),
+                &node_config,
                 &HashMap::new(),
-                &None,
                 None,
-                &connectivity_events_sender,
                 TabletsInfo::new(),
                 &HashMap::new(),
-                &Default::default(),
             )
             .await;
 
@@ -2605,11 +2613,16 @@ mod tests {
         }
 
         let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
+        let node_config = NodeConfig {
+            pool_config: Default::default(),
+            used_keyspace: None,
+            connectivity_events_sender,
+            metrics: Default::default(),
+        };
         let cluster_with_disabled_node_f = ClusterState::new_updated(
             mock_metadata_for_token_aware_tests(),
-            &Default::default(),
+            &node_config,
             &HashMap::new(),
-            &None,
             {
                 struct FHostFilter;
                 impl HostFilter for FHostFilter {
@@ -2620,10 +2633,8 @@ mod tests {
 
                 Some(&FHostFilter)
             },
-            &connectivity_events_sender,
             TabletsInfo::new(),
             &HashMap::new(),
-            &Default::default(),
         )
         .await;
 

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1428,7 +1428,6 @@ mod tests {
                 metadata,
                 &Default::default(),
                 &HashMap::new(),
-                &mut |_, _| (),
                 &None,
                 None,
                 &connectivity_events_sender,
@@ -1471,7 +1470,6 @@ mod tests {
                 info,
                 &Default::default(),
                 &HashMap::new(),
-                &mut |_, _| (),
                 &None,
                 None,
                 &connectivity_events_sender,
@@ -2611,7 +2609,6 @@ mod tests {
             mock_metadata_for_token_aware_tests(),
             &Default::default(),
             &HashMap::new(),
-            &mut |_, _| (),
             &None,
             {
                 struct FHostFilter;

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1173,8 +1173,6 @@ impl<'a> TokenWithStrategy<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use crate::cluster::NodeConfig;
     use crate::frame::types::{Consistency, SerialConsistency};
     use tracing::info;
@@ -1184,7 +1182,6 @@ mod tests {
         mock_cluster_state_for_token_unaware_tests,
     };
     use crate::policies::host_filter::HostFilter;
-    use crate::routing::locator::tablets::TabletsInfo;
     use crate::routing::locator::test::{
         TABLE_NTS_RF_2, TABLE_NTS_RF_3, TABLE_SS_RF_2, id_to_invalid_addr,
         mock_metadata_for_token_aware_tests,
@@ -1218,8 +1215,6 @@ mod tests {
             routing::Token,
             test_utils::setup_tracing,
         };
-
-        use super::TabletsInfo;
 
         #[derive(Debug)]
         enum ExpectedGroup {
@@ -1432,15 +1427,7 @@ mod tests {
                 connectivity_events_sender,
                 metrics: Default::default(),
             };
-            let state = ClusterState::new_updated(
-                metadata,
-                &node_config,
-                &HashMap::new(),
-                None,
-                TabletsInfo::new(),
-                &HashMap::new(),
-            )
-            .await;
+            let state = ClusterState::new(metadata, &node_config, None).await;
 
             for node in state.get_nodes_info() {
                 node.use_enabled_as_connected();
@@ -1477,15 +1464,7 @@ mod tests {
                 connectivity_events_sender,
                 metrics: Default::default(),
             };
-            let state = ClusterState::new_updated(
-                info,
-                &node_config,
-                &HashMap::new(),
-                None,
-                TabletsInfo::new(),
-                &HashMap::new(),
-            )
-            .await;
+            let state = ClusterState::new(info, &node_config, None).await;
 
             for node in state.get_nodes_info() {
                 node.use_enabled_as_connected();
@@ -2619,11 +2598,8 @@ mod tests {
             connectivity_events_sender,
             metrics: Default::default(),
         };
-        let cluster_with_disabled_node_f = ClusterState::new_updated(
-            mock_metadata_for_token_aware_tests(),
-            &node_config,
-            &HashMap::new(),
-            {
+        let cluster_with_disabled_node_f =
+            ClusterState::new(mock_metadata_for_token_aware_tests(), &node_config, {
                 struct FHostFilter;
                 impl HostFilter for FHostFilter {
                     fn accept(&self, peer: &crate::cluster::metadata::Peer) -> bool {
@@ -2632,11 +2608,8 @@ mod tests {
                 }
 
                 Some(&FHostFilter)
-            },
-            TabletsInfo::new(),
-            &HashMap::new(),
-        )
-        .await;
+            })
+            .await;
 
         for node in cluster_with_disabled_node_f.get_nodes_info() {
             node.use_enabled_as_connected();


### PR DESCRIPTION
This PR performs various refactors and simplifications in preparations for partial metadata fetching https://github.com/scylladb/scylla-rust-driver/issues/1280

There should be no semantic change - definitely not any significant ones. Just refactors.
This is one of the rare PRs where AI was not used. Why? Recent changes in those ares (MetadataWorker, ClusterWorker etc) were quite rapid, and I feel that code quality and my understanding of it were a bit hurt as a result of that. This PR is en effort to improve this situation.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1280

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
