### PR TITLE
Fix custom type parser trailing input

### DIFF
--- a/scylla-cql-core/src/frame/frame_errors.rs
+++ b/scylla-cql-core/src/frame/frame_errors.rs
@@ -680,6 +680,9 @@ pub enum CustomTypeParseError {
     InvalidUtf8(Vec<u8>),
     #[error("Wrong number of parameters {actual}, expected: {expected}")]
     InvalidParameterCount { actual: usize, expected: usize },
+    /// Input remained after parsing a complete custom type name.
+    #[error("Unexpected trailing characters: {0:?}")]
+    UnexpectedTrailingCharacters(String),
 }
 
 /// An error type returned when deserialization of CQL type name fails.

--- a/scylla-cql/src/frame/response/custom_type_parser.rs
+++ b/scylla-cql/src/frame/response/custom_type_parser.rs
@@ -390,6 +390,9 @@ impl<'result> CustomTypeParser<'result> {
         // If we go the simple-type route, we want to treat any trailing characters as errors,
         // so we need to restore the parser to the state pre-blank-skip.
         let parser_before_params = self.parser;
+        // Skipping blank here doesn't seem to serve much purpose, but Scylla does that
+        // in their parser: https://github.com/scylladb/scylladb/blob/7a9546f46fd2d95c5abb08a33f44683ef7dc2c1c/db/marshal/type_parser.cc#L83
+        // We just do the same - there should be no harm done by this.
         self.skip_blank();
         let result = self.parser.accept("(");
         match result {
@@ -643,6 +646,20 @@ mod tests {
         assert_eq!(
             CustomTypeParser::parse(
                 "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type) \t\n",
+            ),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                " \t\n".to_string()
+            ))
+        );
+    }
+
+    // Vefifies that whitespace between type name and opening comma of type params
+    // is accepted for complex type, in line with Scylla own parser.
+    #[test]
+    fn custom_cassandra_type_parser_accepts_middle_whitespace_for_complex() {
+        assert_eq!(
+            CustomTypeParser::parse(
+                "org.apache.cassandra.db.marshal.ListType  (org.apache.cassandra.db.marshal.Int32Type) \t\n",
             ),
             Err(CustomTypeParseError::UnexpectedTrailingCharacters(
                 " \t\n".to_string()

--- a/scylla-cql/src/frame/response/custom_type_parser.rs
+++ b/scylla-cql/src/frame/response/custom_type_parser.rs
@@ -54,7 +54,14 @@ impl<'result> CustomTypeParser<'result> {
 
     pub(crate) fn parse(input: &'result str) -> Result<ColumnType<'result>, CustomTypeParseError> {
         let mut parser = CustomTypeParser::new(input);
-        parser.do_parse()
+        let typ = parser.do_parse()?;
+        if parser.parser.is_at_eof() {
+            Ok(typ)
+        } else {
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                parser.parser.s.to_owned(),
+            ))
+        }
     }
 
     fn is_identifier_char(c: char) -> bool {
@@ -379,12 +386,19 @@ impl<'result> CustomTypeParser<'result> {
                 .map_err(|_| CustomTypeParseError::BadHexString(name.to_owned()))?;
             name = self.read_next_identifier();
         }
+
+        // If we go the simple-type route, we want to treat any trailing characters as errors,
+        // so we need to restore the parser to the state pre-blank-skip.
+        let parser_before_params = self.parser;
         self.skip_blank();
         let result = self.parser.accept("(");
         match result {
             // Here we do not change the parser state, because we want to keep the state as it was before the accept.
             Ok(_) => self.get_complex_abstract_type(name),
-            Err(_) => CustomTypeParser::get_simple_abstract_type(name),
+            Err(_) => {
+                self.parser = parser_before_params;
+                CustomTypeParser::get_simple_abstract_type(name)
+            }
         }
     }
 }
@@ -598,6 +612,41 @@ mod tests {
         assert_eq!(
             CustomTypeParser::parse("zz:org.apache.cassandra.db.marshal.Int32Type"),
             Err(CustomTypeParseError::BadHexString("zz".to_string()))
+        );
+
+        assert_eq!(
+            CustomTypeParser::parse("org.apache.cassandra.db.marshal.Int32Type garbage"),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                " garbage".to_string()
+            ))
+        );
+
+        assert_eq!(
+            CustomTypeParser::parse(
+                "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)garbage"
+            ),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                "garbage".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn custom_cassandra_type_parser_rejects_trailing_whitespace() {
+        assert_eq!(
+            CustomTypeParser::parse("org.apache.cassandra.db.marshal.Int32Type \t\n"),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                " \t\n".to_string()
+            ))
+        );
+
+        assert_eq!(
+            CustomTypeParser::parse(
+                "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type) \t\n",
+            ),
+            Err(CustomTypeParseError::UnexpectedTrailingCharacters(
+                " \t\n".to_string()
+            ))
         );
     }
 }


### PR DESCRIPTION
Continuation of https://github.com/scylladb/scylla-rust-driver/pull/1710 by @Photon101 

Our custom type parser ignores any trailing characters after a type parser successfully.
This PR fixes that: now any trailing characters, including whitespace, are rejected.
Tests are added for such cases.

There is one unobvious thing here. Scylla parser skips blanks after the type name: https://github.com/scylladb/scylladb/blob/7a9546f46fd2d95c5abb08a33f44683ef7dc2c1c/db/marshal/type_parser.cc#L83

This is done for both simple, and complex types, so Scylla accepts a trailing whitespace for simple types, and whitespace before type name and `(` for complex types.

Whitespace before type name and `(` sounds to me like something that could some day happen, and doesn't seem hurful at all, so I kept it. Trailing whitespace, like any other trailing characters, are rejected. This is a discrepancy from Scylla parser, but imo a good one, in line with the goal of rejecting trailing trash. I added a comment explaining why this blank skip even exists.


Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1661
Ref: https://scylladb.atlassian.net/browse/DRIVER-1029


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
