### PR TITLE
Add an example iterating the token ring and its replicas

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -135,6 +135,10 @@ name = "tls_rustls"
 path = "tls_rustls.rs"
 
 [[example]]
+name = "token_ring"
+path = "token_ring.rs"
+
+[[example]]
 name = "tower"
 path = "tower.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,6 +56,7 @@ cargo run -p examples --example basic
 | `speculative_execution` | Configuring a speculative execution policy so that one slow replica does not hold up an idempotent request. |
 | `tls_openssl` | Connecting to a cluster over TLS with the `openssl` backend. |
 | `tls_rustls` | Connecting to a cluster over TLS with the `rustls` backend. |
+| `token_ring` | Walking the cluster's token ring and listing the replicas that own each token range. |
 | `tower` | Wrapping a `Session` in a `tower::Service`. |
 | `tracing` | Enabling CQL tracing for queries, prepares, executions, paged reads and batches, and fetching the resulting tracing information. |
 | `user_defined_type` | Mapping a CQL user-defined type onto a Rust struct with `SerializeValue`/`DeserializeValue`. |

--- a/examples/token_ring.rs
+++ b/examples/token_ring.rs
@@ -5,7 +5,7 @@
 //! at a given token starts just after the previous token in the ring and is owned
 //! by the replicas the cluster returns for any token inside it. Which nodes those
 //! are depends on the keyspace's replication strategy, so replica sets are looked
-//! up per keyspace and table.
+//! up per keyspace.
 
 use anyhow::Result;
 use scylla::client::session::Session;
@@ -43,35 +43,32 @@ async fn main() -> Result<()> {
     let ring = cluster_state.replica_locator().ring();
     println!("The token ring has {} entries.", ring.len());
 
-    let mut previous_token: Option<i64> = None;
+    // Seed the lower bound from the ring's last token so the first (wrap-around)
+    // range prints its real start rather than a placeholder. An empty ring simply
+    // skips the loop below.
+    let mut previous_token: Option<i64> = ring.iter().last().map(|(token, _)| token.value());
+
     for (token, _owner) in ring.iter() {
         // Replicas that own the range ending at this token. `get_token_endpoints`
         // resolves them through the keyspace's replication strategy, so a token
-        // range can have different replicas in different keyspaces.
+        // range can have different replicas in different keyspaces. An empty table
+        // name keeps the lookup on the keyspace-wide vnode ring instead of any
+        // per-table tablet routing.
         let replicas: Vec<NodeAddr> = cluster_state
-            .get_token_endpoints("examples_ks", "token_ring", *token)
+            .get_token_endpoints("examples_ks", "", *token)
             .into_iter()
             .map(|(node, _shard)| node.address)
             .collect();
 
-        match previous_token {
-            Some(previous) => {
-                println!(
-                    "Range ({}, {}] is owned by {:?}",
-                    previous,
-                    token.value(),
-                    replicas
-                );
-            }
-            None => {
-                // The first range wraps around: it starts after the highest token
-                // in the ring and continues up to the lowest one.
-                println!(
-                    "Range (highest token, {}] is owned by {:?}",
-                    token.value(),
-                    replicas
-                );
-            }
+        // `previous_token` is always `Some` here: it was seeded from the ring's
+        // last token and the loop only runs when the ring is non-empty.
+        if let Some(previous) = previous_token {
+            println!(
+                "Range ({}, {}] is owned by {:?}",
+                previous,
+                token.value(),
+                replicas
+            );
         }
 
         previous_token = Some(token.value());

--- a/examples/token_ring.rs
+++ b/examples/token_ring.rs
@@ -1,0 +1,83 @@
+//! Walking the cluster's token ring and, for each token range, listing the
+//! replicas that own it.
+//!
+//! The token ring is a sorted, circular sequence of tokens. The range that ends
+//! at a given token starts just after the previous token in the ring and is owned
+//! by the replicas the cluster returns for any token inside it. Which nodes those
+//! are depends on the keyspace's replication strategy, so replica sets are looked
+//! up per keyspace and table.
+
+use anyhow::Result;
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::cluster::NodeAddr;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| "172.42.0.2:9042".to_string());
+
+    println!("Connecting to {uri} ...");
+
+    let session: Session = SessionBuilder::new().known_node(uri).build().await?;
+
+    session
+        .query_unpaged(
+            "CREATE KEYSPACE IF NOT EXISTS examples_ks WITH REPLICATION = \
+             {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}",
+            &[],
+        )
+        .await?;
+
+    session
+        .query_unpaged(
+            "CREATE TABLE IF NOT EXISTS examples_ks.token_ring (pk bigint PRIMARY KEY)",
+            &[],
+        )
+        .await?;
+
+    let cluster_state = session.get_cluster_state();
+
+    // The ring is a sorted list of tokens; each entry belongs to one node. Walking
+    // it in order visits every token range in the cluster once.
+    let ring = cluster_state.replica_locator().ring();
+    println!("The token ring has {} entries.", ring.len());
+
+    let mut previous_token: Option<i64> = None;
+    for (token, _owner) in ring.iter() {
+        // Replicas that own the range ending at this token. `get_token_endpoints`
+        // resolves them through the keyspace's replication strategy, so a token
+        // range can have different replicas in different keyspaces.
+        let replicas: Vec<NodeAddr> = cluster_state
+            .get_token_endpoints("examples_ks", "token_ring", *token)
+            .into_iter()
+            .map(|(node, _shard)| node.address)
+            .collect();
+
+        match previous_token {
+            Some(previous) => {
+                println!(
+                    "Range ({}, {}] is owned by {:?}",
+                    previous,
+                    token.value(),
+                    replicas
+                );
+            }
+            None => {
+                // The first range wraps around: it starts after the highest token
+                // in the ring and continues up to the lowest one.
+                println!(
+                    "Range (highest token, {}] is owned by {:?}",
+                    token.value(),
+                    replicas
+                );
+            }
+        }
+
+        previous_token = Some(token.value());
+    }
+
+    println!("Ok.");
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a runnable example that walks the cluster's token ring and lists the replicas that own each token range, using `ReplicaLocator::ring` and `ClusterState::get_token_endpoints`. It follows the approach @wprzytula described on the issue.

Fixes: #651

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
