### PR TITLE
Expose compute_token_preserialized for nodejs-rs

### DIFF
--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -735,7 +735,10 @@ impl ClusterState {
 }
 
 /// Additional API for interop-based code.
-#[cfg(all(scylla_unstable, feature = "unstable-csharp-rs"))]
+#[cfg(all(
+    scylla_unstable,
+    any(feature = "unstable-csharp-rs", feature = "unstable-nodejs-rs")
+))]
 impl ClusterState {
     /// Compute token for an externally-provided **serialized** partition key.
     ///


### PR DESCRIPTION
Allow access to the `compute_token_preserialized` method with the unstable-node-js feature enabled.

This is needed for https://github.com/scylladb/nodejs-rs-driver/pull/529.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
