### PR TITLE
IT: Don't disable tablets unnecessarily

### DIFF
--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -432,7 +432,7 @@ mod tests {
     use crate::statement::prepared::PreparedStatement;
     use crate::statement::unprepared::Statement;
     use crate::test_utils::{
-        PerformDDL, create_new_session_builder, scylla_supports_tablets, setup_tracing,
+        PerformDDL, create_new_session_builder, disable_tablets_unless_supported, setup_tracing,
     };
     use crate::utils::test_utils::unique_keyspace_name;
     use crate::value::Row;
@@ -448,7 +448,12 @@ mod tests {
 
     use super::CachingSession;
 
-    async fn new_for_test(with_tablet_support: bool) -> Session {
+    /// Creates a session with a fresh keyspace.
+    ///
+    /// If `required_tablet_feature` is `Some`, tablets are disabled in that keyspace
+    /// unless the cluster supports the given feature - see
+    /// [`disable_tablets_unless_supported`].
+    async fn new_for_test(required_tablet_feature: Option<&str>) -> Session {
         let session = create_new_session_builder()
             .build()
             .await
@@ -459,8 +464,8 @@ mod tests {
             "CREATE KEYSPACE IF NOT EXISTS {ks}
         WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
         );
-        if !with_tablet_support && scylla_supports_tablets(&session).await {
-            create_ks += " AND TABLETS = {'enabled': false}";
+        if let Some(feature) = required_tablet_feature {
+            create_ks += disable_tablets_unless_supported(&session, feature).await;
         }
 
         session
@@ -489,7 +494,7 @@ mod tests {
     }
 
     async fn create_caching_session() -> CachingSession {
-        let session = CachingSession::from(new_for_test(true).await, 2);
+        let session = CachingSession::from(new_for_test(None).await, 2);
 
         // Add a row, this makes it easier to check if the caching works combined with the regular execute fn on Session
         session
@@ -668,13 +673,13 @@ mod tests {
         setup_tracing();
 
         let session: CachingSession<std::collections::hash_map::RandomState> =
-            CachingSession::from(new_for_test(true).await, 2);
+            CachingSession::from(new_for_test(None).await, 2);
         teardown_keyspace(session.get_session()).await;
         let session: CachingSession<CustomBuildHasher> =
-            CachingSession::from(new_for_test(true).await, 2);
+            CachingSession::from(new_for_test(None).await, 2);
         teardown_keyspace(session.get_session()).await;
         let session: CachingSession<CustomBuildHasher> =
-            CachingSession::with_hasher(new_for_test(true).await, 2, Default::default());
+            CachingSession::with_hasher(new_for_test(None).await, 2, Default::default());
         teardown_keyspace(session.get_session()).await;
     }
 
@@ -803,7 +808,7 @@ mod tests {
     #[tokio::test]
     async fn test_parameters_caching() {
         setup_tracing();
-        let session: CachingSession = CachingSession::from(new_for_test(true).await, 100);
+        let session: CachingSession = CachingSession::from(new_for_test(None).await, 100);
 
         session
             .ddl("CREATE TABLE tbl (a int PRIMARY KEY, b int)")
@@ -858,8 +863,8 @@ mod tests {
     async fn test_partitioner_name_caching() {
         setup_tracing();
 
-        // This test uses CDC which is not yet compatible with Scylla's tablets.
-        let session: CachingSession = CachingSession::from(new_for_test(false).await, 100);
+        let session: CachingSession =
+            CachingSession::from(new_for_test(Some("CDC_WITH_TABLETS")).await, 100);
 
         session
             .ddl("CREATE TABLE tbl (a int PRIMARY KEY) with cdc = {'enabled': true}")

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -101,6 +101,28 @@ pub(crate) async fn scylla_supports_tablets(session: &Session) -> bool {
     supports_feature(session, "TABLETS").await
 }
 
+/// Returns the `CREATE KEYSPACE` option that disables tablets, if the cluster supports
+/// tablets but does not support the given cluster feature - and an empty string otherwise.
+///
+/// ScyllaDB gained support for various functionalities on tablet keyspaces gradually,
+/// each guarded by its own `*_WITH_TABLETS` cluster feature (`CDC_WITH_TABLETS`,
+/// `LWT_WITH_TABLETS`, `VIEWS_WITH_TABLETS`, `COUNTERS_WITH_TABLETS`). A test relying on
+/// such a functionality should run on the default, tablet-enabled setup wherever the
+/// server supports it, and fall back to vnodes on older servers that do not.
+///
+/// # Warning
+/// This function **requires full schema metadata** to function correctly.
+pub(crate) async fn disable_tablets_unless_supported(
+    session: &Session,
+    feature: &str,
+) -> &'static str {
+    if scylla_supports_tablets(session).await && !supports_feature(session, feature).await {
+        " AND TABLETS = {'enabled': false}"
+    } else {
+        ""
+    }
+}
+
 pub(crate) fn setup_tracing() {
     let testing_layer = tracing_subscriber::fmt::layer()
         .with_test_writer()

--- a/scylla/tests/integration/load_balancing/lwt_optimisation.rs
+++ b/scylla/tests/integration/load_balancing/lwt_optimisation.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    PerformDDL, scylla_supports_tablets, setup_tracing, test_with_3_node_cluster,
+    PerformDDL, disable_tablets_unless_supported, setup_tracing, test_with_3_node_cluster,
     unique_keyspace_name,
 };
 use scylla::client::execution_profile::ExecutionProfile;
@@ -70,10 +70,11 @@ async fn if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optima
 
         // Create schema
         let ks = unique_keyspace_name();
-        let mut create_ks = format!("CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}");
-        if scylla_supports_tablets(&session).await {
-            create_ks += " and TABLETS = { 'enabled': false}";
-        }
+        // This test uses LWT, which older ScyllaDB versions do not support on tablet keyspaces.
+        let create_ks = format!(
+            "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}{}",
+            disable_tablets_unless_supported(&session, "LWT_WITH_TABLETS").await
+        );
         session.ddl(create_ks).await.unwrap();
         session.use_keyspace(&ks, false).await.unwrap();
 

--- a/scylla/tests/integration/metadata/configuration.rs
+++ b/scylla/tests/integration/metadata/configuration.rs
@@ -2,8 +2,8 @@
 //! iff ScyllaDB is the target node (else ignores the custom timeout).
 
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, scylla_supports_tablets, setup_tracing,
-    test_with_3_node_cluster, unique_keyspace_name,
+    PerformDDL as _, create_new_session_builder, disable_tablets_unless_supported,
+    scylla_supports_tablets, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
 };
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
@@ -39,13 +39,10 @@ fn map_fedback_message<'a, T, F: Fn(RequestFrame) -> T + 'a>(
     })
 }
 
-async fn setup_minimal_schema_metadata_session() -> (Session, String) {
-    // Two sessions are required here:
-    // 1. The first session fetches full schema metadata, which is required by `scylla_supports_tablets`
-    //    to accurately verify if the cluster supports tablets.
-    // 2. The second session disables schema metadata fetching (`fetch_full_schema_metadata(false)`)
-    let session = create_new_session_builder().build().await.unwrap();
-    let supports_tablets = scylla_supports_tablets(&session).await;
+/// Creates a session with full schema metadata fetching disabled, along with a fresh
+/// keyspace that is already `USE`d. `extra_ks_opts` is appended verbatim to the
+/// `CREATE KEYSPACE` statement.
+async fn setup_minimal_schema_metadata_session(extra_ks_opts: &str) -> (Session, String) {
     let session = create_new_session_builder()
         .fetch_full_schema_metadata(false)
         .build()
@@ -53,14 +50,12 @@ async fn setup_minimal_schema_metadata_session() -> (Session, String) {
         .unwrap();
     let ks = unique_keyspace_name();
 
-    let mut create_ks = format!(
-        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
-    );
-    if supports_tablets {
-        create_ks += " AND TABLETS = {'enabled': false}";
-    }
-
-    session.ddl(create_ks).await.unwrap();
+    session
+        .ddl(format!(
+            "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}{extra_ks_opts}"
+        ))
+        .await
+        .unwrap();
     session.use_keyspace(&ks, false).await.unwrap();
 
     (session, ks)
@@ -395,7 +390,20 @@ async fn test_fetching_minimal_schema_metadata() {
 #[tokio::test]
 async fn test_token_awareness_with_minimal_schema_metadata() {
     setup_tracing();
-    let (session, ks) = setup_minimal_schema_metadata_session().await;
+
+    // Tablets make token routing work differently, and this test verifies the classic
+    // token ring behaviour, so tablets have to be disabled. Checking whether the cluster
+    // supports tablets requires full schema metadata, which the session under test
+    // deliberately does not fetch - hence a separate, throwaway session just for the check.
+    let disable_tablets = {
+        let session = create_new_session_builder().build().await.unwrap();
+        if scylla_supports_tablets(&session).await {
+            " AND TABLETS = {'enabled': false}"
+        } else {
+            ""
+        }
+    };
+    let (session, ks) = setup_minimal_schema_metadata_session(disable_tablets).await;
 
     session
         .ddl("CREATE TABLE token_table (pk int PRIMARY KEY, value text)")
@@ -430,7 +438,15 @@ async fn test_token_awareness_with_minimal_schema_metadata() {
 #[cfg_attr(cassandra_tests, ignore)]
 async fn test_cdc_partitioner_with_minimal_schema_metadata() {
     setup_tracing();
-    let (session, ks) = setup_minimal_schema_metadata_session().await;
+    // This test uses CDC, which older ScyllaDB versions do not support on tablet keyspaces.
+    // Checking cluster feature support requires full schema metadata, which the session
+    // under test deliberately does not fetch - hence a separate, throwaway session just
+    // for the check.
+    let disable_tablets = {
+        let session = create_new_session_builder().build().await.unwrap();
+        disable_tablets_unless_supported(&session, "CDC_WITH_TABLETS").await
+    };
+    let (session, ks) = setup_minimal_schema_metadata_session(disable_tablets).await;
     session
         .ddl("CREATE TABLE cdc_table (pk int PRIMARY KEY) WITH cdc = {'enabled': true}")
         .await

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -9,8 +9,8 @@ use scylla::{
 };
 
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, scylla_supports_tablets, setup_tracing,
-    unique_keyspace_name,
+    PerformDDL as _, create_new_session_builder, disable_tablets_unless_supported,
+    scylla_supports_tablets, setup_tracing, unique_keyspace_name,
 };
 
 fn udt_type_a_def(ks: &str) -> Arc<UserDefinedType<'_>> {
@@ -397,13 +397,11 @@ async fn test_table_partitioner_in_metadata() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    // This test uses CDC which is not yet compatible with Scylla's tablets.
-    let mut create_ks = format!(
-        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+    // This test uses CDC, which older ScyllaDB versions do not support on tablet keyspaces.
+    let create_ks = format!(
+        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}{}",
+        disable_tablets_unless_supported(&session, "CDC_WITH_TABLETS").await
     );
-    if scylla_supports_tablets(&session).await {
-        create_ks += " AND TABLETS = {'enabled': false}";
-    }
 
     session.ddl(create_ks).await.unwrap();
 

--- a/scylla/tests/integration/metadata/contents.rs
+++ b/scylla/tests/integration/metadata/contents.rs
@@ -439,13 +439,12 @@ async fn test_views_in_schema_info() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    let mut create_ks = format!(
-        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+    // This test uses materialized views, which older ScyllaDB versions do not support
+    // on tablet keyspaces.
+    let create_ks = format!(
+        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}{}",
+        disable_tablets_unless_supported(&session, "VIEWS_WITH_TABLETS").await
     );
-    // Materialized views + tablets are not supported in Scylla 2025.1.
-    if scylla_supports_tablets(&session).await {
-        create_ks += " and TABLETS = { 'enabled': false}";
-    }
     session.ddl(create_ks).await.unwrap();
     session.use_keyspace(ks.clone(), false).await.unwrap();
 

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -33,7 +33,7 @@ use tracing::info;
 
 use crate::utils::{
     CapturingRetryPolicy, PerformDDL as _, create_new_session_builder, fetch_negotiated_features,
-    scylla_supports_tablets, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
+    setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
 };
 
 /// Basic pager functionality test
@@ -143,7 +143,12 @@ async fn test_pager_multi_page(ks: &str, session: &Session) {
     );
 }
 
-// Reproduces the problem with execute_iter mentioned in #608.
+/// Reproduces the problem with execute_iter mentioned in #608.
+///
+/// Verifies that the pager honours [`RetryDecision::IgnoreWriteError`]: when a request
+/// fails and the retry policy tells the driver to ignore the error, `query_iter()` and
+/// `execute_iter()` must yield an empty, successful result instead of propagating
+/// the error.
 #[tokio::test]
 async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
     setup_tracing();
@@ -181,19 +186,14 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
     // and a failing DDL is reported instead of being silently ignored.
     let session = create_new_session_builder().build().await.unwrap();
 
-    // Create a keyspace with replication factor that is larger than the cluster size
-    let cluster_size = session.get_cluster_state().get_nodes_info().len();
     let ks = unique_keyspace_name();
-    let mut create_ks = format!(
-        "CREATE KEYSPACE {} WITH
-            REPLICATION = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {}}}",
-        ks,
-        cluster_size + 1
-    );
-    if scylla_supports_tablets(&session).await {
-        create_ks += " and TABLETS = { 'enabled': false}";
-    }
-    session.ddl(create_ks).await.unwrap();
+    session
+        .ddl(format!(
+            "CREATE KEYSPACE {ks} WITH \
+             REPLICATION = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
+        ))
+        .await
+        .unwrap();
     session.use_keyspace(&ks, true).await.unwrap();
     session
         .ddl("CREATE TABLE t (pk int PRIMARY KEY, v int)")
@@ -201,12 +201,12 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
         .unwrap();
 
     assert!(!retried_flag.load(Ordering::Relaxed));
-    // Try to write something to the new table - it should fail and the policy
-    // will tell us to ignore the error
-    let mut failing_write = Statement::new("INSERT INTO t (pk v) VALUES (1, 2)");
-    failing_write.set_execution_profile_handle(Some(handle.clone()));
+    // An unparseable statement fails on the server, and the policy tells us
+    // to ignore the error.
+    let mut unparseable = Statement::new("BLAH BLAH BLAH");
+    unparseable.set_execution_profile_handle(Some(handle.clone()));
     let mut stream = session
-        .query_iter(failing_write, ())
+        .query_iter(unparseable, ())
         .await
         .unwrap()
         .rows_stream::<Row>()
@@ -216,12 +216,15 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
     while stream.try_next().await.unwrap().is_some() {}
 
     retried_flag.store(false, Ordering::Relaxed);
-    // Try the same with execute_iter()
+    // Try the same with execute_iter(). An unparseable statement cannot be prepared,
+    // so prepare a valid one and then remove the table it targets - this way it is
+    // the execution, not the preparation, that fails.
     let mut p = session
         .prepare("INSERT INTO t (pk, v) VALUES (?, ?)")
         .await
         .unwrap();
     p.set_execution_profile_handle(Some(handle));
+    session.ddl("DROP TABLE t").await.unwrap();
     let mut iter = session
         .execute_iter(p, (1, 2))
         .await

--- a/scylla/tests/integration/session/pager.rs
+++ b/scylla/tests/integration/session/pager.rs
@@ -176,11 +176,10 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
         .build()
         .into_handle();
 
-    let session = create_new_session_builder()
-        .default_execution_profile_handle(handle)
-        .build()
-        .await
-        .unwrap();
+    // The handle is attached to the two statements under test rather than to the
+    // session's default profile, so that the DDL below keeps the default retry policy
+    // and a failing DDL is reported instead of being silently ignored.
+    let session = create_new_session_builder().build().await.unwrap();
 
     // Create a keyspace with replication factor that is larger than the cluster size
     let cluster_size = session.get_cluster_state().get_nodes_info().len();
@@ -204,8 +203,10 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
     assert!(!retried_flag.load(Ordering::Relaxed));
     // Try to write something to the new table - it should fail and the policy
     // will tell us to ignore the error
+    let mut failing_write = Statement::new("INSERT INTO t (pk v) VALUES (1, 2)");
+    failing_write.set_execution_profile_handle(Some(handle.clone()));
     let mut stream = session
-        .query_iter("INSERT INTO t (pk v) VALUES (1, 2)", ())
+        .query_iter(failing_write, ())
         .await
         .unwrap()
         .rows_stream::<Row>()
@@ -216,10 +217,11 @@ async fn test_iter_works_when_retry_policy_returns_ignore_write_error() {
 
     retried_flag.store(false, Ordering::Relaxed);
     // Try the same with execute_iter()
-    let p = session
+    let mut p = session
         .prepare("INSERT INTO t (pk, v) VALUES (?, ?)")
         .await
         .unwrap();
+    p.set_execution_profile_handle(Some(handle));
     let mut iter = session
         .execute_iter(p, (1, 2))
         .await

--- a/scylla/tests/integration/statements/batch.rs
+++ b/scylla/tests/integration/statements/batch.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, scylla_supports_tablets, setup_tracing,
-    unique_keyspace_name,
+    PerformDDL as _, create_new_session_builder, disable_tablets_unless_supported,
+    scylla_supports_tablets, setup_tracing, unique_keyspace_name,
 };
 use assert_matches::assert_matches;
 use scylla::client::session::Session;
@@ -244,12 +244,11 @@ async fn test_batch_lwts() {
     let session = create_new_session_builder().build().await.unwrap();
 
     let ks = unique_keyspace_name();
-    let mut create_ks = format!(
-        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
+    // This test uses LWT, which older ScyllaDB versions do not support on tablet keyspaces.
+    let create_ks = format!(
+        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}{}",
+        disable_tablets_unless_supported(&session, "LWT_WITH_TABLETS").await
     );
-    if scylla_supports_tablets(&session).await {
-        create_ks += " and TABLETS = { 'enabled': false}";
-    }
     session.ddl(create_ks).await.unwrap();
     session.use_keyspace(ks.clone(), false).await.unwrap();
 

--- a/scylla/tests/integration/statements/batch.rs
+++ b/scylla/tests/integration/statements/batch.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, disable_tablets_unless_supported,
-    scylla_supports_tablets, setup_tracing, unique_keyspace_name,
+    PerformDDL as _, create_new_session_builder, disable_tablets_unless_supported, setup_tracing,
+    unique_keyspace_name,
 };
 use assert_matches::assert_matches;
 use scylla::client::session::Session;
@@ -568,15 +568,12 @@ async fn test_counter_batch() {
     let session = Arc::new(create_new_session_builder().build().await.unwrap());
     let ks = unique_keyspace_name();
 
-    // Need to disable tablets in this test because they don't support counters yet.
-    // (https://github.com/scylladb/scylladb/commit/c70f321c6f581357afdf3fd8b4fe8e5c5bb9736e).
-    let mut create_ks = format!(
-        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+    // This test uses counters, which older ScyllaDB versions do not support
+    // on tablet keyspaces.
+    let create_ks = format!(
+        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}{}",
+        disable_tablets_unless_supported(&session, "COUNTERS_WITH_TABLETS").await
     );
-    if scylla_supports_tablets(&session).await {
-        create_ks += " AND TABLETS = {'enabled': false}"
-    }
-
     session.ddl(create_ks).await.unwrap();
     session
         .ddl(format!(

--- a/scylla/tests/integration/statements/prepared.rs
+++ b/scylla/tests/integration/statements/prepared.rs
@@ -24,8 +24,8 @@ use tracing::{debug, info};
 use uuid::Uuid;
 
 use crate::utils::{
-    PerformDDL as _, create_new_session_builder, fetch_negotiated_features,
-    scylla_supports_tablets, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
+    PerformDDL as _, create_new_session_builder, disable_tablets_unless_supported,
+    fetch_negotiated_features, setup_tracing, test_with_3_node_cluster, unique_keyspace_name,
 };
 
 #[tokio::test]
@@ -224,13 +224,11 @@ async fn test_prepared_partitioner() {
     let session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
 
-    // This test uses CDC which is not yet compatible with Scylla's tablets.
-    let mut create_ks = format!(
-        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+    // This test uses CDC, which older ScyllaDB versions do not support on tablet keyspaces.
+    let create_ks = format!(
+        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}{}",
+        disable_tablets_unless_supported(&session, "CDC_WITH_TABLETS").await
     );
-    if scylla_supports_tablets(&session).await {
-        create_ks += " AND TABLETS = {'enabled': false}"
-    }
 
     session.ddl(create_ks).await.unwrap();
     session.use_keyspace(&ks, false).await.unwrap();

--- a/scylla/tests/integration/types/cql_types.rs
+++ b/scylla/tests/integration/types/cql_types.rs
@@ -9,17 +9,18 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
 use crate::utils::{
-    DeserializeOwnedValue, PerformDDL, create_new_session_builder, scylla_supports_tablets,
-    setup_tracing, unique_keyspace_name,
+    DeserializeOwnedValue, PerformDDL, create_new_session_builder,
+    disable_tablets_unless_supported, setup_tracing, unique_keyspace_name,
 };
 
 // Used to prepare a table for test
-// Creates a new keyspace, without tablets if requested and the ScyllaDB instance supports them.
+// Creates a new keyspace, with tablets disabled if `required_tablet_feature` is `Some`
+// and the cluster does not support it.
 // Drops and creates table {table_name} (id int PRIMARY KEY, val {type_name})
 async fn init_test_maybe_without_tablets(
     table_name: &str,
     type_name: &str,
-    supports_tablets: bool,
+    required_tablet_feature: Option<&str>,
 ) -> Session {
     let session: Session = create_new_session_builder().build().await.unwrap();
     let ks = unique_keyspace_name();
@@ -28,9 +29,8 @@ async fn init_test_maybe_without_tablets(
         "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = \
     {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
     );
-
-    if !supports_tablets && scylla_supports_tablets(&session).await {
-        create_ks += " AND TABLETS = {'enabled': false}"
+    if let Some(feature) = required_tablet_feature {
+        create_ks += disable_tablets_unless_supported(&session, feature).await;
     }
 
     session.ddl(create_ks).await.unwrap();
@@ -55,7 +55,7 @@ async fn init_test_maybe_without_tablets(
 // Creates a new keyspace
 // Drops and creates table {table_name} (id int PRIMARY KEY, val {type_name})
 async fn init_test(table_name: &str, type_name: &str) -> Session {
-    init_test_maybe_without_tablets(table_name, type_name, true).await
+    init_test_maybe_without_tablets(table_name, type_name, None).await
 }
 
 // This function tests serialization and deserialization mechanisms by sending insert and select
@@ -269,9 +269,12 @@ async fn test_counter() {
     let big_increment = i64::MAX.to_string();
     let tests = ["1", "997", big_increment.as_str()];
 
-    // Can't use run_tests, because counters are special and can't be inserted
+    // Can't use run_tests, because counters are special and can't be inserted.
+    // This test uses counters, which older ScyllaDB versions do not support
+    // on tablet keyspaces.
     let type_name = "counter";
-    let session: Session = init_test_maybe_without_tablets(type_name, type_name, false).await;
+    let session: Session =
+        init_test_maybe_without_tablets(type_name, type_name, Some("COUNTERS_WITH_TABLETS")).await;
 
     for (i, test) in tests.iter().enumerate() {
         let update_bound_value = format!("UPDATE {type_name} SET val = val + ? WHERE id = ?");

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -182,6 +182,28 @@ pub(crate) async fn scylla_supports_tablets(session: &Session) -> bool {
     supports_feature(session, "TABLETS").await
 }
 
+/// Returns the `CREATE KEYSPACE` option that disables tablets, if the cluster supports
+/// tablets but does not support the given cluster feature - and an empty string otherwise.
+///
+/// ScyllaDB gained support for various functionalities on tablet keyspaces gradually,
+/// each guarded by its own `*_WITH_TABLETS` cluster feature (`CDC_WITH_TABLETS`,
+/// `LWT_WITH_TABLETS`, `VIEWS_WITH_TABLETS`, `COUNTERS_WITH_TABLETS`). A test relying on
+/// such a functionality should run on the default, tablet-enabled setup wherever the
+/// server supports it, and fall back to vnodes on older servers that do not.
+///
+/// # Warning
+/// This function **requires full schema metadata** to function correctly.
+pub(crate) async fn disable_tablets_unless_supported(
+    session: &Session,
+    feature: &str,
+) -> &'static str {
+    if scylla_supports_tablets(session).await && !supports_feature(session, feature).await {
+        " AND TABLETS = {'enabled': false}"
+    } else {
+        ""
+    }
+}
+
 // Creates a generic session builder based on conditional compilation configuration
 // For SessionBuilder of DefaultMode type, adds localhost to known hosts, as all of the tests
 // connect to localhost.


### PR DESCRIPTION
Fixes: #1858

Note: the PR was written by Claude Opus and reviewed by me. Commit messages are original; I think they don't matter much because the changes are very simple and regard tests only.

--------------------------------

There were many places in our tests where we decided to disable tablets, because at the moment of writing ScyllaDB didn't support multiple features with tablets. Those features included:
- LWTs
- CDC
- materialized views
- counters

All those features are supported now, so those tests can migrate to tablets (by no longer explicitly disabling them). Not to break tests on ScyllaDB clusters that don't yet support some features with tablets, tablets are still disabled in such case.

--------------------------------

`test_iter_works_when_retry_policy_returns_ignore_write_error` relied on having _RF > number of nodes_ for the statement to fail, which is not allowed with tablets. The test is rewritten to make statement execution fail due to different reasons (syntax error, dropped table).

--------------------------------

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
