### PR TITLE
Smarter metadata fetching: topology

### DIFF
--- a/scylla/src/cluster/metadata/cc_establisher.rs
+++ b/scylla/src/cluster/metadata/cc_establisher.rs
@@ -446,11 +446,13 @@ impl ControlConnectionEstablisher {
 
 /// Freshly fetched topology that the [`ControlConnectionEstablisher`] has not yet absorbed.
 ///
-/// [`ControlConnection::query_metadata`] returns its result wrapped in this
-/// guard, so that the fetched metadata cannot be used without the establisher
-/// updating its known peers from it first: the only way to extract the
-/// [`Metadata`] is [`apply`](Self::apply).
-#[must_use = "the fetched metadata must be applied to the ControlConnectionEstablisher"]
+/// [`ControlConnection::query_metadata`] and
+/// [`ControlConnection::query_topology`] return their results wrapped in this
+/// guard, so that what was fetched cannot be used without the establisher
+/// updating its known peers from it first: the only way to extract the payload
+/// (full [`Metadata`], or just the peer list of a partial topology fetch) is
+/// [`apply`](Self::apply).
+#[must_use = "the fetched topology must be applied to the ControlConnectionEstablisher"]
 pub(super) struct TopologyUpdateGuard<T = Metadata> {
     inner: T,
 }
@@ -466,6 +468,15 @@ impl TopologyUpdateGuard<Metadata> {
     /// the metadata itself.
     pub(super) fn apply(self, establisher: &mut ControlConnectionEstablisher) -> Metadata {
         establisher.update_known_peers(&self.inner.peers);
+        self.inner
+    }
+}
+
+impl TopologyUpdateGuard<Vec<Peer>> {
+    /// Updates the establisher's known peers from the fetched peer list and
+    /// releases the list itself.
+    pub(super) fn apply(self, establisher: &mut ControlConnectionEstablisher) -> Vec<Peer> {
+        establisher.update_known_peers(&self.inner);
         self.inner
     }
 }

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -202,6 +202,27 @@ impl ControlConnection {
         }))
     }
 
+    /// Queries only the cluster topology: the peer list (`system.peers` and
+    /// `system.local`).
+    ///
+    /// The `cluster_name` that comes along the peers is dropped: it is fixed for
+    /// the lifetime of a cluster, so the one read by the last full fetch stands.
+    ///
+    /// The result comes wrapped in a [`TopologyUpdateGuard`] for the same reason
+    /// as in `query_metadata`: the establisher must absorb the new peer list
+    /// before anything else uses it.
+    pub(super) async fn query_topology(
+        &self,
+    ) -> Result<TopologyUpdateGuard<Vec<Peer>>, MetadataError> {
+        let connect_port = self.endpoint().address().port();
+
+        let (peers, _cluster_name) = self.query_peers(connect_port).await?;
+
+        Self::validate_peers(&peers)?;
+
+        Ok(TopologyUpdateGuard::new(peers))
+    }
+
     /// Rejects a peer list that could not describe a working cluster, so that
     /// the caller treats the fetch as failed instead of publishing it.
     fn validate_peers(peers: &[Peer]) -> Result<(), PeersMetadataError> {

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -192,15 +192,7 @@ impl ControlConnection {
 
         let (peers, cluster_name) = peers_and_cluster_name;
 
-        // There must be at least one peer
-        if peers.is_empty() {
-            return Err(MetadataError::Peers(PeersMetadataError::EmptyPeers));
-        }
-
-        // At least one peer has to have some tokens
-        if peers.iter().all(|peer| peer.tokens.is_empty()) {
-            return Err(MetadataError::Peers(PeersMetadataError::EmptyTokenLists));
-        }
+        Self::validate_peers(&peers)?;
 
         Ok(TopologyUpdateGuard::new(Metadata {
             peers,
@@ -208,6 +200,22 @@ impl ControlConnection {
             cluster_name,
             client_routes,
         }))
+    }
+
+    /// Rejects a peer list that could not describe a working cluster, so that
+    /// the caller treats the fetch as failed instead of publishing it.
+    fn validate_peers(peers: &[Peer]) -> Result<(), PeersMetadataError> {
+        // There must be at least one peer
+        if peers.is_empty() {
+            return Err(PeersMetadataError::EmptyPeers);
+        }
+
+        // At least one peer has to have some tokens
+        if peers.iter().all(|peer| peer.tokens.is_empty()) {
+            return Err(PeersMetadataError::EmptyTokenLists);
+        }
+
+        Ok(())
     }
 }
 

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -5,7 +5,7 @@ use tokio::sync::oneshot;
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::cluster::metadata::{ClientRoute, ClientRoutes, Metadata};
+use crate::cluster::metadata::{ClientRoute, ClientRoutes, Metadata, Peer};
 use crate::errors::MetadataError;
 
 /// An explicit request to refresh cluster metadata, sent by
@@ -50,7 +50,6 @@ pub(in super::super) enum MetadataChanges {
 
 /// The partial counterpart of a full metadata fetch: independently fetched
 /// updates of individual metadata aspects, one field per partial fetch type.
-/// Currently only client routes can be fetched partially.
 ///
 /// Each field merges on its own, without looking at the others. This makes
 /// merging commutative across types, which keeps this struct correct even when
@@ -61,6 +60,12 @@ pub(in super::super) struct PartialMetadataChanges {
     /// Partial client-routes snapshots fetched in response to
     /// CLIENT_ROUTES_CHANGE events.
     pub(in super::super) client_routes_updates: Option<ClientRoutesUpdate>,
+    /// The peer list fetched in response to TOPOLOGY_CHANGE events.
+    ///
+    /// Not partial within its own aspect: a topology fetch always reads the
+    /// whole peer list, so this replaces the topology of the state it is
+    /// applied to.
+    pub(in super::super) peers: Option<Vec<Peer>>,
 }
 
 impl PartialMetadataChanges {
@@ -71,6 +76,12 @@ impl PartialMetadataChanges {
             None => self.client_routes_updates = Some(new_client_routes),
             Some(existing) => existing.merge(new_client_routes),
         }
+    }
+
+    /// Records a freshly fetched peer list, dropping the one pending so far:
+    /// each fetch reads the whole list, so the newest one subsumes the rest.
+    fn merge_peers(&mut self, peers: Vec<Peer>) {
+        self.peers = Some(peers);
     }
 }
 
@@ -137,6 +148,30 @@ impl MetadataUpdate {
                     return;
                 };
                 metadata_routes.merge(new_client_routes);
+            }
+        }
+    }
+
+    /// Records a freshly fetched peer list, obtained by a partial topology
+    /// fetch performed in response to TOPOLOGY_CHANGE events.
+    pub(crate) fn merge_topology_update(slot: &mut Option<Self>, peers: Vec<Peer>) {
+        let update = Self::slot_mut(slot);
+        match &mut update.metadata_changes {
+            None => {
+                let mut partial = PartialMetadataChanges::default();
+                partial.merge_peers(peers);
+                update.metadata_changes = Some(MetadataChanges::Partial(partial));
+            }
+            Some(MetadataChanges::Partial(partial)) => partial.merge_peers(peers),
+            Some(MetadataChanges::Full {
+                metadata,
+                refresh_responses: _,
+            }) => {
+                // The partial fetch is necessarily newer: a full fetch preempts
+                // the partial ones in flight, so a partial fetch can only
+                // complete after a pending full fetch if it was started after
+                // that fetch completed.
+                metadata.peers = peers;
             }
         }
     }

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -60,7 +60,7 @@ pub(in super::super) struct PartialMetadataChanges {
     /// Partial client-routes snapshots fetched in response to
     /// CLIENT_ROUTES_CHANGE events.
     pub(in super::super) client_routes_updates: Option<ClientRoutesUpdate>,
-    /// The peer list fetched in response to TOPOLOGY_CHANGE events.
+    /// The peer list fetched in response to TOPOLOGY_CHANGE / STATUS_CHANGE events.
     ///
     /// Not partial within its own aspect: a topology fetch always reads the
     /// whole peer list, so this replaces the topology of the state it is

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -12,7 +12,7 @@ use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
 };
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
-use crate::cluster::metadata::{ClientRoutesUpdate, Metadata};
+use crate::cluster::metadata::{ClientRoutesUpdate, Metadata, Peer};
 use crate::errors::{
     BrokenConnectionErrorKind, ConnectionError, ConnectionPoolError, MetadataError,
 };
@@ -120,9 +120,12 @@ enum FetchPlan {
     /// server event, or owed because a partial fetch failed.
     Full,
     /// Partial fetch work is owed, at most one entry per partial fetch type.
-    /// Currently client routes is the only such type.
     Partial {
+        /// The (connection id, host id) pairs whose client routes are to be
+        /// re-read, accumulated from CLIENT_ROUTES_CHANGE events.
         client_routes: Option<ClientRoutesFetchRequest>,
+        /// Whether the peer list is to be re-read.
+        topology: bool,
     },
 }
 
@@ -151,9 +154,22 @@ impl FetchPlan {
         }
     }
 
+    /// Records that the peer list is to be re-read.
+    ///
+    /// If a full fetch is already owed, this is dropped - subsumed, by the
+    /// argument in [`note_full_needed`](Self::note_full_needed).
+    fn note_topology(&mut self) {
+        match self {
+            FetchPlan::Partial { topology, .. } => *topology = true,
+            FetchPlan::Full => (),
+        }
+    }
+
+    /// Nothing owed: the state of a plan whose work has all been started.
     const fn empty() -> Self {
         Self::Partial {
             client_routes: None,
+            topology: false,
         }
     }
 }
@@ -196,6 +212,12 @@ impl ClientRoutesFetchRequest {
 type FullFetch<'cc> =
     Pin<Box<dyn Future<Output = Result<TopologyUpdateGuard, MetadataError>> + Send + 'cc>>;
 
+/// A partial topology fetch (the peer list alone) in flight; boxed for the same
+/// reason as [`FullFetch`].
+type TopologyFetch<'cc> = Pin<
+    Box<dyn Future<Output = Result<TopologyUpdateGuard<Vec<Peer>>, MetadataError>> + Send + 'cc>,
+>;
+
 /// A partial client-routes fetch in flight; boxed for the same reason as
 /// [`FullFetch`].
 type ClientRoutesFetch<'cc> =
@@ -207,21 +229,28 @@ type ClientRoutesFetch<'cc> =
 /// The shape makes the scheduling rules structural:
 /// - a full fetch never has anything running beside it (it subsumes and
 ///   preempts all partial work), and
-/// - per partial fetch type, at most one fetch runs at a time. Currently
-///   client routes is the only such type;
+/// - per partial fetch type, at most one fetch runs at a time - one slot per
+///   type, which is also how partial fetches of different types get to run
+///   concurrently.
 ///
 /// [`start_due_fetches`](Self::start_due_fetches) starts the fetches that the
 /// [`FetchPlan`] owes. As a [`Future`], `PendingFetches` resolves to the
-/// [`FetchOutcome`] of the in-flight fetch once it completes.
+/// [`FetchOutcome`] of an in-flight fetch once it completes, dropping that
+/// fetch's future - so a completed fetch is never polled again. With every slot
+/// empty (see [`empty`](Self::empty)) polling pends forever *without registering
+/// a waker*: a value with nothing in flight never wakes the worker.
 ///
 /// Cancel-safe: the futures live in this value, not in the `select!` branch
-/// polling it, so losing the `select!` race leaves the in-flight fetch intact.
+/// polling it, so losing the `select!` race leaves the in-flight fetches intact.
 enum PendingFetches<'cc> {
     /// A full metadata fetch is in flight.
     Full { fetch: FullFetch<'cc> },
-    /// Some partial fetches may be in progress.
+    /// Partial fetches, at most one per partial fetch type. Any slot may be
+    /// empty; with all of them empty (see [`empty`](Self::empty)) nothing is in
+    /// flight at all.
     Partial {
         client_routes_fetch: Option<ClientRoutesFetch<'cc>>,
+        topology_fetch: Option<TopologyFetch<'cc>>,
     },
 }
 
@@ -255,22 +284,41 @@ impl<'cc> PendingFetches<'cc> {
             return;
         }
 
-        // Partial client-routes work starts when isn't already in flight.
+        // Each partial fetch starts only if its own slot is free; work for a
+        // busy slot waits in the plan. Nothing partial starts while a full
+        // fetch is in flight (or is owed but could not be started above): the
+        // full fetch reads all of that data, while partial work owed meanwhile
+        // stays in the plan, because its triggering event may postdate what the
+        // full fetch read.
         if let PendingFetches::Partial {
-            client_routes_fetch: None,
+            client_routes_fetch,
+            topology_fetch,
         } = self
-            && let FetchPlan::Partial { client_routes } = plan
-            && let Some(request) = client_routes.take()
+            && let FetchPlan::Partial {
+                client_routes,
+                topology,
+            } = plan
         {
-            *self = PendingFetches::Partial {
-                client_routes_fetch: Some(Box::pin(request.fetch_on(cc))),
-            };
+            if client_routes_fetch.is_none()
+                && let Some(request) = client_routes.take()
+            {
+                debug!("Requesting a partial client-routes fetch");
+                *client_routes_fetch = Some(Box::pin(request.fetch_on(cc)));
+            }
+
+            if topology_fetch.is_none() && std::mem::take(topology) {
+                debug!("Requesting a partial topology fetch");
+                *topology_fetch = Some(Box::pin(cc.query_topology()));
+            }
         }
     }
 
+    /// Nothing in flight: the state a fetch's completion leaves behind when no
+    /// other one is running.
     const fn empty() -> Self {
         Self::Partial {
             client_routes_fetch: None,
+            topology_fetch: None,
         }
     }
 }
@@ -279,7 +327,23 @@ impl<'cc> PendingFetches<'cc> {
 /// fetch completed, tagged with its fetch type.
 enum FetchOutcome {
     Full(Result<TopologyUpdateGuard, MetadataError>),
+    Topology(Result<TopologyUpdateGuard<Vec<Peer>>, MetadataError>),
     ClientRoutes(Result<Option<ClientRoutesUpdate>, MetadataError>),
+}
+
+/// Polls one partial fetch slot, emptying it if the fetch completed.
+///
+/// Generic over the future type so that both slots of
+/// [`PendingFetches::Partial`] can use it; both are heap-pinned, hence `Unpin`.
+fn poll_slot<F: Future + Unpin>(slot: &mut Option<F>, cx: &mut Context<'_>) -> Option<F::Output> {
+    let fetch = slot.as_mut()?;
+    match Pin::new(fetch).poll(cx) {
+        Poll::Ready(output) => {
+            slot.take();
+            Some(output)
+        }
+        Poll::Pending => None,
+    }
 }
 
 impl Future for PendingFetches<'_> {
@@ -298,13 +362,20 @@ impl Future for PendingFetches<'_> {
             }
             PendingFetches::Partial {
                 client_routes_fetch,
+                topology_fetch,
             } => {
-                if let Some(client_routes) = client_routes_fetch
-                    && let Poll::Ready(result) = client_routes.as_mut().poll(cx)
+                // Only one outcome can be reported per poll, so the slots are
+                // polled until one completes; the rest stay in flight and are
+                // polled again right away, because `work_on_cc` re-polls this
+                // value on the loop iteration that each outcome triggers.
+                if let Some(outcome) =
+                    poll_slot(client_routes_fetch, cx).map(FetchOutcome::ClientRoutes)
                 {
-                    // The completed fetch has been consumed; drop its future.
-                    *client_routes_fetch = None;
-                    return Poll::Ready(FetchOutcome::ClientRoutes(result));
+                    return Poll::Ready(outcome);
+                }
+
+                if let Some(outcome) = poll_slot(topology_fetch, cx).map(FetchOutcome::Topology) {
+                    return Poll::Ready(outcome);
                 }
             }
         };
@@ -532,7 +603,7 @@ impl MetadataWorker {
     /// - At most one fetch per type runs at a time; work for a busy type waits
     ///   in the plan.
     /// - A due full fetch preempts everything: it abandons the running partial
-    ///   fetch and drops the plan's partial work. Both are subsumed - the full
+    ///   fetches and drops the plan's partial work. Both are subsumed - the full
     ///   fetch reads all of that data, and reads it after the events that made
     ///   the partial work due. Conversely, partial work that becomes due *while*
     ///   a full fetch runs stays in the plan: the fetch may have read the
@@ -588,6 +659,20 @@ impl MetadataWorker {
                             // The control connection is considered defunct - drop it. The pending
                             // request, if any, is retried (and answered) while establishing a new one.
                             return ControlFlow::Continue(());
+                        }
+                        FetchOutcome::Topology(Ok(topology_update)) => {
+                            debug!("Fetched new topology");
+                            let peers = topology_update.apply(&mut self.cc_establisher);
+                            if self.send_update(|slot| MetadataUpdate::merge_topology_update(slot, peers)).is_err() {
+                                return ControlFlow::Break(());
+                            }
+                        }
+                        FetchOutcome::Topology(Err(err)) => {
+                            error!(
+                                "Error when fetching topology: {err}. \
+                                Scheduling a metadata refresh, because the control connection is likely defunct."
+                            );
+                            plan.note_full_needed();
                         }
                         FetchOutcome::ClientRoutes(Ok(None)) => (), // Nothing to apply.
                         FetchOutcome::ClientRoutes(Ok(Some(routes))) => {
@@ -680,7 +765,9 @@ impl MetadataWorker {
         #[deny(clippy::wildcard_enum_match_arm)]
         match event {
             Event::SchemaChange(_) => (), // For now only fetched during periodic refresh.
-            Event::TopologyChange(_) => plan.note_full_needed(),
+            // A node was added, removed or moved - only the peer list can have
+            // changed, so a partial topology fetch suffices.
+            Event::TopologyChange(_) => plan.note_topology(),
             Event::ClientRoutesChange(evt) => {
                 // An UPDATE_NODES event pairs `connection_ids[i]` with
                 // `host_ids[i]`.
@@ -805,13 +892,16 @@ fn deadline_after(start: Instant, interval: Duration) -> Instant {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::future::pending;
     use std::pin::Pin;
     use std::task::{Context, Poll, Waker};
 
     use crate::cluster::metadata::Metadata;
 
-    use super::{FetchOutcome, PendingFetches, TopologyUpdateGuard};
+    use super::{
+        ClientRoutesFetchRequest, FetchOutcome, FetchPlan, PendingFetches, TopologyUpdateGuard,
+    };
 
     fn poll_once(pending_fetches: &mut PendingFetches<'_>) -> Poll<FetchOutcome> {
         Pin::new(pending_fetches).poll(&mut Context::from_waker(Waker::noop()))
@@ -821,18 +911,35 @@ mod tests {
         TopologyUpdateGuard::new(Metadata::new_dummy(&[]))
     }
 
-    /// While idle, `PendingFetches` must pend (and not panic or spin):
-    /// `work_on_cc` polls it in its `select!` unconditionally.
+    fn client_routes_request() -> ClientRoutesFetchRequest {
+        ClientRoutesFetchRequest {
+            pairs: HashSet::new(),
+        }
+    }
+
+    /// Asserts that no fetch is in flight, i.e. every partial slot is empty.
+    fn assert_nothing_in_flight(pending_fetches: &PendingFetches<'_>) {
+        assert!(matches!(
+            pending_fetches,
+            PendingFetches::Partial {
+                client_routes_fetch: None,
+                topology_fetch: None
+            }
+        ));
+    }
+
+    /// With nothing in flight, `PendingFetches` must pend (and not panic or
+    /// spin): `work_on_cc` polls it in its `select!` unconditionally.
     #[test]
-    fn idle_pends() {
+    fn nothing_in_flight_pends() {
         let mut pending_fetches = PendingFetches::empty();
 
         assert!(poll_once(&mut pending_fetches).is_pending());
     }
 
     /// A completed fetch yields its output, tagged with the fetch type, and
-    /// empties the value back to `Idle`, so that the next starter step can
-    /// start another fetch (and the completed future is never polled again).
+    /// leaves nothing in flight behind, so that the next starter step can start
+    /// another fetch (and the completed future is never polled again).
     #[test]
     fn completed_fetch_resolves_and_empties() {
         let mut pending_fetches = PendingFetches::Full {
@@ -842,17 +949,40 @@ mod tests {
             poll_once(&mut pending_fetches),
             Poll::Ready(FetchOutcome::Full(Ok(_)))
         ));
-        assert!(matches!(
-            pending_fetches,
-            PendingFetches::Partial {
-                client_routes_fetch: None
-            }
-        ));
+        assert_nothing_in_flight(&pending_fetches);
         assert!(poll_once(&mut pending_fetches).is_pending());
 
         let mut pending_fetches = PendingFetches::Partial {
             client_routes_fetch: Some(Box::pin(async { Ok(None) })),
+            topology_fetch: None,
         };
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::ClientRoutes(Ok(None)))
+        ));
+        assert_nothing_in_flight(&pending_fetches);
+
+        let mut pending_fetches = PendingFetches::Partial {
+            client_routes_fetch: None,
+            topology_fetch: Some(Box::pin(async { Ok(TopologyUpdateGuard::new(Vec::new())) })),
+        };
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::Topology(Ok(_)))
+        ));
+        assert_nothing_in_flight(&pending_fetches);
+    }
+
+    /// Partial fetches of different types run concurrently: reporting the
+    /// outcome of one must leave the other in flight, to be reported by a
+    /// later poll.
+    #[test]
+    fn completed_partial_fetch_keeps_the_other_in_flight() {
+        let mut pending_fetches = PendingFetches::Partial {
+            client_routes_fetch: Some(Box::pin(async { Ok(None) })),
+            topology_fetch: Some(Box::pin(async { Ok(TopologyUpdateGuard::new(Vec::new())) })),
+        };
+
         assert!(matches!(
             poll_once(&mut pending_fetches),
             Poll::Ready(FetchOutcome::ClientRoutes(Ok(None)))
@@ -860,9 +990,39 @@ mod tests {
         assert!(matches!(
             pending_fetches,
             PendingFetches::Partial {
-                client_routes_fetch: None
+                client_routes_fetch: None,
+                topology_fetch: Some(_)
             }
         ));
+
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::Topology(Ok(_)))
+        ));
+        assert_nothing_in_flight(&pending_fetches);
+    }
+
+    /// A partial fetch that is still in flight must not block reporting the
+    /// outcome of one that completed.
+    #[test]
+    fn pending_partial_fetch_does_not_hide_a_completed_one() {
+        let mut pending_fetches = PendingFetches::Partial {
+            client_routes_fetch: Some(Box::pin(pending())),
+            topology_fetch: Some(Box::pin(async { Ok(TopologyUpdateGuard::new(Vec::new())) })),
+        };
+
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::Topology(Ok(_)))
+        ));
+        assert!(matches!(
+            pending_fetches,
+            PendingFetches::Partial {
+                client_routes_fetch: Some(_),
+                topology_fetch: None
+            }
+        ));
+        assert!(poll_once(&mut pending_fetches).is_pending());
     }
 
     /// Losing a `select!` race (the polling borrow being dropped) must leave
@@ -875,5 +1035,48 @@ mod tests {
 
         assert!(poll_once(&mut pending_fetches).is_pending());
         assert!(matches!(pending_fetches, PendingFetches::Full { .. }));
+    }
+
+    /// Partial work of different types accumulates side by side: neither type
+    /// may drop the work owed for the other.
+    #[test]
+    fn partial_work_of_different_types_coexists() {
+        let mut plan = FetchPlan::empty();
+        plan.note_client_routes(client_routes_request());
+        plan.note_topology();
+        assert!(matches!(
+            plan,
+            FetchPlan::Partial {
+                client_routes: Some(_),
+                topology: true
+            }
+        ));
+
+        let mut plan = FetchPlan::empty();
+        plan.note_topology();
+        plan.note_client_routes(client_routes_request());
+        assert!(matches!(
+            plan,
+            FetchPlan::Partial {
+                client_routes: Some(_),
+                topology: true
+            }
+        ));
+    }
+
+    /// A due full fetch subsumes all partial work, and partial work noted while
+    /// it is owed is subsumed too - it would be dropped by the starter step
+    /// anyway.
+    #[test]
+    fn full_fetch_subsumes_partial_work() {
+        let mut plan = FetchPlan::empty();
+        plan.note_topology();
+        plan.note_client_routes(client_routes_request());
+        plan.note_full_needed();
+        assert!(matches!(plan, FetchPlan::Full));
+
+        plan.note_topology();
+        plan.note_client_routes(client_routes_request());
+        assert!(matches!(plan, FetchPlan::Full));
     }
 }

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -787,6 +787,9 @@ impl MetadataWorker {
                 // for:
                 // - PoolRefiller - UP triggers immediate pool refill attempt, and
                 // - Keepaliver - DOWN triggers immediate keepalive query attempt.
+                //
+                // Besides the hint, a status change also schedules a topology
+                // re-read - see below the `match`.
 
                 match status {
                     StatusChangeEvent::Up(addr) => {
@@ -825,6 +828,12 @@ impl MetadataWorker {
                         }
                     }
                 }
+
+                // A node's `rpc_address` can change while the node itself is
+                // neither added nor removed (e.g. it is restarted with a new
+                // address), and no TOPOLOGY_CHANGE announces that - the only
+                // events it produces are this DOWN/UP pair.
+                plan.note_topology();
             }
             _ => unreachable!("clippy testifies that the match is exhaustive"),
         };

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -749,7 +749,7 @@ impl MetadataWorker {
     }
 
     /// Handles a single server event synchronously (status hints are published
-    /// right away) and returns the fetch work the event implies.
+    /// right away) and updates the fetch plan accordingly.
     ///
     /// An associated function taking just the updates sender, so that event
     /// handling does not require exclusive access to the whole worker.

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -25,7 +25,7 @@ use super::node::{Node, NodeRef};
 /// Helper struct to group parameters that are only needed to
 /// construct `Node` objects.
 pub(crate) struct NodeConfig {
-    // Config for `NodeConnectioPool` for all new nodes.
+    // Config for `NodeConnectionPool` for all new nodes.
     pub(crate) pool_config: PoolConfig,
     // Keyspace send in "USE <keyspace name>" when opening each connection.
     pub(crate) used_keyspace: Option<VerifiedKeyspaceName>,

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -199,22 +199,22 @@ impl ClusterState {
         }
     }
 
-    /// Creates new ClusterState using information about topology held in `metadata`.
-    /// Uses `self` to reuse data when possible.
+    /// Creates new ClusterState using information about topology and schema held
+    /// in `metadata`. Uses `self` to reuse data when possible.
     pub(crate) async fn new_updated(
         &self,
         metadata: Metadata,
         node_config: &NodeConfig,
         host_filter: Option<&dyn HostFilter>,
     ) -> Self {
+        let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, &self.keyspaces);
+
         let (new_known_nodes, ring) = Self::calculate_new_topology(
             metadata.peers,
             &self.known_nodes,
             node_config,
             host_filter,
         );
-
-        let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, &self.keyspaces);
 
         let mut tablets = self.locator.tablets.clone();
         Self::perform_tablets_maintenance(
@@ -232,6 +232,39 @@ impl ClusterState {
             keyspaces,
             locator,
             cluster_name: metadata.cluster_name,
+        }
+    }
+
+    /// Creates new ClusterState from a freshly fetched topology (the peer list),
+    /// reusing the schema metadata and cluster name of `self` - the counterpart
+    /// of [`new_updated`](Self::new_updated) for a partial topology fetch, which
+    /// reads nothing but the peers.
+    pub(crate) async fn new_with_updated_topology(
+        &self,
+        peers: Vec<Peer>,
+        node_config: &NodeConfig,
+        host_filter: Option<&dyn HostFilter>,
+    ) -> Self {
+        let (new_known_nodes, ring) =
+            Self::calculate_new_topology(peers, &self.known_nodes, node_config, host_filter);
+
+        let mut tablets = self.locator.tablets.clone();
+        Self::perform_tablets_maintenance(
+            &mut tablets,
+            &self.known_nodes,
+            &new_known_nodes,
+            &self.keyspaces,
+        );
+
+        let (locator, keyspaces) =
+            Self::calculate_new_locator(self.keyspaces.clone(), ring, tablets).await;
+
+        ClusterState {
+            all_nodes: new_known_nodes.values().cloned().collect(),
+            known_nodes: new_known_nodes,
+            keyspaces,
+            locator,
+            cluster_name: self.cluster_name.clone(),
         }
     }
 

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -451,8 +451,8 @@ impl ClusterWorker {
             }
         };
 
-        // Regardless of wheter we have a new state or not, we need to publish UP hints.
-        // If no new state - publish using new one.
+        // Regardless of whether we have a new state, we need to process UP hints.
+        // If there is no new state, process them using the current one.
         let Some((new_cluster_state, refresh_responses)) = new_state_with_requests else {
             process_up_hints(&cluster_state);
             return;

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -428,6 +428,23 @@ impl ClusterWorker {
                 );
                 Some((new_cluster_state, refresh_responses))
             }
+            // A partial topology fetch replaces the peer list; the rest of the
+            // state (schema, tablets, connection pools) is reused.
+            Some(MetadataChanges::Partial(PartialMetadataChanges {
+                peers: Some(peers),
+                client_routes_updates: _, // Already applied above.
+            })) => {
+                let new_cluster_state = Arc::new(
+                    cluster_state
+                        .new_with_updated_topology(
+                            peers,
+                            &self.node_config,
+                            self.host_filter.as_deref(),
+                        )
+                        .await,
+                );
+                Some((new_cluster_state, Vec::new()))
+            }
             None | Some(MetadataChanges::Partial(_)) => {
                 // For now there is nothing that requires publishing new ClusterState.
                 None
@@ -487,6 +504,7 @@ impl ClusterWorker {
             }
             MetadataChanges::Partial(PartialMetadataChanges {
                 client_routes_updates,
+                peers: _,
             }) => match client_routes_updates.take() {
                 Some(client_routes_update) => {
                     subscriber.merge_client_routes_update(client_routes_update)

--- a/scylla/tests/integration/metadata/mod.rs
+++ b/scylla/tests/integration/metadata/mod.rs
@@ -1,3 +1,4 @@
 mod configuration;
 mod contents;
 mod event_flood;
+mod partial_fetch;

--- a/scylla/tests/integration/metadata/partial_fetch.rs
+++ b/scylla/tests/integration/metadata/partial_fetch.rs
@@ -1,0 +1,139 @@
+//! Tests of partial metadata fetches: a server event announcing a change of one
+//! metadata aspect must make the driver re-read that aspect alone, instead of
+//! performing a full metadata fetch.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use scylla::client::session_builder::SessionBuilder;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, RunningProxy,
+    ShardAwareness, WorkerError,
+};
+use tokio::sync::mpsc;
+
+use crate::utils::{
+    inject_status_change_down, inject_status_change_up, inject_topology_change_new_node,
+    setup_tracing, test_with_3_node_cluster, wait_until_all_nodes_are_connected,
+};
+
+/// The requests a partial topology fetch issues: one for `system.peers` and one
+/// for `system.local`. A full fetch would add at least one per schema table
+/// (`system_schema.keyspaces`, `.tables`, `.columns`, ...).
+const TOPOLOGY_FETCH_REQUESTS: usize = 2;
+
+/// A TOPOLOGY_CHANGE event can only have changed the peer list, so the driver
+/// must react with a partial topology fetch: re-read `system.peers` and
+/// `system.local`, and nothing else.
+#[tokio::test]
+async fn topology_change_event_triggers_only_a_topology_fetch() {
+    assert_event_triggers_only_a_topology_fetch(inject_topology_change_new_node).await;
+}
+
+/// A STATUS_CHANGE UP event must trigger a partial topology fetch too.
+///
+/// A node's `rpc_address` can change while the node is neither added nor
+/// removed - a restart under a new address, for instance - and no
+/// TOPOLOGY_CHANGE announces that: the only events it produces are DOWN and UP.
+/// Re-reading the peers on status changes is what keeps the driver from
+/// addressing such a node by its stale address.
+#[tokio::test]
+async fn status_change_up_event_triggers_only_a_topology_fetch() {
+    assert_event_triggers_only_a_topology_fetch(inject_status_change_up).await;
+}
+
+/// A STATUS_CHANGE DOWN event must trigger a partial topology fetch too, for
+/// the reason given in [`status_change_up_event_triggers_only_a_topology_fetch`].
+#[tokio::test]
+async fn status_change_down_event_triggers_only_a_topology_fetch() {
+    assert_event_triggers_only_a_topology_fetch(inject_status_change_down).await;
+}
+
+/// Injects one event with `inject_event` and requires the driver to react with
+/// exactly one partial topology fetch: two metadata requests on the control
+/// connection, and a new `ClusterState` that kept the schema metadata of the
+/// previous one (the event cannot have affected the schema, and the fetch does
+/// not re-read it).
+async fn assert_event_triggers_only_a_topology_fetch(
+    inject_event: impl FnOnce(&RunningProxy, SocketAddr),
+) {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map.clone()))
+                // Far beyond the test duration: the only fetch on the
+                // established control connection is the one the injected event
+                // triggers.
+                .cluster_metadata_refresh_interval(Duration::from_secs(10_000))
+                .build()
+                .await
+                .unwrap();
+            wait_until_all_nodes_are_connected(3, &session).await;
+
+            let state_before_event = session.get_cluster_state();
+
+            // Count the metadata requests of the control connection (only it
+            // registers for events, hence the registration condition). The
+            // driver prepares its metadata statements, so what identifies a
+            // fetch is the number of EXECUTEs, not any query text. Installed
+            // only now, so that the session's initial (full) fetch is not
+            // counted.
+            let (metadata_request_tx, mut metadata_request_rx) = mpsc::unbounded_channel();
+            for node in running_proxy.running_nodes.iter_mut() {
+                node.prepend_request_rules(vec![RequestRule(
+                    Condition::ConnectionRegisteredAnyEvent
+                        .and(Condition::RequestOpcode(RequestOpcode::Execute)),
+                    RequestReaction::noop()
+                        .with_feedback_when_performed(metadata_request_tx.clone()),
+                )]);
+            }
+
+            // The address named by the event does not matter for the fetch: the
+            // driver reacts by re-reading the whole peer list anyway. An address
+            // of no known node also keeps the status hints from provoking
+            // anything else (a keepalive or a pool refill).
+            inject_event(&running_proxy, SocketAddr::from(([127, 0, 0, 1], 9042)));
+
+            metadata_request_rx
+                .recv()
+                .await
+                .expect("proxy feedback channel closed unexpectedly");
+
+            // The fetched topology is published as a new `ClusterState`, which
+            // must have kept the schema metadata of the previous one.
+            let state_after_event = loop {
+                let state = session.get_cluster_state();
+                if !Arc::ptr_eq(&state, &state_before_event) {
+                    break state;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            };
+
+            let mut requests = 1;
+            while metadata_request_rx.try_recv().is_ok() {
+                requests += 1;
+            }
+            assert_eq!(
+                requests, TOPOLOGY_FETCH_REQUESTS,
+                "the control connection issued {requests} metadata requests, so the event \
+                triggered something other than a partial topology fetch"
+            );
+
+            assert_eq!(state_after_event.get_nodes_info().len(), 3);
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -697,26 +697,25 @@ impl RetrySession for CapturingRetrySession {
     }
 }
 
-/// Builds the body of a `STATUS_CHANGE` / `DOWN` EVENT frame for `addr`:
-/// `[string] "STATUS_CHANGE"`, `[string] "DOWN"`, `[inet] addr`.
-pub(crate) fn status_change_down_event_body(addr: SocketAddr) -> Bytes {
+/// Builds the body of an EVENT frame for `addr`: `[string] event_type`,
+/// `[string] change`, `[inet] addr` - the shape shared by `STATUS_CHANGE` and
+/// `TOPOLOGY_CHANGE` events.
+fn cluster_change_event_body(event_type: &str, change: &str, addr: SocketAddr) -> Bytes {
     use scylla_cql::frame::types::{write_inet, write_string};
 
     let mut body = BytesMut::new();
-    write_string("STATUS_CHANGE", &mut body).unwrap();
-    write_string("DOWN", &mut body).unwrap();
+    write_string(event_type, &mut body).unwrap();
+    write_string(change, &mut body).unwrap();
     write_inet(addr, &mut body);
     body.freeze()
 }
 
-/// Injects a forged `STATUS_CHANGE DOWN` event for `addr` into every proxy
-/// node's control connections.
+/// Injects a forged event into every proxy node's control connections.
 ///
 /// Only one of the proxied nodes hosts the driver's control connection, hence
 /// the broadcast; at least one injection must have found a registered control
 /// connection.
-pub(crate) fn inject_status_change_down(running_proxy: &RunningProxy, addr: SocketAddr) {
-    let body = status_change_down_event_body(addr);
+fn inject_event_to_ccs(running_proxy: &RunningProxy, body: Bytes) {
     let injected = running_proxy
         .running_nodes
         .iter()
@@ -725,5 +724,29 @@ pub(crate) fn inject_status_change_down(running_proxy: &RunningProxy, addr: Sock
     assert!(
         injected > 0,
         "no proxy node had a registered control connection to inject the event into"
+    );
+}
+
+/// Injects a forged `STATUS_CHANGE DOWN` event for `addr`.
+pub(crate) fn inject_status_change_down(running_proxy: &RunningProxy, addr: SocketAddr) {
+    inject_event_to_ccs(
+        running_proxy,
+        cluster_change_event_body("STATUS_CHANGE", "DOWN", addr),
+    );
+}
+
+/// Injects a forged `STATUS_CHANGE UP` event for `addr`.
+pub(crate) fn inject_status_change_up(running_proxy: &RunningProxy, addr: SocketAddr) {
+    inject_event_to_ccs(
+        running_proxy,
+        cluster_change_event_body("STATUS_CHANGE", "UP", addr),
+    );
+}
+
+/// Injects a forged `TOPOLOGY_CHANGE NEW_NODE` event for `addr`.
+pub(crate) fn inject_topology_change_new_node(running_proxy: &RunningProxy, addr: SocketAddr) {
+    inject_event_to_ccs(
+        running_proxy,
+        cluster_change_event_body("TOPOLOGY_CHANGE", "NEW_NODE", addr),
     );
 }


### PR DESCRIPTION
Based on https://github.com/scylladb/scylla-rust-driver/pull/1849

This PR changes the behavior on TOPOLOGY_CHANGE events. Previously, full metadata was fetched on each such event.
This PR now introduces a partial fetch, so only the topology (`system.local` and `system.peers`) is fetched.

Additionally, I added the exact same fetch on STATUS_CHANGE. This is because nodes `rpc_address` can change with just a restart. If we get rid of a periodic topology fetch, we would miss such changes.

Last commit introduces a small optimization: if the new topology is identical, there is no reason to publish new ClusterState.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1280

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
