### PR TITLE
Improve schema agreement tests

### DIFF
--- a/scylla-cql/src/frame/response/event.rs
+++ b/scylla-cql/src/frame/response/event.rs
@@ -1,5 +1,6 @@
 //! CQL protocol-level representation of an `EVENT` response.
 
+use bytes::BufMut;
 use uuid::Uuid;
 
 use crate::frame::frame_errors::{
@@ -191,7 +192,80 @@ impl EventV2 {
     }
 }
 
+impl SchemaChangeType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Created => "CREATED",
+            Self::Updated => "UPDATED",
+            Self::Dropped => "DROPPED",
+            Self::Invalid => "INVALID",
+        }
+    }
+}
+
 impl SchemaChangeEvent {
+    /// Serializes the event in the wire format read by [`Self::deserialize`].
+    ///
+    /// Lets test tooling, like `scylla-proxy`, forge `RESULT::SchemaChange` responses.
+    pub fn serialize(&self, buf: &mut impl BufMut) -> Result<(), std::num::TryFromIntError> {
+        let (change_type, target, keyspace_name) = match self {
+            Self::KeyspaceChange {
+                change_type,
+                keyspace_name,
+            } => (change_type, "KEYSPACE", keyspace_name),
+            Self::TableChange {
+                change_type,
+                keyspace_name,
+                ..
+            } => (change_type, "TABLE", keyspace_name),
+            Self::TypeChange {
+                change_type,
+                keyspace_name,
+                ..
+            } => (change_type, "TYPE", keyspace_name),
+            Self::FunctionChange {
+                change_type,
+                keyspace_name,
+                ..
+            } => (change_type, "FUNCTION", keyspace_name),
+            Self::AggregateChange {
+                change_type,
+                keyspace_name,
+                ..
+            } => (change_type, "AGGREGATE", keyspace_name),
+        };
+        types::write_string(change_type.as_str(), buf)?;
+        types::write_string(target, buf)?;
+        types::write_string(keyspace_name, buf)?;
+
+        match self {
+            Self::KeyspaceChange { .. } => (),
+            Self::TableChange {
+                object_name: name, ..
+            }
+            | Self::TypeChange {
+                type_name: name, ..
+            } => types::write_string(name, buf)?,
+            Self::FunctionChange {
+                function_name: name,
+                arguments,
+                ..
+            }
+            | Self::AggregateChange {
+                aggregate_name: name,
+                arguments,
+                ..
+            } => {
+                types::write_string(name, buf)?;
+                types::write_short_length(arguments.len(), buf)?;
+                for argument in arguments {
+                    types::write_string(argument, buf)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Deserialize a schema change event from the provided buffer.
     pub fn deserialize(buf: &mut &[u8]) -> Result<Self, SchemaChangeEventParseError> {
         let type_of_change_string =

--- a/scylla-cql/src/frame/response/result.rs
+++ b/scylla-cql/src/frame/response/result.rs
@@ -1062,8 +1062,8 @@ pub fn deserialize(
 
 // This is not #[cfg(test)], because it is used by scylla crate.
 // Unfortunately, this attribute does not apply recursively to
-// children item. Therefore, every `pub` item here must use have
-// the specifier, too.
+// child items. Therefore, every test-only `pub` item here must
+// have the specifier, too.
 #[doc(hidden)]
 mod test_utils {
     use std::num::TryFromIntError;
@@ -1196,7 +1196,10 @@ mod test_utils {
             }
         }
 
-        pub(crate) fn serialize(
+        /// Serializes the metadata in the CQL wire format.
+        ///
+        /// Lets test tooling, like `scylla-proxy`, forge `RESULT::Rows` responses.
+        pub fn serialize(
             &self,
             buf: &mut impl BufMut,
             no_metadata: bool,

--- a/scylla-proxy/src/errors.rs
+++ b/scylla-proxy/src/errors.rs
@@ -3,7 +3,17 @@ use std::net::SocketAddr;
 use scylla_cql::frame::frame_errors::{
     FrameBodyExtensionsParseError, FrameHeaderParseError, LowLevelDeserializationError,
 };
+use scylla_cql::serialize::SerializationError;
 use thiserror::Error;
+
+/// Error of [`ResponseFrame::forged_rows`](crate::ResponseFrame::forged_rows).
+#[derive(Debug, Error)]
+pub enum ForgedRowsError {
+    #[error("Result metadata does not fit in the frame: {0}")]
+    Metadata(#[from] std::num::TryFromIntError),
+    #[error("Failed to serialize a row: {0}")]
+    Row(#[from] SerializationError),
+}
 
 #[derive(Debug, Error)]
 pub enum ReadFrameError {

--- a/scylla-proxy/src/frame.rs
+++ b/scylla-proxy/src/frame.rs
@@ -8,12 +8,16 @@ pub use scylla_cql::frame::request::RequestOpcode;
 use scylla_cql::frame::request::{RequestDeserializationError, RequestV2};
 pub use scylla_cql::frame::response::ResponseOpcode;
 use scylla_cql::frame::response::error::DbError;
+use scylla_cql::frame::response::event::SchemaChangeEvent;
+use scylla_cql::frame::response::result::{ColumnSpec, ResultMetadata};
 use scylla_cql::frame::types;
+use scylla_cql::serialize::RowWriter;
+use scylla_cql::serialize::row::{RowSerializationContext, SerializeRow};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use tracing::warn;
 
-use crate::errors::ReadFrameError;
+use crate::errors::{ForgedRowsError, ReadFrameError};
 use crate::proxy::CompressionReader;
 
 const HEADER_SIZE: usize = 9;
@@ -189,6 +193,55 @@ impl ResponseFrame {
         Ok(ResponseFrame::new(
             request_params.for_response(),
             ResponseOpcode::Supported,
+            buf.freeze(),
+        ))
+    }
+
+    /// Creates a `RESULT::Rows` response frame with the given columns and rows.
+    ///
+    /// Rows are serialized with the same machinery as bound values, so anything
+    /// implementing [`SerializeRow`] (e.g. a tuple) is a valid row, and it is
+    /// type checked against `col_specs`.
+    pub fn forged_rows<R: SerializeRow>(
+        request_params: FrameParams,
+        col_specs: &[ColumnSpec<'_>],
+        rows: impl IntoIterator<Item = R>,
+    ) -> Result<Self, ForgedRowsError> {
+        let ctx = RowSerializationContext::from_specs(col_specs);
+        let mut rows_buf = Vec::new();
+        let mut rows_count: usize = 0;
+        for row in rows {
+            row.serialize(&ctx, &mut RowWriter::new(&mut rows_buf))?;
+            rows_count += 1;
+        }
+
+        let mut buf = BytesMut::new();
+        types::write_int(0x0002, &mut buf); // Kind: Rows.
+        // Every column carries its own table spec, so columns of different tables are allowed.
+        ResultMetadata::new_for_test(col_specs.len(), col_specs.to_vec())
+            .serialize(&mut buf, false, false)?;
+        types::write_int(i32::try_from(rows_count)?, &mut buf);
+        buf.extend_from_slice(&rows_buf);
+
+        Ok(ResponseFrame::new(
+            request_params.for_response(),
+            ResponseOpcode::Result,
+            buf.freeze(),
+        ))
+    }
+
+    /// Creates a `RESULT::SchemaChange` response frame, as sent by a server after a DDL statement.
+    pub fn forged_schema_change(
+        request_params: FrameParams,
+        event: &SchemaChangeEvent,
+    ) -> Result<Self, std::num::TryFromIntError> {
+        let mut buf = BytesMut::new();
+        types::write_int(0x0005, &mut buf); // Kind: SchemaChange.
+        event.serialize(&mut buf)?;
+
+        Ok(ResponseFrame::new(
+            request_params.for_response(),
+            ResponseOpcode::Result,
             buf.freeze(),
         ))
     }

--- a/scylla-proxy/src/lib.rs
+++ b/scylla-proxy/src/lib.rs
@@ -10,7 +10,7 @@ pub use actions::{
     Action, Condition, Reaction, RequestReaction, RequestRule, ResponseReaction, ResponseRule,
     example_db_errors,
 };
-pub use errors::{DoorkeeperError, ProxyError, WorkerError};
+pub use errors::{DoorkeeperError, ForgedRowsError, ProxyError, WorkerError};
 pub use frame::{RequestFrame, RequestOpcode, ResponseFrame, ResponseOpcode};
 pub use proxy::{Node, Proxy, RunningProxy, ShardAwareness, TransportFactory};
 

--- a/scylla/tests/integration/session/schema_agreement.rs
+++ b/scylla/tests/integration/session/schema_agreement.rs
@@ -307,6 +307,7 @@ async fn test_schema_await_with_transient_failure() {
 
 // Test that produces SchemaAgreementError::RequiredHostAbsent to prove that
 // such condition is possible, and handled correctly.
+// As in `run_ddl_with_unreachable_node`, the DDL and the schema versions are forged by the proxy.
 #[tokio::test]
 async fn test_schema_await_required_host_absent() {
     setup_tracing();
@@ -320,6 +321,12 @@ async fn test_schema_await_required_host_absent() {
                 .address_translator(Arc::new(translation_map.clone()))
                 // Needed to have pools filled immediately after session creation.
                 .pool_size(PoolSize::PerHost(1.try_into().unwrap()))
+                // Speeds up session creation. Schema metadata is not needed in this test.
+                .fetch_schema_metadata(false)
+                // Avoid unnecessary warning
+                .fetch_full_schema_metadata(false)
+                // Keep the forged DDL path isolated from real-cluster metadata.
+                .refresh_metadata_on_auto_schema_agreement(false)
                 // Schema agreement will only return error after timeout,
                 // so without this line the test would take over 60s.
                 .schema_agreement_timeout(Duration::from_secs(1))
@@ -330,9 +337,15 @@ async fn test_schema_await_required_host_absent() {
 
             let host_ids = calculate_proxy_host_ids(&proxy_uris, &translation_map, &session);
 
-            let coordinator = NodeIdentifier::HostId(host_ids[1]);
-
-            running_proxy.running_nodes[1].change_request_rules(Some(vec![
+            let (ks, request) = forged_create_keyspace(NodeIdentifier::HostId(host_ids[1]));
+            let agreed_version = Uuid::new_v4();
+            running_proxy.running_nodes.iter_mut().for_each(|node| {
+                node.change_request_rules(Some(vec![
+                    RequestRule(create_keyspace_query(), forge_keyspace_created(ks.clone())),
+                    RequestRule(schema_version_query(), forge_schema_version(agreed_version)),
+                ]))
+            });
+            running_proxy.running_nodes[1].prepend_request_rules(vec![
                 // This prevents opening new connections to the node
                 RequestRule(
                     Condition::RequestOpcode(RequestOpcode::Startup),
@@ -340,25 +353,8 @@ async fn test_schema_await_required_host_absent() {
                 ),
                 // This prevents schema agreement check on this node, and closes connection.
                 // After some attempts, no connections will be left.
-                RequestRule(
-                    Condition::not(Condition::ConnectionRegisteredAnyEvent)
-                        .and(Condition::RequestOpcode(RequestOpcode::Query))
-                        .and(Condition::BodyContainsCaseSensitive(Box::new(
-                            *b"system.local",
-                        ))),
-                    RequestReaction::drop_connection(),
-                ),
-            ]));
-
-            let ks = unique_keyspace_name();
-            let mut request = Statement::new(format!(
-                "CREATE KEYSPACE {ks}
-                    WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
-            ));
-            request.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
-                coordinator,
-                None,
-            )));
+                RequestRule(schema_version_query(), RequestReaction::drop_connection()),
+            ]);
 
             let result = session.query_unpaged(request, &[]).await;
             let Err(ExecutionError::SchemaAgreementError(
@@ -369,32 +365,6 @@ async fn test_schema_await_required_host_absent() {
             };
 
             assert_eq!(host, host_ids[1]);
-
-            // Cleanup
-            running_proxy.running_nodes[1].change_request_rules(Some(vec![]));
-            // Prepare a new session. The old one has a very small schema agreement timeout,
-            // so awaiting schema agreement may fail (especially on Cassandra). We do need to await
-            // because:
-            // 1. CREATE KEYSPACE may not have propagated yet, which would cause the DROP below to fail,
-            //    so we need to await before DROP
-            // 2. We have a tool that verifies all keyspaces are dropped after tests.
-            //    If we don't auto-await after DROP, it is theoretically possible for this
-            //    tool to see the undropped keyspace.
-            let session: Session = SessionBuilder::new()
-                .known_node(proxy_uris[0].as_str())
-                .address_translator(Arc::new(translation_map.clone()))
-                // Let's have small pool for quicker session creation.
-                .pool_size(PoolSize::PerHost(1.try_into().unwrap()))
-                // Let's try more often to speed up the test.
-                .schema_agreement_interval(Duration::from_millis(50))
-                .build()
-                .await
-                .unwrap();
-            session.await_schema_agreement().await.unwrap();
-            session
-                .query_unpaged(format!("DROP KEYSPACE {ks}"), &[])
-                .await
-                .unwrap();
 
             running_proxy
         },

--- a/scylla/tests/integration/session/schema_agreement.rs
+++ b/scylla/tests/integration/session/schema_agreement.rs
@@ -12,9 +12,11 @@ use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancing
 use scylla::response::PagingState;
 use scylla::response::query_result::QueryResult;
 use scylla::statement::Statement;
+use scylla_cql::frame::response::event::{SchemaChangeEvent, SchemaChangeType};
+use scylla_cql::frame::response::result::{ColumnSpec, ColumnType, NativeType, TableSpec};
 use scylla_proxy::{
-    Condition, ProxyError, Reaction, RequestOpcode, RequestReaction, RequestRule, RunningProxy,
-    ShardAwareness, WorkerError,
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    ResponseFrame, RunningProxy, ShardAwareness, WorkerError,
 };
 use tracing::info;
 use uuid::Uuid;
@@ -24,48 +26,51 @@ use crate::utils::{
     unique_keyspace_name,
 };
 
-async fn run_some_ddl_with_unreachable_node(
-    coordinator: NodeIdentifier,
-    paused: usize,
-    session: &Session,
-    running_proxy: &mut RunningProxy,
-    util_session: &Session,
-) -> Result<QueryResult, ExecutionError> {
-    running_proxy.running_nodes.iter_mut().for_each(|node| {
-        node.change_request_rules(Some(vec![
-            // First check goes without trouble
-            RequestRule(
-                Condition::not(Condition::ConnectionRegisteredAnyEvent)
-                    .and(Condition::RequestOpcode(RequestOpcode::Query))
-                    .and(Condition::BodyContainsCaseSensitive(Box::new(
-                        *b"system.local",
-                    )))
-                    .and(Condition::TrueForLimitedTimes(1)),
-                RequestReaction::noop(),
-            ),
-            // Second check stalls on non-paused nodes, to time it out and
-            // return the error stored from first attempt.
-            RequestRule(
-                Condition::not(Condition::ConnectionRegisteredAnyEvent)
-                    .and(Condition::RequestOpcode(RequestOpcode::Query))
-                    .and(Condition::BodyContainsCaseSensitive(Box::new(
-                        *b"system.local",
-                    ))),
-                RequestReaction::delay(Duration::from_secs(10)),
-            ),
-        ]))
-    });
+/// Matches the schema version query issued by agreement checks.
+fn schema_version_query() -> Condition {
+    Condition::not(Condition::ConnectionRegisteredAnyEvent)
+        .and(Condition::RequestOpcode(RequestOpcode::Query))
+        .and(Condition::BodyContainsCaseSensitive(Box::new(
+            *b"system.local",
+        )))
+}
 
-    running_proxy.running_nodes[paused].prepend_request_rules(vec![RequestRule(
-        Condition::not(Condition::ConnectionRegisteredAnyEvent)
-            .and(Condition::RequestOpcode(RequestOpcode::Query))
-            .and(Condition::BodyContainsCaseSensitive(Box::new(
-                *b"system.local",
-            ))),
-        // Simulates driver discovering that node is unreachable.
-        RequestReaction::drop_connection(),
-    )]);
+/// Matches the `CREATE KEYSPACE` statements executed by tests in this module.
+fn create_keyspace_query() -> Condition {
+    Condition::not(Condition::ConnectionRegisteredAnyEvent)
+        .and(Condition::RequestOpcode(RequestOpcode::Query))
+        .and(Condition::BodyContainsCaseSensitive(Box::new(
+            *b"CREATE KEYSPACE",
+        )))
+}
 
+/// Forges the `RESULT::SchemaChange` response a server sends after `CREATE KEYSPACE`.
+fn forge_keyspace_created(ks: String) -> RequestReaction {
+    RequestReaction::forge_response(Arc::new(move |request: RequestFrame| {
+        let event = SchemaChangeEvent::KeyspaceChange {
+            change_type: SchemaChangeType::Created,
+            keyspace_name: ks.clone(),
+        };
+        ResponseFrame::forged_schema_change(request.params, &event).unwrap()
+    }))
+}
+
+/// Forges the `RESULT::Rows` response to the schema version query,
+/// with a single row holding `version`.
+fn forge_schema_version(version: Uuid) -> RequestReaction {
+    RequestReaction::forge_response(Arc::new(move |request: RequestFrame| {
+        let col_specs = [ColumnSpec::owned(
+            "schema_version".to_owned(),
+            ColumnType::Native(NativeType::Uuid),
+            TableSpec::owned("system".to_owned(), "local".to_owned()),
+        )];
+        ResponseFrame::forged_rows(request.params, &col_specs, [(version,)]).unwrap()
+    }))
+}
+
+/// Builds the `CREATE KEYSPACE` statement whose response the proxy forges.
+/// The name is unique, so that a DDL leaking to the cluster is caught as a stale test keyspace.
+fn forged_create_keyspace(coordinator: NodeIdentifier) -> (String, Statement) {
     let ks = unique_keyspace_name();
     let mut request = Statement::new(format!(
         "CREATE KEYSPACE {ks}
@@ -75,20 +80,49 @@ async fn run_some_ddl_with_unreachable_node(
         coordinator,
         None,
     )));
+    (ks, request)
+}
+
+/// Executes `CREATE KEYSPACE` on `coordinator` while `paused` node is unreachable
+/// for schema agreement checks, and returns the result of the DDL.
+///
+/// Nothing reaches the cluster: proxy forges the DDL response and the schema versions.
+/// Real schema propagation is slow and, with other tests running DDLs concurrently,
+/// unpredictable, which made this test time out on Cassandra.
+async fn run_ddl_with_unreachable_node(
+    session: &Session,
+    coordinator: NodeIdentifier,
+    paused: usize,
+    running_proxy: &mut RunningProxy,
+) -> Result<QueryResult, ExecutionError> {
+    let (ks, request) = forged_create_keyspace(coordinator);
+    let agreed_version = Uuid::new_v4();
+    running_proxy.running_nodes.iter_mut().for_each(|node| {
+        node.change_request_rules(Some(vec![
+            RequestRule(create_keyspace_query(), forge_keyspace_created(ks.clone())),
+            // First check goes without trouble: all nodes agree on the version.
+            RequestRule(
+                schema_version_query().and(Condition::TrueForLimitedTimes(1)),
+                forge_schema_version(agreed_version),
+            ),
+            // Second check never completes on non-paused nodes, to time it out and
+            // return the error stored from the first attempt.
+            RequestRule(schema_version_query(), RequestReaction::drop_frame()),
+        ]))
+    });
+
+    running_proxy.running_nodes[paused].prepend_request_rules(vec![RequestRule(
+        schema_version_query(),
+        // Simulates driver discovering that node is unreachable.
+        RequestReaction::drop_connection(),
+    )]);
 
     let result = session.query_unpaged(request, &[]).await;
 
-    // Cleanup
     running_proxy
         .running_nodes
         .iter_mut()
         .for_each(|node| node.change_request_rules(Some(vec![])));
-    // Schema may have not propagated from the coordinator of CREATE KEYSPACE
-    util_session.await_schema_agreement().await.unwrap();
-    util_session
-        .query_unpaged(format!("DROP KEYSPACE {ks}"), &[])
-        .await
-        .unwrap();
 
     result
 }
@@ -104,7 +138,7 @@ async fn run_some_ddl_with_unreachable_node(
 // Node is simulated as paused by dropping connection on schema request.
 // Normally, for coordinator this would cause `RequiredHostAbsent` error because
 // all connections to required host would be dropped. We prevent that by not allowing more
-// than one agreement check: during second check, other nodes will delay the reponse, triggering
+// than one agreement check: during second check, other nodes never respond, triggering
 // schema agreement timeout, which will return the error stored during the first check (broken connection).
 #[tokio::test]
 async fn test_schema_await_with_unreachable_node() {
@@ -113,10 +147,6 @@ async fn test_schema_await_with_unreachable_node() {
     let res = test_with_3_node_cluster(
         ShardAwareness::QueryNode,
         |proxy_uris, translation_map, mut running_proxy| async move {
-            let normal_timeout = Duration::from_millis(60000);
-            let short_timeout = Duration::from_millis(300);
-
-            // DB preparation phase
             let builder = SessionBuilder::new()
                 .known_node(proxy_uris[0].as_str())
                 .address_translator(Arc::new(translation_map.clone()))
@@ -124,132 +154,67 @@ async fn test_schema_await_with_unreachable_node() {
                 // Shard connections are created asynchronously, so it's hard to predict how many will be opened
                 // already when we check schema agreement.
                 .pool_size(PoolSize::PerHost(1.try_into().unwrap()))
-                // This speeds up the test significantly on my machine.
-                // From ~11s to ~4s when executed individually
-                // From ~18s to ~9s when running all tests.
-                // I doubt Scylla needs this much time to perform the requests,
-                // so we probably have some inefficiency in Driver or Proxy.
+                // Speeds up session creation. Schema metadata is not needed in this test.
                 .fetch_schema_metadata(false)
+                // Avoid unnecessary warning
+                .fetch_full_schema_metadata(false)
+                // Keep the forged DDL path isolated from real-cluster metadata.
+                .refresh_metadata_on_auto_schema_agreement(false)
                 // Let's try more often to prevent timeouts.
                 .schema_agreement_interval(Duration::from_millis(5));
 
-            // Session used for cleanups (DROP TABLE) and some other actions needed in test.
-            let normal_session = builder
-                .clone()
-                .schema_agreement_timeout(normal_timeout)
-                .build()
-                .await
-                .unwrap();
+            // Sub-cases: (coordinator of the DDL, paused node, should the DDL succeed).
+            // Node 0 hosts the control connection, which must not affect the results.
+            let cases = [
+                // Paused node is the coordinator, so the agreement must fail.
+                (1, 1, false),
+                // Paused node is not the coordinator. Agreement only needs available nodes to agree.
+                (2, 1, true),
+                // The same two cases, but the paused node also hosts the control connection.
+                (0, 0, false),
+                (1, 0, true),
+            ];
 
-            let host_ids = calculate_proxy_host_ids(&proxy_uris, &translation_map, &normal_session);
+            for (coordinator, paused, should_succeed) in cases {
+                info!(
+                    "================= Sub test: coordinator={coordinator}, paused={paused} ================="
+                );
 
-            {
-                tracing::info!("================= Sub test 1 =================");
-
+                // A failing agreement ends only by timing out, so keep that short.
+                // A successful one ends at the first check, so the timeout only bounds a broken test.
+                let timeout = if should_succeed {
+                    Duration::from_secs(60)
+                } else {
+                    Duration::from_millis(300)
+                };
                 let session: Session = builder
                     .clone()
-                    .schema_agreement_timeout(short_timeout)
+                    .schema_agreement_timeout(timeout)
                     .build()
                     .await
                     .unwrap();
+                let host_ids = calculate_proxy_host_ids(&proxy_uris, &translation_map, &session);
 
-                // Case 1: Paused node is a coordinator for DDL.
-                // DDL needs to fail.
-                let result = run_some_ddl_with_unreachable_node(
-                    NodeIdentifier::HostId(host_ids[1]),
-                    1,
+                let result = run_ddl_with_unreachable_node(
                     &session,
+                    NodeIdentifier::HostId(host_ids[coordinator]),
+                    paused,
                     &mut running_proxy,
-                    &normal_session,
                 )
                 .await;
-                assert_matches!(
-                    result,
-                    Err(ExecutionError::SchemaAgreementError(
-                        SchemaAgreementError::RequestError(
-                            RequestAttemptError::BrokenConnectionError(_)
-                        )
-                    ))
-                )
-            }
 
-            {
-                tracing::info!("================= Sub test 2 =================");
-
-                let session: Session = builder
-                    .clone()
-                    .schema_agreement_timeout(normal_timeout)
-                    .build()
-                    .await
-                    .unwrap();
-
-                // Case 2: Paused node is NOT a coordinator for DDL.
-                // DDL should succeed, because auto schema agreement only needs available nodes to agree.
-                let result = run_some_ddl_with_unreachable_node(
-                    NodeIdentifier::HostId(host_ids[2]),
-                    1,
-                    &session,
-                    &mut running_proxy,
-                    &normal_session,
-                )
-                .await;
-                assert_matches!(result, Ok(_))
-            }
-
-            {
-                tracing::info!("================= Sub test 3 =================");
-
-                let session: Session = builder
-                    .clone()
-                    .schema_agreement_timeout(short_timeout)
-                    .build()
-                    .await
-                    .unwrap();
-
-                // Case 3: Paused node is a coordinator for DDL, and is used by control connection.
-                // It is the same as case 1, but paused node is also control connection.
-                // DDL needs to fail.
-                let result = run_some_ddl_with_unreachable_node(
-                    NodeIdentifier::HostId(host_ids[0]),
-                    0,
-                    &session,
-                    &mut running_proxy,
-                    &normal_session,
-                )
-                .await;
-                assert_matches!(
-                    result,
-                    Err(ExecutionError::SchemaAgreementError(
-                        SchemaAgreementError::RequestError(
-                            RequestAttemptError::BrokenConnectionError(_)
-                        )
-                    ))
-                )
-            }
-
-            {
-                tracing::info!("================= Sub test 4 =================");
-
-                let session: Session = builder
-                    .clone()
-                    .schema_agreement_timeout(normal_timeout)
-                    .build()
-                    .await
-                    .unwrap();
-
-                // Case 4: Paused node is NOT a coordinator for DDL, but is used by control connection.
-                // It is the same as case 2, but paused node is also control connection.
-                // DDL should succeed, because auto schema agreement only needs available nodes to agree,
-                // and control connection is not used for that at all.
-                let result = run_some_ddl_with_unreachable_node(
-                    NodeIdentifier::HostId(host_ids[1]),
-                    0,
-                    &session,
-                    &mut running_proxy,
-                    &normal_session,
-                )
-                .await;
-                assert_matches!(result, Ok(_))
+                if should_succeed {
+                    assert_matches!(result, Ok(_));
+                } else {
+                    assert_matches!(
+                        result,
+                        Err(ExecutionError::SchemaAgreementError(
+                            SchemaAgreementError::RequestError(
+                                RequestAttemptError::BrokenConnectionError(_)
+                            )
+                        ))
+                    );
+                }
             }
 
             running_proxy


### PR DESCRIPTION
Those tests relied on real cluster schema agreement. On a test cluster, that executes many schema-changing tests concurrently, it can take a long time - especially on Cassandra.

This PR moves 2 most affected tests to not touch the cluster at all: both the response to CREATE KEYSPACE, and to schema version fetching queries are now forged by proxy. Those tests become fast and deterministic, getting rid of flakiness permanently without touching any timeouts and increasing test duration.

As a bonus, turns out that those tests are now massively simplified, because they don't need to work around issues of the real cluster.

Some helpers had to be exposed from scylla-cql and scylla-proxy to allow forging ROWS responses. I think this is a nice change on its own.

Fixes: https://github.com/scylladb/scylla-rust-driver/issues/1433 (for good)
Ref: https://scylladb.atlassian.net/browse/DRIVER-1028

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
