### PR TITLE
statement: make BoundStatement configurable

### DIFF
--- a/docs/source/statements/bound.md
+++ b/docs/source/statements/bound.md
@@ -110,9 +110,9 @@ session.execute_unpaged(&prepared, (12345,)).await?; // serializes them again
 
 ### Configuration
 
-`BoundStatement` does not expose configuration modifiers. Configure the `PreparedStatement`
-(consistency, page size, execution profile, ...) *before* binding - the bound statement
-inherits all of its settings, and you can inspect them through `BoundStatement::prepared`.
+`BoundStatement` inherits the prepared statement's configuration when it is created. You can
+also update options such as consistency, page size, and execution profile directly on the bound
+statement before execution.
 
 ```rust
 # extern crate scylla;
@@ -121,15 +121,12 @@ inherits all of its settings, and you can inspect them through `BoundStatement::
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::statement::Consistency;
 
-let mut prepared = session
+let prepared = session
     .prepare("INSERT INTO ks.tab (a) VALUES(?)")
     .await?;
 
-// Set the options first...
-prepared.set_consistency(Consistency::One);
-
-// ...then bind. The bound statement will be executed with Consistency::One.
-let bound = prepared.bind(&(12345,))?;
+let mut bound = prepared.bind(&(12345,))?;
+bound.set_consistency(Consistency::One);
 assert_eq!(bound.prepared().get_consistency(), Some(Consistency::One));
 
 session.execute_bound_unpaged(&bound).await?;

--- a/docs/source/statements/bound.md
+++ b/docs/source/statements/bound.md
@@ -121,13 +121,16 @@ statement before execution.
 # async fn check_only_compiles(session: &Session) -> Result<(), Box<dyn Error>> {
 use scylla::statement::Consistency;
 
-let prepared = session
+let mut prepared = session
     .prepare("INSERT INTO ks.tab (a) VALUES(?)")
     .await?;
+prepared.set_consistency(Consistency::Quorum);
+prepared.set_page_size(100);
 
 let mut bound = prepared.bind(&(12345,))?;
 bound.set_consistency(Consistency::One);
 assert_eq!(bound.prepared().get_consistency(), Some(Consistency::One));
+assert_eq!(bound.prepared().get_page_size(), 100);
 
 session.execute_bound_unpaged(&bound).await?;
 # Ok(())

--- a/scylla/src/statement/bound.rs
+++ b/scylla/src/statement/bound.rs
@@ -2,7 +2,14 @@
 //! that has already been bound with values to be executed with.
 
 use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
 
+use crate::client::execution_profile::ExecutionProfileHandle;
+use crate::frame::types::{Consistency, SerialConsistency};
+use crate::observability::history::HistoryListener;
+use crate::policies::load_balancing::LoadBalancingPolicy;
+use crate::policies::retry::RetryPolicy;
 use crate::routing::Token;
 use crate::serialize::SerializationError;
 use crate::serialize::row::{SerializeRow, SerializedValues};
@@ -43,5 +50,101 @@ impl BoundStatement {
     /// Returns the prepared statement behind the `BoundStatement`.
     pub fn prepared(&self) -> &PreparedStatement {
         &self.prepared
+    }
+
+    /// Sets the page size for this CQL query.
+    ///
+    /// Panics if the given number is nonpositive.
+    pub fn set_page_size(&mut self, page_size: i32) {
+        self.prepared.set_page_size(page_size);
+    }
+
+    /// Sets the consistency to be used when executing this statement.
+    pub fn set_consistency(&mut self, consistency: Consistency) {
+        self.prepared.set_consistency(consistency);
+    }
+
+    /// Unsets the consistency overridden on this statement.
+    ///
+    /// The consistency will be derived from the per-statement execution profile,
+    /// or from the session's default execution profile if one is not set.
+    pub fn unset_consistency(&mut self) {
+        self.prepared.unset_consistency();
+    }
+
+    /// Sets the serial consistency to be used when executing this statement.
+    ///
+    /// This setting is ignored unless the statement is an LWT.
+    pub fn set_serial_consistency(&mut self, serial_consistency: Option<SerialConsistency>) {
+        self.prepared.set_serial_consistency(serial_consistency);
+    }
+
+    /// Unsets the serial consistency overridden on this statement.
+    ///
+    /// The serial consistency will be derived from the per-statement execution
+    /// profile, or from the session's default execution profile if one is not set.
+    pub fn unset_serial_consistency(&mut self) {
+        self.prepared.unset_serial_consistency();
+    }
+
+    /// Sets whether this statement is idempotent.
+    ///
+    /// Retry policies use this information to decide whether retrying the
+    /// statement is safe.
+    pub fn set_is_idempotent(&mut self, is_idempotent: bool) {
+        self.prepared.set_is_idempotent(is_idempotent);
+    }
+
+    /// Enables or disables CQL tracing for this statement.
+    pub fn set_tracing(&mut self, should_trace: bool) {
+        self.prepared.set_tracing(should_trace);
+    }
+
+    /// Sets whether cached result metadata should be used to decode results.
+    pub fn set_use_cached_result_metadata(&mut self, use_cached_metadata: bool) {
+        self.prepared
+            .set_use_cached_result_metadata(use_cached_metadata);
+    }
+
+    /// Sets the default timestamp for this statement in microseconds.
+    pub fn set_timestamp(&mut self, timestamp: Option<i64>) {
+        self.prepared.set_timestamp(timestamp);
+    }
+
+    /// Sets the client-side timeout for this statement.
+    pub fn set_request_timeout(&mut self, timeout: Option<Duration>) {
+        self.prepared.set_request_timeout(timeout);
+    }
+
+    /// Sets the retry policy for this statement, overriding the execution
+    /// profile's policy when one is provided.
+    pub fn set_retry_policy(&mut self, retry_policy: Option<Arc<dyn RetryPolicy>>) {
+        self.prepared.set_retry_policy(retry_policy);
+    }
+
+    /// Sets the load balancing policy for this statement, overriding the
+    /// execution profile's policy when one is provided.
+    pub fn set_load_balancing_policy(
+        &mut self,
+        load_balancing_policy: Option<Arc<dyn LoadBalancingPolicy>>,
+    ) {
+        self.prepared
+            .set_load_balancing_policy(load_balancing_policy);
+    }
+
+    /// Sets the listener that observes this statement's execution history.
+    pub fn set_history_listener(&mut self, history_listener: Arc<dyn HistoryListener>) {
+        self.prepared.set_history_listener(history_listener);
+    }
+
+    /// Removes and returns the execution history listener set on this statement.
+    pub fn remove_history_listener(&mut self) -> Option<Arc<dyn HistoryListener>> {
+        self.prepared.remove_history_listener()
+    }
+
+    /// Associates this statement with the execution profile referred to by the
+    /// provided handle.
+    pub fn set_execution_profile_handle(&mut self, profile_handle: Option<ExecutionProfileHandle>) {
+        self.prepared.set_execution_profile_handle(profile_handle);
     }
 }

--- a/scylla/tests/integration/statements/bound.rs
+++ b/scylla/tests/integration/statements/bound.rs
@@ -215,10 +215,13 @@ async fn bound_statement_inherits_prepared_statement_config(session: &Session) {
 /// available after values have been bound, without exposing mutable access to
 /// the prepared statement itself.
 async fn bound_statement_can_be_configured_after_binding(session: &Session) {
-    let prepared = session
+    let mut prepared = session
         .prepare("SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?")
         .await
         .unwrap();
+    prepared.set_page_size(3);
+    prepared.set_consistency(Consistency::One);
+    prepared.set_serial_consistency(Some(SerialConsistency::LocalSerial));
     let mut bound = prepared.bind(&("system_schema",)).unwrap();
 
     let retry_policy: Arc<dyn RetryPolicy> = Arc::new(FallthroughRetryPolicy::new());
@@ -228,6 +231,16 @@ async fn bound_statement_can_be_configured_after_binding(session: &Session) {
 
     bound.set_page_size(7);
     bound.set_consistency(Consistency::Two);
+
+    // Options changed on the bound statement override the prepared statement,
+    // while options not changed after binding retain their inherited value.
+    assert_eq!(bound.prepared().get_page_size(), 7);
+    assert_eq!(bound.prepared().get_consistency(), Some(Consistency::Two));
+    assert_eq!(
+        bound.prepared().get_serial_consistency(),
+        Some(SerialConsistency::LocalSerial)
+    );
+
     bound.set_serial_consistency(Some(SerialConsistency::Serial));
     bound.set_is_idempotent(true);
     bound.set_tracing(true);

--- a/scylla/tests/integration/statements/bound.rs
+++ b/scylla/tests/integration/statements/bound.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use futures::TryStreamExt as _;
 use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
-use scylla::observability::history::HistoryCollector;
+use scylla::observability::history::{HistoryCollector, HistoryListener};
 use scylla::policies::load_balancing::{DefaultPolicy, LoadBalancingPolicy};
 use scylla::policies::retry::{FallthroughRetryPolicy, RetryPolicy};
 use scylla::response::{PagingState, PagingStateResponse};
@@ -35,6 +35,7 @@ async fn test_bound_statement() {
 
     // Cases that only read - system tables suffice.
     bound_statement_inherits_prepared_statement_config(&session).await;
+    bound_statement_can_be_configured_after_binding(&session).await;
     bound_statement_is_executed_with_inherited_config(&session).await;
     bound_statement_calculates_token_from_its_values(&session).await;
     bind_rejects_invalid_values(&session).await;
@@ -208,6 +209,77 @@ async fn bound_statement_inherits_prepared_statement_config(session: &Session) {
     // The prepared statement itself is, of course, untouched by all of this.
     assert_eq!(inherited.get_statement(), prepared.get_statement());
     assert_eq!(inherited.get_id(), prepared.get_id());
+}
+
+/// Every public configuration setter exposed by `PreparedStatement` remains
+/// available after values have been bound, without exposing mutable access to
+/// the prepared statement itself.
+async fn bound_statement_can_be_configured_after_binding(session: &Session) {
+    let prepared = session
+        .prepare("SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?")
+        .await
+        .unwrap();
+    let mut bound = prepared.bind(&("system_schema",)).unwrap();
+
+    let retry_policy: Arc<dyn RetryPolicy> = Arc::new(FallthroughRetryPolicy::new());
+    let load_balancing_policy: Arc<dyn LoadBalancingPolicy> = DefaultPolicy::builder().build();
+    let execution_profile_handle = ExecutionProfile::builder().build().into_handle();
+    let history_listener: Arc<dyn HistoryListener> = Arc::new(HistoryCollector::new());
+
+    bound.set_page_size(7);
+    bound.set_consistency(Consistency::Two);
+    bound.set_serial_consistency(Some(SerialConsistency::Serial));
+    bound.set_is_idempotent(true);
+    bound.set_tracing(true);
+    bound.set_use_cached_result_metadata(true);
+    bound.set_timestamp(Some(123));
+    bound.set_request_timeout(Some(Duration::from_secs(9)));
+    bound.set_retry_policy(Some(Arc::clone(&retry_policy)));
+    bound.set_load_balancing_policy(Some(Arc::clone(&load_balancing_policy)));
+    bound.set_history_listener(history_listener.clone());
+    bound.set_execution_profile_handle(Some(execution_profile_handle));
+
+    let configured = bound.prepared();
+    assert_eq!(configured.get_page_size(), 7);
+    assert_eq!(configured.get_consistency(), Some(Consistency::Two));
+    assert_eq!(
+        configured.get_serial_consistency(),
+        Some(SerialConsistency::Serial)
+    );
+    assert!(configured.get_is_idempotent());
+    assert!(configured.get_tracing());
+    assert!(configured.get_use_cached_result_metadata());
+    assert_eq!(configured.get_timestamp(), Some(123));
+    assert_eq!(
+        configured.get_request_timeout(),
+        Some(Duration::from_secs(9))
+    );
+    assert!(Arc::ptr_eq(
+        configured.get_retry_policy().unwrap(),
+        &retry_policy
+    ));
+    assert!(Arc::ptr_eq(
+        configured.get_load_balancing_policy().unwrap(),
+        &load_balancing_policy
+    ));
+    assert!(configured.get_execution_profile_handle().is_some());
+
+    assert!(Arc::ptr_eq(
+        &bound.remove_history_listener().unwrap(),
+        &history_listener
+    ));
+    bound.unset_consistency();
+    bound.unset_serial_consistency();
+    bound.set_retry_policy(None);
+    bound.set_load_balancing_policy(None);
+    bound.set_execution_profile_handle(None);
+
+    let reset = bound.prepared();
+    assert_eq!(reset.get_consistency(), None);
+    assert_eq!(reset.get_serial_consistency(), None);
+    assert!(reset.get_retry_policy().is_none());
+    assert!(reset.get_load_balancing_policy().is_none());
+    assert!(reset.get_execution_profile_handle().is_none());
 }
 
 /// The inherited configuration is not merely stored in the bound statement -


### PR DESCRIPTION
## Summary

- I added the full set of public `PreparedStatement` configuration mutators to `BoundStatement`.
- Each method delegates to the owned prepared statement, so configuration can change after binding without exposing mutable access to it.
- I added regression coverage for setting and resetting every forwarded option after binding.
- I updated the bound-statement book chapter to document and demonstrate post-binding configuration.

## Validation

- `cargo check -p scylla --lib`
- `cargo test -p scylla --test integration --no-run`
- `cargo clippy -p scylla --lib -- -D warnings -A unfulfilled-lint-expectations`
- `cargo fmt --all -- --check`
- `cargo test -j 2 -p scylla --doc book_tests::statements::bound` (4 passed)
- `git diff --check upstream/main...HEAD`

The integration test binary compiles successfully. I could not run the database-backed integration test locally because this environment cannot access the Docker socket, so I am leaving the runtime integration suite to CI.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test. (Compilation and static checks pass; the database-backed runtime test is deferred to CI as noted above.)
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes #1876
