### PR TITLE
tests: introduce new test for compression

### DIFF
--- a/scylla-proxy/src/actions.rs
+++ b/scylla-proxy/src/actions.rs
@@ -127,15 +127,15 @@ impl Condition {
 
             Condition::RequestConsistency(expected_cl, features) => match ctx.opcode {
                 FrameOpcode::Request(opcode) => {
-                    let frame = RequestFrame {
-                        params: FrameParams {
+                    let frame = RequestFrame::new(
+                        FrameParams {
                             version: 0x04,
                             flags: 0,
                             stream: 0,
                         },
                         opcode,
-                        body: ctx.frame_body.clone(),
-                    };
+                        ctx.frame_body.clone(),
+                    );
                     frame
                         .deserialize(features)
                         .ok()

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -43,7 +43,8 @@ impl FrameParams {
     /// Tells whether the frame carried a compressed body on the wire.
     ///
     /// Note that frames handed out by the proxy always expose a *decompressed*
-    /// body, so this flag is the only way to tell that compression was in play.
+    /// body, so this flag (together with [`RequestFrame::wire_body_len`]) is the
+    /// only way to tell that compression was in play.
     pub const fn is_compressed(&self) -> bool {
         self.flags & flag::COMPRESSION != 0
     }
@@ -61,19 +62,37 @@ pub(crate) enum FrameOpcode {
     Response(ResponseOpcode),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq)]
 pub struct RequestFrame {
     pub params: FrameParams,
     pub opcode: RequestOpcode,
+    /// The frame body, decompressed if the frame arrived compressed.
     pub body: Bytes,
+    /// Number of body bytes as they appeared on the wire, i.e. *before* decompression.
+    /// For frames that were not compressed this is equal to `body.len()`.
+    ///
+    /// This is what makes it possible to observe how effective compression is;
+    /// [`Self::body`] is always decompressed, so its length says nothing about
+    /// how much data actually travelled over the network.
+    pub wire_body_len: usize,
+}
+
+/// Excludes [`RequestFrame::wire_body_len`], which is an observation about how the frame
+/// was transferred rather than a part of its logical content.
+impl PartialEq for RequestFrame {
+    fn eq(&self, other: &Self) -> bool {
+        self.params == other.params && self.opcode == other.opcode && self.body == other.body
+    }
 }
 
 impl RequestFrame {
-    /// Creates a frame out of its parts.
+    /// Creates a frame whose body did not undergo compression, so that its
+    /// [`Self::wire_body_len`] is simply the body length.
     pub fn new(params: FrameParams, opcode: RequestOpcode, body: Bytes) -> Self {
         Self {
             params,
             opcode,
+            wire_body_len: body.len(),
             body,
         }
     }
@@ -100,19 +119,35 @@ impl RequestFrame {
         RequestV2::deserialize(&mut &self.body[..], self.opcode, features)
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq)]
 pub struct ResponseFrame {
     pub params: FrameParams,
     pub opcode: ResponseOpcode,
+    /// The frame body, decompressed if the frame arrived compressed.
     pub body: Bytes,
+    /// Number of body bytes as they appeared on the wire, i.e. *before* decompression.
+    /// For frames that were not compressed this is equal to `body.len()`.
+    ///
+    /// See [`RequestFrame::wire_body_len`] for the rationale.
+    pub wire_body_len: usize,
+}
+
+/// Excludes [`ResponseFrame::wire_body_len`], which is an observation about how the frame
+/// was transferred rather than a part of its logical content.
+impl PartialEq for ResponseFrame {
+    fn eq(&self, other: &Self) -> bool {
+        self.params == other.params && self.opcode == other.opcode && self.body == other.body
+    }
 }
 
 impl ResponseFrame {
-    /// Creates a frame out of its parts.
+    /// Creates a frame whose body did not undergo compression, so that its
+    /// [`Self::wire_body_len`] is simply the body length.
     pub fn new(params: FrameParams, opcode: ResponseOpcode, body: Bytes) -> Self {
         Self {
             params,
             opcode,
+            wire_body_len: body.len(),
             body,
         }
     }
@@ -295,11 +330,16 @@ pub(crate) async fn write_frame(
     Ok(())
 }
 
+/// Reads a single frame off the wire.
+///
+/// Returns the body already decompressed, accompanied by the number of body bytes
+/// that were actually read from the socket (i.e. the compressed length, if the frame
+/// was compressed).
 pub(crate) async fn read_frame(
     reader: &mut (impl AsyncRead + Unpin),
     frame_type: FrameType,
     compression: &CompressionReader,
-) -> Result<(FrameParams, FrameOpcode, Bytes), ReadFrameError> {
+) -> Result<(FrameParams, FrameOpcode, Bytes, usize), ReadFrameError> {
     let mut raw_header = [0u8; HEADER_SIZE];
     reader
         .read_exact(&mut raw_header[..])
@@ -365,7 +405,8 @@ pub(crate) async fn read_frame(
 
     let body = compression.maybe_decompress_body(flags, body.into_inner().into())?;
 
-    Ok((frame_params, opcode, body))
+    // `length` is the number of body bytes read off the socket, before any decompression.
+    Ok((frame_params, opcode, body, length))
 }
 
 pub(crate) async fn read_request_frame(
@@ -374,13 +415,14 @@ pub(crate) async fn read_request_frame(
 ) -> Result<RequestFrame, ReadFrameError> {
     read_frame(reader, FrameType::Request, compression)
         .await
-        .map(|(params, opcode, body)| RequestFrame {
+        .map(|(params, opcode, body, wire_body_len)| RequestFrame {
             params,
             opcode: match opcode {
                 FrameOpcode::Request(op) => op,
                 FrameOpcode::Response(_) => unreachable!(),
             },
             body,
+            wire_body_len,
         })
 }
 
@@ -390,12 +432,13 @@ pub(crate) async fn read_response_frame(
 ) -> Result<ResponseFrame, ReadFrameError> {
     read_frame(reader, FrameType::Response, compression)
         .await
-        .map(|(params, opcode, body)| ResponseFrame {
+        .map(|(params, opcode, body, wire_body_len)| ResponseFrame {
             params,
             opcode: match opcode {
                 FrameOpcode::Request(_) => unreachable!(),
                 FrameOpcode::Response(op) => op,
             },
             body,
+            wire_body_len,
         })
 }

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use scylla_cql::frame::flag;
 use scylla_cql::frame::frame_errors::FrameHeaderParseError;
 use scylla_cql::frame::protocol_features::ProtocolFeatures;
 pub use scylla_cql::frame::request::RequestOpcode;
@@ -37,6 +38,14 @@ impl FrameParams {
             version: 0x80 | (self.version & 0x7F),
             ..*self
         }
+    }
+
+    /// Tells whether the frame carried a compressed body on the wire.
+    ///
+    /// Note that frames handed out by the proxy always expose a *decompressed*
+    /// body, so this flag is the only way to tell that compression was in play.
+    pub const fn is_compressed(&self) -> bool {
+        self.flags & flag::COMPRESSION != 0
     }
 }
 

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -60,6 +60,15 @@ pub struct RequestFrame {
 }
 
 impl RequestFrame {
+    /// Creates a frame out of its parts.
+    pub fn new(params: FrameParams, opcode: RequestOpcode, body: Bytes) -> Self {
+        Self {
+            params,
+            opcode,
+            body,
+        }
+    }
+
     pub(crate) async fn write(
         &self,
         writer: &mut (impl AsyncWrite + Unpin),
@@ -90,6 +99,15 @@ pub struct ResponseFrame {
 }
 
 impl ResponseFrame {
+    /// Creates a frame out of its parts.
+    pub fn new(params: FrameParams, opcode: ResponseOpcode, body: Bytes) -> Self {
+        Self {
+            params,
+            opcode,
+            body,
+        }
+    }
+
     /// Creates a response frame that signifies the given DbError type.
     /// Useful for testing server-side error handling in drivers.
     pub fn forged_error(
@@ -109,11 +127,11 @@ impl ResponseFrame {
 
         serialize_error_specific_fields(&mut buf, error)?;
 
-        Ok(ResponseFrame {
-            params: request_params.for_response(),
-            opcode: ResponseOpcode::Error,
-            body: buf.freeze(),
-        })
+        Ok(ResponseFrame::new(
+            request_params.for_response(),
+            ResponseOpcode::Error,
+            buf.freeze(),
+        ))
     }
 
     /// Creates a Supported response frame with given supported options.
@@ -124,19 +142,19 @@ impl ResponseFrame {
         let mut buf = BytesMut::new();
         types::write_string_multimap(options, &mut buf)?;
 
-        Ok(ResponseFrame {
-            params: request_params.for_response(),
-            opcode: ResponseOpcode::Supported,
-            body: buf.freeze(),
-        })
+        Ok(ResponseFrame::new(
+            request_params.for_response(),
+            ResponseOpcode::Supported,
+            buf.freeze(),
+        ))
     }
 
     pub fn forged_ready(request_params: FrameParams) -> Self {
-        ResponseFrame {
-            params: request_params.for_response(),
-            opcode: ResponseOpcode::Ready,
-            body: Bytes::new(),
-        }
+        ResponseFrame::new(
+            request_params.for_response(),
+            ResponseOpcode::Ready,
+            Bytes::new(),
+        )
     }
 
     pub(crate) async fn write(

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -535,16 +535,16 @@ impl RunningNode {
         }
         let mut any_sent = false;
         guard.retain(|_conn_no, tx| {
-            let frame = ResponseFrame {
-                params: FrameParams {
+            let frame = ResponseFrame::new(
+                FrameParams {
                     version: 4,
                     flags: 0,
                     stream: -1,
                 }
                 .for_response(),
-                opcode: ResponseOpcode::Event,
-                body: body.clone(),
-            };
+                ResponseOpcode::Event,
+                body.clone(),
+            );
             let ok = tx.send(frame).is_ok();
             any_sent |= ok;
             // Remove dead senders (connection already closed on the
@@ -2071,11 +2071,11 @@ mod tests {
                 RequestRule(
                     Condition::RequestOpcode(RequestOpcode::Register),
                     RequestReaction::forge_response(Arc::new(|RequestFrame { params, .. }| {
-                        ResponseFrame {
-                            params: params.for_response(),
-                            opcode: ResponseOpcode::Event,
-                            body: Bytes::from_static(test_msg),
-                        }
+                        ResponseFrame::new(
+                            params.for_response(),
+                            ResponseOpcode::Event,
+                            Bytes::from_static(test_msg),
+                        )
                     })),
                 ),
                 RequestRule(
@@ -2085,11 +2085,11 @@ mod tests {
                 RequestRule(
                     Condition::True, // only the first matching rule is applied, so "True" covers all remaining cases
                     RequestReaction::forge_response(Arc::new(|RequestFrame { params, .. }| {
-                        ResponseFrame {
-                            params: params.for_response(),
-                            opcode: ResponseOpcode::Ready,
-                            body: Bytes::new(),
-                        }
+                        ResponseFrame::new(
+                            params.for_response(),
+                            ResponseOpcode::Ready,
+                            Bytes::new(),
+                        )
                     })),
                 ),
             ]),
@@ -2629,11 +2629,11 @@ mod tests {
                 RequestRule(
                     Condition::RequestOpcode(RequestOpcode::Register),
                     RequestReaction::forge_response(Arc::new(|RequestFrame { params, .. }| {
-                        ResponseFrame {
-                            params: params.for_response(),
-                            opcode: ResponseOpcode::Event,
-                            body: Bytes::from_static(test_msg),
-                        }
+                        ResponseFrame::new(
+                            params.for_response(),
+                            ResponseOpcode::Event,
+                            Bytes::from_static(test_msg),
+                        )
                     })),
                 ),
                 RequestRule(
@@ -2643,11 +2643,11 @@ mod tests {
                 RequestRule(
                     Condition::True, // only the first matching rule is applied, so "True" covers all remaining cases
                     RequestReaction::forge_response(Arc::new(|RequestFrame { params, .. }| {
-                        ResponseFrame {
-                            params: params.for_response(),
-                            opcode: ResponseOpcode::Ready,
-                            body: Bytes::new(),
-                        }
+                        ResponseFrame::new(
+                            params.for_response(),
+                            ResponseOpcode::Ready,
+                            Bytes::new(),
+                        )
                     })),
                 ),
             ]),
@@ -3080,11 +3080,11 @@ mod tests {
         // 1. "driver" sends an uncompressed, e.g., QUERY frame, feedback returns its uncompressed body,
         //    and "node" receives the uncompressed frame.
         {
-            let sent_frame = RequestFrame {
-                params: PARAMS_REQUEST_NO_COMPRESSION,
-                opcode: RequestOpcode::Query,
-                body: random_body(),
-            };
+            let sent_frame = RequestFrame::new(
+                PARAMS_REQUEST_NO_COMPRESSION,
+                RequestOpcode::Query,
+                random_body(),
+            );
 
             sent_frame
                 .write(&mut driver_conn, &no_compression())
@@ -3103,11 +3103,11 @@ mod tests {
         // 2. "node" responds with an uncompressed RESULT frame, feedback returns its uncompressed body,
         //    and "driver" receives the uncompressed frame.
         {
-            let sent_frame = ResponseFrame {
-                params: PARAMS_RESPONSE_NO_COMPRESSION,
-                opcode: ResponseOpcode::Result,
-                body: random_body(),
-            };
+            let sent_frame = ResponseFrame::new(
+                PARAMS_RESPONSE_NO_COMPRESSION,
+                ResponseOpcode::Result,
+                random_body(),
+            );
 
             sent_frame
                 .write(&mut node_conn, &no_compression())
@@ -3138,11 +3138,11 @@ mod tests {
             .to_bytes()
             .unwrap();
 
-            let sent_frame = RequestFrame {
-                params: PARAMS_REQUEST_NO_COMPRESSION,
-                opcode: RequestOpcode::Startup,
-                body: startup_body,
-            };
+            let sent_frame = RequestFrame::new(
+                PARAMS_REQUEST_NO_COMPRESSION,
+                RequestOpcode::Startup,
+                startup_body,
+            );
 
             sent_frame
                 .write(&mut driver_conn, &no_compression())
@@ -3161,11 +3161,11 @@ mod tests {
         // 4. "driver" sends a compressed, e.g., QUERY frame, feedback returns its uncompressed body,
         //    and "node" receives the compressed frame.
         {
-            let sent_frame = RequestFrame {
-                params: PARAMS_REQUEST_COMPRESSION,
-                opcode: RequestOpcode::Query,
-                body: random_body(),
-            };
+            let sent_frame = RequestFrame::new(
+                PARAMS_REQUEST_COMPRESSION,
+                RequestOpcode::Query,
+                random_body(),
+            );
 
             sent_frame
                 .write(&mut driver_conn, &with_compression(Compression::Lz4))
@@ -3185,11 +3185,11 @@ mod tests {
         // 5. "node" responds with a compressed RESULT frame, feedback returns its uncompressed body,
         //    and "driver" receives the compressed frame.
         {
-            let sent_frame = ResponseFrame {
-                params: PARAMS_RESPONSE_COMPRESSION,
-                opcode: ResponseOpcode::Result,
-                body: random_body(),
-            };
+            let sent_frame = ResponseFrame::new(
+                PARAMS_RESPONSE_COMPRESSION,
+                ResponseOpcode::Result,
+                random_body(),
+            );
 
             sent_frame
                 .write(&mut node_conn, &with_compression(Compression::Lz4))

--- a/scylla-proxy/src/proxy.rs
+++ b/scylla-proxy/src/proxy.rs
@@ -1818,6 +1818,7 @@ mod tests {
             params: recvd_params,
             opcode: recvd_opcode,
             body: recvd_body,
+            wire_body_len: _,
         } = read_request_frame(conn, compression).await.unwrap();
         assert_eq!(recvd_params, HARDCODED_OPTIONS_PARAMS);
         assert_eq!(recvd_opcode, RequestOpcode::Options);
@@ -1923,6 +1924,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = read_request_frame(&mut conn, &no_compression())
                 .await
                 .unwrap();
@@ -2146,6 +2148,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = read_response_frame(&mut conn, &no_compression())
                 .await
                 .unwrap();
@@ -2157,6 +2160,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = read_response_frame(&mut conn, &no_compression())
                 .await
                 .unwrap();
@@ -2173,6 +2177,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = read_request_frame(&mut conn, &no_compression())
                 .await
                 .unwrap();
@@ -2246,6 +2251,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = request(&mut driver, &mut node, params, opcode, &body)
                 .await
                 .unwrap();
@@ -2274,6 +2280,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = request(&mut driver, &mut node, params, opcode, &body)
                 .await
                 .unwrap();
@@ -2367,6 +2374,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = request(&mut driver, &mut node, params, opcode, &body)
                 .await
                 .unwrap();
@@ -2572,6 +2580,7 @@ mod tests {
                 params: recvd_params,
                 opcode: recvd_opcode,
                 body: recvd_body,
+                wire_body_len: _,
             } = read_request_frame(&mut conn, &no_compression())
                 .await
                 .unwrap();
@@ -2700,6 +2709,7 @@ mod tests {
             params: recvd_params,
             opcode: recvd_opcode,
             body: recvd_body,
+            wire_body_len: _,
         } = read_response_frame(&mut conn, &no_compression())
             .await
             .unwrap();
@@ -2711,6 +2721,7 @@ mod tests {
             params: recvd_params,
             opcode: recvd_opcode,
             body: recvd_body,
+            wire_body_len: _,
         } = read_response_frame(&mut conn, &no_compression())
             .await
             .unwrap();

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -3054,11 +3054,13 @@ mod tests {
     /// Forges a RESULT response of Void kind, i.e. the kind of response that a
     /// non-SELECT statement would yield.
     fn forge_void_result() -> RequestReaction {
-        RequestReaction::forge_response(Arc::new(|frame: RequestFrame| ResponseFrame {
-            params: frame.params.for_response(),
-            opcode: scylla_proxy::ResponseOpcode::Result,
-            // The body of a RESULT response begins with its kind; 0x0001 is Void.
-            body: Bytes::from_static(&[0, 0, 0, 1]),
+        RequestReaction::forge_response(Arc::new(|frame: RequestFrame| {
+            ResponseFrame::new(
+                frame.params.for_response(),
+                scylla_proxy::ResponseOpcode::Result,
+                // The body of a RESULT response begins with its kind; 0x0001 is Void.
+                Bytes::from_static(&[0, 0, 0, 1]),
+            )
         }))
     }
 
@@ -3618,10 +3620,12 @@ mod tests {
         let make_delayed_response = |delay: Duration| {
             RequestReaction::forge_response_with_delay(
                 delay,
-                Arc::new(|RequestFrame { params, .. }| ResponseFrame {
-                    params: params.for_response(),
-                    opcode: ResponseOpcode::Result,
-                    body: Bytes::from_static(&[0, 0, 0, 1]), // Void response
+                Arc::new(|RequestFrame { params, .. }| {
+                    ResponseFrame::new(
+                        params.for_response(),
+                        ResponseOpcode::Result,
+                        Bytes::from_static(&[0, 0, 0, 1]), // Void response
+                    )
                 }),
             )
         };
@@ -3642,11 +3646,11 @@ mod tests {
             mk_rule(
                 SUCCESSFUL_QUERY,
                 RequestReaction::forge_response(Arc::new(|RequestFrame { params, .. }| {
-                    ResponseFrame {
-                        params: params.for_response(),
-                        opcode: ResponseOpcode::Result,
-                        body: Bytes::from_static(&[0, 0, 0, 1]), // Void response
-                    }
+                    ResponseFrame::new(
+                        params.for_response(),
+                        ResponseOpcode::Result,
+                        Bytes::from_static(&[0, 0, 0, 1]), // Void response
+                    )
                 })),
             ),
             mk_rule(DROP_QUERY, RequestReaction::drop_frame()),

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1566,11 +1566,11 @@ mod tests {
         let make_rules = |shard_info: Option<ShardInfo>, keyspace_succeeds: bool| {
             let query_reaction = if keyspace_succeeds {
                 RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
-                    ResponseFrame {
-                        params: frame.params.for_response(),
-                        opcode: ResponseOpcode::Result,
-                        body: Bytes::from_static(b"\0\0\0\x03\0\x08keyspace"),
-                    }
+                    ResponseFrame::new(
+                        frame.params.for_response(),
+                        ResponseOpcode::Result,
+                        Bytes::from_static(b"\0\0\0\x03\0\x08keyspace"),
+                    )
                 }))
             } else {
                 RequestReaction::forge().server_error()
@@ -2273,11 +2273,11 @@ mod tests {
             rules.push(RequestRule(
                 Condition::RequestOpcode(RequestOpcode::Query),
                 RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
-                    ResponseFrame {
-                        params: frame.params.for_response(),
-                        opcode: ResponseOpcode::Result,
-                        body: Bytes::from_static(b"\0\0\0\x03\0\x08keyspace"),
-                    }
+                    ResponseFrame::new(
+                        frame.params.for_response(),
+                        ResponseOpcode::Result,
+                        Bytes::from_static(b"\0\0\0\x03\0\x08keyspace"),
+                    )
                 })),
             ));
             rules

--- a/scylla/tests/integration/session/compression.rs
+++ b/scylla/tests/integration/session/compression.rs
@@ -1,0 +1,202 @@
+//! Tests of frame compression: that the driver actually compresses the frames
+//! it sends, and that requests and responses survive the round trip intact
+//! with each of the supported algorithms.
+//!
+//! The frames are counted by a proxy sitting between the driver and the
+//! cluster. The proxy hands out *decompressed* bodies, so the measurement
+//! relies on [`RequestFrame::wire_body_len`](scylla_proxy::RequestFrame),
+//! which records how many body bytes actually travelled over the network.
+//!
+//! All the cases live in one `#[tokio::test]`, sharing a single proxy and a
+//! single keyspace, so that the shared cluster is not burdened with a keyspace
+//! per case. Each case does need a session of its own, though - compression is
+//! negotiated once, upon connecting.
+
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::frame::Compression;
+use scylla::statement::unprepared::Statement;
+
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, ShardAwareness,
+    WorkerError,
+};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::ops::Range;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+use crate::utils::{PerformDDL, setup_tracing, test_with_3_node_cluster, unique_keyspace_name};
+
+/// A single compression setting to exercise, together with what it is expected
+/// to do to the size of the frames sent.
+struct Case {
+    /// Compression to configure the session with, `None` for no compression.
+    compression: Option<Compression>,
+    /// Length of the (highly compressible) text inserted and read back.
+    text_size: usize,
+    /// Expected total size of the bodies of the request frames, as sent over
+    /// the network.
+    expected_wire_size: Range<usize>,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        compression: None,
+        text_size: 1_000,
+        expected_wire_size: 1_050..1_300,
+    },
+    Case {
+        compression: None,
+        text_size: 1_000_000,
+        expected_wire_size: 1_000_000..1_005_000,
+    },
+    Case {
+        compression: Some(Compression::Snappy),
+        text_size: 1_000,
+        expected_wire_size: 100..400,
+    },
+    Case {
+        compression: Some(Compression::Snappy),
+        text_size: 1_000_000,
+        expected_wire_size: 40_000..55_000,
+    },
+    Case {
+        compression: Some(Compression::Lz4),
+        text_size: 1_000,
+        expected_wire_size: 100..400,
+    },
+    Case {
+        compression: Some(Compression::Lz4),
+        text_size: 1_000_000,
+        expected_wire_size: 3_500..8_000,
+    },
+];
+
+async fn connect(
+    proxy_uris: &[String; 3],
+    translation_map: &HashMap<SocketAddr, SocketAddr>,
+    compression: Option<Compression>,
+) -> Session {
+    SessionBuilder::new()
+        .known_node(proxy_uris[0].as_str())
+        .address_translator(Arc::new(translation_map.clone()))
+        .compression(compression)
+        .build()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn compression_shrinks_frames_and_preserves_data() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            // Report every request the driver makes, except the ones on the
+            // control connection - those are unrelated to the cases below and
+            // would pollute the counts.
+            let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+            for running_node in running_proxy.running_nodes.iter_mut() {
+                running_node.change_request_rules(Some(vec![RequestRule(
+                    Condition::or(
+                        Condition::RequestOpcode(RequestOpcode::Query),
+                        Condition::RequestOpcode(RequestOpcode::Execute),
+                    )
+                    .and(Condition::not(Condition::ConnectionRegisteredAnyEvent)),
+                    RequestReaction::noop().with_feedback_when_performed(request_tx.clone()),
+                )]));
+            }
+
+            // A session of its own for the schema, so that the DDL frames are
+            // not counted against any of the cases.
+            let setup_session = connect(&proxy_uris, &translation_map, None).await;
+            let ks = unique_keyspace_name();
+            setup_session.ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3}}")).await.unwrap();
+            setup_session
+                .ddl(format!(
+                    "CREATE TABLE {ks}.t (k text PRIMARY KEY, t text, i int, f float)"
+                ))
+                .await
+                .unwrap();
+
+            for (
+                case_no,
+                Case {
+                    compression,
+                    text_size,
+                    expected_wire_size,
+                },
+            ) in CASES.iter().enumerate()
+            {
+                // Discard whatever the previous case (or the schema setup) left behind.
+                while request_rx.try_recv().is_ok() {}
+
+                let session = connect(&proxy_uris, &translation_map, *compression).await;
+
+                // A partition of its own, so that the cases do not overwrite
+                // each other's rows.
+                let key = format!("key{case_no}");
+                let text = "a".repeat(*text_size);
+
+                session
+                    .query_unpaged(
+                        Statement::from(format!(
+                            "INSERT INTO {ks}.t (k, t, i, f) VALUES (?, ?, ?, ?)"
+                        )),
+                        (&key, text.as_str(), 42_i32, 24.03_f32),
+                    )
+                    .await
+                    .unwrap();
+
+                let row = session
+                    .query_unpaged(
+                        Statement::from(format!("SELECT k, t, i, f FROM {ks}.t WHERE k = ?")),
+                        (&key,),
+                    )
+                    .await
+                    .unwrap()
+                    .into_rows_result()
+                    .unwrap()
+                    .single_row::<(String, String, i32, f32)>()
+                    .unwrap();
+                assert_eq!(row, (key, text, 42_i32, 24.03_f32));
+
+                // The proxy hands out decompressed bodies, so `body.len()` would
+                // be the same no matter the compression; `wire_body_len` is what
+                // actually travelled.
+                let mut total_wire_size = 0;
+                while let Ok((request_frame, _shard)) = request_rx.try_recv() {
+                    assert_eq!(
+                        request_frame.params.is_compressed(),
+                        compression.is_some(),
+                        "Case {case_no} ({compression:?}): frame compression flag does not match \
+                         the configured compression"
+                    );
+                    total_wire_size += request_frame.wire_body_len;
+                }
+                assert!(
+                    expected_wire_size.contains(&total_wire_size),
+                    "Case {case_no} ({compression:?}, {text_size} B of text): total wire size \
+                     {total_wire_size} not in expected range {expected_wire_size:?}"
+                );
+            }
+
+            setup_session
+                .ddl(format!("DROP KEYSPACE {ks}"))
+                .await
+                .unwrap();
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -1,5 +1,6 @@
 mod caching_session;
 mod cluster_reachability;
+mod compression;
 mod db_errors;
 mod history;
 mod host_id_mismatch;


### PR DESCRIPTION
A revival of #1218 authored by @fruch.

### Original cover letter

test are trying both algorithms (snappy, lz4), while counting the size of the frames coming into scylla

for reference we also have one test doing the same without compression

test main structure was borrowed from java-driver, the usage of proxy to count the packets is unique to this change.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1424

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.