### PR TITLE
treewide: Avoid relying on names of unnamed markers

### DIFF
--- a/docs/source/statements/values.md
+++ b/docs/source/statements/values.md
@@ -35,7 +35,7 @@ session
     .await?;
 
 // Sending an integer and a string using a named struct.
-// Names of fields must match names of columns in request,
+// Names of fields must match names of bind markers in the request,
 // but having them in the same order is not required.
 // If the fields are in the same order, you can use attribute:
 // `#[scylla(flavor = "enforce_order")]`
@@ -54,10 +54,10 @@ let int_string = IntString {
 };
 
 session
-    .query_unpaged("INSERT INTO ks.tab (a, b) VALUES(?, ?)", int_string)
+    .query_unpaged("INSERT INTO ks.tab (a, b) VALUES(:a, :b)", int_string)
     .await?;
 
-// You can use named bind markers in statement if you want
+// You can name bind markers differently than the columns if you want
 // your names in struct to be different than column names.
 #[derive(SerializeRow)]
 struct IntStringCustom {

--- a/examples/custom_serialization.rs
+++ b/examples/custom_serialization.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
 
     session
         .query_unpaged(
-            "INSERT INTO examples_ks.custom_serialization (k, my) VALUES (?, ?)",
+            "INSERT INTO examples_ks.custom_serialization (k, my) VALUES (:k, :my)",
             to_insert,
         )
         .await?;
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
 
     session
         .query_unpaged(
-            "INSERT INTO examples_ks.custom_serialization (k, my) VALUES (?, ?)",
+            "INSERT INTO examples_ks.custom_serialization (k, my) VALUES (:k, :my)",
             to_insert_2,
         )
         .await?;

--- a/scylla/tests/integration/macros/complex_pk.rs
+++ b/scylla/tests/integration/macros/complex_pk.rs
@@ -34,7 +34,7 @@ async fn test_macros_complex_pk() {
         };
         session
             .query_unpaged(
-                "INSERT INTO complex_pk (a,b,c,d,e) VALUES (?,?,?,?,?)",
+                "INSERT INTO complex_pk (a,b,c,d,e) VALUES (:a,:b,:c,:d,:e)",
                 input.clone(),
             )
             .await


### PR DESCRIPTION
In the binary CQL protocol, each bind marker in PREPARED response must have a name. If a user didn't provide one (because they used unnamed `?` marker), then server must generate one.
In general we should advise users to not rely on those names, in case they unexpectedely change between server versions. To do that, we need to avoid relying on those generated names in our examples / docs / most tests. 

This PR does just that. I intentionally left a test that specifically asserts simple unnamed markers are named after the column they bind to - `scylla/tests/integration/statements/prepared.rs:436 — test_prepared_statement_col_specs`. I think such test is useful to tell us if even such basic behavior breaks.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1869
Fixes: https://scylladb.atlassian.net/browse/DRIVER-899

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
