### PR TITLE
Add test for SELECT without FROM

### DIFF
--- a/scylla/tests/integration/statements/mod.rs
+++ b/scylla/tests/integration/statements/mod.rs
@@ -7,6 +7,7 @@ mod named_bind_markers;
 mod prepared;
 mod request_timeout;
 mod result_metadata_extension;
+mod select_without_from;
 mod timestamps;
 mod transparent_reprepare;
 mod unprepared;

--- a/scylla/tests/integration/statements/select_without_from.rs
+++ b/scylla/tests/integration/statements/select_without_from.rs
@@ -1,0 +1,104 @@
+use crate::utils::{create_new_session_builder, setup_tracing};
+use scylla::errors::{DbError, ExecutionError, RequestAttemptError};
+use scylla::frame::response::result::{ColumnType, NativeType};
+use scylla::value::CqlTimeuuid;
+
+#[tokio::test]
+async fn test_select_without_from() {
+    setup_tracing();
+    // The test touches no user schema, so schema metadata is dead weight.
+    let session = create_new_session_builder()
+        .fetch_schema_metadata(false)
+        .fetch_full_schema_metadata(false)
+        .build()
+        .await
+        .unwrap();
+
+    // A cluster without the extension rejects the statement in the grammar, before any
+    // semantic check runs, so `SyntaxError` - and only `SyntaxError` - means "unsupported".
+    // `Invalid` must not be accepted here: it is what a *supporting* cluster returns for
+    // statements it parsed but refused, so treating it
+    // as "unsupported" would silently skip every assertion below.
+    let result = match session.query_unpaged("SELECT 1", &[]).await {
+        Ok(result) => result,
+        Err(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
+            DbError::SyntaxError,
+            _,
+        ))) => {
+            println!("Skipping because the cluster doesn't support SELECT without FROM");
+            return;
+        }
+        Err(err) => panic!("SELECT without FROM failed unexpectedly: {err}"),
+    };
+
+    let rows = result.into_rows_result().unwrap();
+    let spec = rows.column_specs().get_by_index(0).unwrap();
+    assert_eq!(rows.column_specs().len(), 1);
+    assert_eq!(spec.name(), "1");
+    assert_eq!(rows.single_row::<(i32,)>().unwrap(), (1,));
+
+    // Selector naming: an unaliased selector is named after its expression text, with
+    // function names keyspace-qualified, and `AS` overrides that.
+    let rows = session
+        .query_unpaged("SELECT 1, 'hi' AS greeting, now()", &[])
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap();
+    let names: Vec<&str> = rows.column_specs().iter().map(|spec| spec.name()).collect();
+    assert_eq!(names, ["1", "greeting", "system.now()"]);
+
+    let (one, greeting, _now) = rows
+        .single_row::<(i32, &str, CqlTimeuuid)>()
+        .unwrap_or_else(|err| panic!("failed to deserialize: {err}"));
+    assert_eq!((one, greeting), (1, "hi"));
+
+    // Preparing the statement yields the same result metadata.
+    let prepared = session.prepare("SELECT 1").await.unwrap();
+    let rows = session
+        .execute_unpaged(&prepared, &[])
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap();
+    let spec = rows.column_specs().get_by_index(0).unwrap();
+    assert_eq!(rows.column_specs().len(), 1);
+    assert_eq!(spec.name(), "1");
+    assert_eq!(rows.single_row::<(i32,)>().unwrap(), (1,));
+
+    // A bind marker is only allowed where a type can be inferred for it. There are no
+    // columns in scope, so the type has to come from a function signature or from a clause
+    // with a fixed type, such as LIMIT.
+    //
+    // Only the marker types are asserted. The table spec of a marker typed by a function
+    // argument is `(<session keyspace>, "one_row")`, because the server resolves function
+    // names against the session keyspace; that pair is meaningless and not worth pinning.
+    let prepared = session
+        .prepare("SELECT intAsBlob(?) AS b LIMIT ?")
+        .await
+        .unwrap();
+    let variable_types: Vec<&ColumnType> = prepared
+        .get_variable_col_specs()
+        .iter()
+        .map(|spec| spec.typ())
+        .collect();
+    assert_eq!(
+        variable_types,
+        [
+            &ColumnType::Native(NativeType::Int),
+            &ColumnType::Native(NativeType::Int)
+        ]
+    );
+    let rows = session
+        .execute_unpaged(&prepared, (42_i32, 1_i32))
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap();
+    let spec = rows.column_specs().get_by_index(0).unwrap();
+    assert_eq!(spec.name(), "b");
+    assert_eq!(
+        rows.single_row::<(Vec<u8>,)>().unwrap(),
+        (42_i32.to_be_bytes().to_vec(),)
+    );
+}


### PR DESCRIPTION
SELECT without FROM is a new Scylla functionality. This test verifies that drivers works correctly with it.
Test is skipped if server throws syntax error on such SELECT.
This is not available on any released version yet, but I did (Claude did) verify that the test works as expected on a nightly that has this feature.

This is https://github.com/scylladb/scylla-rust-driver/pull/1782 but expanded a bit - more asserts + a test case with bind marker.

Fixes: https://scylladb.atlassian.net/browse/DRIVER-783
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1781

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
