### PR TITLE
tests: add integration tests for batch statements

### DIFF
--- a/scylla/tests/integration/statements/batch.rs
+++ b/scylla/tests/integration/statements/batch.rs
@@ -4,14 +4,14 @@ use crate::utils::{
 };
 use assert_matches::assert_matches;
 use scylla::client::session::Session;
-use scylla::errors::{BadQuery, ExecutionError, RequestAttemptError};
+use scylla::errors::{BadQuery, DbError, ExecutionError, RequestAttemptError};
 use scylla::frame::frame_errors::{BatchSerializationError, CqlRequestSerializationError};
 use scylla::response::query_result::{QueryResult, QueryRowsResult};
 use scylla::statement::batch::{Batch, BatchStatement, BatchType};
 use scylla::statement::prepared::PreparedStatement;
 use scylla::statement::unprepared::Statement;
-use scylla::value::Counter;
-use std::collections::BTreeSet;
+use scylla::value::{Counter, CqlValue, MaybeUnset, Row};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 #[tokio::test]
@@ -650,4 +650,393 @@ async fn test_batch_to_multiple_tables() {
         .unwrap();
 
     session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+/// Tests of batching statements of every supported kind: simple, prepared,
+/// batch-prepared, with unset values, with named variables, and mixtures of
+/// those - plus the batch types that constrain what may be batched together
+/// (LWT/CAS, counter, logged).
+///
+/// All the cases live in one `#[tokio::test]`, sharing a single session and a
+/// single keyspace, so that the shared cluster is not burdened with a keyspace
+/// per case. The cases that write to the shared table each use a partition
+/// key of their own, so they do not observe each other's rows.
+#[tokio::test]
+async fn test_batches_of_various_statement_kinds() {
+    setup_tracing();
+    let session = create_new_session_builder().build().await.unwrap();
+    let ks = unique_keyspace_name();
+
+    // Some of the cases below use counters, others use LWTs; older ScyllaDB
+    // versions support neither on tablet keyspaces.
+    let disable_tablets = if disable_tablets_unless_supported(&session, "COUNTERS_WITH_TABLETS")
+        .await
+        .is_empty()
+    {
+        disable_tablets_unless_supported(&session, "LWT_WITH_TABLETS").await
+    } else {
+        disable_tablets_unless_supported(&session, "COUNTERS_WITH_TABLETS").await
+    };
+
+    session.ddl(format!(
+        "CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}{disable_tablets}"
+    )).await.unwrap();
+    session
+        .ddl(format!(
+            "CREATE TABLE {ks}.t (k0 text, k1 int, v int, PRIMARY KEY (k0, k1))"
+        ))
+        .await
+        .unwrap();
+    for i in 1..=3 {
+        session
+            .ddl(format!(
+                "CREATE TABLE {ks}.counter{i} (k0 text PRIMARY KEY, c counter)"
+            ))
+            .await
+            .unwrap();
+    }
+
+    batch_of_simple_statements(&session, &ks).await;
+    batch_of_prepared_statements(&session, &ks).await;
+    batch_prepared_as_a_whole(&session, &ks).await;
+    batch_of_bound_statements_with_unset_values(&session, &ks).await;
+    batch_of_bound_statements_with_named_variables(&session, &ks).await;
+    batch_of_mixed_bound_and_simple_statements(&session, &ks).await;
+    cas_batch_is_applied_only_once(&session, &ks).await;
+    counter_batch_increments_counters(&session, &ks).await;
+    logged_batch_rejects_counter_increments(&session, &ks).await;
+    counter_batch_rejects_non_counter_increments(&session, &ks).await;
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+/// Number of statements appended to each of the batches below.
+const BATCH_COUNT: usize = 100;
+
+/// Asserts that the case identified by `partition` inserted exactly
+/// `BATCH_COUNT` rows, each of them holding `v == k1 + 1`.
+async fn assert_batch_inserted_rows(session: &Session, ks: &str, partition: &str) {
+    let rows: Vec<(String, i32, i32)> = session
+        .query_unpaged(
+            format!("SELECT k0, k1, v FROM {ks}.t WHERE k0 = ?"),
+            (partition,),
+        )
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap()
+        .rows::<(String, i32, i32)>()
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+
+    assert_eq!(rows.len(), BATCH_COUNT);
+    for (k0, k1, v) in rows {
+        assert_eq!(k0, partition);
+        assert_eq!(v, k1 + 1);
+    }
+}
+
+async fn prepare_insert(session: &Session, ks: &str) -> PreparedStatement {
+    session
+        .prepare(format!("INSERT INTO {ks}.t (k0, k1, v) VALUES (?, ?, ?)"))
+        .await
+        .unwrap()
+}
+
+/// A batch of unprepared statements with all values inlined in their text.
+async fn batch_of_simple_statements(session: &Session, ks: &str) {
+    let partition = "simple_statements";
+
+    let mut batch = Batch::new(BatchType::Unlogged);
+    for i in 0..BATCH_COUNT {
+        batch.append_statement(Statement::new(format!(
+            "INSERT INTO {ks}.t (k0, k1, v) VALUES ('{partition}', {i}, {})",
+            i + 1
+        )));
+    }
+    session.batch(&batch, vec![(); BATCH_COUNT]).await.unwrap();
+
+    assert_batch_inserted_rows(session, ks, partition).await;
+}
+
+/// A batch of one prepared statement repeated, each time with its own values.
+async fn batch_of_prepared_statements(session: &Session, ks: &str) {
+    let partition = "prepared_statements";
+
+    let prepared = prepare_insert(session, ks).await;
+    let mut batch = Batch::new(BatchType::Unlogged);
+    let mut values = Vec::with_capacity(BATCH_COUNT);
+    for i in 0..BATCH_COUNT as i32 {
+        batch.append_statement(prepared.clone());
+        values.push((partition, i, i + 1));
+    }
+    session.batch(&batch, values).await.unwrap();
+
+    assert_batch_inserted_rows(session, ks, partition).await;
+}
+
+/// A batch of unprepared statements prepared in one go, with
+/// [`Session::prepare_batch`], rather than statement by statement.
+async fn batch_prepared_as_a_whole(session: &Session, ks: &str) {
+    let partition = "prepared_batch";
+
+    let mut batch = Batch::new(BatchType::Unlogged);
+    let mut values = Vec::with_capacity(BATCH_COUNT);
+    for i in 0..BATCH_COUNT as i32 {
+        batch.append_statement(Statement::new(format!(
+            "INSERT INTO {ks}.t (k0, k1, v) VALUES (?, ?, ?)"
+        )));
+        values.push((partition, i, i + 1));
+    }
+    let prepared_batch = session.prepare_batch(&batch).await.unwrap();
+    session.batch(&prepared_batch, values).await.unwrap();
+
+    assert_batch_inserted_rows(session, ks, partition).await;
+}
+
+/// An unset value leaves the column as it was, rather than overwriting it
+/// with NULL.
+async fn batch_of_bound_statements_with_unset_values(session: &Session, ks: &str) {
+    let partition = "unset_values";
+
+    let prepared = prepare_insert(session, ks).await;
+
+    let mut batch = Batch::new(BatchType::Unlogged);
+    let mut values = Vec::with_capacity(BATCH_COUNT);
+    for i in 0..BATCH_COUNT as i32 {
+        batch.append_statement(prepared.clone());
+        values.push((partition, i, i + 1));
+    }
+    session.batch(&batch, values).await.unwrap();
+
+    // Update v to (k1 + 2), but for every 20th row leave v unset.
+    let mut batch = Batch::new(BatchType::Unlogged);
+    let mut values = Vec::with_capacity(BATCH_COUNT);
+    for i in 0..BATCH_COUNT as i32 {
+        batch.append_statement(prepared.clone());
+        values.push((
+            MaybeUnset::Set(partition),
+            MaybeUnset::Set(i),
+            if i % 20 == 0 {
+                MaybeUnset::Unset
+            } else {
+                MaybeUnset::Set(i + 2)
+            },
+        ));
+    }
+    session.batch(&batch, values).await.unwrap();
+
+    let rows: Vec<(String, i32, i32)> = session
+        .query_unpaged(
+            format!("SELECT k0, k1, v FROM {ks}.t WHERE k0 = ?"),
+            (partition,),
+        )
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap()
+        .rows::<(String, i32, i32)>()
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+
+    assert_eq!(rows.len(), BATCH_COUNT);
+    for (k0, k1, v) in rows {
+        assert_eq!(k0, partition);
+        // The rows left unset retain the value the first batch gave them.
+        assert_eq!(v, if k1 % 20 == 0 { k1 + 1 } else { k1 + 2 });
+    }
+}
+
+/// Values may also be bound by name, rather than by position.
+async fn batch_of_bound_statements_with_named_variables(session: &Session, ks: &str) {
+    let partition = "named_variables";
+
+    let prepared = session
+        .prepare(format!(
+            "INSERT INTO {ks}.t (k0, k1, v) VALUES (:k0, :k1, :v)"
+        ))
+        .await
+        .unwrap();
+
+    let mut batch = Batch::new(BatchType::Unlogged);
+    let mut values = Vec::with_capacity(BATCH_COUNT);
+    for i in 0..BATCH_COUNT as i32 {
+        batch.append_statement(prepared.clone());
+        values.push(HashMap::from([
+            ("k0", CqlValue::Text(partition.to_owned())),
+            ("k1", CqlValue::Int(i)),
+            ("v", CqlValue::Int(i + 1)),
+        ]));
+    }
+    session.batch(&batch, values).await.unwrap();
+
+    assert_batch_inserted_rows(session, ks, partition).await;
+}
+
+/// Prepared and unprepared statements may be mixed within one batch.
+async fn batch_of_mixed_bound_and_simple_statements(session: &Session, ks: &str) {
+    let partition = "mixed_statements";
+
+    let prepared = prepare_insert(session, ks).await;
+
+    let mut batch = Batch::new(BatchType::Unlogged);
+    let mut values: Vec<Vec<CqlValue>> = Vec::with_capacity(BATCH_COUNT);
+    for i in 0..BATCH_COUNT as i32 {
+        if i % 2 == 1 {
+            batch.append_statement(Statement::new(format!(
+                "INSERT INTO {ks}.t (k0, k1, v) VALUES ('{partition}', {i}, {})",
+                i + 1
+            )));
+            values.push(vec![]);
+        } else {
+            batch.append_statement(prepared.clone());
+            values.push(vec![
+                CqlValue::Text(partition.to_owned()),
+                CqlValue::Int(i),
+                CqlValue::Int(i + 1),
+            ]);
+        }
+    }
+    session.batch(&batch, values).await.unwrap();
+
+    assert_batch_inserted_rows(session, ks, partition).await;
+}
+
+/// A batch of conditional (LWT) statements is applied only if the condition
+/// holds; running the very same batch again is a no-op.
+async fn cas_batch_is_applied_only_once(session: &Session, ks: &str) {
+    let partition = "cas_batch";
+
+    // All the statements condition on the same partition, as a CAS batch
+    // must not span partitions.
+    let prepared = session
+        .prepare(format!(
+            "INSERT INTO {ks}.t (k0, k1, v) VALUES (?, ?, ?) IF NOT EXISTS"
+        ))
+        .await
+        .unwrap();
+
+    let mut batch = Batch::new(BatchType::Logged);
+    let mut values = Vec::with_capacity(BATCH_COUNT);
+    for i in 0..BATCH_COUNT as i32 {
+        batch.append_statement(prepared.clone());
+        values.push((partition, i, i + 1));
+    }
+
+    // Scylla answers a CAS batch with `[applied]` followed by the row's
+    // columns, Cassandra with `[applied]` alone - so read the first column
+    // and ignore whatever follows it.
+    let applied = |result: QueryResult| -> bool {
+        let row = result
+            .into_rows_result()
+            .unwrap()
+            .first_row::<Row>()
+            .unwrap();
+        match row.columns.first().unwrap() {
+            Some(CqlValue::Boolean(applied)) => *applied,
+            other => panic!("Expected `[applied]` to be a boolean, got {other:?}"),
+        }
+    };
+
+    assert!(
+        applied(session.batch(&batch, values.clone()).await.unwrap()),
+        "The first CAS batch should have been applied - the rows did not exist yet"
+    );
+    assert_batch_inserted_rows(session, ks, partition).await;
+
+    assert!(
+        !applied(session.batch(&batch, values).await.unwrap()),
+        "The second CAS batch should not have been applied - the rows exist by now"
+    );
+}
+
+/// A counter batch increments the counters it targets.
+async fn counter_batch_increments_counters(session: &Session, ks: &str) {
+    let partition = "counter_batch";
+
+    let mut batch = Batch::new(BatchType::Counter);
+    let mut values = Vec::with_capacity(3);
+    for i in 1..=3_i64 {
+        batch.append_statement(
+            session
+                .prepare(format!("UPDATE {ks}.counter{i} SET c = c + ? WHERE k0 = ?"))
+                .await
+                .unwrap(),
+        );
+        values.push((Counter(i), partition));
+    }
+    session.batch(&batch, values).await.unwrap();
+
+    for i in 1..=3_i64 {
+        let (Counter(c),) = session
+            .query_unpaged(
+                format!("SELECT c FROM {ks}.counter{i} WHERE k0 = ?"),
+                (partition,),
+            )
+            .await
+            .unwrap()
+            .into_rows_result()
+            .unwrap()
+            .single_row::<(Counter,)>()
+            .unwrap();
+        assert_eq!(c, i);
+    }
+}
+
+/// Counter increments may not appear in a LOGGED batch.
+async fn logged_batch_rejects_counter_increments(session: &Session, ks: &str) {
+    let partition = "logged_batch_with_counters";
+
+    let mut batch = Batch::new(BatchType::Logged);
+    let mut values = Vec::with_capacity(3);
+    for i in 1..=3_i64 {
+        batch.append_statement(
+            session
+                .prepare(format!("UPDATE {ks}.counter{i} SET c = c + ? WHERE k0 = ?"))
+                .await
+                .unwrap(),
+        );
+        values.push((Counter(i), partition));
+    }
+
+    let err = session.batch(&batch, values).await.unwrap_err();
+    assert_matches!(
+        err,
+        ExecutionError::LastAttemptError(RequestAttemptError::DbError(DbError::Invalid, _))
+    );
+}
+
+/// Conversely, a COUNTER batch may not carry a non-counter statement.
+async fn counter_batch_rejects_non_counter_increments(session: &Session, ks: &str) {
+    let partition = "counter_batch_with_non_counters";
+
+    let mut batch = Batch::new(BatchType::Counter);
+    let mut values: Vec<Vec<CqlValue>> = Vec::with_capacity(4);
+    for i in 1..=3_i64 {
+        batch.append_statement(
+            session
+                .prepare(format!("UPDATE {ks}.counter{i} SET c = c + ? WHERE k0 = ?"))
+                .await
+                .unwrap(),
+        );
+        values.push(vec![
+            CqlValue::Counter(Counter(i)),
+            CqlValue::Text(partition.to_owned()),
+        ]);
+    }
+
+    batch.append_statement(prepare_insert(session, ks).await);
+    values.push(vec![
+        CqlValue::Text(partition.to_owned()),
+        CqlValue::Int(0),
+        CqlValue::Int(1),
+    ]);
+
+    let err = session.batch(&batch, values).await.unwrap_err();
+    assert_matches!(
+        err,
+        ExecutionError::LastAttemptError(RequestAttemptError::DbError(DbError::Invalid, _))
+    );
 }


### PR DESCRIPTION
A revival of #1226 authored by @dimakr.

Cover batching of every supported statement kind - simple, prepared, batch-prepared, with unset values, with named variables, and mixtures of those - along with the batch types that constrain what may be batched together: CAS/LWT, counter, and logged.

All the cases share one session and one keyspace, each writing to a partition of its own, so that the shared cluster is not burdened with a keyspace per case.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
