### PR TITLE
fix(serialize): reject vector elements that have no size-less encoding

### DIFF
--- a/scylla-cql-core/src/serialize/value.rs
+++ b/scylla-cql-core/src/serialize/value.rs
@@ -25,7 +25,7 @@ use crate::value::{
 #[cfg(feature = "chrono-04")]
 use crate::value::ValueOverflow;
 
-use super::writers::WrittenCellProof;
+use super::writers::{SizeLessCellError, WrittenCellProof, cell_payload};
 use super::{CellValueBuilder, CellWriter, SerializationError};
 
 /// A type that can be serialized and sent along with a CQL statement.
@@ -992,6 +992,11 @@ pub fn serialize_next_constant_length_elem_unstable<'t, T: SerializeValue + 't>(
     serialize_next_constant_length_elem(rust_name, element_type, typ, builder, element)
 }
 
+/// Serializes one element of a constant-width vector, looking the width up
+/// from the element type. `serialize_vector` reads the width once for the whole
+/// vector and calls [`serialize_next_elem_of_width`] directly, so this exists
+/// only for the unstable entry point above.
+#[cfg(all(scylla_unstable, feature = "unstable-python-rs"))]
 pub(crate) fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
     rust_name: &'static str,
     element_type: &ColumnType,
@@ -999,6 +1004,48 @@ pub(crate) fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
     builder: &mut CellValueBuilder,
     element: &'t T,
 ) -> Result<(), SerializationError> {
+    let expected = match element_type.type_size_for_vector() {
+        Some(size) if size > 0 => size,
+        // Reachable only through the unstable entry point above, or from a
+        // hand-built `ColumnType`. `serialize_vector` never routes a type
+        // without a fixed non-zero width here.
+        _ => {
+            return Err(mk_ser_err_named(
+                rust_name,
+                typ,
+                VectorSerializationErrorKind::ElementTypeNotConstantLength,
+            ));
+        }
+    };
+    serialize_next_elem_of_width(rust_name, element_type, typ, builder, element, expected)
+}
+
+/// Serializes one element of a constant-width vector, given the width its type
+/// requires. `serialize_vector` reads the width once for the whole vector, so
+/// this stays off the per-element path.
+///
+/// A constant-width vector element is a bare payload: no length header, so no
+/// room for a null or unset sentinel and no room for a payload of the wrong
+/// width. [`CellWriter::set_null`] and [`CellWriter::set_unset`] are infallible
+/// and consume the writer, so the element serializer cannot be stopped from
+/// reaching for them. What a size-less writer does instead is write nothing at
+/// all in those two cases, which turns "is this element representable" into
+/// "did it write exactly the number of bytes its type requires".
+///
+/// That works because the required width is never zero, so null and unset can
+/// never coincide with a valid payload. Inspecting the bytes instead would be
+/// unsound in the other direction: a null in a `vector<int, n>` writes the same
+/// four bytes as the perfectly legal value -1.
+fn serialize_next_elem_of_width<'t, T: SerializeValue + 't>(
+    rust_name: &'static str,
+    element_type: &ColumnType,
+    typ: &ColumnType,
+    builder: &mut CellValueBuilder,
+    element: &'t T,
+    expected: usize,
+) -> Result<(), SerializationError> {
+    debug_assert!(expected > 0);
+    let before = builder.content_len();
     T::serialize(
         element,
         element_type,
@@ -1011,6 +1058,25 @@ pub(crate) fn serialize_next_constant_length_elem<'t, T: SerializeValue + 't>(
             VectorSerializationErrorKind::ElementSerializationFailed(err),
         )
     })?;
+    let written = builder.content_len() - before;
+
+    if written != expected {
+        return Err(mk_ser_err_named(
+            rust_name,
+            typ,
+            if written == 0 {
+                // Null and unset write nothing, and so does an empty value.
+                // Which of the three it was is not recoverable here, and the
+                // consequence is the same: the element has no encoding.
+                VectorSerializationErrorKind::ElementIsNotRepresentable
+            } else {
+                VectorSerializationErrorKind::ElementSizeMismatch {
+                    expected,
+                    actual: written,
+                }
+            },
+        ));
+    }
     Ok(())
 }
 
@@ -1033,8 +1099,14 @@ pub(crate) fn serialize_next_variable_length_elem<'t, T: SerializeValue + 't>(
     builder: &mut CellValueBuilder,
     element: &'t T,
 ) -> Result<(), SerializationError> {
+    // Here the length check that guards the constant-length path above is no
+    // help: a variable-length element may legitimately be any length including
+    // zero, so an empty payload and a null are the same observation. Serialize
+    // through a normal, sized writer into the scratch buffer instead and read
+    // the 4 byte header, which names null and unset outright. The header is
+    // then dropped and only the payload is re-encoded behind its vint length.
     let mut element_buffer = Vec::new();
-    let inner_writer = CellWriter::new_without_size(&mut element_buffer);
+    let inner_writer = CellWriter::new(&mut element_buffer);
     T::serialize(element, element_type, inner_writer).map_err(|err| {
         mk_ser_err_named(
             rust_name,
@@ -1042,13 +1114,25 @@ pub(crate) fn serialize_next_variable_length_elem<'t, T: SerializeValue + 't>(
             VectorSerializationErrorKind::ElementSerializationFailed(err),
         )
     })?;
+    let element_payload = cell_payload(&element_buffer).map_err(|err| {
+        mk_ser_err_named(
+            rust_name,
+            typ,
+            match err {
+                SizeLessCellError::Null | SizeLessCellError::Unset => {
+                    VectorSerializationErrorKind::ElementIsNullOrUnset
+                }
+                SizeLessCellError::Malformed => VectorSerializationErrorKind::ElementIsMalformed,
+            },
+        )
+    })?;
     let mut element_length_buffer = Vec::new();
     unsigned_vint_encode(
-        element_buffer.len().try_into().unwrap(),
+        element_payload.len().try_into().unwrap(),
         &mut element_length_buffer,
     );
     builder.append_bytes(element_length_buffer.as_slice());
-    builder.append_bytes(element_buffer.as_slice());
+    builder.append_bytes(element_payload);
     Ok(())
 }
 
@@ -1070,16 +1154,29 @@ fn serialize_vector<'t, 'b, T: SerializeValue + 't>(
     }
     let mut builder = writer.into_value_builder();
     match element_type.type_size_for_vector() {
-        Some(_) => {
+        // The width is read once here, not once per element.
+        Some(element_width) if element_width > 0 => {
             for element in iter {
-                serialize_next_constant_length_elem(
+                serialize_next_elem_of_width(
                     rust_name,
                     element_type,
                     typ,
                     &mut builder,
                     element,
+                    element_width,
                 )?;
             }
+        }
+        // A zero-width element type has no usable encoding: the payload would
+        // be empty however many elements the vector holds, so the elements
+        // could never be recovered. Only reachable from a hand-built
+        // `ColumnType` such as `vector<vector<float, 0>, n>`.
+        Some(_) => {
+            return Err(mk_ser_err_named(
+                rust_name,
+                typ,
+                VectorSerializationErrorKind::ElementTypeNotConstantLength,
+            ));
         }
         None => {
             for element in iter {
@@ -1463,6 +1560,47 @@ pub enum VectorSerializationErrorKind {
     /// One of the elements of the vector failed to serialize.
     #[error("failed to serialize one of the elements: {0}")]
     ElementSerializationFailed(SerializationError),
+
+    /// One of the elements of a constant-width vector serialized to nothing.
+    /// Null, unset and an empty value all do that, and none of the three has a
+    /// vector element encoding: the element carries no length header, so there
+    /// is nowhere to put a sentinel and no way to be zero bytes wide.
+    #[error(
+        "one of the elements serialized to nothing, which happens for null, unset and empty values, none of which a vector element can represent"
+    )]
+    ElementIsNotRepresentable,
+
+    /// One of the elements of a variable-width vector serialized to null or to
+    /// an unset value. Neither has a vector element encoding: the sentinel
+    /// bytes would be read back as payload.
+    #[error(
+        "one of the elements serialized to null or unset, which a vector element cannot represent"
+    )]
+    ElementIsNullOrUnset,
+
+    /// One of the elements of a constant-length vector serialized to the wrong
+    /// number of bytes. The element type fixes the width, so any other length
+    /// shifts every element that follows.
+    #[error(
+        "one of the elements serialized to {actual} bytes, but its type requires exactly {expected}"
+    )]
+    ElementSizeMismatch {
+        /// The width the element type requires.
+        expected: usize,
+        /// The width the element serializer actually produced.
+        actual: usize,
+    },
+
+    /// A constant-length element was requested for a type that has no fixed,
+    /// non-zero width, so it has no size-less encoding.
+    #[error("the element type has no fixed, non-zero width and no size-less encoding")]
+    ElementTypeNotConstantLength,
+
+    /// One of the elements produced a malformed cell, which happens when a
+    /// [`CellValueBuilder`] is leaked without calling
+    /// [`finish`](CellValueBuilder::finish).
+    #[error("one of the elements serialized to a malformed cell")]
+    ElementIsMalformed,
 }
 
 /// Describes why type checking of a tuple failed.

--- a/scylla-cql-core/src/serialize/value_tests.rs
+++ b/scylla-cql-core/src/serialize/value_tests.rs
@@ -4,6 +4,7 @@ use crate::serialize::value::{
     BuiltinTypeCheckErrorKind, MapSerializationErrorKind, MapTypeCheckErrorKind, SerializeValue,
     SetOrListSerializationErrorKind, SetOrListTypeCheckErrorKind, TupleSerializationErrorKind,
     TupleTypeCheckErrorKind, UdtSerializationErrorKind, UdtTypeCheckErrorKind,
+    VectorSerializationErrorKind,
 };
 use crate::serialize::writers::WrittenCellProof;
 use crate::serialize::{CellWriter, SerializationError};
@@ -1944,4 +1945,239 @@ fn test_maybe_empty_with_custom_error() {
     let err = do_serialize_err(value, &ColumnType::Native(NativeType::Int));
     err.downcast_ref::<CustomSerializationError>()
         .expect("CustomSerializationError");
+}
+
+// Tests for https://github.com/scylladb/scylla-rust-driver/issues/1669:
+// a size-less CellWriter cannot refuse null, unset or a wrong-length payload,
+// so those used to reach the wire as raw bytes inside a vector element.
+
+/// A `SerializeValue` that writes an arbitrary payload through `set_value`,
+/// ignoring the width the element type declares. Used to reach the
+/// wrong-length case, which no built-in type produces.
+struct RawPayload(&'static [u8]);
+
+impl SerializeValue for RawPayload {
+    fn serialize<'b>(
+        &self,
+        _typ: &ColumnType,
+        writer: CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, SerializationError> {
+        Ok(writer.set_value(self.0).unwrap())
+    }
+}
+
+fn vector_of(element: ColumnType<'static>, dimensions: u16) -> ColumnType<'static> {
+    ColumnType::Vector {
+        typ: Box::new(element),
+        dimensions,
+    }
+}
+
+fn vector_err_kind(err: &SerializationError) -> VectorSerializationErrorKind {
+    match &get_ser_err(err).kind {
+        BuiltinSerializationErrorKind::VectorError(kind) => kind.clone(),
+        other => panic!("not a vector serialization error: {other:?}"),
+    }
+}
+
+#[test]
+fn vector_rejects_null_constant_length_element() {
+    let typ = vector_of(ColumnType::Native(NativeType::Int), 1);
+    // Before the fix this returned Ok with the payload ff ff ff ff, which the
+    // server reads back as the int -1.
+    let err = do_serialize_err(vec![None::<i32>], &typ);
+    assert_matches!(
+        vector_err_kind(&err),
+        VectorSerializationErrorKind::ElementIsNotRepresentable
+    );
+}
+
+#[test]
+fn vector_rejects_unset_constant_length_element() {
+    let typ = vector_of(ColumnType::Native(NativeType::Int), 1);
+    let err = do_serialize_err(vec![MaybeUnset::<i32>::Unset], &typ);
+    assert_matches!(
+        vector_err_kind(&err),
+        VectorSerializationErrorKind::ElementIsNotRepresentable
+    );
+}
+
+#[test]
+fn vector_rejects_null_variable_length_element() {
+    let typ = vector_of(ColumnType::Native(NativeType::Text), 1);
+    let err = do_serialize_err(vec![None::<String>], &typ);
+    assert_matches!(
+        vector_err_kind(&err),
+        VectorSerializationErrorKind::ElementIsNullOrUnset
+    );
+}
+
+#[test]
+fn vector_rejects_unset_variable_length_element() {
+    let typ = vector_of(ColumnType::Native(NativeType::Text), 1);
+    let err = do_serialize_err(vec![MaybeUnset::<String>::Unset], &typ);
+    assert_matches!(
+        vector_err_kind(&err),
+        VectorSerializationErrorKind::ElementIsNullOrUnset
+    );
+}
+
+/// A null in a variable-length element is not distinguishable from an empty
+/// value by length, which is why that path checks the length header instead.
+#[test]
+fn vector_accepts_empty_variable_length_element() {
+    let typ = vector_of(ColumnType::Native(NativeType::Text), 1);
+    assert_eq!(
+        do_serialize(vec!["".to_string()], &typ),
+        vec![0, 0, 0, 1, 0]
+    );
+}
+
+#[test]
+fn vector_rejects_wrong_size_constant_length_element() {
+    let typ = vector_of(ColumnType::Native(NativeType::Int), 2);
+    let err = do_serialize_err(
+        vec![RawPayload(&[1, 2, 3]), RawPayload(&[4, 5, 6, 7])],
+        &typ,
+    );
+    assert_matches!(
+        vector_err_kind(&err),
+        VectorSerializationErrorKind::ElementSizeMismatch {
+            expected: 4,
+            actual: 3
+        }
+    );
+}
+
+/// A null and a legal payload can have the same length, which is exactly the
+/// case for `int` and `float`. Comparing the bytes a size-less writer produced
+/// therefore cannot work; the fix makes null write nothing instead.
+#[test]
+fn vector_null_and_minus_one_would_have_the_same_bytes() {
+    let typ = vector_of(ColumnType::Native(NativeType::Int), 1);
+    assert_eq!(
+        do_serialize(vec![-1_i32], &typ),
+        vec![0, 0, 0, 4, 255, 255, 255, 255]
+    );
+
+    let err = do_serialize_err(vec![None::<i32>], &typ);
+    assert_matches!(
+        vector_err_kind(&err),
+        VectorSerializationErrorKind::ElementIsNotRepresentable
+    );
+}
+
+/// Round-trip harness. For every element type, the vector encoding must be
+/// exactly what the sized cell path produces with the length headers removed
+/// for constant-length elements, or replaced by a vint length for
+/// variable-length ones. This is what proves the fix leaves valid values
+/// byte-for-byte unchanged.
+#[test]
+fn vector_matches_sized_path_byte_for_byte() {
+    fn check<T: SerializeValue + Clone>(element_type: ColumnType<'static>, elements: Vec<T>) {
+        let dimensions: u16 = elements.len().try_into().unwrap();
+        let vector_type = vector_of(element_type.clone(), dimensions);
+        let got = do_serialize(elements.clone(), &vector_type);
+
+        // Rebuild the expected bytes using the sized path only.
+        let mut payload = Vec::new();
+        let constant_length = element_type.type_size_for_vector();
+        for element in &elements {
+            let cell = do_serialize(element.clone(), &element_type);
+            let (header, body) = cell.split_at(4);
+            let len = i32::from_be_bytes(header.try_into().unwrap());
+            assert!(len >= 0, "{element_type:?} produced a null/unset cell");
+            assert_eq!(len as usize, body.len());
+            match constant_length {
+                Some(expected) => {
+                    assert_eq!(
+                        body.len(),
+                        expected,
+                        "{element_type:?} is not constant width"
+                    );
+                    payload.extend_from_slice(body);
+                }
+                None => {
+                    crate::frame::types::unsigned_vint_encode(
+                        body.len().try_into().unwrap(),
+                        &mut payload,
+                    );
+                    payload.extend_from_slice(body);
+                }
+            }
+        }
+        let mut expected = (payload.len() as i32).to_be_bytes().to_vec();
+        expected.extend_from_slice(&payload);
+
+        assert_eq!(got, expected, "mismatch for {element_type:?}");
+    }
+
+    // Constant-width element types, the size-less encoding.
+    check(ColumnType::Native(NativeType::Boolean), vec![true, false]);
+    check(
+        ColumnType::Native(NativeType::Int),
+        vec![-1_i32, -2, 0, i32::MAX],
+    );
+    check(
+        ColumnType::Native(NativeType::Float),
+        vec![-1.0_f32, 0.0, f32::MAX],
+    );
+    check(
+        ColumnType::Native(NativeType::BigInt),
+        vec![-1_i64, 0, i64::MAX],
+    );
+    check(
+        ColumnType::Native(NativeType::Uuid),
+        vec![Uuid::from_u128(0), Uuid::from_u128(u128::MAX)],
+    );
+
+    // Variable-width element types, the vint-prefixed encoding.
+    check(
+        ColumnType::Native(NativeType::Text),
+        vec!["".to_string(), "a".to_string(), "ą".repeat(200)],
+    );
+    check(
+        ColumnType::Native(NativeType::Blob),
+        vec![vec![], vec![0_u8], vec![255_u8; 300]],
+    );
+    check(
+        ColumnType::Native(NativeType::SmallInt),
+        vec![-1_i16, 0, i16::MAX],
+    );
+}
+
+/// An empty value has no constant-width vector element encoding either, and is
+/// caught by the same zero-length check.
+#[test]
+fn vector_rejects_empty_constant_length_element() {
+    let typ = vector_of(ColumnType::Native(NativeType::Int), 1);
+    let err = do_serialize_err(vec![MaybeEmpty::<i32>::Empty], &typ);
+    assert_matches!(
+        vector_err_kind(&err),
+        VectorSerializationErrorKind::ElementIsNotRepresentable
+    );
+}
+
+/// Null and unset stay legal everywhere the cell does carry a length header.
+#[test]
+fn null_and_unset_still_work_outside_vectors() {
+    let list = ColumnType::Collection {
+        frozen: false,
+        typ: CollectionType::List(Box::new(ColumnType::Native(NativeType::Int))),
+    };
+    assert_eq!(
+        do_serialize(vec![None::<i32>], &list),
+        vec![0, 0, 0, 8, 0, 0, 0, 1, 255, 255, 255, 255]
+    );
+    assert_eq!(
+        do_serialize(None::<i32>, &ColumnType::Native(NativeType::Int)),
+        vec![255, 255, 255, 255]
+    );
+    assert_eq!(
+        do_serialize(
+            MaybeUnset::<i32>::Unset,
+            &ColumnType::Native(NativeType::Int)
+        ),
+        vec![255, 255, 255, 254]
+    );
 }

--- a/scylla-cql-core/src/serialize/writers.rs
+++ b/scylla-cql-core/src/serialize/writers.rs
@@ -89,9 +89,26 @@ impl<'buf> CellWriter<'buf> {
         }
     }
 
-    // Creates a new cell writer based on an existing Vec, without writing size.
+    /// Creates a new cell writer based on an existing Vec, without writing size.
     ///
     /// The newly created row writer will append data to the end of the vec.
+    ///
+    /// # Correctness
+    ///
+    /// A size-less cell carries no length header, so the reader recovers the
+    /// value boundaries from the CQL type alone. That makes null and unset
+    /// unrepresentable, and it makes a payload of the wrong length unreadable.
+    /// Neither condition can be reported through
+    /// [`set_null`](CellWriter::set_null) or
+    /// [`set_unset`](CellWriter::set_unset), which are infallible and consume
+    /// the writer.
+    ///
+    /// So that the caller can still detect both, a size-less writer writes
+    /// nothing at all for null and unset instead of the -1 and -2 sentinels a
+    /// normal writer would emit. A caller that knows how many bytes the element
+    /// type requires, and that number is never zero, can then reject null,
+    /// unset and a wrong-length payload with a single length comparison. See
+    /// `serialize_next_constant_length_elem` in the `value` module.
     #[inline]
     pub fn new_without_size(buf: &'buf mut Vec<u8>) -> Self {
         Self {
@@ -101,16 +118,26 @@ impl<'buf> CellWriter<'buf> {
     }
 
     /// Sets this value to be null, consuming this object.
+    ///
+    /// A size-less writer, see [`new_without_size`](CellWriter::new_without_size),
+    /// has no encoding for null and writes nothing instead of the -1 sentinel.
     #[inline]
     pub fn set_null(self) -> WrittenCellProof<'buf> {
-        self.buf.extend_from_slice(&(-1i32).to_be_bytes());
+        if self.write_size {
+            self.buf.extend_from_slice(&(-1i32).to_be_bytes());
+        }
         WrittenCellProof::new()
     }
 
     /// Sets this value to represent an unset value, consuming this object.
+    ///
+    /// A size-less writer, see [`new_without_size`](CellWriter::new_without_size),
+    /// has no encoding for unset and writes nothing instead of the -2 sentinel.
     #[inline]
     pub fn set_unset(self) -> WrittenCellProof<'buf> {
-        self.buf.extend_from_slice(&(-2i32).to_be_bytes());
+        if self.write_size {
+            self.buf.extend_from_slice(&(-2i32).to_be_bytes());
+        }
         WrittenCellProof::new()
     }
 
@@ -196,9 +223,24 @@ impl<'buf> CellValueBuilder<'buf> {
 
     /// Appends a sub-value to the end of the current contents of the cell
     /// and returns an object that allows to fill it in, without writing size.
+    ///
+    /// See [`CellWriter::new_without_size`] for the correctness obligations
+    /// that come with a size-less writer.
     #[inline]
     pub fn make_sub_writer_without_size(&mut self) -> CellWriter<'_> {
         CellWriter::new_without_size(self.buf)
+    }
+
+    /// Number of content bytes written into this cell so far, not counting the
+    /// length header of the cell itself.
+    ///
+    /// Bracketing a [`make_sub_writer_without_size`](CellValueBuilder::make_sub_writer_without_size)
+    /// call with this is how a caller recovers the length of a size-less
+    /// sub-value, which is the only thing that distinguishes a valid payload
+    /// from the null and unset that a size-less writer cannot encode.
+    #[inline]
+    pub(crate) fn content_len(&self) -> usize {
+        self.buf.len() - self.starting_pos - if self.write_size { 4 } else { 0 }
     }
 
     /// Finishes serializing the value.
@@ -252,6 +294,50 @@ impl WrittenCellProof<'_> {
     }
 }
 
+/// Why a cell written by a normal [`CellWriter`] has no size-less form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SizeLessCellError {
+    /// The value serialized to null, encoded as a length of -1.
+    Null,
+    /// The value serialized to unset, encoded as a length of -2.
+    Unset,
+    /// The header is neither a valid length nor a null/unset sentinel. In
+    /// practice this means a [`CellValueBuilder`] was leaked without calling
+    /// [`CellValueBuilder::finish`], leaving the -3 poison behind.
+    Malformed,
+}
+
+/// Splits a cell written by a normal [`CellWriter`] into header and payload,
+/// returning the payload only if the cell has a size-less form.
+///
+/// Used where a length comparison cannot decide the question on its own,
+/// namely for a variable-length vector element, whose payload may legitimately
+/// be of any length including zero. The header settles it: null and unset are
+/// visible as -1 and -2 rather than as an empty payload.
+#[inline]
+pub(crate) fn cell_payload(cell: &[u8]) -> Result<&[u8], SizeLessCellError> {
+    let (header, payload) = cell
+        .split_at_checked(4)
+        .ok_or(SizeLessCellError::Malformed)?;
+    let header = i32::from_be_bytes(
+        header
+            .try_into()
+            .expect("split_at_checked(4) yields 4 bytes"),
+    );
+    match header {
+        -1 => Err(SizeLessCellError::Null),
+        -2 => Err(SizeLessCellError::Unset),
+        len if len < 0 => Err(SizeLessCellError::Malformed),
+        // A successful write always leaves a header that matches the payload,
+        // both for `set_value` and for `CellValueBuilder::finish`. Checking it
+        // anyway keeps a malformed cell from being re-encoded as a valid one.
+        len if u64::from(len.cast_unsigned()) != payload.len() as u64 => {
+            Err(SizeLessCellError::Malformed)
+        }
+        _ => Ok(payload),
+    }
+}
+
 /// There was an attempt to produce a CQL value over the maximum size limit (i32::MAX)
 #[derive(Debug, Clone, Copy, Error)]
 #[error("CQL cell overflowed the maximum allowed size of 2^31 - 1")]
@@ -297,6 +383,82 @@ mod tests {
                 255, 255, 255, 253, // Invalid value
             ]
         );
+    }
+
+    #[test]
+    fn size_less_writer_does_not_emit_null_or_unset_sentinels() {
+        // Regression test for https://github.com/scylladb/scylla-rust-driver/issues/1669.
+        // A size-less cell has no length header, so the -1 and -2 sentinels
+        // would land in the buffer as payload. Writing nothing instead leaves
+        // a length that no fixed-size element type can match.
+        let mut data = Vec::new();
+        CellWriter::new_without_size(&mut data).set_null();
+        assert_eq!(data, [] as [u8; 0]);
+
+        let mut data = Vec::new();
+        CellWriter::new_without_size(&mut data).set_unset();
+        assert_eq!(data, [] as [u8; 0]);
+
+        // A normal writer is unchanged.
+        let mut data = Vec::new();
+        CellWriter::new(&mut data).set_null();
+        assert_eq!(data, [255, 255, 255, 255]);
+
+        let mut data = Vec::new();
+        CellWriter::new(&mut data).set_unset();
+        assert_eq!(data, [255, 255, 255, 254]);
+    }
+
+    #[test]
+    fn size_less_sub_writer_content_len_reports_what_was_written() {
+        let mut data = Vec::new();
+        let mut builder = CellWriter::new(&mut data).into_value_builder();
+
+        let before = builder.content_len();
+        builder
+            .make_sub_writer_without_size()
+            .set_value(&[1, 2, 3, 4])
+            .unwrap();
+        assert_eq!(builder.content_len() - before, 4);
+
+        let before = builder.content_len();
+        builder.make_sub_writer_without_size().set_null();
+        assert_eq!(builder.content_len() - before, 0);
+
+        let before = builder.content_len();
+        builder.make_sub_writer_without_size().set_unset();
+        assert_eq!(builder.content_len() - before, 0);
+
+        builder.finish().unwrap();
+        assert_eq!(data, [0, 0, 0, 4, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn cell_payload_classifies_written_cells() {
+        use super::{SizeLessCellError, cell_payload};
+
+        let mut data = Vec::new();
+        CellWriter::new(&mut data).set_value(&[7, 7, 7]).unwrap();
+        assert_eq!(cell_payload(&data), Ok(&[7, 7, 7][..]));
+
+        let mut data = Vec::new();
+        CellWriter::new(&mut data).set_value(&[]).unwrap();
+        assert_eq!(cell_payload(&data), Ok(&[][..]));
+
+        let mut data = Vec::new();
+        CellWriter::new(&mut data).set_null();
+        assert_eq!(cell_payload(&data), Err(SizeLessCellError::Null));
+
+        let mut data = Vec::new();
+        CellWriter::new(&mut data).set_unset();
+        assert_eq!(cell_payload(&data), Err(SizeLessCellError::Unset));
+
+        // Builder leaked without `finish`, leaving the -3 poison.
+        let mut data = Vec::new();
+        let _ = CellWriter::new(&mut data).into_value_builder();
+        assert_eq!(cell_payload(&data), Err(SizeLessCellError::Malformed));
+
+        assert_eq!(cell_payload(&[0, 0, 0]), Err(SizeLessCellError::Malformed));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1669.

A size-less CellWriter writes a cell with no length header. But set_null and set_unset are infallible and consume the writer, so they had no way to refuse. They wrote the -1 and -2 sentinel values straight into the buffer as if they were real data. Size-less writers are only used for vector elements, so sending Vec<Option<i32>> to a vector<int, 1> column put a well-formed vector holding the integer -1 on the wire. Plain Option<T> is enough to hit this; no custom SerializeValue needed.

You noted in the issue that checking the byte count would not help, since a null is just a size and four bytes of null look like four bytes of float. That is true while null writes four bytes. So this changes a size-less writer to emit nothing at all for null and unset. Vector element widths are only ever 1, 4, 8 or 16 bytes, so zero bytes can never be valid, and one length check now rejects null, unset, empty values and wrong-width payloads together.
