### PR TITLE
Fix clippy 1.98

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,3 +2,14 @@ avoid-breaking-exported-api = false
 disallowed-methods = [
     { path = "itertools::Itertools::format", reason = "Footgun: panics on double formatting.", replacement = "crate::utils::safe_format::IteratorSafeFormatExt::safe_format" }
 ]
+# TODO(2.0): Some of our error types are big. We need to address this in 2.0
+large-error-ignored = [
+    "scylla::errors::PagerExecutionError",
+    "scylla::errors::ExecutionError",
+    "scylla::errors::MetadataError",
+    "scylla::errors::MetadataFetchError",
+    "scylla::errors::NewSessionError",
+    "scylla::errors::SchemaAgreementError",
+    "scylla::client::session::AutoSchemaAwaitingError",
+    "scylla::errors::TracingError"
+]

--- a/scylla-cql/src/frame/response/custom_type_parser.rs
+++ b/scylla-cql/src/frame/response/custom_type_parser.rs
@@ -181,17 +181,17 @@ impl<'result> CustomTypeParser<'result> {
 
     /// Parse a string of hexadecimal representation of bytes into a byte vector.
     fn from_hex(s: &'result str) -> Result<Vec<u8>, CustomTypeParseError> {
-        if !s.len().is_multiple_of(2) {
-            return Err(CustomTypeParseError::BadHexString(s.to_owned()));
-        }
         for c in s.chars() {
             if !c.is_ascii_hexdigit() {
                 return Err(CustomTypeParseError::BadHexString(s.to_owned()));
             }
         }
-        let bytes: Vec<_> = s
-            .as_bytes()
-            .chunks_exact(2)
+        let (chunks, remainder) = s.as_bytes().as_chunks::<2>();
+        if !remainder.is_empty() {
+            return Err(CustomTypeParseError::BadHexString(s.to_owned()));
+        }
+        let bytes: Vec<_> = chunks
+            .iter()
             .map(|chunk| {
                 // Safety: All characters were checked to be valid ASCII hexdigits,
                 // so two-byte chunks are valid ASCII strings, too.

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -549,7 +549,6 @@ impl Default for SessionConfig {
 impl SessionConfig {
     /// [SessionConfig] may unfortunately represent invalid configurations. We need to rule them out
     /// at runtime by running validation.
-    #[expect(clippy::result_large_err)] // TODO(2.0): Make NewSessionError smaller.
     fn validate(&self) -> Result<(), NewSessionError> {
         // Ensure there is at least one known node
         if self.known_nodes.is_empty() {
@@ -2405,8 +2404,6 @@ impl Session {
 
         // Now we no longer need all the errors. We can return if there is
         // irrecoverable one, and collect the Ok values otherwise.
-        // TODO(2.0): This expect can be avoided in next major release
-        #[expect(clippy::result_large_err)]
         let versions_results: Vec<_> = versions_results
             .into_iter()
             .map(|(_, result)| result)

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1743,15 +1743,14 @@ impl Session {
         paged: bool,
         paging_state: PagingState,
     ) -> Result<(QueryResult, PagingStateResponse), ExecutionError> {
-        let page_size;
-        let request_paging;
-        if paged {
-            page_size = Some(prepared.get_validated_page_size());
-            request_paging = RequestPaging::Manual;
+        let (page_size, request_paging) = if paged {
+            (
+                Some(prepared.get_validated_page_size()),
+                RequestPaging::Manual,
+            )
         } else {
-            page_size = None;
-            request_paging = RequestPaging::Unpaged;
-        }
+            (None, RequestPaging::Unpaged)
+        };
 
         self.execute(
             prepared,

--- a/scylla/src/cluster/metadata/cc_establisher.rs
+++ b/scylla/src/cluster/metadata/cc_establisher.rs
@@ -248,6 +248,7 @@ impl ControlConnectionEstablisher {
     ///
     /// Returns `Err(None)` if the iterator was empty (no connection was ever
     /// attempted), or `Err(Some(err))` with the most recent error otherwise.
+    #[expect(clippy::result_large_err)] // The `Option` in Err variant causes the ignore in `clippy.toml` to not work here.
     async fn try_establish_on_nodes<F: FetchOnCandidate>(
         &mut self,
         initial: bool,

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -523,7 +523,6 @@ impl ControlConnection {
         // If empty, all host ids are accepted.
         host_ids: &[Uuid],
     ) -> Result<ClientRoutes, MetadataError> {
-        #[expect(clippy::result_large_err)]
         async fn query_client_routes_with_values(
             conn: &ControlConnection,
             query_str: &str,
@@ -678,7 +677,6 @@ impl ControlConnection {
             .try_flatten()
     }
 
-    #[expect(clippy::result_large_err)]
     async fn query_keyspaces(
         &self,
         keyspaces_to_fetch: &[String],
@@ -857,7 +855,6 @@ impl TryFrom<UdtRow> for UdtRowWithParsedFieldTypes {
 }
 
 impl ControlConnection {
-    #[expect(clippy::result_large_err)]
     async fn query_user_defined_types(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1201,7 +1198,6 @@ mod toposort_tests {
 }
 
 impl ControlConnection {
-    #[expect(clippy::result_large_err)]
     async fn query_tables(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1249,7 +1245,6 @@ impl ControlConnection {
         Ok(result)
     }
 
-    #[expect(clippy::result_large_err)]
     async fn query_views(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1309,7 +1304,6 @@ impl ControlConnection {
         Ok(result)
     }
 
-    #[expect(clippy::result_large_err)]
     async fn query_tables_schema(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1689,7 +1683,6 @@ fn freeze_type(typ: PreColumnType) -> PreColumnType {
 }
 
 impl ControlConnection {
-    #[expect(clippy::result_large_err)]
     async fn query_table_partitioners(
         &self,
         keyspaces_to_fetch: &[String],
@@ -1739,7 +1732,6 @@ impl ControlConnection {
     /// table does not exist. This is handled the same way as in
     /// [`Self::query_table_partitioners`]: the resulting `DbError::Invalid` is caught
     /// and an empty set is returned (so all keyspaces default to non-tablet-based).
-    #[expect(clippy::result_large_err)]
     async fn query_keyspaces_tablets(
         &self,
         keyspaces_to_fetch: &[String],


### PR DESCRIPTION
This PR fixes all the warnings produced by clippy 1.98. Additionally, I proposed some improvements to `from_hex` function.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [ ] ~~All commits compile, pass static checks and pass test.~~
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
