### PR TITLE
connection: add tests for orphaning + transport factory

### DIFF
--- a/scylla-proxy/Cargo.toml
+++ b/scylla-proxy/Cargo.toml
@@ -20,6 +20,7 @@ defaults = []
 scylla-cql = { version = "1.8.0", path = "../scylla-cql" }
 bytes = "1.10"
 futures = "0.3.6"
+itertools = "0.15.0"
 tokio = { version = "1.40", features = [
     "net",
     "time",

--- a/scylla-proxy/src/lib.rs
+++ b/scylla-proxy/src/lib.rs
@@ -12,7 +12,7 @@ pub use actions::{
 };
 pub use errors::{DoorkeeperError, ProxyError, WorkerError};
 pub use frame::{RequestFrame, RequestOpcode, ResponseFrame, ResponseOpcode};
-pub use proxy::{Node, Proxy, RunningProxy, ShardAwareness};
+pub use proxy::{Node, Proxy, RunningProxy, ShardAwareness, TransportFactory};
 
 pub use proxy::get_exclusive_local_address;
 

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -7,6 +7,7 @@ use crate::frame::{
 use crate::{RequestOpcode, TargetShard};
 use bytes::Bytes;
 use compression::no_compression;
+use itertools::Either;
 use scylla_cql::frame::types::read_string_multimap;
 use std::collections::HashMap;
 use std::env::VarError;
@@ -15,9 +16,10 @@ use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, DuplexStream};
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::sync::mpsc::error::TryRecvError;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, info, trace, warn};
 
@@ -343,7 +345,7 @@ impl Proxy {
         let (finish_guard, finish_waiter) = mpsc::channel(1);
 
         let (error_propagator, error_sink) = mpsc::unbounded_channel();
-        let (doorkeepers, running_nodes): (Vec<_>, Vec<RunningNode>) = self
+        let (addresses_and_doorkeepers, running_nodes): (Vec<_>, Vec<RunningNode>) = self
             .nodes
             .into_iter()
             .map(|node| {
@@ -365,29 +367,86 @@ impl Proxy {
                         cc_event_sender: cc_event_sender.clone(),
                     }
                 };
-                (
+                let proxy_addr = node.proxy_addr();
+                let doorkeeper = {
                     Doorkeeper::spawn(
                         node,
                         terminate_signaler.clone(),
                         finish_guard.clone(),
                         error_propagator.clone(),
                         cc_event_sender,
-                    ),
-                    running,
-                )
+                    )
+                };
+                let address_and_doorkeeper = async move { Ok((proxy_addr, doorkeeper.await?)) };
+                (address_and_doorkeeper, running)
             })
             .unzip();
 
-        for doorkeeper in doorkeepers {
-            doorkeeper.await?; // await doorkeeper creation, including binding to a socket
+        let mut duplex_submitter_map = HashMap::new();
+        for address_and_doorkeeper in addresses_and_doorkeepers {
+            let (proxy_addr, duplex_submitter) = address_and_doorkeeper.await?; // await doorkeeper creation, including binding to a socket
+            duplex_submitter_map.insert(proxy_addr, duplex_submitter);
         }
+
+        let transport_factory = Arc::new(TransportFactory {
+            duplex_submitter_map,
+        });
 
         Ok(RunningProxy {
             terminate_signaler,
             finish_waiter,
             running_nodes,
             error_sink,
+            transport_factory,
         })
+    }
+}
+
+/// Creates [`DuplexStream`]s that directly connect to the associated proxy's
+/// nodes.
+///
+/// This is an alternative method of establishing a transport layer connection
+/// to the proxy nodes. The purpose of this alternative method is to allow
+/// writing tests that use tokio's paused time feature. The advantage of using
+/// a channel is that, when some data is sent on the channel, the waiting
+/// task will be immediately notified and scheduled for execution. For
+/// system sockets this is not guaranteed and the receiving task may be
+/// notified after a real-time delay, which can trick tokio's timer auto-advance
+/// and make it move the time forward, even if the task on the receiving
+/// side would have been notified earlier in a real scenario.
+pub struct TransportFactory {
+    duplex_submitter_map: HashMap<SocketAddr, UnboundedSender<(DuplexStream, SocketAddr)>>,
+}
+
+impl TransportFactory {
+    pub fn connect(
+        &self,
+        connect_address: SocketAddr,
+        source_ip: Option<IpAddr>,
+        source_port: Option<u16>,
+    ) -> Result<tokio::io::DuplexStream, std::io::Error> {
+        let sender = self
+            .duplex_submitter_map
+            .get(&connect_address)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::HostUnreachable,
+                    format!("No host under address {connect_address}"),
+                )
+            })?;
+
+        let source_ip = source_ip.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let source_port = source_port.unwrap_or_else(|| rand::random_range(49152..=65535));
+        let source_address = SocketAddr::from((source_ip, source_port));
+
+        let (duplex1, duplex2) = tokio::io::duplex(8 * 1024);
+        sender.send((duplex2, source_address)).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                format!("The proxy node {connect_address} no longer accepts connections"),
+            )
+        })?;
+        Ok(duplex1)
     }
 }
 
@@ -502,6 +561,7 @@ pub struct RunningProxy {
     finish_waiter: FinishWaiter,
     pub running_nodes: Vec<RunningNode>,
     error_sink: ErrorSink,
+    transport_factory: Arc<TransportFactory>,
 }
 
 impl RunningProxy {
@@ -535,6 +595,11 @@ impl RunningProxy {
     /// Waits until an error occurs in proxy. If proxy finishes with no errors occurred, returns Err(()).
     pub async fn wait_for_error(&mut self) -> Option<ProxyError> {
         self.error_sink.recv().await
+    }
+
+    /// Returns the [`TransportFactory`] object associated with the proxy.
+    pub fn transport_factory(&self) -> Arc<TransportFactory> {
+        Arc::clone(&self.transport_factory)
     }
 
     /// Requests termination of all proxy workers and awaits its completion.
@@ -578,6 +643,11 @@ struct Doorkeeper {
     shards_count: Option<u16>,
     error_propagator: ErrorPropagator,
     cc_event_sender: Arc<Mutex<HashMap<usize, mpsc::UnboundedSender<ResponseFrame>>>>,
+    duplex_receiver: UnboundedReceiver<(DuplexStream, SocketAddr)>,
+    // The other side of the `duplex_receiver`. Not used directly by the doorkeeper
+    // but kept as a field in order to keep `duplex_receiver` open which allows
+    // to simplify some logic and not care about it getting closed.
+    _duplex_submitter: UnboundedSender<(DuplexStream, SocketAddr)>,
 }
 
 impl Doorkeeper {
@@ -587,7 +657,7 @@ impl Doorkeeper {
         finish_guard: FinishGuard,
         error_propagator: ErrorPropagator,
         cc_event_sender: Arc<Mutex<HashMap<usize, mpsc::UnboundedSender<ResponseFrame>>>>,
-    ) -> Result<(), DoorkeeperError> {
+    ) -> Result<UnboundedSender<(DuplexStream, SocketAddr)>, DoorkeeperError> {
         let listener = TcpListener::bind(node.proxy_addr())
             .await
             .map_err(|err| DoorkeeperError::DriverConnectionAttempt(node.proxy_addr(), err))?;
@@ -615,6 +685,7 @@ impl Doorkeeper {
             )
         };
 
+        let (duplex_submitter, duplex_receiver) = mpsc::unbounded_channel();
         let doorkeeper = Doorkeeper {
             shards_count: None, // temporarily, until Doorkeeper examines its ShardAwareness
             node,
@@ -623,9 +694,11 @@ impl Doorkeeper {
             finish_guard,
             error_propagator,
             cc_event_sender,
+            duplex_receiver,
+            _duplex_submitter: duplex_submitter.clone(),
         };
         tokio::task::spawn(doorkeeper.run());
-        Ok(())
+        Ok(duplex_submitter)
     }
 
     async fn run(mut self) {
@@ -695,17 +768,17 @@ impl Doorkeeper {
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     async fn spawn_workers(
         &mut self,
         driver_addr: SocketAddr,
         connection_close_tx: &ConnectionCloseSignaler,
         connection_no: usize,
-        driver_stream: TcpStream,
+        driver_read: impl AsyncRead + Send + Unpin + 'static,
+        driver_write: impl AsyncWrite + Send + Unpin + 'static,
         cluster_stream: Option<TcpStream>,
         shard: Option<TargetShard>,
     ) {
-        let (driver_read, driver_write) = driver_stream.into_split();
-
         let new_worker = || ProxyWorker {
             terminate_notifier: self.terminate_signaler.subscribe(),
             finish_guard: self.finish_guard.clone(),
@@ -858,11 +931,22 @@ impl Doorkeeper {
             InternalNode::Simulated { .. } => (None, None),
         };
 
+        let (driver_read, driver_write): (
+            Box<dyn AsyncRead + Send + Unpin + 'static>,
+            Box<dyn AsyncWrite + Send + Unpin + 'static>,
+        ) = driver_stream
+            .map_either(TcpStream::into_split, tokio::io::split)
+            .either(
+                |(l, r)| (Box::new(l) as _, Box::new(r) as _),
+                |(l, r)| (Box::new(l) as _, Box::new(r) as _),
+            );
+
         self.spawn_workers(
             driver_addr,
             connection_close_tx,
             connection_no,
-            driver_stream,
+            driver_read,
+            driver_write,
             cluster_stream,
             shard,
         )
@@ -874,11 +958,21 @@ impl Doorkeeper {
     async fn make_driver_stream(
         &mut self,
         connection_no: usize,
-    ) -> Result<(TcpStream, SocketAddr), DoorkeeperError> {
-        let (driver_stream, driver_addr) =
-            self.listener.accept().await.map_err(|err| {
-                DoorkeeperError::DriverConnectionAttempt(self.node.proxy_addr(), err)
-            })?;
+    ) -> Result<(Either<TcpStream, DuplexStream>, SocketAddr), DoorkeeperError> {
+        let (driver_stream, driver_addr) = tokio::select! {
+            v = self.listener.accept() => {
+                let (stream, addr) = v.map_err(|err| DoorkeeperError::DriverConnectionAttempt(self.node.proxy_addr(), err))?;
+                (Either::Left(stream), addr)
+            },
+            v = self.duplex_receiver.recv(), if !self.duplex_receiver.is_closed() => {
+                // Doorkeeper (which is passed by reference in `self`) keeps
+                // the send half of the `duplex_receiver` alive as one of its
+                // fields, just so that we can avoid dealing with the doorkeeper
+                // becoming closed here
+                let (duplex, addr) = v.expect("receiver should be open because Doorkeeper keeps the sender alive");
+                (Either::Right(duplex), addr)
+            },
+        };
         info!(
             "Connected driver from {} to {}, connection no={}.",
             driver_addr,

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2559,18 +2559,21 @@ mod tests {
     use assert_matches::assert_matches;
     use scylla_proxy::{
         Condition, Node, Proxy, Reaction, RequestFrame, RequestOpcode, RequestReaction,
-        RequestRule, ResponseFrame, ShardAwareness,
+        RequestRule, ResponseFrame, ResponseOpcode, RunningProxy, ShardAwareness,
     };
 
     use bytes::Bytes;
     use tokio::select;
     use tokio::sync::mpsc;
+    use tokio::task::JoinHandle;
+    use tokio::time::Instant;
 
     use super::{HostConnectionConfig, open_connection};
     use crate::cluster::metadata::UntranslatedEndpoint;
     use crate::cluster::node::ResolvedContactPoint;
     use crate::errors::{
-        CqlResponseKind, DbError, NextPageError, NextRowError, RequestAttemptError, RequestError,
+        ConnectionError, CqlResponseKind, DbError, NextPageError, NextRowError,
+        RequestAttemptError, RequestError,
     };
     use crate::statement::prepared::PreparedStatement;
     use crate::statement::unprepared::Statement;
@@ -3432,5 +3435,311 @@ mod tests {
         );
 
         let _ = proxy.finish().await;
+    }
+
+    const DROP_QUERY: &str = "DROP";
+    const DELAY_HALF_THRESHOLD_QUERY: &str = "DELAY_HALF_THRESHOLD";
+    const DELAY_DOUBLE_THRESHOLD_QUERY: &str = "DELAY_DOUBLE_THRESHOLD";
+
+    async fn orphaning_test_setup() -> (RunningProxy, Arc<super::Connection>, super::ErrorReceiver)
+    {
+        let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
+        let uri = std::env::var("SCYLLA_URI").unwrap_or_else(|_| "172.42.0.2:9042".to_string());
+        let node_addr: SocketAddr = resolve_hostname(&uri).await;
+
+        let mk_rule = |marker: &str, reaction: RequestReaction| {
+            RequestRule(
+                Condition::And(
+                    Box::new(Condition::RequestOpcode(RequestOpcode::Query)),
+                    Box::new(Condition::BodyContainsCaseSensitive(
+                        marker.as_bytes().to_owned().into_boxed_slice(),
+                    )),
+                ),
+                reaction,
+            )
+        };
+        let make_delayed_response = |delay: Duration| {
+            RequestReaction::forge_response_with_delay(
+                delay,
+                Arc::new(|RequestFrame { params, .. }| ResponseFrame {
+                    params: params.for_response(),
+                    opcode: ResponseOpcode::Result,
+                    body: Bytes::from_static(&[0, 0, 0, 1]), // Void response
+                }),
+            )
+        };
+
+        let request_rules = vec![
+            mk_rule(DROP_QUERY, RequestReaction::drop_frame()),
+            mk_rule(
+                DELAY_HALF_THRESHOLD_QUERY,
+                make_delayed_response(super::OLD_AGE_ORPHAN_THRESHOLD / 2),
+            ),
+            mk_rule(
+                DELAY_DOUBLE_THRESHOLD_QUERY,
+                make_delayed_response(2 * super::OLD_AGE_ORPHAN_THRESHOLD),
+            ),
+        ];
+
+        let proxy = Proxy::builder()
+            .with_node(
+                Node::builder()
+                    .proxy_address(proxy_addr)
+                    .real_address(node_addr)
+                    .shard_awareness(ShardAwareness::QueryNode)
+                    .request_rules(request_rules)
+                    .build(),
+            )
+            .build()
+            .run()
+            .await
+            .unwrap();
+
+        let (conn, error_receiver) = open_connection(
+            &UntranslatedEndpoint::ContactPoint(ResolvedContactPoint {
+                address: proxy_addr,
+            }),
+            None,
+            &HostConnectionConfig {
+                transport_factory: Some(proxy.transport_factory()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        (proxy, Arc::new(conn), error_receiver)
+    }
+
+    fn assert_too_many_orphaned_streams_error(err: ConnectionError) {
+        use crate::errors::BrokenConnectionErrorKind;
+
+        let ConnectionError::BrokenConnection(reason) = err else {
+            panic!("Expected ConnectionError::BrokenConnection, got {}", err);
+        };
+        let Some(err_inner) = reason.downcast_ref::<BrokenConnectionErrorKind>() else {
+            panic!("Expected BrokenConnectionErrorKind inner type, got something else");
+        };
+        assert_matches!(
+            err_inner,
+            BrokenConnectionErrorKind::TooManyOrphanedStreamIds(_)
+        );
+    }
+
+    /// Verifies that the orphaning mechanism detects connections with a large
+    /// number of dead requests and shuts them down.
+    #[tokio::test(start_paused = true)]
+    async fn test_orphaning_shuts_down_stuck_connections() {
+        setup_tracing();
+        let (_proxy, conn, error_receiver) = orphaning_test_setup().await;
+        let start_time = Instant::now();
+
+        // Spawn enough queries to cross the orphaning threshold.
+        // Because of the proxy rule, those requests will not reach the DB at all
+        // and proxy will not send any response. This will simulate a case
+        // when DB gets stuck and does not respond for a long time.
+        // The requests time out and thus become orphaned.
+        let timeout = Duration::from_millis(500);
+        let mut query_tasks = Vec::new();
+        for _ in 0..super::OLD_ORPHAN_COUNT_THRESHOLD + 1 {
+            let conn = Arc::clone(&conn);
+            query_tasks.push(tokio::spawn(async move {
+                let statement = Statement::new(DROP_QUERY);
+                // Timeouts are not enforced by connections, so use tokio built-ins
+                tokio::time::timeout(timeout, conn.query_unpaged(&statement)).await
+            }));
+        }
+
+        // All queries should fail because of a timeout
+        for task in query_tasks {
+            let result = task.await.unwrap();
+            let _ = result.expect_err("One of the requests did not time out as expected");
+        }
+
+        // The orphaner should shut down the connection within `OLD_AGE_ORPHAN_THRESHOLD``
+        let err = error_receiver.await.unwrap();
+        assert_too_many_orphaned_streams_error(err);
+
+        // Verify that at least `timeout` + `OLD_AGE_ORPHAN_THRESHOLD` has passed
+        let elapsed = Instant::now() - start_time;
+        println!("Time elapsed: {}s", elapsed.as_secs_f64());
+        assert!(Instant::now() - start_time >= timeout + super::OLD_AGE_ORPHAN_THRESHOLD);
+    }
+
+    /// Verifies that orphaning tolerates a large number of requests getting stuck
+    /// for a duration that is shorter than the orphaning threshold.
+    #[tokio::test(start_paused = true)]
+    async fn test_orphaning_tolerates_short_spikes_of_orphaned_requests() {
+        setup_tracing();
+        let (_proxy, conn, mut error_receiver) = orphaning_test_setup().await;
+
+        // Spawn enough queries to cross the orphaning threshold.
+        // Because of the proxy rule, those requests will not reach the DB at all.
+        // This will simulate a case when DB gets stuck and does not respond
+        // for a long time.
+        let mut query_tasks = Vec::new();
+        for _ in 0..super::OLD_ORPHAN_COUNT_THRESHOLD + 1 {
+            let conn = Arc::clone(&conn);
+            query_tasks.push(tokio::spawn(async move {
+                let statement = Statement::new(DELAY_HALF_THRESHOLD_QUERY);
+                // Orphan after a short timeout
+                tokio::time::timeout(Duration::from_millis(10), conn.query_unpaged(&statement))
+                    .await
+            }));
+        }
+
+        // All queries should fail because of a timeout
+        for task in query_tasks {
+            let result = task.await.unwrap();
+            let _ = result.expect_err("One of the requests did not time out as expected");
+        }
+
+        // Give a chance for the requests to clear their orphaned status
+        // and also for the orphaner to check and see that everything's alright
+        tokio::time::sleep(2 * super::OLD_AGE_ORPHAN_THRESHOLD).await;
+
+        // The orphaner should not have been triggered and the connection
+        // should still be working
+        assert!(error_receiver.try_recv().is_err());
+
+        // Send one more request to verify that it works
+        let statement = Statement::new("SELECT * FROM system.local");
+        conn.query_unpaged(&statement)
+            .await
+            .expect("Request should have succeeded");
+
+        assert!(error_receiver.try_recv().is_err());
+    }
+
+    /// Verifies that a number of persistently orphaned requests that is large
+    /// but still below the threshold will not cause the connection to be closed.
+    #[tokio::test(start_paused = true)]
+    async fn test_orphaning_tolerates_long_running_orphaned_requests_under_count_threshold() {
+        setup_tracing();
+        let (_proxy, conn, mut error_receiver) = orphaning_test_setup().await;
+
+        let mut query_tasks = Vec::new();
+        for _ in 0..super::OLD_ORPHAN_COUNT_THRESHOLD {
+            let conn = Arc::clone(&conn);
+            query_tasks.push(tokio::spawn(async move {
+                let statement = Statement::new(DROP_QUERY);
+                // Orphan after a short timeout
+                tokio::time::timeout(Duration::from_millis(10), conn.query_unpaged(&statement))
+                    .await
+            }));
+        }
+
+        // All queries should fail because of a timeout
+        for task in query_tasks {
+            let result = task.await.unwrap();
+            let _ = result.expect_err("One of the requests did not time out as expected");
+        }
+
+        // Give a chance for the orphaner to notice that there are orphaned
+        // requests and that they got stuck for a long time; however, there
+        // are not enough of them to close the connection so the connection
+        // should keep working afterwards.
+        tokio::time::sleep(2 * super::OLD_AGE_ORPHAN_THRESHOLD).await;
+
+        assert!(error_receiver.try_recv().is_err());
+
+        // Send one more request to verify that it works
+        let statement = Statement::new("SELECT * FROM system.local");
+        conn.query_unpaged(&statement)
+            .await
+            .expect("Request should have succeeded");
+
+        assert!(error_receiver.try_recv().is_err());
+    }
+
+    /// Submit request in regular intervals so that, at the steady state,
+    /// there will be `count_threshold_percentage` * `count threshold` orphaned
+    /// requests that are also old enough to contribute to closing the connection.
+    /// Below 100% the connection should not get closed, but above 100% it will be.
+    async fn submit_sustained_orphaned_requests(
+        conn: &Arc<super::Connection>,
+        count_threshold_percentage: f64,
+        submit_period_duration: Duration,
+    ) -> Vec<
+        JoinHandle<
+            Result<Result<super::QueryResult, RequestAttemptError>, tokio::time::error::Elapsed>,
+        >,
+    > {
+        // Delaying responses for double the threshold means that each request
+        // contributes to the orphaned requests count condition for about
+        // 1 * time threshold. We need to divide the age threshold by count
+        // threshold multiplied by the desired percentage
+        let submit_interval = super::OLD_AGE_ORPHAN_THRESHOLD
+            .div_f64(super::OLD_ORPHAN_COUNT_THRESHOLD as f64 * count_threshold_percentage);
+        let stop_submitting_at = Instant::now() + submit_period_duration;
+        let mut next_submit_at = Instant::now();
+        let mut query_tasks = Vec::new();
+        while Instant::now() < stop_submitting_at {
+            // Tokio's timers operate with a millisecond resolution. Considering
+            // the current values of the count and time orphaning threshold,
+            // this little dance with `next_submit_at` is necessary to work around
+            // the precision issues and make the test useful.
+            next_submit_at += submit_interval;
+            tokio::time::sleep_until(next_submit_at).await;
+
+            let conn = Arc::clone(conn);
+            query_tasks.push(tokio::spawn(async move {
+                let statement = Statement::new(DELAY_DOUBLE_THRESHOLD_QUERY);
+                // Orphan after a short timeout
+                tokio::time::timeout(Duration::from_millis(10), conn.query_unpaged(&statement))
+                    .await
+            }));
+        }
+
+        query_tasks
+    }
+
+    /// Simulate a situation where, constantly, we have lots of orphaned requests,
+    /// but not enough of them are old enough to close the connection.
+    #[tokio::test(start_paused = true)]
+    async fn test_orphaning_tolerates_many_short_lived_orphaned_requests() {
+        setup_tracing();
+        let (_proxy, conn, mut error_receiver) = orphaning_test_setup().await;
+
+        let query_tasks =
+            submit_sustained_orphaned_requests(&conn, 0.9, 5 * super::OLD_AGE_ORPHAN_THRESHOLD)
+                .await;
+
+        // All queries should fail because of a timeout
+        for task in query_tasks {
+            let result = task.await.unwrap();
+            let _ = result.expect_err("One of the requests did not time out as expected");
+        }
+
+        // Give a chance for the requests to clear their orphaned status
+        // and also for the orphaner to check and see that everything's alright
+        tokio::time::sleep(3 * super::OLD_AGE_ORPHAN_THRESHOLD).await;
+
+        assert!(error_receiver.try_recv().is_err());
+
+        // Send one more request to verify that it works
+        let statement = Statement::new("SELECT * FROM system.local");
+        conn.query_unpaged(&statement)
+            .await
+            .expect("Request should have succeeded");
+
+        assert!(error_receiver.try_recv().is_err());
+    }
+
+    /// Simulate a workload where the number of orphaned requests gradually
+    /// increases and crosses both the age and count thresholds, which should
+    /// lead to the connection becoming closed.
+    #[tokio::test(start_paused = true)]
+    async fn test_orphaning_closes_connection_after_gradual_increase_of_orphaned_requests() {
+        setup_tracing();
+        let (_proxy, conn, error_receiver) = orphaning_test_setup().await;
+
+        let _ = submit_sustained_orphaned_requests(&conn, 1.1, 5 * super::OLD_AGE_ORPHAN_THRESHOLD)
+            .await;
+
+        // The orphaner should have had enough time to consider the connection
+        // to be orphaned.
+        let err = error_receiver.await.unwrap();
+        assert_too_many_orphaned_streams_error(err);
     }
 }

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -369,6 +369,8 @@ impl ConnectionConfig {
             keepalive_timeout: self.keepalive_timeout,
             tablet_sender: self.tablet_sender.clone(),
             identity: self.identity.clone(),
+            #[cfg(test)]
+            transport_factory: None,
         }
     }
 }
@@ -397,6 +399,9 @@ pub(crate) struct HostConnectionConfig {
     pub(crate) tablet_sender: Option<mpsc::Sender<(TableSpec<'static>, RawTablet)>>,
 
     pub(crate) identity: SelfIdentity<'static>,
+
+    #[cfg(test)]
+    pub(crate) transport_factory: Option<Arc<scylla_proxy::TransportFactory>>,
 }
 
 #[cfg(test)]
@@ -423,6 +428,9 @@ impl Default for HostConnectionConfig {
             tablet_sender: None,
 
             identity: SelfIdentity::default(),
+
+            #[cfg(test)]
+            transport_factory: None,
         }
     }
 }
@@ -479,6 +487,21 @@ impl Connection {
         source_port: Option<u16>,
         config: HostConnectionConfig,
     ) -> Result<(Self, ErrorReceiver), ConnectionError> {
+        #[cfg(test)]
+        if let Some(transport_factory) = &config.transport_factory {
+            let duplex =
+                transport_factory.connect(connect_address, config.local_ip_address, source_port)?;
+
+            return Self::new_with_transport(
+                duplex,
+                connect_address,
+                config,
+                #[cfg(test)]
+                None,
+            )
+            .await;
+        }
+
         let stream_connector = tokio::time::timeout(
             config.connect_timeout,
             connect_with_source_ip_and_port(
@@ -513,7 +536,7 @@ impl Connection {
     }
 
     async fn new_with_transport(
-        stream: TcpStream,
+        stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
         connect_address: SocketAddr,
         config: HostConnectionConfig,
         #[cfg(test)] socket: Option<socket2::Socket>,
@@ -1467,7 +1490,7 @@ impl Connection {
 
     async fn run_router(
         config: HostConnectionConfig,
-        stream: TcpStream,
+        stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
         receiver: mpsc::Receiver<Task>,
         error_sender: tokio::sync::oneshot::Sender<ConnectionError>,
         orphan_notification_receiver: mpsc::UnboundedReceiver<RequestId>,

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -101,7 +101,7 @@ pub(crate) struct Connection {
     features: ConnectionFeatures,
     router_handle: Arc<RouterHandle>,
     #[cfg(test)]
-    socket: socket2::Socket,
+    socket: Option<socket2::Socket>,
 }
 
 struct RouterHandle {
@@ -512,7 +512,7 @@ impl Connection {
         #[cfg(test)]
         let socket = {
             use std::os::unix::io::AsFd;
-            socket2::Socket::from(stream.as_fd().try_clone_to_owned()?)
+            Some(socket2::Socket::from(stream.as_fd().try_clone_to_owned()?))
         };
 
         let _worker_handle = Self::run_router(
@@ -1984,8 +1984,8 @@ impl Connection {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_sock_ref(&self) -> socket2::SockRef<'_> {
-        socket2::SockRef::from(&self.socket)
+    pub(crate) fn get_sock_ref(&self) -> Option<socket2::SockRef<'_>> {
+        self.socket.as_ref().map(socket2::SockRef::from)
     }
 }
 
@@ -3366,7 +3366,7 @@ mod tests {
             .get_random_connection()
             .unwrap();
 
-        let sock_ref = connection.get_sock_ref();
+        let sock_ref = connection.get_sock_ref().unwrap();
 
         // Linux kernel doubles SO_RCVBUF and SO_SNDBUF values,
         // so we check that the actual buffer sizes are at least as large as the requested ones.

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -496,6 +496,28 @@ impl Connection {
             }
         };
 
+        #[cfg(test)]
+        let socket = {
+            use std::os::unix::io::AsFd;
+            Some(socket2::Socket::from(stream.as_fd().try_clone_to_owned()?))
+        };
+
+        Self::new_with_transport(
+            stream,
+            connect_address,
+            config,
+            #[cfg(test)]
+            socket,
+        )
+        .await
+    }
+
+    async fn new_with_transport(
+        stream: TcpStream,
+        connect_address: SocketAddr,
+        config: HostConnectionConfig,
+        #[cfg(test)] socket: Option<socket2::Socket>,
+    ) -> Result<(Self, ErrorReceiver), ConnectionError> {
         // TODO: What should be the size of the channel?
         let (sender, receiver) = mpsc::channel(1024);
         let (error_sender, error_receiver) = tokio::sync::oneshot::channel();
@@ -508,12 +530,6 @@ impl Connection {
             orphan_notification_sender,
             keepalive_hint: Notify::new(),
         });
-
-        #[cfg(test)]
-        let socket = {
-            use std::os::unix::io::AsFd;
-            Some(socket2::Socket::from(stream.as_fd().try_clone_to_owned()?))
-        };
 
         let _worker_handle = Self::run_router(
             config.clone(),


### PR DESCRIPTION
There are currently no tests for the orphaning logic. Add some tests that use the proxy to simulate requests getting stuck on the DB side and verify that the orphaning logic reacts accordingly.

Additionally, introduce the TransportFactory object which allows connections created in the tests to communicate over DuplexStreams instead of TcpStreams. The DuplexStream is an in-memory bidirectional stream of bytes similar in function to a TCP stream but bypasses the system entirely. Thanks to this bypass, it is now possible to write tests that use tokio's paused timer and auto-advance functionality effectively - with TCP streams, even if the process communicates with itself, the task waiting for the data on the other side might not get woken up by the time tokio decides to auto-advance the timer - thinking that there is currently nothing to do. This functionality is actively used in the new tests but will definitely be useful in future tests.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~I have provided docstrings for the public items that I want to introduce.~
- [ ] ~I have adjusted the documentation in `./docs/source/`.~
- [ ] ~I added appropriate `Fixes:` annotations to PR description.~
