### PR TITLE
tests: check that a CachingSession really caches

### DIFF
--- a/scylla/tests/integration/session/caching_session.rs
+++ b/scylla/tests/integration/session/caching_session.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use scylla::client::caching_session::{CachingSession, CachingSessionBuilder};
+use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
+use scylla::statement::batch::{Batch, BatchType};
 use scylla_cql::frame::request::RequestV2;
 use scylla_cql::frame::request::execute::ExecuteV2;
 use scylla_proxy::Condition;
@@ -14,7 +17,10 @@ use scylla_proxy::RequestRule;
 use scylla_proxy::WorkerError;
 use tokio::sync::mpsc;
 
-use crate::utils::{fetch_negotiated_features, test_with_3_node_cluster};
+use crate::utils::{
+    PerformDDL as _, fetch_negotiated_features, setup_tracing, test_with_3_node_cluster,
+    unique_keyspace_name,
+};
 
 #[tokio::test]
 async fn test_caching_session_metadata_cache() {
@@ -95,6 +101,189 @@ async fn test_caching_session_metadata_cache() {
 
             // It should also be present when executing statement already in cache
             verify_statement_metadata(&caching_session, REQUEST, true, &mut feedback_rx).await;
+
+            running_proxy
+        },
+    )
+    .await;
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// Takes every feedback frame that has arrived so far, without waiting for more,
+/// and returns how many there were.
+fn consume_current_feedbacks(
+    rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
+) -> usize {
+    std::iter::from_fn(|| rx.try_recv().ok()).count()
+}
+
+/// A `CachingSession` prepares a statement it has not seen before and reuses
+/// the prepared statement afterwards, so a statement executed again must not be
+/// prepared again.
+///
+/// The check is made on the wire: a proxy rule feeds back every PREPARE frame
+/// reaching any node, and the test counts them. `Session::prepare` goes to one
+/// connection per node, so a statement costs one PREPARE per node, and the
+/// counts below are in terms of the cluster's size.
+#[tokio::test]
+async fn test_caching_session_statement_cache() {
+    setup_tracing();
+    let res = test_with_3_node_cluster(
+        scylla_proxy::ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            const CLUSTER_SIZE: usize = 3;
+
+            let session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::new(translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            let (feedback_txs, mut feedback_rxs): (Vec<_>, Vec<_>) =
+                (0..CLUSTER_SIZE).map(|_| mpsc::unbounded_channel()).unzip();
+            for (node, tx) in running_proxy.running_nodes.iter_mut().zip(feedback_txs) {
+                node.change_request_rules(Some(vec![RequestRule(
+                    Condition::and(
+                        Condition::RequestOpcode(RequestOpcode::Prepare),
+                        Condition::not(Condition::ConnectionRegisteredAnyEvent),
+                    ),
+                    RequestReaction::noop().with_feedback_when_performed(tx),
+                )]));
+            }
+            let mut prepares_so_far =
+                || -> usize { feedback_rxs.iter_mut().map(consume_current_feedbacks).sum() };
+
+            let ks = unique_keyspace_name();
+            session
+                .ddl(format!(
+                    "CREATE KEYSPACE {ks} WITH REPLICATION = \
+                     {{'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1}}"
+                ))
+                .await
+                .unwrap();
+            session.use_keyspace(&ks, false).await.unwrap();
+            session
+                .ddl("CREATE TABLE tab (a int, b int, c int, primary key (a, b, c))")
+                .await
+                .unwrap();
+
+            // All the nodes are assumed to have the same number of shards.
+            let nr_shards = session
+                .get_cluster_state()
+                .get_nodes_info()
+                .first()
+                .expect("No nodes information available")
+                .sharder()
+                .map_or(1, |sharder| sharder.nr_shards.get() as usize);
+
+            // Setting up the schema prepared statements of its own; they are not
+            // what is being counted.
+            prepares_so_far();
+
+            let caching_session = CachingSession::from(session, 100);
+
+            const BATCH_SIZE: usize = 4;
+            let mut batch = Batch::new(BatchType::Logged);
+            for i in 1..=BATCH_SIZE {
+                batch.append_statement(
+                    format!("INSERT INTO tab (a, b, c) VALUES ({i}, ?, ?)").as_str(),
+                );
+            }
+            let batch_values: Vec<(i32, i32)> = (1..=BATCH_SIZE as i32).map(|i| (i, i)).collect();
+
+            // None of the batch's statements has been seen before, so each is
+            // prepared - once per node, as `Session::prepare` goes to one
+            // connection per node rather than to every shard.
+            caching_session
+                .batch(&batch, batch_values.clone())
+                .await
+                .unwrap();
+            assert_eq!(prepares_so_far(), BATCH_SIZE * CLUSTER_SIZE);
+
+            // They are all in the cache now, so running the same batch again
+            // must not prepare anything.
+            for _ in 0..4 {
+                caching_session
+                    .batch(&batch, batch_values.clone())
+                    .await
+                    .unwrap();
+                assert_eq!(prepares_so_far(), 0);
+            }
+
+            // A statement the cache has not seen is prepared, once per node.
+            let mut rows: Vec<(i32, i32, i32)> = caching_session
+                .execute_unpaged("SELECT a, b, c FROM tab", &[])
+                .await
+                .unwrap()
+                .into_rows_result()
+                .unwrap()
+                .rows()
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap();
+            assert_eq!(prepares_so_far(), CLUSTER_SIZE);
+
+            // The batches did write what they were given.
+            rows.sort_unstable();
+            let expected: Vec<(i32, i32, i32)> =
+                (1..=BATCH_SIZE as i32).map(|i| (i, i, i)).collect();
+            assert_eq!(rows, expected);
+
+            // Renaming the columns back and forth leaves the table as it was but
+            // invalidates the statements the server holds, so the next execution
+            // of each has to be reprepared.
+            for alter in [
+                "ALTER TABLE tab RENAME c to tmp",
+                "ALTER TABLE tab RENAME b to c",
+                "ALTER TABLE tab RENAME tmp to b",
+            ] {
+                caching_session.ddl(alter).await.unwrap();
+            }
+            prepares_so_far();
+
+            // Send the batch to each shard of each node in turn. A node updates
+            // its cache upon the first mismatch, so on every node it is only the
+            // shard contacted first that answers `Unprepared` and causes a
+            // repreparation; by the time the other shards are asked, the node
+            // already agrees with the driver.
+            for node in caching_session
+                .get_session()
+                .get_cluster_state()
+                .get_nodes_info()
+                .iter()
+            {
+                for shard in 0..nr_shards {
+                    let profile = ExecutionProfile::builder()
+                        .load_balancing_policy(SingleTargetLoadBalancingPolicy::new(
+                            NodeIdentifier::Node(Arc::clone(node)),
+                            Some(shard as u32),
+                        ))
+                        .build();
+                    batch.set_execution_profile_handle(Some(profile.into_handle()));
+
+                    caching_session
+                        .batch(&batch, batch_values.clone())
+                        .await
+                        .unwrap();
+
+                    let expected = if shard == 0 { BATCH_SIZE } else { 0 };
+                    assert_eq!(
+                        prepares_so_far(),
+                        expected,
+                        "Unexpected number of prepares on node {node:?}, shard {shard}"
+                    );
+                }
+            }
+
+            caching_session
+                .ddl(format!("DROP KEYSPACE {ks}"))
+                .await
+                .unwrap();
 
             running_proxy
         },


### PR DESCRIPTION
This is a revival of #1237 by @Bouncheck.

------------------------------------------------------------------------

`session/caching_session.rs` has one test today, and it is about result metadata caching: it inspects what a request carries, not how many requests there are. So nothing checked the actual point of `CachingSession` — that a statement it has already prepared is not prepared again. A cache that silently reprepared on every execution would have passed the whole suite.

`test_caching_session_statement_cache` checks it on the wire. A proxy rule feeds back every PREPARE frame reaching any node and the test counts them:

- A batch of four statements, none seen before, costs one PREPARE per statement per node.
- Running the same batch four more times costs none.
- A statement outside the cache is prepared when first executed.
- Renaming the table's columns back and forth — which leaves the table as it was but invalidates the statements the server holds — makes the next execution on each node reprepare, once, on whichever shard is contacted first.

The first two together are what make this worth having: the same batch is observably twelve prepares and then zero. An assertion that only said "no more than a few" would have been satisfied by a broken cache.

### Changes from the original PR

The original had a second commit moving a test-local `SingleTargetLBP` into shared test utils. That is obsolete — main has since promoted it to a real public policy, `policies::load_balancing::SingleTargetLoadBalancingPolicy` — so the test uses that and the commit is dropped.

The expected number of prepares needed correcting. The original asserted `batch_size * nr_shards * cluster_size`, which is what preparation used to cost. Main now starts by "attempting preparation on a single (random) connection to every node" (`session.rs:1887`), falling back to every shard only if that whole pass fails, so a statement costs one PREPARE per node and not one per shard. The test asserted 24 and saw 12. Both counts and the comments explaining them are adjusted; relaxing the assertion into a range instead would have kept it passing while asserting much less.

The test also drops its keyspace, which the original did not: the `test_rust*` keyspace count on the shared cluster is unchanged across a run.

### Testing

Verified against a local 3-node cluster: the full integration suite passes, 160 tests including the proxy ones. clippy and `cargo fmt` are clean.

### Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
