### PR TITLE
Send SESSION_ID in STARTUP

### DIFF
--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -51,6 +51,20 @@ Creating many `Session`'s in one application (e.g. `Session` per thread / per To
 
 If you need to share `Session` with different threads / Tokio tasks etc. use `Arc<Session>` - all methods of `Session` take `&self`, so it doesn't hinder the functionality in any way.
 
+## Session identification
+
+Every connection the driver opens sends a `SESSION_ID` option in the CQL `STARTUP` message - a UUID generated once per `Session`.
+The server exposes it in `system.clients.client_options`, so all rows belonging to one session can be told apart from other clients.
+
+`Session::session_id()` returns that UUID; log it to correlate client-side observations with `system.clients`:
+```rust
+# extern crate scylla;
+# use scylla::client::session::Session;
+# fn check_only_compiles(session: &Session) {
+println!("session id: {}", session.session_id());
+# }
+```
+
 ## Metadata
 
 The driver keeps an up-to-date view of the cluster topology (and client routes, if used) and of the cluster schema.

--- a/scylla-cql/src/frame/request/options.rs
+++ b/scylla-cql/src/frame/request/options.rs
@@ -30,6 +30,7 @@ pub const DRIVER_VERSION: &str = "DRIVER_VERSION";
 pub const APPLICATION_NAME: &str = "APPLICATION_NAME";
 pub const APPLICATION_VERSION: &str = "APPLICATION_VERSION";
 pub const CLIENT_ID: &str = "CLIENT_ID";
+pub const SESSION_ID: &str = "SESSION_ID";
 
 /* Value names for options in SUPPORTED/STARTUP */
 pub const DEFAULT_CQL_PROTOCOL_VERSION: &str = "4.0.0";

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -105,6 +105,7 @@ pub struct Session {
     tracing_info_fetch_consistency: Consistency,
     node_location_preference: Arc<NodeLocationPreference>,
     internal_statements: InternalStatements,
+    session_id: Uuid,
 }
 
 /// This implementation deliberately omits some details from Cluster in order
@@ -147,6 +148,7 @@ impl std::fmt::Debug for Session {
             &self.tracing_info_fetch_consistency,
         )
         .field("node_location_preference", &self.node_location_preference)
+        .field("session_id", &self.session_id)
         .finish()
     }
 }
@@ -1364,6 +1366,8 @@ impl Session {
     pub async fn connect(config: SessionConfig) -> Result<Self, NewSessionError> {
         config.validate()?;
 
+        let session_id = Uuid::new_v4();
+
         let node_location_preference = config.node_location_preference;
         let known_nodes = config.known_nodes;
 
@@ -1414,6 +1418,7 @@ impl Session {
             keepalive_timeout: config.keepalive_timeout,
             tablet_sender: Some(tablet_sender),
             identity: config.identity,
+            session_id,
         };
 
         let pool_config = PoolConfig {
@@ -1496,6 +1501,7 @@ impl Session {
             tracing_info_fetch_consistency: config.tracing_info_fetch_consistency,
             node_location_preference: Arc::new(node_location_preference),
             internal_statements: InternalStatements::default(),
+            session_id,
         };
 
         if let Some(keyspace_name) = config.used_keyspace {
@@ -2317,6 +2323,20 @@ impl Session {
     #[inline]
     pub fn get_keyspace(&self) -> Option<Arc<String>> {
         self.keyspace_name.load_full()
+    }
+
+    /// Returns the identifier of this session.
+    ///
+    /// Every connection the session opens reports this value to the cluster
+    /// under the `SESSION_ID` `STARTUP` option, where it lands in
+    /// `system.clients.client_options`. Logging it, or attaching it as a metric
+    /// label, is what allows client-side observations to be matched with those
+    /// rows, instead of correlating by address and port.
+    ///
+    /// The identifier is assigned at session creation and never changes.
+    #[inline]
+    pub fn session_id(&self) -> Uuid {
+        self.session_id
     }
 
     // Tries getting the tracing info

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -341,6 +341,13 @@ pub(crate) struct ConnectionConfig {
     pub(crate) tablet_sender: Option<mpsc::Sender<(TableSpec<'static>, RawTablet)>>,
 
     pub(crate) identity: SelfIdentity<'static>,
+
+    /// Identifier of the [`Session`](crate::client::session::Session) that owns
+    /// the connections created with this config.
+    ///
+    /// Reported to the cluster in `STARTUP`, so that the `system.clients` rows
+    /// of all connections belonging to one session can be correlated.
+    pub(crate) session_id: Uuid,
 }
 
 impl ConnectionConfig {
@@ -371,6 +378,7 @@ impl ConnectionConfig {
             keepalive_timeout: self.keepalive_timeout,
             tablet_sender: self.tablet_sender.clone(),
             identity: self.identity.clone(),
+            session_id: self.session_id,
             #[cfg(test)]
             transport_factory: None,
         }
@@ -401,6 +409,7 @@ pub(crate) struct HostConnectionConfig {
     pub(crate) tablet_sender: Option<mpsc::Sender<(TableSpec<'static>, RawTablet)>>,
 
     pub(crate) identity: SelfIdentity<'static>,
+    pub(crate) session_id: Uuid,
 
     #[cfg(test)]
     pub(crate) transport_factory: Option<Arc<scylla_proxy::TransportFactory>>,
@@ -430,6 +439,9 @@ impl Default for HostConnectionConfig {
             tablet_sender: None,
 
             identity: SelfIdentity::default(),
+
+            // Test connections do not correlate anything in `system.clients`.
+            session_id: Uuid::nil(),
 
             #[cfg(test)]
             transport_factory: None,
@@ -461,6 +473,9 @@ impl Default for ConnectionConfig {
             tablet_sender: None,
 
             identity: SelfIdentity::default(),
+
+            // Test connections do not correlate anything in `system.clients`.
+            session_id: Uuid::nil(),
         }
     }
 }
@@ -2206,6 +2221,14 @@ pub(crate) async fn open_connection(
     connection.set_features(features);
 
     /* Prepare options that the driver opts-in in STARTUP frame. */
+    // Formatted into a stack buffer: this runs for every connection, and a
+    // heap allocation per connection is avoidable here.
+    let mut session_id_buf = Uuid::encode_buffer();
+    let session_id = config
+        .session_id
+        .hyphenated()
+        .encode_lower(&mut session_id_buf);
+
     let mut options = HashMap::new();
     protocol_features.add_startup_options(&mut options);
 
@@ -2217,6 +2240,13 @@ pub(crate) async fn open_connection(
 
     // Application & driver's identity.
     config.identity.add_startup_options(&mut options);
+
+    // Session identity, reported on every connection so that `system.clients`
+    // rows of one session can be correlated.
+    options.insert(
+        Cow::Borrowed(options::SESSION_ID),
+        Cow::Borrowed(&*session_id),
+    );
 
     // Optional compression.
     if let Some(compression) = &config.compression {

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -11,6 +11,7 @@ mod pager;
 mod retries;
 mod schema_agreement;
 mod self_identity;
+mod startup_options;
 mod status_change_hints;
 mod tracing;
 mod use_keyspace;

--- a/scylla/tests/integration/session/startup_options.rs
+++ b/scylla/tests/integration/session/startup_options.rs
@@ -1,0 +1,109 @@
+use crate::utils::{setup_tracing, test_with_3_node_cluster};
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla_cql::frame::request::options;
+use scylla_cql::frame::types;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    ShardAwareness, WorkerError,
+};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+/// The number of connections a freshly built session opens: one control
+/// connection plus, with the default `PoolSize::PerShard(1)`, one pool
+/// connection per shard of every node. A non-ScyllaDB node reports no sharding
+/// and gets a single pool connection.
+fn expected_connection_count(session: &Session) -> usize {
+    1 + session
+        .get_cluster_state()
+        .get_nodes_info()
+        .iter()
+        .map(|node| {
+            node.sharder()
+                .map_or(1, |sharder| usize::from(sharder.nr_shards.get()))
+        })
+        .sum::<usize>()
+}
+
+/// Receives exactly `count` STARTUP frames, asserting that each of them carries
+/// a `SESSION_ID` option reporting `session_id`.
+///
+/// Receiving a known count is the barrier that makes this test deterministic:
+/// `Session::connect` only waits for the first connection to each node
+/// (`ClusterState::wait_until_all_pools_are_initialized`), so the remaining pool
+/// connections are opened asynchronously by the pool refiller and their frames
+/// arrive later. Awaiting them is sleep-free; any surplus frame stays queued.
+async fn recv_session_ids(
+    startup_rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
+    session_id: Uuid,
+    count: usize,
+) {
+    let expected = session_id.to_string();
+    let mut received = 0;
+    let recv_all = async {
+        while received < count {
+            let (startup_frame, _shard) = startup_rx.recv().await.unwrap();
+            let startup_options = types::read_string_map(&mut &*startup_frame.body).unwrap();
+            let reported = startup_options
+                .get(options::SESSION_ID)
+                .expect("STARTUP frame without a SESSION_ID option");
+            assert_eq!(
+                *reported, expected,
+                "unexpected SESSION_ID reported in STARTUP"
+            );
+            received += 1;
+        }
+    };
+
+    tokio::time::timeout(Duration::from_secs(30), recv_all)
+        .await
+        .unwrap_or_else(|_| {
+            panic!("received only {received} of {count} expected STARTUP frames for {expected}")
+        });
+}
+
+/// Every connection of a session - the control connection and all pool
+/// connections alike - must report the same `SESSION_ID`, and it must be the
+/// one returned by [`Session::session_id`].
+#[tokio::test]
+async fn session_id_is_sent_on_every_connection() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            // The proxy informs us (via startup_rx) about every STARTUP frame the driver
+            // sends. The rule is installed on all three nodes, so that both the control
+            // connection and the per-shard pool connections are observed.
+            let (startup_tx, mut startup_rx) = mpsc::unbounded_channel();
+            for node in running_proxy.running_nodes.iter_mut() {
+                node.change_request_rules(Some(vec![RequestRule(
+                    Condition::RequestOpcode(RequestOpcode::Startup),
+                    RequestReaction::noop().with_feedback_when_performed(startup_tx.clone()),
+                )]));
+            }
+
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            let expected = expected_connection_count(&session);
+            recv_session_ids(&mut startup_rx, session.session_id(), expected).await;
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}


### PR DESCRIPTION
ScyllaDB stores every STARTUP option in system.clients.client_options. Until now nothing there told the connections of one session apart from those of another client, so a row could only be attributed by address and port - which reveals nothing once a client opens dozens of connections.

Generate a UUID per Session and report it on every connection, so that rows can be grouped by session, and expose it as Session::session_id() so the same value can be logged client side and the two correlated.

This will be necessary for Driver Config Reporting: report will only be sent on CC, and we need a way to connect the connection of a single Session.
This is a nice feature on its own, so it deserves a separate PR.

Ref: https://github.com/scylladb/scylla-rust-driver/issues/1859
Ref: https://scylladb.atlassian.net/browse/DRIVER-378

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
