### PR TITLE
Driver config reporting

### DIFF
--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -65,6 +65,11 @@ println!("session id: {}", session.session_id());
 # }
 ```
 
+The control connection additionally sends a `DRIVER_CONFIG` option: a JSON document describing the configuration the session actually runs with - timeouts, connection pooling, load balancing and retry policy.
+It surfaces in `system.clients.client_options` as well, and follows a schema shared by all ScyllaDB drivers, so the same query answers the question for any of them.
+
+If the client's configuration should not be disclosed to the cluster, `SessionBuilder::driver_config_reporting(false)` turns the report off. That does not affect `SESSION_ID`.
+
 ## Metadata
 
 The driver keeps an up-to-date view of the cluster topology (and client routes, if used) and of the cluster schema.

--- a/docs/source/connecting/connecting.md
+++ b/docs/source/connecting/connecting.md
@@ -65,7 +65,7 @@ println!("session id: {}", session.session_id());
 # }
 ```
 
-The control connection additionally sends a `DRIVER_CONFIG` option: a JSON document describing the configuration the session actually runs with - timeouts, connection pooling, load balancing and retry policy.
+The control connection additionally sends a `DRIVER_CONFIG` option: a JSON document describing the configuration the session actually runs with - timeouts, connection pooling, load balancing, retry and speculative execution policies.
 It surfaces in `system.clients.client_options` as well, and follows a schema shared by all ScyllaDB drivers, so the same query answers the question for any of them.
 
 If the client's configuration should not be disclosed to the cluster, `SessionBuilder::driver_config_reporting(false)` turns the report off. That does not affect `SESSION_ID`.

--- a/scylla-cql/src/frame/request/options.rs
+++ b/scylla-cql/src/frame/request/options.rs
@@ -31,6 +31,7 @@ pub const APPLICATION_NAME: &str = "APPLICATION_NAME";
 pub const APPLICATION_VERSION: &str = "APPLICATION_VERSION";
 pub const CLIENT_ID: &str = "CLIENT_ID";
 pub const SESSION_ID: &str = "SESSION_ID";
+pub const DRIVER_CONFIG: &str = "DRIVER_CONFIG";
 
 /* Value names for options in SUPPORTED/STARTUP */
 pub const DEFAULT_CQL_PROTOCOL_VERSION: &str = "4.0.0";

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -156,6 +156,11 @@ arc-swap = "1.3.0"
 hashbrown = "0.17"
 # Used to avoid allocs when representing PK values / replica list.
 smallvec = "1.8.0"
+# Used to build the configuration report sent in STARTUP. That report is a JSON
+# document defined by an external cross-driver schema.
+# Not part of public API - the report types are all `pub(crate)`.
+serde = { version = "1.0.184", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 num-bigint-03 = { package = "num-bigint", version = "0.3" }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -182,3 +182,8 @@ env_logger = "0.11"
 # Used by the TLS-inspecting proxy of the session ticket ccm test to classify
 # the handshakes it forwards.
 tls-parser = "0.12.2"
+# Validates the driver configuration report against the vendored copy of the
+# cross-driver schema it must conform to. Default features are off: they pull in
+# reqwest and a TLS stack to resolve remote `$ref`s, and the schema's references
+# are all internal.
+jsonschema = { version = "0.52", default-features = false }

--- a/scylla/src/client/driver-config-schema.json
+++ b/scylla/src/client/driver-config-schema.json
@@ -1,0 +1,1026 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://scylladb.com/schemas/driver-client-options/v1.json",
+  "title": "ScyllaDB driver DRIVER_CONFIG configuration",
+  "description": "Schema for the JSON value sent under the STARTUP option key DRIVER_CONFIG, describing the effective client configuration. The top-level object must include `version` and the required configuration groups listed by this schema. Unknown top-level keys are rejected. Built-in groups reject unknown keys and require the keys listed in each group; custom policy objects may include additional implementation-specific public attributes where explicitly allowed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "connection",
+    "control-plane",
+    "query"
+  ],
+  "properties": {
+    "version": {
+      "description": "Major schema version. Adding keys is backward-compatible and does not bump this; only changing/removing the meaning of an existing key does.",
+      "type": "integer",
+      "const": 1
+    },
+    "connection": {
+      "$ref": "#/$defs/connection"
+    },
+    "control-plane": {
+      "$ref": "#/$defs/control-plane"
+    },
+    "query": {
+      "$ref": "#/$defs/query"
+    }
+  },
+  "$defs": {
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "retryPolicyBackoff": {
+      "description": "Delay inserted between retry attempts of a retry policy. Discriminated union: when present, `type` selects the backoff algorithm and each algorithm carries only its own parameters. Absent when there is no delay between attempts.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Exponential backoff: the delay starts at base-ms and doubles after each attempt (capped at max-ms), with a small random jitter to de-synchronize concurrent retries. When max-ms is present, it MUST be greater than or equal to base-ms; this cross-property invariant must be checked by the producer or consumer because JSON Schema Draft 2020-12 cannot compare sibling numeric values.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "base-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "exponential",
+              "description": "Exponential backoff algorithm."
+            },
+            "base-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Initial delay between retries in milliseconds; the starting delay that doubles each attempt."
+            },
+            "max-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum delay between retries in milliseconds; the exponentially growing delay is capped here. MUST be greater than or equal to base-ms. Absent when no maximum delay is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Constant backoff: wait a fixed, strictly positive delay between every retry attempt.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "delay-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "constant",
+              "description": "Constant (fixed-delay) backoff algorithm."
+            },
+            "delay-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Fixed delay between retries in milliseconds. Must be greater than 0; omit backoff when no delay is configured."
+            }
+          }
+        }
+      ]
+    },
+    "requests": {
+      "type": "object",
+      "description": "Per-connection CQL request and protocol stream capacity. `orphaned.max` is expected to be lower than `in-flight.max`.",
+      "additionalProperties": false,
+      "required": [
+        "in-flight"
+      ],
+      "properties": {
+        "in-flight": {
+          "type": "object",
+          "description": "Requests currently awaiting a response on the connection.",
+          "additionalProperties": false,
+          "required": [
+            "max"
+          ],
+          "properties": {
+            "max": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of concurrent in-flight requests allowed on one connection."
+            }
+          }
+        },
+        "orphaned": {
+          "type": "object",
+          "description": "Requests that the client stopped waiting for but whose stream identifiers cannot yet be safely reused.",
+          "additionalProperties": false,
+          "required": [
+            "max"
+          ],
+          "properties": {
+            "max": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of orphaned requests allowed on one connection before the driver closes and replaces it. Absent only when this bound is unknown, for example when the client never replaces a connection over accumulated orphans and so has no limit to report."
+            }
+          }
+        }
+      }
+    },
+    "connection-pool": {
+      "description": "Connection pooling configuration.",
+      "type": "object",
+      "required": [
+        "shard-aware"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "shard-aware": {
+          "type": "object",
+          "required": [
+            "enabled"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether the client is configured to use ScyllaDB's dedicated shard-aware port (default 19042, TLS 19043) to reach a chosen shard in a single connect, versus the fallback of opening connections on the normal port and reading the server-assigned shard. Reports configuration intent; at runtime the port must also be advertised by the server and reachable, otherwise the client falls back transparently."
+            }
+          }
+        }
+      }
+    },
+    "connection": {
+      "description": "Connection-level settings: socket read/write/connect timeouts plus the CQL-level idle heartbeat. Durations are in milliseconds. Optional duration fields are absent when unset or not applicable.",
+      "type": "object",
+      "required": [
+        "connect",
+        "requests",
+        "pool",
+        "socket",
+        "reconnection"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "$ref": "#/$defs/requests"
+        },
+        "node-preference": {
+          "$ref": "#/$defs/node-location-preference",
+          "description": "Defines part of the cluster driver holds connections to."
+        },
+        "connect": {
+          "type": "object",
+          "description": "Settings for establishing a TCP/CQL connection to a node.",
+          "additionalProperties": false,
+          "properties": {
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Timeout for establishing a TCP/CQL connection to a node."
+            }
+          }
+        },
+        "read": {
+          "type": "object",
+          "description": "Settings for reading from a connection.",
+          "additionalProperties": false,
+          "properties": {
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Read operation timeout."
+            }
+          }
+        },
+        "write": {
+          "type": "object",
+          "description": "Settings for writing to a connection. Direction-specific options such as write coalescing are expected to be added here in a future schema version.",
+          "additionalProperties": false,
+          "properties": {
+            "coalescing": {
+              "type": "object",
+              "description": "Settings for write coalescing. It is a placeholder for v2",
+              "additionalProperties": false,
+              "properties": {}
+            },
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Write operation timeout."
+            }
+          }
+        },
+        "heartbeat": {
+          "type": "object",
+          "description": "Reserved for CQL-level idle heartbeat settings. Optional and intentionally empty in this schema version. It is a placeholder for v2",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "pool": {
+          "$ref": "#/$defs/connection-pool",
+          "description": "A connection pooling configuration."
+        },
+        "socket": {
+          "$ref": "#/$defs/socket"
+        },
+        "reconnection": {
+          "description": "Connection reconnection configuration.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/reconnection-policy"
+            }
+          }
+        },
+        "tls": {
+          "$ref": "#/$defs/tls"
+        }
+      }
+    },
+    "control-plane": {
+      "description": "Control-plane timeout settings for internal/system queries run over the control connection and for schema agreement. Each value is in milliseconds. Optional values are absent when unset or not applicable.",
+      "type": "object",
+      "required": [
+        "queries",
+        "schema"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "queries": {
+          "type": "object",
+          "description": "Control-plane query settings.",
+          "additionalProperties": false,
+          "required": [
+            "system"
+          ],
+          "properties": {
+            "system": {
+              "type": "object",
+              "description": "Settings for internal/system queries run over the control connection.",
+              "additionalProperties": false,
+              "required": [
+                "timeout"
+              ],
+              "properties": {
+                "timeout": {
+                  "type": "object",
+                  "description": "Timeouts applied to internal/system queries. Each value is in milliseconds. Optional values are absent when unset or not applicable.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "client-side-ms": {
+                      "$ref": "#/$defs/positiveInteger",
+                      "description": "A client-side timeout for internal queries."
+                    },
+                    "server-side-ms": {
+                      "$ref": "#/$defs/positiveInteger",
+                      "description": "A server-side timeout for internal queries."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "schema": {
+          "type": "object",
+          "description": "Control-plane schema settings.",
+          "additionalProperties": false,
+          "required": [
+            "agreement"
+          ],
+          "properties": {
+            "agreement": {
+              "type": "object",
+              "description": "Settings for schema agreement across nodes.",
+              "additionalProperties": false,
+              "required": [
+                "timeout-ms"
+              ],
+              "properties": {
+                "timeout-ms": {
+                  "$ref": "#/$defs/nonNegativeInteger",
+                  "description": "Maximum time to wait for schema agreement across nodes. Always a concrete value; 0 means do not wait for agreement."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "socket": {
+      "description": "Low-level TCP socket options applied to client connections. Boolean options (tcp-no-delay, keep-alive, reuse-address) report the effective on/off state: when no explicit value is configured, the OS/platform default is reported. Buffer sizes are in bytes and linger is in seconds; these fields are absent when unset (kernel auto-tuned buffer / linger disabled).",
+      "type": "object",
+      "required": [
+        "tcp-no-delay",
+        "keep-alive",
+        "reuse-address"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "tcp-no-delay": {
+          "type": "boolean",
+          "description": "TCP_NODELAY: disable Nagle's algorithm. Reports the effective value; when no explicit value is configured, the OS/platform default is reported."
+        },
+        "keep-alive": {
+          "type": "boolean",
+          "description": "SO_KEEPALIVE: OS-level TCP keep-alive probes on idle connections. Reports the effective on/off state; when no explicit value is configured, the OS/platform default is reported."
+        },
+        "reuse-address": {
+          "type": "boolean",
+          "description": "SO_REUSEADDR: allow reuse of a local address. Reports the effective on/off state; when no explicit value is configured, the OS/platform default is reported."
+        },
+        "linger": {
+          "type": "object",
+          "required": [
+            "interval-s"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "interval-s": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "SO_LINGER lingering-close interval in seconds."
+            }
+          }
+        },
+        "receive-buffer": {
+          "type": "object",
+          "required": [
+            "size-bytes"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "size-bytes": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "SO_RCVBUF socket receive buffer size hint in bytes."
+            }
+          }
+        },
+        "send-buffer": {
+          "type": "object",
+          "required": [
+            "size-bytes"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "size-bytes": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "SO_SNDBUF socket send buffer size hint in bytes."
+            }
+          }
+        }
+      }
+    },
+    "reconnection-policy": {
+      "description": "Defines how connection attempts to a node are retried after a connection failure.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Exponential backoff reconnection policy. max-ms MUST be greater than or equal to base-ms; this cross-property invariant must be checked by the producer or consumer because JSON Schema Draft 2020-12 cannot compare sibling numeric values.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "base-ms",
+            "max-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "exponential",
+              "description": "Reconnection policy type."
+            },
+            "base-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Initial delay before the first reconnection attempt in milliseconds. Always a concrete value when this policy is reported."
+            },
+            "max-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum delay between reconnection attempts in milliseconds. MUST be greater than or equal to base-ms. Always a concrete value when this policy is reported."
+            },
+            "max-attempts": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of reconnection attempts before giving up. Absent when attempts are unlimited."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Constant-delay reconnection policy. A delay of 0 means reconnect immediately.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "delay-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "constant",
+              "description": "Reconnection policy type."
+            },
+            "delay-ms": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Fixed delay between reconnection attempts in milliseconds; 0 means reconnect immediately. Always a concrete value when this policy is reported."
+            },
+            "max-attempts": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of reconnection attempts before giving up. Absent when attempts are unlimited."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied reconnection policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Reconnection policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            }
+          }
+        },
+        {
+          "type": "null",
+          "description": "No reconnection attempts will be made."
+        }
+      ]
+    },
+    "retry-policy": {
+      "description": "Controls whether and how a failed query is retried. Discriminated on `type`; each policy only permits its own parameters.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Standard error-aware retry policy.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "standard-error-aware",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Simple retry policy with a fixed number of retries.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "max-retries"
+          ],
+          "properties": {
+            "type": {
+              "const": "simple",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up. Always a concrete value when this policy is reported; 0 means no retries."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Fall-through retry policy: never retries anything and always rethrows the original error to the caller. Every error type — read timeout, write timeout, unavailable, and unexpected request errors (connection errors, Overloaded, ServerError, Bootstrapping) — is propagated unchanged. This is a true no-op and is stricter than the 'never' policy, which still retries the next host on connection/server errors.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "fallthrough",
+              "description": "Retry policy type."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Never-retry policy: does not retry read timeouts, write timeouts, or unavailable errors, but may try the next host for connection and server errors.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "never",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Downgrading-consistency retry policy: retries at a lower consistency level on failure.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "downgrading-consistency",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied retry policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Retry policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Textual description of what this policy does."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        }
+      ]
+    },
+    "speculative-execution-policy": {
+      "description": "Controls pre-emptive duplicate requests to other replicas. Discriminated on `type`; each policy only permits its own parameters.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Constant-delay speculative execution: launch extra executions after a fixed delay. A delay of 0 means launch them immediately.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "max-executions",
+            "delay-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "constant",
+              "description": "Speculative execution policy type."
+            },
+            "max-executions": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of speculative executions per request."
+            },
+            "delay-ms": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Delay before launching each additional execution in milliseconds; 0 means launch immediately."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Percentile-based speculative execution: launch extra executions once latency exceeds a percentile threshold.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "max-executions",
+            "percentile"
+          ],
+          "properties": {
+            "type": {
+              "const": "percentile",
+              "description": "Speculative execution policy type."
+            },
+            "max-executions": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of speculative executions per request."
+            },
+            "percentile": {
+              "type": "number",
+              "exclusiveMinimum": 0,
+              "exclusiveMaximum": 100,
+              "description": "Latency percentile (0–100, exclusive; e.g. 99.0) that triggers an additional execution."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied speculative execution policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Speculative execution policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Textual description of what this policy does."
+            }
+          }
+        }
+      ]
+    },
+    "adaptive-ordering": {
+      "type": "object",
+      "description": "Dynamic reordering of otherwise eligible candidate nodes using runtime responsiveness, load, or health observations. Absent when adaptive ordering is disabled. This capability does not imply a particular algorithm.",
+      "additionalProperties": false,
+      "required": [
+        "signals"
+      ],
+      "properties": {
+        "signals": {
+          "type": "array",
+          "description": "Runtime observations used to influence ordering.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "latency",
+              "response-rate",
+              "in-flight-requests",
+              "recovery-state"
+            ]
+          }
+        }
+      }
+    },
+    "load-balancing-policy": {
+      "description": "Load balancing / host selection policy, discriminated by `type`. A built-in token-aware policy is reported with `type` set to `token-aware` and the normalized capability flags below. A user-supplied policy is reported with `type` set to `custom`, a `name`, and, optionally, serialized public attributes.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "A built-in load balancing policy, reported with normalized location/awareness flags.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "load-distribution",
+            "fallback-to-non-preferred-nodes"
+          ],
+          "properties": {
+            "type": {
+              "const": "token-aware",
+              "description": "Load balancing policy type: the built-in token-aware policy."
+            },
+            "load-distribution": {
+              "type": "string",
+              "enum": [
+                "shuffle",
+                "round-robin",
+                "replica-set"
+              ],
+              "description": "Strategy used to distribute requests across otherwise equally preferred nodes. `shuffle` randomizes node selection across query plans; `round-robin` rotates the first selected node across successive query plans; `replica-set` preserves the replica set's existing order without reordering it."
+            },
+            "fallback-to-non-preferred-nodes": {
+              "type": "boolean",
+              "description": "Whether requests may fail over to nodes outside of the preference configured by `query.load-balancing.node-preference`."
+            },
+            "adaptive-ordering": {
+              "$ref": "#/$defs/adaptive-ordering"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied load balancing policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Load balancing policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Textual description of what this policy does."
+            }
+          }
+        }
+      ]
+    },
+    "node-location-preference": {
+      "description": "Session-level datacenter/rack preference, set independently of the load balancing policy. Some implementations let users set a preferred DC/rack directly on the session configuration; the load balancing policy and other components read this preference unless a policy overrides it. May be sourced from different places; if DC/rack preferences are specified in the load balancing policy, they should be reported here.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Explicitly configured datacenter preference.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "local-dc"
+          ],
+          "properties": {
+            "type": {
+              "const": "dc",
+              "description": "Session-level location preference: explicit datacenter."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred datacenter."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Explicitly configured datacenter and rack preference.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "local-dc",
+            "local-rack"
+          ],
+          "properties": {
+            "type": {
+              "const": "rack",
+              "description": "Session-level location preference: explicit datacenter and rack."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred datacenter."
+            },
+            "local-rack": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred rack."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Datacenter preference inferred from the first node the client connects to.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "dc-auto",
+              "description": "Session-level location preference: inferred datacenter."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Inferred preferred datacenter. Absent when not yet known at report time."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Datacenter and/or rack preference inferred from the connected node. Configured and inferred values are reported separately.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "rack-auto",
+              "description": "At least one part of the location preference is inferred."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred datacenter."
+            },
+            "local-rack": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred rack."
+            },
+            "inferred-local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Inferred preferred datacenter. Absent when not yet known."
+            },
+            "inferred-local-rack": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Inferred preferred rack. Absent when not yet known."
+            }
+          },
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "local-dc",
+                  "inferred-local-dc"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "local-rack",
+                  "inferred-local-rack"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "local-dc",
+                  "local-rack"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "query": {
+      "description": "Query execution configuration.",
+      "type": "object",
+      "required": [
+        "defaults",
+        "retry",
+        "load-balancing"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "defaults": {
+          "$ref": "#/$defs/query-defaults"
+        },
+        "retry": {
+          "description": "Query retry configuration. Backoff is optional and is omitted when no retry delay is configured.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "policy": {
+                    "properties": {
+                      "type": {
+                        "const": "fallthrough"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ]
+                  }
+                },
+                "required": [
+                  "policy"
+                ]
+              },
+              "then": {
+                "not": {
+                  "required": [
+                    "backoff"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/retry-policy"
+            },
+            "backoff": {
+              "$ref": "#/$defs/retryPolicyBackoff",
+              "description": "Delay inserted between retries. Omitted when no retry backoff is configured. Every configured delay must be greater than 0."
+            }
+          }
+        },
+        "load-balancing": {
+          "description": "Load-balancing configuration applied to queries.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/load-balancing-policy"
+            },
+            "node-preference": {
+              "$ref": "#/$defs/node-location-preference",
+              "description": "Defines part of the cluster queries will be scheduled on"
+            }
+          }
+        },
+        "speculative-execution": {
+          "description": "Speculative-execution configuration applied to queries. Absent when speculative execution is disabled.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/speculative-execution-policy"
+            }
+          }
+        }
+      }
+    },
+    "query-defaults": {
+      "description": "Default per-request settings applied to statements that do not override them.",
+      "type": "object",
+      "required": [
+        "consistency",
+        "idempotence"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "page": {
+          "type": "object",
+          "required": [
+            "size"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Default page (fetch) size for result sets. Absent when page is not limited."
+            }
+          }
+        },
+        "consistency": {
+          "description": "Default consistency level applied to requests that do not override it. Always present when this group is reported.",
+          "type": "string",
+          "enum": [
+            "ANY",
+            "ONE",
+            "TWO",
+            "THREE",
+            "QUORUM",
+            "ALL",
+            "LOCAL_QUORUM",
+            "EACH_QUORUM",
+            "LOCAL_ONE",
+            "SERIAL",
+            "LOCAL_SERIAL"
+          ]
+        },
+        "serial-consistency": {
+          "description": "Default serial consistency for LWT/conditional statements. Absent when unset; the server default applies.",
+          "type": "string",
+          "enum": [
+            "SERIAL",
+            "LOCAL_SERIAL"
+          ]
+        },
+        "idempotence": {
+          "description": "Default idempotence flag applied to statements that do not set their own.",
+          "type": "boolean"
+        },
+        "client-timestamps": {
+          "description": "True when the client assigns the write timestamp client-side (protocol-level/USING TIMESTAMP) instead of letting the coordinator assign it. Absent only when this behavior is unknown, for example when a custom timestamp generator may or may not enforce a timestamp.",
+          "type": "boolean"
+        },
+        "request": {
+          "type": "object",
+          "description": "Default request-level settings.",
+          "additionalProperties": false,
+          "properties": {
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Client-side timeout for a single request/query in milliseconds. Absent when the timeout is disabled or unset."
+            }
+          }
+        }
+      }
+    },
+    "tls": {
+      "description": "TLS/SSL transport settings. Absent when TLS is disabled. Reports only booleans; never credentials, keys, or host lists.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hostname-verification": {
+          "type": "boolean",
+          "description": "Whether the server hostname is verified against its certificate. Absent only when this behavior is unknown, for example when a custom certificate validator may or may not enforce hostname verification."
+        }
+      }
+    }
+  }
+}

--- a/scylla/src/client/driver_config.rs
+++ b/scylla/src/client/driver_config.rs
@@ -1,0 +1,108 @@
+//! Reporting of the driver's effective configuration to the cluster.
+//!
+//! The driver sends its configuration as a JSON document under the
+//! `DRIVER_CONFIG` `STARTUP` option, where ScyllaDB exposes it in
+//! `system.clients.client_options`. That makes the configuration a session
+//! actually runs with inspectable from the server side, without having to
+//! correlate it with client-side logs. The document follows an external schema
+//! shared by all ScyllaDB drivers, so that one
+//! query answers the same question regardless of which driver a client uses.
+//! Only the control connection sends it: the value is identical for every
+//! connection of a session, so sending it on all of them would only bloat their
+//! `STARTUP` frames.
+
+use serde::Serialize;
+
+/// The major version of the reported configuration schema.
+///
+/// Adding keys is backwards compatible and does not bump this; only changing or
+/// removing the meaning of an existing key does.
+const REPORT_VERSION: u32 = 1;
+
+/// Reports larger than this are omitted instead of being sent.
+///
+/// ScyllaDB's protocol-extensions spec requires drivers to validate the size
+/// client side and omit the option above this limit, so that reporting the
+/// configuration never prevents a connection from being established. 32 KiB is
+/// the limit gocql and csharp-driver use, keeping it consistent across drivers.
+///
+/// It also leaves a 2x margin to the driver's own hard limit: `write_string`
+/// prefixes every `STARTUP` value with a 16-bit length via `write_short_length`,
+/// so a value above 64 KiB would fail `STARTUP` serialization and take down the
+/// control-connection handshake, and with it session creation.
+const MAX_REPORT_SIZE: usize = 32 * 1024;
+
+/// The reported configuration document.
+///
+/// The `connection`, `control-plane` and `query` groups are yet to be added.
+/// The schema requires all three, so the report this currently produces does
+/// not validate against it.
+#[derive(Serialize)]
+struct Report {
+    version: u32,
+}
+
+/// Builds the configuration report of a session.
+///
+/// Carries no configuration yet, because `{"version":1}` needs no inputs; the
+/// configuration each group reports is added alongside that group.
+pub(crate) struct DriverConfigReporter {}
+
+impl DriverConfigReporter {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    /// Renders the report, or returns `None` when there is nothing safe to send.
+    ///
+    /// Never fails and never panics: the report is a diagnostic aid, and must
+    /// never prevent a connection from being established. Problems are logged
+    /// and the option omitted.
+    ///
+    /// The report is rebuilt on every call rather than cached, because it is not
+    /// constant for the lifetime of a session: `target_is_scylladb` is only
+    /// known after the `OPTIONS`/`SUPPORTED` exchange of the connection being
+    /// established, and configuration read through an `ExecutionProfileHandle`
+    /// can be remapped at runtime.
+    ///
+    /// `target_is_scylladb` tells whether the peer is a ScyllaDB node, as some
+    /// reported values only apply to ScyllaDB. It is not read yet, hence the
+    /// scoped `expect`: a leading underscore would only have to be renamed once
+    /// a group starts using it.
+    pub(crate) fn report(
+        &self,
+        #[expect(unused_variables)] target_is_scylladb: bool,
+    ) -> Option<String> {
+        let report = Report {
+            version: REPORT_VERSION,
+        };
+
+        // `serde_json::to_string` cannot fail for the report's current shape; the
+        // branch keeps reporting best effort once a future one can fail. It will
+        // not catch a non-finite `f64`: `serde_json` emits those as `null`, which
+        // the schema rejects under a numeric key, so such values have to be
+        // filtered out where they are read rather than here.
+        let report = match serde_json::to_string(&report) {
+            Ok(report) => report,
+            Err(err) => {
+                tracing::warn!("Failed to serialize the driver configuration report: {err}");
+                return None;
+            }
+        };
+
+        if report.len() > MAX_REPORT_SIZE {
+            tracing::warn!(
+                "Driver configuration report is too large to be reported: {} bytes, the limit is {} bytes",
+                report.len(),
+                MAX_REPORT_SIZE
+            );
+            return None;
+        }
+
+        Some(report)
+    }
+}
+
+#[cfg(test)]
+#[path = "driver_config_tests.rs"]
+mod tests;

--- a/scylla/src/client/driver_config.rs
+++ b/scylla/src/client/driver_config.rs
@@ -11,6 +11,7 @@
 //! connection of a session, so sending it on all of them would only bloat their
 //! `STARTUP` frames.
 
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -30,6 +31,11 @@ use crate::policies::reconnect::{
 };
 use crate::policies::retry::{
     DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy, RetryPolicy,
+};
+#[cfg(feature = "metrics")]
+use crate::policies::speculative_execution::PercentileSpeculativeExecutionPolicy;
+use crate::policies::speculative_execution::{
+    SimpleSpeculativeExecutionPolicy, SpeculativeExecutionPolicy,
 };
 use crate::routing::NodeLocationPreference;
 use crate::statement::PageSize;
@@ -56,9 +62,9 @@ const MAX_REPORT_SIZE: usize = 32 * 1024;
 /// The reported configuration document.
 ///
 /// Carries every group the schema requires, so the produced document validates
-/// against it. Of the optional ones only `query.speculative-execution` is yet
-/// to be added; each type below states why the keys it does not populate are
-/// absent.
+/// against it. The schema's optional keys are populated where this driver has
+/// something to report; each type below states why it does not where it does
+/// not.
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct Report {
@@ -280,6 +286,10 @@ struct QueryReport {
     defaults: QueryDefaultsReport,
     retry: QueryRetryReport,
     load_balancing: QueryLoadBalancingReport,
+    /// Omitted when speculative execution never fires, which the schema gives
+    /// the group's absence as its meaning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speculative_execution: Option<QuerySpeculativeExecutionReport>,
 }
 
 /// The defaults a statement gets when it overrides nothing, read from the
@@ -403,6 +413,39 @@ enum LoadBalancingPolicyReport {
 #[serde(rename_all = "kebab-case")]
 struct AdaptiveOrderingReport {
     signals: &'static [&'static str],
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct QuerySpeculativeExecutionReport {
+    policy: SpeculativeExecutionPolicyReport,
+}
+
+/// `max-executions` is a [`NonZeroUsize`] because the schema declares it
+/// `positiveInteger`, and a policy that permits zero extra executions never
+/// fires at all - such a policy is reported as no speculative execution rather
+/// than as one with an unrepresentable count.
+#[derive(Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "kebab-case"
+)]
+enum SpeculativeExecutionPolicyReport {
+    Constant {
+        max_executions: NonZeroUsize,
+        /// A schema `nonNegativeInteger`, where 0 means "launch immediately"
+        /// rather than a disabled feature, so it is reported verbatim.
+        delay_ms: u64,
+    },
+    #[cfg(feature = "metrics")]
+    Percentile {
+        max_executions: NonZeroUsize,
+        percentile: f64,
+    },
+    Custom {
+        name: &'static str,
+    },
 }
 
 /// The schema's `query.defaults.consistency` name of `consistency`.
@@ -547,6 +590,65 @@ fn custom_policy_name(policy: &Arc<dyn LoadBalancingPolicy>) -> String {
     } else {
         name
     }
+}
+
+/// What a speculative execution policy can be reported as.
+///
+/// Three outcomes, named rather than encoded as a nested `Option`, because the
+/// middle one is not simply "not a built-in": a built-in whose parameters fall
+/// outside what the schema can carry lands there too, and a bare
+/// `Option<Option<_>>` gave no place to say so.
+enum SpeculativeExecutionReported {
+    /// The policy never launches an extra execution, so there is no speculative
+    /// execution to report at all and the group is omitted.
+    NeverFires,
+    /// Report the policy as `custom`, named but not described. Either the driver
+    /// does not know the policy, or it does and its parameters cannot be
+    /// expressed under the schema's branch for it.
+    Generic,
+    /// A built-in, described precisely.
+    Precise(SpeculativeExecutionPolicyReport),
+}
+
+/// How to report one of the built-in speculative execution policies.
+fn speculative_execution_policy_report(policy: &dyn std::any::Any) -> SpeculativeExecutionReported {
+    if let Some(policy) = policy.downcast_ref::<SimpleSpeculativeExecutionPolicy>() {
+        let Some(max_executions) = NonZeroUsize::new(policy.max_retry_count) else {
+            return SpeculativeExecutionReported::NeverFires;
+        };
+        return SpeculativeExecutionReported::Precise(SpeculativeExecutionPolicyReport::Constant {
+            max_executions,
+            delay_ms: non_negative_millis(policy.retry_interval),
+        });
+    }
+
+    #[cfg(feature = "metrics")]
+    if let Some(policy) = policy.downcast_ref::<PercentileSpeculativeExecutionPolicy>() {
+        let Some(max_executions) = NonZeroUsize::new(policy.max_retry_count) else {
+            return SpeculativeExecutionReported::NeverFires;
+        };
+
+        // `percentile` is an unvalidated `f64`, and two kinds of value cannot be
+        // reported under it. The schema's bounds are exclusive, so 0, 100 and
+        // anything outside them is simply invalid. A non-finite value is worse:
+        // `serde_json` renders `NaN` and the infinities as `null` rather than
+        // failing, so nothing downstream would catch it and it has to be
+        // rejected here. The policy still fires, so it is named rather than
+        // dropped.
+        if !policy.percentile.is_finite() || policy.percentile <= 0.0 || policy.percentile >= 100.0
+        {
+            return SpeculativeExecutionReported::Generic;
+        }
+
+        return SpeculativeExecutionReported::Precise(
+            SpeculativeExecutionPolicyReport::Percentile {
+                max_executions,
+                percentile: policy.percentile,
+            },
+        );
+    }
+
+    SpeculativeExecutionReported::Generic
 }
 
 /// Builds the configuration report of a session.
@@ -798,6 +900,10 @@ impl DriverConfigReporter {
                 policy: Self::retry_policy_report(&profile.retry_policy),
             },
             load_balancing: self.load_balancing_report(&profile.load_balancing_policy),
+            speculative_execution: profile
+                .speculative_execution_policy
+                .as_ref()
+                .and_then(Self::speculative_execution_report),
         }
     }
 
@@ -877,6 +983,30 @@ impl DriverConfigReporter {
                 },
             ),
         }
+    }
+
+    /// The schema's `query.speculative-execution` group, or `None` when
+    /// speculative execution never fires.
+    fn speculative_execution_report(
+        policy: &Arc<dyn SpeculativeExecutionPolicy>,
+    ) -> Option<QuerySpeculativeExecutionReport> {
+        // `max_retry_count(&Context)` is deliberately not called on a policy
+        // reported generically: building a `Context` requires the session's
+        // metrics, and the schema's `custom` branch does not ask for a count.
+        let generic = || SpeculativeExecutionPolicyReport::Custom {
+            name: policy.reported_name(),
+        };
+
+        let policy = match policy.as_any() {
+            None => generic(),
+            Some(downcastable) => match speculative_execution_policy_report(downcastable) {
+                SpeculativeExecutionReported::NeverFires => return None,
+                SpeculativeExecutionReported::Generic => generic(),
+                SpeculativeExecutionReported::Precise(report) => report,
+            },
+        };
+
+        Some(QuerySpeculativeExecutionReport { policy })
     }
 
     fn retry_policy_report(policy: &Arc<dyn RetryPolicy>) -> RetryPolicyReport {

--- a/scylla/src/client/driver_config.rs
+++ b/scylla/src/client/driver_config.rs
@@ -16,8 +16,10 @@ use std::time::Duration;
 
 use serde::Serialize;
 
+use crate::client::execution_profile::ExecutionProfileHandle;
 use crate::client::session::SessionConfig;
 use crate::cluster::control_connection::MetadataRequestTimeouts;
+use crate::frame::types::{Consistency, SerialConsistency};
 use crate::network::{
     MAX_IN_FLIGHT_REQUESTS, OLD_ORPHAN_COUNT_THRESHOLD, PoolSize, TcpSocketOptions,
 };
@@ -25,6 +27,7 @@ use crate::policies::host_filter::{DcHostFilter, HostFilter};
 use crate::policies::reconnect::{
     ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy,
 };
+use crate::statement::PageSize;
 
 /// The major version of the reported configuration schema.
 ///
@@ -47,15 +50,16 @@ const MAX_REPORT_SIZE: usize = 32 * 1024;
 
 /// The reported configuration document.
 ///
-/// The `query` group is yet to be added. The schema requires it next to
-/// `connection` and `control-plane`, so the report this currently produces does
-/// not validate against it.
+/// The `query` group is still incomplete: the schema requires its
+/// `load-balancing` member, which is yet to be added, so the report this
+/// currently produces does not validate against the schema.
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct Report {
     version: u32,
     connection: ConnectionReport,
     control_plane: ControlPlaneReport,
+    query: QueryReport,
 }
 
 /// The schema's `control-plane` group: the timeouts of the metadata statements
@@ -255,6 +259,95 @@ enum NodePreferenceReport {
 #[serde(rename_all = "kebab-case")]
 struct TlsReport {}
 
+/// The schema's `query` group.
+///
+/// Its `retry`, `load-balancing` and `speculative-execution` members are yet
+/// to be added.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct QueryReport {
+    defaults: QueryDefaultsReport,
+}
+
+/// The defaults a statement gets when it overrides nothing, read from the
+/// session's default execution profile.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct QueryDefaultsReport {
+    consistency: &'static str,
+    /// Omitted when the profile has no serial consistency, in which case the
+    /// server's own default applies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    serial_consistency: Option<&'static str>,
+    /// Always `false`, because idempotence is only ever set per statement, via
+    /// `StatementConfig::is_idempotent`, with neither a session- nor a
+    /// profile-level setting to read. A statement that sets nothing is
+    /// therefore treated as not known to be idempotent.
+    idempotence: bool,
+    /// Always present, unlike in drivers whose timestamp generator may decline
+    /// to produce a timestamp: [`TimestampGenerator::next_timestamp`] returns a
+    /// plain `i64`, so a configured generator always assigns the timestamp
+    /// client side.
+    ///
+    /// [`TimestampGenerator::next_timestamp`]: crate::policies::timestamp_generator::TimestampGenerator::next_timestamp
+    client_timestamps: bool,
+    page: PageReport,
+    /// Omitted entirely when the profile disables the request timeout. The
+    /// schema does not require the group, so an empty object would say no more
+    /// than its absence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request: Option<RequestDefaultsReport>,
+}
+
+/// The page size a paged statement that sets none is executed with; the unpaged
+/// APIs send none at all. There is no session- or profile-level setting, so
+/// this is always the driver's default.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct PageReport {
+    size: i32,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct RequestDefaultsReport {
+    timeout_ms: u64,
+}
+
+/// The schema's `query.defaults.consistency` name of `consistency`.
+///
+/// Neither [`Consistency`]'s `Display` nor its `Debug` can serve here: both
+/// render CamelCase, and the schema's enum is SCREAMING_SNAKE. The match has no
+/// `_` arm on purpose - a variant added upstream must fail to compile here
+/// rather than silently report a name the schema rejects.
+fn consistency_name(consistency: Consistency) -> &'static str {
+    match consistency {
+        Consistency::Any => "ANY",
+        Consistency::One => "ONE",
+        Consistency::Two => "TWO",
+        Consistency::Three => "THREE",
+        Consistency::Quorum => "QUORUM",
+        Consistency::All => "ALL",
+        Consistency::LocalQuorum => "LOCAL_QUORUM",
+        Consistency::EachQuorum => "EACH_QUORUM",
+        Consistency::LocalOne => "LOCAL_ONE",
+        // The schema's enum includes the serial levels, which a `SELECT` may
+        // legitimately run at, so every variant is reportable.
+        Consistency::Serial => "SERIAL",
+        Consistency::LocalSerial => "LOCAL_SERIAL",
+    }
+}
+
+/// The schema's `query.defaults.serial-consistency` name of
+/// `serial_consistency`. Exhaustive for the same reason as
+/// [`consistency_name`].
+fn serial_consistency_name(consistency: SerialConsistency) -> &'static str {
+    match consistency {
+        SerialConsistency::Serial => "SERIAL",
+        SerialConsistency::LocalSerial => "LOCAL_SERIAL",
+    }
+}
+
 /// Milliseconds of a duration reported under a schema `positiveInteger` key.
 ///
 /// Floored at 1: a sub-millisecond duration truncates to 0, which the schema
@@ -291,8 +384,10 @@ fn buffer_report(size: Option<usize>) -> Option<BufferReport> {
 
 /// Builds the configuration report of a session.
 ///
-/// Holds a snapshot of the configuration taken when the session was created,
-/// because [`SessionConfig`] itself is consumed by session creation.
+/// Holds a snapshot of everything fixed for the session's lifetime, because
+/// [`SessionConfig`] itself is consumed by session creation. The default
+/// execution profile is not such a thing: the handle is held instead of its
+/// contents, so that remapping it is reflected by the next report.
 pub(crate) struct DriverConfigReporter {
     connect_timeout: Duration,
     socket_options: TcpSocketOptions,
@@ -302,6 +397,8 @@ pub(crate) struct DriverConfigReporter {
     reconnect_policy: Arc<dyn ReconnectPolicy>,
     metadata_request_timeouts: MetadataRequestTimeouts,
     schema_agreement_timeout: Duration,
+    default_execution_profile_handle: ExecutionProfileHandle,
+    timestamp_generator_configured: bool,
 }
 
 impl DriverConfigReporter {
@@ -332,6 +429,8 @@ impl DriverConfigReporter {
             reconnect_policy,
             metadata_request_timeouts,
             schema_agreement_timeout: config.schema_agreement_timeout,
+            default_execution_profile_handle: config.default_execution_profile_handle.clone(),
+            timestamp_generator_configured: config.timestamp_generator.is_some(),
         }
     }
 
@@ -355,6 +454,7 @@ impl DriverConfigReporter {
             version: REPORT_VERSION,
             connection: self.connection_report(),
             control_plane: self.control_plane_report(target_is_scylladb),
+            query: self.query_report(),
         };
 
         // `serde_json::to_string` cannot fail for the report's current shape; the
@@ -494,6 +594,29 @@ impl DriverConfigReporter {
                 agreement: SchemaAgreementReport {
                     timeout_ms: non_negative_millis(self.schema_agreement_timeout),
                 },
+            },
+        }
+    }
+
+    /// The profile is read here rather than at construction: the handle may have
+    /// been remapped since, and the report must name the configuration in force.
+    fn query_report(&self) -> QueryReport {
+        let profile = self.default_execution_profile_handle.access();
+
+        QueryReport {
+            defaults: QueryDefaultsReport {
+                consistency: consistency_name(profile.consistency),
+                serial_consistency: profile.serial_consistency.map(serial_consistency_name),
+                idempotence: false,
+                client_timestamps: self.timestamp_generator_configured,
+                page: PageReport {
+                    size: PageSize::default().inner(),
+                },
+                request: profile
+                    .request_timeout
+                    .map(|timeout| RequestDefaultsReport {
+                        timeout_ms: positive_millis(timeout),
+                    }),
             },
         }
     }

--- a/scylla/src/client/driver_config.rs
+++ b/scylla/src/client/driver_config.rs
@@ -27,6 +27,9 @@ use crate::policies::host_filter::{DcHostFilter, HostFilter};
 use crate::policies::reconnect::{
     ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy,
 };
+use crate::policies::retry::{
+    DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy, RetryPolicy,
+};
 use crate::statement::PageSize;
 
 /// The major version of the reported configuration schema.
@@ -261,12 +264,13 @@ struct TlsReport {}
 
 /// The schema's `query` group.
 ///
-/// Its `retry`, `load-balancing` and `speculative-execution` members are yet
-/// to be added.
+/// Its `load-balancing` and `speculative-execution` members are yet to be
+/// added.
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct QueryReport {
     defaults: QueryDefaultsReport,
+    retry: QueryRetryReport,
 }
 
 /// The defaults a statement gets when it overrides nothing, read from the
@@ -312,6 +316,36 @@ struct PageReport {
 #[serde(rename_all = "kebab-case")]
 struct RequestDefaultsReport {
     timeout_ms: u64,
+}
+
+/// `backoff` is never reported: no retry policy of this driver waits between
+/// attempts. Neither is `max-retries`, which every variant below leaves
+/// optional: the built-ins do cap some retries - each keeps an "already
+/// retried" flag per error kind - but that cap does not bound the retries on
+/// the next target that a connection or server error triggers, so there is no
+/// single count to report.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct QueryRetryReport {
+    policy: RetryPolicyReport,
+}
+
+#[derive(Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "kebab-case"
+)]
+enum RetryPolicyReport {
+    /// [`DefaultRetryPolicy`], whose decisions are driven by the error kind -
+    /// what the schema calls error-aware. csharp-driver maps its own default
+    /// policy to this type as well.
+    StandardErrorAware,
+    Fallthrough,
+    DowngradingConsistency,
+    Custom {
+        name: &'static str,
+    },
 }
 
 /// The schema's `query.defaults.consistency` name of `consistency`.
@@ -618,6 +652,29 @@ impl DriverConfigReporter {
                         timeout_ms: positive_millis(timeout),
                     }),
             },
+            retry: QueryRetryReport {
+                policy: Self::retry_policy_report(&profile.retry_policy),
+            },
+        }
+    }
+
+    fn retry_policy_report(policy: &Arc<dyn RetryPolicy>) -> RetryPolicyReport {
+        let Some(downcastable) = policy.as_any() else {
+            return RetryPolicyReport::Custom {
+                name: policy.reported_name(),
+            };
+        };
+
+        if downcastable.is::<DefaultRetryPolicy>() {
+            RetryPolicyReport::StandardErrorAware
+        } else if downcastable.is::<FallthroughRetryPolicy>() {
+            RetryPolicyReport::Fallthrough
+        } else if downcastable.is::<DowngradingConsistencyRetryPolicy>() {
+            RetryPolicyReport::DowngradingConsistency
+        } else {
+            RetryPolicyReport::Custom {
+                name: policy.reported_name(),
+            }
         }
     }
 }

--- a/scylla/src/client/driver_config.rs
+++ b/scylla/src/client/driver_config.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use serde::Serialize;
 
 use crate::client::session::SessionConfig;
+use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::network::{
     MAX_IN_FLIGHT_REQUESTS, OLD_ORPHAN_COUNT_THRESHOLD, PoolSize, TcpSocketOptions,
 };
@@ -46,14 +47,60 @@ const MAX_REPORT_SIZE: usize = 32 * 1024;
 
 /// The reported configuration document.
 ///
-/// The `control-plane` and `query` groups are yet to be added. The schema
-/// requires them next to `connection`, so the report this currently produces
-/// does not validate against it.
+/// The `query` group is yet to be added. The schema requires it next to
+/// `connection` and `control-plane`, so the report this currently produces does
+/// not validate against it.
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct Report {
     version: u32,
     connection: ConnectionReport,
+    control_plane: ControlPlaneReport,
+}
+
+/// The schema's `control-plane` group: the timeouts of the metadata statements
+/// the control connection runs, and of schema agreement.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ControlPlaneReport {
+    queries: ControlPlaneQueriesReport,
+    schema: ControlPlaneSchemaReport,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ControlPlaneQueriesReport {
+    system: SystemQueriesReport,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct SystemQueriesReport {
+    timeout: SystemQueriesTimeoutReport,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct SystemQueriesTimeoutReport {
+    /// Always present: the control connection always has a client-side timeout,
+    /// explicit or derived.
+    client_side_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_side_ms: Option<u64>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ControlPlaneSchemaReport {
+    agreement: SchemaAgreementReport,
+}
+
+/// `timeout-ms` is always reported, including 0: the schema documents 0 as
+/// meaningful ("do not wait for agreement"), not as unset.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct SchemaAgreementReport {
+    timeout_ms: u64,
 }
 
 /// The schema's `connection` group.
@@ -174,6 +221,8 @@ enum ReconnectionPolicyReport {
         max_ms: u64,
     },
     Constant {
+        /// A schema `nonNegativeInteger`, where 0 means an immediate retry rather
+        /// than a disabled feature, so it is reported verbatim.
         delay_ms: u64,
     },
     Custom {
@@ -218,8 +267,9 @@ fn positive_millis(duration: Duration) -> u64 {
         .max(1)
 }
 
-/// Milliseconds of a duration reported under a schema `nonNegativeInteger` key,
-/// verbatim: there 0 is a meaningful value, not a disabled feature.
+/// Milliseconds of a duration, verbatim: truncating as [`Duration::as_millis`]
+/// does, saturating at `u64::MAX` - `u64` milliseconds is half a billion years,
+/// so the clamp is unreachable in practice.
 fn non_negative_millis(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
@@ -250,19 +300,22 @@ pub(crate) struct DriverConfigReporter {
     tls_configured: bool,
     host_filter: Option<Arc<dyn HostFilter>>,
     reconnect_policy: Arc<dyn ReconnectPolicy>,
+    metadata_request_timeouts: MetadataRequestTimeouts,
+    schema_agreement_timeout: Duration,
 }
 
 impl DriverConfigReporter {
-    /// `socket_options` and `reconnect_policy` are passed in rather than derived
-    /// from `config`, so that the report describes the values the session is
-    /// actually built with: the socket options are assembled once by the caller,
-    /// and the effective reconnect policy is not always the one on `config`
-    /// (without the unstable feature the field does not exist and a default is
-    /// used).
+    /// `socket_options`, `reconnect_policy` and `metadata_request_timeouts` are
+    /// passed in rather than derived from `config`, so that the report describes
+    /// the values the session is actually built with: those are assembled once by
+    /// the caller and handed to the components that use them, and the effective
+    /// reconnect policy is not always the one on `config` (without the unstable
+    /// feature the field does not exist and a default is used).
     pub(crate) fn new(
         config: &SessionConfig,
         socket_options: TcpSocketOptions,
         reconnect_policy: Arc<dyn ReconnectPolicy>,
+        metadata_request_timeouts: MetadataRequestTimeouts,
     ) -> Self {
         Self {
             connect_timeout: config.connect_timeout,
@@ -277,6 +330,8 @@ impl DriverConfigReporter {
             tls_configured: config.tls_context.is_some(),
             host_filter: config.host_filter.clone(),
             reconnect_policy,
+            metadata_request_timeouts,
+            schema_agreement_timeout: config.schema_agreement_timeout,
         }
     }
 
@@ -292,17 +347,14 @@ impl DriverConfigReporter {
     /// established, and configuration read through an `ExecutionProfileHandle`
     /// can be remapped at runtime.
     ///
-    /// `target_is_scylladb` tells whether the peer is a ScyllaDB node, as some
-    /// reported values only apply to ScyllaDB. It is not read yet, hence the
-    /// scoped `expect`: a leading underscore would only have to be renamed once
-    /// a group starts using it.
-    pub(crate) fn report(
-        &self,
-        #[expect(unused_variables)] target_is_scylladb: bool,
-    ) -> Option<String> {
+    /// `target_is_scylladb` tells whether the peer is a ScyllaDB node, which the
+    /// server-side metadata request timeout depends on: `USING TIMEOUT` is a
+    /// ScyllaDB-only extension.
+    pub(crate) fn report(&self, target_is_scylladb: bool) -> Option<String> {
         let report = Report {
             version: REPORT_VERSION,
             connection: self.connection_report(),
+            control_plane: self.control_plane_report(target_is_scylladb),
         };
 
         // `serde_json::to_string` cannot fail for the report's current shape; the
@@ -408,6 +460,42 @@ impl DriverConfigReporter {
         (!filter.local_dc.is_empty()).then(|| NodePreferenceReport::Dc {
             local_dc: filter.local_dc.clone(),
         })
+    }
+
+    fn control_plane_report(&self, target_is_scylladb: bool) -> ControlPlaneReport {
+        let timeouts = &self.metadata_request_timeouts;
+
+        ControlPlaneReport {
+            queries: ControlPlaneQueriesReport {
+                system: SystemQueriesReport {
+                    timeout: SystemQueriesTimeoutReport {
+                        // Floored, unlike `server-side-ms` below: this bounds a
+                        // client-side deadline, which a sub-millisecond duration
+                        // expresses perfectly well.
+                        client_side_ms: positive_millis(timeouts.clientside()),
+                        // Gated on the target, because `USING TIMEOUT` is a
+                        // ScyllaDB-only extension and the control connection only
+                        // appends the clause against ScyllaDB.
+                        //
+                        // Truncating rather than floored, because the report must
+                        // name the value the clause actually carries, and
+                        // `ControlConnection::maybe_append_timeout_override`
+                        // formats `as_millis()`: a sub-millisecond timeout is sent
+                        // as `USING TIMEOUT 0ms`. The key is then omitted, as the
+                        // schema's `positiveInteger` cannot carry 0.
+                        server_side_ms: timeouts
+                            .serverside(target_is_scylladb)
+                            .map(non_negative_millis)
+                            .filter(|&millis| millis > 0),
+                    },
+                },
+            },
+            schema: ControlPlaneSchemaReport {
+                agreement: SchemaAgreementReport {
+                    timeout_ms: non_negative_millis(self.schema_agreement_timeout),
+                },
+            },
+        }
     }
 }
 

--- a/scylla/src/client/driver_config.rs
+++ b/scylla/src/client/driver_config.rs
@@ -24,12 +24,14 @@ use crate::network::{
     MAX_IN_FLIGHT_REQUESTS, OLD_ORPHAN_COUNT_THRESHOLD, PoolSize, TcpSocketOptions,
 };
 use crate::policies::host_filter::{DcHostFilter, HostFilter};
+use crate::policies::load_balancing::{DefaultPolicy, LoadBalancingPolicy};
 use crate::policies::reconnect::{
     ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy,
 };
 use crate::policies::retry::{
     DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy, RetryPolicy,
 };
+use crate::routing::NodeLocationPreference;
 use crate::statement::PageSize;
 
 /// The major version of the reported configuration schema.
@@ -53,9 +55,10 @@ const MAX_REPORT_SIZE: usize = 32 * 1024;
 
 /// The reported configuration document.
 ///
-/// The `query` group is still incomplete: the schema requires its
-/// `load-balancing` member, which is yet to be added, so the report this
-/// currently produces does not validate against the schema.
+/// Carries every group the schema requires, so the produced document validates
+/// against it. Of the optional ones only `query.speculative-execution` is yet
+/// to be added; each type below states why the keys it does not populate are
+/// absent.
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct Report {
@@ -237,11 +240,13 @@ enum ReconnectionPolicyReport {
     },
 }
 
-/// Which nodes the driver holds connections to at all - a different claim from
-/// `query.load-balancing.node-preference`, which is about where a request may be
-/// routed. Only a datacenter preference is representable: the schema has no
-/// branch for selection by address, and no other built-in filter states a
-/// location.
+/// The schema's `node-location-preference`, used by both `connection` and
+/// `query.load-balancing`: which nodes the driver holds connections to at all,
+/// and which of those a request may be routed to. The two are different claims
+/// but have the same shape, and the schema's `$def` is shared.
+///
+/// The `dc-auto` and `rack-auto` branches are never produced: this driver
+/// infers no location, every preference it reports is one a user configured.
 #[derive(Serialize)]
 #[serde(
     tag = "type",
@@ -249,7 +254,13 @@ enum ReconnectionPolicyReport {
     rename_all_fields = "kebab-case"
 )]
 enum NodePreferenceReport {
-    Dc { local_dc: String },
+    Dc {
+        local_dc: String,
+    },
+    Rack {
+        local_dc: String,
+        local_rack: String,
+    },
 }
 
 /// `hostname-verification` is deliberately absent, which the schema permits
@@ -263,14 +274,12 @@ enum NodePreferenceReport {
 struct TlsReport {}
 
 /// The schema's `query` group.
-///
-/// Its `load-balancing` and `speculative-execution` members are yet to be
-/// added.
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct QueryReport {
     defaults: QueryDefaultsReport,
     retry: QueryRetryReport,
+    load_balancing: QueryLoadBalancingReport,
 }
 
 /// The defaults a statement gets when it overrides nothing, read from the
@@ -348,6 +357,54 @@ enum RetryPolicyReport {
     },
 }
 
+/// The schema's `query.load-balancing`, read from the default execution
+/// profile's load balancing policy.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct QueryLoadBalancingReport {
+    policy: LoadBalancingPolicyReport,
+    /// The effective node location preference: the policy's own, or the
+    /// session-level one it falls back to. `policy`'s
+    /// `fallback-to-non-preferred-nodes` is derived from this very value, so
+    /// that the two cannot contradict each other.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    node_preference: Option<NodePreferenceReport>,
+}
+
+#[derive(Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "kebab-case"
+)]
+enum LoadBalancingPolicyReport {
+    /// A token-aware [`DefaultPolicy`]. The schema's only built-in branch
+    /// presumes token awareness, so a `DefaultPolicy` with it switched off is
+    /// reported as [`Custom`](Self::Custom) instead - naming it `token-aware`
+    /// would be a plain lie about how plans are built.
+    TokenAware {
+        load_distribution: &'static str,
+        fallback_to_non_preferred_nodes: bool,
+        /// Present only when latency awareness is enabled, which the schema
+        /// spells as "absent when adaptive ordering is disabled".
+        #[serde(skip_serializing_if = "Option::is_none")]
+        adaptive_ordering: Option<AdaptiveOrderingReport>,
+    },
+    Custom {
+        name: String,
+    },
+}
+
+/// Which runtime observations reorder otherwise eligible candidates. The schema
+/// stops there deliberately: it records the signals, not the algorithm or its
+/// thresholds, so `DefaultPolicy`'s exclusion threshold and retry period have
+/// nowhere to go and are not reported.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct AdaptiveOrderingReport {
+    signals: &'static [&'static str],
+}
+
 /// The schema's `query.defaults.consistency` name of `consistency`.
 ///
 /// Neither [`Consistency`]'s `Display` nor its `Debug` can serve here: both
@@ -416,6 +473,82 @@ fn buffer_report(size: Option<usize>) -> Option<BufferReport> {
         })
 }
 
+/// The schema's `node-location-preference` of an effective
+/// [`NodeLocationPreference`].
+///
+/// An empty datacenter name drops the whole preference: `local-dc` is a
+/// `nonEmptyString` and required on every branch that names a location, so there
+/// is nothing left to report. An empty rack name only drops the rack half, and
+/// the datacenter is still reported: at runtime the rack tier of the plan
+/// matches no node - `make_rack_predicate` compares against `Some("")` - while
+/// `preferred_node_set` and `is_datacenter_failover_possible` keep scoping and
+/// gating by the datacenter, so routing is confined exactly as a plain
+/// [`NodeLocationPreference::Datacenter`] would confine it.
+fn location_preference_report(preference: &NodeLocationPreference) -> Option<NodePreferenceReport> {
+    match preference {
+        NodeLocationPreference::Any => None,
+        NodeLocationPreference::Datacenter(dc) => {
+            (!dc.is_empty()).then(|| NodePreferenceReport::Dc {
+                local_dc: dc.clone(),
+            })
+        }
+        NodeLocationPreference::DatacenterAndRack(dc, rack) => (!dc.is_empty()).then(|| {
+            if rack.is_empty() {
+                NodePreferenceReport::Dc {
+                    local_dc: dc.clone(),
+                }
+            } else {
+                NodePreferenceReport::Rack {
+                    local_dc: dc.clone(),
+                    local_rack: rack.clone(),
+                }
+            }
+        }),
+    }
+}
+
+/// Whether a request may reach a node outside the reported `node-preference`.
+///
+/// Derived from the very preference report the document carries, so the two
+/// keys cannot disagree about which preference they describe.
+fn fallback_to_non_preferred_nodes(
+    node_preference: Option<&NodePreferenceReport>,
+    permit_dc_failover: bool,
+) -> bool {
+    match node_preference {
+        // Nothing confines requests, and `permit_dc_failover` has no effect
+        // without a preferred datacenter.
+        None => true,
+        Some(NodePreferenceReport::Dc { .. }) => permit_dc_failover,
+        // A rack preference is always escaped, whatever `permit_dc_failover`
+        // says. `is_datacenter_failover_possible` only ever gates tiers that
+        // leave the preferred datacenter; every tier scoped to that datacenter
+        // is unconditional. In `DefaultPolicy::fallback` those are the whole-
+        // datacenter replica tier inside `maybe_replicas`, `robinned_local_nodes`
+        // and `maybe_down_local_nodes`, all three covering the datacenter's other
+        // racks. `pick` behaves the same, falling from its local-rack attempt
+        // straight to the whole-datacenter one with no failover check. Disabling
+        // failover only stops requests leaving the datacenter, which the schema's
+        // single boolean cannot express.
+        Some(NodePreferenceReport::Rack { .. }) => true,
+    }
+}
+
+/// The schema's `name` of a load balancing policy the driver cannot describe
+/// precisely.
+///
+/// [`LoadBalancingPolicy::name`] is implemented by the user and may return an
+/// empty string, which `nonEmptyString` rejects. A literal stands in for it,
+/// matching what gocql reports for a policy it cannot name.
+fn custom_policy_name(policy: &Arc<dyn LoadBalancingPolicy>) -> String {
+    let name = policy.name();
+    if name.is_empty() {
+        "unknown".to_owned()
+    } else {
+        name
+    }
+}
+
 /// Builds the configuration report of a session.
 ///
 /// Holds a snapshot of everything fixed for the session's lifetime, because
@@ -431,6 +564,9 @@ pub(crate) struct DriverConfigReporter {
     reconnect_policy: Arc<dyn ReconnectPolicy>,
     metadata_request_timeouts: MetadataRequestTimeouts,
     schema_agreement_timeout: Duration,
+    /// The session-level preference a load balancing policy that states none of
+    /// its own falls back to.
+    node_location_preference: NodeLocationPreference,
     default_execution_profile_handle: ExecutionProfileHandle,
     timestamp_generator_configured: bool,
 }
@@ -463,6 +599,7 @@ impl DriverConfigReporter {
             reconnect_policy,
             metadata_request_timeouts,
             schema_agreement_timeout: config.schema_agreement_timeout,
+            node_location_preference: config.node_location_preference.clone(),
             default_execution_profile_handle: config.default_execution_profile_handle.clone(),
             timestamp_generator_configured: config.timestamp_generator.is_some(),
         }
@@ -585,6 +722,11 @@ impl DriverConfigReporter {
         }
     }
 
+    /// The schema's `connection.node-preference`: which nodes the driver holds
+    /// connections to at all, which only the host filter narrows. Of the
+    /// built-in filters only [`DcHostFilter`] states a location - the schema has
+    /// no branch for selection by address - so every other filter reports no
+    /// preference.
     fn node_preference_report(&self) -> Option<NodePreferenceReport> {
         let filter = self.host_filter.as_ref()?.as_any()?;
         let filter = filter.downcast_ref::<DcHostFilter>()?;
@@ -655,6 +797,85 @@ impl DriverConfigReporter {
             retry: QueryRetryReport {
                 policy: Self::retry_policy_report(&profile.retry_policy),
             },
+            load_balancing: self.load_balancing_report(&profile.load_balancing_policy),
+        }
+    }
+
+    fn load_balancing_report(
+        &self,
+        policy: &Arc<dyn LoadBalancingPolicy>,
+    ) -> QueryLoadBalancingReport {
+        let default_policy = policy
+            .as_any()
+            .and_then(|policy| policy.downcast_ref::<DefaultPolicy>());
+
+        // The effective preference, resolved the way `DefaultPolicy::routing_info`
+        // resolves it: the policy's own preference if it states one, else the
+        // session-level one. Computed once, because `node-preference` and
+        // `fallback-to-non-preferred-nodes` both describe it and would contradict
+        // each other if they were derived separately.
+        let preference = default_policy
+            .and_then(|policy| policy.preferences.as_ref())
+            .unwrap_or(&self.node_location_preference);
+        let node_preference = location_preference_report(preference);
+
+        QueryLoadBalancingReport {
+            policy: Self::load_balancing_policy_report(
+                policy,
+                default_policy,
+                node_preference.as_ref(),
+            ),
+            node_preference,
+        }
+    }
+
+    fn load_balancing_policy_report(
+        policy: &Arc<dyn LoadBalancingPolicy>,
+        default_policy: Option<&DefaultPolicy>,
+        node_preference: Option<&NodePreferenceReport>,
+    ) -> LoadBalancingPolicyReport {
+        // A `DefaultPolicy` with token awareness switched off falls in here too:
+        // the schema's only built-in load-balancing type presumes token
+        // awareness, so there is no built-in shape such a chain could be reported
+        // under.
+        let custom = || LoadBalancingPolicyReport::Custom {
+            name: custom_policy_name(policy),
+        };
+
+        let Some(default_policy) = default_policy.filter(|policy| policy.is_token_aware) else {
+            return custom();
+        };
+
+        LoadBalancingPolicyReport::TokenAware {
+            // Keyed on `fixed_seed`, which is what the policy branches on at
+            // runtime: `pick_random_replica` and `maybe_shuffled_replicas` build
+            // a fresh `Pcg32::new(seed, 0)` per call, so a fixed seed yields the
+            // same choice and the same permutation for every query plan - not
+            // randomised selection, which is what the schema's `shuffle` means.
+            // An unfixed seed draws from the thread rng and does randomise.
+            // `replica-set` is then the closest of the remaining two: it is the
+            // only value asserting an order stable across plans, and gocql
+            // branches on its own equivalent flag to the same value.
+            //
+            // One value per policy is all the schema has, so this necessarily
+            // describes only the replica tiers: other tiers are round-robined
+            // regardless (`round_robin_nodes`, which ignores `fixed_seed`), and
+            // LWT statements always get deterministic ring order
+            // (`ReplicaOrder::Deterministic`).
+            load_distribution: if default_policy.fixed_seed.is_some() {
+                "replica-set"
+            } else {
+                "shuffle"
+            },
+            fallback_to_non_preferred_nodes: fallback_to_non_preferred_nodes(
+                node_preference,
+                default_policy.permit_dc_failover,
+            ),
+            adaptive_ordering: default_policy.latency_awareness.is_some().then_some(
+                AdaptiveOrderingReport {
+                    signals: &["latency"],
+                },
+            ),
         }
     }
 

--- a/scylla/src/client/driver_config.rs
+++ b/scylla/src/client/driver_config.rs
@@ -11,7 +11,19 @@
 //! connection of a session, so sending it on all of them would only bloat their
 //! `STARTUP` frames.
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use serde::Serialize;
+
+use crate::client::session::SessionConfig;
+use crate::network::{
+    MAX_IN_FLIGHT_REQUESTS, OLD_ORPHAN_COUNT_THRESHOLD, PoolSize, TcpSocketOptions,
+};
+use crate::policies::host_filter::{DcHostFilter, HostFilter};
+use crate::policies::reconnect::{
+    ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy,
+};
 
 /// The major version of the reported configuration schema.
 ///
@@ -34,23 +46,238 @@ const MAX_REPORT_SIZE: usize = 32 * 1024;
 
 /// The reported configuration document.
 ///
-/// The `connection`, `control-plane` and `query` groups are yet to be added.
-/// The schema requires all three, so the report this currently produces does
-/// not validate against it.
+/// The `control-plane` and `query` groups are yet to be added. The schema
+/// requires them next to `connection`, so the report this currently produces
+/// does not validate against it.
 #[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
 struct Report {
     version: u32,
+    connection: ConnectionReport,
+}
+
+/// The schema's `connection` group.
+///
+/// The schema's sibling `read`, `write` and `heartbeat` groups are never
+/// populated. There is no socket read or write timeout to report at all. The
+/// features that would belong under the other two - write coalescing
+/// (`enable_write_coalescing`, `write_coalescing_delay`) and the CQL-level idle
+/// heartbeat (`keepalive_interval`, `keepalive_timeout`) - do exist, but v1
+/// declares `write.coalescing` and `heartbeat` as `additionalProperties: false`
+/// with no properties: explicit placeholders for a future schema version, with
+/// nowhere for those values to go.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ConnectionReport {
+    connect: ConnectReport,
+    requests: RequestsReport,
+    pool: PoolReport,
+    socket: SocketReport,
+    reconnection: ReconnectionReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    node_preference: Option<NodePreferenceReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls: Option<TlsReport>,
+}
+
+/// `timeout-ms` is always reported: `connect_timeout` goes verbatim to
+/// `tokio::time::timeout`, so it has no "unset" state that an absent key could
+/// stand for.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ConnectReport {
+    timeout_ms: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct RequestsReport {
+    in_flight: MaxReport,
+    /// The driver's bound on orphaned requests is not quite what the schema
+    /// asks for: it counts only orphans older than `OLD_AGE_ORPHAN_THRESHOLD`,
+    /// a qualifier the schema cannot express. Reporting the threshold is still
+    /// much closer to the truth than omitting the group, which means "no bound
+    /// at all".
+    orphaned: MaxReport,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct MaxReport {
+    max: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct PoolReport {
+    shard_aware: ShardAwareReport,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ShardAwareReport {
+    enabled: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct SocketReport {
+    tcp_no_delay: bool,
+    keep_alive: bool,
+    reuse_address: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    linger: Option<LingerReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    receive_buffer: Option<BufferReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    send_buffer: Option<BufferReport>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct LingerReport {
+    /// Whole seconds, the only granularity the schema offers - and the only one
+    /// `SO_LINGER` offers either. A configured linger below one second reports
+    /// 0, which reads as "reset the connection on close", and that is exact
+    /// rather than approximate: `apply_socket_options` sets the option through
+    /// `socket2`, whose `into_linger` truncates with the very same `as_secs`, so
+    /// the kernel is given the 0 this reports. Do not "fix" this to floor at 1;
+    /// it would describe a lingering close the socket does not perform.
+    interval_s: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct BufferReport {
+    size_bytes: u32,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ReconnectionReport {
+    /// The schema permits `null` here, meaning that no reconnection is ever
+    /// attempted. This driver always has a policy in force, so it never is.
+    policy: ReconnectionPolicyReport,
+}
+
+#[derive(Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "kebab-case"
+)]
+enum ReconnectionPolicyReport {
+    /// `max-attempts` is omitted, which the schema defines as unlimited: the
+    /// pool retries forever.
+    Exponential {
+        base_ms: u64,
+        max_ms: u64,
+    },
+    Constant {
+        delay_ms: u64,
+    },
+    Custom {
+        name: &'static str,
+    },
+}
+
+/// Which nodes the driver holds connections to at all - a different claim from
+/// `query.load-balancing.node-preference`, which is about where a request may be
+/// routed. Only a datacenter preference is representable: the schema has no
+/// branch for selection by address, and no other built-in filter states a
+/// location.
+#[derive(Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "kebab-case"
+)]
+enum NodePreferenceReport {
+    Dc { local_dc: String },
+}
+
+/// `hostname-verification` is deliberately absent, which the schema permits
+/// "when this behavior is unknown", and here it genuinely is. With openssl the
+/// driver never calls `X509_VERIFY_PARAM_set1_host` and `SslContextRef` exposes
+/// no getter for the host verification parameter; with rustls the driver
+/// connects with `ServerName::IpAddress`, and a user-installed dangerous
+/// verifier is invisible to it. Reporting either boolean would be a guess.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct TlsReport {}
+
+/// Milliseconds of a duration reported under a schema `positiveInteger` key.
+///
+/// Floored at 1: a sub-millisecond duration truncates to 0, which the schema
+/// rejects, and a sub-millisecond timeout is still a timeout. Saturates instead
+/// of truncating - `u64` milliseconds is half a billion years, so the clamp is
+/// unreachable in practice.
+fn positive_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis())
+        .unwrap_or(u64::MAX)
+        .max(1)
+}
+
+/// Milliseconds of a duration reported under a schema `nonNegativeInteger` key,
+/// verbatim: there 0 is a meaningful value, not a disabled feature.
+fn non_negative_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+/// A socket buffer size hint, or `None` when unset.
+///
+/// A configured 0 is reported as unset, because `size-bytes` is a schema
+/// `positiveInteger` and 0 cannot be expressed under it. That loses a real
+/// distinction: the driver does call `set_recv_buffer_size`/
+/// `set_send_buffer_size` with 0, which pins the buffer to the kernel minimum,
+/// whereas an unset size leaves auto-tuning on.
+fn buffer_report(size: Option<usize>) -> Option<BufferReport> {
+    size.filter(|size| *size > 0)
+        .map(|size_bytes| BufferReport {
+            // Truncating because this is what we do in the driver code when calling Tokio methods.
+            size_bytes: size_bytes as u32,
+        })
 }
 
 /// Builds the configuration report of a session.
 ///
-/// Carries no configuration yet, because `{"version":1}` needs no inputs; the
-/// configuration each group reports is added alongside that group.
-pub(crate) struct DriverConfigReporter {}
+/// Holds a snapshot of the configuration taken when the session was created,
+/// because [`SessionConfig`] itself is consumed by session creation.
+pub(crate) struct DriverConfigReporter {
+    connect_timeout: Duration,
+    socket_options: TcpSocketOptions,
+    shard_aware_port_allowed: bool,
+    tls_configured: bool,
+    host_filter: Option<Arc<dyn HostFilter>>,
+    reconnect_policy: Arc<dyn ReconnectPolicy>,
+}
 
 impl DriverConfigReporter {
-    pub(crate) fn new() -> Self {
-        Self {}
+    /// `socket_options` and `reconnect_policy` are passed in rather than derived
+    /// from `config`, so that the report describes the values the session is
+    /// actually built with: the socket options are assembled once by the caller,
+    /// and the effective reconnect policy is not always the one on `config`
+    /// (without the unstable feature the field does not exist and a default is
+    /// used).
+    pub(crate) fn new(
+        config: &SessionConfig,
+        socket_options: TcpSocketOptions,
+        reconnect_policy: Arc<dyn ReconnectPolicy>,
+    ) -> Self {
+        Self {
+            connect_timeout: config.connect_timeout,
+            socket_options,
+            // Two static conditions have to hold for a shard-aware connection to
+            // ever be attempted, and the schema has one boolean for both: the
+            // port must not be disallowed, and the pool must be per-shard -
+            // `NodeConnectionPoolRefiller::start_filling` only takes the
+            // shard-aware path for `PoolSize::PerShard`.
+            shard_aware_port_allowed: !config.disallow_shard_aware_port
+                && matches!(config.connection_pool_size, PoolSize::PerShard(_)),
+            tls_configured: config.tls_context.is_some(),
+            host_filter: config.host_filter.clone(),
+            reconnect_policy,
+        }
     }
 
     /// Renders the report, or returns `None` when there is nothing safe to send.
@@ -75,6 +302,7 @@ impl DriverConfigReporter {
     ) -> Option<String> {
         let report = Report {
             version: REPORT_VERSION,
+            connection: self.connection_report(),
         };
 
         // `serde_json::to_string` cannot fail for the report's current shape; the
@@ -100,6 +328,86 @@ impl DriverConfigReporter {
         }
 
         Some(report)
+    }
+
+    fn connection_report(&self) -> ConnectionReport {
+        let options = &self.socket_options;
+
+        ConnectionReport {
+            connect: ConnectReport {
+                timeout_ms: positive_millis(self.connect_timeout),
+            },
+            requests: RequestsReport {
+                in_flight: MaxReport {
+                    max: MAX_IN_FLIGHT_REQUESTS,
+                },
+                orphaned: MaxReport {
+                    max: OLD_ORPHAN_COUNT_THRESHOLD,
+                },
+            },
+            pool: PoolReport {
+                shard_aware: ShardAwareReport {
+                    enabled: self.shard_aware_port_allowed,
+                },
+            },
+            socket: SocketReport {
+                tcp_no_delay: options.nodelay,
+                keep_alive: options.keepalive_interval.is_some(),
+                // The schema asks for the effective value, and for the OS
+                // default when nothing is configured. That default is off on
+                // every platform the driver targets.
+                reuse_address: options.reuse_address.unwrap_or(false),
+                linger: options.linger.map(|linger| LingerReport {
+                    interval_s: linger.as_secs(),
+                }),
+                receive_buffer: buffer_report(options.recv_buffer_size),
+                send_buffer: buffer_report(options.send_buffer_size),
+            },
+            reconnection: ReconnectionReport {
+                policy: self.reconnection_policy_report(),
+            },
+            node_preference: self.node_preference_report(),
+            tls: self.tls_configured.then_some(TlsReport {}),
+        }
+    }
+
+    fn reconnection_policy_report(&self) -> ReconnectionPolicyReport {
+        let Some(policy) = self.reconnect_policy.as_any() else {
+            return ReconnectionPolicyReport::Custom {
+                name: self.reconnect_policy.reported_name(),
+            };
+        };
+
+        if let Some(policy) = policy.downcast_ref::<ExponentialReconnectPolicy>() {
+            // Both keys are required and `positiveInteger`, so neither may be
+            // omitted or floored away. The schema also demands
+            // `max-ms >= base-ms`; the policy's only constructors are `new` and
+            // `with_backoff_limits`, which asserts `min <= max`, and flooring is
+            // monotone, so the reported pair preserves the ordering.
+            ReconnectionPolicyReport::Exponential {
+                base_ms: positive_millis(policy.min_fill_backoff),
+                max_ms: positive_millis(policy.max_fill_backoff),
+            }
+        } else if let Some(policy) = policy.downcast_ref::<ConstantReconnectPolicy>() {
+            ReconnectionPolicyReport::Constant {
+                delay_ms: non_negative_millis(policy.delay),
+            }
+        } else {
+            ReconnectionPolicyReport::Custom {
+                name: self.reconnect_policy.reported_name(),
+            }
+        }
+    }
+
+    fn node_preference_report(&self) -> Option<NodePreferenceReport> {
+        let filter = self.host_filter.as_ref()?.as_any()?;
+        let filter = filter.downcast_ref::<DcHostFilter>()?;
+
+        // `local-dc` is a `nonEmptyString`, and an empty DC name accepts no node
+        // anyway, so there is no preference worth reporting.
+        (!filter.local_dc.is_empty()).then(|| NodePreferenceReport::Dc {
+            local_dc: filter.local_dc.clone(),
+        })
     }
 }
 

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -1057,3 +1057,454 @@ fn percentile_speculative_execution_report_cases() {
     assert_eq!(percentile_report(0, 99.0), None);
     assert_eq!(percentile_report(0, f64::NAN), None);
 }
+
+/// The cross-driver schema the reported document must conform to.
+///
+/// A verbatim vendored copy of
+/// <https://raw.githubusercontent.com/scylladb/gocql/master/docs/driver-config-schema.json>,
+/// whose `$id` is `https://scylladb.com/schemas/driver-client-options/v1.json`.
+/// It is an external contract shared by every ScyllaDB driver, so the copy
+/// is never edited locally - editing it would validate the report against a
+/// schema nobody else uses - and must be refreshed in lockstep with upstream
+/// whenever the shared schema changes. Checked in rather than fetched so the
+/// test needs no network.
+const SCHEMA: &str = include_str!("driver-config-schema.json");
+
+/// The configurations [`every_report_conforms_to_the_schema`] validates.
+///
+/// A per-axis sweep against the default configuration, plus a few configs
+/// combining several axes. A full cartesian product of the axes below runs
+/// into the millions of documents for no gain: the reporter reads each group
+/// from a disjoint part of the configuration, so a key can only go invalid
+/// because of its own axis. The combined configs are there for the one place
+/// that is not true - `node-preference` and
+/// `fallback-to-non-preferred-nodes` are derived from the same preference -
+/// and to keep a document where every optional key is populated at once.
+fn conformance_configurations() -> Vec<(String, SessionConfig, Arc<dyn ReconnectPolicy>)> {
+    type Configs = Vec<(String, SessionConfig, Arc<dyn ReconnectPolicy>)>;
+
+    fn push(configs: &mut Configs, name: impl Into<String>, config: SessionConfig) {
+        configs.push((
+            name.into(),
+            config,
+            Arc::new(ExponentialReconnectPolicy::new()),
+        ));
+    }
+
+    fn with_profile(configs: &mut Configs, name: impl Into<String>, profile: ExecutionProfile) {
+        let mut config = SessionConfig::new();
+        config.default_execution_profile_handle = profile.into_handle();
+        push(configs, name, config);
+    }
+
+    fn with_load_balancing(
+        configs: &mut Configs,
+        name: impl Into<String>,
+        policy: Arc<dyn LoadBalancingPolicy>,
+        session_preference: NodeLocationPreference,
+    ) {
+        let mut config = SessionConfig::new();
+        config.node_location_preference = session_preference;
+        config.default_execution_profile_handle = ExecutionProfile::builder()
+            .load_balancing_policy(policy)
+            .build()
+            .into_handle();
+        push(configs, name, config);
+    }
+
+    let configs = &mut Configs::new();
+
+    push(configs, "default", SessionConfig::new());
+
+    // Connection group: the zero values are where `positiveInteger` keys can
+    // go invalid, and the pool flags are booleans that cannot.
+    let mut config = SessionConfig::new();
+    config.connect_timeout = Duration::ZERO;
+    push(configs, "zero connect timeout", config);
+
+    let mut config = SessionConfig::new();
+    config.tcp_recv_buffer_size = Some(0);
+    config.tcp_send_buffer_size = Some(0);
+    push(configs, "zero socket buffers", config);
+
+    let mut config = SessionConfig::new();
+    config.tcp_linger = Some(Duration::ZERO);
+    push(configs, "zero linger", config);
+
+    let mut config = SessionConfig::new();
+    config.connection_pool_size = PoolSize::PerHost(NonZeroUsize::new(2).unwrap());
+    push(configs, "per-host pool", config);
+
+    let mut config = SessionConfig::new();
+    config.timestamp_generator = Some(Arc::new(SimpleTimestampGenerator::new()));
+    push(configs, "client timestamps", config);
+
+    for (name, filter, _) in host_filters() {
+        let mut config = SessionConfig::new();
+        config.host_filter = Some(filter);
+        push(configs, name, config);
+    }
+
+    for (name, policy, _) in reconnection_policies() {
+        configs.push((name.to_owned(), SessionConfig::new(), policy));
+    }
+
+    // Control plane.
+    let mut config = SessionConfig::new();
+    config.schema_agreement_timeout = Duration::ZERO;
+    push(configs, "zero schema agreement timeout", config);
+
+    let mut config = SessionConfig::new();
+    config.metadata_request_serverside_timeout = Some(Duration::from_micros(500));
+    push(
+        configs,
+        "sub-millisecond server-side metadata timeout",
+        config,
+    );
+
+    let mut config = SessionConfig::new();
+    config.metadata_request_serverside_timeout = None;
+    push(configs, "no server-side metadata timeout", config);
+
+    // Query defaults: every consistency name the schema enumerates, and the
+    // two optional keys in both states.
+    for (consistency, name) in CONSISTENCY_NAMES {
+        with_profile(
+            configs,
+            format!("consistency {name}"),
+            ExecutionProfile::builder().consistency(consistency).build(),
+        );
+    }
+
+    with_profile(
+        configs,
+        "no serial consistency and no request timeout",
+        ExecutionProfile::builder()
+            .serial_consistency(None)
+            .request_timeout(None)
+            .build(),
+    );
+    with_profile(
+        configs,
+        "non-local serial consistency",
+        ExecutionProfile::builder()
+            .serial_consistency(Some(SerialConsistency::Serial))
+            .build(),
+    );
+    with_profile(
+        configs,
+        "sub-millisecond request timeout",
+        ExecutionProfile::builder()
+            .request_timeout(Some(Duration::from_micros(500)))
+            .build(),
+    );
+
+    for (name, policy, _) in retry_policies() {
+        with_profile(
+            configs,
+            name,
+            ExecutionProfile::builder().retry_policy(policy).build(),
+        );
+    }
+
+    // Load balancing: the policy shape, and every preference the report can
+    // carry - including the two that are only partly expressible.
+    with_load_balancing(
+        configs,
+        "token-unaware default policy",
+        DefaultPolicy::builder().token_aware(false).build(),
+        NodeLocationPreference::Any,
+    );
+    with_load_balancing(
+        configs,
+        "unshuffled replicas",
+        DefaultPolicy::builder()
+            .enable_shuffling_replicas(false)
+            .build(),
+        NodeLocationPreference::Any,
+    );
+    with_load_balancing(
+        configs,
+        "latency awareness",
+        DefaultPolicy::builder()
+            .latency_awareness(LatencyAwarenessBuilder::new())
+            .build(),
+        NodeLocationPreference::Any,
+    );
+
+    let preferences = [
+        ("no preference", NodeLocationPreference::Any),
+        (
+            "datacenter preference",
+            NodeLocationPreference::Datacenter("dc1".to_owned()),
+        ),
+        (
+            "empty datacenter preference",
+            NodeLocationPreference::Datacenter(String::new()),
+        ),
+        (
+            "rack preference",
+            NodeLocationPreference::DatacenterAndRack("dc1".to_owned(), "rack1".to_owned()),
+        ),
+        (
+            "empty rack preference",
+            NodeLocationPreference::DatacenterAndRack("dc1".to_owned(), String::new()),
+        ),
+        (
+            "empty datacenter and rack preference",
+            NodeLocationPreference::DatacenterAndRack(String::new(), String::new()),
+        ),
+    ];
+
+    for (name, preference) in preferences {
+        for permit_dc_failover in [false, true] {
+            with_load_balancing(
+                configs,
+                format!("{name}, dc failover {permit_dc_failover}"),
+                DefaultPolicy::builder()
+                    .permit_dc_failover(permit_dc_failover)
+                    .build(),
+                preference.clone(),
+            );
+        }
+    }
+
+    // A user policy names itself, and may name itself with the empty string
+    // that `nonEmptyString` rejects.
+    for name in ["ForeignPolicy", ""] {
+        with_load_balancing(
+            configs,
+            format!("foreign load balancing policy named {name:?}"),
+            ForeignLoadBalancingPolicy::new(name),
+            NodeLocationPreference::Datacenter("dc1".to_owned()),
+        );
+    }
+
+    // Speculative execution.
+    for (name, policy, _) in speculative_execution_policies() {
+        with_profile(
+            configs,
+            name,
+            ExecutionProfile::builder()
+                .speculative_execution_policy(policy)
+                .build(),
+        );
+    }
+
+    // `percentile` is the only floating-point key in the document, and the
+    // schema bounds it exclusively; the policy carrying it needs `metrics`.
+    #[cfg(feature = "metrics")]
+    {
+        use crate::policies::speculative_execution::PercentileSpeculativeExecutionPolicy;
+
+        for percentile in [f64::MIN_POSITIVE, 99.0, 99.999, f64::NAN, 0.0, 100.0] {
+            with_profile(
+                configs,
+                format!("percentile speculative execution at {percentile}"),
+                ExecutionProfile::builder()
+                    .speculative_execution_policy(Some(Arc::new(
+                        PercentileSpeculativeExecutionPolicy {
+                            max_retry_count: 3,
+                            percentile,
+                        },
+                    )))
+                    .build(),
+            );
+        }
+    }
+
+    // Everything at once, so that a document with every optional key
+    // populated is validated too, and the derived
+    // `fallback-to-non-preferred-nodes` is seen next to the preference it is
+    // derived from. `connection.tls` is part of "every optional key", which
+    // is why the TLS context is set here rather than on a config of its own
+    // - and why it needs a feature gate, a `TlsContext` being unbuildable
+    // without a backend. That gate is the only one besides `percentile`
+    // above; gating the whole test on it would hide every other axis from a
+    // default-feature run.
+    let mut config = customised_config();
+    #[cfg(feature = "openssl-010")]
+    {
+        use openssl::ssl::{SslContextBuilder, SslMethod};
+
+        config.tls_context = Some(
+            SslContextBuilder::new(SslMethod::tls())
+                .unwrap()
+                .build()
+                .into(),
+        );
+    }
+    config.default_execution_profile_handle = ExecutionProfile::builder()
+        .consistency(Consistency::Quorum)
+        .serial_consistency(Some(SerialConsistency::Serial))
+        .request_timeout(Some(Duration::from_millis(1500)))
+        .retry_policy(Arc::new(DowngradingConsistencyRetryPolicy::new()))
+        .load_balancing_policy(
+            DefaultPolicy::builder()
+                .prefer_datacenter_and_rack("dc1".to_owned(), "rack1".to_owned())
+                .permit_dc_failover(true)
+                .latency_awareness(LatencyAwarenessBuilder::new())
+                .build(),
+        )
+        .speculative_execution_policy(Some(Arc::new(SimpleSpeculativeExecutionPolicy {
+            max_retry_count: 3,
+            retry_interval: Duration::from_millis(50),
+        })))
+        .build()
+        .into_handle();
+    configs.push((
+        "every optional key populated".to_owned(),
+        config,
+        Arc::new(ConstantReconnectPolicy::new(Duration::from_millis(250))),
+    ));
+
+    std::mem::take(configs)
+}
+
+/// The size of the sweep, asserted so that a generator broken into producing
+/// nothing, or an axis dropped by a bad merge, fails rather than passes.
+const CONFORMANCE_CONFIGURATION_COUNT: usize = 59 + if cfg!(feature = "metrics") { 6 } else { 0 };
+
+/// The report of every configuration of the sweep, against both target
+/// kinds - `server-side-ms` is reported only against ScyllaDB - each paired
+/// with a name for the configuration that produced it.
+///
+/// Shared by the two tests below, which ask different questions of the same
+/// documents: whether each of them is accepted by the schema, and which of
+/// the schema's keys all of them together populate.
+fn conformance_reports() -> Vec<(String, Value)> {
+    let configs = conformance_configurations();
+    assert_eq!(
+        configs.len(),
+        CONFORMANCE_CONFIGURATION_COUNT,
+        "the configuration sweep changed size"
+    );
+
+    // The name is all a failure has to point at the configuration that
+    // produced a report, so two axes must not share one.
+    let mut names: Vec<&str> = configs.iter().map(|(name, ..)| name.as_str()).collect();
+    names.sort_unstable();
+    let named = names.len();
+    names.dedup();
+    assert_eq!(
+        names.len(),
+        named,
+        "the configuration sweep names a configuration more than once"
+    );
+
+    let mut reports = Vec::with_capacity(2 * configs.len());
+    for (name, config, policy) in configs {
+        for target_is_scylladb in [false, true] {
+            let report = reporter_with_policy(&config, Arc::clone(&policy))
+                .report(target_is_scylladb)
+                .unwrap();
+            reports.push((
+                format!("{name:?} (scylladb: {target_is_scylladb})"),
+                serde_json::from_str(&report).unwrap(),
+            ));
+        }
+    }
+
+    reports
+}
+
+/// The report is only worth anything if it validates against the schema
+/// every ScyllaDB driver reports under: that is what makes one
+/// `system.clients` query answer the same question across drivers. Nothing
+/// else in this module checks that - the assertions elsewhere pin the exact
+/// bytes this driver emits, not whether the contract accepts them.
+///
+/// A Tokio runtime is needed only by [`LatencyAwarenessBuilder::build`],
+/// which spawns the task updating latency averages.
+#[tokio::test]
+async fn every_report_conforms_to_the_schema() {
+    let schema: Value = serde_json::from_str(SCHEMA).unwrap();
+    assert_eq!(
+        schema["$id"],
+        "https://scylladb.com/schemas/driver-client-options/v1.json"
+    );
+    let validator = jsonschema::validator_for(&schema).unwrap();
+
+    // Names why a document is rejected, so that a failing sweep points at
+    // the key at fault instead of just at the configuration.
+    let errors = |document: &Value| -> Vec<String> {
+        validator
+            .iter_errors(document)
+            .map(|error| format!("  at {}: {error}", error.instance_path()))
+            .collect()
+    };
+
+    // Negative control, first: a schema that failed to load, or one loaded
+    // with its constraints silently dropped, would accept everything and
+    // make every assertion below vacuously true. The two documents below are
+    // known-bad, so the sweep only means something while they keep failing.
+    let valid: Value =
+        serde_json::from_str(&reporter(&SessionConfig::new()).report(true).unwrap()).unwrap();
+    assert!(
+        errors(&valid).is_empty(),
+        "the default report does not conform to the schema:\n{}\nreport: {valid}",
+        errors(&valid).join("\n")
+    );
+
+    let mut camel_cased = valid.clone();
+    camel_cased["query"]["defaults"]["consistency"] = Value::String("LocalQuorum".to_owned());
+    assert!(
+        !validator.is_valid(&camel_cased),
+        "the schema accepted a CamelCase consistency, so it is not constraining anything"
+    );
+
+    let mut group_removed = valid.clone();
+    group_removed
+        .as_object_mut()
+        .unwrap()
+        .remove("connection")
+        .unwrap();
+    assert!(
+        !validator.is_valid(&group_removed),
+        "the schema accepted a document missing a required group"
+    );
+
+    for (name, report) in conformance_reports() {
+        assert!(
+            errors(&report).is_empty(),
+            "the report of configuration {name} does not conform to the schema:\n{}\n\
+             report: {report}",
+            errors(&report).join("\n")
+        );
+    }
+}
+
+/// The spec requires an oversized report to be omitted rather than sent, and
+/// here the requirement has teeth: `write_string` length-prefixes every
+/// `STARTUP` value with a `u16`, so a report above 64 KiB would fail
+/// serialization and take the control-connection handshake, and with it
+/// session creation, down with it.
+///
+/// A user policy's `name` is the one input to the document with no bound on
+/// its length, so it is what drives the size here.
+#[test]
+fn oversized_reports_are_omitted() {
+    // The padding is measured rather than hardcoded: any key added to the
+    // document elsewhere shifts it, and a magic number would then either
+    // stop testing the boundary or start failing for the wrong reason. `a`
+    // needs no JSON escaping, so each byte of the name is one byte of the
+    // document.
+    let report_len = |name_len: usize| {
+        let profile = ExecutionProfile::builder()
+            .load_balancing_policy(ForeignLoadBalancingPolicy::new("a".repeat(name_len)))
+            .build();
+        reporter_with_profile(profile)
+            .report(true)
+            .map(|report| report.len())
+    };
+
+    // A one-character name, not an empty one: the empty name is replaced by
+    // a literal, so it is the only length that does not scale linearly.
+    let padding = MAX_REPORT_SIZE - report_len(1).unwrap();
+
+    assert_eq!(report_len(padding), Some(MAX_REPORT_SIZE - 1));
+    // The limit itself is not exceeded, so the report is still sent.
+    assert_eq!(report_len(1 + padding), Some(MAX_REPORT_SIZE));
+    assert_eq!(report_len(2 + padding), None);
+    assert_eq!(report_len(2 * MAX_REPORT_SIZE), None);
+}

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -25,6 +25,10 @@ use crate::policies::retry::{
     DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy, RetryPolicy,
     RetrySession,
 };
+use crate::policies::speculative_execution::{
+    Context as SpeculativeExecutionContext, SimpleSpeculativeExecutionPolicy,
+    SpeculativeExecutionPolicy,
+};
 use crate::policies::timestamp_generator::SimpleTimestampGenerator;
 use crate::routing::{NodeLocationPreference, Shard};
 use crate::statement::{Consistency, SerialConsistency};
@@ -84,6 +88,19 @@ struct ForeignRetryPolicy;
 
 impl RetryPolicy for ForeignRetryPolicy {
     fn new_session(&self) -> Box<dyn RetrySession> {
+        unimplemented!("the report never runs the policy")
+    }
+}
+
+#[derive(Debug)]
+struct ForeignSpeculativeExecutionPolicy;
+
+impl SpeculativeExecutionPolicy for ForeignSpeculativeExecutionPolicy {
+    fn max_retry_count(&self, _: &SpeculativeExecutionContext) -> usize {
+        unimplemented!("the report never runs the policy")
+    }
+
+    fn retry_interval(&self, _: &SpeculativeExecutionContext) -> Duration {
         unimplemented!("the report never runs the policy")
     }
 }
@@ -909,4 +926,134 @@ fn custom_load_balancing_policies_are_reported_by_name() {
             serde_json::json!({"policy": {"type": "custom", "name": name}})
         );
     }
+}
+
+fn speculative_execution_report(
+    policy: Option<Arc<dyn SpeculativeExecutionPolicy>>,
+) -> Option<serde_json::Value> {
+    let profile = ExecutionProfile::builder()
+        .speculative_execution_policy(policy)
+        .build();
+    let report = reporter_with_profile(profile).report(true).unwrap();
+    // Asserted on the serialized report rather than on the parsed value: a
+    // non-finite `f64` reaches the document as a bare `null`, and the point
+    // is to catch it in the bytes the server would be sent.
+    assert!(!report.contains("null"), "{report}");
+    optional_group(&report, "/query/speculative-execution")
+}
+
+/// [`reconnection_policies`] for the speculative execution policies, with
+/// the `query.speculative-execution` group each must be reported as - which
+/// for two of them is no group at all.
+#[expect(clippy::type_complexity)]
+fn speculative_execution_policies() -> [(
+    &'static str,
+    Option<Arc<dyn SpeculativeExecutionPolicy>>,
+    Option<Value>,
+); 5] {
+    [
+        // Speculative execution is disabled by default.
+        ("no speculative execution", None, None),
+        (
+            "constant speculative execution",
+            Some(Arc::new(SimpleSpeculativeExecutionPolicy {
+                max_retry_count: 2,
+                retry_interval: Duration::from_millis(150),
+            })),
+            Some(serde_json::json!({
+                "policy": {"type": "constant", "max-executions": 2, "delay-ms": 150},
+            })),
+        ),
+        (
+            // A zero interval means "launch immediately", not "unset".
+            "zero-interval speculative execution",
+            Some(Arc::new(SimpleSpeculativeExecutionPolicy {
+                max_retry_count: 1,
+                retry_interval: Duration::ZERO,
+            })),
+            Some(serde_json::json!({
+                "policy": {"type": "constant", "max-executions": 1, "delay-ms": 0},
+            })),
+        ),
+        (
+            // A policy permitting no extra execution never fires, so there
+            // is no speculative execution to report.
+            "zero-count speculative execution",
+            Some(Arc::new(SimpleSpeculativeExecutionPolicy {
+                max_retry_count: 0,
+                retry_interval: Duration::from_millis(150),
+            })),
+            None,
+        ),
+        (
+            "foreign speculative execution policy",
+            Some(Arc::new(ForeignSpeculativeExecutionPolicy)),
+            Some(serde_json::json!({
+                "policy": {"type": "custom", "name": "ForeignSpeculativeExecutionPolicy"},
+            })),
+        ),
+    ]
+}
+
+#[test]
+fn speculative_execution_report_cases() {
+    for (name, policy, expected) in speculative_execution_policies() {
+        assert_eq!(speculative_execution_report(policy), expected, "{name}");
+    }
+}
+
+/// [`PercentileSpeculativeExecutionPolicy::percentile`] is an unvalidated
+/// `f64`, and the schema's bounds on it are exclusive. A non-finite value is
+/// the dangerous one: `serde_json` renders it as `null`, which no downstream
+/// check would catch, hence the `null`-free assertion on every report here.
+#[cfg(feature = "metrics")]
+#[test]
+fn percentile_speculative_execution_report_cases() {
+    use crate::policies::speculative_execution::PercentileSpeculativeExecutionPolicy;
+
+    let percentile_report = |max_retry_count, percentile| {
+        speculative_execution_report(Some(Arc::new(PercentileSpeculativeExecutionPolicy {
+            max_retry_count,
+            percentile,
+        })))
+    };
+
+    assert_eq!(
+        percentile_report(3, 99.0),
+        Some(serde_json::json!({
+            "policy": {"type": "percentile", "max-executions": 3, "percentile": 99.0},
+        }))
+    );
+
+    // Out of the schema's exclusive range, or not a number at all: reported
+    // as a policy the driver cannot describe rather than not at all, because
+    // speculative execution does fire. `-1.0` is the only case reaching the
+    // lower-bound comparison - the non-finite values are rejected before it
+    // - so it is what pins `<= 0.0` rather than `== 0.0`.
+    let unreportable = [
+        f64::NAN,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        -1.0,
+        0.0,
+        100.0,
+        150.0,
+    ];
+
+    for percentile in unreportable {
+        assert_eq!(
+            percentile_report(3, percentile),
+            Some(serde_json::json!({
+                "policy": {
+                    "type": "custom",
+                    "name": "PercentileSpeculativeExecutionPolicy",
+                },
+            })),
+            "{percentile}"
+        );
+    }
+
+    // The zero-count rule applies whatever the percentile is.
+    assert_eq!(percentile_report(0, 99.0), None);
+    assert_eq!(percentile_report(0, f64::NAN), None);
 }

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -93,7 +93,7 @@ fn patched(report: &str, patches: &[(&str, &str)]) -> String {
 /// The report of an unconfigured session against a ScyllaDB target, spelled
 /// out in full: the one document key order is pinned on, and the baseline
 /// the single-axis cases below are expressed as patches of.
-const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}}}"#;
+const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}}}"#;
 
 fn reporter(config: &SessionConfig) -> DriverConfigReporter {
     reporter_with_policy(config, Arc::new(ExponentialReconnectPolicy::new()))
@@ -103,7 +103,12 @@ fn reporter_with_policy(
     config: &SessionConfig,
     policy: Arc<dyn ReconnectPolicy>,
 ) -> DriverConfigReporter {
-    DriverConfigReporter::new(config, config.tcp_socket_options(), policy)
+    DriverConfigReporter::new(
+        config,
+        config.tcp_socket_options(),
+        policy,
+        config.metadata_request_timeouts(),
+    )
 }
 
 #[test]
@@ -183,7 +188,7 @@ fn customised_report(config: &SessionConfig) -> String {
 /// The report of [`customised_config`], the second document spelled out in
 /// full: nearly every key of it differs from [`DEFAULT_REPORT`], so there is
 /// no difference to point at.
-const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}}}"#;
+const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}}}"#;
 
 #[test]
 fn fully_customised_configuration_report() {
@@ -210,6 +215,66 @@ fn tls_is_reported_as_an_empty_object() {
             CUSTOMISED_REPORT,
             &[(r#""local-dc":"dc1"}}"#, r#""local-dc":"dc1"},"tls":{}}"#)],
         )
+    );
+}
+
+/// `server-side-ms` describes the `USING TIMEOUT` clause the control
+/// connection appends, so it must be absent whenever no such clause is sent:
+/// against Cassandra, or when the clause would read `0ms`. `client-side-ms`
+/// bounds a client-side deadline and is reported either way.
+#[test]
+fn control_plane_report_cases() {
+    let control_plane = |config: &SessionConfig, target_is_scylladb: bool| {
+        let report = reporter(config).report(target_is_scylladb).unwrap();
+        group(&report, "/control-plane")
+    };
+
+    // A Cassandra target honours no `USING TIMEOUT`, so the whole default
+    // report drops that one key and nothing else.
+    assert_eq!(
+        reporter(&SessionConfig::new()).report(false).unwrap(),
+        patched(DEFAULT_REPORT, &[(r#","server-side-ms":30000"#, "")])
+    );
+
+    // A sub-millisecond server-side timeout would be sent as
+    // `USING TIMEOUT 0ms`, which `positiveInteger` cannot carry.
+    let mut config = SessionConfig::new();
+    config.metadata_request_serverside_timeout = Some(Duration::from_micros(500));
+    assert_eq!(
+        control_plane(&config, true),
+        serde_json::json!({
+            "queries": {"system": {"timeout": {"client-side-ms": 1000}}},
+            "schema": {"agreement": {"timeout-ms": 60000}},
+        })
+    );
+
+    // No server-side timeout at all: the client-side one falls back to its
+    // own default, and there is no clause to report even against ScyllaDB.
+    let mut config = SessionConfig::new();
+    config.metadata_request_serverside_timeout = None;
+    assert_eq!(
+        control_plane(&config, true),
+        serde_json::json!({
+            "queries": {"system": {"timeout": {"client-side-ms": 30000}}},
+            "schema": {"agreement": {"timeout-ms": 60000}},
+        })
+    );
+
+    // An explicit client-side override wins over the derived value; a zero
+    // schema agreement timeout means "do not wait", not "unset".
+    let mut config = SessionConfig::new();
+    config.metadata_request_serverside_timeout = Some(Duration::from_secs(5));
+    config.metadata_request_clientside_timeout = Some(Duration::from_secs(7));
+    config.schema_agreement_timeout = Duration::ZERO;
+    assert_eq!(
+        control_plane(&config, true),
+        serde_json::json!({
+            "queries": {"system": {"timeout": {
+                "client-side-ms": 7000,
+                "server-side-ms": 5000,
+            }}},
+            "schema": {"agreement": {"timeout-ms": 0}},
+        })
     );
 }
 

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -1474,6 +1474,265 @@ async fn every_report_conforms_to_the_schema() {
     }
 }
 
+/// What the driver leaves out of the report, as opposed to what it puts in.
+///
+/// Gated on `metrics`, which
+/// [`PercentileSpeculativeExecutionPolicy`](crate::policies::speculative_execution::PercentileSpeculativeExecutionPolicy)
+/// needs: without it [`conformance_configurations`] cannot reach the
+/// `percentile` branch of the schema and the allowlist below would have to
+/// differ.
+#[cfg(feature = "metrics")]
+mod coverage {
+    use std::collections::BTreeSet;
+
+    use serde_json::Value;
+
+    use super::{SCHEMA, conformance_reports};
+
+    /// Schema keys the driver never populates, as dotted paths whose `<...>`
+    /// segments name the branch of a discriminated union they belong to.
+    ///
+    /// Every entry is a deliberate omission, documented at the type that would
+    /// have carried it above. The reasons in brief:
+    const UNREPORTED_KEYS: &[&str] = &[
+        // Placeholders that schema v1 declares as empty objects with
+        // `additionalProperties: false`, so the driver's own idle heartbeat
+        // (`keepalive_interval`) and write coalescing (`write_coalescing`)
+        // settings have nowhere to go, and the two direction-specific timeouts
+        // describe per-operation deadlines this driver does not have.
+        "connection.heartbeat",
+        "connection.read.timeout-ms",
+        "connection.write.coalescing",
+        "connection.write.timeout-ms",
+        // Only `DcHostFilter` narrows which nodes the driver connects to at all,
+        // and it names a datacenter and nothing more: there is no filter that
+        // states a rack, and none that infers a location.
+        "connection.node-preference.<dc-auto>.local-dc",
+        "connection.node-preference.<dc-auto>.type",
+        "connection.node-preference.<rack-auto>.inferred-local-dc",
+        "connection.node-preference.<rack-auto>.inferred-local-rack",
+        "connection.node-preference.<rack-auto>.local-dc",
+        "connection.node-preference.<rack-auto>.local-rack",
+        "connection.node-preference.<rack-auto>.type",
+        "connection.node-preference.<rack>.local-dc",
+        "connection.node-preference.<rack>.local-rack",
+        "connection.node-preference.<rack>.type",
+        // The pool retries forever, which the schema spells as an absent
+        // `max-attempts`, and a session always has a reconnection policy in
+        // force, so the `null` branch that means "never reconnect" never
+        // applies.
+        "connection.reconnection.policy.<constant>.max-attempts",
+        "connection.reconnection.policy.<exponential>.max-attempts",
+        "connection.reconnection.policy.<null>",
+        // Neither TLS backend exposes whether hostname verification is on, so
+        // reporting the boolean either way would be a guess. Nothing else lives
+        // under `connection.tls`, which is why a TLS context only ever adds the
+        // empty group that `tls_is_reported_as_an_empty_object` pins.
+        "connection.tls.hostname-verification",
+        // The load balancing policy resolves the preference it reports from
+        // configured values only, never from the connected node.
+        "query.load-balancing.node-preference.<dc-auto>.local-dc",
+        "query.load-balancing.node-preference.<dc-auto>.type",
+        "query.load-balancing.node-preference.<rack-auto>.inferred-local-dc",
+        "query.load-balancing.node-preference.<rack-auto>.inferred-local-rack",
+        "query.load-balancing.node-preference.<rack-auto>.local-dc",
+        "query.load-balancing.node-preference.<rack-auto>.local-rack",
+        "query.load-balancing.node-preference.<rack-auto>.type",
+        // A policy the driver does not recognise is named, not described: the
+        // `name` a user implementation supplies is all there is to go on.
+        "query.load-balancing.policy.<custom>.description",
+        "query.retry.policy.<custom>.description",
+        "query.speculative-execution.policy.<custom>.description",
+        // No retry policy of this driver waits between attempts, and none of
+        // them has a single retry count to report - the built-ins cap retries
+        // per error kind, which does not bound the retries a new target may
+        // trigger.
+        "query.retry.backoff.<constant>.delay-ms",
+        "query.retry.backoff.<constant>.type",
+        "query.retry.backoff.<exponential>.base-ms",
+        "query.retry.backoff.<exponential>.max-ms",
+        "query.retry.backoff.<exponential>.type",
+        "query.retry.policy.<custom>.max-retries",
+        "query.retry.policy.<downgrading-consistency>.max-retries",
+        "query.retry.policy.<standard-error-aware>.max-retries",
+        // Two retry policies of the schema this driver has no equivalent of at
+        // all.
+        "query.retry.policy.<never>.max-retries",
+        "query.retry.policy.<never>.type",
+        "query.retry.policy.<simple>.max-retries",
+        "query.retry.policy.<simple>.type",
+    ];
+
+    /// Follows a `$ref`, which this schema only ever points at its own `$defs`.
+    fn resolve<'schema>(schema: &'schema Value, mut node: &'schema Value) -> &'schema Value {
+        while let Some(reference) = node.get("$ref").and_then(Value::as_str) {
+            let name = reference
+                .strip_prefix("#/$defs/")
+                .unwrap_or_else(|| panic!("unsupported schema reference {reference}"));
+            node = schema
+                .pointer("/$defs")
+                .and_then(|defs| defs.get(name))
+                .unwrap_or_else(|| panic!("dangling schema reference {reference}"));
+        }
+        node
+    }
+
+    /// The `type` const discriminating one branch of a `oneOf`. Every union in
+    /// the schema has one, bar the single `null` branch of the reconnection
+    /// policy.
+    fn branch_discriminant<'schema>(
+        schema: &'schema Value,
+        branch: &'schema Value,
+    ) -> Option<&'schema str> {
+        resolve(schema, branch)
+            .pointer("/properties/type/const")
+            .and_then(Value::as_str)
+    }
+
+    /// The path segment naming one branch of a `oneOf`. The index is the
+    /// fallback for a union shaped some other way, so that a schema bump
+    /// introducing one still yields distinct paths.
+    fn branch_tag(schema: &Value, branch: &Value, index: usize) -> String {
+        match branch_discriminant(schema, branch) {
+            Some(discriminant) => format!("<{discriminant}>"),
+            None if resolve(schema, branch).get("type") == Some(&Value::from("null")) => {
+                "<null>".to_owned()
+            }
+            None => format!("<oneOf{index}>"),
+        }
+    }
+
+    /// Whether a schema node describes a group of keys rather than a key.
+    ///
+    /// A group is an object with properties; everything else - a scalar, an
+    /// array, or one of the schema's deliberately empty placeholder objects - is
+    /// a key that a report either carries or does not.
+    fn group_properties(node: &Value) -> Option<&serde_json::Map<String, Value>> {
+        node.get("properties")
+            .and_then(Value::as_object)
+            .filter(|properties| !properties.is_empty())
+    }
+
+    /// Collects every key the schema declares, into `found`.
+    fn schema_keys(
+        schema: &Value,
+        node: &Value,
+        path: &mut Vec<String>,
+        found: &mut BTreeSet<String>,
+    ) {
+        let node = resolve(schema, node);
+
+        if let Some(branches) = node.get("oneOf").and_then(Value::as_array) {
+            for (index, branch) in branches.iter().enumerate() {
+                path.push(branch_tag(schema, branch, index));
+                schema_keys(schema, branch, path, found);
+                path.pop();
+            }
+        } else if let Some(properties) = group_properties(node) {
+            for (name, property) in properties {
+                path.push(name.clone());
+                schema_keys(schema, property, path, found);
+                path.pop();
+            }
+        } else {
+            found.insert(path.join("."));
+        }
+    }
+
+    /// Collects the keys `report` populates, into `found`.
+    ///
+    /// Walks the report and the schema in lockstep rather than the report alone,
+    /// so that a key is credited to the union branch it actually belongs to:
+    /// `max-retries` under one retry policy is a different key from
+    /// `max-retries` under another, and only the schema says which branch a
+    /// report is in. That a report fits the schema at all is not rechecked here
+    /// - [`every_report_conforms_to_the_schema`] validates these very documents.
+    fn reported_keys(
+        schema: &Value,
+        node: &Value,
+        report: &Value,
+        path: &mut Vec<String>,
+        found: &mut BTreeSet<String>,
+    ) {
+        let node = resolve(schema, node);
+
+        if let Some(branches) = node.get("oneOf").and_then(Value::as_array) {
+            let (index, branch) = branches
+                .iter()
+                .enumerate()
+                .find(|(_, branch)| match branch_discriminant(schema, branch) {
+                    Some(discriminant) => {
+                        report.get("type").and_then(Value::as_str) == Some(discriminant)
+                    }
+                    None => report.is_null(),
+                })
+                .expect("the schema accepted a report matching no branch of a union");
+
+            path.push(branch_tag(schema, branch, index));
+            reported_keys(schema, branch, report, path, found);
+            path.pop();
+        } else if let Some(properties) = group_properties(node) {
+            for (name, value) in report
+                .as_object()
+                .expect("the schema accepted a key where it declares a group")
+            {
+                path.push(name.clone());
+                reported_keys(schema, &properties[name], value, path, found);
+                path.pop();
+            }
+        } else {
+            found.insert(path.join("."));
+        }
+    }
+
+    /// Schema validation only constrains what the report does say. Every key the
+    /// schema declares is optional unless a `required` list names it, so a value
+    /// the driver forgot to report is indistinguishable from one it has nothing
+    /// to say about. This closes that gap from the other side: the keys the
+    /// sweep's reports leave over must be *exactly* [`UNREPORTED_KEYS`].
+    ///
+    /// Both directions of that equality are load-bearing. A key that stops being
+    /// reported fails here rather than silently disappearing from what operators
+    /// can inspect, and a schema bump that adds keys fails here until someone
+    /// either reports them or writes down why the driver cannot.
+    ///
+    /// A Tokio runtime is needed only by `LatencyAwarenessBuilder::build`,
+    /// which spawns the task updating latency averages.
+    #[tokio::test]
+    async fn every_reportable_schema_key_is_reported() {
+        let schema: Value = serde_json::from_str(SCHEMA).unwrap();
+
+        let mut declared = BTreeSet::new();
+        schema_keys(&schema, &schema, &mut Vec::new(), &mut declared);
+
+        let mut reported = BTreeSet::new();
+        for (_, report) in conformance_reports() {
+            reported_keys(&schema, &schema, &report, &mut Vec::new(), &mut reported);
+        }
+
+        let unreported: BTreeSet<&str> = declared
+            .iter()
+            .map(String::as_str)
+            .filter(|key| !reported.contains(*key))
+            .collect();
+        let allowed: BTreeSet<&str> = UNREPORTED_KEYS.iter().copied().collect();
+
+        let undocumented: Vec<&&str> = unreported.difference(&allowed).collect();
+        let stale: Vec<&&str> = allowed.difference(&unreported).collect();
+        assert!(
+            undocumented.is_empty() && stale.is_empty(),
+            "the set of schema keys the driver does not report has changed.\n\
+             Not reported and not in UNREPORTED_KEYS - report them, or add them \
+             to the list with a reason: {undocumented:#?}\n\
+             In UNREPORTED_KEYS but reported after all - drop them from the \
+             list: {stale:#?}\n\
+             Of the {} keys the schema declares, {} were reported.",
+            declared.len(),
+            reported.len(),
+        );
+    }
+}
+
 /// The spec requires an oversized report to be omitted rather than sent, and
 /// here the requirement has teeth: `write_string` length-prefixes every
 /// `STARTUP` value with a `u16`, so a report above 64 KiB would fail

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -3,14 +3,20 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::Value;
+use uuid::Uuid;
 
 use super::{DriverConfigReporter, MAX_REPORT_SIZE, non_negative_millis, positive_millis};
 use crate::client::execution_profile::ExecutionProfile;
 use crate::client::session::SessionConfig;
 use crate::cluster::metadata::Peer;
+use crate::cluster::{ClusterState, NodeRef};
 use crate::network::PoolSize;
 use crate::policies::host_filter::{
     AcceptAllHostFilter, AllowListHostFilter, DcHostFilter, HostFilter,
+};
+use crate::policies::load_balancing::{
+    DefaultPolicy, FallbackPlan, LatencyAwarenessBuilder, LoadBalancingPolicy, NodeIdentifier,
+    RoutingInfo, SingleTargetLoadBalancingPolicy,
 };
 use crate::policies::reconnect::{
     ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy, ReconnectPolicySession,
@@ -20,6 +26,7 @@ use crate::policies::retry::{
     RetrySession,
 };
 use crate::policies::timestamp_generator::SimpleTimestampGenerator;
+use crate::routing::{NodeLocationPreference, Shard};
 use crate::statement::{Consistency, SerialConsistency};
 
 /// Every consistency level the schema enumerates, with the SCREAMING_SNAKE
@@ -81,6 +88,42 @@ impl RetryPolicy for ForeignRetryPolicy {
     }
 }
 
+/// Unlike its siblings this one carries its `name`, because a load balancing
+/// policy is reported by [`LoadBalancingPolicy::name`] rather than by type
+/// name. That makes it the only input to the document with no bound on its
+/// length, which [`oversized_reports_are_omitted`] relies on, and the only
+/// one that can be empty, which `nonEmptyString` rejects.
+#[derive(Debug)]
+struct ForeignLoadBalancingPolicy(String);
+
+impl ForeignLoadBalancingPolicy {
+    fn new(name: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self(name.into()))
+    }
+}
+
+impl LoadBalancingPolicy for ForeignLoadBalancingPolicy {
+    fn pick<'a>(
+        &'a self,
+        _request: &'a RoutingInfo,
+        _cluster: &'a ClusterState,
+    ) -> Option<(NodeRef<'a>, Option<Shard>)> {
+        unimplemented!("the report never runs the policy")
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        _request: &'a RoutingInfo,
+        _cluster: &'a ClusterState,
+    ) -> FallbackPlan<'a> {
+        unimplemented!("the report never runs the policy")
+    }
+
+    fn name(&self) -> String {
+        self.0.clone()
+    }
+}
+
 /// The value the report carries at `pointer`.
 ///
 /// Assertions on one group of the document go through this rather than
@@ -133,7 +176,7 @@ fn patched(report: &str, patches: &[(&str, &str)]) -> String {
 /// The report of an unconfigured session against a ScyllaDB target, spelled
 /// out in full: the one document key order is pinned on, and the baseline
 /// the single-axis cases below are expressed as patches of.
-const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"LOCAL_QUORUM","serial-consistency":"LOCAL_SERIAL","idempotence":false,"client-timestamps":false,"page":{"size":5000},"request":{"timeout-ms":30000}},"retry":{"policy":{"type":"standard-error-aware"}}}}"#;
+const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"LOCAL_QUORUM","serial-consistency":"LOCAL_SERIAL","idempotence":false,"client-timestamps":false,"page":{"size":5000},"request":{"timeout-ms":30000}},"retry":{"policy":{"type":"standard-error-aware"}},"load-balancing":{"policy":{"type":"token-aware","load-distribution":"shuffle","fallback-to-non-preferred-nodes":true}}}}"#;
 
 fn reporter(config: &SessionConfig) -> DriverConfigReporter {
     reporter_with_policy(config, Arc::new(ExponentialReconnectPolicy::new()))
@@ -236,7 +279,7 @@ fn customised_report(config: &SessionConfig) -> String {
 /// The report of [`customised_config`], the second document spelled out in
 /// full: nearly every key of it differs from [`DEFAULT_REPORT`], so there is
 /// no difference to point at.
-const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"QUORUM","serial-consistency":"SERIAL","idempotence":false,"client-timestamps":true,"page":{"size":5000},"request":{"timeout-ms":1500}},"retry":{"policy":{"type":"downgrading-consistency"}}}}"#;
+const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"QUORUM","serial-consistency":"SERIAL","idempotence":false,"client-timestamps":true,"page":{"size":5000},"request":{"timeout-ms":1500}},"retry":{"policy":{"type":"downgrading-consistency"}},"load-balancing":{"policy":{"type":"token-aware","load-distribution":"shuffle","fallback-to-non-preferred-nodes":true}}}}"#;
 
 #[test]
 fn fully_customised_configuration_report() {
@@ -472,6 +515,16 @@ fn remapping_the_default_profile_changes_the_report() {
     config.default_execution_profile_handle = handle.clone();
     let reporter = reporter(&config);
 
+    // The one group a profile feeds, in full, so that remapping is seen to
+    // change every key of it that the new profile touches - and none other.
+    let token_aware_load_balancing = serde_json::json!({
+        "policy": {
+            "type": "token-aware",
+            "load-distribution": "shuffle",
+            "fallback-to-non-preferred-nodes": true,
+        },
+    });
+
     let before = reporter.report(true).unwrap();
     assert_eq!(
         group(&before, "/query"),
@@ -485,6 +538,7 @@ fn remapping_the_default_profile_changes_the_report() {
                 "request": {"timeout-ms": 30000},
             },
             "retry": {"policy": {"type": "standard-error-aware"}},
+            "load-balancing": token_aware_load_balancing,
         })
     );
 
@@ -511,6 +565,7 @@ fn remapping_the_default_profile_changes_the_report() {
                 "request": {"timeout-ms": 3000},
             },
             "retry": {"policy": {"type": "fallthrough"}},
+            "load-balancing": token_aware_load_balancing,
         })
     );
 }
@@ -597,4 +652,261 @@ fn unset_query_defaults_are_omitted() {
             "page": {"size": 5000},
         })
     );
+}
+
+fn load_balancing_report(
+    policy: Arc<dyn LoadBalancingPolicy>,
+    session_preference: NodeLocationPreference,
+) -> serde_json::Value {
+    let mut config = SessionConfig::new();
+    config.node_location_preference = session_preference;
+    config.default_execution_profile_handle = ExecutionProfile::builder()
+        .load_balancing_policy(policy)
+        .build()
+        .into_handle();
+
+    let report = reporter(&config).report(true).unwrap();
+    group(&report, "/query/load-balancing")
+}
+
+/// The expected `query.load-balancing` of a token-aware `DefaultPolicy`
+/// with replica shuffling on and adaptive ordering off: the shape nearly
+/// every case below shares, differing only in the derived
+/// `fallback-to-non-preferred-nodes` and in the preference beside it. The
+/// few cases that vary anything else fill in the difference themselves.
+fn token_aware_expectation(
+    fallback_to_non_preferred_nodes: bool,
+    node_preference: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut expected = serde_json::json!({
+        "policy": {
+            "type": "token-aware",
+            "load-distribution": "shuffle",
+            "fallback-to-non-preferred-nodes": fallback_to_non_preferred_nodes,
+        },
+    });
+
+    if let Some(node_preference) = node_preference {
+        expected["node-preference"] = node_preference;
+    }
+    expected
+}
+
+/// [`dc_preference`] naming a rack as well, which only a load balancing
+/// policy ever does: no host filter states a rack.
+fn rack_preference(local_dc: &str, local_rack: &str) -> serde_json::Value {
+    serde_json::json!({"type": "rack", "local-dc": local_dc, "local-rack": local_rack})
+}
+
+/// Every combination of `DefaultPolicy`'s reportable knobs, and above all
+/// every case of `fallback-to-non-preferred-nodes`: it is the one key
+/// derived rather than read, and the rack case says `true` even with
+/// datacenter failover disabled, which reads like a bug until one follows
+/// `DefaultPolicy::fallback`'s plan composition.
+///
+/// A Tokio runtime is needed only by [`LatencyAwarenessBuilder::build`],
+/// which spawns the task updating latency averages.
+#[tokio::test]
+async fn default_load_balancing_policy_matrix() {
+    let dc = || "dc1".to_owned();
+    let rack = || "rack1".to_owned();
+
+    // Token awareness off: the schema's built-in branch presumes it, so the
+    // policy is reported as custom - preference and failover included, since
+    // the custom branch carries neither.
+    assert_eq!(
+        load_balancing_report(
+            DefaultPolicy::builder()
+                .token_aware(false)
+                .prefer_datacenter(dc())
+                .build(),
+            NodeLocationPreference::Any,
+        ),
+        serde_json::json!({
+            "policy": {"type": "custom", "name": "DefaultPolicy"},
+            "node-preference": dc_preference("dc1"),
+        })
+    );
+
+    // No preference at all: nothing confines requests, so failover cannot
+    // change the answer.
+    for permit_dc_failover in [false, true] {
+        assert_eq!(
+            load_balancing_report(
+                DefaultPolicy::builder()
+                    .permit_dc_failover(permit_dc_failover)
+                    .build(),
+                NodeLocationPreference::Any,
+            ),
+            token_aware_expectation(true, None)
+        );
+    }
+
+    // A datacenter preference is the only case failover decides.
+    for (permit_dc_failover, fallback) in [(false, false), (true, true)] {
+        assert_eq!(
+            load_balancing_report(
+                DefaultPolicy::builder()
+                    .prefer_datacenter(dc())
+                    .permit_dc_failover(permit_dc_failover)
+                    .build(),
+                NodeLocationPreference::Any,
+            ),
+            token_aware_expectation(fallback, Some(dc_preference("dc1")))
+        );
+    }
+
+    // A rack preference is always escaped: the fallback plan chains the
+    // local datacenter's other racks after the local rack unconditionally.
+    for permit_dc_failover in [false, true] {
+        assert_eq!(
+            load_balancing_report(
+                DefaultPolicy::builder()
+                    .prefer_datacenter_and_rack(dc(), rack())
+                    .permit_dc_failover(permit_dc_failover)
+                    .build(),
+                NodeLocationPreference::Any,
+            ),
+            token_aware_expectation(true, Some(rack_preference("dc1", "rack1")))
+        );
+    }
+
+    // Latency awareness is the only adaptive-ordering signal the driver has.
+    let mut adaptive = token_aware_expectation(false, Some(dc_preference("dc1")));
+    adaptive["policy"]["adaptive-ordering"] = serde_json::json!({"signals": ["latency"]});
+    assert_eq!(
+        load_balancing_report(
+            DefaultPolicy::builder()
+                .prefer_datacenter(dc())
+                .permit_dc_failover(false)
+                .latency_awareness(LatencyAwarenessBuilder::new())
+                .build(),
+            NodeLocationPreference::Any,
+        ),
+        adaptive
+    );
+}
+
+/// `load-distribution` is the one key that must follow `fixed_seed` rather
+/// than the policy's type: a fixed seed makes every query plan reuse the
+/// same replica choice and the same permutation, which is not the schema's
+/// randomised `shuffle`.
+#[test]
+fn load_distribution_follows_replica_shuffling() {
+    for (enable_shuffling, distribution) in [(true, "shuffle"), (false, "replica-set")] {
+        let mut expected = token_aware_expectation(true, None);
+        expected["policy"]["load-distribution"] = serde_json::json!(distribution);
+
+        assert_eq!(
+            load_balancing_report(
+                DefaultPolicy::builder()
+                    .enable_shuffling_replicas(enable_shuffling)
+                    .build(),
+                NodeLocationPreference::Any,
+            ),
+            expected
+        );
+    }
+}
+
+/// `node-preference` reports the preference the policy actually routes by,
+/// which `DefaultPolicy::routing_info` takes from the policy when it states
+/// one and from the session otherwise. An empty datacenter name is no
+/// preference at all; an empty rack name only drops the rack half.
+#[test]
+fn effective_node_preference_is_reported() {
+    let unconfined = token_aware_expectation(true, None);
+
+    // No policy-level preference: the session-level one is reported.
+    assert_eq!(
+        load_balancing_report(
+            DefaultPolicy::builder().permit_dc_failover(false).build(),
+            NodeLocationPreference::DatacenterAndRack("dc9".to_owned(), "rack9".to_owned()),
+        ),
+        token_aware_expectation(true, Some(rack_preference("dc9", "rack9")))
+    );
+
+    // A policy-level preference wins over the session-level one.
+    assert_eq!(
+        load_balancing_report(
+            DefaultPolicy::builder()
+                .prefer_datacenter("dc1".to_owned())
+                .permit_dc_failover(false)
+                .build(),
+            NodeLocationPreference::Datacenter("dc9".to_owned()),
+        ),
+        token_aware_expectation(false, Some(dc_preference("dc1")))
+    );
+
+    // Including when it is an explicit "no preference", which also makes
+    // `fallback-to-non-preferred-nodes` true despite failover being off.
+    assert_eq!(
+        load_balancing_report(
+            DefaultPolicy::builder()
+                .prefer_no_datacenter()
+                .permit_dc_failover(false)
+                .build(),
+            NodeLocationPreference::Datacenter("dc9".to_owned()),
+        ),
+        unconfined
+    );
+
+    // An empty datacenter name leaves nothing expressible to report.
+    let empty_datacenters = [
+        NodeLocationPreference::Datacenter(String::new()),
+        NodeLocationPreference::DatacenterAndRack(String::new(), "rack1".to_owned()),
+        NodeLocationPreference::DatacenterAndRack(String::new(), String::new()),
+    ];
+
+    for preference in empty_datacenters {
+        assert_eq!(
+            load_balancing_report(
+                DefaultPolicy::builder().permit_dc_failover(false).build(),
+                preference,
+            ),
+            unconfined
+        );
+    }
+
+    // An empty rack name drops only the rack half: the datacenter still
+    // confines routing, so it is reported and `permit_dc_failover` decides
+    // `fallback-to-non-preferred-nodes` exactly as for a plain datacenter
+    // preference.
+    for (permit_dc_failover, fallback) in [(false, false), (true, true)] {
+        assert_eq!(
+            load_balancing_report(
+                DefaultPolicy::builder()
+                    .permit_dc_failover(permit_dc_failover)
+                    .build(),
+                NodeLocationPreference::DatacenterAndRack("dc1".to_owned(), String::new()),
+            ),
+            token_aware_expectation(fallback, Some(dc_preference("dc1")))
+        );
+    }
+}
+
+/// Anything that is not a token-aware `DefaultPolicy` is named by its own
+/// [`LoadBalancingPolicy::name`], which is user-implemented and may be
+/// empty - and an empty `name` is not a value the schema accepts.
+#[test]
+fn custom_load_balancing_policies_are_reported_by_name() {
+    let named: [(Arc<dyn LoadBalancingPolicy>, &str); 3] = [
+        (
+            ForeignLoadBalancingPolicy::new("ForeignPolicy"),
+            "ForeignPolicy",
+        ),
+        // An empty name would fail the schema's `nonEmptyString`.
+        (ForeignLoadBalancingPolicy::new(""), "unknown"),
+        (
+            SingleTargetLoadBalancingPolicy::new(NodeIdentifier::HostId(Uuid::nil()), None),
+            "SingleTargetLoadBalancingPolicy",
+        ),
+    ];
+
+    for (policy, name) in named {
+        assert_eq!(
+            load_balancing_report(policy, NodeLocationPreference::Any),
+            serde_json::json!({"policy": {"type": "custom", "name": name}})
+        );
+    }
 }

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -1,8 +1,344 @@
-use super::{DriverConfigReporter, MAX_REPORT_SIZE};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::Value;
+
+use super::{DriverConfigReporter, MAX_REPORT_SIZE, non_negative_millis, positive_millis};
+use crate::client::session::SessionConfig;
+use crate::cluster::metadata::Peer;
+use crate::network::PoolSize;
+use crate::policies::host_filter::{
+    AcceptAllHostFilter, AllowListHostFilter, DcHostFilter, HostFilter,
+};
+use crate::policies::reconnect::{
+    ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy, ReconnectPolicySession,
+};
+
+/// A reconnection policy the driver cannot recognise: it keeps the trait's
+/// introspection defaults, so it is neither downcastable nor named.
+///
+/// This and its three siblings below are what drive the schema's `custom`
+/// branches. They are declared once here rather than per test, so that the
+/// name each is reported under - its own type name, via
+/// `policies::simple_type_name` - is written down in one place.
+#[derive(Debug)]
+struct ForeignReconnectPolicy;
+
+impl ReconnectPolicy for ForeignReconnectPolicy {
+    fn new_session(&self) -> Box<dyn ReconnectPolicySession> {
+        unimplemented!("the report never runs the policy")
+    }
+}
+
+/// A host filter that states no location, so that the report has nothing to
+/// derive `connection.node-preference` from.
+struct ForeignHostFilter;
+
+impl HostFilter for ForeignHostFilter {
+    fn accept(&self, _peer: &Peer) -> bool {
+        true
+    }
+}
+
+/// The value the report carries at `pointer`.
+///
+/// Assertions on one group of the document go through this rather than
+/// through substring surgery on the serialized report. A group is delimited
+/// by whichever key happens to follow it, so slicing one out by hand breaks
+/// as soon as a key is added or reordered - and breaks by matching a
+/// different span, not by failing to match. Key order is pinned by the
+/// whole-report assertions instead, which is the one place it belongs.
+fn group(report: &str, pointer: &str) -> serde_json::Value {
+    optional_group(report, pointer)
+        .unwrap_or_else(|| panic!("the report has nothing at {pointer}: {report}"))
+}
+
+/// [`group`], for a group the report may legitimately omit.
+fn optional_group(report: &str, pointer: &str) -> Option<serde_json::Value> {
+    let report: serde_json::Value = serde_json::from_str(report).unwrap();
+    report.pointer(pointer).cloned()
+}
+
+/// The `node-preference` group naming a datacenter. The schema shares one
+/// definition between `connection.node-preference`, which a host filter
+/// feeds, and `query.load-balancing.node-preference`, which the load
+/// balancing policy does, so the tests of both share this.
+fn dc_preference(local_dc: &str) -> serde_json::Value {
+    serde_json::json!({"type": "dc", "local-dc": local_dc})
+}
+
+/// `report` with each `find` replaced by its `with`.
+///
+/// The tests below that pin a whole document mostly differ from
+/// [`DEFAULT_REPORT`] or [`CUSTOMISED_REPORT`] in a key or two, and saying
+/// which keys those are is the point of the test; restating a kilobyte of
+/// JSON leaves a reader to find the difference by eye. Each substring must
+/// occur exactly once, so that a patch matching nothing - or matching
+/// somewhere else as well - fails here instead of quietly asserting
+/// something other than what it reads as.
+fn patched(report: &str, patches: &[(&str, &str)]) -> String {
+    let mut report = report.to_owned();
+    for (find, with) in patches {
+        assert_eq!(
+            report.matches(find).count(),
+            1,
+            "{find} does not occur exactly once in {report}"
+        );
+        report = report.replace(find, with);
+    }
+    report
+}
+
+/// The report of an unconfigured session against a ScyllaDB target, spelled
+/// out in full: the one document key order is pinned on, and the baseline
+/// the single-axis cases below are expressed as patches of.
+const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}}}"#;
+
+fn reporter(config: &SessionConfig) -> DriverConfigReporter {
+    reporter_with_policy(config, Arc::new(ExponentialReconnectPolicy::new()))
+}
+
+fn reporter_with_policy(
+    config: &SessionConfig,
+    policy: Arc<dyn ReconnectPolicy>,
+) -> DriverConfigReporter {
+    DriverConfigReporter::new(config, config.tcp_socket_options(), policy)
+}
 
 #[test]
-fn default_report_is_minimal() {
-    let report = DriverConfigReporter::new().report(true).unwrap();
-    assert_eq!(report, r#"{"version":1}"#);
-    assert!(report.len() < MAX_REPORT_SIZE / 100);
+fn default_configuration_report() {
+    let report = reporter(&SessionConfig::new()).report(true).unwrap();
+    assert_eq!(report, DEFAULT_REPORT);
+    assert!(report.len() < MAX_REPORT_SIZE / 10);
+}
+
+/// A per-host pool never dials the shard-aware port, whatever
+/// `disallow_shard_aware_port` says.
+#[test]
+fn shard_aware_port_is_not_reported_as_enabled_for_a_per_host_pool() {
+    let mut config = SessionConfig::new();
+    config.disallow_shard_aware_port = false;
+    config.connection_pool_size = PoolSize::PerHost(NonZeroUsize::new(2).unwrap());
+
+    let report = reporter(&config).report(true).unwrap();
+    assert_eq!(
+        group(&report, "/connection/pool/shard-aware"),
+        serde_json::json!({"enabled": false})
+    );
+}
+
+/// Zero values are where the schema's `positiveInteger` keys can go invalid.
+/// A zero buffer size cannot be expressed and is dropped; a zero connect
+/// timeout is a real timeout and reports the schema minimum; `linger` is
+/// `nonNegativeInteger`, so its 0 is reported verbatim.
+#[test]
+fn zero_valued_configuration_report() {
+    let mut config = SessionConfig::new();
+    config.connect_timeout = Duration::ZERO;
+    config.tcp_recv_buffer_size = Some(0);
+    config.tcp_linger = Some(Duration::ZERO);
+
+    assert_eq!(
+        reporter(&config).report(true).unwrap(),
+        patched(
+            DEFAULT_REPORT,
+            &[
+                (r#""timeout-ms":5000"#, r#""timeout-ms":1"#),
+                (
+                    r#""reuse-address":false"#,
+                    r#""reuse-address":false,"linger":{"interval-s":0}"#,
+                ),
+            ],
+        )
+    );
+}
+
+/// Everything the customised configuration below shares with
+/// [`tls_is_reported_as_an_empty_object`], which needs a TLS backend and so
+/// must be feature-gated as a whole.
+fn customised_config() -> SessionConfig {
+    let mut config = SessionConfig::new();
+    config.connect_timeout = Duration::from_millis(1234);
+    config.tcp_nodelay = false;
+    config.tcp_keepalive_interval = Some(Duration::from_secs(30));
+    config.tcp_recv_buffer_size = Some(65536);
+    config.tcp_send_buffer_size = Some(32768);
+    config.tcp_reuse_address = Some(true);
+    config.tcp_linger = Some(Duration::from_secs(7));
+    config.disallow_shard_aware_port = true;
+    config.host_filter = Some(Arc::new(DcHostFilter::new("dc1".to_owned())));
+    config
+}
+
+fn customised_report(config: &SessionConfig) -> String {
+    reporter_with_policy(
+        config,
+        Arc::new(ConstantReconnectPolicy::new(Duration::from_millis(250))),
+    )
+    .report(true)
+    .unwrap()
+}
+
+/// The report of [`customised_config`], the second document spelled out in
+/// full: nearly every key of it differs from [`DEFAULT_REPORT`], so there is
+/// no difference to point at.
+const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}}}"#;
+
+#[test]
+fn fully_customised_configuration_report() {
+    assert_eq!(customised_report(&customised_config()), CUSTOMISED_REPORT);
+}
+
+/// Needs a TLS backend to build a `TlsContext` at all, hence the gate.
+#[cfg(feature = "openssl-010")]
+#[test]
+fn tls_is_reported_as_an_empty_object() {
+    use openssl::ssl::{SslContextBuilder, SslMethod};
+
+    let mut config = customised_config();
+    config.tls_context = Some(
+        SslContextBuilder::new(SslMethod::tls())
+            .unwrap()
+            .build()
+            .into(),
+    );
+
+    assert_eq!(
+        customised_report(&config),
+        patched(
+            CUSTOMISED_REPORT,
+            &[(r#""local-dc":"dc1"}}"#, r#""local-dc":"dc1"},"tls":{}}"#)],
+        )
+    );
+}
+
+/// Every reconnection policy the report has a branch for, named, with the
+/// `connection.reconnection.policy` object it must be reported as.
+///
+/// This and the three tables below are each read twice: by the test pinning
+/// the objects, and by [`conformance_configurations`], which puts the same
+/// policies through the schema. Listing them once is what keeps a policy
+/// added to one of those from being missed by the other.
+fn reconnection_policies() -> [(&'static str, Arc<dyn ReconnectPolicy>, Value); 4] {
+    [
+        (
+            "default exponential reconnection",
+            Arc::new(ExponentialReconnectPolicy::new()),
+            serde_json::json!({"type": "exponential", "base-ms": 50, "max-ms": 10000}),
+        ),
+        (
+            // Both bounds sub-millisecond, so both floor to the schema
+            // minimum of 1 rather than to the 0 `as_millis` would give.
+            "sub-millisecond exponential reconnection",
+            Arc::new(
+                ExponentialReconnectPolicy::new()
+                    .with_backoff_limits(Duration::from_micros(1), Duration::from_micros(2)),
+            ),
+            serde_json::json!({"type": "exponential", "base-ms": 1, "max-ms": 1}),
+        ),
+        (
+            "zero constant reconnection",
+            Arc::new(ConstantReconnectPolicy::new(Duration::ZERO)),
+            serde_json::json!({"type": "constant", "delay-ms": 0}),
+        ),
+        (
+            "foreign reconnection policy",
+            Arc::new(ForeignReconnectPolicy),
+            serde_json::json!({"type": "custom", "name": "ForeignReconnectPolicy"}),
+        ),
+    ]
+}
+
+#[test]
+fn reconnection_policy_variants() {
+    let config = SessionConfig::new();
+
+    for (name, policy, expected) in reconnection_policies() {
+        let report = reporter_with_policy(&config, policy).report(true).unwrap();
+        assert_eq!(
+            group(&report, "/connection/reconnection/policy"),
+            expected,
+            "{name}"
+        );
+    }
+}
+
+/// [`reconnection_policies`] for the host filters, with the
+/// `connection.node-preference` group each must be reported as. Only
+/// [`DcHostFilter`] states a location at all, and only a non-empty
+/// datacenter name is expressible.
+fn host_filters() -> [(&'static str, Arc<dyn HostFilter>, Option<Value>); 5] {
+    [
+        (
+            "dc host filter",
+            Arc::new(DcHostFilter::new("dc1".to_owned())),
+            Some(dc_preference("dc1")),
+        ),
+        (
+            "empty dc host filter",
+            Arc::new(DcHostFilter::new(String::new())),
+            None,
+        ),
+        (
+            "allow list host filter",
+            Arc::new(AllowListHostFilter::new(["127.0.0.1:9042"]).unwrap()),
+            None,
+        ),
+        (
+            "accept all host filter",
+            Arc::new(AcceptAllHostFilter),
+            None,
+        ),
+        ("foreign host filter", Arc::new(ForeignHostFilter), None),
+    ]
+}
+
+#[test]
+fn node_preference_follows_the_host_filter() {
+    for (name, filter, expected) in host_filters() {
+        let mut config = SessionConfig::new();
+        config.host_filter = Some(filter);
+        let report = reporter(&config).report(true).unwrap();
+        assert_eq!(
+            optional_group(&report, "/connection/node-preference"),
+            expected,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn millisecond_helpers_handle_zero_and_sub_millisecond_durations() {
+    assert_eq!(positive_millis(Duration::from_nanos(1)), 1);
+    assert_eq!(positive_millis(Duration::ZERO), 1);
+    assert_eq!(positive_millis(Duration::from_millis(7)), 7);
+    assert_eq!(non_negative_millis(Duration::ZERO), 0);
+    assert_eq!(non_negative_millis(Duration::from_nanos(1)), 0);
+}
+
+/// `interval-s` truncates rather than flooring at 1 like the report's
+/// `positiveInteger` keys do, and that is not an oversight: `SO_LINGER`
+/// carries whole seconds too, and `apply_socket_options` sets it through
+/// `socket2`, whose `into_linger` truncates with the same `as_secs`. So a
+/// sub-second linger really does reach the kernel as the abortive close that
+/// a reported 0 describes, and reporting 1 would name a lingering close the
+/// socket never performs.
+#[test]
+fn sub_second_linger_is_reported_as_zero() {
+    let linger = |linger: Duration| {
+        let mut config = SessionConfig::new();
+        config.tcp_linger = Some(linger);
+        let report = reporter(&config).report(true).unwrap();
+        group(&report, "/connection/socket/linger")
+    };
+
+    let abortive = serde_json::json!({"interval-s": 0});
+    assert_eq!(linger(Duration::ZERO), abortive);
+    assert_eq!(linger(Duration::from_millis(1)), abortive);
+    assert_eq!(linger(Duration::from_millis(999)), abortive);
+    assert_eq!(
+        linger(Duration::from_millis(1999)),
+        serde_json::json!({"interval-s": 1})
+    );
 }

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -15,6 +15,10 @@ use crate::policies::host_filter::{
 use crate::policies::reconnect::{
     ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy, ReconnectPolicySession,
 };
+use crate::policies::retry::{
+    DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy, RetryPolicy,
+    RetrySession,
+};
 use crate::policies::timestamp_generator::SimpleTimestampGenerator;
 use crate::statement::{Consistency, SerialConsistency};
 
@@ -65,6 +69,15 @@ struct ForeignHostFilter;
 impl HostFilter for ForeignHostFilter {
     fn accept(&self, _peer: &Peer) -> bool {
         true
+    }
+}
+
+#[derive(Debug)]
+struct ForeignRetryPolicy;
+
+impl RetryPolicy for ForeignRetryPolicy {
+    fn new_session(&self) -> Box<dyn RetrySession> {
+        unimplemented!("the report never runs the policy")
     }
 }
 
@@ -120,7 +133,7 @@ fn patched(report: &str, patches: &[(&str, &str)]) -> String {
 /// The report of an unconfigured session against a ScyllaDB target, spelled
 /// out in full: the one document key order is pinned on, and the baseline
 /// the single-axis cases below are expressed as patches of.
-const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"LOCAL_QUORUM","serial-consistency":"LOCAL_SERIAL","idempotence":false,"client-timestamps":false,"page":{"size":5000},"request":{"timeout-ms":30000}}}}"#;
+const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"LOCAL_QUORUM","serial-consistency":"LOCAL_SERIAL","idempotence":false,"client-timestamps":false,"page":{"size":5000},"request":{"timeout-ms":30000}},"retry":{"policy":{"type":"standard-error-aware"}}}}"#;
 
 fn reporter(config: &SessionConfig) -> DriverConfigReporter {
     reporter_with_policy(config, Arc::new(ExponentialReconnectPolicy::new()))
@@ -205,6 +218,7 @@ fn customised_config() -> SessionConfig {
         .consistency(Consistency::Quorum)
         .serial_consistency(Some(SerialConsistency::Serial))
         .request_timeout(Some(Duration::from_millis(1500)))
+        .retry_policy(Arc::new(DowngradingConsistencyRetryPolicy::new()))
         .build()
         .into_handle();
     config
@@ -222,7 +236,7 @@ fn customised_report(config: &SessionConfig) -> String {
 /// The report of [`customised_config`], the second document spelled out in
 /// full: nearly every key of it differs from [`DEFAULT_REPORT`], so there is
 /// no difference to point at.
-const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"QUORUM","serial-consistency":"SERIAL","idempotence":false,"client-timestamps":true,"page":{"size":5000},"request":{"timeout-ms":1500}}}}"#;
+const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"QUORUM","serial-consistency":"SERIAL","idempotence":false,"client-timestamps":true,"page":{"size":5000},"request":{"timeout-ms":1500}},"retry":{"policy":{"type":"downgrading-consistency"}}}}"#;
 
 #[test]
 fn fully_customised_configuration_report() {
@@ -470,6 +484,7 @@ fn remapping_the_default_profile_changes_the_report() {
                 "page": {"size": 5000},
                 "request": {"timeout-ms": 30000},
             },
+            "retry": {"policy": {"type": "standard-error-aware"}},
         })
     );
 
@@ -478,6 +493,7 @@ fn remapping_the_default_profile_changes_the_report() {
             .consistency(Consistency::EachQuorum)
             .serial_consistency(Some(SerialConsistency::Serial))
             .request_timeout(Some(Duration::from_secs(3)))
+            .retry_policy(Arc::new(FallthroughRetryPolicy::new()))
             .build(),
     );
 
@@ -494,8 +510,45 @@ fn remapping_the_default_profile_changes_the_report() {
                 "page": {"size": 5000},
                 "request": {"timeout-ms": 3000},
             },
+            "retry": {"policy": {"type": "fallthrough"}},
         })
     );
+}
+
+/// [`reconnection_policies`] for the retry policies, with the `query.retry`
+/// group each must be reported as.
+fn retry_policies() -> [(&'static str, Arc<dyn RetryPolicy>, Value); 4] {
+    [
+        (
+            "default retry",
+            Arc::new(DefaultRetryPolicy::new()),
+            serde_json::json!({"policy": {"type": "standard-error-aware"}}),
+        ),
+        (
+            "fallthrough retry",
+            Arc::new(FallthroughRetryPolicy::new()),
+            serde_json::json!({"policy": {"type": "fallthrough"}}),
+        ),
+        (
+            "downgrading consistency retry",
+            Arc::new(DowngradingConsistencyRetryPolicy::new()),
+            serde_json::json!({"policy": {"type": "downgrading-consistency"}}),
+        ),
+        (
+            "foreign retry policy",
+            Arc::new(ForeignRetryPolicy),
+            serde_json::json!({"policy": {"type": "custom", "name": "ForeignRetryPolicy"}}),
+        ),
+    ]
+}
+
+#[test]
+fn retry_policy_variants() {
+    for (name, policy, expected) in retry_policies() {
+        let profile = ExecutionProfile::builder().retry_policy(policy).build();
+        let report = reporter_with_profile(profile).report(true).unwrap();
+        assert_eq!(group(&report, "/query/retry"), expected, "{name}");
+    }
 }
 
 /// The schema's consistency enums are SCREAMING_SNAKE, which neither

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -1,0 +1,8 @@
+use super::{DriverConfigReporter, MAX_REPORT_SIZE};
+
+#[test]
+fn default_report_is_minimal() {
+    let report = DriverConfigReporter::new().report(true).unwrap();
+    assert_eq!(report, r#"{"version":1}"#);
+    assert!(report.len() < MAX_REPORT_SIZE / 100);
+}

--- a/scylla/src/client/driver_config_tests.rs
+++ b/scylla/src/client/driver_config_tests.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use serde_json::Value;
 
 use super::{DriverConfigReporter, MAX_REPORT_SIZE, non_negative_millis, positive_millis};
+use crate::client::execution_profile::ExecutionProfile;
 use crate::client::session::SessionConfig;
 use crate::cluster::metadata::Peer;
 use crate::network::PoolSize;
@@ -14,6 +15,32 @@ use crate::policies::host_filter::{
 use crate::policies::reconnect::{
     ConstantReconnectPolicy, ExponentialReconnectPolicy, ReconnectPolicy, ReconnectPolicySession,
 };
+use crate::policies::timestamp_generator::SimpleTimestampGenerator;
+use crate::statement::{Consistency, SerialConsistency};
+
+/// Every consistency level the schema enumerates, with the SCREAMING_SNAKE
+/// name it must be reported under. Shared by the test pinning the mapping
+/// and the sweep validating the names against the schema's own enum, so the
+/// two cannot come to disagree about which levels exist.
+const CONSISTENCY_NAMES: [(Consistency, &str); 11] = [
+    (Consistency::Any, "ANY"),
+    (Consistency::One, "ONE"),
+    (Consistency::Two, "TWO"),
+    (Consistency::Three, "THREE"),
+    (Consistency::Quorum, "QUORUM"),
+    (Consistency::All, "ALL"),
+    (Consistency::LocalQuorum, "LOCAL_QUORUM"),
+    (Consistency::EachQuorum, "EACH_QUORUM"),
+    (Consistency::LocalOne, "LOCAL_ONE"),
+    (Consistency::Serial, "SERIAL"),
+    (Consistency::LocalSerial, "LOCAL_SERIAL"),
+];
+
+/// [`CONSISTENCY_NAMES`] for the serial levels.
+const SERIAL_CONSISTENCY_NAMES: [(SerialConsistency, &str); 2] = [
+    (SerialConsistency::Serial, "SERIAL"),
+    (SerialConsistency::LocalSerial, "LOCAL_SERIAL"),
+];
 
 /// A reconnection policy the driver cannot recognise: it keeps the trait's
 /// introspection defaults, so it is neither downcastable nor named.
@@ -93,7 +120,7 @@ fn patched(report: &str, patches: &[(&str, &str)]) -> String {
 /// The report of an unconfigured session against a ScyllaDB target, spelled
 /// out in full: the one document key order is pinned on, and the baseline
 /// the single-axis cases below are expressed as patches of.
-const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}}}"#;
+const DEFAULT_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":5000},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":true}},"socket":{"tcp-no-delay":true,"keep-alive":false,"reuse-address":false},"reconnection":{"policy":{"type":"exponential","base-ms":50,"max-ms":10000}}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"LOCAL_QUORUM","serial-consistency":"LOCAL_SERIAL","idempotence":false,"client-timestamps":false,"page":{"size":5000},"request":{"timeout-ms":30000}}}}"#;
 
 fn reporter(config: &SessionConfig) -> DriverConfigReporter {
     reporter_with_policy(config, Arc::new(ExponentialReconnectPolicy::new()))
@@ -173,6 +200,13 @@ fn customised_config() -> SessionConfig {
     config.tcp_linger = Some(Duration::from_secs(7));
     config.disallow_shard_aware_port = true;
     config.host_filter = Some(Arc::new(DcHostFilter::new("dc1".to_owned())));
+    config.timestamp_generator = Some(Arc::new(SimpleTimestampGenerator::new()));
+    config.default_execution_profile_handle = ExecutionProfile::builder()
+        .consistency(Consistency::Quorum)
+        .serial_consistency(Some(SerialConsistency::Serial))
+        .request_timeout(Some(Duration::from_millis(1500)))
+        .build()
+        .into_handle();
     config
 }
 
@@ -188,7 +222,7 @@ fn customised_report(config: &SessionConfig) -> String {
 /// The report of [`customised_config`], the second document spelled out in
 /// full: nearly every key of it differs from [`DEFAULT_REPORT`], so there is
 /// no difference to point at.
-const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}}}"#;
+const CUSTOMISED_REPORT: &str = r#"{"version":1,"connection":{"connect":{"timeout-ms":1234},"requests":{"in-flight":{"max":32768},"orphaned":{"max":1024}},"pool":{"shard-aware":{"enabled":false}},"socket":{"tcp-no-delay":false,"keep-alive":true,"reuse-address":true,"linger":{"interval-s":7},"receive-buffer":{"size-bytes":65536},"send-buffer":{"size-bytes":32768}},"reconnection":{"policy":{"type":"constant","delay-ms":250}},"node-preference":{"type":"dc","local-dc":"dc1"}},"control-plane":{"queries":{"system":{"timeout":{"client-side-ms":31000,"server-side-ms":30000}}},"schema":{"agreement":{"timeout-ms":60000}}},"query":{"defaults":{"consistency":"QUORUM","serial-consistency":"SERIAL","idempotence":false,"client-timestamps":true,"page":{"size":5000},"request":{"timeout-ms":1500}}}}"#;
 
 #[test]
 fn fully_customised_configuration_report() {
@@ -405,5 +439,109 @@ fn sub_second_linger_is_reported_as_zero() {
     assert_eq!(
         linger(Duration::from_millis(1999)),
         serde_json::json!({"interval-s": 1})
+    );
+}
+
+fn reporter_with_profile(profile: ExecutionProfile) -> DriverConfigReporter {
+    let mut config = SessionConfig::new();
+    config.default_execution_profile_handle = profile.into_handle();
+    reporter(&config)
+}
+
+/// The profile is read at report time, so remapping the handle a session was
+/// built with must change what the next report says. Nothing would otherwise
+/// stop the report from describing a profile the session no longer uses.
+#[test]
+fn remapping_the_default_profile_changes_the_report() {
+    let mut handle = ExecutionProfile::builder().build().into_handle();
+    let mut config = SessionConfig::new();
+    config.default_execution_profile_handle = handle.clone();
+    let reporter = reporter(&config);
+
+    let before = reporter.report(true).unwrap();
+    assert_eq!(
+        group(&before, "/query"),
+        serde_json::json!({
+            "defaults": {
+                "consistency": "LOCAL_QUORUM",
+                "serial-consistency": "LOCAL_SERIAL",
+                "idempotence": false,
+                "client-timestamps": false,
+                "page": {"size": 5000},
+                "request": {"timeout-ms": 30000},
+            },
+        })
+    );
+
+    handle.map_to_another_profile(
+        ExecutionProfile::builder()
+            .consistency(Consistency::EachQuorum)
+            .serial_consistency(Some(SerialConsistency::Serial))
+            .request_timeout(Some(Duration::from_secs(3)))
+            .build(),
+    );
+
+    let after = reporter.report(true).unwrap();
+    assert_ne!(before, after);
+    assert_eq!(
+        group(&after, "/query"),
+        serde_json::json!({
+            "defaults": {
+                "consistency": "EACH_QUORUM",
+                "serial-consistency": "SERIAL",
+                "idempotence": false,
+                "client-timestamps": false,
+                "page": {"size": 5000},
+                "request": {"timeout-ms": 3000},
+            },
+        })
+    );
+}
+
+/// The schema's consistency enums are SCREAMING_SNAKE, which neither
+/// `Display` nor `Debug` produces, so every name is spelled out by hand -
+/// and every one of them is checked here, both levels being an exhaustive
+/// match that a variant added upstream must fail to compile against.
+#[test]
+fn consistency_names_follow_the_schema() {
+    for (level, name) in CONSISTENCY_NAMES {
+        let profile = ExecutionProfile::builder().consistency(level).build();
+        let report = reporter_with_profile(profile).report(true).unwrap();
+        assert_eq!(
+            group(&report, "/query/defaults/consistency"),
+            serde_json::json!(name)
+        );
+    }
+
+    for (level, name) in SERIAL_CONSISTENCY_NAMES {
+        let profile = ExecutionProfile::builder()
+            .serial_consistency(Some(level))
+            .build();
+        let report = reporter_with_profile(profile).report(true).unwrap();
+        assert_eq!(
+            group(&report, "/query/defaults/serial-consistency"),
+            serde_json::json!(name)
+        );
+    }
+}
+
+/// Both keys the schema leaves optional: an unset serial consistency drops
+/// its key, a disabled request timeout drops the whole `request` object.
+#[test]
+fn unset_query_defaults_are_omitted() {
+    let profile = ExecutionProfile::builder()
+        .serial_consistency(None)
+        .request_timeout(None)
+        .build();
+
+    let report = reporter_with_profile(profile).report(true).unwrap();
+    assert_eq!(
+        group(&report, "/query/defaults"),
+        serde_json::json!({
+            "consistency": "LOCAL_QUORUM",
+            "idempotence": false,
+            "client-timestamps": false,
+            "page": {"size": 5000},
+        })
     );
 }

--- a/scylla/src/client/mod.rs
+++ b/scylla/src/client/mod.rs
@@ -19,6 +19,8 @@ pub mod execution_profile;
 
 mod execution;
 
+pub(crate) mod driver_config;
+
 pub mod pager;
 
 pub mod client_routes;

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -8,6 +8,7 @@ use super::pager::QueryPager;
 use super::{Compression, PoolSize, SelfIdentity, WriteCoalescingDelay};
 use crate::authentication::AuthenticatorProvider;
 use crate::client::client_routes::ClientRoutesConfig;
+use crate::client::driver_config::DriverConfigReporter;
 use crate::client::execution::{
     NodeAttemptTarget, RequestExecutionOutcome, RequestExecutionParams, RunRequestResult,
     choose_tablet_block_hint,
@@ -1397,6 +1398,8 @@ impl Session {
 
         let tcp_socket_options = config.tcp_socket_options();
 
+        let driver_config_reporter = Some(Arc::new(DriverConfigReporter::new()));
+
         let node_location_preference = config.node_location_preference;
         let known_nodes = config.known_nodes;
 
@@ -1441,6 +1444,10 @@ impl Session {
             tablet_sender: Some(tablet_sender),
             identity: config.identity,
             session_id,
+            // Pool connections do not report the configuration: only the control
+            // connection's config gets the reporter, in
+            // `ControlConnectionEstablisher::new`.
+            driver_config_reporter: None,
         };
 
         let pool_config = PoolConfig {
@@ -1486,6 +1493,7 @@ impl Session {
         let cluster = Cluster::new(
             known_nodes,
             pool_config,
+            driver_config_reporter,
             config.keyspaces_to_fetch,
             schema_metadata_fetch_mode,
             MetadataRequestTimeouts {

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -36,9 +36,7 @@ use crate::observability::tracing::TracingInfo;
 use crate::policies::address_translator::AddressTranslator;
 use crate::policies::host_filter::HostFilter;
 use crate::policies::load_balancing::{self, RoutingInfo};
-use crate::policies::reconnect::ExponentialReconnectPolicy;
-#[cfg(all(scylla_unstable, feature = "unstable-reconnect-policy"))]
-use crate::policies::reconnect::ReconnectPolicy;
+use crate::policies::reconnect::{ExponentialReconnectPolicy, ReconnectPolicy};
 use crate::policies::timestamp_generator::TimestampGenerator;
 use crate::response::query_result::{MaybeFirstRowError, QueryResult, RowsError};
 use crate::response::{
@@ -579,6 +577,19 @@ impl Default for SessionConfig {
 }
 
 impl SessionConfig {
+    /// The socket options connections are opened with, mapping the individual
+    /// `tcp_*` fields in one place rather than at the use site.
+    pub(crate) fn tcp_socket_options(&self) -> TcpSocketOptions {
+        TcpSocketOptions {
+            nodelay: self.tcp_nodelay,
+            keepalive_interval: self.tcp_keepalive_interval,
+            recv_buffer_size: self.tcp_recv_buffer_size,
+            send_buffer_size: self.tcp_send_buffer_size,
+            reuse_address: self.tcp_reuse_address,
+            linger: self.tcp_linger,
+        }
+    }
+
     /// [SessionConfig] may unfortunately represent invalid configurations. We need to rule them out
     /// at runtime by running validation.
     fn validate(&self) -> Result<(), NewSessionError> {
@@ -1370,6 +1381,22 @@ impl Session {
 
         let session_id = Uuid::new_v4();
 
+        // The policy the connection pools will actually use. Derived here
+        // because without the unstable feature the configuration carries no
+        // policy at all and a default stands in for it.
+        let reconnect_policy: Arc<dyn ReconnectPolicy> = {
+            #[cfg(all(scylla_unstable, feature = "unstable-reconnect-policy"))]
+            {
+                Arc::clone(&config.reconnect_policy)
+            }
+            #[cfg(not(all(scylla_unstable, feature = "unstable-reconnect-policy")))]
+            {
+                Arc::new(ExponentialReconnectPolicy::new())
+            }
+        };
+
+        let tcp_socket_options = config.tcp_socket_options();
+
         let node_location_preference = config.node_location_preference;
         let known_nodes = config.known_nodes;
 
@@ -1398,14 +1425,7 @@ impl Session {
             local_ip_address: config.local_ip_address,
             shard_aware_local_port_range: config.shard_aware_local_port_range,
             compression: config.compression,
-            tcp_socket_options: TcpSocketOptions {
-                nodelay: config.tcp_nodelay,
-                keepalive_interval: config.tcp_keepalive_interval,
-                recv_buffer_size: config.tcp_recv_buffer_size,
-                send_buffer_size: config.tcp_send_buffer_size,
-                reuse_address: config.tcp_reuse_address,
-                linger: config.tcp_linger,
-            },
+            tcp_socket_options,
             timestamp_generator: config.timestamp_generator,
             tls_provider,
             authenticator: config.authenticator,
@@ -1427,10 +1447,7 @@ impl Session {
             connection_config,
             pool_size: config.connection_pool_size,
             can_use_shard_aware_port: !config.disallow_shard_aware_port,
-            #[cfg(all(scylla_unstable, feature = "unstable-reconnect-policy"))]
-            reconnect_policy: config.reconnect_policy,
-            #[cfg(not(all(scylla_unstable, feature = "unstable-reconnect-policy")))]
-            reconnect_policy: Arc::new(ExponentialReconnectPolicy::new()),
+            reconnect_policy,
         };
 
         let metrics = Arc::new(Metrics::new());

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -599,6 +599,15 @@ impl SessionConfig {
         }
     }
 
+    /// The timeouts applied to requests on the control connection, mapping the
+    /// two override fields in one place rather than at the use site.
+    pub(crate) fn metadata_request_timeouts(&self) -> MetadataRequestTimeouts {
+        MetadataRequestTimeouts {
+            serverside_override: self.metadata_request_serverside_timeout,
+            clientside_override: self.metadata_request_clientside_timeout,
+        }
+    }
+
     /// [SessionConfig] may unfortunately represent invalid configurations. We need to rule them out
     /// at runtime by running validation.
     fn validate(&self) -> Result<(), NewSessionError> {
@@ -1406,6 +1415,8 @@ impl Session {
 
         let tcp_socket_options = config.tcp_socket_options();
 
+        let metadata_request_timeouts = config.metadata_request_timeouts();
+
         let driver_config_reporter = config.driver_config_reporting.then(|| {
             Arc::new(DriverConfigReporter::new(
                 &config,
@@ -1510,10 +1521,7 @@ impl Session {
             driver_config_reporter,
             config.keyspaces_to_fetch,
             schema_metadata_fetch_mode,
-            MetadataRequestTimeouts {
-                serverside_override: config.metadata_request_serverside_timeout,
-                clientside_override: config.metadata_request_clientside_timeout,
-            },
+            metadata_request_timeouts,
             config.hostname_resolution_timeout,
             config.host_filter,
             host_listener,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -599,8 +599,8 @@ impl SessionConfig {
         }
     }
 
-    /// The timeouts applied to requests on the control connection, mapping the
-    /// two override fields in one place rather than at the use site.
+    /// The timeouts applied to requests on the control connection. Single source
+    /// of the mapping, so that the configuration report cannot drift from it.
     pub(crate) fn metadata_request_timeouts(&self) -> MetadataRequestTimeouts {
         MetadataRequestTimeouts {
             serverside_override: self.metadata_request_serverside_timeout,
@@ -1422,6 +1422,7 @@ impl Session {
                 &config,
                 tcp_socket_options.clone(),
                 Arc::clone(&reconnect_policy),
+                metadata_request_timeouts,
             ))
         });
 

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -1406,9 +1406,13 @@ impl Session {
 
         let tcp_socket_options = config.tcp_socket_options();
 
-        let driver_config_reporter = config
-            .driver_config_reporting
-            .then(|| Arc::new(DriverConfigReporter::new()));
+        let driver_config_reporter = config.driver_config_reporting.then(|| {
+            Arc::new(DriverConfigReporter::new(
+                &config,
+                tcp_socket_options.clone(),
+                Arc::clone(&reconnect_policy),
+            ))
+        });
 
         let node_location_preference = config.node_location_preference;
         let known_nodes = config.known_nodes;

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -441,6 +441,13 @@ pub struct SessionConfig {
     /// Driver and application self-identifying information,
     /// to be sent to server in STARTUP message.
     pub identity: SelfIdentity<'static>,
+
+    /// Whether the driver describes its effective configuration to the server
+    /// in the `DRIVER_CONFIG` STARTUP option.
+    /// Turn it off if the client's configuration must not be disclosed to the
+    /// cluster. Does not affect `SESSION_ID`, which describes nothing about the
+    /// client.
+    pub driver_config_reporting: bool,
 }
 
 impl SessionConfig {
@@ -503,6 +510,7 @@ impl SessionConfig {
             cluster_metadata_refresh_interval: Duration::from_secs(60),
             periodic_metadata_fetch_mode: PeriodicFetchMode::AffectedKeyspaces,
             identity: SelfIdentity::default(),
+            driver_config_reporting: true,
             #[cfg(feature = "unstable-client-routes")]
             client_routes_config: None,
         }
@@ -1398,7 +1406,9 @@ impl Session {
 
         let tcp_socket_options = config.tcp_socket_options();
 
-        let driver_config_reporter = Some(Arc::new(DriverConfigReporter::new()));
+        let driver_config_reporter = config
+            .driver_config_reporting
+            .then(|| Arc::new(DriverConfigReporter::new()));
 
         let node_location_preference = config.node_location_preference;
         let known_nodes = config.known_nodes;

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1556,10 +1556,11 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// The default is `true`.
     ///
     /// The control connection sends a JSON description of the session's
-    /// configuration - timeouts, connection pooling, load balancing and retry
-    /// policy - as the `DRIVER_CONFIG` option of the STARTUP message, which the
-    /// server exposes in `system.clients.client_options`. The document follows
-    /// a schema shared by all ScyllaDB drivers, so one query answers the question of how
+    /// configuration - timeouts, connection pooling, load balancing, retry and
+    /// speculative execution policies - as the `DRIVER_CONFIG` option of the
+    /// STARTUP message, which the server exposes in
+    /// `system.clients.client_options`. The document follows a schema
+    /// shared by all ScyllaDB drivers, so one query answers the question of how
     /// a client is configured regardless of which driver it uses.
     ///
     /// Disable it if the configuration of the client must not be disclosed to

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -1551,6 +1551,38 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self.config.identity = identity;
         self
     }
+
+    /// Sets whether the driver reports its effective configuration to the server.
+    /// The default is `true`.
+    ///
+    /// The control connection sends a JSON description of the session's
+    /// configuration - timeouts, connection pooling, load balancing and retry
+    /// policy - as the `DRIVER_CONFIG` option of the STARTUP message, which the
+    /// server exposes in `system.clients.client_options`. The document follows
+    /// a schema shared by all ScyllaDB drivers, so one query answers the question of how
+    /// a client is configured regardless of which driver it uses.
+    ///
+    /// Disable it if the configuration of the client must not be disclosed to
+    /// the cluster. This does not affect `SESSION_ID`, which is an opaque UUID
+    /// that describes nothing about the client.
+    ///
+    /// # Example
+    /// ```
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .driver_config_reporting(false)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn driver_config_reporting(mut self, report: bool) -> Self {
+        self.config.driver_config_reporting = report;
+        self
+    }
 }
 
 /// Creates a [`SessionBuilder`] with default configuration, same as [`SessionBuilder::new`]
@@ -1600,6 +1632,19 @@ mod tests {
                 .config
                 .metadata_request_clientside_timeout,
             Some(timeout)
+        );
+    }
+
+    #[test]
+    fn driver_config_reporting() {
+        setup_tracing();
+        assert!(SessionBuilder::new().config.driver_config_reporting);
+
+        assert!(
+            !SessionBuilder::new()
+                .driver_config_reporting(false)
+                .config
+                .driver_config_reporting
         );
     }
 

--- a/scylla/src/cluster/control_connection.rs
+++ b/scylla/src/cluster/control_connection.rs
@@ -49,13 +49,13 @@ pub(crate) struct MetadataRequestTimeouts {
 
 impl MetadataRequestTimeouts {
     /// The server-side timeout override actually in effect.
-    fn serverside(&self, target_is_scylladb: bool) -> Option<Duration> {
+    pub(crate) fn serverside(&self, target_is_scylladb: bool) -> Option<Duration> {
         self.serverside_override.filter(|_| target_is_scylladb)
     }
 
     /// The client-side timeout actually in effect, derived from the configured
     /// server-side timeout unless explicitly overridden.
-    fn clientside(&self) -> Duration {
+    pub(crate) fn clientside(&self) -> Duration {
         self.clientside_override.unwrap_or_else(|| {
             self.serverside_override.map_or(
                 DEFAULT_CLIENTSIDE_TIMEOUT,

--- a/scylla/src/cluster/metadata/cc_establisher.rs
+++ b/scylla/src/cluster/metadata/cc_establisher.rs
@@ -23,6 +23,7 @@ use rand::seq::SliceRandom;
 use tracing::{debug, error, warn};
 
 use crate::client::client_routes::ClientRoutesSubscriber;
+use crate::client::driver_config::DriverConfigReporter;
 use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionCache, ControlConnectionConfig, ControlConnectionEvents,
@@ -45,6 +46,10 @@ pub(crate) struct ControlConnectionEstablisher {
     // =======================================================================================
     // Configuration values - they will stay the same during whole lifetime of ControlConnectionEstablisher.
     // =======================================================================================
+    /// The configuration of every control connection this establisher creates.
+    /// It is the only connection config carrying a
+    /// [`DriverConfigReporter`](crate::client::driver_config::DriverConfigReporter),
+    /// because only control connections report their configuration.
     control_connection_config: ConnectionConfig,
     /// Configuration stamped onto every control connection this establisher creates;
     /// governs what the control connection's metadata queries fetch.
@@ -103,6 +108,7 @@ impl ControlConnectionEstablisher {
         initial_known_nodes: Vec<KnownNode>,
         hostname_resolution_timeout: Option<Duration>,
         connection_config: ConnectionConfig,
+        driver_config_reporter: Option<Arc<DriverConfigReporter>>,
         request_timeouts: MetadataRequestTimeouts,
         keyspaces_to_fetch: Vec<String>,
         schema_metadata_fetch_mode: SchemaMetadataFetchMode,
@@ -121,7 +127,10 @@ impl ControlConnectionEstablisher {
         let cc_cache = Arc::new(ControlConnectionCache::new());
 
         Ok(ControlConnectionEstablisher {
-            control_connection_config: connection_config,
+            control_connection_config: ConnectionConfig {
+                driver_config_reporter,
+                ..connection_config
+            },
             cc_config: ControlConnectionConfig {
                 keyspaces_to_fetch,
                 schema_metadata_fetch_mode,

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -1,6 +1,7 @@
 use crate::client::client_routes::{
     ClientRoutesAddressTranslator, ClientRoutesConfig, ClientRoutesSubscriber,
 };
+use crate::client::driver_config::DriverConfigReporter;
 use crate::client::session::TABLET_CHANNEL_SIZE;
 use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::cluster::metadata::update::{
@@ -64,6 +65,7 @@ impl Cluster {
     pub(crate) async fn new(
         known_nodes: Vec<KnownNode>,
         mut pool_config: PoolConfig,
+        driver_config_reporter: Option<Arc<DriverConfigReporter>>,
         keyspaces_to_fetch: Vec<String>,
         schema_metadata_fetch_mode: SchemaMetadataFetchMode,
         metadata_request_timeouts: MetadataRequestTimeouts,
@@ -105,6 +107,7 @@ impl Cluster {
             known_nodes,
             hostname_resolution_timeout,
             pool_config.connection_config.clone(),
+            driver_config_reporter,
             metadata_request_timeouts,
             keyspaces_to_fetch,
             schema_metadata_fetch_mode,

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -73,7 +73,7 @@ use uuid::Uuid;
 // a stream id that is orphaned for a long time. This long time is defined below
 // (`OLD_AGE_ORPHAN_THRESHOLD`). Connection that has a big number (`OLD_ORPHAN_COUNT_THRESHOLD`)
 // of old orphans is shut down (and created again by a connection management layer).
-const OLD_ORPHAN_COUNT_THRESHOLD: usize = 1024;
+pub(crate) const OLD_ORPHAN_COUNT_THRESHOLD: usize = 1024;
 const OLD_AGE_ORPHAN_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Represents a write coalescing delay configuration option.
@@ -2580,7 +2580,7 @@ struct StreamIdSet {
 /// Number of stream ids usable on one connection, i.e. the maximum number of
 /// requests in flight on it. Every id in `0..MAX_IN_FLIGHT_REQUESTS` is
 /// allocatable; none is reserved.
-const MAX_IN_FLIGHT_REQUESTS: usize = i16::MAX as usize + 1;
+pub(crate) const MAX_IN_FLIGHT_REQUESTS: usize = i16::MAX as usize + 1;
 
 impl StreamIdSet {
     fn new() -> Self {

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2,6 +2,7 @@ use super::tls::{TlsConfig, TlsProvider};
 use crate::authentication::AuthenticatorProvider;
 use crate::client::Compression;
 use crate::client::SelfIdentity;
+use crate::client::driver_config::DriverConfigReporter;
 use crate::client::pager::{NextRowError, QueryPager};
 use crate::cluster::NodeAddr;
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
@@ -348,6 +349,18 @@ pub(crate) struct ConnectionConfig {
     /// Reported to the cluster in `STARTUP`, so that the `system.clients` rows
     /// of all connections belonging to one session can be correlated.
     pub(crate) session_id: Uuid,
+
+    /// Builds the configuration report sent in `STARTUP`. `None` disables
+    /// reporting.
+    ///
+    /// Should be `Some` only in control connections: the report's value is the
+    /// same for every connection of a session, so sending it on all of them
+    /// would only bloat their `STARTUP` frames. It is put on the control
+    /// connection's config in [`ControlConnectionEstablisher::new`].
+    ///
+    /// [`ControlConnectionEstablisher::new`]:
+    ///     crate::cluster::metadata::cc_establisher::ControlConnectionEstablisher::new
+    pub(crate) driver_config_reporter: Option<Arc<DriverConfigReporter>>,
 }
 
 impl ConnectionConfig {
@@ -379,6 +392,7 @@ impl ConnectionConfig {
             tablet_sender: self.tablet_sender.clone(),
             identity: self.identity.clone(),
             session_id: self.session_id,
+            driver_config_reporter: self.driver_config_reporter.clone(),
             #[cfg(test)]
             transport_factory: None,
         }
@@ -410,6 +424,8 @@ pub(crate) struct HostConnectionConfig {
 
     pub(crate) identity: SelfIdentity<'static>,
     pub(crate) session_id: Uuid,
+    // should be Some only in control connections
+    pub(crate) driver_config_reporter: Option<Arc<DriverConfigReporter>>,
 
     #[cfg(test)]
     pub(crate) transport_factory: Option<Arc<scylla_proxy::TransportFactory>>,
@@ -442,6 +458,9 @@ impl Default for HostConnectionConfig {
 
             // Test connections do not correlate anything in `system.clients`.
             session_id: Uuid::nil(),
+
+            // Test connections do not report their configuration.
+            driver_config_reporter: None,
 
             #[cfg(test)]
             transport_factory: None,
@@ -476,6 +495,9 @@ impl Default for ConnectionConfig {
 
             // Test connections do not correlate anything in `system.clients`.
             session_id: Uuid::nil(),
+
+            // Test connections do not report their configuration.
+            driver_config_reporter: None,
         }
     }
 }
@@ -2247,6 +2269,16 @@ pub(crate) async fn open_connection(
         Cow::Borrowed(options::SESSION_ID),
         Cow::Borrowed(&*session_id),
     );
+
+    // The configuration report, sent only by the control connection: its value is
+    // the same for every connection of a session, so sending it on all of them
+    // would only bloat their STARTUP frames. Only the control connection's config
+    // carries a reporter - see `ConnectionConfig::driver_config_reporter`.
+    if let Some(reporter) = config.driver_config_reporter.as_deref()
+        && let Some(report) = reporter.report(connection.is_to_scylladb())
+    {
+        options.insert(Cow::Borrowed(options::DRIVER_CONFIG), Cow::Owned(report));
+    }
 
     // Optional compression.
     if let Some(compression) = &config.compression {

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2545,11 +2545,15 @@ struct StreamIdSet {
     used_bitmap: Box<[u64]>,
 }
 
+/// Number of stream ids usable on one connection, i.e. the maximum number of
+/// requests in flight on it. Every id in `0..MAX_IN_FLIGHT_REQUESTS` is
+/// allocatable; none is reserved.
+const MAX_IN_FLIGHT_REQUESTS: usize = i16::MAX as usize + 1;
+
 impl StreamIdSet {
     fn new() -> Self {
-        const BITMAP_SIZE: usize = (i16::MAX as usize + 1) / 64;
         Self {
-            used_bitmap: vec![0; BITMAP_SIZE].into_boxed_slice(),
+            used_bitmap: vec![0; MAX_IN_FLIGHT_REQUESTS / 64].into_boxed_slice(),
         }
     }
 

--- a/scylla/src/network/mod.rs
+++ b/scylla/src/network/mod.rs
@@ -10,7 +10,10 @@ mod connection;
 pub(crate) use connection::HostConnectionConfig;
 pub(crate) use connection::open_connection;
 
-pub(crate) use connection::{Connection, ConnectionConfig, TcpSocketOptions, VerifiedKeyspaceName};
+pub(crate) use connection::{
+    Connection, ConnectionConfig, MAX_IN_FLIGHT_REQUESTS, OLD_ORPHAN_COUNT_THRESHOLD,
+    TcpSocketOptions, VerifiedKeyspaceName,
+};
 
 mod connection_pool;
 

--- a/scylla/src/policies/host_filter.rs
+++ b/scylla/src/policies/host_filter.rs
@@ -15,6 +15,16 @@ use crate::cluster::metadata::Peer;
 pub trait HostFilter: Send + Sync {
     /// Returns whether a peer should be accepted or not.
     fn accept(&self, peer: &Peer) -> bool;
+
+    /// Lets the driver recognise its own built-in filters by downcasting, so that
+    /// the driver configuration report can describe them precisely. Implementations
+    /// outside this crate keep the `None` default and are omitted from the report.
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
 }
 
 /// Unconditionally accepts all nodes.
@@ -80,5 +90,9 @@ impl DcHostFilter {
 impl HostFilter for DcHostFilter {
     fn accept(&self, peer: &Peer) -> bool {
         peer.datacenter.as_ref() == Some(&self.local_dc)
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
     }
 }

--- a/scylla/src/policies/host_filter.rs
+++ b/scylla/src/policies/host_filter.rs
@@ -76,7 +76,7 @@ impl HostFilter for AllowListHostFilter {
 
 /// Accepts nodes from given DC.
 pub struct DcHostFilter {
-    local_dc: String,
+    pub(crate) local_dc: String,
 }
 
 impl DcHostFilter {

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -96,16 +96,16 @@ enum PickedReplica<'a> {
 pub struct DefaultPolicy {
     /// Preferences regarding node location. One of: rack and DC, DC, no DC preference,
     /// or fallback to Session-level preference.
-    preferences: Option<NodeLocationPreference>,
+    pub(crate) preferences: Option<NodeLocationPreference>,
 
     /// Configures whether the policy takes token into consideration when creating plans.
     /// If this is set to `true` AND token, keyspace and table are available,
     /// then policy prefers replicas and puts them earlier in the query plan.
-    is_token_aware: bool,
+    pub(crate) is_token_aware: bool,
 
     /// Whether to permit remote nodes (those not located in the preferred DC) in plans.
     /// If no preferred DC is set, this has no effect.
-    permit_dc_failover: bool,
+    pub(crate) permit_dc_failover: bool,
 
     /// A predicate that a target (node + shard) must satisfy in order to be picked.
     /// This was introduced to make latency awareness cleaner.
@@ -122,12 +122,12 @@ pub struct DefaultPolicy {
     ///   to the end, in a stable way.
     ///
     /// Penalisation is done based on collected and updated latencies.
-    latency_awareness: Option<LatencyAwareness>,
+    pub(crate) latency_awareness: Option<LatencyAwareness>,
 
     /// The policy chooses (in `pick`) and shuffles (in `fallback`) replicas and nodes
     /// based on random number generator. For sake of deterministic testing,
     /// a fixed seed can be used.
-    fixed_seed: Option<u64>,
+    pub(crate) fixed_seed: Option<u64>,
 }
 
 impl fmt::Debug for DefaultPolicy {
@@ -3377,7 +3377,7 @@ mod latency_awareness {
 
     /// A latency-aware load balancing policy module, which enables penalising nodes that are too slow.
     #[derive(Debug)]
-    pub(super) struct LatencyAwareness {
+    pub(crate) struct LatencyAwareness {
         pub(super) exclusion_threshold: f64,
         pub(super) retry_period: Duration,
         pub(super) _update_rate: Duration,

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -574,6 +574,10 @@ or refrain from preferring datacenters (which may ban all other datacenters, if 
         "DefaultPolicy".to_string()
     }
 
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
     fn on_request_success(
         &self,
         _routing_info: &RoutingInfo,

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -187,4 +187,15 @@ pub trait LoadBalancingPolicy: Send + Sync + std::fmt::Debug {
 
     /// Returns the name of load balancing policy.
     fn name(&self) -> String;
+
+    /// Lets the driver recognise its own built-in policies by downcasting, so that
+    /// the driver configuration report can describe them precisely. Implementations
+    /// outside this crate keep the `None` default and are reported generically,
+    /// using [`LoadBalancingPolicy::name`].
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
 }

--- a/scylla/src/policies/mod.rs
+++ b/scylla/src/policies/mod.rs
@@ -29,3 +29,54 @@ pub(crate) mod reconnect;
 pub mod retry;
 pub mod speculative_execution;
 pub mod timestamp_generator;
+
+/// Returns the name of `T` with the leading module path of the outermost type stripped.
+///
+/// Supplies the `name` that the driver configuration report sends for policies
+/// the driver does not recognise, so it must be allocation-free and never empty.
+pub(crate) fn simple_type_name<T: ?Sized>() -> &'static str {
+    let full = std::any::type_name::<T>();
+    // Only the outermost type's path may be stripped: in `a::b::Foo<some::Bar>`
+    // the `::` inside the generic arguments must be left alone.
+    let head = match full.find('<') {
+        Some(idx) => &full[..idx],
+        None => full,
+    };
+    match head.rfind("::") {
+        // The `name` field is declared non-empty by the schema, so fall back to
+        // the unstripped name rather than returning "".
+        Some(idx) if idx + 2 < full.len() => &full[idx + 2..],
+        _ => full,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::simple_type_name;
+    use crate::policies::load_balancing::DefaultPolicy;
+    use crate::policies::retry::{DefaultRetryPolicy, RetryPolicy};
+
+    #[test]
+    fn test_simple_type_name() {
+        // Names without a module path are returned as they are.
+        assert_eq!(simple_type_name::<u32>(), "u32");
+        assert_eq!(simple_type_name::<&str>(), "&str");
+
+        // The leading path of the outermost type is stripped...
+        assert_eq!(simple_type_name::<String>(), "String");
+        assert_eq!(
+            simple_type_name::<DefaultRetryPolicy>(),
+            "DefaultRetryPolicy"
+        );
+        assert_eq!(simple_type_name::<DefaultPolicy>(), "DefaultPolicy");
+
+        // ...including for the trait objects the policy traits pass in as `Self`.
+        assert_eq!(simple_type_name::<dyn RetryPolicy>(), "RetryPolicy");
+
+        // ...but the paths inside the generic arguments are left alone.
+        assert_eq!(
+            simple_type_name::<Vec<String>>(),
+            "Vec<alloc::string::String>"
+        );
+    }
+}

--- a/scylla/src/policies/reconnect.rs
+++ b/scylla/src/policies/reconnect.rs
@@ -36,6 +36,34 @@ pub trait ReconnectPolicySession: Send + std::fmt::Debug {
 pub trait ReconnectPolicy: Send + Sync + std::fmt::Debug {
     /// Returns a new instance of the policy for the single host.
     fn new_session(&self) -> Box<dyn ReconnectPolicySession>;
+
+    /// Lets the driver recognise its own built-in policies by downcasting, so that
+    /// the driver configuration report can describe them precisely. Implementations
+    /// outside this crate keep the `None` default and are reported generically.
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    #[cfg_attr(
+        not(all(scylla_unstable, feature = "unstable-reconnect-policy")),
+        expect(dead_code)
+    )]
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
+
+    /// Name used to describe this policy generically in the driver configuration
+    /// report. The default is the implementor's own type name, so no implementation
+    /// is required.
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    #[cfg_attr(
+        not(all(scylla_unstable, feature = "unstable-reconnect-policy")),
+        expect(dead_code)
+    )]
+    fn reported_name(&self) -> &'static str {
+        crate::policies::simple_type_name::<Self>()
+    }
 }
 
 #[derive(Debug)]
@@ -149,6 +177,10 @@ impl ReconnectPolicy for ExponentialReconnectPolicy {
             jitter_range: self.jitter_range.clone(),
         })
     }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
 }
 
 /// Constant reconnect policy.
@@ -199,6 +231,10 @@ impl ConstantReconnectPolicy {
 impl ReconnectPolicy for ConstantReconnectPolicy {
     fn new_session(&self) -> Box<dyn ReconnectPolicySession> {
         Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
     }
 }
 

--- a/scylla/src/policies/reconnect.rs
+++ b/scylla/src/policies/reconnect.rs
@@ -43,10 +43,6 @@ pub trait ReconnectPolicy: Send + Sync + std::fmt::Debug {
     ///
     /// Not part of the stable API; may change at any time.
     #[doc(hidden)]
-    #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-reconnect-policy")),
-        expect(dead_code)
-    )]
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         None
     }
@@ -57,10 +53,6 @@ pub trait ReconnectPolicy: Send + Sync + std::fmt::Debug {
     ///
     /// Not part of the stable API; may change at any time.
     #[doc(hidden)]
-    #[cfg_attr(
-        not(all(scylla_unstable, feature = "unstable-reconnect-policy")),
-        expect(dead_code)
-    )]
     fn reported_name(&self) -> &'static str {
         crate::policies::simple_type_name::<Self>()
     }
@@ -107,8 +99,8 @@ impl ReconnectPolicySession for HostExponentialReconnectPolicy {
 /// may get close to 0 (when value close to 0.01 is chosen).
 #[derive(Debug)]
 pub struct ExponentialReconnectPolicy {
-    min_fill_backoff: Duration,
-    max_fill_backoff: Duration,
+    pub(crate) min_fill_backoff: Duration,
+    pub(crate) max_fill_backoff: Duration,
     jitter_range: RangeInclusive<f64>,
 }
 
@@ -193,7 +185,7 @@ impl ReconnectPolicy for ExponentialReconnectPolicy {
 /// may get close to 0 (when value close to 0.01 is chosen).
 #[derive(Debug, Clone)]
 pub struct ConstantReconnectPolicy {
-    delay: Duration,
+    pub(crate) delay: Duration,
     jitter_range: RangeInclusive<f64>,
 }
 

--- a/scylla/src/policies/retry/default.rs
+++ b/scylla/src/policies/retry/default.rs
@@ -27,6 +27,10 @@ impl RetryPolicy for DefaultRetryPolicy {
     fn new_session(&self) -> Box<dyn RetrySession> {
         Box::new(DefaultRetrySession::new())
     }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
 }
 
 /// Implementation of [RetrySession] for [DefaultRetryPolicy].

--- a/scylla/src/policies/retry/downgrading_consistency.rs
+++ b/scylla/src/policies/retry/downgrading_consistency.rs
@@ -30,6 +30,10 @@ impl RetryPolicy for DowngradingConsistencyRetryPolicy {
     fn new_session(&self) -> Box<dyn RetrySession> {
         Box::new(DowngradingConsistencyRetrySession::new())
     }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
 }
 
 /// Implementation of [RetrySession] for [DowngradingConsistencyRetryPolicy].

--- a/scylla/src/policies/retry/fallthrough.rs
+++ b/scylla/src/policies/retry/fallthrough.rs
@@ -24,6 +24,10 @@ impl RetryPolicy for FallthroughRetryPolicy {
     fn new_session(&self) -> Box<dyn RetrySession> {
         Box::new(FallthroughRetrySession)
     }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
 }
 
 impl RetrySession for FallthroughRetrySession {

--- a/scylla/src/policies/retry/retry_policy.rs
+++ b/scylla/src/policies/retry/retry_policy.rs
@@ -56,6 +56,26 @@ pub enum RetryDecision {
 pub trait RetryPolicy: std::fmt::Debug + Send + Sync {
     /// Called for each new request, starts a session of deciding about retries
     fn new_session(&self) -> Box<dyn RetrySession>;
+
+    /// Lets the driver recognise its own built-in policies by downcasting, so that
+    /// the driver configuration report can describe them precisely. Implementations
+    /// outside this crate keep the `None` default and are reported generically.
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
+
+    /// Name used to describe this policy generically in the driver configuration
+    /// report. The default is the implementor's own type name, so no implementation
+    /// is required.
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    fn reported_name(&self) -> &'static str {
+        crate::policies::simple_type_name::<Self>()
+    }
 }
 
 /// Used throughout a single request to decide when to retry it

--- a/scylla/src/policies/speculative_execution.rs
+++ b/scylla/src/policies/speculative_execution.rs
@@ -41,6 +41,26 @@ pub trait SpeculativeExecutionPolicy: std::fmt::Debug + Send + Sync {
 
     /// The delay between each speculative execution
     fn retry_interval(&self, context: &Context) -> Duration;
+
+    /// Lets the driver recognise its own built-in policies by downcasting, so that
+    /// the driver configuration report can describe them precisely. Implementations
+    /// outside this crate keep the `None` default and are reported generically.
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
+
+    /// Name used to describe this policy generically in the driver configuration
+    /// report. The default is the implementor's own type name, so no implementation
+    /// is required.
+    ///
+    /// Not part of the stable API; may change at any time.
+    #[doc(hidden)]
+    fn reported_name(&self) -> &'static str {
+        crate::policies::simple_type_name::<Self>()
+    }
 }
 
 /// A [`SpeculativeExecutionPolicy`] that schedules a given number of speculative
@@ -77,6 +97,10 @@ impl SpeculativeExecutionPolicy for SimpleSpeculativeExecutionPolicy {
     fn retry_interval(&self, _: &Context) -> Duration {
         self.retry_interval
     }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
 }
 
 #[cfg(feature = "metrics")]
@@ -98,6 +122,10 @@ impl SpeculativeExecutionPolicy for PercentileSpeculativeExecutionPolicy {
             }
         };
         Duration::from_millis(ms)
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
     }
 }
 

--- a/scylla/tests/integration/session/startup_options.rs
+++ b/scylla/tests/integration/session/startup_options.rs
@@ -1,7 +1,12 @@
-use crate::utils::{setup_tracing, test_with_3_node_cluster};
+use crate::utils::{
+    create_new_session_builder, execute_unprepared_statement_on_every_node, setup_tracing,
+    test_with_3_node_cluster,
+};
+use scylla::client::PoolSize;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::policies::address_translator::AddressTranslator;
+use scylla::statement::Statement;
 use scylla_cql::frame::request::options;
 use scylla_cql::frame::types;
 use scylla_proxy::{
@@ -9,6 +14,7 @@ use scylla_proxy::{
     ShardAwareness, WorkerError,
 };
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -187,9 +193,9 @@ async fn driver_config_is_sent_only_on_the_control_connection_and_can_be_disable
             );
 
             let report = reports[0];
-            // The spec requires drivers to omit an oversized report, so a report
-            // that arrived at all must be within the limit.
-            assert!(report.len() < 32 * 1024, "report is too large: {report}");
+            // The spec requires drivers to omit a report *above* the limit, so a
+            // report that arrived at all is at most that large.
+            assert!(report.len() <= 32 * 1024, "report is too large: {report}");
             let parsed: serde_json::Value = serde_json::from_str(report).unwrap();
             assert_eq!(parsed["version"], 1);
 
@@ -230,4 +236,121 @@ async fn driver_config_is_sent_only_on_the_control_connection_and_can_be_disable
         Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
         Err(err) => panic!("{}", err),
     }
+}
+
+/// The cross-driver schema the report must conform to; the same vendored copy
+/// the unit tests validate against, so that what a real server stored is held
+/// to the same contract as what the reporter produced.
+const SCHEMA: &str = include_str!("../../../src/client/driver-config-schema.json");
+
+/// The whole point of the feature, end to end: the driver sends the options,
+/// the server stores them, and an operator reading `system.clients` can find
+/// them and correlate them with a session.
+///
+/// `system.clients` is ScyllaDB-only, hence the Cassandra gate, and node-local:
+/// each node reports only the clients connected to it, so the query is run once
+/// against every node and the rows unioned. Nothing has to be waited for - the
+/// server registers a client while establishing its connection, and
+/// `Session::builder().build()` only returns once the control connection has
+/// completed its `STARTUP` exchange, so every row asserted on here was written
+/// before the session existed to query with.
+#[cfg_attr(cassandra_tests, ignore)]
+#[tokio::test]
+async fn driver_config_is_readable_from_system_clients() {
+    setup_tracing();
+
+    let session = create_new_session_builder()
+        .fetch_schema_metadata(false)
+        .pool_size(PoolSize::PerHost(NonZeroUsize::new(1).unwrap()))
+        .build()
+        .await
+        .unwrap();
+
+    // Capability detection rather than a version check: `client_options` was
+    // added to the virtual table at some point and older clusters simply do not
+    // have the column.
+    let has_column = session
+        .query_unpaged(
+            "SELECT column_name FROM system_schema.columns \
+             WHERE keyspace_name = 'system' AND table_name = 'clients' \
+             AND column_name = 'client_options'",
+            &[],
+        )
+        .await
+        .unwrap()
+        .into_rows_result()
+        .unwrap()
+        .rows::<(String,)>()
+        .unwrap()
+        .next()
+        .is_some();
+
+    if !has_column {
+        tracing::warn!(
+            "skipping: this cluster's system.clients has no client_options column, \
+             so there is nothing for the driver configuration report to land in"
+        );
+        return;
+    }
+
+    let session_id = session.session_id().to_string();
+    let statement = Statement::new("SELECT client_options FROM system.clients");
+    let cluster = session.get_cluster_state();
+    let results = execute_unprepared_statement_on_every_node(&session, &cluster, &statement, &[])
+        .await
+        .unwrap();
+
+    let mut own_rows = Vec::new();
+    for result in results {
+        let rows = result.into_rows_result().unwrap();
+        for row in rows
+            .rows::<(Option<HashMap<String, String>>,)>()
+            .unwrap()
+            .map(Result::unwrap)
+        {
+            let Some(client_options) = row.0 else {
+                continue;
+            };
+            if client_options.get("SESSION_ID") == Some(&session_id) {
+                own_rows.push(client_options);
+            }
+        }
+    }
+
+    assert!(
+        !own_rows.is_empty(),
+        "no system.clients row reports this session's SESSION_ID {session_id}"
+    );
+
+    let reports: Vec<&String> = own_rows
+        .iter()
+        .filter_map(|options| options.get("DRIVER_CONFIG"))
+        .collect();
+    assert_eq!(
+        reports.len(),
+        1,
+        "exactly one of this session's {} connections must report its configuration",
+        own_rows.len()
+    );
+
+    let report = reports[0];
+    // The spec omits the option only *above* the limit, and
+    // `oversized_reports_are_omitted` pins that a report of exactly the limit is
+    // still sent, so the bound here has to be inclusive too.
+    assert!(report.len() <= 32 * 1024, "report is too large: {report}");
+
+    let report: serde_json::Value = serde_json::from_str(report).unwrap();
+    assert_eq!(report["version"], 1);
+
+    let schema: serde_json::Value = serde_json::from_str(SCHEMA).unwrap();
+    let validator = jsonschema::validator_for(&schema).unwrap();
+    let errors: Vec<String> = validator
+        .iter_errors(&report)
+        .map(|error| format!("  at {}: {error}", error.instance_path()))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "the configuration stored by the server does not conform to the schema:\n{}\nreport: {report}",
+        errors.join("\n")
+    );
 }

--- a/scylla/tests/integration/session/startup_options.rs
+++ b/scylla/tests/integration/session/startup_options.rs
@@ -1,12 +1,14 @@
 use crate::utils::{setup_tracing, test_with_3_node_cluster};
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::policies::address_translator::AddressTranslator;
 use scylla_cql::frame::request::options;
 use scylla_cql::frame::types;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
     ShardAwareness, WorkerError,
 };
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -28,41 +30,72 @@ fn expected_connection_count(session: &Session) -> usize {
         .sum::<usize>()
 }
 
-/// Receives exactly `count` STARTUP frames, asserting that each of them carries
-/// a `SESSION_ID` option reporting `session_id`.
+/// Receives exactly `count` STARTUP frames, returning the option map of each.
 ///
-/// Receiving a known count is the barrier that makes this test deterministic:
+/// Receiving a known count is the barrier that makes these tests deterministic:
 /// `Session::connect` only waits for the first connection to each node
 /// (`ClusterState::wait_until_all_pools_are_initialized`), so the remaining pool
 /// connections are opened asynchronously by the pool refiller and their frames
 /// arrive later. Awaiting them is sleep-free; any surplus frame stays queued.
-async fn recv_session_ids(
+async fn recv_startup_options(
     startup_rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
-    session_id: Uuid,
     count: usize,
-) {
-    let expected = session_id.to_string();
-    let mut received = 0;
+    // Frames not belonging to the session under test are not counted; the
+    // predicate tells the two apart.
+    is_under_test: impl Fn(&HashMap<String, String>) -> bool,
+) -> Vec<HashMap<String, String>> {
+    let mut received = Vec::new();
     let recv_all = async {
-        while received < count {
+        while received.len() < count {
             let (startup_frame, _shard) = startup_rx.recv().await.unwrap();
             let startup_options = types::read_string_map(&mut &*startup_frame.body).unwrap();
-            let reported = startup_options
-                .get(options::SESSION_ID)
-                .expect("STARTUP frame without a SESSION_ID option");
-            assert_eq!(
-                *reported, expected,
-                "unexpected SESSION_ID reported in STARTUP"
-            );
-            received += 1;
+            if is_under_test(&startup_options) {
+                received.push(startup_options);
+            }
         }
     };
 
     tokio::time::timeout(Duration::from_secs(30), recv_all)
         .await
         .unwrap_or_else(|_| {
-            panic!("received only {received} of {count} expected STARTUP frames for {expected}")
+            panic!(
+                "received only {} of {count} expected STARTUP frames",
+                received.len()
+            )
         });
+
+    received
+}
+
+/// Receives exactly `count` STARTUP frames reporting `session_id`, asserting
+/// that every frame carries a `SESSION_ID` option and that the only other value
+/// that may appear is one of `tolerated`.
+///
+/// Returns the option maps of the received frames.
+async fn recv_session_ids(
+    startup_rx: &mut mpsc::UnboundedReceiver<(RequestFrame, Option<u16>)>,
+    session_id: Uuid,
+    count: usize,
+    tolerated: &[Uuid],
+) -> Vec<HashMap<String, String>> {
+    let expected = session_id.to_string();
+    recv_startup_options(startup_rx, count, |startup_options| {
+        let reported = startup_options
+            .get(options::SESSION_ID)
+            .expect("STARTUP frame without a SESSION_ID option");
+
+        if *reported == expected {
+            true
+        } else {
+            let reported = reported.parse::<Uuid>().unwrap();
+            assert!(
+                tolerated.contains(&reported),
+                "unexpected SESSION_ID reported in STARTUP: {reported}"
+            );
+            false
+        }
+    })
+    .await
 }
 
 /// Every connection of a session - the control connection and all pool
@@ -94,7 +127,70 @@ async fn session_id_is_sent_on_every_connection() {
                 .unwrap();
 
             let expected = expected_connection_count(&session);
-            recv_session_ids(&mut startup_rx, session.session_id(), expected).await;
+            recv_session_ids(&mut startup_rx, session.session_id(), expected, &[]).await;
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}
+
+/// The configuration report must be sent by the control connection and by no
+/// other connection of the session, and must be a JSON document of the current
+/// schema version, small enough that the server accepts it.
+#[tokio::test]
+async fn driver_config_is_sent_only_on_the_control_connection() {
+    setup_tracing();
+
+    let res = test_with_3_node_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, translation_map, mut running_proxy| async move {
+            let (startup_tx, mut startup_rx) = mpsc::unbounded_channel();
+            for node in running_proxy.running_nodes.iter_mut() {
+                node.change_request_rules(Some(vec![RequestRule(
+                    Condition::RequestOpcode(RequestOpcode::Startup),
+                    RequestReaction::noop().with_feedback_when_performed(startup_tx.clone()),
+                )]));
+            }
+
+            let translation_map: Arc<dyn AddressTranslator> = Arc::new(translation_map);
+            let session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::clone(&translation_map))
+                .build()
+                .await
+                .unwrap();
+
+            let expected = expected_connection_count(&session);
+            assert!(
+                expected > 1,
+                "the test proves nothing about 'only the control connection' with a single connection"
+            );
+            let frames =
+                recv_session_ids(&mut startup_rx, session.session_id(), expected, &[]).await;
+
+            let reports: Vec<&String> = frames
+                .iter()
+                .filter_map(|opts| opts.get(options::DRIVER_CONFIG))
+                .collect();
+            assert_eq!(
+                reports.len(),
+                1,
+                "expected exactly one of the {expected} connections to report the configuration"
+            );
+
+            let report = reports[0];
+            // The spec requires drivers to omit an oversized report, so a report
+            // that arrived at all must be within the limit.
+            assert!(report.len() < 32 * 1024, "report is too large: {report}");
+            let parsed: serde_json::Value = serde_json::from_str(report).unwrap();
+            assert_eq!(parsed["version"], 1);
 
             running_proxy
         },

--- a/scylla/tests/integration/session/startup_options.rs
+++ b/scylla/tests/integration/session/startup_options.rs
@@ -143,9 +143,10 @@ async fn session_id_is_sent_on_every_connection() {
 
 /// The configuration report must be sent by the control connection and by no
 /// other connection of the session, and must be a JSON document of the current
-/// schema version, small enough that the server accepts it.
+/// schema version, small enough that the server accepts it. Disabling it must
+/// suppress it on every connection, and must leave `SESSION_ID` alone.
 #[tokio::test]
-async fn driver_config_is_sent_only_on_the_control_connection() {
+async fn driver_config_is_sent_only_on_the_control_connection_and_can_be_disabled() {
     setup_tracing();
 
     let res = test_with_3_node_cluster(
@@ -191,6 +192,33 @@ async fn driver_config_is_sent_only_on_the_control_connection() {
             assert!(report.len() < 32 * 1024, "report is too large: {report}");
             let parsed: serde_json::Value = serde_json::from_str(report).unwrap();
             assert_eq!(parsed["version"], 1);
+
+            // A session that opted out must not report anything, while still
+            // identifying itself with SESSION_ID on every connection. The first
+            // session stays alive and may open connections of its own, so its
+            // id is tolerated here, and nothing else is.
+            let silent_session: Session = SessionBuilder::new()
+                .known_node(proxy_uris[0].as_str())
+                .address_translator(Arc::clone(&translation_map))
+                .driver_config_reporting(false)
+                .build()
+                .await
+                .unwrap();
+
+            let silent_expected = expected_connection_count(&silent_session);
+            let silent_frames = recv_session_ids(
+                &mut startup_rx,
+                silent_session.session_id(),
+                silent_expected,
+                &[session.session_id()],
+            )
+            .await;
+            assert!(
+                silent_frames
+                    .iter()
+                    .all(|opts| !opts.contains_key(options::DRIVER_CONFIG)),
+                "a session with reporting disabled sent a configuration report"
+            );
 
             running_proxy
         },

--- a/scylla/tests/integration/utils.rs
+++ b/scylla/tests/integration/utils.rs
@@ -590,7 +590,6 @@ pub(crate) async fn execute_unprepared_statement_everywhere(
 /// at least one connection per node, making it suitable for scenarios where
 /// the pool may not be fully filled yet (e.g. right after a client routes
 /// update).
-#[allow(dead_code)]
 pub(crate) async fn execute_unprepared_statement_on_every_node(
     session: &Session,
     cluster: &ClusterState,


### PR DESCRIPTION
This PR introduces support for reporting driver configuration to the server.

Configuration report is sent to the server as JSON, only on the control connection. It is sent in the STARTUP frame, in `DRIVER_CONFIG` key. It can then be read from `system.clients.client_options['DRIVER_CONFIG']`.

Format of the config report is the same for all drivers, which unfortunately means:
1. We can't send everything
2. Sometimes we need to lose some information in order to conform to the schema.

Schema file is added to the codebase, because it is used for the tests.

## AI usage and review

This PR makes a change that requires tons of relatively simple code, that is almost fully isolated from the rest of the driver.
Carefully reviewing all of it would take a lot of time, and I don't think it would be very beneficial.

I did carefully review all the changes outside `driver_config.rs` / `driver_config_tests.rs`.
For the `driver_config.rs`:
 - Last 2 commits introduce tests that prove two things: 1. Reports always conform to the schema. 2. We send all the optional stuff we realistically can
 - I did review the tests above

Given all of the above, I only briefly reviewed the actual implementation in `driver_config.rs`  / `driver_config_tests.rs`, to make sure there are no stupid bugs, panics etc. I encourage reviewers to take the same approach.


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1859
Fixes: https://scylladb.atlassian.net/browse/DRIVER-378

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
