### PR TITLE
Pager: compute replicas only on trace level

### DIFF
--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -2,6 +2,7 @@
 //! They enable consuming result of a paged query as a stream over rows,
 //! which abstracts over page boundaries.
 
+use std::cell::OnceCell;
 use std::future::Future;
 use std::ops::ControlFlow;
 use std::pin::Pin;
@@ -31,7 +32,9 @@ use crate::frame::frame_errors::ResultMetadataAndRowsCountParseError;
 use crate::frame::request::query::{PagingState, PagingStateResponse};
 use crate::frame::response::NonErrorResponseWithDeserializedMetadataV2 as NonErrorResponseWithDeserializedMetadata;
 use crate::frame::response::result;
-use crate::frame::response::result::{DeserializedMetadataAndRawRows, SchemaChange, SetKeyspace};
+use crate::frame::response::result::{
+    DeserializedMetadataAndRawRows, SchemaChange, SetKeyspace, TableSpec,
+};
 use crate::frame::types::{Consistency, SerialConsistency};
 use crate::network::Connection;
 use crate::observability::driver_tracing::RequestSpan;
@@ -936,15 +939,27 @@ If you are using this API, you are probably doing something wrong."
             partition_key: &Option<PartitionKey>,
             token: Option<Token>,
             serialized_values_size: usize,
-            _cluster_state: &ClusterState,
-            replicas: Option<&Replicas>,
+            cluster_state: &ClusterState,
+            table_spec: Option<&TableSpec<'_>>,
+            replicas: &OnceCell<Replicas>,
         ) -> RequestSpan {
             let span = RequestSpan::new_prepared(
                 partition_key.as_ref().map(|pk| pk.iter()),
                 token,
                 serialized_values_size,
             );
-            if let Some(replicas) = replicas {
+            if !span.span().is_disabled()
+                && let (Some(table_spec), Some(token)) = (table_spec, token)
+            {
+                // Replicas are costly to compute, so we only do it if some page's span is
+                // enabled, and then at most once for the whole paged request: `cluster_state`
+                // is a fixed snapshot, so the replica set cannot change between pages.
+                let replicas = replicas.get_or_init(|| {
+                    cluster_state
+                        .get_token_endpoints_iter(table_spec, token)
+                        .map(|(node, shard)| (node.clone(), shard))
+                        .collect()
+                });
                 span.record_replicas(replicas.iter().map(|(node, shard)| (node, *shard)));
             }
             span
@@ -995,21 +1010,17 @@ If you are using this API, you are probably doing something wrong."
 
         let serialized_values_size = values.buffer_size();
 
-        let replicas: Option<Replicas> =
-            Option::zip(routing_info.table, routing_info.token).map(|(table_spec, token)| {
-                executor
-                    .cluster_state
-                    .get_token_endpoints_iter(table_spec, token)
-                    .map(|(node, shard)| (node.clone(), shard))
-                    .collect()
-            });
+        // Shared by the first page and every remaining page, so that the replica set is
+        // computed at most once - and only if at least one of those spans is enabled.
+        let replicas: OnceCell<Replicas> = OnceCell::new();
 
         let request_span = create_span(
             &partition_key,
             token,
             serialized_values_size,
             &executor.cluster_state,
-            replicas.as_ref(),
+            table_spec,
+            &replicas,
         );
 
         let (first_page, should_fetch_more_pages) = executor
@@ -1082,7 +1093,8 @@ If you are using this API, you are probably doing something wrong."
                             token,
                             serialized_values_size,
                             cluster_state,
-                            replicas.as_ref(),
+                            table_spec,
+                            &replicas,
                         )
                     };
 

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -205,11 +205,11 @@ impl PagingExecutor {
     ) where
         QueryFunc: Fn(Arc<Connection>, Consistency, PagingState) -> QueryFut,
         QueryFut: Future<Output = Result<QueryResponse, RequestAttemptError>>,
-        SpanCreator: Fn() -> RequestSpan,
+        SpanCreator: Fn(&ClusterState) -> RequestSpan,
     {
         // Iterates over pages until exhaustion or non-retriable error.
         loop {
-            let page_span = span_creator();
+            let page_span = span_creator(&self.cluster_state);
 
             let page_res = self
                 .fetch_one_page(&routing_info, &page_span, &page_query)
@@ -907,7 +907,7 @@ If you are using this API, you are probably doing something wrong."
                                 .await
                         };
 
-                    let span_creator = move || create_span(&statement_ref.contents);
+                    let span_creator = move |_: &ClusterState| create_span(&statement_ref.contents);
 
                     executor
                         .query_remaining_pages(sender, page_query, routing_info, span_creator)
@@ -936,6 +936,7 @@ If you are using this API, you are probably doing something wrong."
             partition_key: &Option<PartitionKey>,
             token: Option<Token>,
             serialized_values_size: usize,
+            _cluster_state: &ClusterState,
             replicas: Option<&Replicas>,
         ) -> RequestSpan {
             let span = RequestSpan::new_prepared(
@@ -1007,6 +1008,7 @@ If you are using this API, you are probably doing something wrong."
             &partition_key,
             token,
             serialized_values_size,
+            &executor.cluster_state,
             replicas.as_ref(),
         );
 
@@ -1074,11 +1076,12 @@ If you are using this API, you are probably doing something wrong."
                                 .await
                         };
 
-                    let span_creator = move || {
+                    let span_creator = move |cluster_state: &ClusterState| {
                         create_span(
                             &partition_key,
                             token,
                             serialized_values_size,
+                            cluster_state,
                             replicas.as_ref(),
                         )
                     };


### PR DESCRIPTION
 # Compute replicas only if needed for tracing
    
Non-pager execution APIs already compute replicas only if the execution span is enabled. This is reasonable, because the computation is costly and only surfaces the user at TRACE tracing level, which is unlikely in
prod.

The problem was mentioned by Claude Opus when working on https://github.com/scylladb/cpp-rs-driver/pull/499. Also by @Lorak-mmk in the past IIRC.

This PR makes replicas computed **at most once**, if the span is created at the moment when the tracing level is TRACE, so the execution span is enabled. The _at most once_ semantics is achieved by OnceCell, which BTW is a zero-cost abstraction (compared to a plain Option), yet provides convenient memoization semantics here.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
