### PR TITLE
scylla: Hide ConsistencyMode behind unstable feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,6 +112,10 @@ jobs:
       - name: Cargo check with unstable-client-routes feature
         run: cargo check --all-targets -p scylla --features "unstable-client-routes"
 
+      # unstable-strong-consistency feature.
+      - name: Cargo check with unstable-strong-consistency feature
+        run: cargo check --all-targets -p scylla --features "unstable-strong-consistency"
+
       # No scylla_unstable flag with features
       - name: Cargo check without scylla_unstable
         run: RUSTFLAGS="-Dwarnings" cargo clippy --all-features --tests --examples # No benches, because they require unstable features.

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -85,6 +85,8 @@ unstable-reconnect-policy = []
 # Enables fetching contents of the `system.client_routes` table.
 # Needed for custom routing (AWS PrivateLink, GCP PSC, etc.).
 unstable-client-routes = []
+# Exposes the unstable API of strong consistency.
+unstable-strong-consistency = []
 
 
 [dependencies]

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -1920,9 +1920,10 @@ struct ScyllaKeyspacesMetadata {
 /// Maps the raw `consistency` column value from `system_schema.scylla_keyspaces` to a
 /// [`ConsistencyMode`]. A missing or unrecognized value means eventual consistency.
 fn consistency_mode_from_str(consistency: Option<&str>) -> ConsistencyMode {
+    // Note that local consistency isn't implemented yet, so we only
+    // treat globally-consistent keyspaces as non-eventually-consistent.
     match consistency {
         Some("global") => ConsistencyMode::Global,
-        Some("local") => ConsistencyMode::Local,
         _ => ConsistencyMode::Eventual,
     }
 }
@@ -2012,13 +2013,11 @@ mod tests {
             consistency_mode_from_str(Some("global")),
             ConsistencyMode::Global
         );
-        assert_eq!(
-            consistency_mode_from_str(Some("local")),
-            ConsistencyMode::Local
-        );
         for unrecognised in [
             None,
             Some(""),
+            // Note: Local strong consistency hasn't been implemented yet.
+            Some("local"),
             Some("GLOBAL"),
             Some("none"),
             Some("whatever"),

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -184,13 +184,31 @@ impl Peer {
 /// The consistency mode of a keyspace, as reported by the `consistency` column of
 /// `system_schema.scylla_keyspaces`.
 ///
-/// Deliberately crate-private. Strong consistency is an experimental server-side feature and
-/// these mode names come straight from it, so making the type public would freeze names we may
-/// yet have to change - and an enum's variants cannot be renamed without a major release. Should
-/// this ever become public, it needs `#[non_exhaustive]`, which is pointless until then.
+/// Strong consistency is an experimental feature, and so this type is still unstable.
+/// That's why it's gated behind an unstable feature.
 //
 // Note: Local strong consistency isn't implemented yet.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg(all(scylla_unstable, feature = "unstable-strong-consistency"))]
+pub enum ConsistencyMode {
+    /// Eventual consistency. Covers every non-tablet keyspace and every keyspace
+    /// on a server that does not report a consistency mode.
+    Eventual,
+    /// Global strong consistency (`consistency = 'global'`): the keyspace uses
+    /// strongly-consistent (Raft-based) tablets.
+    Global,
+}
+
+/// The consistency mode of a keyspace, as reported by the `consistency` column of
+/// `system_schema.scylla_keyspaces`.
+///
+/// Strong consistency is an experimental feature, and so this type is still unstable.
+/// Hence crate-private.
+//
+// Note: Local strong consistency isn't implemented yet.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg(not(all(scylla_unstable, feature = "unstable-strong-consistency")))]
 pub(crate) enum ConsistencyMode {
     /// Eventual consistency. Covers every non-tablet keyspace and every keyspace
     /// on a server that does not report a consistency mode.
@@ -216,7 +234,14 @@ pub struct Keyspace {
     pub tablet_based: bool,
     /// The consistency mode of the keyspace.
     ///
-    /// Crate-private along with [`ConsistencyMode`] itself; see that type for why.
+    /// Public only behind the `unstable-strong-consistency` feature because
+    /// strong consistency is still experimental.
+    #[cfg(all(scylla_unstable, feature = "unstable-strong-consistency"))]
+    pub consistency_mode: ConsistencyMode,
+    /// The consistency mode of the keyspace.
+    ///
+    /// Strong consistency is still experimental; hence crate-private.
+    #[cfg(not(all(scylla_unstable, feature = "unstable-strong-consistency")))]
     pub(crate) consistency_mode: ConsistencyMode,
     /// Tables in the keyspace.
     ///

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -188,13 +188,13 @@ impl Peer {
 /// these mode names come straight from it, so making the type public would freeze names we may
 /// yet have to change - and an enum's variants cannot be renamed without a major release. Should
 /// this ever become public, it needs `#[non_exhaustive]`, which is pointless until then.
+//
+// Note: Local strong consistency isn't implemented yet.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum ConsistencyMode {
     /// Eventual consistency. Covers every non-tablet keyspace and every keyspace
     /// on a server that does not report a consistency mode.
     Eventual,
-    /// Reserved for a future per-datacenter strong-consistency mode (`consistency = 'local'`).
-    Local,
     /// Global strong consistency (`consistency = 'global'`): the keyspace uses
     /// strongly-consistent (Raft-based) tablets.
     Global,


### PR DESCRIPTION
ConsistencyMode is needed to implement DefaultPolicy. As long as
it's crate-private, the user cannot implement it on their own.
Expose it conditionally so it's accessible if needed.

Also, drop ConsistencyMode::Local. Local strong consistency is not
implemented yet, so there's no point in exposing it -- it's dead code.

Fixes: scylladb/scylla-rust-driver#1884

Backport: no. The feature is experimental + the relevant code is only present on `main`.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] (N/A) I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.