### PR TITLE
Verify host ids in connection pools

### DIFF
--- a/scylla-cql/src/frame/request/options.rs
+++ b/scylla-cql/src/frame/request/options.rs
@@ -20,6 +20,9 @@ impl SerializableRequest for Options {
 pub const SCYLLA_SHARD_AWARE_PORT: &str = "SCYLLA_SHARD_AWARE_PORT";
 pub const SCYLLA_SHARD_AWARE_PORT_SSL: &str = "SCYLLA_SHARD_AWARE_PORT_SSL";
 
+// Only ever returned by the server in SUPPORTED; never sent by the driver in STARTUP.
+pub const SCYLLA_HOST_ID: &str = "SCYLLA_HOST_ID";
+
 pub const COMPRESSION: &str = "COMPRESSION";
 pub const CQL_VERSION: &str = "CQL_VERSION";
 pub const DRIVER_NAME: &str = "DRIVER_NAME";

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -64,6 +64,7 @@ use tokio::net::{TcpSocket, TcpStream};
 use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::time::Instant;
 use tracing::{debug, error, trace, warn};
+use uuid::Uuid;
 
 // FIXME: Make this constants configurable
 // The term "orphan" refers to stream ids, that were allocated for a {request, response} that no
@@ -180,6 +181,7 @@ pub(crate) struct ConnectionFeatures {
     shard_info: Option<ShardInfo>,
     shard_aware_port: Option<u16>,
     protocol_features: ProtocolFeatures,
+    host_id: Option<Uuid>,
 }
 
 type RequestId = u64;
@@ -1957,6 +1959,14 @@ impl Connection {
         self.features.shard_aware_port
     }
 
+    /// The host ID that the node reported in its `SUPPORTED` response.
+    ///
+    /// `None` if the node did not report one (Cassandra, ScyllaDB without host ID
+    /// discovery) or reported a malformed value.
+    pub(crate) fn get_host_id(&self) -> Option<Uuid> {
+        self.features.host_id
+    }
+
     fn set_features(&mut self, features: ConnectionFeatures) {
         self.features = features;
     }
@@ -2139,6 +2149,27 @@ pub(crate) async fn open_connection(
         .first()
         .and_then(|p| p.parse::<u16>().ok());
 
+    // ScyllaDB reports the host ID of the node that accepted the connection, which lets the
+    // driver verify it reached the node it intended to. Cassandra and older ScyllaDB do not
+    // report it, hence the `Option`.
+    let host_id = supported
+        .options
+        .remove(options::SCYLLA_HOST_ID)
+        .unwrap_or_default()
+        .first()
+        .and_then(|id| match Uuid::parse_str(id) {
+            Ok(uuid) => Some(uuid),
+            Err(err) => {
+                tracing::warn!(
+                    "[{}] Node reported a malformed host ID {:?}: {}. Proceeding with no host ID.",
+                    addr,
+                    id,
+                    err
+                );
+                None
+            }
+        });
+
     // Parse nonstandard protocol extensions.
     let protocol_features = ProtocolFeatures::parse_from_supported(&supported.options);
 
@@ -2148,6 +2179,7 @@ pub(crate) async fn open_connection(
         shard_info,
         shard_aware_port,
         protocol_features,
+        host_id,
     };
     connection.set_features(features);
 
@@ -2558,8 +2590,8 @@ mod tests {
     use crate::serialize::row::SerializedValues;
     use assert_matches::assert_matches;
     use scylla_proxy::{
-        Condition, Node, Proxy, Reaction, RequestFrame, RequestOpcode, RequestReaction,
-        RequestRule, ResponseFrame, ResponseOpcode, RunningProxy, ShardAwareness,
+        Condition, Node, Proxy, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction,
+        RequestRule, ResponseFrame, ResponseOpcode, RunningProxy, ShardAwareness, WorkerError,
     };
 
     use bytes::Bytes;
@@ -2568,7 +2600,7 @@ mod tests {
     use tokio::task::JoinHandle;
     use tokio::time::Instant;
 
-    use super::{HostConnectionConfig, open_connection};
+    use super::{HostConnectionConfig, open_connection, options};
     use crate::cluster::metadata::UntranslatedEndpoint;
     use crate::cluster::node::ResolvedContactPoint;
     use crate::errors::{
@@ -2584,6 +2616,7 @@ mod tests {
     use std::net::SocketAddr;
     use std::sync::Arc;
     use std::time::Duration;
+    use uuid::Uuid;
 
     /// Tests for Connection::execute_iter
     /// 1. SELECT from an empty table.
@@ -3252,6 +3285,79 @@ mod tests {
                 .unwrap(),
             &lwt_optimisation_entry
         )
+    }
+
+    /// The driver must read the host ID that the node reports in SUPPORTED, and degrade
+    /// gracefully (to `None`) when it is malformed or missing.
+    #[tokio::test]
+    async fn host_id_is_read_from_supported() {
+        setup_tracing();
+
+        let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
+        let config = HostConnectionConfig::default();
+        let endpoint = UntranslatedEndpoint::ContactPoint(ResolvedContactPoint {
+            address: proxy_addr,
+        });
+
+        let make_rules = |options: HashMap<String, Vec<String>>| {
+            vec![
+                RequestRule(
+                    Condition::RequestOpcode(RequestOpcode::Options),
+                    RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                        ResponseFrame::forged_supported(frame.params, &options).unwrap()
+                    })),
+                ),
+                RequestRule(
+                    Condition::RequestOpcode(RequestOpcode::Startup),
+                    RequestReaction::forge_response(Arc::new(|frame: RequestFrame| {
+                        ResponseFrame::forged_ready(frame.params)
+                    })),
+                ),
+            ]
+        };
+
+        let host_id = Uuid::parse_str("6bd8b1b6-5b0d-4b0e-8f45-1f3d1a9e0b12").unwrap();
+        let options_with_host_id = HashMap::from([(
+            options::SCYLLA_HOST_ID.to_owned(),
+            vec![host_id.to_string()],
+        )]);
+
+        let mut proxy = Proxy::builder()
+            .with_node(
+                Node::builder()
+                    .proxy_address(proxy_addr)
+                    .request_rules(make_rules(options_with_host_id))
+                    .build_dry_mode(),
+            )
+            .build()
+            .run()
+            .await
+            .unwrap();
+
+        // A valid UUID is picked up.
+        let (connection, _error_receiver) =
+            open_connection(&endpoint, None, &config).await.unwrap();
+        assert_eq!(connection.get_host_id(), Some(host_id));
+
+        // A malformed value must not fail the connection - it just yields no host ID.
+        proxy.running_nodes[0].change_request_rules(Some(make_rules(HashMap::from([(
+            options::SCYLLA_HOST_ID.to_owned(),
+            vec!["not-a-uuid".to_owned()],
+        )]))));
+        let (connection, _error_receiver) =
+            open_connection(&endpoint, None, &config).await.unwrap();
+        assert_eq!(connection.get_host_id(), None);
+
+        // Nodes that do not report a host ID at all (Cassandra, older ScyllaDB).
+        proxy.running_nodes[0].change_request_rules(Some(make_rules(HashMap::new())));
+        let (connection, _error_receiver) =
+            open_connection(&endpoint, None, &config).await.unwrap();
+        assert_eq!(connection.get_host_id(), None);
+
+        match proxy.finish().await {
+            Ok(()) | Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => {}
+            Err(err) => panic!("{err}"),
+        }
     }
 
     #[tokio::test]

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -928,6 +928,10 @@ impl PoolRefiller {
                     return;
                 }
 
+                // Do this after keyspace is set to avoid warning twice
+                // for the same connection.
+                self.verify_host_id(&connection);
+
                 // Update sharding and optionally reshard
                 let shard_info = connection.get_shard_info().as_ref();
                 let sharder = shard_info.map(|s| s.get_sharder());
@@ -1033,6 +1037,38 @@ impl PoolRefiller {
                     }
                 }
             }
+        }
+    }
+
+    /// Logs an error if the node that accepted the connection reported a host ID other than
+    /// the one this pool serves.
+    ///
+    /// A mismatch means requests routed here reach a different node than the driver believes,
+    /// which silently breaks token-aware routing; the likely causes are stale topology metadata
+    /// (the node was replaced by another one reusing its address) or misconfigured address
+    /// translation. Only ScyllaDB new enough to support host ID discovery reports its host ID
+    /// in `SUPPORTED`, so a node that reports none is accepted without complaint.
+    fn verify_host_id(&self, connection: &Connection) {
+        let Some(reported_host_id) = connection.get_host_id() else {
+            return;
+        };
+        let expected_host_id = match &*self.endpoint.read().unwrap() {
+            UntranslatedEndpoint::Peer(PeerEndpoint { host_id, .. }) => *host_id,
+            // Pools are always created for a known peer (`Node::new`); a contact point endpoint
+            // only occurs in unit tests, and then there is no host ID to expect.
+            UntranslatedEndpoint::ContactPoint(_) => return,
+        };
+
+        if expected_host_id != reported_host_id {
+            error!(
+                "[{}] Node reported host ID {} but the pool serves host ID {}. \
+                 Requests routed to this node reach a different node than the driver believes, \
+                 breaking token-aware routing, and possibly the connection pool itself. \
+                 Check for misconfigured address translation or network.",
+                self.endpoint_description(),
+                reported_host_id,
+                expected_host_id,
+            );
         }
     }
 
@@ -1449,7 +1485,8 @@ mod tests {
         ADVANCED_SHARD_AWARENESS_BLOCK_DURATION, ConnectionSetupError, HostPoolConfig,
         MaybePoolConnections, OpenedConnectionEvent, PoolConnections, PoolRefiller, RequestedShard,
     };
-    use crate::cluster::metadata::UntranslatedEndpoint;
+    use crate::cluster::NodeAddr;
+    use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
     use crate::cluster::node::ResolvedContactPoint;
     use crate::errors::{ConnectionError, UseKeyspaceError};
     use crate::frame::request::options;
@@ -1457,7 +1494,7 @@ mod tests {
     use crate::observability::metrics::Metrics;
     use crate::policies::reconnect::{ExponentialReconnectPolicy, ReconnectPolicy as _};
     use crate::routing::{Shard, ShardCount, ShardInfo, Sharder};
-    use crate::test_utils::setup_tracing;
+    use crate::test_utils::{CapturedLogs, capturing_errors, setup_tracing};
     use bytes::Bytes;
     use futures::{FutureExt, StreamExt};
     use scylla_proxy::{
@@ -1469,6 +1506,7 @@ mod tests {
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
     use tokio::sync::{Notify, mpsc};
+    use uuid::Uuid;
 
     #[test]
     fn keyspace_setup_failure_triggers_refill() {
@@ -1752,16 +1790,18 @@ mod tests {
     }
 
     fn mock_pool_refiller() -> PoolRefiller {
-        let endpoint = Arc::new(RwLock::new(UntranslatedEndpoint::ContactPoint(
-            ResolvedContactPoint {
-                address: SocketAddr::from(([127, 0, 0, 1], 9042)),
-            },
-        )));
+        mock_pool_refiller_for(UntranslatedEndpoint::ContactPoint(ResolvedContactPoint {
+            address: SocketAddr::from(([127, 0, 0, 1], 9042)),
+        }))
+    }
+
+    /// Like [mock_pool_refiller], but for a pool that serves the given endpoint.
+    fn mock_pool_refiller_for(endpoint: UntranslatedEndpoint) -> PoolRefiller {
         // The receiver is dropped right away; the refiller only does a best-effort `try_send()`.
         let (pool_empty_notifier, _) = mpsc::channel(1);
 
         PoolRefiller::new(
-            endpoint,
+            Arc::new(RwLock::new(endpoint)),
             HostPoolConfig::default(),
             None,
             None,
@@ -2117,5 +2157,161 @@ mod tests {
 
         drop(refiller);
         let _ = proxy.finish().await;
+    }
+
+    #[tokio::test]
+    async fn unexpected_host_id_is_reported() {
+        setup_tracing();
+
+        let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
+        let make_rules = |host_id: Option<Uuid>| {
+            vec![
+                RequestRule(
+                    Condition::RequestOpcode(RequestOpcode::Options),
+                    RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                        ResponseFrame::forged_supported(frame.params, &{
+                            let mut options = HashMap::new();
+                            if let Some(host_id) = host_id {
+                                options.insert(
+                                    options::SCYLLA_HOST_ID.to_owned(),
+                                    vec![host_id.to_string()],
+                                );
+                            }
+                            options
+                        })
+                        .unwrap()
+                    })),
+                ),
+                RequestRule(
+                    Condition::RequestOpcode(RequestOpcode::Startup),
+                    RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                        ResponseFrame::forged_ready(frame.params)
+                    })),
+                ),
+            ]
+        };
+
+        let expected_host_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let other_host_id = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+
+        let mut proxy = Proxy::builder()
+            .with_node(
+                Node::builder()
+                    .proxy_address(proxy_addr)
+                    .request_rules(make_rules(Some(expected_host_id)))
+                    .build_dry_mode(),
+            )
+            .build()
+            .run()
+            .await
+            .unwrap();
+
+        let endpoint = UntranslatedEndpoint::Peer(PeerEndpoint {
+            host_id: expected_host_id,
+            address: NodeAddr::Untranslatable(proxy_addr),
+            datacenter: None,
+            rack: None,
+        });
+        let connection_config = HostConnectionConfig::default();
+        let mut refiller = mock_pool_refiller_for(endpoint.clone());
+
+        // Feeds one freshly opened connection through the pool, returning whatever was logged
+        // at ERROR level while it was being handled.
+        let handle_connection = async |refiller: &mut PoolRefiller| -> String {
+            let (connection, error_receiver) = open_connection(&endpoint, None, &connection_config)
+                .await
+                .unwrap();
+            let evt = OpenedConnectionEvent {
+                result: Ok((connection, error_receiver)),
+                requested_shard: None,
+                keyspace_name: None,
+            };
+            let capture = CapturedLogs::default();
+            capturing_errors(&capture, || refiller.handle_ready_connection(evt));
+            capture.text()
+        };
+
+        // Sub-case 1: the node reports the host ID the pool expects - nothing to report.
+        let logs = handle_connection(&mut refiller).await;
+        assert!(
+            logs.is_empty(),
+            "matching host ID must not be logged, got: {logs}"
+        );
+
+        // Sub-case 2: the node reports a different host ID - both IDs must appear, exactly once.
+        proxy.running_nodes[0].change_request_rules(Some(make_rules(Some(other_host_id))));
+        let logs = handle_connection(&mut refiller).await;
+        assert!(
+            logs.contains(&expected_host_id.to_string()),
+            "mismatch report must contain the expected host ID, got: {logs}"
+        );
+        assert!(
+            logs.contains(&other_host_id.to_string()),
+            "mismatch report must contain the reported host ID, got: {logs}"
+        );
+        assert_eq!(
+            logs.lines().count(),
+            1,
+            "the mismatch must be reported exactly once, got: {logs}"
+        );
+
+        // Sub-case 3: the node reports no host ID at all (Cassandra / older ScyllaDB) - this must
+        // not produce any log noise.
+        proxy.running_nodes[0].change_request_rules(Some(make_rules(None)));
+        let logs = handle_connection(&mut refiller).await;
+        assert!(
+            logs.is_empty(),
+            "a node that reports no host ID must not be logged about, got: {logs}"
+        );
+
+        // Sub-case 4: a connection that must first switch keyspace travels through
+        // `handle_ready_connection` twice, so the report must not be duplicated.
+        refiller.current_keyspace =
+            Some(VerifiedKeyspaceName::new("keyspace".to_owned(), false).unwrap());
+        proxy.running_nodes[0].change_request_rules(Some({
+            let mut rules = make_rules(Some(other_host_id));
+            rules.push(RequestRule(
+                Condition::RequestOpcode(RequestOpcode::Query),
+                RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                    ResponseFrame {
+                        params: frame.params.for_response(),
+                        opcode: ResponseOpcode::Result,
+                        body: Bytes::from_static(b"\0\0\0\x03\0\x08keyspace"),
+                    }
+                })),
+            ));
+            rules
+        }));
+        let (connection, error_receiver) = open_connection(&endpoint, None, &connection_config)
+            .await
+            .unwrap();
+        let capture = CapturedLogs::default();
+        capturing_errors(&capture, || {
+            refiller.handle_ready_connection(OpenedConnectionEvent {
+                result: Ok((connection, error_receiver)),
+                requested_shard: None,
+                keyspace_name: None,
+            })
+        });
+        // The first pass only started the keyspace switch, so nothing is verified yet.
+        assert!(
+            capture.text().is_empty(),
+            "the keyspace switch must not report anything on its own, got: {}",
+            capture.text()
+        );
+        let evt = refiller.ready_connections.next().await.unwrap();
+        capturing_errors(&capture, || refiller.handle_ready_connection(evt));
+        let logs = capture.text();
+        assert_eq!(
+            logs.lines().count(),
+            1,
+            "a keyspace-bound connection must be reported exactly once, got: {logs}"
+        );
+
+        match proxy.finish().await {
+            Ok(()) | Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => {}
+            Err(err) => panic!("{err}"),
+        }
+        drop(refiller);
     }
 }

--- a/scylla/src/utils/test_utils.rs
+++ b/scylla/src/utils/test_utils.rs
@@ -17,7 +17,7 @@ use crate::policies::retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySessi
 use crate::routing::Shard;
 use crate::statement::unprepared::Statement;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::{num::NonZeroU32, time::Duration};
 
 pub(crate) fn unique_keyspace_name() -> String {
@@ -259,4 +259,46 @@ impl PerformDDL for Connection {
             .map(|_| ())
             .map_err(ExecutionError::LastAttemptError)
     }
+}
+
+/// A `tracing` writer that accumulates the emitted log text in memory, so that a test can
+/// assert on what was (and was not) logged.
+#[derive(Clone, Default)]
+pub(crate) struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+impl CapturedLogs {
+    pub(crate) fn text(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+
+impl std::io::Write for CapturedLogs {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = CapturedLogs;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Runs `f` with a scoped subscriber that appends everything logged at ERROR level to
+/// `capture`. Only works for synchronous `f`, which is what makes the thread-local dispatcher
+/// - and thus the capture - apply.
+pub(crate) fn capturing_errors<T>(capture: &CapturedLogs, f: impl FnOnce() -> T) -> T {
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::ERROR)
+        .without_time()
+        .finish();
+    tracing::subscriber::with_default(subscriber, f)
 }

--- a/scylla/tests/integration/session/host_id_mismatch.rs
+++ b/scylla/tests/integration/session/host_id_mismatch.rs
@@ -1,0 +1,169 @@
+//! Verifies that the driver reports (at ERROR level) a connection pool whose connections land on a
+//! node other than the one the pool serves.
+//!
+//! The mismatch is provoked with an address translator that redirects every node address the driver
+//! discovers - including the local node's own, which `query_peers` reads from `system.local` and
+//! marks translatable just like the `system.peers` rows - to node 0's proxy address. All three pools
+//! therefore connect to node 0 while the driver still believes it keeps one pool per host ID.
+//! Detection relies on the node advertising its host ID under the `SCYLLA_HOST_ID` key of the
+//! `SUPPORTED` response, so the test first inspects the real server's `SUPPORTED` frame and returns
+//! early on clusters (e.g. Cassandra) lacking it.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use scylla::client::PoolSize;
+use scylla::client::session_builder::SessionBuilder;
+use scylla_cql::frame::request::options::SCYLLA_HOST_ID;
+use scylla_cql::frame::response::Supported;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, ResponseOpcode, ResponseReaction, ResponseRule,
+    ShardAwareness, WorkerError,
+};
+use uuid::Uuid;
+
+use crate::utils::{
+    CapturedLogs, HEALTHCHECK_QUERY, run_capturing_errors, setup_tracing, test_with_3_node_cluster,
+    wait_until_all_nodes_are_connected,
+};
+
+#[test]
+fn mismatched_host_id_is_reported() {
+    setup_tracing();
+    let captured = CapturedLogs::default();
+    let logs_of_run = captured.clone();
+
+    let res = run_capturing_errors(
+        &captured,
+        test_with_3_node_cluster(
+            ShardAwareness::Unaware,
+            |proxy_uris, translation_map, mut running_proxy| async move {
+                // Installed before any session exists, so that the handshake's SUPPORTED frame is
+                // observed. The proxy forwards SUPPORTED unchanged, so this is the real server's
+                // advertisement.
+                let (supported_tx, mut supported_rx) = tokio::sync::mpsc::unbounded_channel();
+                running_proxy.running_nodes[0].change_response_rules(Some(vec![ResponseRule(
+                    Condition::ResponseOpcode(ResponseOpcode::Supported),
+                    ResponseReaction::noop().with_feedback_when_performed(supported_tx),
+                )]));
+
+                // Every node address the driver discovers is translated to node 0's proxy address. The
+                // map must cover all three nodes, the local one included: `query_peers` marks it
+                // translatable too, so a missing entry would fail its pool with `NoRuleForAddress`.
+                // The driver thus keeps three `Node`s with three distinct host IDs, while each of the
+                // three pools opens its connections to node 0, which reports its own host ID - a
+                // mismatch for two of the three pools.
+                let first_proxy_addr = SocketAddr::from_str(&proxy_uris[0]).unwrap();
+                let all_to_first: HashMap<SocketAddr, SocketAddr> = translation_map
+                    .keys()
+                    .map(|&real| (real, first_proxy_addr))
+                    .collect();
+
+                let session = SessionBuilder::new()
+                    // Contact points are never translated, so the control connection reaches node 0
+                    // normally and metadata fetch works.
+                    .known_node(proxy_uris[0].as_str())
+                    .address_translator(Arc::new(all_to_first))
+                    // Exactly one connection, hence exactly one report, per pool.
+                    .pool_size(PoolSize::PerHost(1.try_into().unwrap()))
+                    .disallow_shard_aware_port(true)
+                    .fetch_schema_metadata(false)
+                    // Off as well, so that the session does not warn about the two flags disagreeing.
+                    .fetch_full_schema_metadata(false)
+                    .keyspaces_to_fetch(std::iter::empty::<String>())
+                    .build()
+                    .await
+                    .unwrap();
+
+                let supported_frame = supported_rx.recv().await.unwrap().0;
+                let options = Supported::deserialize(&mut &*supported_frame.body)
+                    .unwrap()
+                    .options;
+                if !options.contains_key(SCYLLA_HOST_ID) {
+                    // `println!` as well as the log, because the default `EnvFilter` drops WARN and this
+                    // notice is the only sign that the test asserted nothing.
+                    let msg = format!(
+                        "SKIPPING ASSERTIONS: the cluster does not advertise the {SCYLLA_HOST_ID} key \
+                     in its SUPPORTED response, so the driver cannot detect host ID mismatches at \
+                     all and this test can verify nothing."
+                    );
+                    println!("{msg}");
+                    tracing::warn!("{msg}");
+                    return running_proxy;
+                }
+
+                // Race-free without any sleep: `verify_host_id` logs the mismatch before
+                // `update_shared_conns` publishes the connections, so a pool cannot be seen as
+                // connected before its report has reached the capture buffer.
+                wait_until_all_nodes_are_connected(3, &session).await;
+
+                // All connections land on node 0, so any query is answered by node 0 and
+                // `system.local.host_id` - which the spec guarantees to equal the host ID advertised in
+                // SUPPORTED - identifies the node the pools actually reach.
+                let (reached_host_id,): (Uuid,) = session
+                    .query_unpaged(HEALTHCHECK_QUERY, &[])
+                    .await
+                    .unwrap()
+                    .into_rows_result()
+                    .unwrap()
+                    .single_row::<(Uuid,)>()
+                    .unwrap();
+
+                let logs = logs_of_run.text();
+                let reached_str = reached_host_id.to_string();
+                let reports: Vec<&str> = logs
+                    .lines()
+                    .filter(|line| line.contains(&reached_str))
+                    .collect();
+
+                let mismatching: Vec<Uuid> = session
+                    .get_cluster_state()
+                    .get_nodes_info()
+                    .iter()
+                    .map(|node| node.host_id)
+                    .filter(|&host_id| host_id != reached_host_id)
+                    .collect();
+                assert_eq!(
+                    mismatching.len(),
+                    2,
+                    "expected the 3-node harness to yield 2 host IDs other than the reached one \
+                 ({reached_host_id}), got {mismatching:?}"
+                );
+
+                assert!(
+                    !reports.is_empty(),
+                    "no ERROR log mentions the reached host ID {reached_host_id}; captured logs:\n{logs}"
+                );
+
+                for host_id in &mismatching {
+                    assert!(
+                        reports
+                            .iter()
+                            .any(|line| line.contains(&host_id.to_string())),
+                        "no mismatch reported for the pool of host ID {host_id} (reached host ID is \
+                     {reached_host_id}); captured logs:\n{logs}"
+                    );
+                }
+
+                for line in &reports {
+                    assert!(
+                        mismatching
+                            .iter()
+                            .any(|host_id| line.contains(&host_id.to_string())),
+                        "a mismatch was reported for a pool that reached its own node ({reached_host_id}): \
+                     {line}\ncaptured logs:\n{logs}"
+                    );
+                }
+
+                running_proxy
+            },
+        ),
+    );
+
+    match res {
+        Ok(()) | Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{err}"),
+    }
+}

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -2,6 +2,7 @@ mod caching_session;
 mod cluster_reachability;
 mod db_errors;
 mod history;
+mod host_id_mismatch;
 mod internal_requests;
 #[cfg(feature = "metrics")]
 mod metrics;

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -32,7 +32,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU32;
 use std::process::Command;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{env, iter};
 use tokio::sync::mpsc;
@@ -56,6 +56,70 @@ pub(crate) fn setup_tracing() {
         .with(testing_layer)
         .with(noop_layer)
         .try_init();
+}
+
+/// A `tracing` writer that accumulates the emitted log text in memory, so that a test can assert
+/// on log-only driver behaviour.
+#[derive(Clone, Default)]
+pub(crate) struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+impl CapturedLogs {
+    pub(crate) fn text(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+
+impl std::io::Write for CapturedLogs {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = CapturedLogs;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Drives `test_body` to completion with everything it logs at ERROR level appended to `capture`.
+///
+/// The driver emits the logs a test may want to assert on from tasks it spawns itself, so the
+/// capturing subscriber has to be active while those tasks are polled. A **scoped** subscriber
+/// suffices because the runtime built here is current-thread, so it polls every task on this very
+/// thread, inside the `with_default` scope - which is also what `#[tokio::test]` does, hence the
+/// hand-rolled runtime rather than that attribute.
+///
+/// A global subscriber is deliberately not used: `cargo test` runs the whole integration binary in
+/// one process, where only the first installation would win and the buffer would additionally
+/// receive errors from tests running concurrently.
+///
+/// Being thread-local is also what keeps the capture free of errors logged by tests running
+/// concurrently in the same process. The flip side is that anything the driver logs off this
+/// thread - currently only `tokio::task::spawn_blocking` work - falls back to the global
+/// subscriber and is not captured.
+pub(crate) fn run_capturing_errors<F: Future>(capture: &CapturedLogs, test_body: F) -> F::Output {
+    let testing_layer = tracing_subscriber::fmt::layer()
+        .with_test_writer()
+        .with_filter(tracing_subscriber::EnvFilter::from_default_env());
+    let capturing_layer = tracing_subscriber::fmt::layer()
+        .with_writer(capture.clone())
+        .with_filter(tracing_subscriber::filter::LevelFilter::ERROR);
+    let subscriber = tracing_subscriber::registry()
+        .with(testing_layer)
+        .with(capturing_layer);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    tracing::subscriber::with_default(subscriber, || runtime.block_on(test_body))
 }
 
 /// Finds the local IP address for a given destination IP address.


### PR DESCRIPTION
Recently Scylla added a SCYLLA_HOST_ID key to SUPPORTED message.

It lets drivers discover that they connected to a different node than they expected - because a broken networking setup or a broken AddressTranslator. 

This PR utilizes this new information to warn about such broken setups.

Why not error the connection out? In some cases such misconfiguration might be deliberate - for example in cqlsh-rs. I think breaking the connection would be too severe here.


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1871
Fixes: https://scylladb.atlassian.net/browse/DRIVER-873

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
