### PR TITLE
Add a new OpenSSL variant of TlsContext

### DIFF
--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -69,6 +69,10 @@ address in its subject alternative name. Replace that trust with `set_cert_store
 Beware that `set_ca_file` *adds* to the trusted set rather than replacing it, so it does not
 narrow anything down on its own.
 
+**_NOTE:_** Passing an already-built `SslContext` (`TlsContext::OpenSsl010`) still works, but is
+deprecated since 1.9.0: the driver cannot configure a context it did not build, so such a context
+cannot support TLS session tickets.
+
 For example, if database certificate is in the file `ca.crt`:
 ```rust
 # extern crate scylla;

--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -23,7 +23,7 @@ For rustls, we use `ServerName::IpAddress`, which is passed to `ClientConnection
 To enable use of TLS using `openssl`, add in `Cargo.toml`:
 
 ```toml
-scylla = { version = "0.4", features = ["openssl-010"] }
+scylla = { version = "1.8", features = ["openssl-010"] }
 openssl = "0.10.70"
 ```
 

--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -51,35 +51,48 @@ Then install the package with `openssl`:
     ```
 
 ### Using TLS
-To use TLS you will have to a `TlsContext`. For convenience, both an
-openssl
-[`SslContext`](https://docs.rs/openssl/0.10.33/openssl/ssl/struct.SslContext.html)
-and a rustls
+To use TLS you will have to create a `TlsContext`. For the openssl backend, build an
+[`SslConnector`](https://docs.rs/openssl/0.10/openssl/ssl/struct.SslConnector.html)
+builder and wrap it in an `OpenSsl010Config`; for rustls, an `Arc` of a
 [`ClientConfig`](https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html)
-can be automatically converted to a `TlsContext` when passing to
-`SessionBuilder`.
+is automatically converted to a `TlsContext` when passing it to `SessionBuilder`.
 
-**_NOTE:_** Recommended API in `openssl` crate is `SslConnector`, because it has safer defaults. Please use it, and then call `into_context()` to
-get `SslContext` instance you can pass to the driver.
+**_NOTE:_** `SslConnector` is the recommended openssl API, because it has safe defaults
+(most notably, it verifies the peer's certificate). If you really need full control, you
+can build the context from a raw `SslContextBuilder` with
+`OpenSsl010Config::from_dangerous_builder`, which has no such defaults.
+
+**_NOTE:_** `SslConnector` also trusts the system's CA store, because it calls
+`set_default_verify_paths`. If your cluster has its own CA, that may be wider than you want: a
+certificate chaining to any public root would be accepted as long as it carries the node's IP
+address in its subject alternative name. Replace that trust with `set_cert_store`, as below.
+Beware that `set_ca_file` *adds* to the trusted set rather than replacing it, so it does not
+narrow anything down on its own.
 
 For example, if database certificate is in the file `ca.crt`:
 ```rust
 # extern crate scylla;
 # extern crate openssl;
-use scylla::client::session::Session;
+use scylla::client::session::{OpenSsl010Config, Session};
 use scylla::client::session_builder::SessionBuilder;
-use openssl::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
-use std::path::PathBuf;
+use openssl::ssl::{SslConnector, SslMethod};
+use openssl::x509::X509;
+use openssl::x509::store::X509StoreBuilder;
 
 # use std::error::Error;
 # async fn check_only_compiles() -> Result<(), Box<dyn Error>> {
-let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
-context_builder.set_ca_file("ca.crt")?;
-context_builder.set_verify(SslVerifyMode::PEER);
+let mut builder = SslConnector::builder(SslMethod::tls())?;
+
+// Trust the cluster's CA, and nothing else.
+let mut ca_store = X509StoreBuilder::new()?;
+for cert in X509::stack_from_pem(&std::fs::read("ca.crt")?)? {
+    ca_store.add_cert(cert)?;
+}
+builder.set_cert_store(ca_store.build());
 
 let session: Session = SessionBuilder::new()
     .known_node("127.0.0.1:9142") // The the port is now 9142
-    .tls_context(Some(context_builder.build()))
+    .tls_context(Some(OpenSsl010Config::new(builder)))
     .build()
     .await?;
 

--- a/docs/source/connecting/tls.md
+++ b/docs/source/connecting/tls.md
@@ -91,7 +91,7 @@ for cert in X509::stack_from_pem(&std::fs::read("ca.crt")?)? {
 builder.set_cert_store(ca_store.build());
 
 let session: Session = SessionBuilder::new()
-    .known_node("127.0.0.1:9142") // The the port is now 9142
+    .known_node("127.0.0.1:9142") // The port is now 9142
     .tls_context(Some(OpenSsl010Config::new(builder)))
     .build()
     .await?;

--- a/examples/tls_openssl.rs
+++ b/examples/tls_openssl.rs
@@ -5,9 +5,10 @@
 //! generic one to point at.
 
 use anyhow::Result;
-use openssl::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
+use openssl::ssl::{SslConnector, SslMethod};
 use openssl::x509::X509;
-use scylla::client::session::Session;
+use openssl::x509::store::X509StoreBuilder;
+use scylla::client::session::{OpenSsl010Config, Session};
 
 // Not an example itself: shared CI-only cluster setup, see `examples/ci/`.
 #[path = "ci/tls_cluster.rs"]
@@ -26,21 +27,22 @@ async fn main() -> Result<()> {
     let session_builder = cluster.session_builder().await;
     // --- end of CI setup --------------------------------------------------
 
-    // Teach openssl to trust the certificate authority that signed the nodes'
-    // certificates. Had the CA been handed to us as a `ca.crt` file, this would
-    // be `context_builder.set_ca_file("ca.crt")?`.
-    let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
-    context_builder
-        .cert_store_mut()
-        .add_cert(X509::from_der(ca_cert_der)?)?;
-    // Verify the node's certificate. The driver additionally checks that the
-    // certificate covers the IP address it connected to, so the nodes' certs
-    // must carry that address in their subject alternative name.
-    context_builder.set_verify(SslVerifyMode::PEER);
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    // Trust the certificate authority that signed the nodes' certificates, and
+    // nothing else: `SslConnector` starts out trusting the system roots, which may not be
+    // what you want if you use your own CA. `builder.set_ca_file("ca.crt")?` is the
+    // shorter route when the CA is a file, but it adds to that default trust instead
+    // of replacing it.
+    let mut ca_store = X509StoreBuilder::new()?;
+    ca_store.add_cert(X509::from_der(ca_cert_der)?)?;
+    builder.set_cert_store(ca_store.build());
+    // `SslConnector` verifies the node's certificate by default. The driver
+    // additionally checks that the certificate covers the IP address it
+    // connected to, so the nodes' certs must carry that address in their
+    // subject alternative name.
 
-    // An `SslContext` is accepted by `tls_context` directly.
     let session: Session = session_builder
-        .tls_context(Some(context_builder.build()))
+        .tls_context(Some(OpenSsl010Config::new(builder)))
         .build()
         .await?;
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -156,7 +156,14 @@ impl std::fmt::Debug for Session {
 #[non_exhaustive]
 pub enum TlsContext {
     /// TLS context backed by OpenSSL 0.10.
+    ///
+    /// Deprecated in favour of [`TlsContext::OpenSsl010Config`].
     #[cfg(feature = "openssl-010")]
+    #[deprecated(
+        since = "1.9.0",
+        note = "the driver cannot configure a context it did not build, so this variant \
+                cannot support TLS session tickets; use `OpenSsl010Config` instead"
+    )]
     OpenSsl010(openssl::ssl::SslContext),
     /// TLS context backed by OpenSSL 0.10, created from a builder.
     #[cfg(feature = "openssl-010")]
@@ -169,9 +176,16 @@ pub enum TlsContext {
 #[cfg(feature = "openssl-010")]
 pub use crate::network::tls::openssl::OpenSsl010Config;
 
+/// Deprecated since 1.9.0: prefer [`TlsContext::OpenSsl010Config`].
+///
+/// An already-built `SslContext` cannot be configured by the driver, so it cannot support
+/// TLS session tickets.
+// Documentation-only: rustc rejects `#[deprecated]` on a trait impl block and on a trait
+// method inside one, so this conversion cannot warn at the call site.
 #[cfg(feature = "openssl-010")]
 impl From<openssl::ssl::SslContext> for TlsContext {
     fn from(value: openssl::ssl::SslContext) -> Self {
+        #[expect(deprecated)] // This is the deprecated variant we still have to support.
         TlsContext::OpenSsl010(value)
     }
 }

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -158,10 +158,16 @@ pub enum TlsContext {
     /// TLS context backed by OpenSSL 0.10.
     #[cfg(feature = "openssl-010")]
     OpenSsl010(openssl::ssl::SslContext),
+    /// TLS context backed by OpenSSL 0.10, created from a builder.
+    #[cfg(feature = "openssl-010")]
+    OpenSsl010Config(OpenSsl010Config),
     /// TLS context backed by Rustls 0.23.
     #[cfg(feature = "rustls-023")]
     Rustls023(Arc<rustls::ClientConfig>),
 }
+
+#[cfg(feature = "openssl-010")]
+pub use crate::network::tls::openssl::OpenSsl010Config;
 
 #[cfg(feature = "openssl-010")]
 impl From<openssl::ssl::SslContext> for TlsContext {

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -345,24 +345,39 @@ impl<K: SessionBuilderKindSupportsTls> GenericSessionBuilder<K> {
     #[cfg_attr(
         feature = "openssl-010",
         doc = r#"
-# Example
+# OpenSSL 0.10 example
 
 ```
     # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     use std::fs;
     use std::path::PathBuf;
-    use scylla::client::session::Session;
+    use scylla::client::session::{OpenSsl010Config, Session};
     use scylla::client::session_builder::SessionBuilder;
-    use openssl::ssl::{SslContextBuilder, SslVerifyMode, SslMethod, SslFiletype};
+    use openssl::ssl::{SslConnector, SslMethod};
+    use openssl::x509::X509;
+    use openssl::x509::store::X509StoreBuilder;
 
-    let certdir = fs::canonicalize(PathBuf::from("./examples/certs/scylla.crt"))?;
-    let mut context_builder = SslContextBuilder::new(SslMethod::tls())?;
-    context_builder.set_certificate_file(certdir.as_path(), SslFiletype::PEM)?;
-    context_builder.set_verify(SslVerifyMode::NONE);
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    let certdir = fs::canonicalize(PathBuf::from("ca.crt"))?;
+
+    {
+        // Trust the cluster's CA, and nothing else. `SslConnector` would otherwise also
+        // trust the system's CA store, which is not always what you want.
+        let mut ca_store = X509StoreBuilder::new()?;
+        for cert in X509::stack_from_pem(&fs::read("ca.crt")?)? {
+            ca_store.add_cert(cert)?;
+        }
+        builder.set_cert_store(ca_store.build());
+    }
+
+    {
+        // The alternative to the above, if you are fine with also trusting system CA store.
+        builder.set_ca_file(certdir.as_path())?;
+    }
 
     let session: Session = SessionBuilder::new()
         .known_node("127.0.0.1:9042")
-        .tls_context(Some(context_builder.build()))
+        .tls_context(Some(OpenSsl010Config::new(builder)))
         .build()
         .await?;
     # Ok(())

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -128,6 +128,8 @@ impl TlsConfig {
     pub(crate) fn new_tls(&self) -> Result<Tls, TlsError> {
         match self.context {
             #[cfg(feature = "openssl-010")]
+            // `TlsContext::OpenSsl010` is the deprecated variant we still have to support.
+            #[expect(deprecated)]
             TlsContext::OpenSsl010(ref context) => Ok(Tls::OpenSsl010(openssl::new_ssl(context)?)),
             #[cfg(feature = "openssl-010")]
             TlsContext::OpenSsl010Config(ref context) => Ok(Tls::OpenSsl010(context.new_ssl()?)),

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -2,7 +2,7 @@
 //!
 //! The full picture looks like this:
 //!
-//! ┌─←─ TlsContext (openssl::SslContext / rustls::ClientConfig)
+//! ┌─←─ TlsContext (OpenSsl010Config / openssl::SslContext / rustls::ClientConfig)
 //! │
 //! │ gets wrapped in
 //! │
@@ -129,6 +129,8 @@ impl TlsConfig {
         match self.context {
             #[cfg(feature = "openssl-010")]
             TlsContext::OpenSsl010(ref context) => Ok(Tls::OpenSsl010(openssl::new_ssl(context)?)),
+            #[cfg(feature = "openssl-010")]
+            TlsContext::OpenSsl010Config(ref context) => Ok(Tls::OpenSsl010(context.new_ssl()?)),
             #[cfg(feature = "rustls-023")]
             TlsContext::Rustls023(ref config) => {
                 let connector = tokio_rustls::TlsConnector::from(config.clone());

--- a/scylla/src/network/tls.rs
+++ b/scylla/src/network/tls.rs
@@ -26,6 +26,9 @@
 
 use std::io;
 
+#[cfg(feature = "openssl-010")]
+pub(crate) mod openssl;
+
 use crate::client::session::TlsContext;
 use crate::cluster::metadata::UntranslatedEndpoint;
 
@@ -72,7 +75,7 @@ pub(crate) struct TlsConfig {
 /// An abstraction over connection's TLS layer which holds its state and configuration.
 pub(crate) enum Tls {
     #[cfg(feature = "openssl-010")]
-    OpenSsl010(openssl::ssl::Ssl),
+    OpenSsl010(::openssl::ssl::Ssl),
     #[cfg(feature = "rustls-023")]
     Rustls023 {
         connector: tokio_rustls::TlsConnector,
@@ -88,7 +91,7 @@ pub(crate) enum Tls {
 pub enum TlsError {
     /// Collection of errors coming from OpenSSL 0.10.
     #[cfg(feature = "openssl-010")]
-    OpenSsl010(#[from] openssl::error::ErrorStack),
+    OpenSsl010(#[from] ::openssl::error::ErrorStack),
     /// Invalid DNS name error, coming from rustls 0.23.
     #[cfg(feature = "rustls-023")]
     InvalidName(#[from] rustls::pki_types::InvalidDnsNameError),
@@ -125,12 +128,7 @@ impl TlsConfig {
     pub(crate) fn new_tls(&self) -> Result<Tls, TlsError> {
         match self.context {
             #[cfg(feature = "openssl-010")]
-            TlsContext::OpenSsl010(ref context) => {
-                #[allow(unused_mut)]
-                let mut ssl = openssl::ssl::Ssl::new(context)?;
-                ssl.set_connect_state();
-                Ok(Tls::OpenSsl010(ssl))
-            }
+            TlsContext::OpenSsl010(ref context) => Ok(Tls::OpenSsl010(openssl::new_ssl(context)?)),
             #[cfg(feature = "rustls-023")]
             TlsContext::Rustls023(ref config) => {
                 let connector = tokio_rustls::TlsConnector::from(config.clone());

--- a/scylla/src/network/tls/openssl.rs
+++ b/scylla/src/network/tls/openssl.rs
@@ -1,0 +1,11 @@
+//! The OpenSSL 0.10 TLS backend of the driver.
+
+use openssl::error::ErrorStack;
+use openssl::ssl::{Ssl, SslContext};
+
+/// Creates a fresh per-connection [`Ssl`] object out of an [`SslContext`].
+pub(crate) fn new_ssl(context: &SslContext) -> Result<Ssl, ErrorStack> {
+    let mut ssl = Ssl::new(context)?;
+    ssl.set_connect_state();
+    Ok(ssl)
+}

--- a/scylla/src/network/tls/openssl.rs
+++ b/scylla/src/network/tls/openssl.rs
@@ -1,11 +1,79 @@
 //! The OpenSSL 0.10 TLS backend of the driver.
 
 use openssl::error::ErrorStack;
-use openssl::ssl::{Ssl, SslContext};
+use openssl::ssl::{Ssl, SslConnectorBuilder, SslContext, SslContextBuilder};
+
+use crate::client::session::TlsContext;
+
+/// A TLS context backed by OpenSSL 0.10.
+///
+/// This is the recommended way of configuring the OpenSSL backend of the driver.
+/// Create it from an [`SslConnectorBuilder`] with [`OpenSsl010Config::new`].
+#[derive(Clone)] // Cheaply clonable - reference counted.
+pub struct OpenSsl010Config {
+    context: SslContext,
+}
+
+impl OpenSsl010Config {
+    /// Creates a new context from an [`SslConnectorBuilder`].
+    ///
+    /// This is the recommended constructor: [`SslConnector`](openssl::ssl::SslConnector)
+    /// comes with safe defaults, most notably peer certificate verification.
+    pub fn new(mut builder: SslConnectorBuilder) -> Self {
+        // `SslConnectorBuilder` cannot be unwrapped into its `SslContextBuilder`,
+        // but it dereferences to it, which is enough to configure it.
+        Self::configure(&mut builder);
+        Self {
+            context: builder.build().into_context(),
+        }
+    }
+
+    /// Creates a new context from a raw [`SslContextBuilder`].
+    ///
+    /// This is **dangerous**: unlike [`SslConnector`](openssl::ssl::SslConnector),
+    /// a bare [`SslContextBuilder`] has insecure defaults - in particular, it does
+    /// not verify the peer's certificate at all. Prefer [`OpenSsl010Config::new`]
+    /// unless you really need full control over the context.
+    pub fn from_dangerous_builder(mut builder: SslContextBuilder) -> Self {
+        Self::configure(&mut builder);
+        Self {
+            context: builder.build(),
+        }
+    }
+
+    /// The single place where the driver configures a context builder,
+    /// shared by both constructors.
+    // For now it is empty. It will be used in the future for TLS tickets,
+    // and possibly other stuff.
+    fn configure(_builder: &mut SslContextBuilder) {}
+
+    /// Creates a fresh per-connection [`Ssl`] object out of this context.
+    pub(crate) fn new_ssl(&self) -> Result<Ssl, ErrorStack> {
+        new_ssl(&self.context)
+    }
+}
 
 /// Creates a fresh per-connection [`Ssl`] object out of an [`SslContext`].
 pub(crate) fn new_ssl(context: &SslContext) -> Result<Ssl, ErrorStack> {
     let mut ssl = Ssl::new(context)?;
     ssl.set_connect_state();
     Ok(ssl)
+}
+
+impl From<SslConnectorBuilder> for OpenSsl010Config {
+    fn from(builder: SslConnectorBuilder) -> Self {
+        Self::new(builder)
+    }
+}
+
+impl From<OpenSsl010Config> for TlsContext {
+    fn from(context: OpenSsl010Config) -> Self {
+        TlsContext::OpenSsl010Config(context)
+    }
+}
+
+impl From<SslConnectorBuilder> for TlsContext {
+    fn from(builder: SslConnectorBuilder) -> Self {
+        TlsContext::OpenSsl010Config(OpenSsl010Config::new(builder))
+    }
 }

--- a/scylla/tests/integration/ccm/tls.rs
+++ b/scylla/tests/integration/ccm/tls.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use openssl::pkey::PKey;
-use openssl::ssl::{SslContext, SslMethod, SslVerifyMode};
+use openssl::ssl::{SslConnector, SslContext, SslContextBuilder, SslMethod, SslVerifyMode};
 use openssl::x509::X509;
 use openssl::x509::store::{X509Store, X509StoreBuilder};
 use rcgen::{
@@ -12,7 +12,7 @@ use rcgen::{
 };
 use rustls::ClientConfig;
 use rustls::pki_types::PrivatePkcs8KeyDer;
-use scylla::client::session::TlsContext;
+use scylla::client::session::{OpenSsl010Config, TlsContext};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
@@ -139,6 +139,55 @@ pub(super) fn build_openssl_ca_store(ca: &CertifiedIssuer<'_, KeyPair>) -> X509S
     store_builder.build()
 }
 
+/// The [`TlsContext::OpenSsl010`] flavour: a raw [`SslContextBuilder`], built into an
+/// [`SslContext`] that the driver can only use as-is.
+///
+/// A bare [`SslContextBuilder`] verifies nothing at all by default, so peer verification
+/// has to be switched on here - which is exactly why the driver recommends the other
+/// flavour.
+pub(super) fn openssl_010_context(configure: impl FnOnce(&mut SslContextBuilder)) -> TlsContext {
+    let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
+    builder.set_verify(SslVerifyMode::PEER);
+    configure(&mut builder);
+    TlsContext::OpenSsl010(builder.build())
+}
+
+/// The [`TlsContext::OpenSsl010Config`] flavour: an `SslConnectorBuilder`, which the
+/// driver finishes into a context itself.
+///
+/// Deliberately goes through [`SslConnector`], the recommended API: it already verifies
+/// the peer and is stricter than a bare context builder besides (restricted cipher list,
+/// `SslOptions::ALL`, no compression, no SSLv2/SSLv3), so this is what proves the driver
+/// works under those defaults rather than only under permissive ones.
+///
+/// Yields the [`OpenSsl010Config`] rather than a [`TlsContext`], because that is the type
+/// carrying the driver's own knobs; callers that just want a context can `.into()` it.
+pub(super) fn openssl_010_builder_context(
+    configure: impl FnOnce(&mut SslContextBuilder),
+) -> OpenSsl010Config {
+    let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    // `SslConnectorBuilder` derefs to `SslContextBuilder`, so the same configuration
+    // applies to both flavours.
+    configure(&mut builder);
+    OpenSsl010Config::new(builder)
+}
+
+/// Both openssl-backed [`TlsContext`] flavours, from one shared configuration.
+///
+/// From the driver's point of view these are two different backends, so every openssl
+/// sub-test has to cover both.
+pub(super) fn openssl_contexts(
+    configure: impl Fn(&mut SslContextBuilder),
+) -> [(&'static str, TlsContext); 2] {
+    [
+        ("OpenSsl010", openssl_010_context(&configure)),
+        (
+            "OpenSsl010Config",
+            openssl_010_builder_context(&configure).into(),
+        ),
+    ]
+}
+
 // Basic TLS test, with server not requiring client authentication.
 // It checks that driver can connect to all nodes of TLS-enabled cluster,
 // and execute requests on them.
@@ -154,15 +203,17 @@ async fn test_connect_tls_no_client_auth() {
     }
 
     async fn test(ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster) {
-        {
-            tracing::info!("OpenSsl010 sub-test");
-            let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
-            builder.set_verify(SslVerifyMode::PEER);
+        // Trust our CA and nothing else. Replaces the default verify paths that
+        // `SslConnector` sets up, so the two flavours end up trusting the same thing.
+        let configure = |builder: &mut SslContextBuilder| {
             builder.set_cert_store(build_openssl_ca_store(ca));
+        };
+        for (name, tls_context) in openssl_contexts(configure) {
+            tracing::info!("{name} sub-test");
             let session = cluster
                 .make_session_builder()
                 .await
-                .tls_context(Some(TlsContext::OpenSsl010(builder.build())))
+                .tls_context(Some(tls_context))
                 .build()
                 .await
                 .unwrap();
@@ -205,15 +256,15 @@ async fn test_tls_verifies_hostname() {
     }
 
     async fn test(ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster) {
-        {
-            tracing::info!("OpenSsl010 sub-test");
-            let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
-            builder.set_verify(SslVerifyMode::PEER);
+        let configure = |builder: &mut SslContextBuilder| {
             builder.set_cert_store(build_openssl_ca_store(ca));
+        };
+        for (name, tls_context) in openssl_contexts(configure) {
+            tracing::info!("{name} sub-test");
             let _err = cluster
                 .make_session_builder()
                 .await
-                .tls_context(Some(TlsContext::OpenSsl010(builder.build())))
+                .tls_context(Some(tls_context))
                 .build()
                 .await
                 .unwrap_err();
@@ -286,10 +337,7 @@ async fn test_connect_tls_with_client_auth() {
             .signed_by(&client_key, ca)
             .unwrap();
 
-        {
-            tracing::info!("OpenSsl010 sub-test");
-            let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
-            builder.set_verify(SslVerifyMode::PEER);
+        let configure = |builder: &mut SslContextBuilder| {
             builder.set_cert_store(build_openssl_ca_store(ca));
             builder
                 .set_certificate(&X509::from_der(client_cert.der()).unwrap())
@@ -299,10 +347,13 @@ async fn test_connect_tls_with_client_auth() {
                     &PKey::private_key_from_pkcs8(client_key.serialized_der()).unwrap(),
                 )
                 .unwrap();
+        };
+        for (name, tls_context) in openssl_contexts(configure) {
+            tracing::info!("{name} sub-test");
             let session = cluster
                 .make_session_builder()
                 .await
-                .tls_context(Some(TlsContext::OpenSsl010(builder.build())))
+                .tls_context(Some(tls_context))
                 .build()
                 .await
                 .unwrap();

--- a/scylla/tests/integration/ccm/tls.rs
+++ b/scylla/tests/integration/ccm/tls.rs
@@ -144,11 +144,13 @@ pub(super) fn build_openssl_ca_store(ca: &CertifiedIssuer<'_, KeyPair>) -> X509S
 ///
 /// A bare [`SslContextBuilder`] verifies nothing at all by default, so peer verification
 /// has to be switched on here - which is exactly why the driver recommends the other
-/// flavour.
+/// flavour, and why this one is deprecated. Deprecated is not unsupported, though, so
+/// the tests keep covering it.
 pub(super) fn openssl_010_context(configure: impl FnOnce(&mut SslContextBuilder)) -> TlsContext {
     let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
     builder.set_verify(SslVerifyMode::PEER);
     configure(&mut builder);
+    #[expect(deprecated)]
     TlsContext::OpenSsl010(builder.build())
 }
 

--- a/scylla/tests/integration/ccm/tls_tickets.rs
+++ b/scylla/tests/integration/ccm/tls_tickets.rs
@@ -1,11 +1,12 @@
 //! Tests verifying TLS session resumption (via TLS session tickets / PSK) behaviour
-//! of the driver's two TLS backends.
+//! of the driver's TLS backends.
 //!
 //! Expectation being verified:
 //! - the rustls backend reuses session tickets; TLS 1.2 pools resume every connection after
 //!   the first, while TLS 1.3 pools resume at least two connections per node,
-//! - the openssl backend (as used by the driver) does NOT reuse session tickets, so every
-//!   connection performs a full handshake.
+//! - neither openssl backend reuses session tickets, so every connection performs a full
+//!   handshake. That holds both for `TlsContext::OpenSsl010`, which takes an already-built
+//!   `SslContext`, and for `OpenSsl010Config`, which the driver builds itself.
 //!
 //! This is verified for both TLS 1.2 and TLS 1.3.
 //!
@@ -38,7 +39,7 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use openssl::ssl::{SslContext, SslMethod, SslVerifyMode, SslVersion};
+use openssl::ssl::{SslContextBuilder, SslVersion};
 use rcgen::{CertificateParams, CertifiedIssuer, KeyPair, SanType};
 use rustls::ClientConfig;
 use scylla::client::PoolSize;
@@ -47,7 +48,9 @@ use scylla::client::session_builder::SessionBuilder;
 use scylla_proxy::get_exclusive_local_address;
 use tokio::net::TcpListener;
 
-use super::tls::{build_openssl_ca_store, run_ccm_tls_test};
+use super::tls::{
+    build_openssl_ca_store, openssl_010_builder_context, openssl_010_context, run_ccm_tls_test,
+};
 use super::tls_inspecting_proxy::{ConnRecord, Handshake, SharedRecords, TlsVersion, run_proxy};
 use crate::utils::setup_tracing;
 use scylla_ccm_bridge::cluster::Cluster;
@@ -59,7 +62,10 @@ const CQL_PORT: u16 = 9042;
 #[derive(Clone, Copy, Debug)]
 enum Backend {
     Rustls023,
+    /// The variant taking an already-built `SslContext`.
     OpenSsl010,
+    /// The variant taking an `SslConnectorBuilder`, which the driver finishes itself.
+    OpenSsl010Config,
 }
 
 impl Backend {
@@ -67,9 +73,9 @@ impl Backend {
     fn reuses_session_tickets(self) -> bool {
         match self {
             Backend::Rustls023 => true,
-            // The driver builds a fresh `Ssl` from the `SslContext` per connection and
-            // never calls `SSL_set_session`.
-            Backend::OpenSsl010 => false,
+            // For either openssl flavour the driver builds a fresh `Ssl` from the
+            // `SslContext` per connection and never calls `SSL_set_session`.
+            Backend::OpenSsl010 | Backend::OpenSsl010Config => false,
         }
     }
 }
@@ -157,9 +163,13 @@ const TLS13_TICKETS_PER_HANDSHAKE: usize = 2;
 // TLS context construction
 // -----------------------------------------------------------------------------
 
-fn make_openssl_010_context(ca: &CertifiedIssuer<'_, KeyPair>, version: TlsVersion) -> SslContext {
-    let mut builder = SslContext::builder(SslMethod::tls()).unwrap();
-    builder.set_verify(SslVerifyMode::PEER);
+/// The configuration both openssl flavours share: trust only `ca`, and pin the TLS
+/// version so that a sub-test cannot silently exercise the wrong one.
+fn configure_openssl(
+    builder: &mut SslContextBuilder,
+    ca: &CertifiedIssuer<'_, KeyPair>,
+    version: TlsVersion,
+) {
     builder.set_cert_store(build_openssl_ca_store(ca));
     let ssl_version = match version {
         TlsVersion::V1_2 => SslVersion::TLS1_2,
@@ -167,7 +177,6 @@ fn make_openssl_010_context(ca: &CertifiedIssuer<'_, KeyPair>, version: TlsVersi
     };
     builder.set_min_proto_version(Some(ssl_version)).unwrap();
     builder.set_max_proto_version(Some(ssl_version)).unwrap();
-    builder.build()
 }
 
 fn make_rustls_023_config(
@@ -274,9 +283,11 @@ async fn run_subtest(
     tracing::info!("TLS session ticket sub-test: {case}");
 
     // A fresh TLS context per sub-test, hence a fresh (empty) session cache.
+    let configure = |builder: &mut SslContextBuilder| configure_openssl(builder, ca, version);
     let tls_context: TlsContext = match backend {
         Backend::Rustls023 => TlsContext::Rustls023(make_rustls_023_config(ca, version)),
-        Backend::OpenSsl010 => TlsContext::OpenSsl010(make_openssl_010_context(ca, version)),
+        Backend::OpenSsl010 => openssl_010_context(configure),
+        Backend::OpenSsl010Config => openssl_010_builder_context(configure).into(),
     };
 
     // One pool of POOL_SIZE connections per node, plus the single control connection,
@@ -406,7 +417,7 @@ async fn enable_session_tickets(mut cluster: Cluster) -> Cluster {
     cluster
 }
 
-/// Verifies TLS session-ticket resumption behaviour of both TLS backends, for both
+/// Verifies TLS session-ticket resumption behaviour of every TLS backend, for both
 /// TLS 1.2 and TLS 1.3.
 #[tokio::test]
 async fn test_tls_session_tickets() {
@@ -470,6 +481,8 @@ async fn test_tls_session_tickets() {
                     (Backend::Rustls023, TlsVersion::V1_3),
                     (Backend::OpenSsl010, TlsVersion::V1_2),
                     (Backend::OpenSsl010, TlsVersion::V1_3),
+                    (Backend::OpenSsl010Config, TlsVersion::V1_2),
+                    (Backend::OpenSsl010Config, TlsVersion::V1_3),
                 ] {
                     run_subtest(
                         backend,


### PR DESCRIPTION
Our `TlsContext::OpenSsl010` variant accepts a ready `SslContext`. It is also a tuple variant, so there is no possibility to accept additional args other than the context.

This is bad for several reasons:
- We want to support TLS tickets. Configuring them properly requires using a `SslContextBuilder::set_new_session_callback`.
- We have no sound way to transform `SslContext` into `SslContextBuilder` (both use refcounted `SSL_CTX` underneath, builder guarantees refcount == 1, we have no control over refcount of user-given `SslContext`)
- Apart from the context, we may (and with high probability will) want to offer further customizations, for example using a hardcoded name for hostname verification. There is no space for such settings.

This PR adds a new `OpenSsl 0.10`-based `TlsContext` variant. This variant stores a new `OpenSsl010Context` struct.
This struct has private fields, and is constructed from either `SslContextBuilder` or `SslConnectorBuilder`.
In the future we can add builder-style methods to this struct (and I will do so for TLS tickets).

Ref: https://github.com/scylladb/scylla-rust-driver/issues/879
Ref: https://scylladb.atlassian.net/browse/DRIVER-170

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
