### PR TITLE
Docs: warn about interaction of LBP and retry consistency change

### DIFF
--- a/docs/source/load-balancing/load-balancing.md
+++ b/docs/source/load-balancing/load-balancing.md
@@ -101,6 +101,24 @@ It's possible for the `fallback` method to include the same target that was
 returned by the `pick` method. In such cases, the query execution layer filters
 out the picked target from the iterator returned by `fallback`.
 
+### Consistency level and retries
+
+`RoutingInfo`, the query information passed to `pick` and `fallback`, contains the
+consistency level of the query. A policy may route based on it - for example,
+keep the plan within the local datacenter for `LOCAL_QUORUM`.
+
+:::{warning}
+The consistency level in `RoutingInfo` is that of the **first** attempt. A
+[retry policy](../retry-policy/retry-policy.md) is free to retry with a different
+consistency level, and the load balancing plan is **not** recomputed then - the plan
+built for the original level is used for all attempts of the query. A retry can thus
+be sent to a target that was chosen for a different consistency level than the one it
+is executed with. You need to use RetryPolicy and LoadBalancingPolicy which don't
+have conflicting behaviors and requirements regarding the consistency.
+Our [Default Retry Policy](../retry-policy/default.md) never changes consistency, so it
+should be safe to use with any LBP.
+:::
+
 ### `on_query_success` and `on_query_failure`:
 
 The `on_query_success` and `on_query_failure` methods are useful for load

--- a/docs/source/retry-policy/downgrading-consistency.md
+++ b/docs/source/retry-policy/downgrading-consistency.md
@@ -44,6 +44,14 @@ something is better than reading nothing, even if there is a risk of reading sta
 This policy is based on the one in [DataStax Java Driver](https://docs.datastax.com/en/drivers/java/3.11/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.html).
 The behaviour is the same.
 
+:::{warning}
+Because this policy lowers the consistency level mid-query, it also invalidates the
+assumptions a consistency-aware [load balancing policy](../load-balancing/load-balancing.md)
+made when it built the query's plan - that plan is not recomputed for retries. Use this
+policy only with a load balancing policy whose routing is not impacted by the consistency changes
+this policy can make.
+:::
+
 ### Examples
 To use in `Session`:
 ```rust

--- a/docs/source/retry-policy/retry-policy.md
+++ b/docs/source/retry-policy/retry-policy.md
@@ -12,6 +12,26 @@ By default there are three retry policies:
 
 It's possible to implement a custom `Retry Policy` by implementing the traits `RetryPolicy` and `RetrySession`.
 
+### Changing the consistency level in a retry
+
+The `RetryDecision::RetrySameTarget` and `RetryDecision::RetryNextTarget` variants can
+request that the retry be executed with a different consistency level than the attempt
+that failed.
+
+:::{warning}
+The [load balancing](../load-balancing/load-balancing.md) plan is computed once per
+query, from the consistency level of the first attempt, and is **not** recomputed when
+a retry changes that level. A load balancing policy that routes based on the consistency
+level - for instance, one that keeps the plan within the local datacenter for
+`LOCAL_QUORUM` - will therefore hand out targets picked for the original level. Retrying
+on the next target with a changed consistency level may then send the query somewhere
+that does not satisfy it.
+
+Always choose RetryPolicy and LoadBalancingPolicy that don't conflict in their behaviors
+and assumptions regarding consistency. Our [Default Retry Policy](../retry-policy/default.md)
+never changes consistency, so it should be safe to use with any LBP.
+:::
+
 ### Idempotence and retry policies
 
 Retry policies and [speculative execution](../speculative-execution/speculative.md)

--- a/scylla/src/policies/load_balancing/mod.rs
+++ b/scylla/src/policies/load_balancing/mod.rs
@@ -27,6 +27,24 @@ pub use single_target::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
 #[non_exhaustive]
 pub struct RoutingInfo<'a> {
     /// Consistency level for the request.
+    ///
+    /// <div class="warning">
+    ///
+    /// This is the consistency level of the *first* attempt. The
+    /// [`RetryPolicy`](crate::policies::retry::RetryPolicy) may pick a different consistency
+    /// level for any retry (see
+    /// [`RetryDecision`](crate::policies::retry::RetryDecision)), and the load balancing plan
+    /// is **not** recomputed then - the plan built from this `RoutingInfo` is used for all
+    /// attempts of the request.
+    ///
+    /// Therefore, a policy that derives routing decisions from this field (e.g. confines the
+    /// plan to the local datacenter because the level is `LOCAL_QUORUM`) can have a later
+    /// attempt executed with a consistency level its plan was not built for. If that matters,
+    /// combine such a policy with a retry policy that never changes the consistency level
+    /// (e.g. [`DefaultRetryPolicy`](crate::policies::retry::DefaultRetryPolicy)), and document
+    /// that requirement for the users of your policy.
+    ///
+    /// </div>
     pub consistency: types::Consistency,
 
     /// Serial consistency level to be used for serial part of the request, if set.

--- a/scylla/src/policies/retry/downgrading_consistency.rs
+++ b/scylla/src/policies/retry/downgrading_consistency.rs
@@ -10,6 +10,16 @@ use crate::errors::{DbError, RequestAttemptError, WriteType};
 /// when it believes that the initial CL is reachable.
 /// Behaviour based on [DataStax Java Driver]\
 ///(<https://docs.datastax.com/en/drivers/java/3.11/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.html>)
+///
+/// <div class="warning">
+///
+/// Apart from breaking the consistency guarantees the user asked for, lowering the consistency
+/// level mid-request also invalidates the assumptions a consistency-aware load balancing policy
+/// made when it built the request's plan - see [`RetryDecision`]. Use this policy only with a
+/// load balancing policy whose routing does not depend on the consistency level, or if you
+/// know that downgrades made by this policy won't violate load balancing consictency assumptions.
+///
+/// </div>
 #[derive(Debug)]
 pub struct DowngradingConsistencyRetryPolicy;
 

--- a/scylla/src/policies/retry/retry_policy.rs
+++ b/scylla/src/policies/retry/retry_policy.rs
@@ -17,7 +17,11 @@ pub struct RequestInfo<'a> {
     ///
     /// If set to `false` it is unknown whether it is idempotent.
     pub is_idempotent: bool,
-    /// Consistency with which the request failed
+    /// Consistency with which the request failed.
+    ///
+    /// This is the consistency level of the attempt that just failed, which is not necessarily
+    /// the one the statement was configured with: a previous [`RetryDecision`] may have already
+    /// changed it.
     pub consistency: Consistency,
 }
 
@@ -39,6 +43,18 @@ impl<'a> RequestInfo<'a> {
 
 /// Returned by implementations of RetryPolicy. Instructs the driver on what
 /// to do about the request after it failed.
+///
+/// <div class="warning">
+///
+/// The retrying variants can change the consistency level used for the retry. The load balancing
+/// plan, however, is computed once per request - from a
+/// [`RoutingInfo`](crate::policies::load_balancing::RoutingInfo) holding the consistency level of
+/// the *first* attempt - and is **not** recomputed when the level changes. A load balancing policy
+/// that routes based on the consistency level (e.g. keeps the plan within the local datacenter for
+/// `LOCAL_QUORUM`) will therefore hand out targets chosen for the original level, and the retry may
+/// be sent to a target that does not satisfy the new one.
+///
+/// </div>
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RetryDecision {


### PR DESCRIPTION
LBP can route based on consistency. RetryPolicy can change consistency for further retries. If it does, LBP plan is not recomputed.

This may be a footgun in certain situations. This PR documents it in all relevant places.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1767

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
