### PR TITLE
Improve type tests

### DIFF
--- a/scylla/tests/integration/entry_point.rs
+++ b/scylla/tests/integration/entry_point.rs
@@ -1,0 +1,205 @@
+//! The ways a single statement can be sent, as values a test can loop over.
+//!
+//! A statement is sent through one of six `Session` methods: it is either
+//! unprepared or prepared, and its response is fetched in one shot, iterated,
+//! or one page at a time. Those two axes are independent, so [`PagingMode`]
+//! holds the second one and makes the six calls exactly once, and
+//! [`EntryPoint`] pairs it with the first for tests that have nothing but the
+//! statement text.
+//!
+//! The six do not share an error type - the iterating ones return a
+//! [`PagerExecutionError`] and the rest an [`ExecutionError`] - so [`SendError`]
+//! carries the failure of any of them, and knows where each kind of failure is
+//! expected to surface.
+
+use scylla::client::session::Session;
+use scylla::errors::{ExecutionError, PagerExecutionError, SchemaAgreementError};
+use scylla::response::PagingState;
+use scylla::serialize::row::SerializeRow;
+use scylla::statement::Statement;
+use scylla::statement::prepared::PreparedStatement;
+
+/// How a statement's response is fetched: in one shot, iterated, or one page at
+/// a time. Independent of whether the statement is prepared, which is why the
+/// caller passes the statement in already built and configured.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PagingMode {
+    Unpaged,
+    Iter,
+    SinglePage,
+}
+
+/// One of the six ways a single statement can be sent: a [`PagingMode`],
+/// prepared or not.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum EntryPoint {
+    QueryUnpaged,
+    QueryIter,
+    QuerySinglePage,
+    ExecuteUnpaged,
+    ExecuteIter,
+    ExecuteSinglePage,
+}
+
+/// The error a send failed with. The iterating entry points return a
+/// [`PagerExecutionError`] and the rest an [`ExecutionError`], so a failure
+/// cannot be reported in one type.
+#[derive(Debug)]
+pub(crate) enum SendError {
+    Execution(ExecutionError),
+    Pager(PagerExecutionError),
+}
+
+impl PagingMode {
+    /// Sends an unprepared statement, already configured by the caller.
+    // `ExecutionError` is a large enum, and boxing it here would only make
+    // matching on `SendError` harder to read.
+    #[allow(clippy::result_large_err)]
+    pub(crate) async fn send_unprepared(
+        self,
+        session: &Session,
+        stmt: impl Into<Statement>,
+        values: impl SerializeRow,
+    ) -> Result<(), SendError> {
+        match self {
+            PagingMode::Unpaged => session
+                .query_unpaged(stmt, values)
+                .await
+                .map(|_| ())
+                .map_err(SendError::Execution),
+            PagingMode::Iter => session
+                .query_iter(stmt, values)
+                .await
+                .map(|_| ())
+                .map_err(SendError::Pager),
+            PagingMode::SinglePage => session
+                .query_single_page(stmt, values, PagingState::start())
+                .await
+                .map(|_| ())
+                .map_err(SendError::Execution),
+        }
+    }
+
+    /// Sends a prepared statement, already configured by the caller.
+    #[allow(clippy::result_large_err)]
+    pub(crate) async fn send_prepared(
+        self,
+        session: &Session,
+        stmt: &PreparedStatement,
+        values: impl SerializeRow,
+    ) -> Result<(), SendError> {
+        match self {
+            PagingMode::Unpaged => session
+                .execute_unpaged(stmt, values)
+                .await
+                .map(|_| ())
+                .map_err(SendError::Execution),
+            // `execute_iter` takes the statement by value; the clone is a
+            // handful of `Arc`s.
+            PagingMode::Iter => session
+                .execute_iter(stmt.clone(), values)
+                .await
+                .map(|_| ())
+                .map_err(SendError::Pager),
+            PagingMode::SinglePage => session
+                .execute_single_page(stmt, values, PagingState::start())
+                .await
+                .map(|_| ())
+                .map_err(SendError::Execution),
+        }
+    }
+}
+
+impl EntryPoint {
+    pub(crate) const ALL: [EntryPoint; 6] = [
+        EntryPoint::QueryUnpaged,
+        EntryPoint::QueryIter,
+        EntryPoint::QuerySinglePage,
+        EntryPoint::ExecuteUnpaged,
+        EntryPoint::ExecuteIter,
+        EntryPoint::ExecuteSinglePage,
+    ];
+
+    /// The name of the `Session` method this entry point calls.
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            EntryPoint::QueryUnpaged => "query_unpaged",
+            EntryPoint::QueryIter => "query_iter",
+            EntryPoint::QuerySinglePage => "query_single_page",
+            EntryPoint::ExecuteUnpaged => "execute_unpaged",
+            EntryPoint::ExecuteIter => "execute_iter",
+            EntryPoint::ExecuteSinglePage => "execute_single_page",
+        }
+    }
+
+    fn paging_mode(self) -> PagingMode {
+        match self {
+            EntryPoint::QueryUnpaged | EntryPoint::ExecuteUnpaged => PagingMode::Unpaged,
+            EntryPoint::QueryIter | EntryPoint::ExecuteIter => PagingMode::Iter,
+            EntryPoint::QuerySinglePage | EntryPoint::ExecuteSinglePage => PagingMode::SinglePage,
+        }
+    }
+
+    /// Whether the statement is prepared before being sent. It decides when the
+    /// values are serialized, and so how a bad value list is reported.
+    pub(crate) fn is_prepared(self) -> bool {
+        match self {
+            EntryPoint::QueryUnpaged | EntryPoint::QueryIter | EntryPoint::QuerySinglePage => false,
+            EntryPoint::ExecuteUnpaged
+            | EntryPoint::ExecuteIter
+            | EntryPoint::ExecuteSinglePage => true,
+        }
+    }
+
+    /// Sends `stmt` with `values`, discarding the response. The prepared entry
+    /// points prepare it first, and the prepared statement inherits its
+    /// configuration, so the caller only ever configures the one it passes in.
+    #[allow(clippy::result_large_err)]
+    pub(crate) async fn send(
+        self,
+        session: &Session,
+        stmt: impl Into<Statement>,
+        values: impl SerializeRow,
+    ) -> Result<(), SendError> {
+        let stmt = stmt.into();
+        if self.is_prepared() {
+            let prepared = match session.prepare(stmt).await {
+                Ok(prepared) => prepared,
+                Err(err) => {
+                    return Err(match self.paging_mode() {
+                        PagingMode::Iter => SendError::Pager(err.into()),
+                        PagingMode::Unpaged | PagingMode::SinglePage => {
+                            SendError::Execution(err.into())
+                        }
+                    });
+                }
+            };
+            self.paging_mode()
+                .send_prepared(session, &prepared, values)
+                .await
+        } else {
+            self.paging_mode()
+                .send_unprepared(session, stmt, values)
+                .await
+        }
+    }
+}
+
+impl SendError {
+    /// The schema agreement error this failure carries. Both entry point
+    /// families wrap one, in `ExecutionError::SchemaAgreementError` and
+    /// `PagerExecutionError::SchemaAgreementError` respectively.
+    pub(crate) fn into_schema_agreement_error(
+        self,
+        entry_point: EntryPoint,
+    ) -> SchemaAgreementError {
+        match self {
+            SendError::Execution(ExecutionError::SchemaAgreementError(err))
+            | SendError::Pager(PagerExecutionError::SchemaAgreementError(err)) => err,
+            other => panic!(
+                "{} failed with an unexpected error: {other:?}",
+                entry_point.name()
+            ),
+        }
+    }
+}

--- a/scylla/tests/integration/entry_point.rs
+++ b/scylla/tests/integration/entry_point.rs
@@ -12,9 +12,14 @@
 //! carries the failure of any of them, and knows where each kind of failure is
 //! expected to surface.
 
+use assert_matches::assert_matches;
 use scylla::client::session::Session;
-use scylla::errors::{ExecutionError, PagerExecutionError, SchemaAgreementError};
+use scylla::errors::{
+    BadQuery, DbError, ExecutionError, NextPageError, PagerExecutionError, RequestAttemptError,
+    RequestError, SchemaAgreementError,
+};
 use scylla::response::PagingState;
+use scylla::serialize::SerializationError;
 use scylla::serialize::row::SerializeRow;
 use scylla::statement::Statement;
 use scylla::statement::prepared::PreparedStatement;
@@ -186,6 +191,52 @@ impl EntryPoint {
 }
 
 impl SendError {
+    /// The serialization error this failure carries, asserting on the way that
+    /// it surfaced where it is supposed to.
+    ///
+    /// A prepared statement knows its bind markers before the request is sent,
+    /// so it rejects the values up front, as a `BadQuery`. An unprepared one
+    /// learns them only from the response to its own request, so it fails per
+    /// attempt, as a `LastAttemptError`. Either way an iterating entry point
+    /// reports it as a `PagerExecutionError` of its own.
+    pub(crate) fn into_serialization_error(self, entry_point: EntryPoint) -> SerializationError {
+        match self {
+            SendError::Pager(PagerExecutionError::SerializationError(err)) => err,
+            SendError::Execution(ExecutionError::BadQuery(BadQuery::SerializationError(err)))
+                if entry_point.is_prepared() =>
+            {
+                err
+            }
+            SendError::Execution(ExecutionError::LastAttemptError(
+                RequestAttemptError::SerializationError(err),
+            )) if !entry_point.is_prepared() => err,
+            other => panic!(
+                "{} failed with an unexpected error: {other:?}",
+                entry_point.name()
+            ),
+        }
+    }
+
+    /// Asserts that this failure is the database rejecting the request with
+    /// `Invalid`, and that its message mentions `substring`.
+    pub(crate) fn assert_is_invalid_db_error(self, entry_point: EntryPoint, substring: &str) {
+        let db_error = match self {
+            SendError::Execution(ExecutionError::LastAttemptError(
+                RequestAttemptError::DbError(err, message),
+            )) => (err, message),
+            SendError::Pager(PagerExecutionError::NextPageError(
+                NextPageError::RequestFailure(RequestError::LastAttemptError(
+                    RequestAttemptError::DbError(err, message),
+                )),
+            )) => (err, message),
+            other => panic!(
+                "{} failed with an unexpected error: {other:?}",
+                entry_point.name()
+            ),
+        };
+        assert_matches!(&db_error, (DbError::Invalid, message) if message.contains(substring));
+    }
+
     /// The schema agreement error this failure carries. Both entry point
     /// families wrap one, in `ExecutionError::SchemaAgreementError` and
     /// `PagerExecutionError::SchemaAgreementError` respectively.

--- a/scylla/tests/integration/main.rs
+++ b/scylla/tests/integration/main.rs
@@ -2,6 +2,7 @@
 #![allow(missing_docs)]
 
 pub(crate) mod ccm;
+pub(crate) mod entry_point;
 mod load_balancing;
 mod macros;
 mod metadata;

--- a/scylla/tests/integration/session/schema_agreement.rs
+++ b/scylla/tests/integration/session/schema_agreement.rs
@@ -5,11 +5,8 @@ use assert_matches::assert_matches;
 use scylla::client::PoolSize;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::errors::{
-    DbError, ExecutionError, PagerExecutionError, RequestAttemptError, SchemaAgreementError,
-};
+use scylla::errors::{DbError, ExecutionError, RequestAttemptError, SchemaAgreementError};
 use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
-use scylla::response::PagingState;
 use scylla::response::query_result::QueryResult;
 use scylla::statement::Statement;
 use scylla_proxy::{
@@ -19,6 +16,7 @@ use scylla_proxy::{
 use tracing::info;
 use uuid::Uuid;
 
+use crate::entry_point::EntryPoint;
 use crate::utils::{
     PerformDDL, calculate_proxy_host_ids, setup_tracing, test_with_3_node_cluster,
     unique_keyspace_name,
@@ -501,117 +499,26 @@ async fn test_schema_await_with_various_apis() {
 
             let host_ids = calculate_proxy_host_ids(&proxy_uris, &translation_map, &session);
 
-            fn check_error(err: Result<(), ExecutionError>) {
+            for entry_point in EntryPoint::ALL {
+                tracing::info!(
+                    "================= Sub test: {} =================",
+                    entry_point.name()
+                );
+
+                let result = run_ddl_with_failing_agreement_check(
+                    async |ddl| entry_point.send(&session, ddl, &()).await,
+                    &mut running_proxy,
+                    &host_ids,
+                )
+                .await;
+
                 assert_matches!(
-                    err,
-                    Err(ExecutionError::SchemaAgreementError(
-                        SchemaAgreementError::RequestError(RequestAttemptError::DbError(
-                            DbError::SyntaxError,
-                            _
-                        ))
+                    result.unwrap_err().into_schema_agreement_error(entry_point),
+                    SchemaAgreementError::RequestError(RequestAttemptError::DbError(
+                        DbError::SyntaxError,
+                        _
                     ))
-                )
-            }
-
-            fn check_paging_error(err: Result<(), PagerExecutionError>) {
-                assert_matches!(
-                    err,
-                    Err(PagerExecutionError::SchemaAgreementError(
-                        SchemaAgreementError::RequestError(RequestAttemptError::DbError(
-                            DbError::SyntaxError,
-                            _
-                        ))
-                    ))
-                )
-            }
-
-            {
-                tracing::info!("================= Sub test: query_unpaged =================");
-
-                let result = run_ddl_with_failing_agreement_check(
-                    async |ddl| session.query_unpaged(ddl, &()).await.map(|_| ()),
-                    &mut running_proxy,
-                    &host_ids,
-                )
-                .await;
-                check_error(result);
-            }
-
-            {
-                tracing::info!("================= Sub test: query_single_page =================");
-
-                let result = run_ddl_with_failing_agreement_check(
-                    async |ddl| {
-                        session
-                            .query_single_page(ddl, &(), PagingState::start())
-                            .await
-                            .map(|_| ())
-                    },
-                    &mut running_proxy,
-                    &host_ids,
-                )
-                .await;
-                check_error(result);
-            }
-
-            {
-                tracing::info!("================= Sub test: query_iter =================");
-
-                let result = run_ddl_with_failing_agreement_check(
-                    async |ddl| session.query_iter(ddl, &()).await.map(|_| ()),
-                    &mut running_proxy,
-                    &host_ids,
-                )
-                .await;
-                check_paging_error(result);
-            }
-
-            {
-                tracing::info!("================= Sub test: execute_unpaged =================");
-
-                let result = run_ddl_with_failing_agreement_check(
-                    async |ddl| {
-                        let stmt = session.prepare(ddl).await?;
-                        session.execute_unpaged(&stmt, &()).await.map(|_| ())
-                    },
-                    &mut running_proxy,
-                    &host_ids,
-                )
-                .await;
-                check_error(result);
-            }
-
-            {
-                tracing::info!("================= Sub test: execute_single_page =================");
-
-                let result = run_ddl_with_failing_agreement_check(
-                    async |ddl| {
-                        let stmt = session.prepare(ddl).await?;
-                        session
-                            .execute_single_page(&stmt, &(), PagingState::start())
-                            .await
-                            .map(|_| ())
-                    },
-                    &mut running_proxy,
-                    &host_ids,
-                )
-                .await;
-                check_error(result);
-            }
-
-            {
-                tracing::info!("================= Sub test: execute_iter =================");
-
-                let result = run_ddl_with_failing_agreement_check(
-                    async |ddl| {
-                        let stmt = session.prepare(ddl).await?;
-                        session.execute_iter(stmt, &()).await.map(|_| ())
-                    },
-                    &mut running_proxy,
-                    &host_ids,
-                )
-                .await;
-                check_paging_error(result);
+                );
             }
 
             running_proxy
@@ -656,70 +563,16 @@ async fn test_schema_await_refreshes_metadata() {
         let _table = keyspace.tables.get(table).unwrap();
     }
 
-    {
-        tracing::info!("================= Sub test: query_unpaged =================");
+    for entry_point in EntryPoint::ALL {
+        tracing::info!(
+            "================= Sub test: {} =================",
+            entry_point.name()
+        );
 
-        run_ddl_and_inspect_schema(&session, &ks, "query_unpaged", async |session, ddl| {
-            session.query_unpaged(ddl, &()).await.unwrap();
-        })
-        .await;
-    }
-
-    {
-        tracing::info!("================= Sub test: query_single_page =================");
-
-        run_ddl_and_inspect_schema(&session, &ks, "query_single_page", async |session, ddl| {
-            session
-                .query_single_page(ddl, &(), PagingState::start())
-                .await
-                .unwrap();
-        })
-        .await;
-    }
-
-    {
-        tracing::info!("================= Sub test: query_iter =================");
-
-        run_ddl_and_inspect_schema(&session, &ks, "query_iter", async |session, ddl| {
-            session.query_iter(ddl, &()).await.unwrap();
-        })
-        .await;
-    }
-
-    {
-        tracing::info!("================= Sub test: execute_unpaged =================");
-
-        run_ddl_and_inspect_schema(&session, &ks, "execute_unpaged", async |session, ddl| {
-            let stmt = session.prepare(ddl).await.unwrap();
-            session.execute_unpaged(&stmt, &()).await.unwrap();
-        })
-        .await;
-    }
-
-    {
-        tracing::info!("================= Sub test: execute_single_page =================");
-
-        run_ddl_and_inspect_schema(
-            &session,
-            &ks,
-            "execute_single_page",
-            async |session, ddl| {
-                let stmt = session.prepare(ddl).await.unwrap();
-                session
-                    .execute_single_page(&stmt, &(), PagingState::start())
-                    .await
-                    .unwrap();
-            },
-        )
-        .await;
-    }
-
-    {
-        tracing::info!("================= Sub test: execute_iter =================");
-
-        run_ddl_and_inspect_schema(&session, &ks, "execute_iter", async |session, ddl| {
-            let stmt = session.prepare(ddl).await.unwrap();
-            session.execute_iter(stmt, &()).await.unwrap();
+        // The table is named after the entry point, so that each gets one of
+        // its own and the metadata refresh is checked per entry point.
+        run_ddl_and_inspect_schema(&session, &ks, entry_point.name(), async |session, ddl| {
+            entry_point.send(session, ddl, &()).await.unwrap();
         })
         .await;
     }

--- a/scylla/tests/integration/statements/mod.rs
+++ b/scylla/tests/integration/statements/mod.rs
@@ -4,6 +4,7 @@ mod consistency;
 mod coordinator;
 mod execution_profiles;
 mod named_bind_markers;
+mod positional_values;
 mod prepared;
 mod request_timeout;
 mod result_metadata_extension;

--- a/scylla/tests/integration/statements/named_bind_markers.rs
+++ b/scylla/tests/integration/statements/named_bind_markers.rs
@@ -1,3 +1,8 @@
+use assert_matches::assert_matches;
+use scylla::errors::{BadQuery, ExecutionError};
+use scylla::serialize::SerializationError;
+use scylla::serialize::row::{BuiltinTypeCheckError, BuiltinTypeCheckErrorKind};
+
 use crate::utils::{
     PerformDDL as _, create_new_session_builder, setup_tracing, unique_keyspace_name,
 };
@@ -51,15 +56,38 @@ async fn test_named_bind_markers() {
 
     assert_eq!(rows, vec![(7, 13, 42), (17, 113, 142)]);
 
-    let wrongmaps: Vec<HashMap<&str, i32>> = vec![
-        HashMap::from([("pk", 7), ("fefe", 42), ("ck", 13)]),
-        HashMap::from([("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 7)]),
-        HashMap::new(),
-        HashMap::from([("ck", 9)]),
+    // A map that does not name every bind marker must be rejected, and rejected
+    // for the right reason: the first column it leaves unset. Merely asserting
+    // that the request errors out would be satisfied by any failure at all.
+    let wrongmaps: Vec<(HashMap<&str, i32>, &str)> = vec![
+        // A name that no marker uses does not stand in for the missing one.
+        (HashMap::from([("pk", 7), ("fefe", 42), ("ck", 13)]), "v"),
+        (HashMap::from([("v", 7), ("fefe", 42), ("ck", 13)]), "pk"),
+        (
+            HashMap::from([("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 7)]),
+            "pk",
+        ),
+        (HashMap::new(), "pk"),
+        (HashMap::from([("ck", 9)]), "pk"),
     ];
-    for wrongmap in wrongmaps {
-        assert!(session.execute_unpaged(&prepared, &wrongmap).await.is_err());
+    for (wrongmap, missing_column) in wrongmaps {
+        let err = session
+            .execute_unpaged(&prepared, &wrongmap)
+            .await
+            .unwrap_err();
+        let ExecutionError::BadQuery(BadQuery::SerializationError(err)) = err else {
+            panic!("Expected a serialization error, got {err:?}");
+        };
+        assert_value_missing_for_column(&err, missing_column);
     }
 
     session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+fn assert_value_missing_for_column(err: &SerializationError, column: &str) {
+    let kind = &err.downcast_ref::<BuiltinTypeCheckError>().unwrap().kind;
+    assert_matches!(
+        kind,
+        BuiltinTypeCheckErrorKind::ValueMissingForColumn { name } if name == column
+    );
 }

--- a/scylla/tests/integration/statements/named_bind_markers.rs
+++ b/scylla/tests/integration/statements/named_bind_markers.rs
@@ -1,13 +1,24 @@
+//! Tests of named bind markers: a statement whose markers are written `:name`
+//! takes its values from something that names them - a map, or a struct
+//! deriving [`SerializeRow`](scylla::SerializeRow) - rather than from a
+//! positional value list.
+//!
+//! All the cases live in one `#[tokio::test]`, sharing a single session and a
+//! single keyspace, so that the shared cluster is not burdened with a keyspace
+//! per case.
+
+use std::collections::{BTreeMap, HashMap};
+
 use assert_matches::assert_matches;
+use scylla::client::session::Session;
 use scylla::errors::{BadQuery, ExecutionError};
 use scylla::serialize::SerializationError;
 use scylla::serialize::row::{BuiltinTypeCheckError, BuiltinTypeCheckErrorKind};
 
+use crate::entry_point::EntryPoint;
 use crate::utils::{
     PerformDDL as _, create_new_session_builder, setup_tracing, unique_keyspace_name,
 };
-use std::collections::{BTreeMap, HashMap};
-use std::vec;
 
 #[tokio::test]
 async fn test_named_bind_markers() {
@@ -20,23 +31,35 @@ async fn test_named_bind_markers() {
         .ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"))
         .await
         .unwrap();
-
-    session
-        .query_unpaged(format!("USE {ks}"), &[])
-        .await
-        .unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
 
     session
         .ddl("CREATE TABLE t (pk int, ck int, v int, PRIMARY KEY (pk, ck, v))")
         .await
         .unwrap();
+    session
+        .ddl("CREATE TABLE t2 (k text PRIMARY KEY, v int)")
+        .await
+        .unwrap();
 
     session.await_schema_agreement().await.unwrap();
 
+    values_are_taken_from_the_map_by_name(&session).await;
+    every_marker_must_be_named(&session).await;
+    a_named_value_may_be_null(&session).await;
+    marker_names_are_cql_identifiers(&session).await;
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+/// The values are matched to the markers by name, not by the order they happen
+/// to be in - which for a `HashMap` is no order at all.
+async fn values_are_taken_from_the_map_by_name(session: &Session) {
     let prepared = session
         .prepare("INSERT INTO t (pk, ck, v) VALUES (:pk, :ck, :v)")
         .await
         .unwrap();
+
     let hashmap: HashMap<&str, i32> = HashMap::from([("pk", 7), ("v", 42), ("ck", 13)]);
     session.execute_unpaged(&prepared, &hashmap).await.unwrap();
 
@@ -55,10 +78,17 @@ async fn test_named_bind_markers() {
         .collect();
 
     assert_eq!(rows, vec![(7, 13, 42), (17, 113, 142)]);
+}
 
-    // A map that does not name every bind marker must be rejected, and rejected
-    // for the right reason: the first column it leaves unset. Merely asserting
-    // that the request errors out would be satisfied by any failure at all.
+/// A map that does not name every bind marker must be rejected, and rejected
+/// for the right reason: the first column it leaves unset. Merely asserting
+/// that the request errors out would be satisfied by any failure at all.
+async fn every_marker_must_be_named(session: &Session) {
+    let prepared = session
+        .prepare("INSERT INTO t (pk, ck, v) VALUES (:pk, :ck, :v)")
+        .await
+        .unwrap();
+
     let wrongmaps: Vec<(HashMap<&str, i32>, &str)> = vec![
         // A name that no marker uses does not stand in for the missing one.
         (HashMap::from([("pk", 7), ("fefe", 42), ("ck", 13)]), "v"),
@@ -80,8 +110,68 @@ async fn test_named_bind_markers() {
         };
         assert_value_missing_for_column(&err, missing_column);
     }
+}
 
-    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+/// Naming a marker and giving it `None` binds it to `NULL`; it is not the same
+/// as leaving the marker unnamed, which is what `every_marker_must_be_named`
+/// covers.
+async fn a_named_value_may_be_null(session: &Session) {
+    #[derive(scylla::SerializeRow)]
+    struct Row<'a> {
+        k: &'a str,
+        v: Option<i32>,
+    }
+
+    for entry_point in EntryPoint::ALL {
+        // Each entry point writes a row of its own, so that a write that never
+        // happened cannot be mistaken for another entry point's.
+        let key = entry_point.name();
+        entry_point
+            .send(
+                session,
+                "INSERT INTO t2 (k, v) VALUES (:k, :v)",
+                Row { k: key, v: None },
+            )
+            .await
+            .unwrap();
+
+        let row = session
+            .query_unpaged("SELECT k, v FROM t2 WHERE k = ?", (key,))
+            .await
+            .unwrap()
+            .into_rows_result()
+            .unwrap()
+            .single_row::<(String, Option<i32>)>()
+            .unwrap();
+        assert_eq!(row, (key.to_owned(), None));
+    }
+}
+
+/// A marker name is a CQL identifier, so `:theKey` names the column `thekey`
+/// while `:"theKey"` names `theKey`. The map has to spell the name the way the
+/// database folded it, not the way it was written in the statement.
+async fn marker_names_are_cql_identifiers(session: &Session) {
+    let unquoted = "SELECT v FROM t2 WHERE k = :theKey";
+    let quoted = "SELECT v FROM t2 WHERE k = :\"theKey\"";
+
+    let folded: HashMap<&str, &str> = HashMap::from([("thekey", "some key")]);
+    let verbatim: HashMap<&str, &str> = HashMap::from([("theKey", "some key")]);
+
+    for entry_point in EntryPoint::ALL {
+        for (stmt, right, wrong, missing_column) in [
+            (unquoted, &folded, &verbatim, "thekey"),
+            (quoted, &verbatim, &folded, "theKey"),
+        ] {
+            entry_point.send(session, stmt, right).await.unwrap();
+
+            let err = entry_point
+                .send(session, stmt, wrong)
+                .await
+                .unwrap_err()
+                .into_serialization_error(entry_point);
+            assert_value_missing_for_column(&err, missing_column);
+        }
+    }
 }
 
 fn assert_value_missing_for_column(err: &SerializationError, column: &str) {

--- a/scylla/tests/integration/statements/positional_values.rs
+++ b/scylla/tests/integration/statements/positional_values.rs
@@ -1,0 +1,111 @@
+//! Tests of the positional values sent with a statement: how a value list that
+//! does not match the statement's bind markers is rejected, and that a `NULL`
+//! among the values is not.
+//!
+//! What matters here is that every entry point behaves the same way, so each
+//! case is run through all six of them, via [`EntryPoint`].
+//!
+//! All the cases live in one `#[tokio::test]`, sharing a single session and a
+//! single keyspace, so that the shared cluster is not burdened with a keyspace
+//! per case.
+
+use assert_matches::assert_matches;
+use scylla::client::session::Session;
+use scylla::serialize::SerializationError;
+use scylla::serialize::row::{BuiltinTypeCheckError, BuiltinTypeCheckErrorKind};
+
+use crate::entry_point::EntryPoint;
+
+use crate::utils::{
+    PerformDDL as _, create_new_session_builder, setup_tracing, unique_keyspace_name,
+};
+
+#[tokio::test]
+async fn test_positional_values() {
+    setup_tracing();
+    let session = create_new_session_builder().build().await.unwrap();
+
+    let ks = unique_keyspace_name();
+    session.ddl(format!("CREATE KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}")).await.unwrap();
+    session.use_keyspace(&ks, false).await.unwrap();
+    session
+        .ddl("CREATE TABLE t (k text PRIMARY KEY, v int)")
+        .await
+        .unwrap();
+    session.await_schema_agreement().await.unwrap();
+
+    too_many_values_are_rejected(&session).await;
+    too_few_values_are_rejected(&session).await;
+    nulls_are_accepted_among_values(&session).await;
+
+    session.ddl(format!("DROP KEYSPACE {ks}")).await.unwrap();
+}
+
+fn assert_wrong_column_count(err: &SerializationError, rust_cols: usize, cql_cols: usize) {
+    let kind = &err.downcast_ref::<BuiltinTypeCheckError>().unwrap().kind;
+    assert_matches!(
+        kind,
+        BuiltinTypeCheckErrorKind::WrongColumnCount {
+            rust_cols: got_rust_cols,
+            cql_cols: got_cql_cols,
+        } if *got_rust_cols == rust_cols && *got_cql_cols == cql_cols
+    );
+}
+
+/// More values than the statement has bind markers is caught while serializing
+/// them, whichever entry point sends them.
+async fn too_many_values_are_rejected(session: &Session) {
+    const STMT: &str = "SELECT v FROM t WHERE k = ?";
+
+    for entry_point in EntryPoint::ALL {
+        let err = entry_point
+            .send(session, STMT, ("key", 1))
+            .await
+            .unwrap_err()
+            .into_serialization_error(entry_point);
+        assert_wrong_column_count(&err, 2, 1);
+    }
+}
+
+/// Fewer values than the statement has bind markers is caught too - but only a
+/// prepared statement knows its markers up front and can catch it while
+/// serializing. An unprepared one sends the request and is turned down by the
+/// database.
+async fn too_few_values_are_rejected(session: &Session) {
+    const STMT: &str = "SELECT v FROM t WHERE k = ?";
+
+    for entry_point in EntryPoint::ALL {
+        let err = entry_point.send(session, STMT, ()).await.unwrap_err();
+        if entry_point.is_prepared() {
+            assert_wrong_column_count(&err.into_serialization_error(entry_point), 0, 1);
+        } else {
+            err.assert_is_invalid_db_error(entry_point, "Invalid amount of bind variables");
+        }
+    }
+}
+
+/// A `None` among the values is a value like any other - it binds the marker to
+/// `NULL` rather than leaving it unbound.
+async fn nulls_are_accepted_among_values(session: &Session) {
+    const INSERT: &str = "INSERT INTO t (k, v) VALUES (?, ?)";
+
+    for entry_point in EntryPoint::ALL {
+        // Each entry point writes a row of its own, so that a write that never
+        // happened cannot be mistaken for another entry point's.
+        let key = entry_point.name();
+        entry_point
+            .send(session, INSERT, (key, None::<i32>))
+            .await
+            .unwrap();
+
+        let row = session
+            .query_unpaged("SELECT k, v FROM t WHERE k = ?", (key,))
+            .await
+            .unwrap()
+            .into_rows_result()
+            .unwrap()
+            .single_row::<(String, Option<i32>)>()
+            .unwrap();
+        assert_eq!(row, (key.to_owned(), None));
+    }
+}

--- a/scylla/tests/integration/statements/prepared.rs
+++ b/scylla/tests/integration/statements/prepared.rs
@@ -9,8 +9,8 @@ use scylla::response::{PagingState, PagingStateResponse};
 use scylla::routing::Token;
 use scylla::routing::partitioner::PartitionerName;
 use scylla::serialize::row::SerializeRow;
-use scylla::statement::Statement;
 use scylla::statement::prepared::PreparedStatement;
+use scylla::statement::{Consistency, SerialConsistency, Statement};
 use scylla_cql::frame::types;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
@@ -19,6 +19,7 @@ use scylla_proxy::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, info};
 use uuid::Uuid;
@@ -209,11 +210,27 @@ async fn test_prepared_config() {
     let mut query = Statement::new("SELECT * FROM system_schema.tables");
     query.set_is_idempotent(true);
     query.set_page_size(42);
+    query.set_consistency(Consistency::One);
+    query.set_serial_consistency(Some(SerialConsistency::LocalSerial));
+    query.set_tracing(true);
+    query.set_request_timeout(Some(Duration::from_millis(1)));
+    query.set_timestamp(Some(42));
 
     let prepared_statement = session.prepare(query).await.unwrap();
 
     assert!(prepared_statement.get_is_idempotent());
     assert_eq!(prepared_statement.get_page_size(), 42);
+    assert_eq!(prepared_statement.get_consistency(), Some(Consistency::One));
+    assert_eq!(
+        prepared_statement.get_serial_consistency(),
+        Some(SerialConsistency::LocalSerial)
+    );
+    assert!(prepared_statement.get_tracing());
+    assert_eq!(
+        prepared_statement.get_request_timeout(),
+        Some(Duration::from_millis(1))
+    );
+    assert_eq!(prepared_statement.get_timestamp(), Some(42));
 }
 
 #[tokio::test]

--- a/scylla/tests/integration/statements/timestamps.rs
+++ b/scylla/tests/integration/statements/timestamps.rs
@@ -12,6 +12,7 @@ use scylla::{
     },
 };
 
+use crate::entry_point::PagingMode;
 use crate::utils::{
     PerformDDL as _, create_new_session_builder, setup_tracing, unique_keyspace_name,
 };
@@ -34,42 +35,54 @@ async fn test_timestamp() {
 
     let query_str = format!("INSERT INTO {ks}.t_timestamp (a, b) VALUES (?, ?)");
 
-    // test regular query timestamps
+    // A timestamp set on a statement must be honoured no matter which entry
+    // point sends it, so every one of them is exercised with the same pair of
+    // timestamps: the row must end up carrying the higher one. The timestamp
+    // goes on the statement itself, on the prepared one for the prepared entry
+    // points, so that it is `PreparedStatement::set_timestamp` under test and
+    // not `prepare`'s carrying the configuration over.
+    const TIMESTAMPS: [(i64, &str); 2] = [(420, "higher timestamp"), (42, "lower timestamp")];
 
-    let mut regular_query = Statement::new(query_str.to_string());
+    // test unprepared statement timestamps
 
-    regular_query.set_timestamp(Some(420));
-    session
-        .query_unpaged(regular_query.clone(), ("regular query", "higher timestamp"))
-        .await
-        .unwrap();
-
-    regular_query.set_timestamp(Some(42));
-    session
-        .query_unpaged(regular_query.clone(), ("regular query", "lower timestamp"))
-        .await
-        .unwrap();
+    for (paging_mode, key) in [
+        (PagingMode::Unpaged, "regular query"),
+        (PagingMode::Iter, "regular query iter"),
+        (PagingMode::SinglePage, "regular query single page"),
+    ] {
+        for (timestamp, value) in TIMESTAMPS {
+            let mut stmt = Statement::new(query_str.clone());
+            stmt.set_timestamp(Some(timestamp));
+            paging_mode
+                .send_unprepared(&session, stmt, (key, value))
+                .await
+                .unwrap();
+        }
+    }
 
     // test prepared statement timestamps
 
-    let mut prepared_statement = session.prepare(query_str).await.unwrap();
+    let prepared_statement = session.prepare(query_str.clone()).await.unwrap();
 
-    prepared_statement.set_timestamp(Some(420));
-    session
-        .execute_unpaged(&prepared_statement, ("prepared query", "higher timestamp"))
-        .await
-        .unwrap();
-
-    prepared_statement.set_timestamp(Some(42));
-    session
-        .execute_unpaged(&prepared_statement, ("prepared query", "lower timestamp"))
-        .await
-        .unwrap();
+    for (paging_mode, key) in [
+        (PagingMode::Unpaged, "prepared query"),
+        (PagingMode::Iter, "prepared query iter"),
+        (PagingMode::SinglePage, "prepared query single page"),
+    ] {
+        for (timestamp, value) in TIMESTAMPS {
+            let mut stmt = prepared_statement.clone();
+            stmt.set_timestamp(Some(timestamp));
+            paging_mode
+                .send_prepared(&session, &stmt, (key, value))
+                .await
+                .unwrap();
+        }
+    }
 
     // test batch statement timestamps
 
     let mut batch: Batch = Default::default();
-    batch.append_statement(regular_query);
+    batch.append_statement(Statement::new(query_str));
     batch.append_statement(prepared_statement);
 
     batch.set_timestamp(Some(420));
@@ -116,7 +129,11 @@ async fn test_timestamp() {
     let expected_results = [
         ("first query in batch", "higher timestamp", 420),
         ("prepared query", "higher timestamp", 420),
+        ("prepared query iter", "higher timestamp", 420),
+        ("prepared query single page", "higher timestamp", 420),
         ("regular query", "higher timestamp", 420),
+        ("regular query iter", "higher timestamp", 420),
+        ("regular query single page", "higher timestamp", 420),
         ("second query in batch", "higher timestamp", 420),
     ]
     .into_iter()

--- a/scylla/tests/integration/statements/timestamps.rs
+++ b/scylla/tests/integration/statements/timestamps.rs
@@ -136,7 +136,10 @@ async fn test_timestamp_generator() {
 
     impl TimestampGenerator for LocalTimestampGenerator {
         fn next_timestamp(&self) -> i64 {
-            let timestamp = random::<i64>().abs();
+            // Shifting a `u64` right by one yields `0..=i64::MAX`, so the
+            // timestamp is positive without an `abs()` that would overflow on
+            // `i64::MIN`.
+            let timestamp = (random::<u64>() >> 1) as i64;
             self.generated_timestamps.lock().unwrap().insert(timestamp);
             timestamp
         }


### PR DESCRIPTION
This is a revival of #1235 by @sylwiaszunejko.

------------------------------------------------------------------------

### Changes from #1235

#1235 added integration tests for statement parameters. Most of that PR moved tests between files; `main` has since restructured the integration suite into `statements/`, `session/` and `types/`, so those moves have all happened upstream already. What is left is the coverage it added along the way, rebased and rewritten here.

## (execution) _Entry Point_ abstraction

A statement can be sent through one of six `Session` methods — unprepared or prepared, times unpaged, iterated and one page at a time — and most of what this PR adds is a guarantee that is supposed to hold for all six equally. Spelling all six out at each case is what the original PR did, and it does not scale: it ran to some 670 lines of six-fold copy-paste. So the first commit here pulls the six calls out of the tests that already enumerate them, and everything after it is written against that.

### The extraction

`test_schema_await_with_various_apis` and `test_schema_await_refreshes_metadata` each covered all six entry points as six blocks differing only in the call being made, and the first needed its assertion twice over, once per error type. `entry_point` now holds those calls once:

- `PagingMode` — unpaged, iterated, one page at a time — takes a statement the caller has already built and configured. The two axes are independent, so this is the one that varies.
- `EntryPoint` pairs a `PagingMode` with preparation, for callers that have nothing but the statement text, and delegates.
- `SendError` carries a failure from either family, since the iterating entry points return a `PagerExecutionError` and the rest an `ExecutionError`. That is what lets the two schema agreement assertions collapse into one.

`schema_agreement.rs` loses 176 lines and gains 30. Behaviour is unchanged — the same six tests pass before and after, and swapping the expected `DbError` fails them, so the merged assertion is doing work.

The module is top level rather than under `statements/`, as its first caller is a session test. `session/metrics.rs`, `statements/consistency.rs` and `statements/unprepared.rs` also enumerate entry points by hand and are deliberately left alone: their entry points differ in more than the call — a different expected counter each, frames counted 1:1 against a channel, three different assertions on three response shapes — so a loop would obscure rather than clarify. `statements/coordinator.rs` and `session/tracing.rs` are convertible, but only by having the helper return the response, which is a different tool from this fire-and-forget one; that can be its own change.

## The coverage

**A bug in an existing test.** `test_timestamp_generator`'s generator computed `random::<i64>().abs()`. `i64::MIN` has no positive counterpart, so that panics on it — once every 2^64 timestamps, which is rare enough never to have been seen and still a defect. It now draws a `u64` and shifts right, which is in `0..=i64::MAX` by construction. (#1235 spotted this; its fix, `(random::<u64>() as i64).abs()`, still panics, as `1 << 63` casts to `i64::MIN`.)

**Statement configuration.** `test_prepared_config` guards that `Session::prepare` carries an unprepared statement's configuration over to the prepared one, but set and read back only two of the knobs. Consistency, serial consistency, tracing, request timeout and timestamp were free to be dropped without it noticing; they are asserted now.

**Timestamps on every entry point.** `test_timestamp` only ever used `query_unpaged`, `execute_unpaged` and `batch`. The other four could have dropped the statement's timestamp silently. The timestamp is set on the prepared statement for the prepared cases, rather than on an unprepared one that is then prepared, so that it is `PreparedStatement::set_timestamp` under test and not `prepare` carrying the configuration over — which the commit before it covers.

**Named bind markers.** The existing test fed a prepared statement maps that fail to name every marker and asserted only that each request errored out — satisfied by any failure at all, including one that has nothing to do with the values. Each map is now paired with the column it is expected to leave unset. Two behaviours had no test at all: naming a marker and giving it `None` binds it to `NULL`, which is not the same as leaving it unnamed; and a marker name is a CQL identifier, so `:theKey` names `thekey` while `:"theKey"` names `theKey`, and the map has to spell it the way the database folded it.

**Positional values.** Nothing checked what happens when the values do not line up with the bind markers. Too many and too few are rejected, a `NULL` among them is not, and none of it was tested. The three cases run through all six entry points, which do not report a bad value list in the same place: a prepared statement knows its markers up front and rejects the values as a `BadQuery`, an unprepared one learns them from the response to its own request and so fails per attempt — or, with too few values, is turned down by the database.

## Testing

Verified against a local 3-node cluster: 160 integration tests pass, including the proxy ones. Every commit is clippy- and `cargo fmt`-clean on its own. Assertions that could have been vacuous were mutation-tested: suppressing the timestamp on the iterating path, swapping the folded and verbatim identifier maps, and changing the expected `DbError` in the converted schema agreement test each fail as they should.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~