### PR TITLE
codewide: get rid of trailing backslashes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,8 @@ It must be a full, three-component version (e.g. `2026.2.2`) rather than a trunc
 on each call, making the tests take much more time.
 To run the `docker compose` cluster on a different version ad hoc, set `SCYLLA_VERSION` in your environment - it takes precedence over the value from the file.
 
-When on non-Linux machine, however, it can be impossible to connect to containerized ScyllaDB instance from outside Docker.\
+When on non-Linux machine, however, it can be impossible to connect to containerized ScyllaDB instance from outside Docker.
+
 If you are using macOS, we provide a `dockerized-test` make target for running tests inside another Docker container:
 ```bash
 make dockerized-test
@@ -58,7 +59,8 @@ make dockerized-test
 If working on Windows, run tests in WSL.
 
 The above commands will leave a running ScyllaDB cluster in the background.
-To stop it, use `make down`.\
+To stop it, use `make down`.
+
 Starting a cluster without running any test is possible with `make up`.
 
 The above test commands will run doctests, unit tests and integration tests.
@@ -116,8 +118,10 @@ Tool that we curently use: https://github.com/obi1kenobi/cargo-semver-checks
 
 ## Contributing to the book
 
-The documentation book is written using [mdbook](https://github.com/rust-lang/mdBook)\
-Book source is in `docs/source`\
+The documentation book is written using [mdbook](https://github.com/rust-lang/mdBook).
+
+Book source is in `docs/source`.
+
 This source has to be compatible with `Sphinx` so it might sometimes contain chunks like:
 ````
 ```{eval-rst}

--- a/docs/source/connecting/compression.md
+++ b/docs/source/connecting/compression.md
@@ -1,7 +1,8 @@
 # Compression
 
-By default the driver does not use any compression on connections.\
-It's possible to specify a preferred compression algorithm. \
+By default the driver does not use any compression on connections.
+
+It's possible to specify a preferred compression algorithm.
 The driver will try using it, but if the database doesn't support it, it will fall back to no compression.
 
 Available compression algorithms:

--- a/docs/source/data-types/counter.md
+++ b/docs/source/data-types/counter.md
@@ -1,5 +1,5 @@
 # Counter
-`Counter` is represented as `struct Counter(pub i64)`\
+`Counter` is represented as `struct Counter(pub i64)`
 `Counter` can't be inserted, it can only be read or updated.
 
 ```rust

--- a/docs/source/data-types/data-types.md
+++ b/docs/source/data-types/data-types.md
@@ -5,8 +5,9 @@ to achieve seamless sending and receiving of CQL values.
 
 See the following chapters for examples on how to send and receive each data type. Please note that using some of those types requires enabling respective feature flags. Details are available in chapters for such data types.
 
-See [Statement values](../statements/values.md) for more information about sending values along with statements.\
-See [Query result](../statements/result.md) for more information about retrieving values from queries
+See [Statement values](../statements/values.md) for more information about sending values along with statements.
+
+See [Query result](../statements/result.md) for more information about retrieving values from queries.
 
 Database types and their Rust equivalents:
 * `Boolean` <----> `bool`

--- a/docs/source/data-types/duration.md
+++ b/docs/source/data-types/duration.md
@@ -1,5 +1,5 @@
 # Duration
-`Duration` is represented as [`CqlDuration`](https://docs.rs/scylla/latest/scylla/value/struct.CqlDuration.html)\
+`Duration` is represented as [`CqlDuration`](https://docs.rs/scylla/latest/scylla/value/struct.CqlDuration.html).
 
 ```rust
 # extern crate scylla;

--- a/docs/source/data-types/udt.md
+++ b/docs/source/data-types/udt.md
@@ -1,5 +1,6 @@
 # User defined types
-ScyllaDB allows users to define their own data types with named fields (See [the official documentation](https://opensource.docs.scylladb.com/stable/cql/types.html#user-defined-types))\
+ScyllaDB allows users to define their own data types with named fields (See [the official documentation](https://opensource.docs.scylladb.com/stable/cql/types.html#user-defined-types)).
+
 To use user defined types in the driver, you can create a corresponding struct in Rust, and use it to read and write UDT values.
 
 
@@ -9,11 +10,12 @@ CREATE TYPE ks.my_type (int_val int, text_val text)
 ```
 
 To use this type in the driver, create a matching struct and derive:
-- `SerializeValue`: in order to be able to use this struct in query parameters. \
-- `DeserializeValue`: in order to be able to use this struct in query results. \
+- `SerializeValue`: in order to be able to use this struct in query parameters.
+- `DeserializeValue`: in order to be able to use this struct in query results.
 
 Both macros require fields of UDT and struct to have matching names, but the order
-of the fields is not required to be the same. \
+of the fields is not required to be the same.
+
 Note: you can use different name using `rename` attribute - see `SerializeValue`
 and `DeserializeValue` macros documentation.
 
@@ -35,7 +37,8 @@ struct MyType {
 # }
 ```
 
-> ***Important***\
+> ***Important***
+>
 > For (de)serialization, by default fields in the Rust struct must be defined with the same names as they are in the database.
 > The driver will (de)serialize the fields in the order defined by the UDT, matching Rust fields by name.
 > You can change this behaviour using macro attributes, see `SerializeValue`/`DeserializeValue` macro documentation for more information.

--- a/docs/source/execution-profiles/execution-profiles.md
+++ b/docs/source/execution-profiles/execution-profiles.md
@@ -10,8 +10,8 @@ The settings that an execution profile encapsulates are [as follows](maximal-exa
 * retry policy
 * speculative execution policy
 
-There are two classes of objects related to execution profiles: `ExecutionProfile` and `ExecutionProfileHandle`. The former is simply an immutable set of the settings. The latter is a handle that at particular moment points to some `ExecutionProfile` (but during its lifetime, it can change the profile it points at). Handles are assigned to `Sessions` and `Statements`.\
-\
+There are two classes of objects related to execution profiles: `ExecutionProfile` and `ExecutionProfileHandle`. The former is simply an immutable set of the settings. The latter is a handle that at particular moment points to some `ExecutionProfile` (but during its lifetime, it can change the profile it points at). Handles are assigned to `Sessions` and `Statements`.
+
 At any moment, handles [can be remapped](remap.md) to point to another `ExecutionProfile`. This allows convenient switching between workloads for all `Sessions` and/or `Statements` that, for instance, share common characteristics.
 
 ```{eval-rst}

--- a/docs/source/execution-profiles/priority.md
+++ b/docs/source/execution-profiles/priority.md
@@ -2,8 +2,10 @@
 
 You always have a default execution profile set for the `Session`, either the default one or overridden upon `Session` creation. Moreover, you can set a profile for specific statements, in which case the statement's profile has higher priority. Some options are also available for specific statements to be set directly on them, such as request timeout and consistency. In such case, the directly set options are preferred over those specified in execution profiles.
 
-> **Recap**\
-> Priorities are as follows:\
+> **Recap**
+>
+> Priorities are as follows:
+>
 > `Session`'s default profile < Statement's profile < options set directly on a Statement
 
 

--- a/docs/source/logging/logging.md
+++ b/docs/source/logging/logging.md
@@ -1,9 +1,11 @@
 # Logging
 
-The driver uses the [tracing](https://github.com/tokio-rs/tracing) crate for all logs.\
+The driver uses the [tracing](https://github.com/tokio-rs/tracing) crate for all logs.
+
 There are two ways to view the logs:
 - Create a `tracing` subscriber to which all logs will be written (recommended).
-- Enable `log` feature on `tracing` crate and use some logger from `log` ecosystem. \
+- Enable `log` feature on `tracing` crate and use some logger from `log` ecosystem.
+
 Only do this if you can't use `tracing` subscriber for some reason.
 
 ## Using tracing subscriber

--- a/docs/source/quickstart/scylla-docker.md
+++ b/docs/source/quickstart/scylla-docker.md
@@ -1,6 +1,7 @@
 # Running ScyllaDB using Docker
 
-To make queries we will need a running ScyllaDB instance. The easiest way is to use a [Docker](https://www.docker.com/) image.\
+To make queries we will need a running ScyllaDB instance. The easiest way is to use a [Docker](https://www.docker.com/) image.
+
 Please [install Docker](https://docs.docker.com/engine/install) if it's not installed.
 
 ### Running scylla

--- a/docs/source/retry-policy/default.md
+++ b/docs/source/retry-policy/default.md
@@ -1,5 +1,6 @@
 # Default retry policy
-This is the retry policy used by default. It retries when there is a high chance that it might help.\
+This is the retry policy used by default. It retries when there is a high chance that it might help.
+
 This policy is based on the one in [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.11/manual/core/retries/).
 The behaviour is the same.
 

--- a/docs/source/statements/batch.md
+++ b/docs/source/statements/batch.md
@@ -1,7 +1,8 @@
 # Batch statement
 
-A batch statement allows to execute many data-modifying statements at once.\
-These statements can be [unprepared](unprepared.md) or [prepared](prepared.md).\
+A batch statement allows to execute many data-modifying statements at once.
+
+These statements can be [unprepared](unprepared.md) or [prepared](prepared.md).
 Only `INSERT`, `UPDATE` and `DELETE` statements are allowed.
 
 ```rust
@@ -40,7 +41,8 @@ session.batch(&batch, batch_values).await?;
 # }
 ```
 
-> ***Warning***\
+> ***Warning***
+>
 > Using unprepared statements with bind markers in batches is strongly discouraged.
 > For each unprepared statement with a non-empty list of values in the batch,
 > the driver will send a prepare request, and it will be done **sequentially**.
@@ -79,7 +81,8 @@ session.batch(&prepared_batch, batch_values).await?;
 ```
 
 ### Batch options
-You can set various options by operating on the `Batch` object.\
+You can set various options by operating on the `Batch` object.
+
 For example to change consistency:
 ```rust
 # extern crate scylla;
@@ -108,10 +111,12 @@ for more options
 ### Batch values
 Batch takes a tuple of values specified just like in [unprepared](unprepared.md) or [prepared](prepared.md) statements.
 
-Length of batch values must be equal to the number of statements in a batch.\
+Length of batch values must be equal to the number of statements in a batch.
+
 Each statement must have its values specified, even if they are empty.
 
-Values passed to `Session::batch` must implement the trait `BatchValues`.\
+Values passed to `Session::batch` must implement the trait `BatchValues`.
+
 By default this includes tuples `()` and slices `&[]` of tuples and slices which implement `SerializeRow`.
 
 Example:

--- a/docs/source/statements/paged.md
+++ b/docs/source/statements/paged.md
@@ -6,7 +6,8 @@ In fact, most SELECTs queries should be done with paging, to avoid big load on c
 
 :::{warning}
 Issuing unpaged SELECTs (`Session::query_unpaged` or `Session::execute_unpaged`)
-may have dramatic performance consequences! **BEWARE!**\
+may have dramatic performance consequences! **BEWARE!**
+
 If the result set is big (or, e.g., there are a lot of tombstones), those atrocities can happen:
  - cluster may experience high load,
  - queries may time out,
@@ -26,7 +27,8 @@ or a [prepared statement](prepared.md), respectively, and return a `QueryPager`.
 to be converted into typed `Stream` (by calling `QueryPager::rows_stream::<RowT>`) in order to
 deserialize rows.
 
-> ***Note***\
+> ***Note***
+>
 > Due to lending stream limitations of Rust, `QueryPager` currently only enables deserialization
 > of owned types (i.e., those with `'static` lifetime). If you want to deserialize borrowed types
 > (such as slices, `&str`, etc.) in order to save allocations, you should use the manual paging

--- a/docs/source/statements/prepared.md
+++ b/docs/source/statements/prepared.md
@@ -43,7 +43,8 @@ must be sent as bound values (see [performance section](#performance))
 :::
 
 :::{warning}
-Don't use `execute_unpaged` to receive large amounts of data.\
+Don't use `execute_unpaged` to receive large amounts of data.
+
 Unpaged requests might cause heavy load on the cluster.
 In reality, its almost always wrong to use unpaged SELECTs.
 

--- a/docs/source/statements/result.md
+++ b/docs/source/statements/result.md
@@ -3,7 +3,8 @@
 `Session::query_unpaged`, `Session::query_single_page`, `Session::execute_unpaged` and `Session::execute_single_page`
 return a `QueryResult` with rows in a raw form, yet-to-be lazily deserialized.
 
-> ***Note***\
+> ***Note***
+>
 > Using unpaged queries for SELECTs is discouraged in general.
 > Query results may be so big that it is not preferable to fetch them all at once.
 > Even with small results, if there are a lot of tombstones, then there can be similar bad consequences.
@@ -85,7 +86,8 @@ for row in rows_result.rows::<(i32, Option<&str>)>()? {
 ```
 
 ### Parsing row as a custom struct
-It is possible to receive row as a struct with fields matching the columns.\
+It is possible to receive row as a struct with fields matching the columns.
+
 The struct must:
 * have the same number of fields as the number of queried columns
 * have field types matching the columns being received

--- a/docs/source/statements/statements.md
+++ b/docs/source/statements/statements.md
@@ -12,18 +12,22 @@ They include recommendations on which API to use in what cases.
 
 This is **NOT** strictly related to content of the CQL statement string.
 
-> ***Interesting note***\
+> ***Interesting note***
+>
 > In fact, any kind of CQL statement could contain any CQL statement string.
 > Yet, some of such combinations don't make sense and will be rejected by the DB.
 > For example, SELECTs in a Batch are nonsense.
 
 ### [Unprepared](unprepared.md) vs [Prepared](prepared.md)
 
-> ***GOOD TO KNOW***\
-> Each time a statement is executed by sending a statement string to the DB, it needs to be parsed. Driver does not parse CQL, therefore it sees statement strings as opaque.\
+> ***GOOD TO KNOW***
+>
+> Each time a statement is executed by sending a statement string to the DB, it needs to be parsed. Driver does not parse CQL, therefore it sees statement strings as opaque.
+>
 > There is an option to *prepare* a statement, i.e. parse it once by the DB and associate it with an ID. After preparation, it's enough that driver sends the ID
 > and the DB already knows what operation to perform - no more expensive parsing necessary! Moreover, upon preparation driver receives valuable data for load balancing,
-> enabling advanced load balancing (so better performance!) of all further executions of that prepared statement.\
+> enabling advanced load balancing (so better performance!) of all further executions of that prepared statement.
+>
 > ***Key take-over:*** always prepare statements that you are going to execute multiple times.
 
 :::{warning}
@@ -78,10 +82,14 @@ Takeway from the above: Do NOT use unprepared statements in a batch, unless such
 
 ### [Paged](paged.md) vs Unpaged query
 
-> ***GOOD TO KNOW***\
-> SELECT statements return a [result set](result.md), possibly a large one. Therefore, paging is available to fetch it in chunks, relieving load on cluster and lowering latency.\
-> ***Key take-overs:***\
-> For SELECTs you had better **avoid unpaged queries**.\
+> ***GOOD TO KNOW***
+>
+> SELECT statements return a [result set](result.md), possibly a large one. Therefore, paging is available to fetch it in chunks, relieving load on cluster and lowering latency.
+>
+> ***Key take-overs:***
+>
+> For SELECTs you had better **avoid unpaged queries**.
+>
 > For non-SELECTs, unpaged API is preferred.
 
 | Query result fetching | Unpaged                                                                                                                 | Paged                                                                                                                                                                |

--- a/docs/source/statements/unprepared.md
+++ b/docs/source/statements/unprepared.md
@@ -15,21 +15,26 @@ session
 # }
 ```
 
-> ***Warning***\
-> Don't use unprepared queries to receive large amounts of data.\
-> By default the query is unpaged and might cause heavy load on the cluster.\
-> In such cases use [paged query](paged.md) instead.\
+> ***Warning***
+>
+> Don't use unprepared queries to receive large amounts of data.
+>
+> By default the query is unpaged and might cause heavy load on the cluster.
+>
+> In such cases use [paged query](paged.md) instead.
 > 
 > `query_unpaged` will return all results in one, possibly giant, piece
 > (unless a timeout occurs due to high load incurred by the cluster).
 
-> ***Warning***\
+> ***Warning***
+>
 > If the values are not empty, driver first needs to send a `PREPARE` request
 > in order to fetch information required to serialize values. This will affect
 > performance because 2 round trips will be required instead of 1.
 
 ### First argument - the statement
-As the first argument `Session::query_unpaged` takes anything implementing `Into<Statement>`.\
+As the first argument `Session::query_unpaged` takes anything implementing `Into<Statement>`.
+
 You can create a statement manually to set custom options. For example to change statement consistency:
 ```rust
 # extern crate scylla;
@@ -53,7 +58,8 @@ See [Statement API documentation](https://docs.rs/scylla/latest/scylla/statement
 
 ### Second argument - the values
 Statement text is constant, but the values may change.
-You can pass changing values to a statement by specifying a list of variables as bound values.\
+You can pass changing values to a statement by specifying a list of variables as bound values.
+
 Each `?` in statement text will be filled with the matching value. 
 
 The easiest way is to pass values using a tuple:
@@ -115,9 +121,10 @@ while let Some(read_row) = iter.next().transpose()? {
 See [Query result](result.md) for more information about handling query results
 
 ### Performance
-Unprepared statements should not be used in places where performance matters.\
+Unprepared statements should not be used in places where performance matters.
+
 If performance matters use a [Prepared statement](prepared.md) instead.
 
-With unprepared statement the database has to parse statement text each time it's executed, which worsens performance.\
+With unprepared statement the database has to parse statement text each time it's executed, which worsens performance.
 
 Additionally token and shard aware load balancing does not work with unprepared statements. They are sent to random nodes.

--- a/docs/source/statements/usekeyspace.md
+++ b/docs/source/statements/usekeyspace.md
@@ -46,7 +46,8 @@ session
 # }
 ```
 
-The first argument is the keyspace name.\
+The first argument is the keyspace name.
+
 The second argument states whether this name is case sensitive.
 
 It is also possible to send raw use keyspace statement using `Session::query_*` instead of `Session::use_keyspace` such as:
@@ -70,8 +71,10 @@ This could end up with a part of connections using one keyspace and another part
 
 ### Case sensitivity
 
-In CQL a keyspace name can be case insensitive (without `"`) or case sensitive (with `"`).\
-If the second argument to `use_keyspace` is set to `true` this keyspace name will be wrapped in `"`.\
+In CQL a keyspace name can be case insensitive (without `"`) or case sensitive (with `"`).
+
+If the second argument to `use_keyspace` is set to `true` this keyspace name will be wrapped in `"`.
+
 It is best to avoid the problem altogether and just not create two keyspaces with the same name but different cases.
 
 Let's see what happens when there are two keyspaces with the same name but different cases: `my_keyspace` and `MY_KEYSPACE`:

--- a/docs/source/statements/values.md
+++ b/docs/source/statements/values.md
@@ -1,11 +1,13 @@
 # Statement values
 Statement text is constant, but the values may change.
-You can pass changing values to a statement by specifying a list of variables as bound values.\
+You can pass changing values to a statement by specifying a list of variables as bound values.
+
 Each `?` in statement text will be filled with the matching value. 
 
 > **Never** pass values by adding strings, this could lead to [SQL Injection](https://en.wikipedia.org/wiki/SQL_injection)
 
-Each list of values to send must implement the trait `SerializeRow`.\
+Each list of values to send must implement the trait `SerializeRow`.
+
 By default this can be a slice `&[]`, a tuple `()` (max 16 elements) of values to send,
 or a custom struct which derives from `SerializeRow`.
 
@@ -110,7 +112,8 @@ session
 ```
 
 ### `Unset` values
-When performing an insert with values which might be `NULL`, it's better to use `Unset`.\
+When performing an insert with values which might be `NULL`, it's better to use `Unset`.
+
 Database treats inserting `NULL` as a delete operation and will generate a tombstone.
 Using `Unset` results in better performance:
 

--- a/docs/source/tracing/paged.md
+++ b/docs/source/tracing/paged.md
@@ -1,6 +1,7 @@
 # Tracing a paged query
 
-A paged query performs multiple simple/prepared queries to query subsequent pages.\
+A paged query performs multiple simple/prepared queries to query subsequent pages.
+
 If tracing is enabled the row iterator will contain a list of tracing ids for all performed queries.
 
 

--- a/docs/source/tracing/query-history.md
+++ b/docs/source/tracing/query-history.md
@@ -1,6 +1,7 @@
 # Query Execution History
 
-The driver allows to collect history of query execution.\
+The driver allows to collect history of query execution.
+
 This history includes all requests sent, decisions to retry and speculative execution fibers started.
 
 ## Example code

--- a/docs/source/tracing/tracing.md
+++ b/docs/source/tracing/tracing.md
@@ -16,14 +16,17 @@ Queries that support tracing:
 * [`Session::batch()`](basic.md)
 * [`Session::prepare()`](prepare.md)
 
-After obtaining the tracing id you can use `Session::get_tracing_info()` to query tracing information.\
-`TracingInfo` contains values that are the same in ScyllaDB and Cassandra®, skipping any database-specific ones.\
+After obtaining the tracing id you can use `Session::get_tracing_info()` to query tracing information.
+
+`TracingInfo` contains values that are the same in ScyllaDB and Cassandra®, skipping any database-specific ones.
+
 If `TracingInfo` does not contain some needed value it's possible to query it manually from the tables
 `system_traces.sessions` and `system_traces.events`
 
 ### Query Execution History
 
-Tracing provides information about how the query execution went on database nodes, but it doesn't say anything about what was going on inside the driver.\
+Tracing provides information about how the query execution went on database nodes, but it doesn't say anything about what was going on inside the driver.
+
 This is what query execution history was made for.
 
 It allows to follow what the driver was thinking - all query attempts, retry decisions, speculative executions.

--- a/scylla-cql-core/src/frame/response/error.rs
+++ b/scylla-cql-core/src/frame/response/error.rs
@@ -238,7 +238,7 @@ impl WriteType {
 }
 
 /// An error sent from the database in response to a query
-/// as described in the [specification](https://github.com/apache/cassandra/blob/5ed5e84613ef0e9664a774493db7d2604e3596e0/doc/native_protocol_v4.spec#L1029)\
+/// as described in the [specification](https://github.com/apache/cassandra/blob/5ed5e84613ef0e9664a774493db7d2604e3596e0/doc/native_protocol_v4.spec#L1029)
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DbError {

--- a/scylla/src/client/caching_session.rs
+++ b/scylla/src/client/caching_session.rs
@@ -137,7 +137,8 @@ where
     }
 
     /// Does the same thing as [`Session::batch`] but uses the
-    /// prepared statement cache.\
+    /// prepared statement cache.
+    ///
     /// Prepares batch using [`CachingSession::prepare_batch`]
     /// if needed and then executes it.
     pub async fn batch(

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1,4 +1,5 @@
-//! `Session` is the main object used in the driver.\
+//! `Session` is the main object used in the driver.
+//!
 //! It manages all connections to the cluster and allows to execute CQL requests.
 
 use super::execution::RequestPaging;
@@ -627,7 +628,8 @@ impl SessionConfig {
 /// Represents a CQL session, which can be used to communicate
 /// with the database
 impl Session {
-    /// Sends a request to the database and receives a response.\
+    /// Sends a request to the database and receives a response.
+    ///
     /// Executes an unprepared CQL statement without paging, i.e. all results are received in a single response.
     ///
     /// This is the easiest way to execute a CQL statement, but performance is worse than that of prepared statements.
@@ -752,10 +754,12 @@ impl Session {
             .await
     }
 
-    /// Execute an unprepared CQL statement with paging\
-    /// This method will query all pages of the result\
+    /// Execute an unprepared CQL statement with paging.
     ///
-    /// Returns an async iterator (stream) over all received rows\
+    /// This method will query all pages of the result.
+    ///
+    /// Returns an async iterator (stream) over all received rows.
+    ///
     /// Page size can be specified in the [`Statement`] passed to the function
     ///
     /// It is discouraged to use this method with non-empty values argument ([`SerializeRow::is_empty()`]
@@ -797,7 +801,8 @@ impl Session {
     }
 
     /// Execute a prepared statement. Requires a [PreparedStatement]
-    /// generated using [`Session::prepare`](Session::prepare).\
+    /// generated using [`Session::prepare`](Session::prepare).
+    ///
     /// Performs an unpaged request, i.e. all results are received in a single response.
     ///
     /// As all results come in one response (no paging is done!), the memory footprint and latency may be huge
@@ -810,7 +815,8 @@ impl Session {
     /// * Database doesn't need to parse the statement string upon each execution (only once)
     /// * They are properly load balanced using token aware routing
     ///
-    /// > ***Warning***\
+    /// > ***Warning***
+    /// >
     /// > For token/shard aware load balancing to work properly, all partition key values
     /// > must be sent as bound values
     /// > (see [performance section](https://rust-driver.docs.scylladb.com/stable/statements/prepared.html#performance)).
@@ -939,10 +945,10 @@ impl Session {
         .await
     }
 
-    /// Execute a prepared statement with paging.\
-    /// This method will query all pages of the result.\
+    /// Execute a prepared statement with paging.
+    /// This method will query all pages of the result.
     ///
-    /// Returns an async iterator (stream) over all received rows.\
+    /// Returns an async iterator (stream) over all received rows.
     /// Page size can be specified in the [PreparedStatement] passed to the function.
     ///
     /// See [the book](https://rust-driver.docs.scylladb.com/stable/statements/paged.html) for more information.
@@ -990,8 +996,9 @@ impl Session {
             .await
     }
 
-    /// Execute a batch statement\
-    /// Batch contains many `unprepared` or `prepared` statements which are executed at once\
+    /// Execute a batch statement.
+    ///
+    /// Batch contains many `unprepared` or `prepared` statements which are executed at once.
     /// Batch doesn't return any rows.
     ///
     /// Batch values must contain values for each of the statements.
@@ -1967,13 +1974,15 @@ impl Session {
         Ok(prepared_batch)
     }
 
-    /// Sends `USE <keyspace_name>` request on all connections\
-    /// This allows to write `SELECT * FROM table` instead of `SELECT * FROM keyspace.table`\
+    /// Sends `USE <keyspace_name>` request on all connections.
+    ///
+    /// This allows to write `SELECT * FROM table` instead of `SELECT * FROM keyspace.table`.
     ///
     /// Note that even failed `use_keyspace` can change currently used keyspace - the request is sent on all connections and
     /// can overwrite previously used keyspace.
     ///
-    /// Call only one `use_keyspace` at a time.\
+    /// Call only one `use_keyspace` at a time.
+    ///
     /// Trying to do two `use_keyspace` requests simultaneously with different names
     /// can end with some connections using one keyspace and the rest using the other.
     ///
@@ -2021,11 +2030,12 @@ impl Session {
         self.cluster.use_keyspace(verified_ks_name).await
     }
 
-    /// Manually trigger a metadata refresh\
-    /// The driver will fetch current nodes in the cluster and update its metadata
+    /// Manually trigger a metadata refresh.
     ///
-    /// Normally this is not needed,
-    /// the driver should automatically detect all metadata changes in the cluster
+    /// The driver will fetch current nodes in the cluster and update its metadata.
+    ///
+    /// Normally this is not needed, the driver should automatically detect
+    /// all metadata changes in the cluster.
     pub async fn refresh_metadata(&self) -> Result<(), MetadataError> {
         debug!("Session: requested metadata refresh");
         let res = self.cluster.refresh_metadata().await;
@@ -2033,9 +2043,10 @@ impl Session {
         res
     }
 
-    /// Access metrics collected by the driver\
+    /// Access metrics collected by the driver.
+    ///
     /// Driver collects various metrics like number of queries or query latencies.
-    /// They can be read using this method
+    /// They can be read using this method.
     #[cfg(feature = "metrics")]
     pub fn get_metrics(&self) -> Arc<Metrics> {
         self.get_metrics_priv()

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -386,8 +386,7 @@ impl<K: SessionBuilderKindSupportsTls> GenericSessionBuilder<K> {
 // This block contains configuration options that make sense both for any `Session` type.
 // If an option fit only some of them, it should be put in a specialised block.
 impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
-    /// Set username and password for plain text authentication.\
-    /// If the database server will require authentication\
+    /// Set username and password for plain text authentication.
     ///
     /// # Example
     /// ```
@@ -800,8 +799,10 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
-    /// Set keyspace to be used on all connections.\
-    /// Each connection will send `"USE <keyspace_name>"` before sending any requests.\
+    /// Set keyspace to be used on all connections.
+    ///
+    /// Each connection will send `"USE <keyspace_name>"` before sending any requests.
+    ///
     /// This can be later changed with [`crate::client::session::Session::use_keyspace`]
     ///
     /// # Example

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -2,7 +2,8 @@
 //! Although optimized for ScyllaDB, the driver is also compatible with [Apache Cassandra®](https://cassandra.apache.org/).
 //!
 //! # Documentation book
-//! The best source to learn about this driver is the [documentation book](https://rust-driver.docs.scylladb.com/).\
+//! The best source to learn about this driver is the [documentation book](https://rust-driver.docs.scylladb.com/).
+//!
 //! This page contains mainly API documentation.
 //!
 //! # Other documentation
@@ -13,7 +14,8 @@
 //!
 //! # Driver overview
 //! ### Connecting
-//! All driver activity revolves around the [Session](crate::client::session::Session).\
+//! All driver activity revolves around the [Session](crate::client::session::Session).
+//!
 //! `Session` is created by specifying a few known nodes and connecting to them:
 //!
 //! ```rust,no_run
@@ -32,11 +34,13 @@
 //!    Ok(())
 //! }
 //! ```
-//! `Session` is usually created using the [SessionBuilder](crate::client::session_builder::SessionBuilder).\
+//! `Session` is usually created using the [SessionBuilder](crate::client::session_builder::SessionBuilder).
+//!
 //! All configuration options for a `Session` can be specified while building.
 //!
 //! ### Making queries
-//! After successfully connecting to the cluster we can make queries.\
+//! After successfully connecting to the cluster we can make queries.
+//!
 //! The driver supports multiple query types:
 //! * [Simple](crate::client::session::Session::query_unpaged)
 //! * [Simple paged](crate::client::session::Session::query_iter)
@@ -84,7 +88,7 @@
 //!     .into_rows_result()?;
 //!
 //! for row in query_rows.rows()? {
-//!     // Parse row as int and text \
+//!     // Parse row as int and text
 //!     let (int_val, text_val): (i32, &str) = row?;
 //! }
 //! # Ok(())

--- a/scylla/src/observability/history.rs
+++ b/scylla/src/observability/history.rs
@@ -28,11 +28,14 @@ pub struct AttemptId(pub usize);
 pub struct SpeculativeId(pub usize);
 
 /// Any type implementing this trait can be passed to Session
-/// to collect execution history of specific requests.\
+/// to collect execution history of specific requests.
+///
 /// In order to use it call `set_history_listener` on
-/// `Statement`, `PreparedStatement`, etc...\
+/// `Statement`, `PreparedStatement`, etc...
+///
 /// The listener has to generate unique IDs for new requests, attempts and speculative fibers.
-/// These ids are then used by the caller to identify them.\
+/// These ids are then used by the caller to identify them.
+///
 /// It's important to note that even after a request is finished there still might come events related to it.
 /// These events come from speculative futures that didn't notice the request is done already.
 pub trait HistoryListener: Debug + Send + Sync {
@@ -142,7 +145,8 @@ impl HistoryCollector {
         self.do_with_data(|data| data.clone())
     }
 
-    /// Takes the data out of the collector. The collected events are cleared.\
+    /// Takes the data out of the collector. The collected events are cleared.
+    ///
     /// It's possible that after finishing a request and taking out the events
     /// new ones will still come - from requests that haven't been cancelled yet.
     pub fn take_collected(&self) -> HistoryCollectorData {
@@ -259,9 +263,11 @@ impl HistoryListener for HistoryCollector {
     }
 }
 
-/// Structured representation of requests history.\
+/// Structured representation of requests history.
+///
 /// [HistoryCollector] collects raw events which later can be converted
-/// to this pretty representation.\
+/// to this pretty representation.
+///
 /// It has a `Display` impl which can be used for printing pretty request history.
 #[derive(Debug, Clone)]
 pub struct StructuredHistory {

--- a/scylla/src/observability/metrics.rs
+++ b/scylla/src/observability/metrics.rs
@@ -55,12 +55,14 @@ const INTERVAL: u64 = 5;
 struct ExponentiallyWeightedMovingAverage {
     /// Smoothing factor, a value between 0 and 1.
     alpha: f64,
-    /// Atomic counter to keep track of the number of requests. \
+    /// Atomic counter to keep track of the number of requests.
+    ///
     /// Indicates the number of requests that have not been accounted for EWMA yet.
     uncounted: AtomicU64,
     /// To check if the EWMA has been initialized.
     is_initialized: Mutex<bool>,
-    ///  Atomic value representing the current rate of requests per second. \
+    ///  Atomic value representing the current rate of requests per second.
+    ///
     ///  AtomicU64 is used to store a floating point number as a bit representation.
     rate: AtomicU64,
 }
@@ -80,17 +82,21 @@ impl ExponentiallyWeightedMovingAverage {
         f64::from_bits(self.rate.load(Ordering::Acquire))
     }
 
-    /// Increments the `uncounted` requests counter. \
+    /// Increments the `uncounted` requests counter.
+    ///
     /// Should be called every time a new request is made.
     fn update(&self) {
         self.uncounted.fetch_add(1, ORDER_TYPE);
     }
 
-    /// Updates the `rate` based on the current number of requests. \
+    /// Updates the `rate` based on the current number of requests.
+    ///
     /// Should be called every time the interval has passed.
     ///
-    /// The rate is updated using the formula: \
-    /// `rate = rate + alpha * (instant_rate - rate)` \
+    /// The rate is updated using the formula:
+    ///
+    /// `rate = rate + alpha * (instant_rate - rate)`
+    ///
     /// where `instant_rate` is the number of requests in the last interval.
     ///
     /// The first time this function is called, the `rate` is set to the `instant_rate`.
@@ -393,7 +399,8 @@ impl Metrics {
         }
     }
 
-    /// Returns snapshot of histogram metrics taken at the moment of calling this function. \
+    /// Returns snapshot of histogram metrics taken at the moment of calling this function.
+    ///
     /// Available metrics: min, max, mean, std_dev, median,
     ///                    percentile_75, percentile_95, percentile_98,
     ///                    percentile_99, and percentile_99_9.

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -1,5 +1,7 @@
-//! Load balancing configurations\
-//! `Session` can use any load balancing policy which implements the `LoadBalancingPolicy` trait\
+//! Load balancing configurations
+//!
+//! `Session` can use any load balancing policy which implements the `LoadBalancingPolicy` trait
+//!
 //! See [the book](https://rust-driver.docs.scylladb.com/stable/load-balancing/load-balancing.html) for more information
 
 use crate::cluster::{ClusterState, NodeRef};

--- a/scylla/src/policies/retry/default.rs
+++ b/scylla/src/policies/retry/default.rs
@@ -4,7 +4,8 @@ use crate::errors::RequestAttemptError;
 
 use super::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 
-/// Default retry policy - retries when there is a high chance that a retry might help.\
+/// Default retry policy - retries when there is a high chance that a retry might help.
+///
 /// Behaviour based on [DataStax Java Driver](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/retries/)
 #[derive(Debug)]
 pub struct DefaultRetryPolicy;

--- a/scylla/src/policies/retry/downgrading_consistency.rs
+++ b/scylla/src/policies/retry/downgrading_consistency.rs
@@ -4,7 +4,8 @@ use tracing::debug;
 use super::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
 use crate::errors::{DbError, RequestAttemptError, WriteType};
 
-/// Downgrading consistency retry policy - retries with lower consistency level if it knows\
+/// Downgrading consistency retry policy - retries with lower consistency level if it knows
+///
 /// that the initial CL is unreachable. Also, it behaves as [DefaultRetryPolicy](crate::policies::retry::DefaultRetryPolicy)
 /// when it believes that the initial CL is reachable.
 /// Behaviour based on [DataStax Java Driver]\

--- a/scylla/src/policies/retry/retry_policy.rs
+++ b/scylla/src/policies/retry/retry_policy.rs
@@ -1,6 +1,7 @@
-//! Request retries configurations\
+//! Request retries configurations
+//!
 //! To decide when to retry a request the `Session` can use any object which implements
-//! the `RetryPolicy` trait
+//! the `RetryPolicy` trait.
 
 use crate::errors::RequestAttemptError;
 use crate::frame::types::Consistency;
@@ -8,11 +9,13 @@ use crate::frame::types::Consistency;
 /// Information about a failed request
 #[non_exhaustive]
 pub struct RequestInfo<'a> {
-    /// The error with which the request failed
+    /// The error with which the request failed.
     pub error: &'a RequestAttemptError,
-    /// A request is idempotent if it can be applied multiple times without changing the result of the initial application\
-    /// If set to `true` we can be sure that it is idempotent\
-    /// If set to `false` it is unknown whether it is idempotent
+    /// A request is idempotent if it can be applied multiple times without changing the result of the initial application.
+    ///
+    /// If set to `true` we can be sure that it is idempotent.
+    ///
+    /// If set to `false` it is unknown whether it is idempotent.
     pub is_idempotent: bool,
     /// Consistency with which the request failed
     pub consistency: Consistency,

--- a/scylla/src/response/query_result.rs
+++ b/scylla/src/response/query_result.rs
@@ -165,8 +165,10 @@ impl QueryResult {
         self.deserialized_metadata_and_rows.is_some()
     }
 
-    /// Returns `Ok` for a request's result that shouldn't contain any rows.\
-    /// Will return `Ok` for `INSERT` result, but a `SELECT` result, even an empty one, will cause an error.\
+    /// Returns `Ok` for a request's result that shouldn't contain any rows.
+    ///
+    /// Will return `Ok` for `INSERT` result, but a `SELECT` result, even an empty one, will cause an error.
+    ///
     /// Opposite of [QueryResult::into_rows_result].
     #[inline]
     pub fn result_not_rows(&self) -> Result<(), ResultNotRowsError> {


### PR DESCRIPTION
Trailing backslashes were commonly used to force renderer to render newline. This can be easily achieved cleaner, by leaving an empty line. All such backslashes were changed this way.

In some cases, a blank line was not added, because I believed it's not warranted there. Also added missing punctuation to documentation.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
