### PR TITLE
lib.rs: expose VectorSerializationErrorKind

### DIFF
--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -205,7 +205,7 @@ pub mod serialize {
             BuiltinTypeCheckErrorKind, MapSerializationErrorKind, MapTypeCheckErrorKind,
             SetOrListSerializationErrorKind, SetOrListTypeCheckErrorKind,
             TupleSerializationErrorKind, TupleTypeCheckErrorKind, UdtSerializationErrorKind,
-            UdtTypeCheckErrorKind,
+            UdtTypeCheckErrorKind, VectorSerializationErrorKind,
         };
     }
 


### PR DESCRIPTION
Mistakenly, we didn't expose `VectorSerializationErrorKind` in the `scylla`'s API. This made it impossible to match on the enum's variants. As similar error kinds for other types are exposed, this one gets exposed now, too.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
