### PR TITLE
Maintenance sessions

### DIFF
--- a/scylla/src/client/maintenance_mode.rs
+++ b/scylla/src/client/maintenance_mode.rs
@@ -1,0 +1,69 @@
+//! Maintenance mode: a session pinned to exactly one node.
+//!
+//! A maintenance-mode session is meant for operating on a single node directly,
+//! typically an unhealthy one whose view of the cluster cannot be trusted. It
+//! differs from a regular session in that it:
+//!
+//! - connects to exactly one endpoint, given up front, and never to any other -
+//!   the peer list is never read, so no other node is ever discovered;
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use crate::cluster::metadata::MaintenanceEndpoint;
+use crate::cluster::node::resolve_hostname;
+use crate::errors::NewSessionError;
+
+/// The single endpoint a maintenance-mode session connects to.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MaintenanceModeEndpoint {
+    /// The node is identified by its hostname, which the driver resolves.
+    ///
+    /// If the hostname resolves to several addresses, the driver connects to one
+    /// of them and treats it as the one node of the session.
+    Hostname(String),
+
+    /// The node is identified by its IP address and port.
+    Address(SocketAddr),
+}
+
+impl MaintenanceModeEndpoint {
+    /// Targets the node with the given hostname.
+    pub fn hostname(hostname: impl Into<String>) -> Self {
+        Self::Hostname(hostname.into())
+    }
+
+    /// Targets the node at the given address.
+    pub fn address(address: SocketAddr) -> Self {
+        Self::Address(address)
+    }
+
+    /// Turns the endpoint the user configured into the one the driver connects
+    /// to, resolving a hostname if that is what was given.
+    pub(crate) async fn resolve(
+        self,
+        hostname_resolution_timeout: Option<Duration>,
+    ) -> Result<MaintenanceEndpoint, NewSessionError> {
+        let address = match self {
+            Self::Address(address) => address,
+            Self::Hostname(hostname) => {
+                let address = resolve_hostname(&hostname, hostname_resolution_timeout)
+                    .await
+                    .ok()
+                    .and_then(|addresses| addresses.into_iter().next())
+                    // A hostname that resolves to nothing leaves the session with
+                    // no node at all, which is fatal - there is no second contact
+                    // point to fall back on.
+                    .ok_or(NewSessionError::FailedToResolveAnyHostname(vec![hostname]))?;
+                // A maintenance mode session talks to one node, so if the hostname
+                // resolves to several addresses the first is taken and the session
+                // is pinned to it, rather than treating them as a set to choose
+                // among.
+                address
+            }
+        };
+
+        Ok(MaintenanceEndpoint { address })
+    }
+}

--- a/scylla/src/client/maintenance_mode.rs
+++ b/scylla/src/client/maintenance_mode.rs
@@ -1,17 +1,21 @@
 //! Maintenance mode: a session pinned to exactly one node.
 //!
-//! A maintenance-mode session is meant for operating on a single node directly,
-//! typically an unhealthy one whose view of the cluster cannot be trusted. It
-//! differs from a regular session in that it:
+//! A maintenance-mode session is meant for operating on a single node directly -
+//! typically an unhealthy one, or one reachable only over a local Unix domain
+//! socket. It differs from a regular session in that it:
 //!
 //! - connects to exactly one endpoint, given up front, and never to any other -
 //!   the peer list is never read, so no other node is ever discovered;
 
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
+#[cfg(unix)]
+use std::path::PathBuf;
+#[cfg(unix)]
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::cluster::metadata::MaintenanceEndpoint;
-use crate::cluster::node::resolve_hostname;
+use crate::cluster::node::{Transport, resolve_hostname};
 use crate::errors::NewSessionError;
 
 /// The single endpoint a maintenance-mode session connects to.
@@ -26,6 +30,10 @@ pub enum MaintenanceModeEndpoint {
 
     /// The node is identified by its IP address and port.
     Address(SocketAddr),
+
+    /// The node is reachable over a Unix domain socket at the given path.
+    #[cfg(unix)]
+    UnixSocket(PathBuf),
 }
 
 impl MaintenanceModeEndpoint {
@@ -39,14 +47,30 @@ impl MaintenanceModeEndpoint {
         Self::Address(address)
     }
 
+    /// Targets the node listening on the Unix domain socket at the given path.
+    ///
+    /// # Caveats
+    ///
+    /// A CQL node is identified by a `SocketAddr` throughout the driver's API
+    /// and a Unix socket has no such address. A placeholder of `0.0.0.0:0` therefore
+    /// stands in for it.
+    ///
+    /// TLS is **silently ignored** for a Unix socket connection: such a socket
+    /// is local by construction, so a TLS context configured on the builder is
+    /// skipped.
+    #[cfg(unix)]
+    pub fn unix_socket(path: impl Into<PathBuf>) -> Self {
+        Self::UnixSocket(path.into())
+    }
+
     /// Turns the endpoint the user configured into the one the driver connects
     /// to, resolving a hostname if that is what was given.
     pub(crate) async fn resolve(
         self,
         hostname_resolution_timeout: Option<Duration>,
     ) -> Result<MaintenanceEndpoint, NewSessionError> {
-        let address = match self {
-            Self::Address(address) => address,
+        let (address, transport) = match self {
+            Self::Address(address) => (address, Transport::Tcp),
             Self::Hostname(hostname) => {
                 let address = resolve_hostname(&hostname, hostname_resolution_timeout)
                     .await
@@ -60,10 +84,20 @@ impl MaintenanceModeEndpoint {
                 // resolves to several addresses the first is taken and the session
                 // is pinned to it, rather than treating them as a set to choose
                 // among.
-                address
+                (address, Transport::Tcp)
             }
+            #[cfg(unix)]
+            Self::UnixSocket(path) => (
+                UNIX_SOCKET_PLACEHOLDER_ADDR,
+                Transport::UnixSocket(Arc::from(path.as_path())),
+            ),
         };
 
-        Ok(MaintenanceEndpoint { address })
+        Ok(MaintenanceEndpoint { address, transport })
     }
 }
+
+/// Stands in for the address of a node reached over a Unix domain socket, which
+/// has no address of its own.
+pub(crate) const UNIX_SOCKET_PLACEHOLDER_ADDR: SocketAddr =
+    SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);

--- a/scylla/src/client/mod.rs
+++ b/scylla/src/client/mod.rs
@@ -25,6 +25,8 @@ pub mod pager;
 
 pub mod client_routes;
 
+pub mod maintenance_mode;
+
 pub mod caching_session;
 
 mod self_identity;

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -17,7 +17,7 @@ use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::cluster::metadata::{
     PeriodicFetchMode, SchemaMetadataFetchLevel, SchemaMetadataFetchMode,
 };
-use crate::cluster::node::KnownNode;
+use crate::cluster::node::{InitialEndpoints, KnownNode};
 use crate::cluster::{Cluster, ClusterNeatDebug, ClusterState};
 use crate::errors::DbError;
 use crate::errors::{
@@ -384,6 +384,9 @@ pub struct SessionConfig {
     #[cfg(feature = "unstable-client-routes")]
     pub(crate) client_routes_config: Option<super::client_routes::ClientRoutesConfig>,
 
+    /// The single endpoint of a maintenance-mode session.
+    pub(crate) maintenance_mode: Option<super::maintenance_mode::MaintenanceModeEndpoint>,
+
     /// The host filter decides whether any connections should be opened
     /// to the node or not. The driver will also avoid filtered out nodes when
     /// re-establishing the control connection.
@@ -513,6 +516,7 @@ impl SessionConfig {
             driver_config_reporting: true,
             #[cfg(feature = "unstable-client-routes")]
             client_routes_config: None,
+            maintenance_mode: None,
         }
     }
 
@@ -610,12 +614,7 @@ impl SessionConfig {
 
     /// [SessionConfig] may unfortunately represent invalid configurations. We need to rule them out
     /// at runtime by running validation.
-    fn validate(&self) -> Result<(), NewSessionError> {
-        // Ensure there is at least one known node
-        if self.known_nodes.is_empty() {
-            return Err(NewSessionError::EmptyKnownNodesList);
-        }
-
+    fn validate(&self, initial_endpoints: &InitialEndpoints) -> Result<(), NewSessionError> {
         if self.keepalive_interval == Some(Duration::ZERO) {
             return Err(NewSessionError::IllegalConfig(
                 "Keepalive interval must be non-zero".into(),
@@ -657,6 +656,45 @@ impl SessionConfig {
                 return Err(NewSessionError::IllegalConfig(
                     "TLS is not (yet) supported if ClientRoutesConfig is provided, \
                         because of architectural limitations that are out of the driver's scope"
+                        .into(),
+                ));
+            }
+        }
+
+        // Ensure no illegal configuration with maintenance mode.
+        if initial_endpoints.is_maintenance() {
+            if self.address_translator.is_some() {
+                return Err(NewSessionError::IllegalConfig(
+                    "An address translator is not supported in maintenance mode: the session \
+                        connects only to the maintenance mode endpoint, which is given \
+                        already-translated, and no peer addresses are ever fetched to translate"
+                        .into(),
+                ));
+            }
+
+            if self.host_filter.is_some() {
+                return Err(NewSessionError::IllegalConfig(
+                    "A host filter is not supported in maintenance mode: the session is pinned \
+                        to the maintenance mode endpoint, so filtering could only reject that \
+                        one node and leave the session unable to serve any request"
+                        .into(),
+                ));
+            }
+
+            if !matches!(self.node_location_preference, NodeLocationPreference::Any) {
+                return Err(NewSessionError::IllegalConfig(
+                    "A node location preference is not supported in maintenance mode: no \
+                        metadata is fetched, so the one node's datacenter and rack are unknown \
+                        and any preference would exclude it from query plans"
+                        .into(),
+                ));
+            }
+
+            #[cfg(feature = "unstable-client-routes")]
+            if self.client_routes_config.is_some() {
+                return Err(NewSessionError::IllegalConfig(
+                    "Client routes are not supported in maintenance mode: routes are read from \
+                        `system.client_routes`, and maintenance mode fetches no metadata"
                         .into(),
                 ));
             }
@@ -1394,8 +1432,13 @@ impl Session {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn connect(config: SessionConfig) -> Result<Self, NewSessionError> {
-        config.validate()?;
+    pub async fn connect(mut config: SessionConfig) -> Result<Self, NewSessionError> {
+        // Decide where this session connects before anything else.
+        let initial_endpoints = InitialEndpoints::from_config(
+            std::mem::take(&mut config.known_nodes),
+            config.maintenance_mode.take(),
+        )?;
+        config.validate(&initial_endpoints)?;
 
         let session_id = Uuid::new_v4();
 
@@ -1427,7 +1470,6 @@ impl Session {
         });
 
         let node_location_preference = config.node_location_preference;
-        let known_nodes = config.known_nodes;
 
         let (tablet_sender, tablet_receiver) = tokio::sync::mpsc::channel(TABLET_CHANNEL_SIZE);
 
@@ -1517,7 +1559,7 @@ impl Session {
         };
 
         let cluster = Cluster::new(
-            known_nodes,
+            initial_endpoints,
             pool_config,
             driver_config_reporter,
             config.keyspaces_to_fetch,

--- a/scylla/src/client/session_builder.rs
+++ b/scylla/src/client/session_builder.rs
@@ -15,7 +15,7 @@ use crate::statement::Consistency;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::net::{IpAddr, SocketAddr};
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::warn;
@@ -33,13 +33,27 @@ mod sealed {
 /// used to connect to Scylla Cloud Serverless.
 /// This is used to conditionally enable different sets of methods
 /// on the session builder based on its kind.
-pub trait SessionBuilderKind: sealed::Sealed + Clone {}
+///
+/// This is the bound that every builder kind satisfies.
+pub trait SessionBuilderKindBase: sealed::Sealed + Clone {}
+
+/// Constraint for session builder kinds whose sessions choose which node to send
+/// a request to.
+pub trait SessionBuilderKindSupportsNodeSelection: SessionBuilderKindBase {}
+
+/// A session builder kind that supports every configuration option.
+pub trait SessionBuilderKind:
+    SessionBuilderKindBase + SessionBuilderKindSupportsNodeSelection
+{
+}
+impl<T: SessionBuilderKindBase + SessionBuilderKindSupportsNodeSelection> SessionBuilderKind for T {}
 
 /// Default session builder kind, used to create regular sessions.
 #[derive(Clone)]
 pub enum DefaultMode {}
 impl sealed::Sealed for DefaultMode {}
-impl SessionBuilderKind for DefaultMode {}
+impl SessionBuilderKindBase for DefaultMode {}
+impl SessionBuilderKindSupportsNodeSelection for DefaultMode {}
 
 /// Builder for regular sessions.
 pub type SessionBuilder = GenericSessionBuilder<DefaultMode>;
@@ -51,10 +65,21 @@ pub enum ClientRoutesMode {}
 #[cfg(feature = "unstable-client-routes")]
 impl sealed::Sealed for ClientRoutesMode {}
 #[cfg(feature = "unstable-client-routes")]
-impl SessionBuilderKind for ClientRoutesMode {}
+impl SessionBuilderKindBase for ClientRoutesMode {}
+#[cfg(feature = "unstable-client-routes")]
+impl SessionBuilderKindSupportsNodeSelection for ClientRoutesMode {}
 /// Builder for ClientRoutes sessions.
 #[cfg(feature = "unstable-client-routes")]
 pub type ClientRoutesSessionBuilder = GenericSessionBuilder<ClientRoutesMode>;
+
+/// Session builder kind used to create maintenance mode sessions: sessions pinned
+/// to a single node that never fetch topology metadata.
+#[derive(Clone)]
+pub enum MaintenanceMode {}
+impl sealed::Sealed for MaintenanceMode {}
+impl SessionBuilderKindBase for MaintenanceMode {}
+/// Builder for maintenance mode sessions.
+pub type MaintenanceSessionBuilder = GenericSessionBuilder<MaintenanceMode>;
 
 /// Used to conveniently configure new Session instances.
 ///
@@ -77,7 +102,7 @@ pub type ClientRoutesSessionBuilder = GenericSessionBuilder<ClientRoutesMode>;
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct GenericSessionBuilder<Kind: SessionBuilderKind> {
+pub struct GenericSessionBuilder<Kind: SessionBuilderKindBase> {
     /// Configuration for the session being built.
     pub config: SessionConfig,
     kind: PhantomData<Kind>,
@@ -151,6 +176,95 @@ impl GenericSessionBuilder<ClientRoutesMode> {
                 // a desired shard) is not yet supported in ClientRoutes Cloud deployments
                 // at the moment of writing, so this is disabled by default.
                 disallow_shard_aware_port: true,
+                ..SessionConfig::new()
+            },
+            kind: PhantomData,
+        }
+    }
+}
+
+// NOTE: this `impl` block contains configuration options specific for maintenance mode.
+// Maintenance mode is deliberately narrow: exactly one endpoint, no node
+// discovery. Options that would contradict that are therefore not available on this builder
+// type at all.
+impl GenericSessionBuilder<MaintenanceMode> {
+    /// Creates a new [`MaintenanceSessionBuilder`] targeting the given endpoint.
+    ///
+    /// A maintenance mode session is pinned to that one node for its whole
+    /// lifetime. It never reads the peer list, so it never learns of - let alone
+    /// connects to - any other node, so it does not react to topology, status. This makes it
+    /// suitable for operating on a single node directly, including an unhealthy
+    /// one whose view of the cluster cannot be trusted, or one reachable only over
+    /// a local Unix domain socket.
+    ///
+    /// # Default configuration
+    ///
+    /// The defaults differ from [`SessionBuilder::new`]'s in the ways that follow
+    /// from being pinned to one node and holding no metadata:
+    ///
+    /// * schema metadata fetching is **disabled** (both
+    ///   `fetch_schema_metadata` and `fetch_full_schema_metadata`), as is every
+    ///   other metadata fetch;
+    /// * the connection pool holds a **single connection** per node
+    ///   ([`PoolSize::PerHost(1)`](crate::client::PoolSize::PerHost)), to keep the
+    ///   load the session puts on the node minimal;
+    /// * the **shard-aware port is not used**, for the same reason;
+    /// * automatic waiting for schema agreement is **off**: with no metadata to
+    ///   keep consistent, and only one node in view, agreement cannot be
+    ///   established meaningfully.
+    ///
+    /// # Example
+    /// ```
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use scylla::client::session::Session;
+    /// use scylla::client::session_builder::MaintenanceSessionBuilder;
+    /// use scylla::client::maintenance_mode::MaintenanceModeEndpoint;
+    ///
+    /// let session: Session = MaintenanceSessionBuilder::new(
+    ///         MaintenanceModeEndpoint::hostname("127.0.0.1:9042"),
+    ///     )
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Over a Unix domain socket - note that a TLS context, if one were configured,
+    /// would simply be ignored here. `MaintenanceModeEndpoint::unix_socket` only
+    /// exists on Unix.
+    /// ```
+    /// # #[cfg(unix)]
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::MaintenanceSessionBuilder;
+    /// # use scylla::client::maintenance_mode::MaintenanceModeEndpoint;
+    /// let session: Session = MaintenanceSessionBuilder::new(
+    ///         MaintenanceModeEndpoint::unix_socket("/var/run/scylla/cql.sock"),
+    ///     )
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(unix))]
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn new(endpoint: super::maintenance_mode::MaintenanceModeEndpoint) -> Self {
+        MaintenanceSessionBuilder {
+            config: SessionConfig {
+                maintenance_mode: Some(endpoint),
+
+                // Maintenance mode fetches no metadata whatsoever. These two turn
+                // off the schema part of it.
+                fetch_schema_metadata: false,
+                fetch_full_schema_metadata: false,
+
+                connection_pool_size: PoolSize::PerHost(NonZeroUsize::new(1).unwrap()),
+                disallow_shard_aware_port: true,
+                schema_agreement_automatic_waiting: false,
+                refresh_metadata_on_auto_schema_agreement: false,
+
                 ..SessionConfig::new()
             },
             kind: PhantomData,
@@ -326,14 +440,54 @@ impl<K: SessionBuilderKindSupportsAddressTranslation> GenericSessionBuilder<K> {
     }
 }
 
+// TODO: find a better shape for this pair of traits.
+//
+// There are two of them only to avoid an API break. `SessionBuilderKindSupportsTls`
+// used to have `SessionBuilderKind` as its supertrait, so a downstream bound of
+// `K: SessionBuilderKindSupportsTls` also granted everything else, the node
+// selection options included. Maintenance mode supports TLS but not node
+// selection, so gating the `impl` block below on that trait would have forced its
+// supertrait to be weakened to `SessionBuilderKindBase` - and that would silently
+// take those options away from anyone generic over the TLS trait.
+//
+// So the block is gated on the weaker `...SupportsTlsBase`, which is the real
+// constraint ("this kind accepts a TLS context"), while the original trait is kept
+// with its original guarantee, plus the weaker one as a second supertrait so that
+// the old bound still reaches `tls_context`. Collapsing the two is a job for the
+// next major version.
+//
+// Note the two cannot be linked by a blanket `impl<T: ...SupportsTls>
+// ...SupportsTlsBase for T {}`: that would overlap the concrete impl for
+// `MaintenanceMode` (E0119), since coherence cannot prove a type does *not*
+// implement a trait.
+
+/// Constraint for session builder kinds that accept a TLS context.
+///
+/// This is the constraint the `tls_context` option is actually gated on.
+pub trait SessionBuilderKindSupportsTlsBase: SessionBuilderKindBase {}
+impl SessionBuilderKindSupportsTlsBase for DefaultMode {}
+// A maintenance mode session accepts a TLS context, and ignores it when the
+// endpoint it is pinned to is a Unix domain socket - such a socket is local by
+// construction. It does not support node selection, which is why it implements
+// this trait rather than `SessionBuilderKindSupportsTls`.
+impl SessionBuilderKindSupportsTlsBase for MaintenanceMode {}
+
 /// Constraint for session builder kinds that support setting TLS config on them.
-pub trait SessionBuilderKindSupportsTls: SessionBuilderKind {}
+///
+/// Retained with the guarantee it always had - it implies
+/// [`SessionBuilderKind`] - so that existing bounds on it keep granting every
+/// other option too. The `tls_context` option itself is gated on the weaker
+/// [`SessionBuilderKindSupportsTlsBase`], which this trait also implies.
+pub trait SessionBuilderKindSupportsTls:
+    SessionBuilderKind + SessionBuilderKindSupportsTlsBase
+{
+}
 impl SessionBuilderKindSupportsTls for DefaultMode {}
 // TODO: support TLS for ClientRoutesMode once Cloud comes up with a solution.
 // #[cfg(feature = "unstable-client-routes")]
 // impl SessionBuilderKindSupportsTls for ClientRoutesMode {}
 
-impl<K: SessionBuilderKindSupportsTls> GenericSessionBuilder<K> {
+impl<K: SessionBuilderKindSupportsTlsBase> GenericSessionBuilder<K> {
     /// TLS feature
     ///
     /// Provide SessionBuilder with TlsContext that will be
@@ -400,7 +554,7 @@ impl<K: SessionBuilderKindSupportsTls> GenericSessionBuilder<K> {
 
 // This block contains configuration options that make sense both for any `Session` type.
 // If an option fit only some of them, it should be put in a specialised block.
-impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
+impl<K: SessionBuilderKindBase> GenericSessionBuilder<K> {
     /// Set username and password for plain text authentication.
     ///
     /// # Example
@@ -553,36 +707,6 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// ```
     pub fn compression(mut self, compression: Option<Compression>) -> Self {
         self.config.compression = compression;
-        self
-    }
-
-    /// Sets the preferred datacenter for this session.
-    ///
-    /// Nodes in the given datacenter will be treated as "local" and preferred
-    /// by load balancing policies that do not override this preference.
-    pub fn prefer_datacenter(mut self, datacenter_name: String) -> Self {
-        self.config.node_location_preference = NodeLocationPreference::Datacenter(datacenter_name);
-        self
-    }
-
-    /// Sets the preferred datacenter and rack for this session.
-    ///
-    /// Nodes in the given rack of the given datacenter are tried first,
-    /// followed by other nodes in the same datacenter, and then remote nodes.
-    /// This preference is used by load balancing policies that do not override it.
-    pub fn prefer_datacenter_and_rack(
-        mut self,
-        datacenter_name: String,
-        rack_name: String,
-    ) -> Self {
-        self.config.node_location_preference =
-            NodeLocationPreference::DatacenterAndRack(datacenter_name, rack_name);
-        self
-    }
-
-    /// Clears any node location preference, treating all nodes equally.
-    pub fn prefer_no_datacenter(mut self) -> Self {
-        self.config.node_location_preference = NodeLocationPreference::Any;
         self
     }
 
@@ -1264,40 +1388,6 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
         self
     }
 
-    /// Sets the host filter. The host filter decides whether any connections
-    /// should be opened to the node or not. The driver will also avoid
-    /// those nodes when re-establishing the control connection.
-    ///
-    /// See the [host filter](crate::policies::host_filter) module for a list
-    /// of pre-defined filters. It is also possible to provide a custom filter
-    /// by implementing the HostFilter trait.
-    ///
-    /// # Example
-    /// ```
-    /// # use async_trait::async_trait;
-    /// # use std::net::SocketAddr;
-    /// # use std::sync::Arc;
-    /// # use scylla::client::session::Session;
-    /// # use scylla::client::session_builder::SessionBuilder;
-    /// # use scylla::errors::TranslationError;
-    /// # use scylla::policies::address_translator::AddressTranslator;
-    /// # use scylla::policies::host_filter::DcHostFilter;
-    ///
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// // The session will only connect to nodes from "my-local-dc"
-    /// let session: Session = SessionBuilder::new()
-    ///     .known_node("127.0.0.1:9042")
-    ///     .host_filter(Arc::new(DcHostFilter::new("my-local-dc".to_string())))
-    ///     .build()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn host_filter(mut self, filter: Arc<dyn HostFilter>) -> Self {
-        self.config.host_filter = Some(filter);
-        self
-    }
-
     /// Set the refresh metadata on schema agreement flag.
     /// The default is true.
     ///
@@ -1582,6 +1672,74 @@ impl<K: SessionBuilderKind> GenericSessionBuilder<K> {
     /// ```
     pub fn driver_config_reporting(mut self, report: bool) -> Self {
         self.config.driver_config_reporting = report;
+        self
+    }
+}
+
+/// Constraint for session builder kinds that support choosing which node a
+/// request goes to: the location preference and the host filter.
+impl<K: SessionBuilderKindSupportsNodeSelection> GenericSessionBuilder<K> {
+    /// Sets the preferred datacenter for this session.
+    ///
+    /// Nodes in the given datacenter will be treated as "local" and preferred
+    /// by load balancing policies that do not override this preference.
+    pub fn prefer_datacenter(mut self, datacenter_name: String) -> Self {
+        self.config.node_location_preference = NodeLocationPreference::Datacenter(datacenter_name);
+        self
+    }
+
+    /// Sets the preferred datacenter and rack for this session.
+    ///
+    /// Nodes in the given rack of the given datacenter are tried first,
+    /// followed by other nodes in the same datacenter, and then remote nodes.
+    /// This preference is used by load balancing policies that do not override it.
+    pub fn prefer_datacenter_and_rack(
+        mut self,
+        datacenter_name: String,
+        rack_name: String,
+    ) -> Self {
+        self.config.node_location_preference =
+            NodeLocationPreference::DatacenterAndRack(datacenter_name, rack_name);
+        self
+    }
+
+    /// Clears any node location preference, treating all nodes equally.
+    pub fn prefer_no_datacenter(mut self) -> Self {
+        self.config.node_location_preference = NodeLocationPreference::Any;
+        self
+    }
+
+    /// Sets the host filter. The host filter decides whether any connections
+    /// should be opened to the node or not. The driver will also avoid
+    /// those nodes when re-establishing the control connection.
+    ///
+    /// See the [host filter](crate::policies::host_filter) module for a list
+    /// of pre-defined filters. It is also possible to provide a custom filter
+    /// by implementing the HostFilter trait.
+    ///
+    /// # Example
+    /// ```
+    /// # use async_trait::async_trait;
+    /// # use std::net::SocketAddr;
+    /// # use std::sync::Arc;
+    /// # use scylla::client::session::Session;
+    /// # use scylla::client::session_builder::SessionBuilder;
+    /// # use scylla::errors::TranslationError;
+    /// # use scylla::policies::address_translator::AddressTranslator;
+    /// # use scylla::policies::host_filter::DcHostFilter;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// // The session will only connect to nodes from "my-local-dc"
+    /// let session: Session = SessionBuilder::new()
+    ///     .known_node("127.0.0.1:9042")
+    ///     .host_filter(Arc::new(DcHostFilter::new("my-local-dc".to_string())))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn host_filter(mut self, filter: Arc<dyn HostFilter>) -> Self {
+        self.config.host_filter = Some(filter);
         self
     }
 }
@@ -1932,6 +2090,94 @@ mod tests {
 
         assert!(builder.config.keyspace_case_sensitive);
         assert!(!builder.config.fetch_schema_metadata);
+    }
+
+    mod maintenance_mode {
+        use super::*;
+        use crate::client::PoolSize;
+        use crate::client::maintenance_mode::MaintenanceModeEndpoint;
+        use crate::client::session::Session;
+        use crate::client::session_builder::MaintenanceSessionBuilder;
+        use std::num::NonZeroUsize;
+        use std::sync::Arc;
+
+        fn builder() -> MaintenanceSessionBuilder {
+            MaintenanceSessionBuilder::new(MaintenanceModeEndpoint::hostname("127.0.0.1:9042"))
+        }
+
+        #[test]
+        fn defaults_differ_from_a_regular_session() {
+            setup_tracing();
+            let config = builder().config;
+
+            // No metadata whatsoever.
+            assert!(!config.fetch_schema_metadata);
+            assert!(!config.fetch_full_schema_metadata);
+
+            // Minimal footprint on the single node.
+            assert!(matches!(
+                config.connection_pool_size,
+                PoolSize::PerHost(n) if n == NonZeroUsize::new(1).unwrap()
+            ));
+            assert!(config.disallow_shard_aware_port);
+
+            // Nothing to agree on with one node and no metadata.
+            assert!(!config.schema_agreement_automatic_waiting);
+            assert!(!config.refresh_metadata_on_auto_schema_agreement);
+
+            // The endpoint stands in for the known nodes list, which stays empty
+            // until `connect` lowers the endpoint onto it.
+            assert!(config.known_nodes.is_empty());
+            assert!(config.maintenance_mode.is_some());
+        }
+
+        #[tokio::test]
+        async fn known_nodes_alongside_a_maintenance_endpoint_are_rejected() {
+            setup_tracing();
+            // The builder makes this unrepresentable, but `SessionConfig` is public
+            // and can be assembled by hand, so the runtime check has to hold too.
+            let mut config = builder().config;
+            config.add_known_node("127.0.0.1:9042");
+
+            let error = Session::connect(config).await.unwrap_err();
+            assert!(matches!(error, NewSessionError::IllegalConfig(_)));
+            assert!(
+                error.to_string().contains(
+                    "Known nodes must not be set together with a maintenance mode endpoint"
+                )
+            );
+        }
+
+        #[tokio::test]
+        async fn host_filter_is_rejected() {
+            setup_tracing();
+            let mut config = builder().config;
+            config.host_filter = Some(Arc::new(crate::policies::host_filter::AcceptAllHostFilter));
+
+            let error = Session::connect(config).await.unwrap_err();
+            assert!(matches!(error, NewSessionError::IllegalConfig(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("A host filter is not supported in maintenance mode")
+            );
+        }
+
+        #[tokio::test]
+        async fn node_location_preference_is_rejected() {
+            setup_tracing();
+            let mut config = builder().config;
+            config.node_location_preference =
+                crate::routing::NodeLocationPreference::Datacenter("dc1".to_owned());
+
+            let error = Session::connect(config).await.unwrap_err();
+            assert!(matches!(error, NewSessionError::IllegalConfig(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("A node location preference is not supported in maintenance mode")
+            );
+        }
     }
 
     // This is to assert that #705 does not break the API (i.e. it merely extends it).

--- a/scylla/src/cluster/metadata/cc_establisher.rs
+++ b/scylla/src/cluster/metadata/cc_establisher.rs
@@ -24,15 +24,14 @@ use tracing::{debug, error, warn};
 
 use crate::client::client_routes::ClientRoutesSubscriber;
 use crate::client::driver_config::DriverConfigReporter;
-use crate::cluster::KnownNode;
 use crate::cluster::control_connection::{
     ControlConnection, ControlConnectionCache, ControlConnectionConfig, ControlConnectionEvents,
     MetadataRequestTimeouts,
 };
 use crate::cluster::metadata::{
-    Metadata, Peer, PeerEndpoint, SchemaMetadataFetchMode, UntranslatedEndpoint,
+    Metadata, Peer, PeerEndpoint, SchemaMetadataFetchMode, Topology, UntranslatedEndpoint,
 };
-use crate::cluster::node::resolve_contact_points;
+use crate::cluster::node::InitialEndpoints;
 use crate::errors::{ConnectionPoolError, MetadataError, NewSessionError};
 use crate::frame::server_event_type::EventTypeV2 as EventType;
 use crate::network::{ConnectionConfig, open_connection};
@@ -56,9 +55,9 @@ pub(crate) struct ControlConnectionEstablisher {
     cc_config: ControlConnectionConfig,
     hostname_resolution_timeout: Option<Duration>,
     host_filter: Option<Arc<dyn HostFilter>>,
-    // When no known peer is reachable, initial known nodes are resolved once again as a fallback
-    // and establishing control connection to them is attempted.
-    initial_known_nodes: Vec<KnownNode>,
+    // When no known peer is reachable, the initial endpoints are resolved once again
+    // as a fallback and establishing a control connection to them is attempted.
+    initial_endpoints: InitialEndpoints,
 
     // ====================================================================
     // Mutable state of ControlConnectionEstablisher. It will change during its lifetime.
@@ -105,7 +104,7 @@ impl ControlConnectionEstablisher {
     /// for that.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
-        initial_known_nodes: Vec<KnownNode>,
+        initial_endpoints: InitialEndpoints,
         hostname_resolution_timeout: Option<Duration>,
         connection_config: ConnectionConfig,
         driver_config_reporter: Option<Arc<DriverConfigReporter>>,
@@ -115,14 +114,9 @@ impl ControlConnectionEstablisher {
         host_filter: &Option<Arc<dyn HostFilter>>,
         client_routes_subscriber: Option<Arc<dyn ClientRoutesSubscriber>>,
     ) -> Result<Self, NewSessionError> {
-        let (initial_peers, resolved_hostnames) =
-            resolve_contact_points(&initial_known_nodes, hostname_resolution_timeout).await;
-        // Ensure there is at least one resolved node
-        if initial_peers.is_empty() {
-            return Err(NewSessionError::FailedToResolveAnyHostname(
-                resolved_hostnames,
-            ));
-        }
+        let known_peers = initial_endpoints
+            .resolve(hostname_resolution_timeout)
+            .await?;
 
         let cc_cache = Arc::new(ControlConnectionCache::new());
 
@@ -138,12 +132,9 @@ impl ControlConnectionEstablisher {
                 request_timeouts,
             },
             hostname_resolution_timeout,
-            known_peers: initial_peers
-                .into_iter()
-                .map(UntranslatedEndpoint::ContactPoint)
-                .collect(),
+            known_peers,
             host_filter: host_filter.clone(),
-            initial_known_nodes,
+            initial_endpoints,
             cc_cache,
         })
     }
@@ -152,7 +143,10 @@ impl ControlConnectionEstablisher {
     ///
     /// Iterates over known peers (shuffled), trying to connect and run
     /// `fetcher` on each. If `initial` is false and all known peers are
-    /// exhausted, falls back to re-resolving the initial contact points.
+    /// exhausted, falls back to re-resolving the initial contact points -
+    /// except for a maintenance mode session, which is pinned to its one
+    /// endpoint for its whole lifetime and so never falls back to a re-resolve
+    /// that could silently repin it to a different address.
     ///
     /// `fetcher` is invoked once per candidate connection and must perform the
     /// metadata fetch on it; it is also free to consume the connection's server
@@ -212,22 +206,32 @@ impl ControlConnectionEstablisher {
             return Err(err);
         }
 
-        // If no known peer is reachable, try falling back to initial contact points, in hope that
-        // there are some hostnames there which will resolve to reachable new addresses.
+        if self.initial_endpoints.is_maintenance() {
+            // A maintenance mode session is pinned to one node for its whole lifetime.
+            // Re-resolving the endpoint here could silently repin it to a different
+            // address.
+            let err = known_peers_err.unwrap_or_else(no_nodes_available_error);
+            error!(
+                error = ?err,
+                "Could not establish control connection and fetch metadata on the maintenance mode endpoint"
+            );
+            return Err(err);
+        }
+
+        // If no known peer is reachable, try falling back to the initial endpoints, in hope
+        // that there are some hostnames there which will resolve to reachable new addresses.
         warn!(
-            "Failed to establish control connection and fetch metadata on all known peers. Falling back to initial contact points."
+            "Failed to establish control connection and fetch metadata on all known peers. Falling back to initial endpoints."
         );
-        let (initial_peers, _hostnames) =
-            resolve_contact_points(&self.initial_known_nodes, self.hostname_resolution_timeout)
-                .await;
+
+        let initial_peers = self
+            .initial_endpoints
+            .resolve(self.hostname_resolution_timeout)
+            .await
+            .unwrap_or_default();
+
         match self
-            .try_establish_on_nodes(
-                initial,
-                initial_peers
-                    .into_iter()
-                    .map(UntranslatedEndpoint::ContactPoint),
-                fetcher,
-            )
+            .try_establish_on_nodes(initial, initial_peers.into_iter(), fetcher)
             .await
         {
             Ok(result) => Ok(result),
@@ -382,16 +386,20 @@ impl ControlConnectionEstablisher {
         endpoint: &UntranslatedEndpoint,
         metadata: &Metadata,
     ) -> bool {
-        let control_connection_peer = metadata
-            .peers
+        // A maintenance mode session has no peer list to filter, and no host
+        // filter either so its endpoint can never be the rejected node.
+        let Topology::Peers(peers) = &metadata.topology else {
+            return false;
+        };
+
+        let control_connection_peer = peers
             .iter()
             .find(|peer| matches!(endpoint, UntranslatedEndpoint::Peer(PeerEndpoint{address, ..}) if *address == peer.address));
         if let Some(peer) = control_connection_peer
             && !self.host_filter.as_ref().is_none_or(|f| f.accept(peer))
         {
             warn!(
-                filtered_node_ips = tracing::field::display(metadata
-                    .peers
+                filtered_node_ips = tracing::field::display(peers
                     .iter()
                     .filter(|peer| self.host_filter.as_ref().is_none_or(|p| p.accept(peer)))
                     .map(|peer| peer.address)
@@ -419,11 +427,20 @@ impl ControlConnectionEstablisher {
         // setting event_sender field in connection config will cause control connection to
         // - send REGISTER message to receive server events
         // - send received events via server_event_sender
-        let mut events_to_register_for = vec![
-            EventType::TopologyChange,
-            EventType::StatusChange,
-            EventType::SchemaChange,
-        ];
+        //
+        //
+        // A maintenance mode session subscribes to SCHEMA_CHANGE only. It must not
+        // react to TOPOLOGY_CHANGE or STATUS_CHANGE, as both ask for a peer list
+        // re-read, which is exactly the node discovery that maintenance mode exists to avoid.
+        let mut events_to_register_for = if endpoint.is_maintenance() {
+            vec![EventType::SchemaChange]
+        } else {
+            vec![
+                EventType::TopologyChange,
+                EventType::StatusChange,
+                EventType::SchemaChange,
+            ]
+        };
         if cc_config.client_routes_subscriber.is_some() {
             events_to_register_for.push(EventType::ClientRoutesChange);
         }
@@ -477,7 +494,12 @@ impl TopologyUpdateGuard<Metadata> {
     /// Updates the establisher's known peers from the fetched metadata and releases
     /// the metadata itself.
     pub(super) fn apply(self, establisher: &mut ControlConnectionEstablisher) -> Metadata {
-        establisher.update_known_peers(&self.inner.peers);
+        match &self.inner.topology {
+            Topology::Peers(peers) => establisher.update_known_peers(peers),
+            // A maintenance mode session is pinned to the endpoint the user named,
+            // so its known peer list is fixed.
+            Topology::Maintenance(_) => (),
+        }
         self.inner
     }
 }

--- a/scylla/src/cluster/metadata/fetching.rs
+++ b/scylla/src/cluster/metadata/fetching.rs
@@ -42,7 +42,7 @@ use crate::client::pager::QueryPager;
 use crate::cluster::NodeAddr;
 use crate::cluster::control_connection::ControlConnection;
 use crate::cluster::metadata::update::{FetchedKeyspace, SchemaUpdate};
-use crate::cluster::metadata::{ClientRoutes, ClientRoutesUpdate};
+use crate::cluster::metadata::{ClientRoutes, ClientRoutesUpdate, Topology, UntranslatedEndpoint};
 use crate::deserialize::DeserializeOwnedRow;
 use crate::errors::{
     ClientRoutesMetadataError, DbError, KeyspaceStrategyError, KeyspacesMetadataError,
@@ -171,7 +171,19 @@ impl ControlConnection {
     pub(super) async fn query_metadata(&self) -> Result<TopologyUpdateGuard, MetadataError> {
         let connect_port = self.endpoint().address().port();
 
-        let peers_query = self.query_peers(connect_port);
+        let topology_query = async {
+            match self.endpoint() {
+                // A maintenance mode session never reads the peer list
+                UntranslatedEndpoint::Maintenance(endpoint) => {
+                    Ok((Topology::Maintenance(endpoint.clone()), None))
+                }
+                _ => {
+                    let (peers, cluster_name) = self.query_peers(connect_port).await?;
+                    Self::validate_peers(&peers)?;
+                    Ok((Topology::Peers(peers), cluster_name))
+                }
+            }
+        };
         let keyspaces_query = self.query_keyspaces(
             &self.config.keyspaces_to_fetch,
             self.config.schema_metadata_fetch_mode,
@@ -184,19 +196,17 @@ impl ControlConnection {
                 .await
                 .map(Some)
         };
-        let peers_and_cluster_name;
+        let topology_and_cluster_name;
         let client_routes: Option<ClientRoutes>;
         let keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>;
 
-        (peers_and_cluster_name, client_routes, keyspaces) =
-            tokio::try_join!(peers_query, client_routes_query, keyspaces_query)?;
+        (topology_and_cluster_name, client_routes, keyspaces) =
+            tokio::try_join!(topology_query, client_routes_query, keyspaces_query)?;
 
-        let (peers, cluster_name) = peers_and_cluster_name;
-
-        Self::validate_peers(&peers)?;
+        let (topology, cluster_name) = topology_and_cluster_name;
 
         Ok(TopologyUpdateGuard::new(Metadata {
-            peers,
+            topology,
             keyspaces,
             cluster_name,
             client_routes,
@@ -215,6 +225,14 @@ impl ControlConnection {
     pub(super) async fn query_topology(
         &self,
     ) -> Result<TopologyUpdateGuard<Vec<Peer>>, MetadataError> {
+        // Unreachable in maintenance mode: a partial topology fetch is only ever
+        // requested by the TOPOLOGY_CHANGE and STATUS_CHANGE handlers, and a
+        // maintenance mode session registers for neither event.
+        debug_assert!(
+            !self.endpoint().is_maintenance(),
+            "a maintenance mode session must never read the peer list"
+        );
+
         let connect_port = self.endpoint().address().port();
 
         let (peers, _cluster_name) = self.query_peers(connect_port).await?;

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod update;
 pub(super) mod worker;
 
 use crate::cluster::metadata::update::ClientRoutesUpdate;
-use crate::cluster::node::{NodeAddr, ResolvedContactPoint};
+use crate::cluster::node::{NodeAddr, ResolvedContactPoint, Transport};
 use crate::routing::Token;
 
 use crate::frame::response::result::ColumnSpec;
@@ -146,6 +146,7 @@ pub(crate) enum UntranslatedEndpoint {
 #[derive(Clone, Debug)]
 pub(crate) struct MaintenanceEndpoint {
     pub(crate) address: SocketAddr,
+    pub(crate) transport: Transport,
 }
 
 /// The host id of a node whose identity the driver never read from the cluster:
@@ -156,7 +157,8 @@ impl UntranslatedEndpoint {
     pub(crate) fn address(&self) -> NodeAddr {
         match *self {
             UntranslatedEndpoint::ContactPoint(ResolvedContactPoint { address, .. })
-            // A maintenance endpoint is user-provided, hence already translated.
+            // A maintenance endpoint is user-provided, hence already translated -
+            // and for a Unix socket the address is only a placeholder anyway.
             | UntranslatedEndpoint::Maintenance(MaintenanceEndpoint { address, .. }) => {
                 NodeAddr::Untranslatable(address)
             }
@@ -194,6 +196,16 @@ impl UntranslatedEndpoint {
     pub(crate) fn is_maintenance(&self) -> bool {
         matches!(self, UntranslatedEndpoint::Maintenance(_))
     }
+    /// How to reach the node this endpoint describes.
+    pub(crate) fn transport(&self) -> &Transport {
+        match self {
+            UntranslatedEndpoint::ContactPoint(_) | UntranslatedEndpoint::Peer(_) => {
+                &Transport::Tcp
+            }
+            UntranslatedEndpoint::Maintenance(MaintenanceEndpoint { transport, .. }) => transport,
+        }
+    }
+
     pub(crate) fn set_port(&mut self, port: u16) {
         let inner_addr = match self {
             UntranslatedEndpoint::ContactPoint(ResolvedContactPoint { address, .. })

--- a/scylla/src/cluster/metadata/mod.rs
+++ b/scylla/src/cluster/metadata/mod.rs
@@ -29,6 +29,7 @@ use crate::routing::Token;
 
 use crate::frame::response::result::ColumnSpec;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
@@ -90,9 +91,18 @@ pub(crate) enum SingleKeyspaceMetadataError {
     IncompleteClusteringKey(i32),
 }
 
+/// The nodes a session talks to.
+pub(crate) enum Topology {
+    /// Peers read from `system.peers` and `system.local`.
+    Peers(Vec<Peer>),
+    /// The single endpoint a maintenance mode session is pinned to. Nothing was
+    /// read from the cluster, so there is nothing to describe but the endpoint.
+    Maintenance(MaintenanceEndpoint),
+}
+
 /// Describes all metadata retrieved from the cluster
 pub(crate) struct Metadata {
-    pub(crate) peers: Vec<Peer>,
+    pub(crate) topology: Topology,
     pub(crate) keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>,
     pub(crate) cluster_name: Option<String>,
 
@@ -127,20 +137,67 @@ pub(crate) enum UntranslatedEndpoint {
     ContactPoint(ResolvedContactPoint),
     /// Fetched in Metadata with `query_peers()`
     Peer(PeerEndpoint),
+    /// The single endpoint a maintenance mode session is pinned to, provided by
+    /// the user in `SessionConfig`.
+    Maintenance(MaintenanceEndpoint),
 }
+
+/// The single endpoint of a maintenance mode session.
+#[derive(Clone, Debug)]
+pub(crate) struct MaintenanceEndpoint {
+    pub(crate) address: SocketAddr,
+}
+
+/// The host id of a node whose identity the driver never read from the cluster:
+/// a contact point, or the endpoint a maintenance mode session is pinned to.
+pub(crate) const UNKNOWN_HOST_ID: Uuid = Uuid::nil();
 
 impl UntranslatedEndpoint {
     pub(crate) fn address(&self) -> NodeAddr {
         match *self {
-            UntranslatedEndpoint::ContactPoint(ResolvedContactPoint { address, .. }) => {
+            UntranslatedEndpoint::ContactPoint(ResolvedContactPoint { address, .. })
+            // A maintenance endpoint is user-provided, hence already translated.
+            | UntranslatedEndpoint::Maintenance(MaintenanceEndpoint { address, .. }) => {
                 NodeAddr::Untranslatable(address)
             }
             UntranslatedEndpoint::Peer(PeerEndpoint { address, .. }) => address,
         }
     }
+
+    /// The node's host id, as far as the driver knows it.
+    pub(crate) fn host_id(&self) -> Uuid {
+        match self {
+            UntranslatedEndpoint::Peer(PeerEndpoint { host_id, .. }) => *host_id,
+            UntranslatedEndpoint::ContactPoint(_) | UntranslatedEndpoint::Maintenance(_) => {
+                UNKNOWN_HOST_ID
+            }
+        }
+    }
+
+    /// The datacenter the node is in, if the driver learned it.
+    pub(crate) fn datacenter(&self) -> Option<&str> {
+        match self {
+            UntranslatedEndpoint::Peer(PeerEndpoint { datacenter, .. }) => datacenter.as_deref(),
+            UntranslatedEndpoint::ContactPoint(_) | UntranslatedEndpoint::Maintenance(_) => None,
+        }
+    }
+
+    /// The rack the node is in, if the driver learned it.
+    pub(crate) fn rack(&self) -> Option<&str> {
+        match self {
+            UntranslatedEndpoint::Peer(PeerEndpoint { rack, .. }) => rack.as_deref(),
+            UntranslatedEndpoint::ContactPoint(_) | UntranslatedEndpoint::Maintenance(_) => None,
+        }
+    }
+
+    /// Whether this endpoint is the pinned endpoint of a maintenance mode session.
+    pub(crate) fn is_maintenance(&self) -> bool {
+        matches!(self, UntranslatedEndpoint::Maintenance(_))
+    }
     pub(crate) fn set_port(&mut self, port: u16) {
         let inner_addr = match self {
-            UntranslatedEndpoint::ContactPoint(ResolvedContactPoint { address, .. }) => address,
+            UntranslatedEndpoint::ContactPoint(ResolvedContactPoint { address, .. })
+            | UntranslatedEndpoint::Maintenance(MaintenanceEndpoint { address, .. }) => address,
             UntranslatedEndpoint::Peer(PeerEndpoint { address, .. }) => address.inner_mut(),
         };
         inner_addr.set_port(port);
@@ -450,6 +507,15 @@ impl Metadata {
     /// It can be used as a replacement for real metadata when initial
     /// metadata read fails.
     pub(crate) fn new_dummy(initial_peers: &[UntranslatedEndpoint]) -> Self {
+        if let [UntranslatedEndpoint::Maintenance(endpoint)] = initial_peers {
+            return Metadata {
+                topology: Topology::Maintenance(endpoint.clone()),
+                keyspaces: HashMap::new(),
+                cluster_name: None,
+                client_routes: None,
+            };
+        }
+
         let peers = initial_peers
             .iter()
             .enumerate()
@@ -469,7 +535,7 @@ impl Metadata {
             .collect();
 
         Metadata {
-            peers,
+            topology: Topology::Peers(peers),
             keyspaces: HashMap::new(),
             cluster_name: None,
             client_routes: None,

--- a/scylla/src/cluster/metadata/update.rs
+++ b/scylla/src/cluster/metadata/update.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::cluster::metadata::{
-    ClientRoute, ClientRoutes, Keyspace, Metadata, Peer, SingleKeyspaceMetadataError,
+    ClientRoute, ClientRoutes, Keyspace, Metadata, Peer, SingleKeyspaceMetadataError, Topology,
 };
 use crate::errors::MetadataError;
 
@@ -223,7 +223,7 @@ impl MetadataUpdate {
                 // the partial ones in flight, so a partial fetch can only
                 // complete after a pending full fetch if it was started after
                 // that fetch completed.
-                metadata.peers = peers;
+                metadata.topology = Topology::Peers(peers);
             }
         }
     }
@@ -798,7 +798,7 @@ mod tests {
         FetchedKeyspace, MetadataChanges, MetadataUpdate, SchemaUpdate,
     };
     use crate::cluster::metadata::{
-        ConsistencyMode, Keyspace, Metadata, SingleKeyspaceMetadataError, Strategy,
+        ConsistencyMode, Keyspace, Metadata, SingleKeyspaceMetadataError, Strategy, Topology,
     };
 
     // Keyspaces are told apart by `durable_writes`, which is all it takes to
@@ -823,7 +823,7 @@ mod tests {
 
     fn metadata(keyspaces: Vec<(&str, Result<Keyspace, SingleKeyspaceMetadataError>)>) -> Metadata {
         Metadata {
-            peers: Vec::new(),
+            topology: Topology::Peers(Vec::new()),
             keyspaces: keyspaces
                 .into_iter()
                 .map(|(name, keyspace)| (name.to_owned(), keyspace))

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -2,7 +2,8 @@ use tokio::net::{ToSocketAddrs, lookup_host};
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::errors::{ConnectionPoolError, DnsLookupError, UseKeyspaceError};
+use crate::client::maintenance_mode::MaintenanceModeEndpoint;
+use crate::errors::{ConnectionPoolError, DnsLookupError, NewSessionError, UseKeyspaceError};
 use crate::network::VerifiedKeyspaceName;
 use crate::network::{Connection, ConnectivityChangeEvent};
 use crate::network::{NodeConnectionPool, PoolConfig};
@@ -114,21 +115,21 @@ pub type NodeRef<'a> = &'a Arc<Node>;
 impl Node {
     /// Creates a new node which starts connecting in the background.
     pub(crate) fn new(
-        peer: PeerEndpoint,
+        endpoint: UntranslatedEndpoint,
         pool_config: &PoolConfig,
         connectivity_events_sender: tokio::sync::mpsc::UnboundedSender<ConnectivityChangeEvent>,
         keyspace_name: Option<VerifiedKeyspaceName>,
         metrics: Metrics,
     ) -> Self {
-        let host_id = peer.host_id;
-        let address = peer.address;
-        let datacenter = peer.datacenter.clone();
-        let rack = peer.rack.clone();
+        let host_id = endpoint.host_id();
+        let address = endpoint.address();
+        let datacenter = endpoint.datacenter().map(str::to_owned);
+        let rack = endpoint.rack().map(str::to_owned);
 
         // We aren't interested in the fact that the pool becomes empty, so we immediately drop the receiving part.
         let (pool_empty_notifier, _) = tokio::sync::mpsc::channel(1);
         let pool = NodeConnectionPool::new(
-            UntranslatedEndpoint::Peer(peer),
+            endpoint,
             pool_config,
             Some((host_id, connectivity_events_sender)),
             keyspace_name,
@@ -305,6 +306,72 @@ pub enum KnownNode {
     Hostname(String),
     /// A node identified by its IP address + a port.
     Address(SocketAddr),
+}
+
+/// Where a session's endpoints come from: a list of known nodes to discover the
+/// cluster from, or the single endpoint a maintenance mode session is pinned to.
+#[derive(Debug, Clone)]
+pub(crate) enum InitialEndpoints {
+    /// Contact points to discover the cluster from.
+    KnownNodes(Vec<KnownNode>),
+    /// The single endpoint a maintenance mode session talks to, and the only
+    /// place such a session ever connects.
+    Maintenance(MaintenanceModeEndpoint),
+}
+
+impl InitialEndpoints {
+    /// Decides where a session will connect, rejecting configurations that name
+    /// nowhere and configurations that name two places at once.
+    pub(crate) fn from_config(
+        known_nodes: Vec<KnownNode>,
+        maintenance_mode: Option<MaintenanceModeEndpoint>,
+    ) -> Result<Self, NewSessionError> {
+        match (maintenance_mode, known_nodes) {
+            (Some(endpoint), nodes) if nodes.is_empty() => Ok(Self::Maintenance(endpoint)),
+            (Some(_), _) => Err(NewSessionError::IllegalConfig(
+                "Known nodes must not be set together with a maintenance mode endpoint: a \
+                 maintenance mode session is pinned to exactly one node, and that node is the \
+                 maintenance mode endpoint"
+                    .into(),
+            )),
+            (None, nodes) if !nodes.is_empty() => Ok(Self::KnownNodes(nodes)),
+            (None, _) => Err(NewSessionError::EmptyKnownNodesList),
+        }
+    }
+
+    /// Whether these are the endpoints of a maintenance mode session.
+    pub(crate) fn is_maintenance(&self) -> bool {
+        matches!(self, Self::Maintenance(_))
+    }
+
+    /// Resolves into the endpoints to attempt a control connection on.
+    pub(crate) async fn resolve(
+        &self,
+        hostname_resolution_timeout: Option<Duration>,
+    ) -> Result<Vec<UntranslatedEndpoint>, NewSessionError> {
+        Ok(match self {
+            Self::KnownNodes(known_nodes) => {
+                let (contact_points, resolved_hostnames) =
+                    resolve_contact_points(known_nodes, hostname_resolution_timeout).await;
+                // Ensure there is at least one resolved node
+                if contact_points.is_empty() {
+                    return Err(NewSessionError::FailedToResolveAnyHostname(
+                        resolved_hostnames,
+                    ));
+                }
+                contact_points
+                    .into_iter()
+                    .map(UntranslatedEndpoint::ContactPoint)
+                    .collect()
+            }
+            Self::Maintenance(endpoint) => vec![UntranslatedEndpoint::Maintenance(
+                endpoint
+                    .clone()
+                    .resolve(hostname_resolution_timeout)
+                    .await?,
+            )],
+        })
+    }
 }
 
 /// Describes a database server known on Session startup, with already resolved address.

--- a/scylla/src/cluster/node.rs
+++ b/scylla/src/cluster/node.rs
@@ -374,6 +374,19 @@ impl InitialEndpoints {
     }
 }
 
+/// How the driver actually reaches a node, as opposed to how the node is
+/// identified (which is always a [`SocketAddr`], see [`NodeAddr`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Transport {
+    /// A TCP connection to the node's address.
+    #[default]
+    Tcp,
+    /// A connection to a Unix domain socket at the given path. The node's
+    /// address is then only a placeholder identity, never connected to.
+    #[cfg(unix)]
+    UnixSocket(Arc<std::path::Path>),
+}
+
 /// Describes a database server known on Session startup, with already resolved address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ResolvedContactPoint {

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -96,7 +96,7 @@ type Ring = Vec<(Token, Arc<Node>)>;
 
 impl ClusterState {
     pub(crate) async fn wait_until_all_pools_are_initialized(&self) {
-        for node in self.locator.unique_nodes_in_global_ring().iter() {
+        for node in self.known_nodes.values() {
             node.wait_until_pool_initialized().await;
         }
     }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -1,5 +1,8 @@
 use crate::cluster::metadata::update::{FetchedKeyspace, SchemaUpdate};
-use crate::cluster::metadata::{Peer, SingleKeyspaceMetadataError};
+use crate::cluster::metadata::{
+    MaintenanceEndpoint, Peer, SingleKeyspaceMetadataError, Topology, UNKNOWN_HOST_ID,
+    UntranslatedEndpoint,
+};
 use crate::errors::{ClusterStateTokenError, ConnectionPoolError};
 use crate::network::{Connection, ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
 use crate::observability::metrics::Metrics;
@@ -175,8 +178,12 @@ impl ClusterState {
         node_config: &NodeConfig,
         host_filter: Option<&dyn HostFilter>,
     ) -> Self {
-        let (new_known_nodes, ring) =
-            Self::calculate_new_topology(metadata.peers, &HashMap::new(), node_config, host_filter);
+        let (new_known_nodes, ring) = Self::calculate_new_topology(
+            metadata.topology,
+            &HashMap::new(),
+            node_config,
+            host_filter,
+        );
 
         let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, &HashMap::new());
 
@@ -211,7 +218,7 @@ impl ClusterState {
         let keyspaces = Self::resolve_metadata_keyspaces(metadata.keyspaces, &self.keyspaces);
 
         let (new_known_nodes, ring) = Self::calculate_new_topology(
-            metadata.peers,
+            metadata.topology,
             &self.known_nodes,
             node_config,
             host_filter,
@@ -253,9 +260,12 @@ impl ClusterState {
         host_filter: Option<&dyn HostFilter>,
     ) -> Self {
         let (new_known_nodes, ring) = match peers {
-            Some(peers) => {
-                Self::calculate_new_topology(peers, &self.known_nodes, node_config, host_filter)
-            }
+            Some(peers) => Self::calculate_new_topology(
+                Topology::Peers(peers),
+                &self.known_nodes,
+                node_config,
+                host_filter,
+            ),
             // The ring in place is exactly the (token, node) list that the
             // unchanged topology implies, so it is reused as is.
             None => (
@@ -319,6 +329,46 @@ impl ClusterState {
     ///
     /// Previous topology is used to reuse connection pools and `Node` objects when possible.
     fn calculate_new_topology(
+        topology: Topology,
+        known_nodes: &KnownNodes,
+        node_config: &NodeConfig,
+        host_filter: Option<&dyn HostFilter>,
+    ) -> (KnownNodes, Ring) {
+        match topology {
+            Topology::Peers(peers) => {
+                Self::topology_from_peers(peers, known_nodes, node_config, host_filter)
+            }
+            Topology::Maintenance(endpoint) => {
+                Self::topology_from_maintenance_endpoint(endpoint, known_nodes, node_config)
+            }
+        }
+    }
+
+    /// The topology of a maintenance mode session: the single node it is pinned to.
+    fn topology_from_maintenance_endpoint(
+        endpoint: MaintenanceEndpoint,
+        known_nodes: &KnownNodes,
+        node_config: &NodeConfig,
+    ) -> (KnownNodes, Ring) {
+        let node = match known_nodes.get(&UNKNOWN_HOST_ID) {
+            Some(node) => Arc::clone(node),
+            None => Arc::new(Node::new(
+                UntranslatedEndpoint::Maintenance(endpoint),
+                &node_config.pool_config,
+                node_config.connectivity_events_sender.clone(),
+                node_config.used_keyspace.clone(),
+                node_config.metrics.clone(),
+            )),
+        };
+
+        (
+            HashMap::from([(UNKNOWN_HOST_ID, Arc::clone(&node))]),
+            vec![(Token::new(0), node)],
+        )
+    }
+
+    /// The topology described by a peer list read from the cluster.
+    fn topology_from_peers(
         peers: Vec<Peer>,
         known_nodes: &KnownNodes,
         node_config: &NodeConfig,
@@ -368,7 +418,7 @@ impl ClusterState {
                     }
                 }
                 (true, _) => Arc::new(Node::new(
-                    peer_endpoint,
+                    UntranslatedEndpoint::Peer(peer_endpoint),
                     &node_config.pool_config,
                     node_config.connectivity_events_sender.clone(),
                     node_config.used_keyspace.clone(),
@@ -847,7 +897,7 @@ mod tests {
 
     fn make_metadata(peers: Vec<Peer>) -> Metadata {
         Metadata {
-            peers,
+            topology: Topology::Peers(peers),
             keyspaces: HashMap::new(),
             client_routes: None,
             cluster_name: Some("Test Cluster".into()),

--- a/scylla/src/cluster/worker.rs
+++ b/scylla/src/cluster/worker.rs
@@ -3,13 +3,14 @@ use crate::client::client_routes::{
 };
 use crate::client::driver_config::DriverConfigReporter;
 use crate::client::session::TABLET_CHANNEL_SIZE;
+use crate::cluster::Node;
 use crate::cluster::control_connection::MetadataRequestTimeouts;
 use crate::cluster::metadata::update::{
     MetadataChanges, MetadataUpdate, PartialMetadataChanges, RefreshRequest, StatusHint,
 };
 use crate::cluster::metadata::{PeriodicFetchMode, SchemaMetadataFetchMode};
+use crate::cluster::node::InitialEndpoints;
 use crate::cluster::state::NodeConfig;
-use crate::cluster::{KnownNode, Node};
 use crate::errors::{MetadataError, NewSessionError, RequestAttemptError, UseKeyspaceError};
 use crate::network::{ConnectivityChangeEvent, PoolConfig, VerifiedKeyspaceName};
 use crate::observability::metrics::Metrics;
@@ -63,7 +64,7 @@ impl std::fmt::Debug for ClusterNeatDebug<'_> {
 impl Cluster {
     #[expect(clippy::too_many_arguments)]
     pub(crate) async fn new(
-        known_nodes: Vec<KnownNode>,
+        initial_endpoints: InitialEndpoints,
         mut pool_config: PoolConfig,
         driver_config_reporter: Option<Arc<DriverConfigReporter>>,
         keyspaces_to_fetch: Vec<String>,
@@ -104,7 +105,7 @@ impl Cluster {
             .map(|translator| translator as Arc<dyn ClientRoutesSubscriber>);
 
         let cc_establisher = ControlConnectionEstablisher::new(
-            known_nodes,
+            initial_endpoints,
             hostname_resolution_timeout,
             pool_config.connection_config.clone(),
             driver_config_reporter,

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -6,6 +6,7 @@ use crate::client::driver_config::DriverConfigReporter;
 use crate::client::pager::{NextRowError, QueryPager};
 use crate::cluster::NodeAddr;
 use crate::cluster::metadata::{PeerEndpoint, UntranslatedEndpoint};
+use crate::cluster::node::Transport;
 use crate::errors::{
     BadKeyspaceName, BrokenConnectionError, BrokenConnectionErrorKind, ConnectionError,
     ConnectionSetupRequestError, ConnectionSetupRequestErrorKind, CqlEventHandlingError, DbError,
@@ -61,6 +62,8 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr},
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter, split};
+#[cfg(unix)]
+use tokio::net::UnixStream;
 use tokio::net::{TcpSocket, TcpStream};
 use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::time::Instant;
@@ -369,10 +372,14 @@ impl ConnectionConfig {
         &self,
         endpoint: &UntranslatedEndpoint,
     ) -> HostConnectionConfig {
-        let tls_config = self
-            .tls_provider
-            .as_ref()
-            .and_then(|provider| provider.make_tls_config(endpoint));
+        let transport = endpoint.transport().clone();
+
+        // For a Unix socket TLS context is silently skipped.
+        let tls_provider = self.tls_provider.as_ref();
+        #[cfg(unix)]
+        let tls_provider = tls_provider.filter(|_| !matches!(transport, Transport::UnixSocket(_)));
+
+        let tls_config = tls_provider.and_then(|provider| provider.make_tls_config(endpoint));
 
         HostConnectionConfig {
             local_ip_address: self.local_ip_address,
@@ -393,6 +400,7 @@ impl ConnectionConfig {
             identity: self.identity.clone(),
             session_id: self.session_id,
             driver_config_reporter: self.driver_config_reporter.clone(),
+            transport,
             #[cfg(test)]
             transport_factory: None,
         }
@@ -426,6 +434,10 @@ pub(crate) struct HostConnectionConfig {
     pub(crate) session_id: Uuid,
     // should be Some only in control connections
     pub(crate) driver_config_reporter: Option<Arc<DriverConfigReporter>>,
+
+    /// How to reach the node, taken from its endpoint: over TCP at
+    /// `connect_address`, or over a Unix domain socket whose path this carries.
+    pub(crate) transport: Transport,
 
     #[cfg(test)]
     pub(crate) transport_factory: Option<Arc<scylla_proxy::TransportFactory>>,
@@ -461,6 +473,7 @@ impl Default for HostConnectionConfig {
 
             // Test connections do not report their configuration.
             driver_config_reporter: None,
+            transport: Transport::Tcp,
 
             #[cfg(test)]
             transport_factory: None,
@@ -537,6 +550,34 @@ impl Connection {
                 config,
                 #[cfg(test)]
                 None,
+            )
+            .await;
+        }
+
+        // Maintenance mode may target a Unix domain socket. `connect_address` is then
+        // only a placeholder identity for the endpoint, not something to connect to.
+        #[cfg(unix)]
+        if let Transport::UnixSocket(path) = config.transport.clone() {
+            let stream =
+                match tokio::time::timeout(config.connect_timeout, UnixStream::connect(&*path))
+                    .await
+                {
+                    Ok(stream) => stream.map_err(|e| ConnectionError::IoError(Arc::new(e)))?,
+                    Err(_) => return Err(ConnectionError::ConnectTimeout),
+                };
+
+            #[cfg(test)]
+            let socket = {
+                use std::os::unix::io::AsFd;
+                Some(socket2::Socket::from(stream.as_fd().try_clone_to_owned()?))
+            };
+
+            return Self::new_with_transport(
+                stream,
+                connect_address,
+                config,
+                #[cfg(test)]
+                socket,
             )
             .await;
         }
@@ -2108,7 +2149,7 @@ async fn maybe_translated_addr(
         }
 
         (UntranslatedEndpoint::Maintenance(endpoint), _) => {
-            // A maintenance mode session's endpoint is not inteded to be translated.
+            // A maintenance mode session's endpoint is not intended to be translated.
             Ok(endpoint.address)
         }
 

--- a/scylla/src/network/connection.rs
+++ b/scylla/src/network/connection.rs
@@ -2107,6 +2107,11 @@ async fn maybe_translated_addr(
             Ok(addr.address)
         }
 
+        (UntranslatedEndpoint::Maintenance(endpoint), _) => {
+            // A maintenance mode session's endpoint is not inteded to be translated.
+            Ok(endpoint.address)
+        }
+
         (
             UntranslatedEndpoint::Peer(PeerEndpoint { address, .. }),
             None, // no translator

--- a/scylla/src/network/connection_pool.rs
+++ b/scylla/src/network/connection_pool.rs
@@ -1054,9 +1054,11 @@ impl PoolRefiller {
         };
         let expected_host_id = match &*self.endpoint.read().unwrap() {
             UntranslatedEndpoint::Peer(PeerEndpoint { host_id, .. }) => *host_id,
-            // Pools are always created for a known peer (`Node::new`); a contact point endpoint
-            // only occurs in unit tests, and then there is no host ID to expect.
-            UntranslatedEndpoint::ContactPoint(_) => return,
+            // Neither endpoint carries an authoritative identity to check against:
+            // a contact point is user-provided (and only reaches a pool in unit
+            // tests), and a maintenance mode endpoint describes a node whose peer
+            // entry was never read from the cluster.
+            UntranslatedEndpoint::ContactPoint(_) | UntranslatedEndpoint::Maintenance(_) => return,
         };
 
         if expected_host_id != reported_host_id {

--- a/scylla/src/policies/load_balancing/default.rs
+++ b/scylla/src/policies/load_balancing/default.rs
@@ -1554,7 +1554,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             let info = Metadata {
-                peers,
+                topology: crate::cluster::metadata::Topology::Peers(peers),
                 keyspaces: HashMap::new(),
                 client_routes: None,
                 cluster_name: Some("TestCluster".into()),

--- a/scylla/src/routing/locator/test.rs
+++ b/scylla/src/routing/locator/test.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 use super::tablets::TabletsInfo;
 use super::{ReplicaLocator, ReplicaSet};
 use crate::cluster::Node;
-use crate::cluster::metadata::{ConsistencyMode, Keyspace, Metadata, Peer, Strategy};
+use crate::cluster::metadata::{
+    ConsistencyMode, Keyspace, Metadata, Peer, Strategy, Topology, UntranslatedEndpoint,
+};
 use crate::cluster::{NodeAddr, NodeRef};
 use crate::network::PoolConfig;
 use crate::routing::Token;
@@ -168,7 +170,7 @@ pub(crate) fn mock_metadata_for_token_aware_tests() -> Metadata {
     .collect();
 
     Metadata {
-        peers: Vec::from(peers),
+        topology: Topology::Peers(Vec::from(peers)),
         keyspaces,
         cluster_name: Some("TestCluster".into()),
         client_routes: None,
@@ -193,9 +195,12 @@ pub(crate) fn create_ring(metadata: &Metadata) -> impl Iterator<Item = (Token, A
     let mut ring: Vec<(Token, Arc<Node>)> = Vec::new();
 
     let (connectivity_events_sender, _) = tokio::sync::mpsc::unbounded_channel();
-    for peer in &metadata.peers {
+    let Topology::Peers(peers) = &metadata.topology else {
+        panic!("locator tests always describe a peer list")
+    };
+    for peer in peers {
         let node = Arc::new(Node::new(
-            peer.to_peer_endpoint(),
+            UntranslatedEndpoint::Peer(peer.to_peer_endpoint()),
             &pool_config,
             connectivity_events_sender.clone(),
             None,

--- a/scylla/tests/integration/ccm/maintenance_socket.rs
+++ b/scylla/tests/integration/ccm/maintenance_socket.rs
@@ -1,0 +1,101 @@
+//! CCM test of maintenance mode over ScyllaDB's own maintenance socket.
+//!
+//! ScyllaDB opens a Unix domain socket for maintenance work (the
+//! `maintenance_socket` option of `scylla.yaml`), and talking to a single node
+//! through it is what maintenance mode exists for. This has to be a CCM test:
+//! a CCM cluster runs its nodes as local processes, so that socket lands on the
+//! test's own filesystem, whereas in the dockerized cluster the other
+//! integration tests use it stays inside the container, unreachable.
+
+use std::path::PathBuf;
+
+use scylla::client::maintenance_mode::MaintenanceModeEndpoint;
+use scylla::client::session_builder::MaintenanceSessionBuilder;
+use scylla_ccm_bridge::cluster::{Cluster, ClusterOptions};
+use scylla_ccm_bridge::{CLUSTER_VERSION, run_ccm_test_with_configuration};
+
+use crate::utils::setup_tracing;
+
+fn cluster_1_node() -> ClusterOptions {
+    ClusterOptions {
+        name: "maintenance_socket".to_string(),
+        version: CLUSTER_VERSION.clone(),
+        nodes_per_dc: vec![1],
+        ..ClusterOptions::default()
+    }
+}
+
+/// Where the node is told to open its maintenance socket.
+fn maintenance_socket_path(cluster: &Cluster) -> PathBuf {
+    let unique = cluster
+        .cluster_dir()
+        .parent()
+        .and_then(|config_dir| config_dir.file_name())
+        .expect("the cluster directory is `<config dir>/<cluster name>`")
+        .to_string_lossy()
+        .into_owned();
+
+    std::env::temp_dir().join(format!("{unique}.sock"))
+}
+
+/// Asserts that a maintenance mode session can talk to a node over ScyllaDB's
+/// maintenance socket.
+#[tokio::test]
+async fn test_maintenance_mode_over_maintenance_socket() {
+    setup_tracing();
+
+    // Runs after the cluster is initialised but before it is started, which is
+    // when `scylla.yaml` can still be changed.
+    async fn configure(mut cluster: Cluster) -> Cluster {
+        let socket_path = maintenance_socket_path(&cluster);
+        cluster
+            .updateconf([(
+                "maintenance_socket",
+                socket_path
+                    .to_str()
+                    .expect("the node directory path is valid UTF-8"),
+            )])
+            .await
+            .expect("failed to configure the maintenance socket");
+
+        cluster
+    }
+
+    async fn test(cluster: &mut Cluster) {
+        let socket_path = maintenance_socket_path(cluster);
+
+        let session =
+            MaintenanceSessionBuilder::new(MaintenanceModeEndpoint::unix_socket(&socket_path))
+                .build()
+                .await
+                .unwrap();
+
+        // One node, whose address is the documented placeholder: a Unix socket has
+        // no address of its own.
+        let cluster_state = session.get_cluster_state();
+        let nodes = cluster_state.get_nodes_info();
+        assert_eq!(nodes.len(), 1, "expected exactly one node, got {nodes:?}");
+        assert!(
+            nodes[0].address.ip().is_unspecified() && nodes[0].address.port() == 0,
+            "expected the Unix socket placeholder address, got {}",
+            nodes[0].address
+        );
+
+        // Requests are served over the socket.
+        let (key,): (String,) = session
+            .query_unpaged("SELECT key FROM system.local WHERE key = 'local'", &())
+            .await
+            .unwrap()
+            .into_rows_result()
+            .unwrap()
+            .single_row()
+            .unwrap();
+        assert_eq!(key, "local");
+
+        // `ccm remove` deletes the node directory, not a socket outside it.
+        drop(session);
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    run_ccm_test_with_configuration(cluster_1_node, configure, test).await;
+}

--- a/scylla/tests/integration/ccm/mod.rs
+++ b/scylla/tests/integration/ccm/mod.rs
@@ -4,6 +4,8 @@ mod client_routes;
 mod example;
 #[cfg(all(scylla_unstable, feature = "unstable-host-listener"))]
 mod host_listener;
+#[cfg(unix)]
+mod maintenance_socket;
 
 #[cfg(all(feature = "openssl-010", feature = "rustls-023"))]
 mod tls;

--- a/scylla/tests/integration/session/maintenance_mode.rs
+++ b/scylla/tests/integration/session/maintenance_mode.rs
@@ -1,0 +1,61 @@
+//! Tests of maintenance mode: a session pinned to a single node.
+
+use crate::utils::setup_tracing;
+use scylla::client::maintenance_mode::MaintenanceModeEndpoint;
+use scylla::client::session::Session;
+use scylla::client::session_builder::MaintenanceSessionBuilder;
+use std::net::SocketAddr;
+
+fn node_uri() -> SocketAddr {
+    std::env::var("SCYLLA_URI")
+        .unwrap_or_else(|_| "172.42.0.2:9042".to_string())
+        .parse()
+        .unwrap()
+}
+
+/// Asserts that the session knows of exactly one node, the one it was pinned to.
+///
+/// The test cluster has three nodes, so "exactly one" is only true if the peer
+/// list was never read.
+fn assert_pinned_to_one_node(session: &Session, expected: SocketAddr) {
+    let cluster_state = session.get_cluster_state();
+    let nodes = cluster_state.get_nodes_info();
+
+    assert_eq!(nodes.len(), 1, "expected exactly one node, got {nodes:?}");
+    assert_eq!(
+        (nodes[0].address.ip(), nodes[0].address.port()),
+        (expected.ip(), expected.port())
+    );
+}
+
+/// Asserts that a maintenance mode session sends every request to the one node it
+/// was pinned to, and that refreshing metadata does not discover the others.
+#[tokio::test]
+async fn maintenance_mode_talks_only_to_its_one_node() {
+    setup_tracing();
+    let node_addr = node_uri();
+
+    // Note the absence of `.known_node()`: a maintenance mode session takes
+    // exactly one endpoint, and takes it up front.
+    let session = MaintenanceSessionBuilder::new(MaintenanceModeEndpoint::address(node_addr))
+        .build()
+        .await
+        .unwrap();
+
+    assert_pinned_to_one_node(&session, node_addr);
+
+    // Every request is served by that node. Repeated, because a load balancing
+    // policy that had more than one node to choose from would round-robin.
+    for _ in 0..10 {
+        let result = session
+            .query_unpaged("SELECT key FROM system.local WHERE key = 'local'", &())
+            .await
+            .unwrap();
+
+        assert_eq!(result.request_coordinator().connection_address(), node_addr);
+    }
+
+    // A metadata refresh must not discover the rest of the cluster.
+    session.refresh_metadata().await.unwrap();
+    assert_pinned_to_one_node(&session, node_addr);
+}

--- a/scylla/tests/integration/session/mod.rs
+++ b/scylla/tests/integration/session/mod.rs
@@ -5,6 +5,7 @@ mod db_errors;
 mod history;
 mod host_id_mismatch;
 mod internal_requests;
+mod maintenance_mode;
 #[cfg(feature = "metrics")]
 mod metrics;
 mod new_session;


### PR DESCRIPTION
# Maintenance mode sessions

## What this adds

`MaintenanceSessionBuilder`, which takes exactly one endpoint up front:

```rust
let session: Session = MaintenanceSessionBuilder::new(
        MaintenanceModeEndpoint::address("127.0.0.1:9042".parse()?),
    )
    .build()
    .await?;
```

Such a session never reads the peer list, so no other node is ever discovered,
and it registers only for `SCHEMA_CHANGE` - `TOPOLOGY_CHANGE` and
`STATUS_CHANGE` both ask the metadata worker to re-read peers, which is exactly
what must not happen. The schema itself is still fetched as configured, so
`fetch_schema_metadata(true)` works here as it does anywhere else.

The endpoint may also be a Unix domain socket:

```rust
MaintenanceModeEndpoint::unix_socket("/var/lib/scylla/cql.m")
```

Defaults differ from a regular session's in the ways that follow from being
pinned to one node - one connection per host, no shard-aware port, schema
metadata fetching off, no automatic waiting for schema agreement. All remain
configurable; only the defaults change.

## Design notes

- The session's node set is a `Topology::Maintenance` variant rather than a
  synthesized `Peer`, so no code outside `ClusterState` handles a peer the
  driver invented.
- The one node's host id is nil: nothing was read from the cluster that could
  supply one, and saying so beats inventing a plausible identity. It is also why
  the connection pool skips its host id check for such a node.
- A Unix socket has no address, so a placeholder `SocketAddr` stands in for the
  node's identity wherever that identity is reported. Nothing connects to it.
- TLS is silently ignored for a Unix socket rather than rejected.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1793
Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1616

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
