### PR TITLE
Remove LocalStrategy fallback from get_token_endpoints_iter

### DIFF
--- a/examples/compare_tokens.rs
+++ b/examples/compare_tokens.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
             "Token endpoints for query: {:?}",
             session
                 .get_cluster_state()
-                .get_token_endpoints("examples_ks", "compare_tokens", Token::new(t))
+                .try_get_token_endpoints("examples_ks", "compare_tokens", Token::new(t))?
                 .iter()
                 .map(|(node, _shard)| node.address)
                 .collect::<Vec<NodeAddr>>()

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -941,7 +941,7 @@ If you are using this API, you are probably doing something wrong."
             serialized_values_size: usize,
             cluster_state: &ClusterState,
             table_spec: Option<&TableSpec<'_>>,
-            replicas: &OnceCell<Replicas>,
+            replicas: &OnceCell<Option<Replicas>>,
         ) -> RequestSpan {
             let span = RequestSpan::new_prepared(
                 partition_key.as_ref().map(|pk| pk.iter()),
@@ -957,10 +957,16 @@ If you are using this API, you are probably doing something wrong."
                 let replicas = replicas.get_or_init(|| {
                     cluster_state
                         .get_token_endpoints_iter(table_spec, token)
-                        .map(|(node, shard)| (node.clone(), shard))
-                        .collect()
+                        .ok()
+                        .map(|replicas| {
+                            replicas
+                                .map(|(node, shard)| (node.clone(), shard))
+                                .collect()
+                        })
                 });
-                span.record_replicas(replicas.iter().map(|(node, shard)| (node, *shard)));
+                if let Some(replicas) = replicas {
+                    span.record_replicas(replicas.iter().map(|(node, shard)| (node, *shard)));
+                }
             }
             span
         }
@@ -1012,7 +1018,7 @@ If you are using this API, you are probably doing something wrong."
 
         // Shared by the first page and every remaining page, so that the replica set is
         // computed at most once - and only if at least one of those spans is enabled.
-        let replicas: OnceCell<Replicas> = OnceCell::new();
+        let replicas: OnceCell<Option<Replicas>> = OnceCell::new();
 
         let request_span = create_span(
             &partition_key,

--- a/scylla/src/client/session.rs
+++ b/scylla/src/client/session.rs
@@ -2131,8 +2131,8 @@ impl Session {
 
         if !span.span().is_disabled()
             && let (Some(table_spec), Some(token)) = (routing_info.table, token)
+            && let Ok(replicas) = cluster_state.get_token_endpoints_iter(table_spec, token)
         {
-            let replicas = cluster_state.get_token_endpoints_iter(table_spec, token);
             span.record_replicas(replicas)
         }
 

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -562,21 +562,35 @@ impl ClusterState {
     /// Access to replicas owning a given token
     ///
     /// Returns an empty `Vec` if `ClusterState` holds no metadata for `keyspace`: the
-    /// replica set is undefined without the keyspace's replication strategy.
+    /// replica set is undefined without the keyspace's replication strategy. Use
+    /// [`ClusterState::try_get_token_endpoints`] to tell that case apart from a keyspace
+    /// that genuinely has no replicas for the token.
     pub fn get_token_endpoints(
         &self,
         keyspace: &str,
         table: &str,
         token: Token,
     ) -> Vec<(Arc<Node>, Shard)> {
-        let table_spec = TableSpec::borrowed(keyspace, table);
-        self.get_token_endpoints_iter(&table_spec, token)
-            .map(|replicas| {
-                replicas
-                    .map(|(node, shard)| (node.clone(), shard))
-                    .collect()
-            })
+        self.try_get_token_endpoints(keyspace, table, token)
             .unwrap_or_default()
+    }
+
+    /// Access to replicas owning a given token
+    ///
+    /// Fails with [`ClusterStateTokenError::UnknownTable`] if `ClusterState` holds no
+    /// metadata for `keyspace`: the replica set is undefined without the keyspace's
+    /// replication strategy.
+    pub fn try_get_token_endpoints(
+        &self,
+        keyspace: &str,
+        table: &str,
+        token: Token,
+    ) -> Result<Vec<(Arc<Node>, Shard)>, ClusterStateTokenError> {
+        let table_spec = TableSpec::borrowed(keyspace, table);
+        Ok(self
+            .get_token_endpoints_iter(&table_spec, token)?
+            .map(|(node, shard)| (node.clone(), shard))
+            .collect())
     }
 
     pub(crate) fn get_token_endpoints_iter(
@@ -612,11 +626,7 @@ impl ClusterState {
         partition_key: &dyn SerializeRow,
     ) -> Result<Vec<(Arc<Node>, Shard)>, ClusterStateTokenError> {
         let token = self.compute_token(keyspace, table, partition_key)?;
-        let table_spec = TableSpec::borrowed(keyspace, table);
-        Ok(self
-            .get_token_endpoints_iter(&table_spec, token)?
-            .map(|(node, shard)| (node.clone(), shard))
-            .collect())
+        self.try_get_token_endpoints(keyspace, table, token)
     }
 
     /// Access replica location info
@@ -1085,6 +1095,13 @@ mod tests {
             .unwrap();
         assert_eq!(known.count(), 1);
         assert_eq!(state.get_token_endpoints(KS, "t", Token::new(1)).len(), 1);
+        assert_eq!(
+            state
+                .try_get_token_endpoints(KS, "t", Token::new(1))
+                .unwrap()
+                .len(),
+            1
+        );
 
         // An unknown keyspace is an error for the internal API...
         assert_matches!(
@@ -1094,7 +1111,13 @@ mod tests {
             Err(ClusterStateTokenError::UnknownTable { keyspace, table })
                 if keyspace == UNKNOWN_KS && table == "t"
         );
-        // ...and an empty replica set for the public one, which can't report errors.
+        // ...and for the fallible public API...
+        assert_matches!(
+            state.try_get_token_endpoints(UNKNOWN_KS, "t", Token::new(1)),
+            Err(ClusterStateTokenError::UnknownTable { keyspace, table })
+                if keyspace == UNKNOWN_KS && table == "t"
+        );
+        // ...but an empty replica set for the infallible one, which can't report errors.
         assert!(
             state
                 .get_token_endpoints(UNKNOWN_KS, "t", Token::new(1))

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
-use super::metadata::{Keyspace, Metadata, Strategy, Table};
+use super::metadata::{Keyspace, Metadata, Table};
 use super::node::{Node, NodeRef};
 
 /// Helper struct to group parameters that are only needed to
@@ -560,6 +560,9 @@ impl ClusterState {
     }
 
     /// Access to replicas owning a given token
+    ///
+    /// Returns an empty `Vec` if `ClusterState` holds no metadata for `keyspace`: the
+    /// replica set is undefined without the keyspace's replication strategy.
     pub fn get_token_endpoints(
         &self,
         keyspace: &str,
@@ -568,24 +571,31 @@ impl ClusterState {
     ) -> Vec<(Arc<Node>, Shard)> {
         let table_spec = TableSpec::borrowed(keyspace, table);
         self.get_token_endpoints_iter(&table_spec, token)
-            .map(|(node, shard)| (node.clone(), shard))
-            .collect()
+            .map(|replicas| {
+                replicas
+                    .map(|(node, shard)| (node.clone(), shard))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     pub(crate) fn get_token_endpoints_iter(
         &self,
         table_spec: &TableSpec,
         token: Token,
-    ) -> impl Iterator<Item = (NodeRef<'_>, Shard)> + Clone + use<'_> {
-        let keyspace = self.keyspaces.get(table_spec.ks_name());
-        let strategy = keyspace
-            .map(|k| &k.strategy)
-            .unwrap_or(&Strategy::LocalStrategy);
-        let replica_set = self
-            .replica_locator()
-            .replicas_for_token(token, strategy, None, table_spec);
+    ) -> Result<impl Iterator<Item = (NodeRef<'_>, Shard)> + Clone + use<'_>, ClusterStateTokenError>
+    {
+        let keyspace = self.keyspaces.get(table_spec.ks_name()).ok_or_else(|| {
+            ClusterStateTokenError::UnknownTable {
+                keyspace: table_spec.ks_name().to_owned(),
+                table: table_spec.table_name().to_owned(),
+            }
+        })?;
+        let replica_set =
+            self.replica_locator()
+                .replicas_for_token(token, &keyspace.strategy, None, table_spec);
 
-        replica_set.into_iter()
+        Ok(replica_set.into_iter())
     }
 
     /// Access to replicas owning a given partition key (similar to `nodetool getendpoints`)
@@ -602,7 +612,11 @@ impl ClusterState {
         partition_key: &dyn SerializeRow,
     ) -> Result<Vec<(Arc<Node>, Shard)>, ClusterStateTokenError> {
         let token = self.compute_token(keyspace, table, partition_key)?;
-        Ok(self.get_token_endpoints(keyspace, table, token))
+        let table_spec = TableSpec::borrowed(keyspace, table);
+        Ok(self
+            .get_token_endpoints_iter(&table_spec, token)?
+            .map(|(node, shard)| (node.clone(), shard))
+            .collect())
     }
 
     /// Access replica location info
@@ -817,10 +831,11 @@ impl ClusterState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cluster::metadata::{Metadata, Peer};
+    use crate::cluster::metadata::{ConsistencyMode, Metadata, Peer, Strategy};
     use crate::cluster::node::NodeAddr;
     use crate::policies::host_filter::HostFilter;
     use crate::test_utils::setup_tracing;
+    use assert_matches::assert_matches;
 
     use std::collections::{HashMap, HashSet};
     use std::net::SocketAddr;
@@ -846,11 +861,30 @@ mod tests {
     }
 
     fn make_metadata(peers: Vec<Peer>) -> Metadata {
+        make_metadata_with_keyspaces(peers, HashMap::new())
+    }
+
+    fn make_metadata_with_keyspaces(
+        peers: Vec<Peer>,
+        keyspaces: HashMap<String, Result<Keyspace, SingleKeyspaceMetadataError>>,
+    ) -> Metadata {
         Metadata {
             peers,
-            keyspaces: HashMap::new(),
+            keyspaces,
             client_routes: None,
             cluster_name: Some("Test Cluster".into()),
+        }
+    }
+
+    fn make_keyspace(strategy: Strategy) -> Keyspace {
+        Keyspace {
+            strategy,
+            durable_writes: true,
+            tablet_based: false,
+            consistency_mode: ConsistencyMode::Eventual,
+            tables: HashMap::new(),
+            views: HashMap::new(),
+            user_defined_types: HashMap::new(),
         }
     }
 
@@ -1022,6 +1056,49 @@ mod tests {
         assert!(
             Arc::ptr_eq(&old_node, new_node),
             "Node object should be reused when disabled node's attributes haven't changed"
+        );
+    }
+
+    // A keyspace that `ClusterState` has no metadata for has no known replication
+    // strategy, so its replica set is undefined and must not be guessed - guessing
+    // SimpleStrategy with RF=1 yields an arbitrary node that is not a replica.
+    #[tokio::test]
+    async fn unknown_keyspace_has_no_replicas() {
+        setup_tracing();
+
+        const KS: &str = "ks";
+        const UNKNOWN_KS: &str = "unknown_ks";
+
+        let peer = make_peer(Uuid::new_v4(), make_addr(1), Some("dc1"), Some("r1"));
+        let keyspaces = HashMap::from([(
+            KS.to_owned(),
+            Ok(make_keyspace(Strategy::SimpleStrategy {
+                replication_factor: 1,
+            })),
+        )]);
+        let state =
+            new_cluster_state(make_metadata_with_keyspaces(vec![peer], keyspaces), None).await;
+
+        // Sanity check: a known keyspace does have replicas.
+        let known = state
+            .get_token_endpoints_iter(&TableSpec::borrowed(KS, "t"), Token::new(1))
+            .unwrap();
+        assert_eq!(known.count(), 1);
+        assert_eq!(state.get_token_endpoints(KS, "t", Token::new(1)).len(), 1);
+
+        // An unknown keyspace is an error for the internal API...
+        assert_matches!(
+            state
+                .get_token_endpoints_iter(&TableSpec::borrowed(UNKNOWN_KS, "t"), Token::new(1))
+                .map(|_| ()),
+            Err(ClusterStateTokenError::UnknownTable { keyspace, table })
+                if keyspace == UNKNOWN_KS && table == "t"
+        );
+        // ...and an empty replica set for the public one, which can't report errors.
+        assert!(
+            state
+                .get_token_endpoints(UNKNOWN_KS, "t", Token::new(1))
+                .is_empty()
         );
     }
 }

--- a/scylla/src/cluster/state.rs
+++ b/scylla/src/cluster/state.rs
@@ -562,9 +562,14 @@ impl ClusterState {
     /// Access to replicas owning a given token
     ///
     /// Returns an empty `Vec` if `ClusterState` holds no metadata for `keyspace`: the
-    /// replica set is undefined without the keyspace's replication strategy. Use
-    /// [`ClusterState::try_get_token_endpoints`] to tell that case apart from a keyspace
-    /// that genuinely has no replicas for the token.
+    /// replica set is undefined without the keyspace's replication strategy.
+    ///
+    /// Deprecated in favour of [`ClusterState::try_get_token_endpoints`].
+    #[deprecated(
+        since = "1.9.0",
+        note = "an empty replica set cannot be told apart from a keyspace whose metadata \
+                the driver does not have; use `try_get_token_endpoints` instead"
+    )]
     pub fn get_token_endpoints(
         &self,
         keyspace: &str,
@@ -1094,7 +1099,10 @@ mod tests {
             .get_token_endpoints_iter(&TableSpec::borrowed(KS, "t"), Token::new(1))
             .unwrap();
         assert_eq!(known.count(), 1);
-        assert_eq!(state.get_token_endpoints(KS, "t", Token::new(1)).len(), 1);
+        #[expect(deprecated)] // The deprecated API's fallback is what this test pins down.
+        {
+            assert_eq!(state.get_token_endpoints(KS, "t", Token::new(1)).len(), 1);
+        }
         assert_eq!(
             state
                 .try_get_token_endpoints(KS, "t", Token::new(1))
@@ -1117,11 +1125,14 @@ mod tests {
             Err(ClusterStateTokenError::UnknownTable { keyspace, table })
                 if keyspace == UNKNOWN_KS && table == "t"
         );
-        // ...but an empty replica set for the infallible one, which can't report errors.
-        assert!(
-            state
-                .get_token_endpoints(UNKNOWN_KS, "t", Token::new(1))
-                .is_empty()
-        );
+        // ...but an empty replica set for the deprecated one, which can't report errors.
+        #[expect(deprecated)]
+        {
+            assert!(
+                state
+                    .get_token_endpoints(UNKNOWN_KS, "t", Token::new(1))
+                    .is_empty()
+            );
+        }
     }
 }


### PR DESCRIPTION
`get_token_endpoints_iter` used to default to `LocalStrategy` if the requested keyspace was not present in metadata.
This is wrong, in both directions. The returned answer is not guaranteed to be subset of true replica list (the keyspace ay use NTS and skip some DC for example), and the real replica list is not guaranteed to be a subset of the answer (for example if keyspace doesn't exist). So the return value and real replica list are not connected in any way.

Instead of returning wrong answer, return an error. All internal callers are adjusted.
`get_token_endpoints` doesn't return `Result`, so it return an empty Vec now. It becomes deprecated and replaced by `try_get_token_endpoints`.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1908

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
