### PR TITLE
Partial schema fetch

### DIFF
--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -53,8 +53,14 @@ If you need to share `Session` with different threads / Tokio tasks etc. use `Ar
 
 ## Metadata
 
-The driver refreshes the cluster metadata periodically, which contains information about cluster topology as well as the cluster schema. By default, the driver refreshes the cluster metadata every 60 seconds.
-However, you can set the `cluster_metadata_refresh_interval` to a non-negative value to periodically refresh the cluster metadata. This is useful when you do not have unexpected amount of traffic or when you have an extra traffic causing topology to change frequently.
+The driver keeps an up-to-date view of the cluster topology (and client routes, if used) and of the cluster schema.
+Topology and client routes are refreshed in reaction to the server events announcing a change.
+Schema changes are different: the keyspaces that `SCHEMA_CHANGE` events name are accumulated and re-read by a periodic refresh, which batches the burst of events that a single DDL statement produces.
+
+That refresh runs every 60 seconds by default; `cluster_metadata_refresh_interval` sets the interval. A shorter one picks schema changes up sooner, at the cost of more frequent metadata queries.
+
+Only the affected keyspaces are re-read, not the whole schema.
+If your cluster's events cannot be relied upon, `periodic_metadata_fetch_mode(PeriodicFetchMode::FullMetadata)` makes each refresh re-read the whole metadata instead.
 
 
 ```{eval-rst}

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -11,7 +11,9 @@ use crate::client::execution::{
     NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RunRequestResult,
 };
 use crate::cluster::control_connection::MetadataRequestTimeouts;
-use crate::cluster::metadata::{SchemaMetadataFetchLevel, SchemaMetadataFetchMode};
+use crate::cluster::metadata::{
+    PeriodicFetchMode, SchemaMetadataFetchLevel, SchemaMetadataFetchMode,
+};
 use crate::cluster::node::KnownNode;
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::DbError;
@@ -408,6 +410,10 @@ pub struct SessionConfig {
     /// or they expect the topology to change frequently.
     pub cluster_metadata_refresh_interval: Duration,
 
+    /// What the periodic metadata refresh re-reads. By default only the
+    /// keyspaces whose schema `SCHEMA_CHANGE` events reported as changed.
+    pub periodic_metadata_fetch_mode: PeriodicFetchMode,
+
     /// Driver and application self-identifying information,
     /// to be sent to server in STARTUP message.
     pub identity: SelfIdentity<'static>,
@@ -471,6 +477,7 @@ impl SessionConfig {
             tracing_info_fetch_interval: Duration::from_millis(3),
             tracing_info_fetch_consistency: Consistency::One,
             cluster_metadata_refresh_interval: Duration::from_secs(60),
+            periodic_metadata_fetch_mode: PeriodicFetchMode::AffectedKeyspaces,
             identity: SelfIdentity::default(),
             #[cfg(feature = "unstable-client-routes")]
             client_routes_config: None,
@@ -1244,6 +1251,7 @@ impl Session {
             config.host_filter,
             host_listener,
             config.cluster_metadata_refresh_interval,
+            config.periodic_metadata_fetch_mode,
             tablet_receiver,
             metrics.as_ref().clone(),
             client_routes_config,

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -5,6 +5,7 @@ use super::session::{Session, SessionConfig};
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::{AuthenticatorProvider, PlainTextAuthenticator};
 use crate::client::session::TlsContext;
+use crate::cluster::metadata::PeriodicFetchMode;
 use crate::errors::NewSessionError;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
@@ -1442,8 +1443,13 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
-    /// Set the interval at which the driver refreshes the cluster metadata which contains information
-    /// about the cluster topology as well as the cluster schema.
+    /// Set the interval at which the driver refreshes the cluster metadata.
+    ///
+    /// The refresh re-reads the schema of the keyspaces that `SCHEMA_CHANGE`
+    /// events named since the previous one; every other aspect of the metadata
+    /// is re-read in reaction to the server event announcing its change. See
+    /// [`periodic_metadata_fetch_mode`](Self::periodic_metadata_fetch_mode)
+    /// for making the refresh re-read the whole metadata instead.
     ///
     /// The default is 60 seconds.
     ///
@@ -1464,6 +1470,36 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// ```
     pub fn cluster_metadata_refresh_interval(mut self, interval: Duration) -> Self {
         self.config.cluster_metadata_refresh_interval = interval;
+        self
+    }
+
+    /// Set what the periodic metadata refresh re-reads.
+    ///
+    /// The default is [`PeriodicFetchMode::AffectedKeyspaces`]: only the
+    /// keyspaces that `SCHEMA_CHANGE` events named since the previous refresh.
+    /// [`PeriodicFetchMode::FullMetadata`] restores the behaviour of driver
+    /// versions that did not handle those events, for clusters whose events
+    /// cannot be relied upon.
+    ///
+    /// How often the refresh happens is a separate setting - see
+    /// [`cluster_metadata_refresh_interval`](Self::cluster_metadata_refresh_interval).
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// # use scylla::cluster::metadata::PeriodicFetchMode;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let session: Session = SessionBuilder::new()
+    ///         .known_node("127.0.0.1:9042")
+    ///         .periodic_metadata_fetch_mode(PeriodicFetchMode::FullMetadata)
+    ///         .build()
+    ///         .await?;
+    /// #   Ok(())
+    /// # }
+    /// ```
+    pub fn periodic_metadata_fetch_mode(mut self, mode: PeriodicFetchMode) -> Self {
+        self.config.periodic_metadata_fetch_mode = mode;
         self
     }
 
@@ -1515,6 +1551,7 @@ mod tests {
     use super::super::Compression;
     use super::SessionBuilder;
     use crate::client::execution_profile::{ExecutionProfile, defaults};
+    use crate::cluster::metadata::PeriodicFetchMode;
     use crate::cluster::node::KnownNode;
     use crate::errors::NewSessionError;
     use crate::test_utils::setup_tracing;
@@ -1770,6 +1807,24 @@ mod tests {
         assert_eq!(
             builder.config.cluster_metadata_refresh_interval,
             std::time::Duration::from_secs(60)
+        );
+    }
+
+    /// Fetching only the affected keyspaces is the default; re-reading the
+    /// whole metadata periodically is opt-in.
+    #[test]
+    fn periodic_metadata_fetch_mode() {
+        setup_tracing();
+        let builder = SessionBuilder::new();
+        assert_eq!(
+            builder.config.periodic_metadata_fetch_mode,
+            PeriodicFetchMode::AffectedKeyspaces
+        );
+
+        let builder = builder.periodic_metadata_fetch_mode(PeriodicFetchMode::FullMetadata);
+        assert_eq!(
+            builder.config.periodic_metadata_fetch_mode,
+            PeriodicFetchMode::FullMetadata
         );
     }
 

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -26,6 +26,7 @@ use std::time::Instant;
 use crate::frame::response::result::{ColumnSpec, TableSpec};
 use crate::parse_utils::{ParseErrorCause, ParseResult, ParserState};
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt, future, stream};
+use itertools::{Either, Itertools};
 use rand::Rng;
 use tracing::{debug, trace, warn};
 use uuid::Uuid;
@@ -40,6 +41,7 @@ use crate::DeserializeRow;
 use crate::client::pager::QueryPager;
 use crate::cluster::NodeAddr;
 use crate::cluster::control_connection::ControlConnection;
+use crate::cluster::metadata::update::{FetchedKeyspace, SchemaUpdate};
 use crate::cluster::metadata::{ClientRoutes, ClientRoutesUpdate};
 use crate::deserialize::DeserializeOwnedRow;
 use crate::errors::{
@@ -513,6 +515,16 @@ impl TryFrom<ClientRoutesEntry> for super::ClientRoute {
     }
 }
 
+/// What the last SCHEMA_CHANGE event seen for a keyspace did to it.
+pub(crate) enum LastKeyspaceChange {
+    /// The keyspace itself was dropped, so it is to be removed from the schema
+    /// metadata rather than re-read.
+    Dropped,
+    /// Anything else - the keyspace was created or altered, or an object in it
+    /// was created, altered or dropped - so its metadata is to be re-read.
+    Altered,
+}
+
 impl ControlConnection {
     pub(super) async fn query_client_routes(
         &self,
@@ -635,6 +647,74 @@ impl ControlConnection {
             subscriber.get_connection_ids(),
             &client_routes,
         )))
+    }
+
+    /// Performs a partial fetch of the schema metadata: re-reads the schema
+    /// parts described by `request`.
+    ///
+    /// Each keyspace in `request` is marked as either dropped, or altered.
+    /// The altered keyspaces are fetched from the cluster.
+    /// The dropped ones will be reported as `FetchedKeyspace::Absent`,
+    /// without asking cluster for them.
+    /// If a keyspace marked as `altered` is not present in the cluster,
+    /// it will also be reported as `FetchedKeyspace::Absent`.
+    ///
+    /// Keyspaces in `request` are filtered by this control connection's configuration.
+    ///
+    /// Returns `None` when the configuration leaves nothing to do at all -
+    /// there is then no update to publish.
+    pub(super) async fn fetch_schema_update(
+        &self,
+        request: HashMap<String, LastKeyspaceChange>,
+    ) -> Result<Option<SchemaUpdate>, MetadataError> {
+        if matches!(
+            self.config.schema_metadata_fetch_mode,
+            SchemaMetadataFetchMode::Disabled
+        ) {
+            // No schema metadata is kept at all, so there is nothing to update.
+            return Ok(None);
+        }
+
+        // An empty `keyspaces_to_fetch` means "no restriction".
+        let is_fetched = |keyspace: &String| {
+            self.config.keyspaces_to_fetch.is_empty()
+                || self.config.keyspaces_to_fetch.contains(keyspace)
+        };
+
+        // Split the request into a list of keyspaces to fetch,
+        // and a map containing keyspaces that were dropped.
+        // Later this map will be extended with a fetch result.
+        let (to_fetch, mut keyspaces): (Vec<_>, HashMap<_, _>) = request
+            .into_iter()
+            .filter(|(name, _)| is_fetched(name))
+            .partition_map(|(name, state)| match state {
+                LastKeyspaceChange::Altered => Either::Left(name),
+                LastKeyspaceChange::Dropped => Either::Right((name, FetchedKeyspace::Absent)),
+            });
+
+        if to_fetch.is_empty() {
+            // Careful: an empty keyspace list means "every keyspace" to
+            // `query_keyspaces`, so it must not be called with one.
+            return Ok((!keyspaces.is_empty()).then_some(SchemaUpdate { keyspaces }));
+        }
+
+        let mut fetched = self
+            .query_keyspaces(&to_fetch, self.config.schema_metadata_fetch_mode)
+            .await?;
+
+        keyspaces.extend(to_fetch.into_iter().map(|keyspace| {
+            // A keyspace the fetch found no row for is gone: either the event
+            // announcing its drop is still on its way, or it was dropped
+            // without one. Either way it is dropped from the metadata rather
+            // than left stale.
+            let entry = match fetched.remove(&keyspace) {
+                Some(metadata) => FetchedKeyspace::Present(metadata),
+                None => FetchedKeyspace::Absent,
+            };
+            (keyspace, entry)
+        }));
+
+        Ok(Some(SchemaUpdate { keyspaces }))
     }
 
     fn query_filter_keyspace_name<'a, R>(

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -48,6 +48,32 @@ pub(crate) enum SchemaMetadataFetchLevel {
     Full,
 }
 
+/// What the periodic cluster metadata refresh re-reads.
+///
+/// Set with
+/// [`SessionBuilder::periodic_metadata_fetch_mode`](crate::client::session_builder::SessionBuilder::periodic_metadata_fetch_mode);
+/// how often the refresh happens is a separate setting,
+/// [`SessionBuilder::cluster_metadata_refresh_interval`](crate::client::session_builder::SessionBuilder::cluster_metadata_refresh_interval).
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PeriodicFetchMode {
+    /// The schema of the keyspaces that `SCHEMA_CHANGE` events named since the
+    /// previous refresh, and nothing else. The default.
+    ///
+    /// Every other aspect of the metadata is re-read in reaction to the server
+    /// event announcing its change, so the refresh only has to cover the
+    /// schema, and only the part of it that changed.
+    AffectedKeyspaces,
+    /// All metadata selected by the session's schema-fetch configuration,
+    /// ignoring which keyspaces the `SCHEMA_CHANGE` events named.
+    ///
+    /// This is the behaviour of driver versions that did not handle
+    /// `SCHEMA_CHANGE` events, kept as an escape hatch for clusters whose
+    /// events cannot be relied upon. It costs a query per schema table per
+    /// refresh interval, hence it is not the default.
+    FullMetadata,
+}
+
 /// Indicates that reading metadata failed, but in a way
 /// that we can handle, by throwing out data for a keyspace.
 /// It is possible that some of the errors could be handled in even

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -88,8 +88,18 @@ impl PartialMetadataChanges {
     fn merge_peers(&mut self, peers: Vec<Peer>) {
         self.peers = Some(peers);
     }
+
+    /// Records a partial schema snapshot, merging it into the one already
+    /// pending, if any.
+    fn merge_schema_update(&mut self, new_schema: SchemaUpdate) {
+        match &mut self.schema {
+            None => self.schema = Some(new_schema),
+            Some(existing) => existing.merge(new_schema),
+        }
+    }
 }
 
+#[expect(dead_code)]
 impl MetadataUpdate {
     fn slot_mut(slot: &mut Option<Self>) -> &mut Self {
         slot.get_or_insert_with(Self::default)
@@ -109,7 +119,31 @@ impl MetadataUpdate {
         // Newest wins: an older, not-yet-applied fetch is worthless now.
         // Caveat: We need to NOT drop the old refresh channel.
         match &mut update.metadata_changes {
-            None | Some(MetadataChanges::Partial(_)) => {
+            None => {
+                update.metadata_changes = Some(MetadataChanges::Full {
+                    metadata,
+                    refresh_responses: refresh_response.into_iter().collect(),
+                });
+            }
+            Some(MetadataChanges::Partial(partial_changes)) => {
+                // Merging per-keyspace results: if newer fetch has a per-keyspace error,
+                // but older has a working ks metadata, we need to reuse the old one.
+                if let Some(old_schema_update) = &partial_changes.schema {
+                    for (name, ks) in metadata.keyspaces.iter_mut() {
+                        if let Err(e) = ks
+                            && let Some(FetchedKeyspace::Present(Ok(old_ks))) =
+                                old_schema_update.keyspaces.get(name)
+                        {
+                            warn!(
+                                "Encountered an error while processing\
+                                metadata of keyspace \"{name}\": {e}.\
+                                Re-using older version of this keyspace metadata"
+                            );
+                            *ks = Ok(old_ks.clone())
+                        }
+                    }
+                }
+
                 update.metadata_changes = Some(MetadataChanges::Full {
                     metadata,
                     refresh_responses: refresh_response.into_iter().collect(),
@@ -191,6 +225,41 @@ impl MetadataUpdate {
                 // complete after a pending full fetch if it was started after
                 // that fetch completed.
                 metadata.peers = peers;
+            }
+        }
+    }
+
+    /// Records the per-keyspace schema obtained by a partial schema fetch
+    /// performed in response to SCHEMA_CHANGE events.
+    pub(crate) fn merge_schema_update(slot: &mut Option<Self>, schema: SchemaUpdate) {
+        let update = Self::slot_mut(slot);
+        match &mut update.metadata_changes {
+            None => {
+                let mut partial = PartialMetadataChanges::default();
+                partial.merge_schema_update(schema);
+                update.metadata_changes = Some(MetadataChanges::Partial(partial));
+            }
+            Some(MetadataChanges::Partial(partial)) => partial.merge_schema_update(schema),
+            Some(MetadataChanges::Full {
+                metadata,
+                refresh_responses: _,
+            }) => {
+                // Older full fetch was not consumed yet. We need to update it
+                // with the newly fetched keyspaces.
+                for (name, keyspace) in schema.keyspaces {
+                    match keyspace {
+                        // If new metadata has Err for some keyspace, and the old one has Ok, we should
+                        // not overwrite.
+                        FetchedKeyspace::Present(Err(_))
+                            if matches!(metadata.keyspaces.get(&name), Some(Ok(_))) => {}
+                        FetchedKeyspace::Present(keyspace) => {
+                            metadata.keyspaces.insert(name, keyspace);
+                        }
+                        FetchedKeyspace::Absent => {
+                            metadata.keyspaces.remove(&name);
+                        }
+                    }
+                }
             }
         }
     }
@@ -318,6 +387,30 @@ pub(crate) enum FetchedKeyspace {
     /// The keyspace does not exist: its last event dropped it, or the fetch
     /// found no row for it.
     Absent,
+}
+
+impl SchemaUpdate {
+    /// Merges a newer update into this one: the newer statement about a
+    /// keyspace overrides the older one. We need to handle per-keyspace
+    /// errors: if newer keyspace has an error, but older one doesn't, then
+    /// we need to drop the newer one. This is the same logic we have in
+    /// ClusterState construction.
+    pub(crate) fn merge(&mut self, newer: SchemaUpdate) {
+        for (name, newer_keyspace) in newer.keyspaces {
+            match newer_keyspace {
+                // If newer keyspace is an error, and we already have the non-Err keyspace
+                // with this name, we would only lose information by updating.
+                FetchedKeyspace::Present(Err(_))
+                    if matches!(
+                        self.keyspaces.get(&name),
+                        Some(FetchedKeyspace::Present(Ok(_)))
+                    ) => {}
+                newer_keyspace => {
+                    self.keyspaces.insert(name, newer_keyspace);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -5,7 +5,9 @@ use tokio::sync::oneshot;
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::cluster::metadata::{ClientRoute, ClientRoutes, Metadata, Peer};
+use crate::cluster::metadata::{
+    ClientRoute, ClientRoutes, Keyspace, Metadata, Peer, SingleKeyspaceMetadataError,
+};
 use crate::errors::MetadataError;
 
 /// An explicit request to refresh cluster metadata, sent by
@@ -66,6 +68,9 @@ pub(in super::super) struct PartialMetadataChanges {
     /// whole peer list, so this replaces the topology of the state it is
     /// applied to.
     pub(in super::super) peers: Option<Vec<Peer>>,
+    /// The schema of the keyspaces that SCHEMA_CHANGE events named, fetched in
+    /// response to them.
+    pub(in super::super) schema: Option<SchemaUpdate>,
 }
 
 impl PartialMetadataChanges {
@@ -277,6 +282,42 @@ impl ClientRoutesUpdate {
                 .insert(connection_id, route);
         }
     }
+}
+
+/// A partial, mergeable update of the schema metadata, derived from the
+/// keyspaces named by SCHEMA_CHANGE events and from the per-keyspace schema
+/// fetched in response to them.
+///
+/// Only the named keyspaces are described; every other keyspace of the state
+/// this is applied to is left untouched.
+#[derive(Default)]
+pub(crate) struct SchemaUpdate {
+    /// One entry per named keyspace. A map keyed by keyspace, so that a
+    /// keyspace cannot be said to be both present and absent, and so that
+    /// merging is nothing but "the newer statement wins" - see
+    /// [`merge`](Self::merge).
+    pub(crate) keyspaces: HashMap<String, FetchedKeyspace>,
+}
+
+/// What a partial schema fetch established about one keyspace.
+// Storing `Keyspace` object directly is something we do normally,
+// for example in `Metadata` / `ClusterState`. Here clippy complains
+// only because there is a second, smaller variant. If we boxed the
+// keyspace here, we would then have to unbox it to get it into
+// `ClusterState`. This will change if / when we decide to put keyspaces
+// in `ClusterState` inside `Arc`. Until then, let's just ignore clippy.
+#[expect(clippy::large_enum_variant)]
+#[expect(dead_code)]
+pub(crate) enum FetchedKeyspace {
+    /// The keyspace exists; this is its freshly read metadata.
+    ///
+    /// The `Result` layer is the one of [`Metadata::keyspaces`]: a keyspace
+    /// whose fetched metadata turned out inconsistent is reported as an error
+    /// rather than silently replaced.
+    Present(Result<Keyspace, SingleKeyspaceMetadataError>),
+    /// The keyspace does not exist: its last event dropped it, or the fetch
+    /// found no row for it.
+    Absent,
 }
 
 #[cfg(test)]

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -134,8 +134,8 @@ impl MetadataUpdate {
                                 old_schema_update.keyspaces.get(name)
                         {
                             warn!(
-                                "Encountered an error while processing\
-                                metadata of keyspace \"{name}\": {e}.\
+                                "Encountered an error while processing \
+                                metadata of keyspace \"{name}\": {e}. \
                                 Re-using older version of this keyspace metadata"
                             );
                             *ks = Ok(old_ks.clone())
@@ -159,8 +159,8 @@ impl MetadataUpdate {
                         && let Some(Ok(old_ks)) = slot_metadata.keyspaces.get(name)
                     {
                         warn!(
-                            "Encountered an error while processing\
-                            metadata of keyspace \"{name}\": {e}.\
+                            "Encountered an error while processing \
+                            metadata of keyspace \"{name}\": {e}. \
                             Re-using older version of this keyspace metadata"
                         );
                         *ks = Ok(old_ks.clone())

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -99,7 +99,6 @@ impl PartialMetadataChanges {
     }
 }
 
-#[expect(dead_code)]
 impl MetadataUpdate {
     fn slot_mut(slot: &mut Option<Self>) -> &mut Self {
         slot.get_or_insert_with(Self::default)
@@ -376,7 +375,6 @@ pub(crate) struct SchemaUpdate {
 // `ClusterState`. This will change if / when we decide to put keyspaces
 // in `ClusterState` inside `Arc`. Until then, let's just ignore clippy.
 #[expect(clippy::large_enum_variant)]
-#[expect(dead_code)]
 pub(crate) enum FetchedKeyspace {
     /// The keyspace exists; this is its freshly read metadata.
     ///

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -789,4 +789,249 @@ mod tests {
             vec![(host, "conn-1".to_owned(), None)]
         );
     }
+
+    // ---------------------------------------------------------------
+    // Tests for the handling of per-keyspace errors while merging
+    // ---------------------------------------------------------------
+
+    use crate::cluster::metadata::update::{
+        FetchedKeyspace, MetadataChanges, MetadataUpdate, SchemaUpdate,
+    };
+    use crate::cluster::metadata::{Keyspace, Metadata, SingleKeyspaceMetadataError, Strategy};
+
+    // Keyspaces are told apart by `durable_writes`, which is all it takes to
+    // tell which reading of a keyspace a merge kept.
+    fn keyspace(durable_writes: bool) -> Keyspace {
+        Keyspace {
+            strategy: Strategy::LocalStrategy,
+            durable_writes,
+            tablet_based: false,
+            tables: HashMap::new(),
+            views: HashMap::new(),
+            user_defined_types: HashMap::new(),
+        }
+    }
+
+    // The per-keyspace result of a fetch that read the keyspace but could not
+    // process what it read.
+    fn broken() -> Result<Keyspace, SingleKeyspaceMetadataError> {
+        Err(SingleKeyspaceMetadataError::IncompletePartitionKey(0))
+    }
+
+    fn metadata(keyspaces: Vec<(&str, Result<Keyspace, SingleKeyspaceMetadataError>)>) -> Metadata {
+        Metadata {
+            peers: Vec::new(),
+            keyspaces: keyspaces
+                .into_iter()
+                .map(|(name, keyspace)| (name.to_owned(), keyspace))
+                .collect(),
+            cluster_name: None,
+            client_routes: None,
+        }
+    }
+
+    fn schema_update(keyspaces: Vec<(&str, FetchedKeyspace)>) -> SchemaUpdate {
+        SchemaUpdate {
+            keyspaces: keyspaces
+                .into_iter()
+                .map(|(name, keyspace)| (name.to_owned(), keyspace))
+                .collect(),
+        }
+    }
+
+    // The metadata a merge left pending, or a panic if it left something else.
+    fn pending_metadata(slot: Option<MetadataUpdate>) -> Metadata {
+        match slot.expect("the merge left no update").metadata_changes {
+            Some(MetadataChanges::Full { metadata, .. }) => metadata,
+            _ => panic!("expected pending full metadata"),
+        }
+    }
+
+    // The partial schema update a merge left pending, likewise.
+    fn pending_schema(slot: Option<MetadataUpdate>) -> SchemaUpdate {
+        match slot.expect("the merge left no update").metadata_changes {
+            Some(MetadataChanges::Partial(partial)) => {
+                partial.schema.expect("expected a pending schema update")
+            }
+            _ => panic!("expected pending partial changes"),
+        }
+    }
+
+    // `durable_writes` of a keyspace whose metadata is pending; panics if the
+    // keyspace is missing or its metadata is an error.
+    fn durable_writes_of(metadata: &Metadata, name: &str) -> bool {
+        metadata
+            .keyspaces
+            .get(name)
+            .unwrap_or_else(|| panic!("keyspace \"{name}\" went missing"))
+            .as_ref()
+            .unwrap_or_else(|_| panic!("keyspace \"{name}\" is an error"))
+            .durable_writes
+    }
+
+    fn is_broken(metadata: &Metadata, name: &str) -> bool {
+        matches!(metadata.keyspaces.get(name), Some(Err(_)))
+    }
+
+    // A per-keyspace error says nothing about the keyspace, so when a newer full
+    // fetch supersedes a pending one, the pending fetch's reading of that
+    // keyspace - the freshest one that says anything - has to survive. Every
+    // other keyspace follows the newer fetch, including one it no longer knows:
+    // its keyspace list is a full snapshot, so that keyspace is gone.
+    #[test]
+    fn merging_metadata_reuses_pending_keyspace_on_error() {
+        let mut slot = None;
+        MetadataUpdate::merge_metadata(
+            &mut slot,
+            metadata(vec![
+                ("reused", Ok(keyspace(true))),
+                ("broken_twice", broken()),
+                ("refetched", Ok(keyspace(true))),
+                ("gone", Ok(keyspace(true))),
+            ]),
+            None,
+        );
+        MetadataUpdate::merge_metadata(
+            &mut slot,
+            metadata(vec![
+                ("reused", broken()),
+                ("broken_twice", broken()),
+                ("refetched", Ok(keyspace(false))),
+                ("added", Ok(keyspace(false))),
+            ]),
+            None,
+        );
+
+        let merged = pending_metadata(slot);
+        assert!(durable_writes_of(&merged, "reused"));
+        // Neither fetch could process this one, so there is nothing to reuse:
+        // the error stands, and applying it will fall back to the keyspace
+        // metadata of the published cluster state.
+        assert!(is_broken(&merged, "broken_twice"));
+        assert!(!durable_writes_of(&merged, "refetched"));
+        assert!(!durable_writes_of(&merged, "added"));
+        assert!(!merged.keyspaces.contains_key("gone"));
+    }
+
+    // The same holds when what is pending is a partial schema update: it was
+    // fetched before the metadata that subsumes it, but for a keyspace that
+    // metadata failed to process, it is still the freshest reading around.
+    #[test]
+    fn merging_metadata_reuses_pending_partial_keyspace_on_error() {
+        let mut slot = None;
+        MetadataUpdate::merge_schema_update(
+            &mut slot,
+            schema_update(vec![
+                ("reused", FetchedKeyspace::Present(Ok(keyspace(true)))),
+                ("broken_twice", FetchedKeyspace::Present(broken())),
+                ("dropped_by_partial", FetchedKeyspace::Absent),
+            ]),
+        );
+        MetadataUpdate::merge_metadata(
+            &mut slot,
+            metadata(vec![
+                ("reused", broken()),
+                ("broken_twice", broken()),
+                ("dropped_by_partial", Ok(keyspace(false))),
+                ("unknown_to_partial", broken()),
+            ]),
+            None,
+        );
+
+        let merged = pending_metadata(slot);
+        assert!(durable_writes_of(&merged, "reused"));
+        assert!(is_broken(&merged, "broken_twice"));
+        // The partial update said this keyspace was gone, but the full fetch is
+        // newer and found it, so the full fetch wins.
+        assert!(!durable_writes_of(&merged, "dropped_by_partial"));
+        // Nothing pending says anything about this one.
+        assert!(is_broken(&merged, "unknown_to_partial"));
+    }
+
+    // A partial schema fetch is newer than a pending full one, so what it read
+    // replaces the pending metadata - but a keyspace it failed to process is
+    // exactly what it did not read, so the pending metadata of that keyspace
+    // must not be thrown away.
+    #[test]
+    fn merging_a_schema_update_does_not_overwrite_a_keyspace_with_an_error() {
+        let mut slot = None;
+        MetadataUpdate::merge_metadata(
+            &mut slot,
+            metadata(vec![
+                ("kept", Ok(keyspace(true))),
+                ("repaired", broken()),
+                ("broken_twice", broken()),
+                ("dropped", Ok(keyspace(true))),
+                ("untouched", Ok(keyspace(true))),
+            ]),
+            None,
+        );
+        MetadataUpdate::merge_schema_update(
+            &mut slot,
+            schema_update(vec![
+                ("kept", FetchedKeyspace::Present(broken())),
+                ("repaired", FetchedKeyspace::Present(Ok(keyspace(false)))),
+                ("broken_twice", FetchedKeyspace::Present(broken())),
+                ("dropped", FetchedKeyspace::Absent),
+            ]),
+        );
+
+        let merged = pending_metadata(slot);
+        assert!(durable_writes_of(&merged, "kept"));
+        // A keyspace the schema fetch did read replaces the error left by the
+        // full fetch.
+        assert!(!durable_writes_of(&merged, "repaired"));
+        assert!(is_broken(&merged, "broken_twice"));
+        assert!(!merged.keyspaces.contains_key("dropped"));
+        assert!(durable_writes_of(&merged, "untouched"));
+    }
+
+    // Two partial schema updates coalesce into one, and the same rule applies
+    // per keyspace: the newer statement wins unless it is an error, which says
+    // nothing and so must not displace a keyspace that was read.
+    #[test]
+    fn merging_schema_updates_keeps_the_keyspace_a_newer_error_says_nothing_about() {
+        let mut slot = None;
+        MetadataUpdate::merge_schema_update(
+            &mut slot,
+            schema_update(vec![
+                ("kept", FetchedKeyspace::Present(Ok(keyspace(true)))),
+                ("repaired", FetchedKeyspace::Present(broken())),
+                ("dropped", FetchedKeyspace::Present(Ok(keyspace(true)))),
+                ("absent_then_broken", FetchedKeyspace::Absent),
+            ]),
+        );
+        MetadataUpdate::merge_schema_update(
+            &mut slot,
+            schema_update(vec![
+                ("kept", FetchedKeyspace::Present(broken())),
+                ("repaired", FetchedKeyspace::Present(Ok(keyspace(false)))),
+                ("dropped", FetchedKeyspace::Absent),
+                ("absent_then_broken", FetchedKeyspace::Present(broken())),
+            ]),
+        );
+
+        let merged = pending_schema(slot);
+        assert!(matches!(
+            merged.keyspaces.get("kept"),
+            Some(FetchedKeyspace::Present(Ok(kept))) if kept.durable_writes
+        ));
+        assert!(matches!(
+            merged.keyspaces.get("repaired"),
+            Some(FetchedKeyspace::Present(Ok(repaired))) if !repaired.durable_writes
+        ));
+        // A drop is a statement, not a failure to read one, so the newer update
+        // wins here.
+        assert!(matches!(
+            merged.keyspaces.get("dropped"),
+            Some(FetchedKeyspace::Absent)
+        ));
+        // The older update said the keyspace was gone and the newer one read
+        // rows for it, so it exists again - the error is the newer statement and
+        // stands, to be resolved against the cluster state.
+        assert!(matches!(
+            merged.keyspaces.get("absent_then_broken"),
+            Some(FetchedKeyspace::Present(Err(_)))
+        ));
+    }
 }

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -97,7 +97,7 @@ impl MetadataUpdate {
     /// fetched before this metadata that subsumes them.
     pub(crate) fn merge_metadata(
         slot: &mut Option<Self>,
-        metadata: Metadata,
+        mut metadata: Metadata,
         refresh_response: Option<tokio::sync::oneshot::Sender<Result<(), MetadataError>>>,
     ) {
         let update = Self::slot_mut(slot);
@@ -114,6 +114,20 @@ impl MetadataUpdate {
                 metadata: slot_metadata,
                 refresh_responses,
             }) => {
+                // Merging per-keyspace results: if newer fetch has a per-keyspace error,
+                // but older has a working ks metadata, we need to reuse the old one.
+                for (name, ks) in metadata.keyspaces.iter_mut() {
+                    if let Err(e) = ks
+                        && let Some(Ok(old_ks)) = slot_metadata.keyspaces.get(name)
+                    {
+                        warn!(
+                            "Encountered an error while processing\
+                            metadata of keyspace \"{name}\": {e}.\
+                            Re-using older version of this keyspace metadata"
+                        );
+                        *ks = Ok(old_ks.clone())
+                    }
+                }
                 *slot_metadata = metadata;
                 if let Some(response_channel) = refresh_response {
                     refresh_responses.push(response_channel);

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -13,7 +13,7 @@ use crate::cluster::control_connection::{
 };
 use crate::cluster::metadata::fetching::LastKeyspaceChange;
 use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest, SchemaUpdate};
-use crate::cluster::metadata::{ClientRoutesUpdate, Metadata, Peer};
+use crate::cluster::metadata::{ClientRoutesUpdate, Metadata, Peer, PeriodicFetchMode};
 use crate::errors::{
     BrokenConnectionErrorKind, ConnectionError, ConnectionPoolError, MetadataError,
 };
@@ -46,10 +46,14 @@ pub(in super::super) struct MetadataWorker {
     /// keeps the known peers to establish them to.
     cc_establisher: ControlConnectionEstablisher,
 
-    /// How often the periodic refresh tick fires. The tick paces the partial
-    /// schema fetches; everything else is re-read in reaction to server events
-    /// or on request.
+    /// How often the periodic refresh tick fires, and what it re-reads.
+    ///
+    /// By default the tick paces the partial schema fetches, everything else
+    /// being re-read in reaction to server events or on request; with
+    /// [`PeriodicFetchMode::FullMetadata`] it re-reads the whole metadata
+    /// instead.
     cluster_metadata_refresh_interval: Duration,
+    periodic_fetch_mode: PeriodicFetchMode,
 
     // To listen for refresh requests
     refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
@@ -324,14 +328,20 @@ impl<'cc> PendingFetches<'cc> {
         plan: &mut FetchPlan,
         next_refresh_deadline: &mut Instant,
         refresh_interval: Duration,
+        periodic_fetch_mode: &PeriodicFetchMode,
         cc: &'cc ControlConnection,
     ) {
         let periodic_tick_due = Instant::now() >= *next_refresh_deadline;
 
         // A full fetch is due when a refresh request demanded one or a partial
-        // fetch failed. The periodic tick no longer implies one: everything it
-        // used to re-read is now re-read in reaction to server events.
-        if !matches!(self, PendingFetches::Full { .. }) && matches!(plan, FetchPlan::Full) {
+        // fetch failed. The periodic tick implies one only for a session that
+        // opted out of partial schema fetching; otherwise everything the tick
+        // used to re-read is by now re-read in reaction to server events.
+        let periodic_full_fetch_due =
+            periodic_tick_due && matches!(periodic_fetch_mode, PeriodicFetchMode::FullMetadata);
+        if !matches!(self, PendingFetches::Full { .. })
+            && (matches!(plan, FetchPlan::Full) || periodic_full_fetch_due)
+        {
             // Starting the full fetch drops both the partial work owed by the
             // plan and any running partial fetch: the full fetch reads all of
             // that data, and reads it after the events that made the partial
@@ -483,12 +493,14 @@ impl MetadataWorker {
     pub(in super::super) fn new(
         cc_establisher: ControlConnectionEstablisher,
         cluster_metadata_refresh_interval: Duration,
+        periodic_fetch_mode: PeriodicFetchMode,
         refresh_channel: tokio::sync::mpsc::Receiver<RefreshRequest>,
         updates: merge_channel::Sender<MetadataUpdate>,
     ) -> Self {
         Self {
             cc_establisher,
             cluster_metadata_refresh_interval,
+            periodic_fetch_mode,
             refresh_channel,
             updates,
             pending_request: None,
@@ -732,6 +744,7 @@ impl MetadataWorker {
                 &mut plan,
                 &mut next_refresh_deadline,
                 self.cluster_metadata_refresh_interval,
+                &self.periodic_fetch_mode,
                 &cc,
             );
 

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -12,7 +12,9 @@ use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
 };
 use crate::cluster::metadata::fetching::LastKeyspaceChange;
-use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest, SchemaUpdate};
+use crate::cluster::metadata::update::{
+    FetchedKeyspace, MetadataUpdate, RefreshRequest, SchemaUpdate,
+};
 use crate::cluster::metadata::{ClientRoutesUpdate, Metadata, Peer, PeriodicFetchMode};
 use crate::errors::{
     BrokenConnectionErrorKind, ConnectionError, ConnectionPoolError, MetadataError,
@@ -194,6 +196,20 @@ impl FetchPlan {
         }
     }
 
+    /// Records that fetching `keyspace` failed.
+    ///
+    /// It will only insert the keyspace into the fetch plan
+    /// if it's not already there. If it's there, then we received an
+    /// event after we started the fetch, and it should take precedence.
+    fn note_keyspace_err(&mut self, keyspace: String) {
+        match self {
+            FetchPlan::Partial { schema, .. } => schema
+                .get_or_insert_with(SchemaFetchRequest::default)
+                .note_error(keyspace),
+            FetchPlan::Full => (),
+        }
+    }
+
     /// Nothing owed: the state of a plan whose work has all been started.
     const fn empty() -> Self {
         Self::Partial {
@@ -250,6 +266,13 @@ impl SchemaFetchRequest {
     /// older one did to it.
     fn note(&mut self, keyspace: String, change: LastKeyspaceChange) {
         self.keyspaces.insert(keyspace, change);
+    }
+
+    /// Records that we failed to process the keyspace.
+    fn note_error(&mut self, keyspace: String) {
+        self.keyspaces
+            .entry(keyspace)
+            .or_insert(LastKeyspaceChange::Altered);
     }
 
     /// Performs the partial fetch for the accumulated keyspaces.
@@ -530,7 +553,10 @@ impl MetadataWorker {
         );
         let (kept, metadata) = fetch.await?;
         Ok((
-            kept.map(|(cc, events, plan)| EstablishedCc { cc, events, plan }),
+            kept.map(|(cc, events, mut plan)| {
+                Self::handle_metadata_keyspace_errors(&mut plan, &metadata);
+                EstablishedCc { cc, events, plan }
+            }),
             metadata,
         ))
     }
@@ -758,6 +784,7 @@ impl MetadataWorker {
                         FetchOutcome::Full(Ok(topology_update)) => {
                             debug!("Fetched new metadata");
                             let metadata = topology_update.apply(&mut self.cc_establisher);
+                            Self::handle_metadata_keyspace_errors(&mut plan, &metadata);
                             self.publish_metadata(metadata)?;
                         }
                         FetchOutcome::Full(Err(err)) => {
@@ -800,6 +827,7 @@ impl MetadataWorker {
                         FetchOutcome::Schema(Ok(None)) => (), // Nothing to apply.
                         FetchOutcome::Schema(Ok(Some(schema))) => {
                             debug!("Fetched the schema of the affected keyspaces");
+                            Self::handle_partial_fetch_keyspace_errors(&mut plan, &schema);
                             if self.send_update(|slot| MetadataUpdate::merge_schema_update(slot, schema)).is_err() {
                                 return ControlFlow::Break(());
                             }
@@ -986,6 +1014,28 @@ impl MetadataWorker {
             _ => unreachable!("clippy testifies that the match is exhaustive"),
         };
         ControlFlow::Continue(())
+    }
+
+    fn handle_metadata_keyspace_errors(plan: &mut FetchPlan, metadata: &Metadata) {
+        for (name, ks) in metadata.keyspaces.iter() {
+            if let Err(_e) = ks {
+                // We failed to fetch some keyspace.
+                // Need to note as needed to fetch.
+                // Without it we may never retry.
+                plan.note_keyspace_err(name.clone());
+            }
+        }
+    }
+
+    fn handle_partial_fetch_keyspace_errors(plan: &mut FetchPlan, schema: &SchemaUpdate) {
+        for (name, ks) in schema.keyspaces.iter() {
+            if let FetchedKeyspace::Present(Err(_e)) = ks {
+                // We failed to fetch some keyspace.
+                // Need to note as needed to fetch.
+                // Without it we may never retry.
+                plan.note_keyspace_err(name.clone());
+            }
+        }
     }
 
     /// Publishes freshly fetched metadata to the cluster worker.

--- a/scylla/src/cluster/metadata/worker.rs
+++ b/scylla/src/cluster/metadata/worker.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -11,13 +11,16 @@ use uuid::Uuid;
 use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionEvent, ControlConnectionEvents,
 };
-use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest};
+use crate::cluster::metadata::fetching::LastKeyspaceChange;
+use crate::cluster::metadata::update::{MetadataUpdate, RefreshRequest, SchemaUpdate};
 use crate::cluster::metadata::{ClientRoutesUpdate, Metadata, Peer};
 use crate::errors::{
     BrokenConnectionErrorKind, ConnectionError, ConnectionPoolError, MetadataError,
 };
 use crate::frame::response::event::ClientRoutesChangeEvent;
 use crate::frame::response::event::EventV2 as Event;
+use crate::frame::response::event::SchemaChangeEvent;
+use crate::frame::response::event::SchemaChangeType;
 use crate::frame::response::event::StatusChangeEvent;
 
 use super::cc_establisher::{ControlConnectionEstablisher, FetchOnCandidate, TopologyUpdateGuard};
@@ -43,8 +46,9 @@ pub(in super::super) struct MetadataWorker {
     /// keeps the known peers to establish them to.
     cc_establisher: ControlConnectionEstablisher,
 
-    // This value determines how frequently the metadata
-    // worker will refresh the cluster metadata
+    /// How often the periodic refresh tick fires. The tick paces the partial
+    /// schema fetches; everything else is re-read in reaction to server events
+    /// or on request.
     cluster_metadata_refresh_interval: Duration,
 
     // To listen for refresh requests
@@ -126,6 +130,13 @@ enum FetchPlan {
         client_routes: Option<ClientRoutesFetchRequest>,
         /// Whether the peer list is to be re-read.
         topology: bool,
+        /// The keyspaces whose schema is to be re-read, or dropped from the
+        /// metadata, accumulated from SCHEMA_CHANGE events.
+        ///
+        /// Unlike the other entries, this one is not started as soon as its
+        /// slot is free: it waits for the periodic refresh tick - see
+        /// [`PendingFetches::start_due_fetches`].
+        schema: Option<SchemaFetchRequest>,
     },
 }
 
@@ -165,11 +176,26 @@ impl FetchPlan {
         }
     }
 
+    /// Records that `keyspace`'s schema is to be re-read (or dropped), merging
+    /// it into the work already owed.
+    ///
+    /// If a full fetch is already owed, the work is dropped - subsumed, by the
+    /// argument in [`note_full_needed`](Self::note_full_needed).
+    fn note_schema(&mut self, keyspace: String, change: LastKeyspaceChange) {
+        match self {
+            FetchPlan::Partial { schema, .. } => schema
+                .get_or_insert_with(SchemaFetchRequest::default)
+                .note(keyspace, change),
+            FetchPlan::Full => (),
+        }
+    }
+
     /// Nothing owed: the state of a plan whose work has all been started.
     const fn empty() -> Self {
         Self::Partial {
             client_routes: None,
             topology: false,
+            schema: None,
         }
     }
 }
@@ -202,6 +228,35 @@ impl ClientRoutesFetchRequest {
     }
 }
 
+/// The keyspaces named by SCHEMA_CHANGE events, to be resolved by one partial
+/// schema fetch.
+///
+/// A map keyed by keyspace: merging the work of several events keeps, per
+/// keyspace, only the last change. The fetch re-reads the keyspace's whole
+/// metadata regardless of what changed in it, so what a superseded event named
+/// is of no interest - and a keyspace whose last event dropped it needs no read
+/// at all.
+#[derive(Default)]
+struct SchemaFetchRequest {
+    keyspaces: HashMap<String, LastKeyspaceChange>,
+}
+
+impl SchemaFetchRequest {
+    /// Records what the newest event did to `keyspace`, overriding what an
+    /// older one did to it.
+    fn note(&mut self, keyspace: String, change: LastKeyspaceChange) {
+        self.keyspaces.insert(keyspace, change);
+    }
+
+    /// Performs the partial fetch for the accumulated keyspaces.
+    ///
+    /// Takes `self` by value for the same reason as
+    /// [`ClientRoutesFetchRequest::fetch_on`].
+    async fn fetch_on(self, cc: &ControlConnection) -> Result<Option<SchemaUpdate>, MetadataError> {
+        cc.fetch_schema_update(self.keyspaces).await
+    }
+}
+
 /// A full-metadata fetch in flight.
 ///
 /// Boxed to give the anonymous `async fn` future a nameable type, which is
@@ -222,6 +277,11 @@ type TopologyFetch<'cc> = Pin<
 /// [`FullFetch`].
 type ClientRoutesFetch<'cc> =
     Pin<Box<dyn Future<Output = Result<Option<ClientRoutesUpdate>, MetadataError>> + Send + 'cc>>;
+
+/// A partial schema fetch (the affected keyspaces alone) in flight; boxed for
+/// the same reason as [`FullFetch`].
+type SchemaFetch<'cc> =
+    Pin<Box<dyn Future<Output = Result<Option<SchemaUpdate>, MetadataError>> + Send + 'cc>>;
 
 /// The fetches of [`MetadataWorker::work_on_cc`] currently in flight, owning
 /// their futures - which borrow the control connection, hence the lifetime.
@@ -251,6 +311,7 @@ enum PendingFetches<'cc> {
     Partial {
         client_routes_fetch: Option<ClientRoutesFetch<'cc>>,
         topology_fetch: Option<TopologyFetch<'cc>>,
+        schema_fetch: Option<SchemaFetch<'cc>>,
     },
 }
 
@@ -265,16 +326,18 @@ impl<'cc> PendingFetches<'cc> {
         refresh_interval: Duration,
         cc: &'cc ControlConnection,
     ) {
-        // A full fetch is due when a server event or a refresh request
-        // demanded one, or when the periodic deadline has passed.
-        if !matches!(self, PendingFetches::Full { .. })
-            && (matches!(plan, FetchPlan::Full) || Instant::now() >= *next_refresh_deadline)
-        {
+        let periodic_tick_due = Instant::now() >= *next_refresh_deadline;
+
+        // A full fetch is due when a refresh request demanded one or a partial
+        // fetch failed. The periodic tick no longer implies one: everything it
+        // used to re-read is now re-read in reaction to server events.
+        if !matches!(self, PendingFetches::Full { .. }) && matches!(plan, FetchPlan::Full) {
             // Starting the full fetch drops both the partial work owed by the
             // plan and any running partial fetch: the full fetch reads all of
             // that data, and reads it after the events that made the partial
             // work due, so both are subsumed.
             *plan = FetchPlan::empty();
+            // It reads every keyspace, too, so the schema tick restarts.
             *next_refresh_deadline = deadline_after(Instant::now(), refresh_interval);
 
             debug!("Requesting metadata refresh");
@@ -282,6 +345,17 @@ impl<'cc> PendingFetches<'cc> {
                 fetch: Box::pin(cc.query_metadata()),
             };
             return;
+        }
+
+        // The tick advances whether or not schema work is owed.
+        // We could only restart it on schema fetch. The advantage is that
+        // we would react quicker (immediately) to a lone change. The disadvantage
+        // is that if there is a lot of connected clients, they would all send the request to
+        // the server at the same moment. The main reason to have partial fetches is to
+        // make load on the server lighter in such scenario, so the disadvantage is more
+        // important.
+        if periodic_tick_due {
+            *next_refresh_deadline = deadline_after(Instant::now(), refresh_interval);
         }
 
         // Each partial fetch starts only if its own slot is free; work for a
@@ -293,10 +367,12 @@ impl<'cc> PendingFetches<'cc> {
         if let PendingFetches::Partial {
             client_routes_fetch,
             topology_fetch,
+            schema_fetch,
         } = self
             && let FetchPlan::Partial {
                 client_routes,
                 topology,
+                schema,
             } = plan
         {
             if client_routes_fetch.is_none()
@@ -310,6 +386,18 @@ impl<'cc> PendingFetches<'cc> {
                 debug!("Requesting a partial topology fetch");
                 *topology_fetch = Some(Box::pin(cc.query_topology()));
             }
+
+            // Deliberately gated on the tick: unlike the other partial work,
+            // schema work is batched rather than started right away. A single
+            // DDL statement produces a SCHEMA_CHANGE per affected object, and
+            // fetching a keyspace once per event would be pure waste.
+            if schema_fetch.is_none()
+                && periodic_tick_due
+                && let Some(request) = schema.take()
+            {
+                debug!("Requesting a partial schema fetch");
+                *schema_fetch = Some(Box::pin(request.fetch_on(cc)));
+            }
         }
     }
 
@@ -319,6 +407,7 @@ impl<'cc> PendingFetches<'cc> {
         Self::Partial {
             client_routes_fetch: None,
             topology_fetch: None,
+            schema_fetch: None,
         }
     }
 }
@@ -329,6 +418,7 @@ enum FetchOutcome {
     Full(Result<TopologyUpdateGuard, MetadataError>),
     Topology(Result<TopologyUpdateGuard<Vec<Peer>>, MetadataError>),
     ClientRoutes(Result<Option<ClientRoutesUpdate>, MetadataError>),
+    Schema(Result<Option<SchemaUpdate>, MetadataError>),
 }
 
 /// Polls one partial fetch slot, emptying it if the fetch completed.
@@ -363,6 +453,7 @@ impl Future for PendingFetches<'_> {
             PendingFetches::Partial {
                 client_routes_fetch,
                 topology_fetch,
+                schema_fetch,
             } => {
                 // Only one outcome can be reported per poll, so the slots are
                 // polled until one completes; the rest stay in flight and are
@@ -375,6 +466,10 @@ impl Future for PendingFetches<'_> {
                 }
 
                 if let Some(outcome) = poll_slot(topology_fetch, cx).map(FetchOutcome::Topology) {
+                    return Poll::Ready(outcome);
+                }
+
+                if let Some(outcome) = poll_slot(schema_fetch, cx).map(FetchOutcome::Schema) {
                     return Poll::Ready(outcome);
                 }
             }
@@ -602,6 +697,8 @@ impl MetadataWorker {
     ///
     /// - At most one fetch per type runs at a time; work for a busy type waits
     ///   in the plan.
+    /// - Schema work waits for the periodic refresh tick instead of starting at
+    ///   once, which batches the SCHEMA_CHANGE events of a burst into one fetch.
     /// - A due full fetch preempts everything: it abandons the running partial
     ///   fetches and drops the plan's partial work. Both are subsumed - the full
     ///   fetch reads all of that data, and reads it after the events that made
@@ -687,6 +784,20 @@ impl MetadataWorker {
                             );
                             plan.note_full_needed();
                         }
+                        FetchOutcome::Schema(Ok(None)) => (), // Nothing to apply.
+                        FetchOutcome::Schema(Ok(Some(schema))) => {
+                            debug!("Fetched the schema of the affected keyspaces");
+                            if self.send_update(|slot| MetadataUpdate::merge_schema_update(slot, schema)).is_err() {
+                                return ControlFlow::Break(());
+                            }
+                        }
+                        FetchOutcome::Schema(Err(err)) => {
+                            error!(
+                                "Error when fetching schema: {err}. \
+                                Scheduling a metadata refresh, because the control connection is likely defunct."
+                            );
+                            plan.note_full_needed();
+                        }
                     }
                 }
 
@@ -764,7 +875,31 @@ impl MetadataWorker {
         debug!("Received server event: {:?}", event);
         #[deny(clippy::wildcard_enum_match_arm)]
         match event {
-            Event::SchemaChange(_) => (), // For now only fetched during periodic refresh.
+            // A SCHEMA_CHANGE names the keyspace it concerns, so only that
+            // keyspace's schema needs re-reading - and if the keyspace itself
+            // was dropped, not even that: it simply leaves the metadata.
+            //
+            // The work is recorded rather than started right away; see the
+            // schema rule in the docs of [`work_on_cc`](Self::work_on_cc).
+            Event::SchemaChange(change) => {
+                let (keyspace_name, last_change) = match change {
+                    // Only dropping the keyspace itself makes it disappear.
+                    // Dropping an object inside it leaves the keyspace in
+                    // place, so its metadata must be re-read.
+                    SchemaChangeEvent::KeyspaceChange {
+                        change_type: SchemaChangeType::Dropped,
+                        keyspace_name,
+                    } => (keyspace_name, LastKeyspaceChange::Dropped),
+                    SchemaChangeEvent::KeyspaceChange { keyspace_name, .. }
+                    | SchemaChangeEvent::TableChange { keyspace_name, .. }
+                    | SchemaChangeEvent::TypeChange { keyspace_name, .. }
+                    | SchemaChangeEvent::FunctionChange { keyspace_name, .. }
+                    | SchemaChangeEvent::AggregateChange { keyspace_name, .. } => {
+                        (keyspace_name, LastKeyspaceChange::Altered)
+                    }
+                };
+                plan.note_schema(keyspace_name, last_change);
+            }
             // A node was added, removed or moved - only the peer list can have
             // changed, so a partial topology fetch suffices.
             Event::TopologyChange(_) => plan.note_topology(),
@@ -909,7 +1044,8 @@ mod tests {
     use crate::cluster::metadata::Metadata;
 
     use super::{
-        ClientRoutesFetchRequest, FetchOutcome, FetchPlan, PendingFetches, TopologyUpdateGuard,
+        ClientRoutesFetchRequest, FetchOutcome, FetchPlan, LastKeyspaceChange, PendingFetches,
+        SchemaFetchRequest, TopologyUpdateGuard,
     };
 
     fn poll_once(pending_fetches: &mut PendingFetches<'_>) -> Poll<FetchOutcome> {
@@ -932,7 +1068,8 @@ mod tests {
             pending_fetches,
             PendingFetches::Partial {
                 client_routes_fetch: None,
-                topology_fetch: None
+                topology_fetch: None,
+                schema_fetch: None,
             }
         ));
     }
@@ -964,6 +1101,7 @@ mod tests {
         let mut pending_fetches = PendingFetches::Partial {
             client_routes_fetch: Some(Box::pin(async { Ok(None) })),
             topology_fetch: None,
+            schema_fetch: None,
         };
         assert!(matches!(
             poll_once(&mut pending_fetches),
@@ -974,22 +1112,35 @@ mod tests {
         let mut pending_fetches = PendingFetches::Partial {
             client_routes_fetch: None,
             topology_fetch: Some(Box::pin(async { Ok(TopologyUpdateGuard::new(Vec::new())) })),
+            schema_fetch: None,
         };
         assert!(matches!(
             poll_once(&mut pending_fetches),
             Poll::Ready(FetchOutcome::Topology(Ok(_)))
         ));
         assert_nothing_in_flight(&pending_fetches);
+
+        let mut pending_fetches = PendingFetches::Partial {
+            client_routes_fetch: None,
+            topology_fetch: None,
+            schema_fetch: Some(Box::pin(async { Ok(None) })),
+        };
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::Schema(Ok(None)))
+        ));
+        assert_nothing_in_flight(&pending_fetches);
     }
 
     /// Partial fetches of different types run concurrently: reporting the
-    /// outcome of one must leave the other in flight, to be reported by a
-    /// later poll.
+    /// outcome of one must leave the others in flight, to be reported by later
+    /// polls.
     #[test]
-    fn completed_partial_fetch_keeps_the_other_in_flight() {
+    fn completed_partial_fetch_keeps_the_others_in_flight() {
         let mut pending_fetches = PendingFetches::Partial {
             client_routes_fetch: Some(Box::pin(async { Ok(None) })),
             topology_fetch: Some(Box::pin(async { Ok(TopologyUpdateGuard::new(Vec::new())) })),
+            schema_fetch: Some(Box::pin(async { Ok(None) })),
         };
 
         assert!(matches!(
@@ -1000,13 +1151,18 @@ mod tests {
             pending_fetches,
             PendingFetches::Partial {
                 client_routes_fetch: None,
-                topology_fetch: Some(_)
+                topology_fetch: Some(_),
+                schema_fetch: Some(_),
             }
         ));
 
         assert!(matches!(
             poll_once(&mut pending_fetches),
             Poll::Ready(FetchOutcome::Topology(Ok(_)))
+        ));
+        assert!(matches!(
+            poll_once(&mut pending_fetches),
+            Poll::Ready(FetchOutcome::Schema(Ok(None)))
         ));
         assert_nothing_in_flight(&pending_fetches);
     }
@@ -1018,6 +1174,7 @@ mod tests {
         let mut pending_fetches = PendingFetches::Partial {
             client_routes_fetch: Some(Box::pin(pending())),
             topology_fetch: Some(Box::pin(async { Ok(TopologyUpdateGuard::new(Vec::new())) })),
+            schema_fetch: None,
         };
 
         assert!(matches!(
@@ -1028,7 +1185,8 @@ mod tests {
             pending_fetches,
             PendingFetches::Partial {
                 client_routes_fetch: Some(_),
-                topology_fetch: None
+                topology_fetch: None,
+                schema_fetch: None,
             }
         ));
         assert!(poll_once(&mut pending_fetches).is_pending());
@@ -1046,30 +1204,64 @@ mod tests {
         assert!(matches!(pending_fetches, PendingFetches::Full { .. }));
     }
 
-    /// Partial work of different types accumulates side by side: neither type
-    /// may drop the work owed for the other.
+    /// Partial work of different types accumulates side by side: no type may
+    /// drop the work owed for another.
     #[test]
     fn partial_work_of_different_types_coexists() {
         let mut plan = FetchPlan::empty();
         plan.note_client_routes(client_routes_request());
         plan.note_topology();
+        plan.note_schema("ks".to_owned(), LastKeyspaceChange::Altered);
         assert!(matches!(
             plan,
             FetchPlan::Partial {
                 client_routes: Some(_),
-                topology: true
+                topology: true,
+                schema: Some(_),
             }
         ));
 
         let mut plan = FetchPlan::empty();
+        plan.note_schema("ks".to_owned(), LastKeyspaceChange::Altered);
         plan.note_topology();
         plan.note_client_routes(client_routes_request());
         assert!(matches!(
             plan,
             FetchPlan::Partial {
                 client_routes: Some(_),
-                topology: true
+                topology: true,
+                schema: Some(_),
             }
+        ));
+    }
+
+    /// Only the last event per keyspace matters: the fetch re-reads the whole
+    /// keyspace anyway, and a keyspace whose last event dropped it must not be
+    /// fetched - nor may an earlier drop keep a re-created keyspace from being
+    /// fetched.
+    #[test]
+    fn schema_work_keeps_only_the_last_change_per_keyspace() {
+        let mut plan = FetchPlan::empty();
+        plan.note_schema("dropped".to_owned(), LastKeyspaceChange::Altered);
+        plan.note_schema("dropped".to_owned(), LastKeyspaceChange::Dropped);
+        plan.note_schema("recreated".to_owned(), LastKeyspaceChange::Dropped);
+        plan.note_schema("recreated".to_owned(), LastKeyspaceChange::Altered);
+
+        let FetchPlan::Partial {
+            schema: Some(SchemaFetchRequest { keyspaces }),
+            ..
+        } = plan
+        else {
+            panic!("the noted schema work went missing");
+        };
+        assert_eq!(keyspaces.len(), 2);
+        assert!(matches!(
+            keyspaces.get("dropped"),
+            Some(LastKeyspaceChange::Dropped)
+        ));
+        assert!(matches!(
+            keyspaces.get("recreated"),
+            Some(LastKeyspaceChange::Altered)
         ));
     }
 
@@ -1081,11 +1273,13 @@ mod tests {
         let mut plan = FetchPlan::empty();
         plan.note_topology();
         plan.note_client_routes(client_routes_request());
+        plan.note_schema("ks".to_owned(), LastKeyspaceChange::Altered);
         plan.note_full_needed();
         assert!(matches!(plan, FetchPlan::Full));
 
         plan.note_topology();
         plan.note_client_routes(client_routes_request());
+        plan.note_schema("ks".to_owned(), LastKeyspaceChange::Altered);
         assert!(matches!(plan, FetchPlan::Full));
     }
 }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -413,16 +413,16 @@ impl ClusterState {
             Err(e) => {
                 if let Some(old_ks) = old_keyspaces.get(ks_name) {
                     warn!(
-                        "Encountered an error while processing\
-                        metadata of keyspace \"{ks_name}\": {e}.\
+                        "Encountered an error while processing \
+                        metadata of keyspace \"{ks_name}\": {e}. \
                         Re-using older version of this keyspace metadata"
                     );
                     Some(old_ks.clone())
                 } else {
                     warn!(
-                        "Encountered an error while processing metadata\
-                        of keyspace \"{ks_name}\": {e}.\
-                        No previous version of this keyspace metadata found, so it will not be\
+                        "Encountered an error while processing metadata \
+                        of keyspace \"{ks_name}\": {e}. \
+                        No previous version of this keyspace metadata found, so it will not be \
                         present in ClusterState until next refresh."
                     );
                     None

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,3 +1,4 @@
+use crate::cluster::metadata::update::{FetchedKeyspace, SchemaUpdate};
 use crate::cluster::metadata::{Peer, SingleKeyspaceMetadataError};
 use crate::errors::{ClusterStateTokenError, ConnectionPoolError};
 use crate::network::{Connection, ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
@@ -235,29 +236,48 @@ impl ClusterState {
         }
     }
 
-    /// Creates new ClusterState from a freshly fetched topology (the peer list),
-    /// reusing the schema metadata and cluster name of `self` - the counterpart
-    /// of [`new_updated`](Self::new_updated) for a partial topology fetch, which
-    /// reads nothing but the peers.
-    pub(crate) async fn new_with_updated_topology(
+    /// Creates a new `ClusterState` from partially fetched metadata, reusing
+    /// everything of `self` that the partial fetches did not read - the
+    /// counterpart of [`new_updated`](Self::new_updated) for partial fetches.
+    ///
+    /// `peers` is the peer list read by a partial topology fetch and `schema`
+    /// the per-keyspace schema read by a partial schema fetch; `None` means the
+    /// aspect was not re-read, so the one of `self` stands. The cluster name is
+    /// never re-read by a partial fetch - it is fixed for the lifetime of a
+    /// cluster.
+    pub(crate) async fn new_with_partial_changes(
         &self,
-        peers: Vec<Peer>,
+        peers: Option<Vec<Peer>>,
+        schema: Option<SchemaUpdate>,
         node_config: &NodeConfig,
         host_filter: Option<&dyn HostFilter>,
     ) -> Self {
-        let (new_known_nodes, ring) =
-            Self::calculate_new_topology(peers, &self.known_nodes, node_config, host_filter);
+        let (new_known_nodes, ring) = match peers {
+            Some(peers) => {
+                Self::calculate_new_topology(peers, &self.known_nodes, node_config, host_filter)
+            }
+            // The ring in place is exactly the (token, node) list that the
+            // unchanged topology implies, so it is reused as is.
+            None => (
+                self.known_nodes.clone(),
+                self.locator.ring().iter().cloned().collect(),
+            ),
+        };
+
+        let keyspaces = match schema {
+            Some(schema) => self.updated_keyspaces(schema),
+            None => self.keyspaces.clone(),
+        };
 
         let mut tablets = self.locator.tablets.clone();
         Self::perform_tablets_maintenance(
             &mut tablets,
             &self.known_nodes,
             &new_known_nodes,
-            &self.keyspaces,
+            &keyspaces,
         );
 
-        let (locator, keyspaces) =
-            Self::calculate_new_locator(self.keyspaces.clone(), ring, tablets).await;
+        let (locator, keyspaces) = Self::calculate_new_locator(keyspaces, ring, tablets).await;
 
         ClusterState {
             all_nodes: new_known_nodes.values().cloned().collect(),
@@ -266,6 +286,32 @@ impl ClusterState {
             locator,
             cluster_name: self.cluster_name.clone(),
         }
+    }
+
+    /// Applies a partial schema update onto the schema metadata of `self`:
+    /// replaces the metadata of the re-read keyspaces and removes those that
+    /// ceased to exist, keeping every keyspace the update does not mention.
+    fn updated_keyspaces(&self, schema: SchemaUpdate) -> HashMap<String, Keyspace> {
+        let mut new_keyspaces = self.keyspaces.clone();
+
+        for (name, keyspace) in schema.keyspaces {
+            // A keyspace whose fresh metadata turned out inconsistent keeps its
+            // previous version, as after a full fetch - hence the resolution
+            // step, shared with `new_updated`.
+            let resolved = match keyspace {
+                FetchedKeyspace::Present(keyspace) => {
+                    Self::resolve_metadata_keyspace(&name, keyspace, &self.keyspaces)
+                }
+                FetchedKeyspace::Absent => None,
+            };
+
+            match resolved {
+                Some(keyspace) => new_keyspaces.insert(name, keyspace),
+                None => new_keyspaces.remove(&name),
+            };
+        }
+
+        new_keyspaces
     }
 
     /// Creates a new topology (`Node` objects and token ring) from metadata peers,
@@ -348,28 +394,41 @@ impl ClusterState {
     ) -> HashMap<String, Keyspace> {
         meta_keyspaces
             .into_iter()
-            .filter_map(|(ks_name, ks)| match ks {
-                Ok(ks) => Some((ks_name, ks)),
-                Err(e) => {
-                    if let Some(old_ks) = old_keyspaces.get(&ks_name) {
-                        warn!(
-                            "Encountered an error while processing\
-                            metadata of keyspace \"{ks_name}\": {e}.\
-                            Re-using older version of this keyspace metadata"
-                        );
-                        Some((ks_name, old_ks.clone()))
-                    } else {
-                        warn!(
-                            "Encountered an error while processing metadata\
-                            of keyspace \"{ks_name}\": {e}.\
-                            No previous version of this keyspace metadata found, so it will not be\
-                            present in ClusterState until next refresh."
-                        );
-                        None
-                    }
-                }
+            .filter_map(|(ks_name, ks)| {
+                Self::resolve_metadata_keyspace(&ks_name, ks, old_keyspaces).map(|ks| (ks_name, ks))
             })
             .collect()
+    }
+
+    /// [`resolve_metadata_keyspaces`](Self::resolve_metadata_keyspaces) for a
+    /// single keyspace. `None` means there is no metadata to be had for it,
+    /// neither fresh nor previous, so it belongs in no `ClusterState`.
+    fn resolve_metadata_keyspace(
+        ks_name: &str,
+        ks: Result<Keyspace, SingleKeyspaceMetadataError>,
+        old_keyspaces: &HashMap<String, Keyspace>,
+    ) -> Option<Keyspace> {
+        match ks {
+            Ok(ks) => Some(ks),
+            Err(e) => {
+                if let Some(old_ks) = old_keyspaces.get(ks_name) {
+                    warn!(
+                        "Encountered an error while processing\
+                        metadata of keyspace \"{ks_name}\": {e}.\
+                        Re-using older version of this keyspace metadata"
+                    );
+                    Some(old_ks.clone())
+                } else {
+                    warn!(
+                        "Encountered an error while processing metadata\
+                        of keyspace \"{ks_name}\": {e}.\
+                        No previous version of this keyspace metadata found, so it will not be\
+                        present in ClusterState until next refresh."
+                    );
+                    None
+                }
+            }
+        }
     }
 
     fn perform_tablets_maintenance(

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -428,16 +428,18 @@ impl ClusterWorker {
                 );
                 Some((new_cluster_state, refresh_responses))
             }
-            // A partial topology fetch replaces the peer list; the rest of the
-            // state (schema, tablets, connection pools) is reused.
+            // Partial fetches replace only the aspects they re-read; everything
+            // else (schema or topology, tablets, connection pools) is reused.
             Some(MetadataChanges::Partial(PartialMetadataChanges {
-                peers: Some(peers),
+                peers,
+                schema,
                 client_routes_updates: _, // Already applied above.
-            })) => {
+            })) if peers.is_some() || schema.is_some() => {
                 let new_cluster_state = Arc::new(
                     cluster_state
-                        .new_with_updated_topology(
+                        .new_with_partial_changes(
                             peers,
+                            schema,
                             &self.node_config,
                             self.host_filter.as_deref(),
                         )
@@ -505,6 +507,7 @@ impl ClusterWorker {
             MetadataChanges::Partial(PartialMetadataChanges {
                 client_routes_updates,
                 peers: _,
+                schema: _,
             }) => match client_routes_updates.take() {
                 Some(client_routes_update) => {
                     subscriber.merge_client_routes_update(client_routes_update)

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -3,10 +3,10 @@ use crate::client::client_routes::{
 };
 use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::cluster::control_connection::MetadataRequestTimeouts;
-use crate::cluster::metadata::SchemaMetadataFetchMode;
 use crate::cluster::metadata::update::{
     MetadataChanges, MetadataUpdate, PartialMetadataChanges, RefreshRequest, StatusHint,
 };
+use crate::cluster::metadata::{PeriodicFetchMode, SchemaMetadataFetchMode};
 use crate::cluster::state::NodeConfig;
 use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
@@ -71,6 +71,7 @@ impl Cluster {
         host_filter: Option<Arc<dyn HostFilter>>,
         host_listener: Option<Arc<dyn HostListener>>,
         cluster_metadata_refresh_interval: Duration,
+        periodic_fetch_mode: PeriodicFetchMode,
         tablet_receiver: tokio::sync::mpsc::Receiver<(TableSpec<'static>, RawTablet)>,
         metrics: Metrics,
         client_routes_config: Option<ClientRoutesConfig>,
@@ -119,6 +120,7 @@ impl Cluster {
         let mut metadata_worker = MetadataWorker::new(
             cc_establisher,
             cluster_metadata_refresh_interval,
+            periodic_fetch_mode,
             refresh_receiver,
             metadata_updates_sender,
         );

--- a/scylla/tests/integration/metadata/partial_fetch.rs
+++ b/scylla/tests/integration/metadata/partial_fetch.rs
@@ -6,10 +6,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::cluster::ClusterState;
 use scylla_proxy::{
-    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, RunningProxy,
-    ShardAwareness, WorkerError,
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    RunningProxy, ShardAwareness, WorkerError,
 };
 use tokio::sync::mpsc;
 
@@ -22,6 +24,9 @@ use crate::utils::{
 /// for `system.local`. A full fetch would add at least one per schema table
 /// (`system_schema.keyspaces`, `.tables`, `.columns`, ...).
 const TOPOLOGY_FETCH_REQUESTS: usize = 2;
+
+/// The proxy's feedback channel for the counted metadata requests.
+type MetadataRequestFeedback = mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>;
 
 /// A TOPOLOGY_CHANGE event can only have changed the peer list, so the driver
 /// must react with a partial topology fetch: re-read `system.peers` and
@@ -77,21 +82,7 @@ async fn assert_event_triggers_only_a_topology_fetch(
 
             let state_before_event = session.get_cluster_state();
 
-            // Count the metadata requests of the control connection (only it
-            // registers for events, hence the registration condition). The
-            // driver prepares its metadata statements, so what identifies a
-            // fetch is the number of EXECUTEs, not any query text. Installed
-            // only now, so that the session's initial (full) fetch is not
-            // counted.
-            let (metadata_request_tx, mut metadata_request_rx) = mpsc::unbounded_channel();
-            for node in running_proxy.running_nodes.iter_mut() {
-                node.prepend_request_rules(vec![RequestRule(
-                    Condition::ConnectionRegisteredAnyEvent
-                        .and(Condition::RequestOpcode(RequestOpcode::Execute)),
-                    RequestReaction::noop()
-                        .with_feedback_when_performed(metadata_request_tx.clone()),
-                )]);
-            }
+            let mut metadata_request_rx = count_metadata_requests(&mut running_proxy);
 
             // The address named by the event does not matter for the fetch: the
             // driver reacts by re-reading the whole peer list anyway. An address
@@ -99,25 +90,12 @@ async fn assert_event_triggers_only_a_topology_fetch(
             // anything else (a keepalive or a pool refill).
             inject_event(&running_proxy, SocketAddr::from(([127, 0, 0, 1], 9042)));
 
-            metadata_request_rx
-                .recv()
-                .await
-                .expect("proxy feedback channel closed unexpectedly");
-
             // The fetched topology is published as a new `ClusterState`, which
             // must have kept the schema metadata of the previous one.
-            let state_after_event = loop {
-                let state = session.get_cluster_state();
-                if !Arc::ptr_eq(&state, &state_before_event) {
-                    break state;
-                }
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            };
+            let state_after_event =
+                wait_for_state(&session, |state| !Arc::ptr_eq(state, &state_before_event)).await;
 
-            let mut requests = 1;
-            while metadata_request_rx.try_recv().is_ok() {
-                requests += 1;
-            }
+            let requests = drain_count(&mut metadata_request_rx);
             assert_eq!(
                 requests, TOPOLOGY_FETCH_REQUESTS,
                 "the control connection issued {requests} metadata requests, so the event \
@@ -136,4 +114,45 @@ async fn assert_event_triggers_only_a_topology_fetch(
         Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
         Err(err) => panic!("{}", err),
     }
+}
+
+/// Starts counting the metadata requests of the control connection.
+///
+/// Only the control connection registers for events, hence the registration
+/// condition. The driver prepares its metadata statements, so what identifies a
+/// fetch is the number of EXECUTEs, not any query text. Installed on demand, so
+/// that the requests preceding the behaviour under test are not counted.
+fn count_metadata_requests(running_proxy: &mut RunningProxy) -> MetadataRequestFeedback {
+    let (metadata_request_tx, metadata_request_rx) = mpsc::unbounded_channel();
+    for node in running_proxy.running_nodes.iter_mut() {
+        node.prepend_request_rules(vec![RequestRule(
+            Condition::ConnectionRegisteredAnyEvent
+                .and(Condition::RequestOpcode(RequestOpcode::Execute)),
+            RequestReaction::noop().with_feedback_when_performed(metadata_request_tx.clone()),
+        )]);
+    }
+    metadata_request_rx
+}
+
+/// Waits until the published `ClusterState` satisfies `is_expected`.
+async fn wait_for_state(
+    session: &Session,
+    is_expected: impl Fn(&Arc<ClusterState>) -> bool,
+) -> Arc<ClusterState> {
+    loop {
+        let state = session.get_cluster_state();
+        if is_expected(&state) {
+            return state;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Counts everything the feedback channel holds.
+fn drain_count(metadata_request_rx: &mut MetadataRequestFeedback) -> usize {
+    let mut requests = 0;
+    while metadata_request_rx.try_recv().is_ok() {
+        requests += 1;
+    }
+    requests
 }

--- a/scylla/tests/integration/metadata/partial_fetch.rs
+++ b/scylla/tests/integration/metadata/partial_fetch.rs
@@ -9,9 +9,10 @@ use std::time::Duration;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::cluster::ClusterState;
+use scylla::cluster::metadata::PeriodicFetchMode;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
-    RunningProxy, ShardAwareness, WorkerError,
+    ResponseOpcode, ResponseReaction, ResponseRule, RunningProxy, ShardAwareness, WorkerError,
 };
 use tokio::sync::mpsc;
 use tracing::info;
@@ -34,6 +35,12 @@ const TOPOLOGY_FETCH_REQUESTS: usize = 2;
 /// information). A full fetch would add `system.peers` and `system.local`.
 /// Last 2 tables are not present on Cassandra, so they won't be queried.
 const SCHEMA_FETCH_REQUESTS: usize = if cfg!(cassandra_tests) { 5 } else { 7 };
+
+/// How long [`full_metadata_mode_picks_up_schema_changes_without_events`] waits
+/// for the periodic full fetch to publish the new keyspace: many
+/// [`SCHEMA_REFRESH_INTERVAL`]s, so that only a fetch that never happens times
+/// out.
+const FETCH_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Short enough for the periodic tick that resolves the accumulated schema
 /// changes to come quickly, so that the tests need not wait a minute for it.
@@ -238,6 +245,73 @@ async fn schema_change_event_triggers_only_a_schema_fetch() {
     }
 }
 
+/// What [`PeriodicFetchMode::FullMetadata`] exists for: a cluster whose
+/// `SCHEMA_CHANGE` events cannot be relied upon. With every EVENT frame dropped
+/// by the proxy, the driver has nothing to react to, and only the periodic full
+/// fetch can bring the new keyspace into the metadata.
+#[tokio::test]
+async fn full_metadata_mode_picks_up_schema_changes_without_events() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let keyspace = unique_keyspace_name();
+            let session = new_schema_watching_session(&proxy_uris, &translation_map, &keyspace)
+                .periodic_metadata_fetch_mode(PeriodicFetchMode::FullMetadata)
+                .build()
+                .await
+                .unwrap();
+            wait_until_all_nodes_are_connected(3, &session).await;
+
+            // Installed after the session is up, so that the REGISTER handshake
+            // is untouched and only the announcements are lost.
+            drop_all_events(&mut running_proxy);
+
+            assert!(
+                session
+                    .get_cluster_state()
+                    .get_keyspace(&keyspace)
+                    .is_none()
+            );
+
+            create_keyspace(&session, &keyspace).await;
+            session
+                .ddl(format!("CREATE TABLE {keyspace}.tbl (a int PRIMARY KEY)"))
+                .await
+                .unwrap();
+
+            let _state = tokio::time::timeout(
+                FETCH_WAIT_TIMEOUT,
+                wait_for_state(&session, |state| {
+                    state
+                        .get_keyspace(&keyspace)
+                        .is_some_and(|ks| ks.tables.contains_key("tbl"))
+                }),
+            )
+            .await
+            .expect(
+                "the periodic full fetch did not pick up the new keyspace, so the mode depends \
+                on the events it is meant to work without",
+            );
+
+            session
+                .ddl(format!("DROP KEYSPACE {keyspace}"))
+                .await
+                .unwrap();
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
 /// Builds a session that reacts to schema changes quickly and only for
 /// `keyspace`.
 ///
@@ -309,4 +383,15 @@ fn drain_count(metadata_request_rx: &mut MetadataRequestFeedback) -> usize {
         requests += 1;
     }
     requests
+}
+
+/// Makes the cluster look mute to the driver: every EVENT frame the server
+/// sends is dropped by the proxy.
+fn drop_all_events(running_proxy: &mut RunningProxy) {
+    for node in running_proxy.running_nodes.iter_mut() {
+        node.prepend_response_rules(vec![ResponseRule(
+            Condition::ResponseOpcode(ResponseOpcode::Event),
+            ResponseReaction::drop_frame(),
+        )]);
+    }
 }

--- a/scylla/tests/integration/metadata/partial_fetch.rs
+++ b/scylla/tests/integration/metadata/partial_fetch.rs
@@ -14,16 +14,30 @@ use scylla_proxy::{
     RunningProxy, ShardAwareness, WorkerError,
 };
 use tokio::sync::mpsc;
+use tracing::info;
 
 use crate::utils::{
-    inject_status_change_down, inject_status_change_up, inject_topology_change_new_node,
-    setup_tracing, test_with_3_node_cluster, wait_until_all_nodes_are_connected,
+    PerformDDL as _, inject_keyspace_drop_event, inject_status_change_down,
+    inject_status_change_up, inject_topology_change_new_node, setup_tracing,
+    test_with_3_node_cluster, unique_keyspace_name, wait_until_all_nodes_are_connected,
 };
 
 /// The requests a partial topology fetch issues: one for `system.peers` and one
 /// for `system.local`. A full fetch would add at least one per schema table
 /// (`system_schema.keyspaces`, `.tables`, `.columns`, ...).
 const TOPOLOGY_FETCH_REQUESTS: usize = 2;
+
+/// The requests a partial schema fetch issues at the full schema detail level:
+/// one per schema table read for the affected keyspaces -
+/// `system_schema.keyspaces`, `.types`, `.columns`, `.tables`, `.views`,
+/// `.scylla_tables` (partitioners) and `.scylla_keyspaces` (tablet
+/// information). A full fetch would add `system.peers` and `system.local`.
+/// Last 2 tables are not present on Cassandra, so they won't be queried.
+const SCHEMA_FETCH_REQUESTS: usize = if cfg!(cassandra_tests) { 5 } else { 7 };
+
+/// Short enough for the periodic tick that resolves the accumulated schema
+/// changes to come quickly, so that the tests need not wait a minute for it.
+const SCHEMA_REFRESH_INTERVAL: Duration = Duration::from_millis(100);
 
 /// The proxy's feedback channel for the counted metadata requests.
 type MetadataRequestFeedback = mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>;
@@ -114,6 +128,146 @@ async fn assert_event_triggers_only_a_topology_fetch(
         Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
         Err(err) => panic!("{}", err),
     }
+}
+
+/// A SCHEMA_CHANGE event names the keyspace it concerns, so the driver must
+/// react by re-reading that keyspace's schema alone - not the whole metadata,
+/// as it used to on every periodic refresh.
+/// On keyspace drop, no queries should be issued.
+#[tokio::test]
+async fn schema_change_event_triggers_only_a_schema_fetch() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let keyspace = unique_keyspace_name();
+            let session = new_schema_watching_session(&proxy_uris, &translation_map, &keyspace)
+                .build()
+                .await
+                .unwrap();
+
+            info!("Part 1: Creating keyspace");
+
+            let mut metadata_request_rx = count_metadata_requests(&mut running_proxy);
+
+            let state_before_event = session.get_cluster_state();
+            assert!(state_before_event.get_keyspace(&keyspace).is_none());
+
+            // First schema change, creating the keyspace.
+            create_keyspace(&session, &keyspace).await;
+
+            let _state_after_event_1 =
+                wait_for_state(&session, |state| state.get_keyspace(&keyspace).is_some()).await;
+
+            let requests = drain_count(&mut metadata_request_rx);
+            assert_eq!(
+                requests, SCHEMA_FETCH_REQUESTS,
+                "the control connection issued {requests} metadata requests, so the event \
+                triggered something other than a partial schema fetch"
+            );
+
+            info!("Part 2: Creating table");
+
+            // Another schema change, modifying the keyspace.
+            session
+                .ddl(format!("CREATE TABLE {keyspace}.tbl (a int PRIMARY KEY)"))
+                .await
+                .unwrap();
+
+            // The event alone proves nothing - the driver must have re-read the
+            // keyspace and published the result.
+            let _state_after_event_2 = wait_for_state(&session, |state| {
+                state
+                    .get_keyspace(&keyspace)
+                    .is_some_and(|ks| ks.tables.contains_key("tbl"))
+            })
+            .await;
+
+            let requests = drain_count(&mut metadata_request_rx);
+            assert_eq!(
+                requests, SCHEMA_FETCH_REQUESTS,
+                "the control connection issued {requests} metadata requests, so the event \
+                triggered something other than a partial schema fetch"
+            );
+
+            info!("Part 3: Dropping keyspace");
+
+            // Only one more thing left to test: Dropping a keyspace must
+            // remove it from state without issuing any queries.
+
+            // The checks are intentionally commented out.
+            // When dropping a keyspace that contains some tables, Scylla can send the events in the wrong order:
+            //     2026-08-21T16:12:16.255229Z DEBUG scylla::cluster::metadata::worker: Received server event: SchemaChange(KeyspaceChange { change_type: Dropped, keyspace_name: "test_rust_4cf8c3ab7e0940cc8970ef8c2397c1fe" })
+            //     2026-08-21T16:12:16.255279Z DEBUG scylla::cluster::metadata::worker: Received server event: SchemaChange(TableChange { change_type: Dropped, keyspace_name: "test_rust_4cf8c3ab7e0940cc8970ef8c2397c1fe", object_name: "tbl" })
+            //
+
+            // let requests = drain_count(&mut metadata_request_rx).await;
+            // assert_eq!(
+            //     requests, 0,
+            //     "No queries should be needed to drop a keyspace"
+            // );
+
+            // To avoid this, we can inject the event manually.
+
+            inject_keyspace_drop_event(&running_proxy, &keyspace);
+
+            let _state_after_event_3 =
+                wait_for_state(&session, |state| state.get_keyspace(&keyspace).is_none()).await;
+
+            let requests = drain_count(&mut metadata_request_rx);
+            assert_eq!(
+                requests, 0,
+                "No requests should be needed for drop of a keyspace"
+            );
+
+            session
+                .ddl(format!("DROP KEYSPACE {keyspace}"))
+                .await
+                .unwrap();
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Builds a session that reacts to schema changes quickly and only for
+/// `keyspace`.
+///
+/// The keyspace restriction is what makes the request counting of the schema
+/// tests meaningful: the cluster is shared with the other tests, whose DDL
+/// produces SCHEMA_CHANGE events of its own, and a restricted session fetches
+/// nothing for the keyspaces it was told to ignore.
+fn new_schema_watching_session(
+    proxy_uris: &[String],
+    translation_map: &std::collections::HashMap<SocketAddr, SocketAddr>,
+    keyspace: &str,
+) -> SessionBuilder {
+    SessionBuilder::new()
+        .known_node(proxy_uris[0].as_str())
+        .address_translator(Arc::new(translation_map.clone()))
+        .cluster_metadata_refresh_interval(SCHEMA_REFRESH_INTERVAL)
+        // Off, so that the DDL of the tests is answered by the event handling
+        // under test rather than by an explicit full refresh.
+        .refresh_metadata_on_auto_schema_agreement(false)
+        .keyspaces_to_fetch([keyspace])
+}
+
+async fn create_keyspace(session: &Session, keyspace: &str) {
+    session
+        .ddl(format!(
+            "CREATE KEYSPACE {keyspace} WITH REPLICATION = \
+            {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
+        ))
+        .await
+        .unwrap();
 }
 
 /// Starts counting the metadata requests of the control connection.

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -710,6 +710,17 @@ fn cluster_change_event_body(event_type: &str, change: &str, addr: SocketAddr) -
     body.freeze()
 }
 
+fn keyspace_drop_event_body(keyspace: &str) -> Bytes {
+    use scylla_cql::frame::types::write_string;
+
+    let mut body = BytesMut::new();
+    write_string("SCHEMA_CHANGE", &mut body).unwrap();
+    write_string("DROPPED", &mut body).unwrap();
+    write_string("KEYSPACE", &mut body).unwrap();
+    write_string(keyspace, &mut body).unwrap();
+    body.freeze()
+}
+
 /// Injects a forged event into every proxy node's control connections.
 ///
 /// Only one of the proxied nodes hosts the driver's control connection, hence
@@ -749,4 +760,9 @@ pub(crate) fn inject_topology_change_new_node(running_proxy: &RunningProxy, addr
         running_proxy,
         cluster_change_event_body("TOPOLOGY_CHANGE", "NEW_NODE", addr),
     );
+}
+
+/// Injects a forged `SCHEMA_CHANGE DROPPED KEYSPACE` event for `ks`.
+pub(crate) fn inject_keyspace_drop_event(running_proxy: &RunningProxy, ks: &str) {
+    inject_event_to_ccs(running_proxy, keyspace_drop_event_body(ks));
 }


### PR DESCRIPTION
This PR introduces partial schema fetching: driver can now fetch only the keyspaces affected by SCHEMA_CHANGE events, instead of all keyspaces.
This is the new behavior on metadata refresh intervals. Previously, all metadata was fetched then. Now only the affected schema is.
This finalizes the effort of smarter metadata fetching. We could try to make it more granular, but it would be much more difficult, and most likely fragile - I don't want to do that unless a strong reason comes up.

A nice property of the new system: on a stable cluster with no schema changes no metadata queries will be issued on metadata refresh intervals.

A new config is introduced: `PeriodicFetchMode`. By default, it is set to the new behavior above, but the user can set it to `FullMetadata` to get back the old behavior in case the CQL events turn out to not be reliable enough.


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1280
Fixes: https://scylladb.atlassian.net/browse/DRIVER-764

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
